### PR TITLE
fix(cli): harden --cli-path against Chromium argv displacement

### DIFF
--- a/electron/lifecycle/__tests__/appLifecycle.test.ts
+++ b/electron/lifecycle/__tests__/appLifecycle.test.ts
@@ -974,10 +974,12 @@ describe("extractDntrPaths", () => {
     ]);
   });
 
-  it("does not route a dot-segment path to an ancestor named *.dntr", async () => {
+  it("ignores tokens that only resolve onto a *.dntr directory", async () => {
     const { extractDntrPaths } = await import("../appLifecycle.js");
-    // Resolving before the extension check would collapse this to
-    // `/work/plugin.dntr` and treat a directory as an archive.
+    // Both name a directory, not an archive. Resolving before the extension
+    // check would strip the trailing separator / collapse the `..` and hand a
+    // directory to the archive-install pipeline.
+    expect(extractDntrPaths(["daintree", "plugin.dntr/"], "/work")).toEqual([]);
     expect(extractDntrPaths(["daintree", "plugin.dntr/child/.."], "/work")).toEqual([]);
   });
 });

--- a/electron/lifecycle/__tests__/appLifecycle.test.ts
+++ b/electron/lifecycle/__tests__/appLifecycle.test.ts
@@ -779,11 +779,46 @@ describe("extractCliPath", () => {
     expect(errorSpy).toHaveBeenCalled();
   });
 
-  it("falls back past an adjacent token that is a regular file", async () => {
+  it("fails rather than substituting when the adjacent token is an explicit bad value", async () => {
     const { extractCliPath } = await import("../appLifecycle.js");
-    expect(extractCliPath(["daintree", "--cli-path", plainFile, projectDir], root)).toBe(
-      projectDir
+    // Nothing displaced this value — the launcher really did name a file.
+    // Opening some other positional instead would be a project the user never
+    // asked for.
+    expect(extractCliPath(["daintree", "--cli-path", plainFile, projectDir], root)).toBeNull();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("does not substitute a later directory for an explicit missing path", async () => {
+    const { extractCliPath } = await import("../appLifecycle.js");
+    const missing = nodePath.join(root, "gone");
+    expect(extractCliPath(["daintree", "--cli-path", missing, projectDir], root)).toBeNull();
+  });
+
+  it("never scans behind the flag for the displaced path", async () => {
+    const { extractCliPath } = await import("../appLifecycle.js");
+    // Chromium orders positionals after the switches, so a directory sitting
+    // before the flag is someone else's argument — taking it would open the
+    // wrong project.
+    expect(
+      extractCliPath(["daintree", otherDir, "--cli-path", "--injected", projectDir], root)
+    ).toBe(projectDir);
+  });
+
+  it("returns null when the flag is last, even if an earlier token is a directory", async () => {
+    const { extractCliPath } = await import("../appLifecycle.js");
+    expect(extractCliPath(["daintree", projectDir, "--cli-path"], root)).toBeNull();
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[MAIN] Failed to resolve --cli-path to an existing directory",
+      expect.objectContaining({ argument: null })
     );
+  });
+
+  it("accepts a switch-like directory name in the single-token form", async () => {
+    const { extractCliPath } = await import("../appLifecycle.js");
+    // The `=` form is unambiguous, so the switch guard must not apply to it.
+    const oddDir = nodePath.join(root, "--project");
+    fs.mkdirSync(oddDir);
+    expect(extractCliPath(["daintree", `--cli-path=${oddDir}`], root)).toBe(oddDir);
   });
 
   it("does not select a .dntr archive as the fallback directory", async () => {
@@ -797,6 +832,17 @@ describe("extractCliPath", () => {
     const { extractCliPath } = await import("../appLifecycle.js");
     expect(extractCliPath([projectDir, "--cli-path", "--injected"], root)).toBeNull();
   });
+
+  it.skipIf(process.platform === "win32")(
+    "does not home-expand a leading ~ followed by a backslash on POSIX",
+    async () => {
+      const { extractCliPath } = await import("../appLifecycle.js");
+      // `\` is a legal filename character here, so `~\x` is a literal name.
+      const odd = nodePath.join(root, "~\\x");
+      fs.mkdirSync(odd);
+      expect(extractCliPath(["daintree", "--cli-path=~\\x"], root)).toBe(odd);
+    }
+  );
 
   it("takes the first qualifying directory when several positionals exist", async () => {
     const { extractCliPath } = await import("../appLifecycle.js");
@@ -926,6 +972,27 @@ describe("extractDntrPaths", () => {
     expect(extractDntrPaths(["daintree", nodePath.join("~", "plugin.dntr")], "/work")).toEqual([
       nodePath.join(os.homedir(), "plugin.dntr"),
     ]);
+  });
+
+  it("does not route a dot-segment path to an ancestor named *.dntr", async () => {
+    const { extractDntrPaths } = await import("../appLifecycle.js");
+    // Resolving before the extension check would collapse this to
+    // `/work/plugin.dntr` and treat a directory as an archive.
+    expect(extractDntrPaths(["daintree", "plugin.dntr/child/.."], "/work")).toEqual([]);
+  });
+});
+
+describe("hasCliPathFlag", () => {
+  it("reports a requested path in either form, regardless of whether it resolves", async () => {
+    const { hasCliPathFlag } = await import("../appLifecycle.js");
+    expect(hasCliPathFlag(["daintree", "--cli-path", "/gone"])).toBe(true);
+    expect(hasCliPathFlag(["daintree", "--cli-path=/gone"])).toBe(true);
+    expect(hasCliPathFlag(["daintree", "--cli-path"])).toBe(true);
+  });
+
+  it("is false when no path was requested", async () => {
+    const { hasCliPathFlag } = await import("../appLifecycle.js");
+    expect(hasCliPathFlag(["daintree", "--other", "/some/dir"])).toBe(false);
   });
 
   it.skipIf(process.platform === "win32")(

--- a/electron/lifecycle/__tests__/appLifecycle.test.ts
+++ b/electron/lifecycle/__tests__/appLifecycle.test.ts
@@ -248,10 +248,19 @@ describe("registerAppLifecycleHandlers – second-instance", () => {
     };
   }
 
+  // `extractCliPath` only yields paths that exist and are directories (#11410),
+  // so these handler tests need a real directory rather than a fictional one.
+  let cliDir: string;
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(process, "on").mockImplementation(() => process);
     vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    cliDir = fs.mkdtempSync(nodePath.join(os.tmpdir(), "daintree-second-instance-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(cliDir, { recursive: true, force: true });
   });
 
   it("creates a new window via onCreateWindowForPath when CLI path and existing window", async () => {
@@ -274,9 +283,9 @@ describe("registerAppLifecycleHandlers – second-instance", () => {
       workingDirectory: string
     ) => void;
 
-    handler({}, ["daintree", "--cli-path", "/path/to/repo"], "/");
+    handler({}, ["daintree", `--cli-path=${cliDir}`], "/");
 
-    expect(onCreateWindowForPath).toHaveBeenCalledWith("/path/to/repo");
+    expect(onCreateWindowForPath).toHaveBeenCalledWith(cliDir);
     expect(handleDirectoryOpen).not.toHaveBeenCalled();
     expect(mainWindow.focus).not.toHaveBeenCalled();
   });
@@ -299,9 +308,11 @@ describe("registerAppLifecycleHandlers – second-instance", () => {
       workingDirectory: string
     ) => void;
 
-    handler({}, ["daintree", "--cli-path", "/path/to/repo"], "/");
+    // Two-token form kept here on purpose: it must still work when the adjacent
+    // token really is the path.
+    handler({}, ["daintree", "--cli-path", cliDir], "/");
 
-    expect(handleDirectoryOpen).toHaveBeenCalledWith("/path/to/repo", mainWindow, undefined);
+    expect(handleDirectoryOpen).toHaveBeenCalledWith(cliDir, mainWindow, undefined);
   });
 
   it("queues CLI path as pending when no window exists", async () => {
@@ -318,11 +329,11 @@ describe("registerAppLifecycleHandlers – second-instance", () => {
       workingDirectory: string
     ) => void;
 
-    handler({}, ["daintree", "--cli-path", "/pending/path"], "/");
+    handler({}, ["daintree", `--cli-path=${cliDir}`], "/");
 
     expect(onCreateWindowForPath).not.toHaveBeenCalled();
     expect(handleDirectoryOpen).not.toHaveBeenCalled();
-    expect(getPendingCliPath()).toBe("/pending/path");
+    expect(getPendingCliPath()).toBe(cliDir);
   });
 
   it("focuses primary window when no CLI path is provided", async () => {
@@ -706,6 +717,160 @@ describe("registerWindowSessionEndHandler – Windows planned-shutdown wiring", 
   });
 });
 
+describe("extractCliPath", () => {
+  // Real fixtures rather than mocked fs: choosing between candidate positionals
+  // is now a filesystem-driven decision, so the behaviour under test is the
+  // filesystem check itself.
+  let root: string;
+  let projectDir: string;
+  let otherDir: string;
+  let plainFile: string;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(nodePath.join(os.tmpdir(), "daintree-cli-path-"));
+    projectDir = nodePath.join(root, "project");
+    otherDir = nodePath.join(root, "other");
+    plainFile = nodePath.join(root, "notes.txt");
+    fs.mkdirSync(projectDir);
+    fs.mkdirSync(otherDir);
+    fs.writeFileSync(plainFile, "x");
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("returns null and stays silent when no --cli-path is present", async () => {
+    const { extractCliPath } = await import("../appLifecycle.js");
+    // A bare positional directory must not be treated as a project-open request.
+    expect(extractCliPath(["daintree", projectDir], root)).toBeNull();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("accepts an existing directory in the single-token form", async () => {
+    const { extractCliPath } = await import("../appLifecycle.js");
+    expect(extractCliPath(["daintree", `--cli-path=${projectDir}`], root)).toBe(projectDir);
+  });
+
+  it("accepts the two-token form when the adjacent token is the real path", async () => {
+    const { extractCliPath } = await import("../appLifecycle.js");
+    expect(extractCliPath(["daintree", "--cli-path", projectDir], root)).toBe(projectDir);
+  });
+
+  it("ignores an injected switch and recovers the displaced path (#11410)", async () => {
+    const { extractCliPath } = await import("../appLifecycle.js");
+    // The exact shape reported in #11410: Chromium slots one of its own
+    // switches between the flag and the folder, which lands at the end.
+    expect(
+      extractCliPath(["daintree", "--cli-path", "--allow-file-access-from-files", projectDir], root)
+    ).toBe(projectDir);
+  });
+
+  it("never returns a switch as the path when nothing else qualifies", async () => {
+    const { extractCliPath } = await import("../appLifecycle.js");
+    const result = extractCliPath(
+      ["daintree", "--cli-path", "--allow-file-access-from-files"],
+      root
+    );
+    expect(result).toBeNull();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("falls back past an adjacent token that is a regular file", async () => {
+    const { extractCliPath } = await import("../appLifecycle.js");
+    expect(extractCliPath(["daintree", "--cli-path", plainFile, projectDir], root)).toBe(
+      projectDir
+    );
+  });
+
+  it("does not select a .dntr archive as the fallback directory", async () => {
+    const { extractCliPath } = await import("../appLifecycle.js");
+    const archive = nodePath.join(root, "plugin.dntr");
+    fs.writeFileSync(archive, "x");
+    expect(extractCliPath(["daintree", "--cli-path", "--injected", archive], root)).toBeNull();
+  });
+
+  it("never considers argv[0], even when it names a real directory", async () => {
+    const { extractCliPath } = await import("../appLifecycle.js");
+    expect(extractCliPath([projectDir, "--cli-path", "--injected"], root)).toBeNull();
+  });
+
+  it("takes the first qualifying directory when several positionals exist", async () => {
+    const { extractCliPath } = await import("../appLifecycle.js");
+    expect(
+      extractCliPath(["daintree", "--cli-path", "--injected", otherDir, projectDir], root)
+    ).toBe(otherDir);
+  });
+
+  it("treats the single-token form as authoritative and never falls back", async () => {
+    const { extractCliPath } = await import("../appLifecycle.js");
+    // An explicit value that can't be resolved must not silently open some
+    // other directory the user never named.
+    expect(extractCliPath(["daintree", "--cli-path=/does/not/exist", projectDir], root)).toBeNull();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("resolves a relative path against the launching instance's workingDirectory", async () => {
+    const { extractCliPath } = await import("../appLifecycle.js");
+    expect(extractCliPath(["daintree", "--cli-path=project"], root)).toBe(projectDir);
+  });
+
+  it("expands a leading ~ to the home directory", async () => {
+    const { extractCliPath } = await import("../appLifecycle.js");
+    // `~` alone resolves to the home directory itself, which always exists.
+    expect(extractCliPath(["daintree", "--cli-path=~"], root)).toBe(os.homedir());
+  });
+
+  it("reports a failure for a path that does not exist", async () => {
+    const { extractCliPath } = await import("../appLifecycle.js");
+    expect(extractCliPath(["daintree", "--cli-path=/nope/nope"], root)).toBeNull();
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[MAIN] Failed to resolve --cli-path to an existing directory",
+      expect.objectContaining({ workingDirectory: root })
+    );
+  });
+
+  it("rejects a path that exists but is not a directory", async () => {
+    const { extractCliPath } = await import("../appLifecycle.js");
+    expect(extractCliPath(["daintree", `--cli-path=${plainFile}`], root)).toBeNull();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it.skipIf(process.platform === "win32")("decodes a file:// directory URI", async () => {
+    const { extractCliPath } = await import("../appLifecycle.js");
+    expect(extractCliPath(["daintree", `--cli-path=file://${projectDir}`], root)).toBe(projectDir);
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "decodes percent-encoded characters in a file:// URI",
+    async () => {
+      const { extractCliPath } = await import("../appLifecycle.js");
+      const spaced = nodePath.join(root, "my project");
+      fs.mkdirSync(spaced);
+      expect(extractCliPath(["daintree", `--cli-path=file://${root}/my%20project`], root)).toBe(
+        spaced
+      );
+    }
+  );
+
+  it.skipIf(process.platform === "win32")("follows a symlink to a directory", async () => {
+    const { extractCliPath } = await import("../appLifecycle.js");
+    const link = nodePath.join(root, "link");
+    fs.symlinkSync(projectDir, link);
+    expect(extractCliPath(["daintree", `--cli-path=${link}`], root)).toBe(link);
+  });
+
+  it("rejects a malformed file:// URI", async () => {
+    const { extractCliPath } = await import("../appLifecycle.js");
+    // An encoded path separator makes fileURLToPath throw on every platform.
+    expect(extractCliPath(["daintree", "--cli-path=file:///a%2Fb"], root)).toBeNull();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});
+
 describe("extractDntrPaths", () => {
   it("returns absolute .dntr paths unchanged", async () => {
     const { extractDntrPaths } = await import("../appLifecycle.js");
@@ -754,6 +919,13 @@ describe("extractDntrPaths", () => {
   it("returns an empty array when no .dntr path is present", async () => {
     const { extractDntrPaths } = await import("../appLifecycle.js");
     expect(extractDntrPaths(["daintree"], "/work")).toEqual([]);
+  });
+
+  it("expands a leading ~ through the shared path normalization", async () => {
+    const { extractDntrPaths } = await import("../appLifecycle.js");
+    expect(extractDntrPaths(["daintree", nodePath.join("~", "plugin.dntr")], "/work")).toEqual([
+      nodePath.join(os.homedir(), "plugin.dntr"),
+    ]);
   });
 
   it.skipIf(process.platform === "win32")(
@@ -826,6 +998,7 @@ describe("registerAppLifecycleHandlers – second-instance .dntr handling", () =
   }
 
   let dntrFile: string;
+  let cliDir: string;
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -833,6 +1006,7 @@ describe("registerAppLifecycleHandlers – second-instance .dntr handling", () =
     vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
     dntrFile = nodePath.join(os.tmpdir(), `dntr-handler-${process.pid}.dntr`);
     fs.writeFileSync(dntrFile, Buffer.from([0x50, 0x4b, 0x03, 0x04]));
+    cliDir = fs.mkdtempSync(nodePath.join(os.tmpdir(), "daintree-dntr-cli-"));
     enqueueArchiveInstallIntentsMock.mockResolvedValue(undefined);
   });
 
@@ -842,6 +1016,7 @@ describe("registerAppLifecycleHandlers – second-instance .dntr handling", () =
     } catch {
       // already gone
     }
+    fs.rmSync(cliDir, { recursive: true, force: true });
   });
 
   function getHandler() {
@@ -906,10 +1081,10 @@ describe("registerAppLifecycleHandlers – second-instance .dntr handling", () =
       })
     );
 
-    getHandler()({}, ["daintree", "--cli-path", "/repo", dntrFile], "/work");
+    getHandler()({}, ["daintree", `--cli-path=${cliDir}`, dntrFile], "/work");
     await vi.waitFor(() => expect(enqueueArchiveInstallIntentsMock).toHaveBeenCalled());
 
-    expect(onCreateWindowForPath).toHaveBeenCalledWith("/repo");
+    expect(onCreateWindowForPath).toHaveBeenCalledWith(cliDir);
     expect(enqueueArchiveInstallIntentsMock).toHaveBeenCalledWith([dntrFile]);
   });
 });

--- a/electron/lifecycle/appLifecycle.ts
+++ b/electron/lifecycle/appLifecycle.ts
@@ -27,18 +27,28 @@ export function setPendingCliPath(p: string | null): void {
 const CLI_PATH_FLAG = "--cli-path";
 const CLI_PATH_PREFIX = `${CLI_PATH_FLAG}=`;
 
-// Shared normalization for every path-shaped argv token, used by both
-// `extractCliPath` and `extractDntrPaths` so the two can't drift (#11283).
-// Returns null for anything that isn't a usable path candidate.
-function normalizeArgPath(arg: string | undefined, workingDirectory: string): string | null {
-  // A `--`-prefixed token is a switch, never a path. Chromium injects its own
-  // switches into the reconstructed `second-instance` command line, so this is
-  // the guard that stops one being mistaken for a project directory (#11410).
-  if (!arg || arg.startsWith("--")) return null;
+// `\` separates path segments only on Windows; on POSIX it is a legal filename
+// character, so `~\foo` there names a file and must not be home-expanded.
+const TILDE_PREFIX = process.platform === "win32" ? /^~(?=[/\\]|$)/ : /^~(?=\/|$)/;
+
+// A `--`-prefixed token is a switch, never a path. Chromium injects its own
+// switches into the reconstructed `second-instance` command line, so this is
+// the guard that stops one being mistaken for a project directory (#11410).
+// Bare argv tokens only — the value of `--cli-path=<path>` is unambiguous even
+// when the directory is itself named `--something`.
+function isSwitchToken(arg: string | undefined): arg is undefined | string {
+  return !arg || arg.startsWith("--");
+}
+
+// Decode an argv token to an OS path, without resolving it. Callers that care
+// about the literal filename see it before `path.resolve` collapses a trailing
+// `.`/`..` into an ancestor directory's name.
+function decodeArgPath(arg: string | undefined): string | null {
+  if (!arg) return null;
 
   // XDG file managers pass `file://` URIs because electron-builder appends
   // `%U` to the Linux .desktop Exec line, and macOS Shortcuts/Automator produce
-  // them by default. Decode to an OS path before resolution.
+  // them by default.
   let candidate = arg;
   if (candidate.startsWith("file://")) {
     try {
@@ -51,11 +61,16 @@ function normalizeArgPath(arg: string | undefined, workingDirectory: string): st
   // Only the current user's own `~` — `~other` would need an account lookup.
   // The function replacer keeps a `$` in the home path from being read as a
   // replacement pattern.
-  candidate = candidate.replace(/^~(?=[/\\]|$)/, () => os.homedir());
+  return candidate.replace(TILDE_PREFIX, () => os.homedir());
+}
 
-  // The OS may supply a path relative to the launching shell's cwd, so resolve
-  // against the launching instance's `workingDirectory`.
-  return path.resolve(workingDirectory, candidate);
+// Shared normalization for every path-shaped argv token, used by both
+// `extractCliPath` and `extractDntrPaths` so the two can't drift (#11283). The
+// OS may supply a path relative to the launching shell's cwd, so it resolves
+// against the launching instance's `workingDirectory`.
+function normalizeArgPath(arg: string | undefined, workingDirectory: string): string | null {
+  const decoded = decodeArgPath(arg);
+  return decoded === null ? null : path.resolve(workingDirectory, decoded);
 }
 
 // As `normalizeArgPath`, but only returns candidates that are an existing
@@ -110,14 +125,22 @@ export function extractCliPath(argv: string[], workingDirectory: string): string
     if (arg !== CLI_PATH_FLAG) continue;
 
     const adjacent = argv[i + 1];
-    const adjacentPath = normalizeArgDirectory(adjacent, workingDirectory);
-    if (adjacentPath) return adjacentPath;
+    if (adjacent !== undefined && !adjacent.startsWith("--")) {
+      // Nothing displaced the value — this token is what the launcher passed.
+      // If it doesn't name a directory the request has failed; substituting
+      // some other positional would open a project the user never asked for.
+      const adjacentPath = normalizeArgDirectory(adjacent, workingDirectory);
+      if (!adjacentPath) reportUnresolvedCliPath(adjacent, workingDirectory);
+      return adjacentPath;
+    }
 
-    // The value was displaced. Scan the other positionals for it, skipping
-    // argv[0] (the executable) and the token we already rejected. A `.dntr`
-    // archive is a file, so the directory check keeps it out of the running.
-    for (let j = 1; j < argv.length; j++) {
-      if (j === i || j === i + 1) continue;
+    // An injected switch sits where the value should be (#11410). Chromium
+    // orders positionals after the switches, so the displaced path is further
+    // along — never behind the flag. Take the first token past the displaced
+    // slot that names a directory; a `.dntr` archive is a file, so the
+    // directory check keeps it out of the running.
+    for (let j = i + 2; j < argv.length; j++) {
+      if (isSwitchToken(argv[j])) continue;
       const fallback = normalizeArgDirectory(argv[j], workingDirectory);
       if (fallback) return fallback;
     }
@@ -131,6 +154,13 @@ export function extractCliPath(argv: string[], workingDirectory: string): string
   return null;
 }
 
+// True when argv asks for a project directory at all, whether or not it
+// resolves. Lets a caller retire a one-shot `process.argv` read even when the
+// request failed, instead of re-parsing — and re-reporting — it per window.
+export function hasCliPathFlag(argv: string[]): boolean {
+  return argv.some((arg) => arg === CLI_PATH_FLAG || arg.startsWith(CLI_PATH_PREFIX));
+}
+
 // `.dntr` plugin archives double-clicked on Windows/Linux arrive as bare argv
 // entries (no `--flag`) on the `second-instance` event. Extension matching is
 // case-insensitive for Windows. No existence check: the archive-preview
@@ -138,9 +168,12 @@ export function extractCliPath(argv: string[], workingDirectory: string): string
 export function extractDntrPaths(argv: string[], workingDirectory: string): string[] {
   const paths: string[] = [];
   for (const arg of argv) {
-    const candidate = normalizeArgPath(arg, workingDirectory);
-    if (!candidate?.toLowerCase().endsWith(".dntr")) continue;
-    paths.push(candidate);
+    if (isSwitchToken(arg)) continue;
+    const decoded = decodeArgPath(arg);
+    // Match the literal filename: resolving first would collapse a trailing
+    // `.`/`..` and route `some.dntr/..` to an ancestor named `*.dntr`.
+    if (!decoded || !path.basename(decoded).toLowerCase().endsWith(".dntr")) continue;
+    paths.push(path.resolve(workingDirectory, decoded));
   }
   return paths;
 }

--- a/electron/lifecycle/appLifecycle.ts
+++ b/electron/lifecycle/appLifecycle.ts
@@ -36,7 +36,7 @@ const TILDE_PREFIX = process.platform === "win32" ? /^~(?=[/\\]|$)/ : /^~(?=\/|$
 // the guard that stops one being mistaken for a project directory (#11410).
 // Bare argv tokens only — the value of `--cli-path=<path>` is unambiguous even
 // when the directory is itself named `--something`.
-function isSwitchToken(arg: string | undefined): arg is undefined | string {
+function isSwitchToken(arg: string | undefined): boolean {
   return !arg || arg.startsWith("--");
 }
 
@@ -170,9 +170,11 @@ export function extractDntrPaths(argv: string[], workingDirectory: string): stri
   for (const arg of argv) {
     if (isSwitchToken(arg)) continue;
     const decoded = decodeArgPath(arg);
-    // Match the literal filename: resolving first would collapse a trailing
-    // `.`/`..` and route `some.dntr/..` to an ancestor named `*.dntr`.
-    if (!decoded || !path.basename(decoded).toLowerCase().endsWith(".dntr")) continue;
+    // Match the literal token, before `path.resolve` normalizes it: resolving
+    // first would strip a trailing separator and collapse `.`/`..`, routing
+    // `some.dntr/` or `some.dntr/child/..` — which name a directory — to the
+    // archive-install pipeline.
+    if (!decoded || !decoded.toLowerCase().endsWith(".dntr")) continue;
     paths.push(path.resolve(workingDirectory, decoded));
   }
   return paths;

--- a/electron/lifecycle/appLifecycle.ts
+++ b/electron/lifecycle/appLifecycle.ts
@@ -1,5 +1,7 @@
 // eager-import-allow: manages application lifetime hooks and native deep link triggers on startup
 import { app, BrowserWindow } from "electron";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { CliAvailabilityService } from "../services/CliAvailabilityService.js";
@@ -22,40 +24,123 @@ export function setPendingCliPath(p: string | null): void {
   pendingCliPath = p;
 }
 
-export function extractCliPath(argv: string[]): string | null {
-  for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === "--cli-path" && argv[i + 1]) {
-      return argv[i + 1];
-    }
-    if (argv[i].startsWith("--cli-path=")) {
-      return argv[i].slice("--cli-path=".length);
+const CLI_PATH_FLAG = "--cli-path";
+const CLI_PATH_PREFIX = `${CLI_PATH_FLAG}=`;
+
+// Shared normalization for every path-shaped argv token, used by both
+// `extractCliPath` and `extractDntrPaths` so the two can't drift (#11283).
+// Returns null for anything that isn't a usable path candidate.
+function normalizeArgPath(arg: string | undefined, workingDirectory: string): string | null {
+  // A `--`-prefixed token is a switch, never a path. Chromium injects its own
+  // switches into the reconstructed `second-instance` command line, so this is
+  // the guard that stops one being mistaken for a project directory (#11410).
+  if (!arg || arg.startsWith("--")) return null;
+
+  // XDG file managers pass `file://` URIs because electron-builder appends
+  // `%U` to the Linux .desktop Exec line, and macOS Shortcuts/Automator produce
+  // them by default. Decode to an OS path before resolution.
+  let candidate = arg;
+  if (candidate.startsWith("file://")) {
+    try {
+      candidate = fileURLToPath(candidate);
+    } catch {
+      return null;
     }
   }
+
+  // Only the current user's own `~` — `~other` would need an account lookup.
+  // The function replacer keeps a `$` in the home path from being read as a
+  // replacement pattern.
+  candidate = candidate.replace(/^~(?=[/\\]|$)/, () => os.homedir());
+
+  // The OS may supply a path relative to the launching shell's cwd, so resolve
+  // against the launching instance's `workingDirectory`.
+  return path.resolve(workingDirectory, candidate);
+}
+
+// As `normalizeArgPath`, but only returns candidates that are an existing
+// directory. `statSync` follows symlinks (a symlinked project dir is valid) and
+// the try/catch covers absence, permission errors, and anything else stat can
+// throw, all of which mean "not usable as a project path".
+function normalizeArgDirectory(arg: string | undefined, workingDirectory: string): string | null {
+  const resolved = normalizeArgPath(arg, workingDirectory);
+  if (!resolved) return null;
+  try {
+    return fs.statSync(resolved).isDirectory() ? resolved : null;
+  } catch {
+    return null;
+  }
+}
+
+// Single reporting point for a `--cli-path` that was asked for but couldn't be
+// resolved. Error surfacing in the UI is #11409 — this is the hook it replaces.
+function reportUnresolvedCliPath(arg: string | undefined, workingDirectory: string): void {
+  console.error("[MAIN] Failed to resolve --cli-path to an existing directory", {
+    argument: arg ?? null,
+    workingDirectory,
+  });
+}
+
+// The `commandLine` array Electron hands the `second-instance` event is not the
+// literal argv of the second process — it's Chromium's `base::CommandLine`
+// reconstruction, which groups switches ahead of positional arguments and may
+// inject its own switches between them. In the two-token `--cli-path <path>`
+// form the flag parses as a valueless switch and the folder as a positional, so
+// the adjacent token can be an unrelated switch (#11410 saw
+// `--allow-file-access-from-files` land there). Hence: the single-token
+// `--cli-path=<path>` form is authoritative, the adjacent token is only trusted
+// when it resolves to a real directory, and otherwise we search the remaining
+// positionals for the displaced path.
+//
+// Returns an absolute path to an existing directory, or null.
+export function extractCliPath(argv: string[], workingDirectory: string): string | null {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+
+    // Single-token form: unambiguous, so its value is final. Never fall back to
+    // a positional here — that could silently open a directory the user never
+    // named in place of the one they did.
+    if (arg.startsWith(CLI_PATH_PREFIX)) {
+      const raw = arg.slice(CLI_PATH_PREFIX.length);
+      const resolved = normalizeArgDirectory(raw, workingDirectory);
+      if (!resolved) reportUnresolvedCliPath(raw, workingDirectory);
+      return resolved;
+    }
+
+    if (arg !== CLI_PATH_FLAG) continue;
+
+    const adjacent = argv[i + 1];
+    const adjacentPath = normalizeArgDirectory(adjacent, workingDirectory);
+    if (adjacentPath) return adjacentPath;
+
+    // The value was displaced. Scan the other positionals for it, skipping
+    // argv[0] (the executable) and the token we already rejected. A `.dntr`
+    // archive is a file, so the directory check keeps it out of the running.
+    for (let j = 1; j < argv.length; j++) {
+      if (j === i || j === i + 1) continue;
+      const fallback = normalizeArgDirectory(argv[j], workingDirectory);
+      if (fallback) return fallback;
+    }
+
+    reportUnresolvedCliPath(adjacent, workingDirectory);
+    return null;
+  }
+
+  // No `--cli-path` was asked for. Stay silent — and never treat a bare
+  // positional directory as a project-open request on its own.
   return null;
 }
 
 // `.dntr` plugin archives double-clicked on Windows/Linux arrive as bare argv
-// entries (no `--flag`) on the `second-instance` event. The OS may supply a
-// relative path resolved against the launching shell's cwd, so the second
-// instance's `workingDirectory` is used to normalize it. Extension matching is
-// case-insensitive for Windows.
+// entries (no `--flag`) on the `second-instance` event. Extension matching is
+// case-insensitive for Windows. No existence check: the archive-preview
+// pipeline owns missing-file failures.
 export function extractDntrPaths(argv: string[], workingDirectory: string): string[] {
   const paths: string[] = [];
   for (const arg of argv) {
-    if (!arg || arg.startsWith("--")) continue;
-    // XDG file managers pass `file://` URIs because electron-builder appends
-    // `%U` to the Linux .desktop Exec line. Decode to an OS path before the
-    // extension check and resolution.
-    let candidate = arg;
-    if (candidate.startsWith("file://")) {
-      try {
-        candidate = fileURLToPath(candidate);
-      } catch {
-        continue;
-      }
-    }
-    if (!candidate.toLowerCase().endsWith(".dntr")) continue;
-    paths.push(path.resolve(workingDirectory, candidate));
+    const candidate = normalizeArgPath(arg, workingDirectory);
+    if (!candidate?.toLowerCase().endsWith(".dntr")) continue;
+    paths.push(candidate);
   }
   return paths;
 }
@@ -141,7 +226,7 @@ export function registerAppLifecycleHandlers(opts: AppLifecycleOptions): void {
     console.log("[MAIN] Second instance detected");
     const mainWindow = opts.windowRegistry?.getPrimary()?.browserWindow ?? opts.getMainWindow();
     const liveWindow = mainWindow && !mainWindow.isDestroyed() ? mainWindow : null;
-    const cliPath = extractCliPath(commandLine);
+    const cliPath = extractCliPath(commandLine, workingDirectory);
     const dntrPaths = extractDntrPaths(commandLine, workingDirectory);
     // Windows/Linux: a warm `daintree://` deep link arrives as an argv entry on
     // the relaunched second instance. Route it through the same handler as the

--- a/electron/services/CliInstallService.ts
+++ b/electron/services/CliInstallService.ts
@@ -43,7 +43,10 @@ function generateAppImageWrapper(appImagePath: string): string {
     "set -euo pipefail",
     'TARGET="${1:-.}"',
     `ABSOLUTE_PATH="$(cd -- "$TARGET" 2>/dev/null && pwd -P)" || { echo "${CLI_COMMAND_NAME}: '$TARGET' is not a directory" >&2; exit 1; }`,
-    `'${escaped}' --cli-path "$ABSOLUTE_PATH" &`,
+    // Single-token `=` form: Chromium's `second-instance` command-line
+    // reconstruction can inject a switch between a bare flag and its value
+    // (#11410).
+    `'${escaped}' --cli-path="$ABSOLUTE_PATH" &`,
     "exit 0",
     "",
   ].join("\n");

--- a/electron/services/__tests__/CliInstallService.test.ts
+++ b/electron/services/__tests__/CliInstallService.test.ts
@@ -304,7 +304,10 @@ describe("CliInstallService", () => {
       );
       const content = writeCall![1] as string;
       expect(content).toContain("#!/usr/bin/env bash");
-      expect(content).toContain("--cli-path");
+      // Single-token form only — the two-token form is displaceable by
+      // Chromium's command-line reconstruction (#11410).
+      expect(content).toContain('--cli-path="$ABSOLUTE_PATH"');
+      expect(content).not.toContain('--cli-path "$ABSOLUTE_PATH"');
       expect(content).toContain("set -euo pipefail");
     });
   });

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -553,7 +553,9 @@ export async function setupWindowServices(
     initializePowerSaveBlockerService();
     console.log("[MAIN] AgentAvailabilityStore and PowerSaveBlocker initialized");
 
-    const processArgvCli = !getProcessArgvCliHandled() ? extractCliPath(process.argv) : null;
+    const processArgvCli = !getProcessArgvCliHandled()
+      ? extractCliPath(process.argv, process.cwd())
+      : null;
     const skipDefaultSpawn =
       opts.initialProjectPath || processArgvCli || getPendingCliPath() || restoreProject;
     if (skipDefaultSpawn) {
@@ -709,7 +711,9 @@ export async function setupWindowServices(
 
   // CLI path handling — skip if this window was opened with an explicit initialProjectPath
   if (!opts.initialProjectPath) {
-    const firstLaunchCliPath = !getProcessArgvCliHandled() ? extractCliPath(process.argv) : null;
+    const firstLaunchCliPath = !getProcessArgvCliHandled()
+      ? extractCliPath(process.argv, process.cwd())
+      : null;
     if (firstLaunchCliPath) setProcessArgvCliHandled(true);
     const cliPath = firstLaunchCliPath ?? getPendingCliPath();
     if (cliPath) {

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -32,6 +32,7 @@ import { shouldDeferRendererLoadForE2E } from "./earlyRenderer.js";
 import { isE2EFaultMode } from "../setup/runtimeFlags.js";
 import {
   extractCliPath,
+  hasCliPathFlag,
   getPendingCliPath,
   setPendingCliPath,
   extractDntrPaths,
@@ -714,7 +715,10 @@ export async function setupWindowServices(
     const firstLaunchCliPath = !getProcessArgvCliHandled()
       ? extractCliPath(process.argv, process.cwd())
       : null;
-    if (firstLaunchCliPath) setProcessArgvCliHandled(true);
+    // Retire the one-shot read whenever argv asked for a path at all, not only
+    // when it resolved: an unresolvable `--cli-path` is still consumed, so it
+    // isn't re-parsed (and re-reported) by every window created afterwards.
+    if (firstLaunchCliPath || hasCliPathFlag(process.argv)) setProcessArgvCliHandled(true);
     const cliPath = firstLaunchCliPath ?? getPendingCliPath();
     if (cliPath) {
       setPendingCliPath(null);

--- a/scripts/daintree-cli.sh
+++ b/scripts/daintree-cli.sh
@@ -108,7 +108,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
 
   # Fall back to Spotlight if the script is not installed as an app symlink.
   if [[ -z "$APP_PATH" ]] && command -v mdfind &>/dev/null; then
-    APP_PATH="$(mdfind 'kMDItemCFBundleIdentifier == "com.daintree.commandcenter"' 2>/dev/null | head -1)"
+    APP_PATH="$(mdfind 'kMDItemCFBundleIdentifier == "org.daintree.app"' 2>/dev/null | head -1)"
     [[ -n "$APP_PATH" && ! -d "$APP_PATH" ]] && APP_PATH=""
   fi
 
@@ -129,8 +129,11 @@ if [[ "$(uname)" == "Darwin" ]]; then
     exit 1
   fi
 
-  # open -a respects single-instance; the app's second-instance handler picks up --cli-path
-  open -a "$APP_PATH" --args --cli-path "$ABSOLUTE_PATH"
+  # open -a respects single-instance; the app's second-instance handler picks up
+  # --cli-path. The single-token `=` form is required: Chromium's command-line
+  # reconstruction can slot an injected switch between a bare flag and its
+  # value (#11410).
+  open -a "$APP_PATH" --args --cli-path="$ABSOLUTE_PATH"
   exit 0
 fi
 
@@ -165,5 +168,7 @@ if [[ -z "$DAINTREE_BIN" ]]; then
   exit 1
 fi
 
-"$DAINTREE_BIN" --cli-path "$ABSOLUTE_PATH" &
+# Single-token `=` form — a warm launch here spawns a real second process, whose
+# command line Chromium reconstructs and can inject switches into (#11410).
+"$DAINTREE_BIN" --cli-path="$ABSOLUTE_PATH" &
 exit 0

--- a/scripts/daintree-cli.test.ts
+++ b/scripts/daintree-cli.test.ts
@@ -12,7 +12,7 @@ const SCRIPT_SOURCE = path.join(path.dirname(fileURLToPath(import.meta.url)), "d
 // `--cli-path=<path>` guarantee testable: asserting the script's source text
 // would only restate it, whereas a displaced or word-split value shows up here
 // as two argv entries instead of one (#11410).
-function runCli(target: string): { argv: string[]; root: string } {
+async function runCli(target: string): Promise<{ argv: string[]; root: string }> {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-cli-sh-"));
   const argvFile = path.join(root, "argv");
   const binDir = path.join(root, "shim");
@@ -49,13 +49,17 @@ function runCli(target: string): { argv: string[]; root: string } {
     encoding: "utf-8",
   });
 
-  // The Linux branch backgrounds the launch and exits immediately.
+  // The Linux branch backgrounds the launch and exits immediately, and the
+  // recorder's `>` redirect creates the file before writing it — so wait for a
+  // trailing NUL rather than for the file to merely exist.
   const deadline = Date.now() + 5000;
-  while (!fs.existsSync(argvFile) && Date.now() < deadline) {
-    execFileSync("sleep", ["0.05"]);
+  let raw = "";
+  while (Date.now() < deadline) {
+    raw = fs.existsSync(argvFile) ? fs.readFileSync(argvFile, "utf-8") : "";
+    if (raw.endsWith("\0")) break;
+    await new Promise((resolve) => setTimeout(resolve, 25));
   }
 
-  const raw = fs.readFileSync(argvFile, "utf-8");
   return { argv: raw.split("\0").filter((entry) => entry.length > 0), root };
 }
 
@@ -76,8 +80,8 @@ describe.skipIf(process.platform === "win32")("daintree-cli.sh", () => {
     for (const dir of roots.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("passes the project directory as a single --cli-path= argument", () => {
-    const { argv, root } = runCli(projectDir);
+  it("passes the project directory as a single --cli-path= argument", async () => {
+    const { argv, root } = await runCli(projectDir);
     roots.push(root);
 
     // `pwd -P` in the script resolves symlinks (macOS /var -> /private/var).
@@ -85,8 +89,8 @@ describe.skipIf(process.platform === "win32")("daintree-cli.sh", () => {
     expect(argv).toContain(`--cli-path=${expected}`);
   });
 
-  it("never emits the flag and the path as two separate arguments", () => {
-    const { argv, root } = runCli(projectDir);
+  it("never emits the flag and the path as two separate arguments", async () => {
+    const { argv, root } = await runCli(projectDir);
     roots.push(root);
 
     // The #11410 failure mode: a bare `--cli-path` switch whose value is a
@@ -95,8 +99,8 @@ describe.skipIf(process.platform === "win32")("daintree-cli.sh", () => {
     expect(argv.filter((entry) => entry.startsWith("--cli-path"))).toHaveLength(1);
   });
 
-  it("keeps a path containing spaces in one argument", () => {
-    const { argv, root } = runCli(projectDir);
+  it("keeps a path containing spaces in one argument", async () => {
+    const { argv, root } = await runCli(projectDir);
     roots.push(root);
 
     const cliArg = argv.find((entry) => entry.startsWith("--cli-path="));

--- a/scripts/daintree-cli.test.ts
+++ b/scripts/daintree-cli.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_SOURCE = path.join(path.dirname(fileURLToPath(import.meta.url)), "daintree-cli.sh");
+
+// Executes the shipped CLI with the app launch stubbed out, then reports the
+// argv the launcher actually received. This is what makes the single-token
+// `--cli-path=<path>` guarantee testable: asserting the script's source text
+// would only restate it, whereas a displaced or word-split value shows up here
+// as two argv entries instead of one (#11410).
+function runCli(target: string): { argv: string[]; root: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-cli-sh-"));
+  const argvFile = path.join(root, "argv");
+  const binDir = path.join(root, "shim");
+  fs.mkdirSync(binDir);
+
+  const recorder = [
+    "#!/usr/bin/env bash",
+    // NUL-delimited so a value containing spaces stays one field.
+    `printf '%s\\0' "$@" > ${JSON.stringify(argvFile)}`,
+    "",
+  ].join("\n");
+
+  let scriptPath: string;
+  if (process.platform === "darwin") {
+    // The script derives the bundle from its own location when installed
+    // inside one, so no Spotlight/`/Applications` lookup is involved.
+    scriptPath = path.join(root, "Daintree.app", "Contents", "MacOS", "bin", "daintree");
+    fs.mkdirSync(path.dirname(scriptPath), { recursive: true });
+    // macOS hands off through `open -a <bundle> --args …`.
+    const openShim = path.join(binDir, "open");
+    fs.writeFileSync(openShim, recorder, { mode: 0o755 });
+  } else {
+    // Linux resolves the binary as ../daintree relative to the script's dir.
+    scriptPath = path.join(root, "opt", "bin", "daintree");
+    fs.mkdirSync(path.dirname(scriptPath), { recursive: true });
+    fs.writeFileSync(path.join(root, "opt", "daintree"), recorder, { mode: 0o755 });
+  }
+
+  fs.copyFileSync(SCRIPT_SOURCE, scriptPath);
+  fs.chmodSync(scriptPath, 0o755);
+
+  execFileSync("bash", [scriptPath, target], {
+    env: { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` },
+    encoding: "utf-8",
+  });
+
+  // The Linux branch backgrounds the launch and exits immediately.
+  const deadline = Date.now() + 5000;
+  while (!fs.existsSync(argvFile) && Date.now() < deadline) {
+    execFileSync("sleep", ["0.05"]);
+  }
+
+  const raw = fs.readFileSync(argvFile, "utf-8");
+  return { argv: raw.split("\0").filter((entry) => entry.length > 0), root };
+}
+
+describe.skipIf(process.platform === "win32")("daintree-cli.sh", () => {
+  let projectDir: string;
+  let workspace: string;
+  const roots: string[] = [];
+
+  beforeEach(() => {
+    workspace = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-cli-target-"));
+    // A space is the case the two-token form silently word-split.
+    projectDir = path.join(workspace, "my project");
+    fs.mkdirSync(projectDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(workspace, { recursive: true, force: true });
+    for (const dir of roots.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("passes the project directory as a single --cli-path= argument", () => {
+    const { argv, root } = runCli(projectDir);
+    roots.push(root);
+
+    // `pwd -P` in the script resolves symlinks (macOS /var -> /private/var).
+    const expected = fs.realpathSync(projectDir);
+    expect(argv).toContain(`--cli-path=${expected}`);
+  });
+
+  it("never emits the flag and the path as two separate arguments", () => {
+    const { argv, root } = runCli(projectDir);
+    roots.push(root);
+
+    // The #11410 failure mode: a bare `--cli-path` switch whose value is a
+    // detached positional Chromium is free to displace.
+    expect(argv).not.toContain("--cli-path");
+    expect(argv.filter((entry) => entry.startsWith("--cli-path"))).toHaveLength(1);
+  });
+
+  it("keeps a path containing spaces in one argument", () => {
+    const { argv, root } = runCli(projectDir);
+    roots.push(root);
+
+    const cliArg = argv.find((entry) => entry.startsWith("--cli-path="));
+    expect(cliArg).toBeDefined();
+    expect(cliArg).toContain("my project");
+  });
+});


### PR DESCRIPTION
## Summary

- `--cli-path=<path>` (single-token) is now the primary, authoritative form: its value is final and never falls back to a positional, so an explicit path can't be silently swapped for a different directory.
- The two-token form is hardened against Chromium's argv reconstruction, which can inject a switch into the value slot.
- Paths get decoded, `~`-expanded, and resolved before reaching `addProject`, matching what `extractDntrPaths` already did.
- Drive-by: fixes a Spotlight lookup in `scripts/daintree-cli.sh` that used the wrong bundle id.

Resolves #11410

## The bug

Electron's `second-instance` `commandLine` array isn't the literal argv of the second process. It's Chromium's `base::CommandLine` reconstruction, which groups switches ahead of positional arguments and can inject its own switches in between them.

In the two-token `--cli-path <path>` form, `--cli-path` parses as a valueless switch and the folder parses as a positional argument, so an injected switch can land in the slot meant for the path.

A user hit this twice on Daintree 0.28.1, macOS 26.5.1. A Finder Quick Action ran the app binary directly with `--cli-path "$f"`. With Daintree already running, the log recorded `rootPath: "--allow-file-access-from-files"`. That value flowed through `handleDirectoryOpen` to `ProjectStore.addProject`, where `simple-git` threw because a switch name isn't a directory.

This is documented upstream Electron behavior (electron/electron#20322, electron/electron#32933). Thanks to Justin Priday for the reproduction and the log evidence.

## What changed

- `--cli-path=<path>` (single-token) is now the primary form and is authoritative: its value is final, and it never falls back to a positional, so an explicit value can't be silently replaced by a different directory. Our own launchers emit it: `scripts/daintree-cli.sh` (macOS `open -a … --args` and the Linux warm-launch) and the AppImage wrapper from `CliInstallService.generateAppImageWrapper`.
- The two-token form still works for third-party and manual invocations, but it's hardened: the adjacent token is trusted only when it isn't a switch. When an injected switch lands in the value slot, the displaced path gets recovered by scanning forward only, since Chromium orders positionals after switches, so a directory sitting behind the flag belongs to some other argument. When the adjacent token is a non-switch that just isn't a directory, that's a genuine failure: it reports and returns `null` rather than grabbing another positional.
- Values get decoded (`file://`, which macOS Shortcuts, Automator, and XDG file managers all produce), a leading `~` expanded, and resolved against the launching instance's `workingDirectory`. The resolved path has to be an existing directory before it reaches `addProject`.
- The `--`/`file://`/`~`/resolve normalization is factored into shared helpers that both `extractCliPath` and its sibling `extractDntrPaths` call, so the two can't drift apart (precedent #11283).
- `hasCliPathFlag` lets `windowServices` retire the one-shot `process.argv` read even when the path can't be resolved. Without it, every window created afterward would re-parse and re-report the same failure.
- The cold-launch paths (`windowServices.ts:556` and `:712`) read `process.argv` directly, which is literal argv and was never affected by the reconstruction. They pick up the same validation for free through the shared function.
- Drive-by: `scripts/daintree-cli.sh` looked the app up in Spotlight by `com.daintree.commandcenter`, but the shipped bundle id is `org.daintree.app` (`electron-builder.config.cjs:100`). That fallback could never match, so a CLI installed outside the app bundle silently dropped through to the two hardcoded `/Applications` candidates.

## Out of scope

Surfacing this failure in the UI is out of scope here. That's #11409. This PR just makes sure the failure gets reported once, at a single greppable log point, so that issue has something to hook into.

## Testing

218 tests pass across every module touched. `extractCliPath` had no dedicated unit tests before, just indirect coverage through the `second-instance` handler. It now has a full suite, including the exact `--allow-file-access-from-files` repro from the bug report. `scripts/daintree-cli.sh` had no behavioral coverage at all: a new `scripts/daintree-cli.test.ts` runs the real shipped script with the launcher stubbed out and asserts it emits exactly one `--cli-path=<abs path>` argv token for a directory containing a space, verified stable over 3 consecutive runs. Own-file prettier and eslint are clean.

## Worth a reviewer's eye

A few deliberate calls, in case they raise an eyebrow:

- When several positionals after a displaced slot are all directories, the first one wins rather than the parse failing outright. Recovery only runs on input that's already mangled, and refusing to recover would just reinstate the silent no-op this bug reported. `addProject`'s git check still catches bad values downstream anyway.
- `--cli-path=file://` decodes to the root directory `/` and gets accepted as valid. No real launcher produces an authority-only file URL like that, and the downstream `NOT_A_GIT_REPO` check would catch it if one ever did.
- The two cold-launch parse call sites in `windowServices.ts` weren't merged into one, because the first sits inside a service-initialization readiness block. The practical effect: a single cold launch with an invalid path now logs the failure twice instead of once, but a warm launch (second-instance) no longer silently logs it once per every window created afterward, which was the actual bug.