### PR TITLE
fix(forge): honour the forgeRemote setting in toolbar issue/PR resolution

### DIFF
--- a/electron/ipc/handlers/__tests__/forgeResolution.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeResolution.test.ts
@@ -169,8 +169,53 @@ describe("resolveForCwd", () => {
       gitServiceMock.listRemotes.mockResolvedValue([{ name: "origin", fetchUrl: FORK }]);
       resolvesToGitea();
 
-      await expect(resolveForCwd("/repo")).rejects.toThrow(/no longer exists/);
+      await expect(resolveForCwd("/repo")).rejects.toThrow(/isn't available/);
       expect(resolverMock.resolveForgeProvider).not.toHaveBeenCalled();
+    });
+
+    it("rejects rather than auto-detecting when the settings read fails", async () => {
+      // A registered project whose settings are unreadable may well have a
+      // forgeRemote — auto-detecting past it could point a mutation at origin.
+      projectStoreMock.getProjectSettings.mockRejectedValue(new Error("db locked"));
+      gitServiceMock.listRemotes.mockResolvedValue([{ name: "origin", fetchUrl: FORK }]);
+      resolvesToGitea();
+
+      await expect(resolveForCwd("/repo")).rejects.toThrow(/forge settings/);
+      expect(resolverMock.resolveForgeProvider).not.toHaveBeenCalled();
+    });
+
+    it("still auto-detects when the path is not a registered project", async () => {
+      // No project means there is no setting to honour, so this stays on the
+      // pre-fix behaviour rather than going dark.
+      projectStoreMock.getProjectByPath.mockResolvedValue(null);
+      gitServiceMock.listRemotes.mockResolvedValue([{ name: "origin", fetchUrl: CANONICAL }]);
+      resolvesToGitea();
+
+      await resolveForCwd("/repo");
+
+      expect(lastResolverInputs()?.remoteUrl).toBe(CANONICAL);
+    });
+
+    it("does not let hostname matching veto a remote when a provider override is set", async () => {
+      // The override bypasses hostname matching by design, so a self-hosted
+      // origin it exists to support must not be filtered out in favour of a
+      // sibling that happens to match some other provider's hostname.
+      projectStoreMock.getProjectSettings.mockResolvedValue({
+        runCommands: [],
+        forgeProviderOverride: "acme.gitea",
+      });
+      gitServiceMock.listRemotes.mockResolvedValue([
+        { name: "origin", fetchUrl: "https://self-hosted.internal/owner/repo.git" },
+        { name: "mirror", fetchUrl: CANONICAL },
+      ]);
+      registryMock.listMatchingProviders.mockImplementation((url: string) =>
+        url.includes("gitea.example.com") ? [{}] : []
+      );
+      resolvesToGitea();
+
+      await resolveForCwd("/repo");
+
+      expect(lastResolverInputs()?.remoteUrl).toBe("https://self-hosted.internal/owner/repo.git");
     });
 
     it("falls back to the origin lookup when listRemotes fails and nothing is configured", async () => {
@@ -332,12 +377,14 @@ describe("resolveForCwd", () => {
     expect(lastResolverInputs().forgeProviderOverride).toBeNull();
   });
 
-  it("passes a null override when the settings fetch rejects", async () => {
+  it("refuses to resolve at all when the settings fetch rejects", async () => {
+    // Was "passes a null override": treating an unreadable settings row as
+    // "no settings" also discards any `forgeRemote` it holds, which would let
+    // a mutation resolve against origin instead of the selected repo (#11408).
     projectStoreMock.getProjectSettings.mockRejectedValue(new Error("db locked"));
 
-    await resolveForCwd("/repo").catch(() => null);
-
-    expect(lastResolverInputs().forgeProviderOverride).toBeNull();
+    await expect(resolveForCwd("/repo")).rejects.toThrow(/forge settings/);
+    expect(resolverMock.resolveForgeProvider).not.toHaveBeenCalled();
   });
 
   it("passes a null override when project settings have no override set", async () => {

--- a/electron/ipc/handlers/__tests__/forgeResolution.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeResolution.test.ts
@@ -17,6 +17,10 @@ vi.mock("../../../store.js", () => ({ store: storeMock }));
 
 const registryMock = vi.hoisted(() => ({
   getForgeProviderImpl: vi.fn<(id: string) => unknown>(() => undefined),
+  // Remote selection asks the registry whether a URL is parseable at all
+  // (#11408). Default: every remote is supported, so selection falls through
+  // to name preference and these tests stay about provider resolution.
+  listMatchingProviders: vi.fn<(remoteUrl: string) => unknown[]>(() => [{}]),
 }));
 
 vi.mock("../../../services/forgeProviderRegistry.js", () => registryMock);
@@ -38,6 +42,7 @@ vi.mock("../../../services/ProjectStore.js", () => ({ projectStore: projectStore
 
 const gitServiceMock = vi.hoisted(() => ({
   getRemoteUrl: vi.fn(),
+  listRemotes: vi.fn<() => Promise<Array<{ name: string; fetchUrl: string }>>>(async () => []),
   listWorktrees: vi.fn(),
   getRepositoryRoot: vi.fn(),
 }));
@@ -84,8 +89,93 @@ describe("resolveForCwd", () => {
       p === "/repo" ? { id: "project-1", path: "/repo" } : null
     );
     projectStoreMock.getProjectSettings.mockResolvedValue({ runCommands: [] });
+    gitServiceMock.listRemotes.mockResolvedValue([]);
     registryMock.getForgeProviderImpl.mockReturnValue(undefined);
+    registryMock.listMatchingProviders.mockReturnValue([{}]);
     resolverMock.resolveForgeProvider.mockReturnValue({ entry: null, resolvedVia: null });
+  });
+
+  describe("remote selection (#11408)", () => {
+    const FORK = "https://gitea.example.com/me/repo.git";
+    const CANONICAL = "https://gitea.example.com/owner/repo.git";
+
+    function resolvesToGitea() {
+      registryMock.getForgeProviderImpl.mockReturnValue({
+        parseRemote: vi.fn(() => ({ owner: "owner", repo: "repo" })),
+      });
+      resolverMock.resolveForgeProvider.mockReturnValue({
+        entry: giteaEntry,
+        resolvedVia: "hostname",
+      });
+    }
+
+    it("resolves against the remote named by forgeRemote, not origin", async () => {
+      projectStoreMock.getProjectSettings.mockResolvedValue({
+        runCommands: [],
+        forgeRemote: "upstream",
+      });
+      gitServiceMock.listRemotes.mockResolvedValue([
+        { name: "origin", fetchUrl: FORK },
+        { name: "upstream", fetchUrl: CANONICAL },
+      ]);
+      resolvesToGitea();
+
+      await resolveForCwd("/repo");
+
+      expect(lastResolverInputs()?.remoteUrl).toBe(CANONICAL);
+    });
+
+    it("honours the legacy githubRemote alias", async () => {
+      projectStoreMock.getProjectSettings.mockResolvedValue({
+        runCommands: [],
+        githubRemote: "upstream",
+      });
+      gitServiceMock.listRemotes.mockResolvedValue([
+        { name: "origin", fetchUrl: FORK },
+        { name: "upstream", fetchUrl: CANONICAL },
+      ]);
+      resolvesToGitea();
+
+      await resolveForCwd("/repo");
+
+      expect(lastResolverInputs()?.remoteUrl).toBe(CANONICAL);
+    });
+
+    it("auto-detects the only provider-matching remote when no setting is stored", async () => {
+      gitServiceMock.listRemotes.mockResolvedValue([
+        { name: "origin", fetchUrl: "https://internal.example/owner/repo.git" },
+        { name: "backup", fetchUrl: CANONICAL },
+      ]);
+      registryMock.listMatchingProviders.mockImplementation((url: string) =>
+        url.includes("gitea.example.com") ? [{}] : []
+      );
+      resolvesToGitea();
+
+      await resolveForCwd("/repo");
+
+      expect(lastResolverInputs()?.remoteUrl).toBe(CANONICAL);
+    });
+
+    it("falls back to the origin lookup when listRemotes fails", async () => {
+      // A transient git failure must not become a hard "no provider" — that
+      // would read downstream as a genuinely unlinked repo.
+      gitServiceMock.listRemotes.mockRejectedValue(new Error("git exploded"));
+      resolvesToGitea();
+
+      await resolveForCwd("/repo");
+
+      expect(lastResolverInputs()?.remoteUrl).toBe(CANONICAL);
+      expect(gitServiceMock.getRemoteUrl).toHaveBeenCalled();
+    });
+
+    it("falls back to the origin lookup when the repo reports no remotes", async () => {
+      gitServiceMock.listRemotes.mockResolvedValue([]);
+      resolvesToGitea();
+
+      await resolveForCwd("/repo");
+
+      expect(lastResolverInputs()?.remoteUrl).toBe(CANONICAL);
+    });
   });
 
   it("passes the per-project forgeProviderOverride to the resolver (#9984)", async () => {
@@ -305,11 +395,15 @@ describe("resolveForCwd", () => {
     expect(resolverMock.resolveForgeProvider).not.toHaveBeenCalled();
   });
 
-  it("rejects when no remote URL is found, without touching project settings", async () => {
+  it("rejects when the repo has no usable remote", async () => {
+    // Project settings are now read BEFORE the remote lookup (#11408): the
+    // `forgeRemote` setting decides which remote to read, so it cannot be
+    // deferred until after one has been chosen. The reject itself still
+    // short-circuits provider resolution.
     gitServiceMock.getRemoteUrl.mockResolvedValue(null);
+    gitServiceMock.listRemotes.mockResolvedValue([]);
 
     await expect(resolveForCwd("/repo")).rejects.toThrow("No remote URL found");
-    expect(projectStoreMock.getProjectByPath).not.toHaveBeenCalled();
     expect(resolverMock.resolveForgeProvider).not.toHaveBeenCalled();
   });
 });

--- a/electron/ipc/handlers/__tests__/forgeResolution.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeResolution.test.ts
@@ -89,7 +89,10 @@ describe("resolveForCwd", () => {
       p === "/repo" ? { id: "project-1", path: "/repo" } : null
     );
     projectStoreMock.getProjectSettings.mockResolvedValue({ runCommands: [] });
-    gitServiceMock.listRemotes.mockResolvedValue([]);
+    // Mirrors the `getRemoteUrl` default above: a plain single-origin repo.
+    gitServiceMock.listRemotes.mockResolvedValue([
+      { name: "origin", fetchUrl: "https://gitea.example.com/owner/repo.git" },
+    ]);
     registryMock.getForgeProviderImpl.mockReturnValue(undefined);
     registryMock.listMatchingProviders.mockReturnValue([{}]);
     resolverMock.resolveForgeProvider.mockReturnValue({ entry: null, resolvedVia: null });
@@ -156,9 +159,23 @@ describe("resolveForCwd", () => {
       expect(lastResolverInputs()?.remoteUrl).toBe(CANONICAL);
     });
 
-    it("falls back to the origin lookup when listRemotes fails", async () => {
+    it("rejects instead of retargeting when forgeRemote names a missing remote", async () => {
+      // Auto-detecting here would silently point assign/close/merge at a
+      // different repository than the one the user named.
+      projectStoreMock.getProjectSettings.mockResolvedValue({
+        runCommands: [],
+        forgeRemote: "renamed-away",
+      });
+      gitServiceMock.listRemotes.mockResolvedValue([{ name: "origin", fetchUrl: FORK }]);
+      resolvesToGitea();
+
+      await expect(resolveForCwd("/repo")).rejects.toThrow(/no longer exists/);
+      expect(resolverMock.resolveForgeProvider).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the origin lookup when listRemotes fails and nothing is configured", async () => {
       // A transient git failure must not become a hard "no provider" — that
-      // would read downstream as a genuinely unlinked repo.
+      // would read downstream as a genuinely unlinked repo and wipe counts.
       gitServiceMock.listRemotes.mockRejectedValue(new Error("git exploded"));
       resolvesToGitea();
 
@@ -168,13 +185,26 @@ describe("resolveForCwd", () => {
       expect(gitServiceMock.getRemoteUrl).toHaveBeenCalled();
     });
 
-    it("falls back to the origin lookup when the repo reports no remotes", async () => {
+    it("does NOT substitute origin when listRemotes fails and a remote is configured", async () => {
+      // We cannot tell whether the configured remote still exists, so origin
+      // would be a guess at which repo to talk to.
+      projectStoreMock.getProjectSettings.mockResolvedValue({
+        runCommands: [],
+        forgeRemote: "upstream",
+      });
+      gitServiceMock.listRemotes.mockRejectedValue(new Error("git exploded"));
+      resolvesToGitea();
+
+      await expect(resolveForCwd("/repo")).rejects.toThrow("No remote URL found");
+      expect(gitServiceMock.getRemoteUrl).not.toHaveBeenCalled();
+    });
+
+    it("enumerates the remote table only once for a repo with no remotes", async () => {
       gitServiceMock.listRemotes.mockResolvedValue([]);
       resolvesToGitea();
 
-      await resolveForCwd("/repo");
-
-      expect(lastResolverInputs()?.remoteUrl).toBe(CANONICAL);
+      await expect(resolveForCwd("/repo")).rejects.toThrow("No remote URL found");
+      expect(gitServiceMock.getRemoteUrl).not.toHaveBeenCalled();
     });
   });
 

--- a/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
@@ -28,6 +28,9 @@ vi.mock("../../../store.js", () => ({
 const registryMock = vi.hoisted(() => ({
   getRegisteredForgeProviders: vi.fn<() => ForgeProviderEntry[]>(() => []),
   getForgeProviderImpl: vi.fn<(id: string) => unknown>(() => undefined),
+  // Consulted by remote selection (#11408) to decide whether a URL is
+  // parseable. Default "yes" keeps these tests about provider resolution.
+  listMatchingProviders: vi.fn<(remoteUrl: string) => unknown[]>(() => [{}]),
 }));
 
 vi.mock("../../../services/forgeProviderRegistry.js", () => registryMock);
@@ -55,7 +58,10 @@ const projectStoreMock = vi.hoisted(() => ({
 
 vi.mock("../../../services/ProjectStore.js", () => ({ projectStore: projectStoreMock }));
 
-const gitServiceMock = vi.hoisted(() => ({ getRemoteUrl: vi.fn() }));
+const gitServiceMock = vi.hoisted(() => ({
+  getRemoteUrl: vi.fn(),
+  listRemotes: vi.fn<() => Promise<Array<{ name: string; fetchUrl: string }>>>(async () => []),
+}));
 const gitServiceCacheMock = vi.hoisted(() => ({ getGitService: vi.fn(() => gitServiceMock) }));
 
 vi.mock("../../../services/GitServiceCache.js", () => ({
@@ -100,6 +106,8 @@ describe("registerForgeSettingsHandlers", () => {
     });
     projectStoreMock.getProjectSettings.mockResolvedValue({ runCommands: [] });
     gitServiceMock.getRemoteUrl.mockResolvedValue("https://github.com/owner/repo.git");
+    gitServiceMock.listRemotes.mockResolvedValue([]);
+    registryMock.listMatchingProviders.mockReturnValue([{}]);
   });
 
   it("registers all IPC handlers including the credential channels", () => {
@@ -324,6 +332,45 @@ describe("registerForgeSettingsHandlers", () => {
       forgeProviderOverride: null,
       globalDefaultProviderId: null,
     });
+  });
+
+  it("resolveProvider resolves against the project's forgeRemote, not origin (#11408)", async () => {
+    // The pill visibility gate. An origin-only lookup here hid issues and PRs
+    // on every fork whose forge remote is named something else.
+    projectStoreMock.getProjectSettings.mockResolvedValue({ forgeRemote: "upstream" });
+    gitServiceMock.listRemotes.mockResolvedValue([
+      { name: "origin", fetchUrl: "https://github.com/me/fork.git" },
+      { name: "upstream", fetchUrl: "https://github.com/acme/canonical.git" },
+    ]);
+    resolverMock.resolveForgeProvider.mockReturnValueOnce({ entry: null, resolvedVia: null });
+    registerForgeSettingsHandlers();
+    const resolveProvider = findHandler("forge:resolve-provider");
+
+    await resolveProvider(null, "project-1");
+
+    expect(resolverMock.resolveForgeProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ remoteUrl: "https://github.com/acme/canonical.git" })
+    );
+  });
+
+  it("resolveProvider still honours an explicitly passed remoteUrl over the setting (#11408)", async () => {
+    // The Settings routing panel probes each remote in turn — the project's
+    // own selection must not override what the caller asked about.
+    projectStoreMock.getProjectSettings.mockResolvedValue({ forgeRemote: "upstream" });
+    gitServiceMock.listRemotes.mockResolvedValue([
+      { name: "origin", fetchUrl: "https://github.com/me/fork.git" },
+      { name: "upstream", fetchUrl: "https://github.com/acme/canonical.git" },
+    ]);
+    resolverMock.resolveForgeProvider.mockReturnValueOnce({ entry: null, resolvedVia: null });
+    registerForgeSettingsHandlers();
+    const resolveProvider = findHandler("forge:resolve-provider");
+
+    await resolveProvider(null, "project-1", "https://github.com/me/fork.git");
+
+    expect(resolverMock.resolveForgeProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ remoteUrl: "https://github.com/me/fork.git" })
+    );
+    expect(gitServiceMock.listRemotes).not.toHaveBeenCalled();
   });
 
   it("resolveProvider returns no-match for invalid projectId payloads without calling the resolver", async () => {

--- a/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
@@ -106,7 +106,10 @@ describe("registerForgeSettingsHandlers", () => {
     });
     projectStoreMock.getProjectSettings.mockResolvedValue({ runCommands: [] });
     gitServiceMock.getRemoteUrl.mockResolvedValue("https://github.com/owner/repo.git");
-    gitServiceMock.listRemotes.mockResolvedValue([]);
+    // Mirrors the `getRemoteUrl` default above: a plain single-origin repo.
+    gitServiceMock.listRemotes.mockResolvedValue([
+      { name: "origin", fetchUrl: "https://github.com/owner/repo.git" },
+    ]);
     registryMock.listMatchingProviders.mockReturnValue([{}]);
   });
 
@@ -326,7 +329,9 @@ describe("registerForgeSettingsHandlers", () => {
     registerForgeSettingsHandlers();
     const resolveProvider = findHandler("forge:resolve-provider");
     await expect(resolveProvider(null, "project-1", 42)).resolves.toEqual(resolved);
-    expect(gitServiceMock.getRemoteUrl).toHaveBeenCalledTimes(1);
+    // Selection reads the remote table (#11408); `getRemoteUrl` is now only
+    // the fallback for when enumeration itself fails.
+    expect(gitServiceMock.listRemotes).toHaveBeenCalledTimes(1);
     expect(resolverMock.resolveForgeProvider).toHaveBeenCalledWith({
       remoteUrl: "https://github.com/owner/repo.git",
       forgeProviderOverride: null,

--- a/electron/ipc/handlers/forgeResolution.ts
+++ b/electron/ipc/handlers/forgeResolution.ts
@@ -45,7 +45,17 @@ export interface ResolvedForgeContext {
 /** The subset of `GitService` remote selection needs. */
 interface RemoteReader {
   getRemoteUrl(repoPath: string): Promise<string | null>;
-  listRemotes?(repoPath: string): Promise<Array<{ name: string; fetchUrl: string }>>;
+  listRemotes(repoPath: string): Promise<Array<{ name: string; fetchUrl: string }>>;
+}
+
+/** Thrown when `forgeRemote` names a remote the repo no longer has. */
+export class StaleForgeRemoteError extends Error {
+  constructor(readonly remoteName: string) {
+    super(
+      `This project is set to use the "${remoteName}" remote, which no longer exists. Pick a different remote in Project settings.`
+    );
+    this.name = "StaleForgeRemoteError";
+  }
 }
 
 /**
@@ -55,29 +65,37 @@ interface RemoteReader {
  * visibility gate and the data it gates can never disagree about which remote
  * is live.
  *
- * Degrades to the previous origin-only lookup whenever `listRemotes` is
- * unavailable or fails, and never introduces a throw where the old path
- * returned a URL — a transient failure here would otherwise read as "no
- * provider" downstream and wipe the toolbar's persisted counts.
+ * Two deliberate asymmetries:
+ *
+ *  - A configured-but-missing remote throws {@link StaleForgeRemoteError}
+ *    rather than auto-detecting. `resolveForCwd` backs mutations, so silently
+ *    retargeting a renamed remote could push a write at the wrong repository.
+ *  - Enumeration failure falls back to the origin-only lookup ONLY when no
+ *    remote was configured. With a configured remote we cannot tell whether it
+ *    still exists, and substituting origin has the same wrong-repo risk. This
+ *    keeps the no-setting path byte-identical to the pre-fix behavior, so no
+ *    project that resolved before can start reading as "no provider" and wipe
+ *    the toolbar's persisted counts.
  */
 export async function resolveEffectiveRemoteUrl(
   gitService: RemoteReader,
   cwd: string,
   forgeRemote: string | null
 ): Promise<string | null> {
-  const remotes =
-    typeof gitService.listRemotes === "function"
-      ? await gitService.listRemotes(cwd).catch(() => [])
-      : [];
+  const remotes = await gitService.listRemotes(cwd).catch(() => null);
 
-  const selected = resolveForgeRemote({
+  if (remotes === null) {
+    if (forgeRemote) return null;
+    return gitService.getRemoteUrl(cwd).catch(() => null);
+  }
+
+  const { remote, missingConfiguredRemote } = resolveForgeRemote({
     remotes,
     forgeRemote,
     isSupportedRemote: (url) => listMatchingProviders(url).length > 0,
   });
-  if (selected) return selected.fetchUrl;
-
-  return gitService.getRemoteUrl(cwd).catch(() => null);
+  if (missingConfiguredRemote) throw new StaleForgeRemoteError(missingConfiguredRemote);
+  return remote?.fetchUrl ?? null;
 }
 
 export async function resolveForCwd(cwd: string): Promise<ResolvedForgeContext> {

--- a/electron/ipc/handlers/forgeResolution.ts
+++ b/electron/ipc/handlers/forgeResolution.ts
@@ -10,6 +10,7 @@ import { resolveForgeRemote } from "../../../shared/utils/forgeRemoteSelection.j
 import { gitServiceCache } from "../../services/GitServiceCache.js";
 import { projectStore } from "../../services/ProjectStore.js";
 import type { ForgeProviderImpl, RepoRef } from "../../../shared/types/forge.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import {
   makeForgeProviderId,
   normalizeProviderId,
@@ -145,7 +146,8 @@ export async function resolveForCwd(cwd: string): Promise<ResolvedForgeContext> 
       settings = await projectStore.getProjectSettings(project.id);
     } catch (error) {
       throw new Error(
-        `Couldn't read this project's forge settings, so the remote to use is unknown: ${error instanceof Error ? error.message : String(error)}`
+        `Couldn't read this project's forge settings, so the remote to use is unknown: ${formatErrorMessage(error, "settings read failed")}`,
+        { cause: error }
       );
     }
   }

--- a/electron/ipc/handlers/forgeResolution.ts
+++ b/electron/ipc/handlers/forgeResolution.ts
@@ -1,8 +1,12 @@
 // eager-import-allow: reads forge-resolution config via store.get synchronously in the IPC handler
 import path from "node:path";
 import { store } from "../../store.js";
-import { getForgeProviderImpl } from "../../services/forgeProviderRegistry.js";
+import {
+  getForgeProviderImpl,
+  listMatchingProviders,
+} from "../../services/forgeProviderRegistry.js";
 import { resolveForgeProvider } from "../../services/forgeProviderResolver.js";
+import { resolveForgeRemote } from "../../../shared/utils/forgeRemoteSelection.js";
 import { gitServiceCache } from "../../services/GitServiceCache.js";
 import { projectStore } from "../../services/ProjectStore.js";
 import type { ForgeProviderImpl, RepoRef } from "../../../shared/types/forge.js";
@@ -38,6 +42,44 @@ export interface ResolvedForgeContext {
   impl: ForgeProviderImpl;
 }
 
+/** The subset of `GitService` remote selection needs. */
+interface RemoteReader {
+  getRemoteUrl(repoPath: string): Promise<string | null>;
+  listRemotes?(repoPath: string): Promise<Array<{ name: string; fetchUrl: string }>>;
+}
+
+/**
+ * Read the repo's remote table and pick the one the forge integration should
+ * use, honouring the project's `forgeRemote` setting (#11408). Shared by
+ * `resolveForCwd` and the `FORGE_RESOLVE_PROVIDER` handler so the pill's
+ * visibility gate and the data it gates can never disagree about which remote
+ * is live.
+ *
+ * Degrades to the previous origin-only lookup whenever `listRemotes` is
+ * unavailable or fails, and never introduces a throw where the old path
+ * returned a URL — a transient failure here would otherwise read as "no
+ * provider" downstream and wipe the toolbar's persisted counts.
+ */
+export async function resolveEffectiveRemoteUrl(
+  gitService: RemoteReader,
+  cwd: string,
+  forgeRemote: string | null
+): Promise<string | null> {
+  const remotes =
+    typeof gitService.listRemotes === "function"
+      ? await gitService.listRemotes(cwd).catch(() => [])
+      : [];
+
+  const selected = resolveForgeRemote({
+    remotes,
+    forgeRemote,
+    isSupportedRemote: (url) => listMatchingProviders(url).length > 0,
+  });
+  if (selected) return selected.fetchUrl;
+
+  return gitService.getRemoteUrl(cwd).catch(() => null);
+}
+
 export async function resolveForCwd(cwd: string): Promise<ResolvedForgeContext> {
   if (typeof cwd !== "string" || !cwd) {
     throw new Error("Invalid working directory");
@@ -51,14 +93,14 @@ export async function resolveForCwd(cwd: string): Promise<ResolvedForgeContext> 
     throw new Error("Not a git repository");
   }
 
-  const remoteUrl = await gitService.getRemoteUrl(cwd).catch(() => null);
-  if (!remoteUrl) {
-    throw new Error("No remote URL found for this repository");
-  }
-
   // The cwd may be a linked-worktree subdirectory, so an exact match against
   // `project.path` would miss. `git worktree list` reports the main worktree
   // first from anywhere inside the repo — that path is what ProjectStore keys on.
+  //
+  // Resolved before the remote URL (#11408): the project's `forgeRemote`
+  // setting decides *which* remote we read, so the settings have to be in hand
+  // first. Previously this block ran after an origin-only `getRemoteUrl`, which
+  // is why the setting never reached the toolbar's data path.
   const worktrees = await gitService.listWorktrees().catch(() => []);
   const mainWorktreePath =
     worktrees.find((wt) => wt.isMainWorktree)?.path ??
@@ -69,6 +111,15 @@ export async function resolveForCwd(cwd: string): Promise<ResolvedForgeContext> 
     ? await projectStore.getProjectSettings(project.id).catch(() => null)
     : null;
   const forgeProviderOverride = settings?.forgeProviderOverride ?? null;
+
+  const remoteUrl = await resolveEffectiveRemoteUrl(
+    gitService,
+    cwd,
+    settings?.forgeRemote ?? settings?.githubRemote ?? null
+  );
+  if (!remoteUrl) {
+    throw new Error("No remote URL found for this repository");
+  }
 
   const globalDefaultProviderId = normalizeProviderId(store.get("forgeDefaultProviderId"));
 

--- a/electron/ipc/handlers/forgeResolution.ts
+++ b/electron/ipc/handlers/forgeResolution.ts
@@ -51,8 +51,10 @@ interface RemoteReader {
 /** Thrown when `forgeRemote` names a remote the repo no longer has. */
 export class StaleForgeRemoteError extends Error {
   constructor(readonly remoteName: string) {
+    // Deliberately not "no longer exists": the name may still be present but
+    // carry no fetch URL (a push-only remote), which is equally unusable.
     super(
-      `This project is set to use the "${remoteName}" remote, which no longer exists. Pick a different remote in Project settings.`
+      `This project is set to use the "${remoteName}" remote, which isn't available. Pick a different remote in Project settings.`
     );
     this.name = "StaleForgeRemoteError";
   }
@@ -80,7 +82,8 @@ export class StaleForgeRemoteError extends Error {
 export async function resolveEffectiveRemoteUrl(
   gitService: RemoteReader,
   cwd: string,
-  forgeRemote: string | null
+  forgeRemote: string | null,
+  forgeProviderOverride: string | null = null
 ): Promise<string | null> {
   const remotes = await gitService.listRemotes(cwd).catch(() => null);
 
@@ -92,7 +95,14 @@ export async function resolveEffectiveRemoteUrl(
   const { remote, missingConfiguredRemote } = resolveForgeRemote({
     remotes,
     forgeRemote,
-    isSupportedRemote: (url) => listMatchingProviders(url).length > 0,
+    // A per-project provider override deliberately bypasses hostname matching
+    // (`forgeProviderResolver` searches the whole registry for it), so the
+    // hostname registry must not get a veto over which remote we pick either.
+    // Filtering here would discard a self-hosted origin the override exists to
+    // support and hand the override's provider a sibling mirror instead.
+    isSupportedRemote: forgeProviderOverride
+      ? undefined
+      : (url) => listMatchingProviders(url).length > 0,
   });
   if (missingConfiguredRemote) throw new StaleForgeRemoteError(missingConfiguredRemote);
   return remote?.fetchUrl ?? null;
@@ -125,15 +135,27 @@ export async function resolveForCwd(cwd: string): Promise<ResolvedForgeContext> 
     (await gitService.getRepositoryRoot(cwd).catch(() => null)) ??
     cwd;
   const project = await projectStore.getProjectByPath(mainWorktreePath).catch(() => null);
-  const settings = project
-    ? await projectStore.getProjectSettings(project.id).catch(() => null)
-    : null;
+  // A registered project whose settings we cannot read is NOT the same as an
+  // unregistered path: the former may well have a `forgeRemote` we are about to
+  // ignore, and auto-detecting past it would point a mutation at whichever repo
+  // origin happens to be. Only a genuinely absent project may auto-detect.
+  let settings = null;
+  if (project) {
+    try {
+      settings = await projectStore.getProjectSettings(project.id);
+    } catch (error) {
+      throw new Error(
+        `Couldn't read this project's forge settings, so the remote to use is unknown: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
   const forgeProviderOverride = settings?.forgeProviderOverride ?? null;
 
   const remoteUrl = await resolveEffectiveRemoteUrl(
     gitService,
     cwd,
-    settings?.forgeRemote ?? settings?.githubRemote ?? null
+    settings?.forgeRemote ?? settings?.githubRemote ?? null,
+    forgeProviderOverride
   );
   if (!remoteUrl) {
     throw new Error("No remote URL found for this repository");

--- a/electron/ipc/handlers/forgeSettings.ts
+++ b/electron/ipc/handlers/forgeSettings.ts
@@ -7,6 +7,7 @@ import {
   getRegisteredForgeProviders,
 } from "../../services/forgeProviderRegistry.js";
 import { resolveForgeProvider } from "../../services/forgeProviderResolver.js";
+import { resolveEffectiveRemoteUrl } from "./forgeResolution.js";
 import { projectStore } from "../../services/ProjectStore.js";
 import { gitServiceCache } from "../../services/GitServiceCache.js";
 import { normalizeProviderId } from "../../../shared/utils/forgeProviderIds.js";
@@ -133,10 +134,21 @@ export function registerForgeSettingsHandlers(): () => void {
 
         let effectiveRemoteUrl: string | null;
         if (typeof remoteUrl === "string" && remoteUrl.length > 0) {
+          // An explicit URL means the caller is asking about one specific
+          // remote (the Settings routing panel probes each in turn) — the
+          // project's selection must not override that.
           effectiveRemoteUrl = remoteUrl;
         } else {
+          // No URL: answer for whichever remote the project actually routes
+          // through (#11408). This is the toolbar's pill-visibility gate, so an
+          // origin-only lookup here hid issues and PRs on every fork or mirror
+          // whose forge remote is named something else.
           const gitService = gitServiceCache.getGitService(project.path);
-          effectiveRemoteUrl = await gitService.getRemoteUrl(project.path).catch(() => null);
+          effectiveRemoteUrl = await resolveEffectiveRemoteUrl(
+            gitService,
+            project.path,
+            settings?.forgeRemote ?? settings?.githubRemote ?? null
+          );
         }
 
         const globalDefaultProviderId = readDefaultProviderId();

--- a/electron/ipc/handlers/forgeSettings.ts
+++ b/electron/ipc/handlers/forgeSettings.ts
@@ -147,7 +147,8 @@ export function registerForgeSettingsHandlers(): () => void {
           effectiveRemoteUrl = await resolveEffectiveRemoteUrl(
             gitService,
             project.path,
-            settings?.forgeRemote ?? settings?.githubRemote ?? null
+            settings?.forgeRemote ?? settings?.githubRemote ?? null,
+            forgeProviderOverride
           );
         }
 

--- a/electron/ipc/handlers/projectCrud/settings.ts
+++ b/electron/ipc/handlers/projectCrud/settings.ts
@@ -19,7 +19,12 @@ async function getRunCommandDetector(): Promise<
   return cachedRunCommandDetector;
 }
 import { z } from "zod";
-import { typedHandle, typedHandleValidated, checkRateLimit } from "../../utils.js";
+import {
+  typedHandle,
+  typedHandleValidated,
+  checkRateLimit,
+  broadcastToRenderer,
+} from "../../utils.js";
 import { validateFolderName } from "../../../../shared/utils/folderName.js";
 import { ProjectSettingsSaveSchema } from "../../../services/projectSettingsCodec.js";
 import type { ProjectSettings } from "../../../types/index.js";
@@ -67,6 +72,17 @@ export function registerProjectSettingsHandlers(deps: HandlerDependencies = {}):
           console.warn("[IPC] Failed to push forge settings to workspace host:", error);
         });
       }
+    }
+    if (remoteChanged) {
+      // The renderer caches provider resolution per project and only drops it
+      // on `forge:remote-changed` (#11155). That event is signature-gated on
+      // `.git/config`, which a settings change never touches — so without this
+      // broadcast the toolbar keeps resolving against the OLD remote until a
+      // reload, which is the bug this fix exists to close (#11408).
+      broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
+        name: "forge:remote-changed",
+        payload: { projectId },
+      });
     }
   };
   handlers.push(

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -206,6 +206,7 @@ export class WorkspaceService {
   // it to pick the same remote the toolbar routes through — otherwise the
   // worktree cards probe `origin` while the toolbar talks to `upstream`.
   private forgeRemoteName: string | null = null;
+  private forgeReselectSeq = 0;
   private forgeRemoteProbeSeq = 0;
   private forgeRemoteReprobeTimer: NodeJS.Timeout | null = null;
   // Bumped whenever a `.git/config` write is OBSERVED. A baseline read that
@@ -1626,7 +1627,9 @@ export class WorkspaceService {
       // Selection honours the project's `forgeRemote` setting (#11408). The
       // signature above deliberately still covers ALL remotes: it answers "did
       // the remote table change", independent of which entry we route through.
-      const selected = resolveForgeRemote({
+      // A configured-but-missing remote selects nothing, leaving the
+      // affordance hidden rather than silently probing a different repo.
+      const { remote: selected } = resolveForgeRemote({
         remotes: remotes.map((r) => ({ name: r.name, fetchUrl: r.refs?.fetch ?? "" })),
         forgeRemote: this.forgeRemoteName,
         // The host has no provider registry — it matches against the matcher
@@ -1859,6 +1862,13 @@ export class WorkspaceService {
         fetchUrl ? matchProviderForRemoteUrl(fetchUrl, this.forgeProviderMatchers) : null
       );
     }
+    // Re-matching the REMEMBERED url is not enough (#11408): which remote is
+    // selected depends on the matcher table too. At cold start the table is
+    // empty, so auto-detect ranks by name alone and can settle on a remote no
+    // provider ends up supporting — re-matching that URL would leave the
+    // affordance hidden forever while a sibling remote was usable all along.
+    // Same story when enabling or disabling a provider plugin at runtime.
+    void this.reselectForgeRemote();
   }
 
   private handleInotifyLimitReached(): void {
@@ -3399,8 +3409,24 @@ ${lines.map((l) => "+" + l).join("\n")}`;
   private async reselectForgeRemote(): Promise<void> {
     const cwd = this.forgeProbeCwd();
     if (!cwd) return;
+    // Its OWN sequence, deliberately not `forgeRemoteProbeSeq`: bumping that
+    // would cancel an in-flight `reprobeForgeRemotes` before it consumed its
+    // fingerprint, silently dropping a real `.git/config` change until the
+    // next watcher event. This counter only makes two rapid setting changes
+    // land in order.
+    const seq = ++this.forgeReselectSeq;
+    // Snapshot WITHOUT bumping: bumping `forgeRemoteProbeSeq` would cancel an
+    // in-flight `reprobeForgeRemotes` before it consumed its fingerprint,
+    // silently dropping a real `.git/config` change until the next watcher
+    // event. Yielding to it instead is safe — a reprobe re-reads the table
+    // with the current `forgeRemoteName`, so its result already reflects this
+    // settings change. The same check covers teardown and project switch,
+    // which bump the probe seq in `stopForgeRemoteDetection`.
+    const probeSeq = this.forgeRemoteProbeSeq;
     const probed = await this.readForgeRemotes(cwd);
-    if (!probed || this._shutdownController.signal.aborted) return;
+    if (!probed || seq !== this.forgeReselectSeq) return;
+    if (probeSeq !== this.forgeRemoteProbeSeq) return;
+    if (this._shutdownController.signal.aborted) return;
 
     const matchedProviderId = probed.fetchUrl
       ? matchProviderForRemoteUrl(probed.fetchUrl, this.forgeProviderMatchers)

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -3437,11 +3437,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
   private async reselectForgeRemote(): Promise<void> {
     const cwd = this.forgeProbeCwd();
     if (!cwd) return;
-    // Its OWN sequence, deliberately not `forgeRemoteProbeSeq`: bumping that
-    // would cancel an in-flight `reprobeForgeRemotes` before it consumed its
-    // fingerprint, silently dropping a real `.git/config` change until the
-    // next watcher event. This counter only makes two rapid setting changes
-    // land in order.
+    // Its OWN sequence — it only makes two rapid setting changes land in order.
     const seq = ++this.forgeReselectSeq;
     // Snapshot WITHOUT bumping: bumping `forgeRemoteProbeSeq` would cancel an
     // in-flight `reprobeForgeRemotes` before it consumed its fingerprint,

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -55,6 +55,7 @@ import {
   matchProviderForRemoteUrl,
   type ForgeProviderMatcher,
 } from "../../shared/utils/forgeHostnames.js";
+import { resolveForgeRemote } from "../../shared/utils/forgeRemoteSelection.js";
 import { applyResourceConfigToMonitor } from "./resourceConfigHelpers.js";
 import { ResourceActionExecutor } from "./ResourceActionExecutor.js";
 import { TopologyWatcher, type TopologyWatcherHost } from "./TopologyWatcher.js";
@@ -200,6 +201,11 @@ export class WorkspaceService {
   // config writes that already wake the watcher (`git push -u`,
   // `branch --set-upstream-to`) cost nothing and cannot churn the provider.
   private forgeRemoteSignature: string | null = null;
+  // The project's selected forge remote *name* (#11408). Kept on the service
+  // (not just handed to `pullRequestService`) because `readForgeRemotes` needs
+  // it to pick the same remote the toolbar routes through — otherwise the
+  // worktree cards probe `origin` while the toolbar talks to `upstream`.
+  private forgeRemoteName: string | null = null;
   private forgeRemoteProbeSeq = 0;
   private forgeRemoteReprobeTimer: NodeJS.Timeout | null = null;
   // Bumped whenever a `.git/config` write is OBSERVED. A baseline read that
@@ -630,6 +636,7 @@ export class WorkspaceService {
         this.wslGitByWorktree = { ...wslGitByWorktree, ...this.wslGitByWorktree };
       }
       if (forgeSettings) {
+        this.forgeRemoteName = forgeSettings.forgeRemote;
         pullRequestService.setForgeSettings(forgeSettings);
       }
       // Merge: global (lowest priority) < project-level < DAINTREE_* (set in buildEnv)
@@ -1601,8 +1608,8 @@ export class WorkspaceService {
   }
 
   /**
-   * Read the repo's remote table once. Returns origin's (or the first remote's)
-   * fetch URL plus a stable signature of every name→fetch-URL pair, used to tell
+   * Read the repo's remote table once. Returns the selected remote's fetch URL
+   * plus a stable signature of every name→fetch-URL pair, used to tell
    * a real remote change from an unrelated `.git/config` write. The signature
    * stays in this process — remote URLs can carry embedded credentials.
    */
@@ -1612,12 +1619,22 @@ export class WorkspaceService {
     try {
       const git = await createHardenedGit(cwd);
       const remotes = await git.getRemotes(true);
-      const origin = remotes.find((r) => r.name === "origin") ?? remotes[0];
       const signature = remotes
         .map((remote) => `${remote.name} ${remote.refs?.fetch ?? ""}`)
         .sort()
         .join("");
-      return { fetchUrl: origin?.refs?.fetch, signature };
+      // Selection honours the project's `forgeRemote` setting (#11408). The
+      // signature above deliberately still covers ALL remotes: it answers "did
+      // the remote table change", independent of which entry we route through.
+      const selected = resolveForgeRemote({
+        remotes: remotes.map((r) => ({ name: r.name, fetchUrl: r.refs?.fetch ?? "" })),
+        forgeRemote: this.forgeRemoteName,
+        // The host has no provider registry — it matches against the matcher
+        // table main relays via `setForgeProviderMatchers`.
+        isSupportedRemote: (url) =>
+          matchProviderForRemoteUrl(url, this.forgeProviderMatchers) !== null,
+      });
+      return { fetchUrl: selected?.fetchUrl, signature };
     } catch {
       // Remote probe is best-effort; keep the affordance hidden on failure.
       return null;
@@ -3364,8 +3381,35 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     forgeDefaultProviderId: string | null;
     forgeRemote: string | null;
   }): void {
+    const remoteSelectionChanged = args.forgeRemote !== this.forgeRemoteName;
+    this.forgeRemoteName = args.forgeRemote;
     pullRequestService.setForgeSettings(args);
     void pullRequestService.refresh();
+    // The remote table on disk is unchanged, so the signature-gated reprobe
+    // would never fire — but the remote we *select* from it just moved, which
+    // changes the matched provider for every monitor (#11408).
+    if (remoteSelectionChanged) void this.reselectForgeRemote();
+  }
+
+  /**
+   * Re-run remote selection after the `forgeRemote` setting changed. Unlike
+   * `reprobeForgeRemotes` this deliberately skips the `.git/config`
+   * fingerprint and signature gates: neither moved, only the choice did.
+   */
+  private async reselectForgeRemote(): Promise<void> {
+    const cwd = this.forgeProbeCwd();
+    if (!cwd) return;
+    const probed = await this.readForgeRemotes(cwd);
+    if (!probed || this._shutdownController.signal.aborted) return;
+
+    const matchedProviderId = probed.fetchUrl
+      ? matchProviderForRemoteUrl(probed.fetchUrl, this.forgeProviderMatchers)
+      : null;
+    for (const monitor of this.monitors.values()) {
+      if (!monitor.isRunning) continue;
+      monitor.setRemoteFetchUrl(probed.fetchUrl);
+      monitor.setMatchedForgeProviderId(matchedProviderId);
+    }
   }
 
   /**

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -135,6 +135,10 @@ const HOST_REFRESH_TIMEOUT_MS = 45_000;
 // lock-then-rename (two events), so a short trailing debounce collapses the
 // burst into one `getRemotes()` spawn.
 const FORGE_REMOTE_REPROBE_DEBOUNCE_MS = 250;
+// Re-arm budget for a settings/matcher-driven reselect whose probe was
+// superseded or failed. Bounded because a deleted repo fails enumeration
+// forever and nothing else retries this path (`.git/config` never changed).
+const FORGE_RESELECT_MAX_RETRIES = 3;
 
 // Backstop cadence for the config fingerprint check when the git watcher is
 // disabled or has silently degraded. A stat, not a subprocess.
@@ -207,6 +211,8 @@ export class WorkspaceService {
   // worktree cards probe `origin` while the toolbar talks to `upstream`.
   private forgeRemoteName: string | null = null;
   private forgeReselectSeq = 0;
+  private forgeReselectTimer: NodeJS.Timeout | null = null;
+  private forgeReselectRetries = 0;
   private forgeRemoteProbeSeq = 0;
   private forgeRemoteReprobeTimer: NodeJS.Timeout | null = null;
   // Bumped whenever a `.git/config` write is OBSERVED. A baseline read that
@@ -1835,6 +1841,10 @@ export class WorkspaceService {
       clearInterval(this.forgeConfigPollTimer);
       this.forgeConfigPollTimer = null;
     }
+    if (this.forgeReselectTimer) {
+      clearTimeout(this.forgeReselectTimer);
+      this.forgeReselectTimer = null;
+    }
     if (this.forgeRemoteReprobeTimer) {
       clearTimeout(this.forgeRemoteReprobeTimer);
       this.forgeRemoteReprobeTimer = null;
@@ -1868,7 +1878,13 @@ export class WorkspaceService {
     // provider ends up supporting — re-matching that URL would leave the
     // affordance hidden forever while a sibling remote was usable all along.
     // Same story when enabling or disabling a provider plugin at runtime.
-    void this.reselectForgeRemote();
+    //
+    // Coalesced: the relay pushes on EVERY registry change, so plugin init
+    // arrives as a burst of calls that would otherwise be one `git remote -v`
+    // each. Mirrors the reprobe debounce, minus its config-fingerprint gate —
+    // nothing wrote `.git/config` here, only the matcher table moved.
+    this.forgeReselectRetries = 0;
+    this.scheduleForgeReselect();
   }
 
   private handleInotifyLimitReached(): void {
@@ -3398,7 +3414,10 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     // The remote table on disk is unchanged, so the signature-gated reprobe
     // would never fire — but the remote we *select* from it just moved, which
     // changes the matched provider for every monitor (#11408).
-    if (remoteSelectionChanged) void this.reselectForgeRemote();
+    if (remoteSelectionChanged) {
+      this.forgeReselectRetries = 0;
+      void this.reselectForgeRemote();
+    }
   }
 
   /**
@@ -3406,6 +3425,15 @@ ${lines.map((l) => "+" + l).join("\n")}`;
    * `reprobeForgeRemotes` this deliberately skips the `.git/config`
    * fingerprint and signature gates: neither moved, only the choice did.
    */
+  private scheduleForgeReselect(): void {
+    if (this._shutdownController.signal.aborted) return;
+    if (this.forgeReselectTimer) return;
+    this.forgeReselectTimer = setTimeout(() => {
+      this.forgeReselectTimer = null;
+      void this.reselectForgeRemote();
+    }, FORGE_REMOTE_REPROBE_DEBOUNCE_MS);
+  }
+
   private async reselectForgeRemote(): Promise<void> {
     const cwd = this.forgeProbeCwd();
     if (!cwd) return;
@@ -3424,8 +3452,26 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     // which bump the probe seq in `stopForgeRemoteDetection`.
     const probeSeq = this.forgeRemoteProbeSeq;
     const probed = await this.readForgeRemotes(cwd);
-    if (!probed || seq !== this.forgeReselectSeq) return;
-    if (probeSeq !== this.forgeRemoteProbeSeq) return;
+    // A newer reselect is already authoritative — drop this one outright.
+    if (seq !== this.forgeReselectSeq) return;
+    // The other two bail-outs are NOT terminal, so they re-arm the debounce
+    // instead of returning. A config probe that superseded us may itself have
+    // exited at its fingerprint gate without ever reading the remotes, and a
+    // failed enumeration leaves monitors pointing at the previously selected
+    // remote. Either way the new selection would otherwise never be applied,
+    // and nothing else would retry: `.git/config` did not change, so the
+    // fingerprint-gated backstop skips this repo entirely.
+    if (!probed || probeSeq !== this.forgeRemoteProbeSeq) {
+      // Bounded: a repo that was deleted under us fails enumeration forever,
+      // and an unbounded re-arm would spawn a git process every debounce tick
+      // for the life of the host.
+      if (this.forgeReselectRetries < FORGE_RESELECT_MAX_RETRIES) {
+        this.forgeReselectRetries++;
+        this.scheduleForgeReselect();
+      }
+      return;
+    }
+    this.forgeReselectRetries = 0;
     if (this._shutdownController.signal.aborted) return;
 
     const matchedProviderId = probed.fetchUrl

--- a/electron/workspace-host/__tests__/WorkspaceService.forgeRemote.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.forgeRemote.test.ts
@@ -298,6 +298,24 @@ describe("WorkspaceService forge-remote detection (#11155)", () => {
       expect(main.remoteFetchUrl).toBe("https://github.com/acme/app.git");
     });
 
+    it("coalesces a burst of matcher pushes into one git read", async () => {
+      // The relay fires on every registry change, so plugin init arrives as a
+      // burst — one `git remote -v` each would be pure waste.
+      registerMonitor("/test/main", { isMainWorktree: true });
+      await seedBaseline([]);
+      mockSimpleGit.getRemotes.mockResolvedValue([ORIGIN_GITHUB]);
+
+      for (let i = 0; i < 4; i++) {
+        service.setForgeProviderMatchers([
+          { providerId: GITHUB_PROVIDER_ID, hostnames: ["github.com"] },
+        ]);
+      }
+      await vi.advanceTimersByTimeAsync(300);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(mockSimpleGit.getRemotes).toHaveBeenCalledTimes(1);
+    });
+
     it("re-selects when the matcher table arrives after a cold start", async () => {
       // Cold start: no matchers yet, so name preference alone picks origin
       // even though no provider can read it. Once the GitHub matcher lands,
@@ -315,6 +333,7 @@ describe("WorkspaceService forge-remote detection (#11155)", () => {
       service.setForgeProviderMatchers([
         { providerId: GITHUB_PROVIDER_ID, hostnames: ["github.com"] },
       ]);
+      await vi.advanceTimersByTimeAsync(300);
       await vi.advanceTimersByTimeAsync(0);
 
       expect(main.remoteFetchUrl).toBe("https://github.com/upstream/app.git");

--- a/electron/workspace-host/__tests__/WorkspaceService.forgeRemote.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.forgeRemote.test.ts
@@ -87,6 +87,7 @@ const mockPullRequestService = {
   reset: vi.fn(),
   cleanup: vi.fn(),
   refresh: vi.fn().mockResolvedValue(undefined),
+  setForgeSettings: vi.fn(),
   getStatus: vi.fn().mockReturnValue({
     state: "idle",
     isPolling: false,
@@ -262,6 +263,66 @@ describe("WorkspaceService forge-remote detection (#11155)", () => {
   }
 
   const ORIGIN_GITHUB = remote("origin", "https://github.com/acme/app.git");
+
+  describe("remote selection honours the project setting (#11408)", () => {
+    const ORIGIN_INTERNAL = remote("origin", "https://git.internal.example/acme/app.git");
+    const UPSTREAM_GITHUB = remote("upstream", "https://github.com/upstream/app.git");
+
+    it("probes the remote named by forgeRemote rather than origin", async () => {
+      service["forgeRemoteName"] = "upstream";
+      const main = registerMonitor("/test/main", { isMainWorktree: true });
+      await seedBaseline([]);
+      await runStartProbe(main, [ORIGIN_GITHUB, UPSTREAM_GITHUB]);
+
+      expect(main.remoteFetchUrl).toBe("https://github.com/upstream/app.git");
+    });
+
+    it("auto-detects a provider-matching remote when origin matches nothing", async () => {
+      service["forgeRemoteName"] = null;
+      const main = registerMonitor("/test/main", { isMainWorktree: true });
+      await seedBaseline([]);
+      await runStartProbe(main, [ORIGIN_INTERNAL, UPSTREAM_GITHUB]);
+
+      expect(main.getSnapshot().matchedForgeProviderId).toBe(GITHUB_PROVIDER_ID);
+      expect(main.remoteFetchUrl).toBe("https://github.com/upstream/app.git");
+    });
+
+    it("keeps the signature across ALL remotes, not just the selected one", async () => {
+      // The signature answers "did the remote table change" — adding an
+      // unselected remote must still be detected as a change.
+      service["forgeRemoteName"] = "upstream";
+      registerMonitor("/test/main", { isMainWorktree: true });
+      await seedBaseline([UPSTREAM_GITHUB]);
+
+      mockSimpleGit.getRemotes.mockResolvedValue([UPSTREAM_GITHUB, ORIGIN_INTERNAL]);
+      await fireConfigChange();
+
+      expect(sysRemoteChanged).toHaveBeenCalledTimes(1);
+      expect(mockSendEvent).toHaveBeenCalledWith({ type: "forge-remote-changed" });
+    });
+
+    it("re-selects and fans out when updateForgeSettings changes the remote", async () => {
+      // `.git/config` is untouched, so the signature-gated reprobe never fires
+      // — the selection change itself has to drive the update.
+      // `mirror` is not a preferred name, so auto-detect starts on origin.
+      const MIRROR_GITHUB = remote("mirror", "https://github.com/mirror/app.git");
+      service["forgeRemoteName"] = null;
+      const main = registerMonitor("/test/main", { isMainWorktree: true });
+      await seedBaseline([]);
+      await runStartProbe(main, [ORIGIN_GITHUB, MIRROR_GITHUB]);
+      expect(main.remoteFetchUrl).toBe("https://github.com/acme/app.git");
+
+      mockSimpleGit.getRemotes.mockResolvedValue([ORIGIN_GITHUB, MIRROR_GITHUB]);
+      service.updateForgeSettings({
+        forgeProviderOverride: null,
+        forgeDefaultProviderId: null,
+        forgeRemote: "mirror",
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(main.remoteFetchUrl).toBe("https://github.com/mirror/app.git");
+    });
+  });
 
   it("resolves the provider after an origin is added to a repo that had none", async () => {
     const main = registerMonitor("/test/main", { isMainWorktree: true });

--- a/electron/workspace-host/__tests__/WorkspaceService.forgeRemote.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.forgeRemote.test.ts
@@ -287,6 +287,40 @@ describe("WorkspaceService forge-remote detection (#11155)", () => {
       expect(main.remoteFetchUrl).toBe("https://github.com/upstream/app.git");
     });
 
+    it("keeps auto-detect on origin when origin itself matches a provider", async () => {
+      // Origin-first parity with PullRequestService — the toolbar and the
+      // worktree PR badges must not read different repositories.
+      service["forgeRemoteName"] = null;
+      const main = registerMonitor("/test/main", { isMainWorktree: true });
+      await seedBaseline([]);
+      await runStartProbe(main, [ORIGIN_GITHUB, UPSTREAM_GITHUB]);
+
+      expect(main.remoteFetchUrl).toBe("https://github.com/acme/app.git");
+    });
+
+    it("re-selects when the matcher table arrives after a cold start", async () => {
+      // Cold start: no matchers yet, so name preference alone picks origin
+      // even though no provider can read it. Once the GitHub matcher lands,
+      // re-matching that remembered URL is not enough — selection must re-run
+      // or the affordance stays hidden while upstream was usable all along.
+      service["forgeProviderMatchers"] = [];
+      service["forgeRemoteName"] = null;
+      const main = registerMonitor("/test/main", { isMainWorktree: true });
+      await seedBaseline([]);
+      await runStartProbe(main, [ORIGIN_INTERNAL, UPSTREAM_GITHUB]);
+      expect(main.remoteFetchUrl).toBe("https://git.internal.example/acme/app.git");
+      expect(main.getSnapshot().matchedForgeProviderId).toBeFalsy();
+
+      mockSimpleGit.getRemotes.mockResolvedValue([ORIGIN_INTERNAL, UPSTREAM_GITHUB]);
+      service.setForgeProviderMatchers([
+        { providerId: GITHUB_PROVIDER_ID, hostnames: ["github.com"] },
+      ]);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(main.remoteFetchUrl).toBe("https://github.com/upstream/app.git");
+      expect(main.getSnapshot().matchedForgeProviderId).toBe(GITHUB_PROVIDER_ID);
+    });
+
     it("keeps the signature across ALL remotes, not just the selected one", async () => {
       // The signature answers "did the remote table change" — adding an
       // unselected remote must still be detected as a change.

--- a/plugins/builtin/github/main/GitHubRepoContext.ts
+++ b/plugins/builtin/github/main/GitHubRepoContext.ts
@@ -38,6 +38,9 @@ export async function getRepoContext(cwd: string): Promise<RepoContext | null> {
     const gitService = new GitService(cwd);
 
     let fetchUrl: string | null = null;
+    // Set once we know the project named a remote, so a lookup miss below
+    // stays a miss instead of quietly resolving against origin (#11408).
+    let remoteWasConfigured = false;
 
     try {
       const { projectStore } = await import("../../../../electron/services/ProjectStore.js");
@@ -47,6 +50,7 @@ export async function getRepoContext(cwd: string): Promise<RepoContext | null> {
         const settings = await projectStore.getProjectSettings(project.id);
         const selectedRemote = settings.forgeRemote ?? settings.githubRemote;
         if (selectedRemote) {
+          remoteWasConfigured = true;
           const remotes = await gitService.listRemotes(cwd);
           const match = remotes.find((r) => r.name === selectedRemote);
           if (match?.fetchUrl) {
@@ -58,7 +62,7 @@ export async function getRepoContext(cwd: string): Promise<RepoContext | null> {
       // Fall through to default origin lookup
     }
 
-    if (!fetchUrl) {
+    if (!fetchUrl && !remoteWasConfigured) {
       fetchUrl = await gitService.getRemoteUrl(cwd);
     }
 

--- a/shared/utils/__tests__/forgeRemoteSelection.test.ts
+++ b/shared/utils/__tests__/forgeRemoteSelection.test.ts
@@ -9,32 +9,35 @@ const INTERNAL = "https://git.internal.example/acme/widgets.git";
 const githubOnly = (url: string) => url.includes("github.com");
 
 describe("resolveForgeRemote", () => {
-  it("returns null when there are no remotes", () => {
-    expect(resolveForgeRemote({ remotes: [], forgeRemote: null })).toBeNull();
+  it("selects nothing when there are no remotes", () => {
+    expect(resolveForgeRemote({ remotes: [], forgeRemote: null })).toEqual({
+      remote: null,
+      missingConfiguredRemote: null,
+    });
   });
 
   it("ignores remotes with an empty fetch URL", () => {
-    const result = resolveForgeRemote({
+    const { remote } = resolveForgeRemote({
       remotes: [
         { name: "origin", fetchUrl: "" },
         { name: "upstream", fetchUrl: GITHUB },
       ],
       forgeRemote: null,
     });
-    expect(result?.name).toBe("upstream");
+    expect(remote?.name).toBe("upstream");
   });
 
-  it("returns null when every remote has an empty fetch URL", () => {
-    const result = resolveForgeRemote({
+  it("selects nothing when every remote has an empty fetch URL", () => {
+    const { remote } = resolveForgeRemote({
       remotes: [{ name: "origin", fetchUrl: "" }],
       forgeRemote: null,
     });
-    expect(result).toBeNull();
+    expect(remote).toBeNull();
   });
 
   describe("explicit forgeRemote setting", () => {
     it("wins over name preference and provider matching", () => {
-      const result = resolveForgeRemote({
+      const { remote } = resolveForgeRemote({
         remotes: [
           { name: "origin", fetchUrl: GITHUB },
           { name: "upstream", fetchUrl: GITHUB },
@@ -43,11 +46,11 @@ describe("resolveForgeRemote", () => {
         forgeRemote: "mirror",
         isSupportedRemote: githubOnly,
       });
-      expect(result).toEqual({ name: "mirror", fetchUrl: INTERNAL });
+      expect(remote).toEqual({ name: "mirror", fetchUrl: INTERNAL });
     });
 
     it("selects a non-origin remote — the issue's reported case", () => {
-      const result = resolveForgeRemote({
+      const { remote } = resolveForgeRemote({
         remotes: [
           { name: "origin", fetchUrl: FORK },
           { name: "upstream", fetchUrl: GITHUB },
@@ -55,35 +58,47 @@ describe("resolveForgeRemote", () => {
         forgeRemote: "upstream",
         isSupportedRemote: githubOnly,
       });
-      expect(result?.fetchUrl).toBe(GITHUB);
+      expect(remote?.fetchUrl).toBe(GITHUB);
     });
 
-    it("falls through to auto-detect when the named remote no longer exists", () => {
-      // A renamed or deleted remote must not silently disable forge
-      // affordances — that is the failure this resolver exists to prevent.
+    it("fails closed when the named remote no longer exists", () => {
+      // Must NOT auto-detect: resolveForCwd backs assign/close/merge, so
+      // substituting origin here could redirect a write to a fork.
       const result = resolveForgeRemote({
         remotes: [{ name: "origin", fetchUrl: GITHUB }],
-        forgeRemote: "deleted-remote",
+        forgeRemote: "renamed-away",
         isSupportedRemote: githubOnly,
       });
-      expect(result?.name).toBe("origin");
+      expect(result).toEqual({ remote: null, missingConfiguredRemote: "renamed-away" });
+    });
+
+    it("fails closed even when the named remote exists but has no fetch URL", () => {
+      const result = resolveForgeRemote({
+        remotes: [
+          { name: "upstream", fetchUrl: "" },
+          { name: "origin", fetchUrl: GITHUB },
+        ],
+        forgeRemote: "upstream",
+      });
+      expect(result).toEqual({ remote: null, missingConfiguredRemote: "upstream" });
     });
 
     it("treats an empty-string setting as unset", () => {
-      const result = resolveForgeRemote({
+      const { remote, missingConfiguredRemote } = resolveForgeRemote({
         remotes: [
+          { name: "fork", fetchUrl: FORK },
           { name: "origin", fetchUrl: GITHUB },
-          { name: "upstream", fetchUrl: GITHUB },
         ],
         forgeRemote: "",
       });
-      expect(result?.name).toBe("upstream");
+      expect(remote?.name).toBe("origin");
+      expect(missingConfiguredRemote).toBeNull();
     });
   });
 
   describe("auto-detect", () => {
     it("prefers a provider-matching remote over a better-named unmatched one", () => {
-      const result = resolveForgeRemote({
+      const { remote } = resolveForgeRemote({
         remotes: [
           { name: "origin", fetchUrl: INTERNAL },
           { name: "backup", fetchUrl: GITHUB },
@@ -91,35 +106,53 @@ describe("resolveForgeRemote", () => {
         forgeRemote: null,
         isSupportedRemote: githubOnly,
       });
-      expect(result?.name).toBe("backup");
+      expect(remote?.name).toBe("backup");
     });
 
-    it("prefers upstream over origin when both match a provider", () => {
-      const result = resolveForgeRemote({
+    it("prefers origin over upstream when both match a provider", () => {
+      // Origin-first on purpose: PullRequestService and the built-in GitHub
+      // context both auto-detect origin, and a resolver that preferred
+      // upstream would point the toolbar at a different repo than the
+      // worktree PR badges.
+      const { remote } = resolveForgeRemote({
         remotes: [
+          { name: "upstream", fetchUrl: GITHUB },
           { name: "origin", fetchUrl: FORK },
+        ],
+        forgeRemote: null,
+        isSupportedRemote: githubOnly,
+      });
+      expect(remote?.name).toBe("origin");
+    });
+
+    it("prefers upstream once origin is not a candidate", () => {
+      const { remote } = resolveForgeRemote({
+        remotes: [
+          { name: "zed", fetchUrl: GITHUB },
           { name: "upstream", fetchUrl: GITHUB },
         ],
         forgeRemote: null,
         isSupportedRemote: githubOnly,
       });
-      expect(result?.name).toBe("upstream");
+      expect(remote?.name).toBe("upstream");
     });
 
-    it("prefers origin over an arbitrarily-named remote", () => {
-      const result = resolveForgeRemote({
+    it("skips an unparseable origin for a remote a provider recognises", () => {
+      // The reported bug: origin exists but no provider can read it, so the
+      // toolbar went dark instead of using the remote that works.
+      const { remote } = resolveForgeRemote({
         remotes: [
-          { name: "fork", fetchUrl: FORK },
-          { name: "origin", fetchUrl: GITHUB },
+          { name: "origin", fetchUrl: INTERNAL },
+          { name: "upstream", fetchUrl: GITHUB },
         ],
         forgeRemote: null,
         isSupportedRemote: githubOnly,
       });
-      expect(result?.name).toBe("origin");
+      expect(remote?.name).toBe("upstream");
     });
 
     it("falls back to git's listing order when no name is preferred", () => {
-      const result = resolveForgeRemote({
+      const { remote } = resolveForgeRemote({
         remotes: [
           { name: "alpha", fetchUrl: GITHUB },
           { name: "beta", fetchUrl: GITHUB },
@@ -127,27 +160,27 @@ describe("resolveForgeRemote", () => {
         forgeRemote: null,
         isSupportedRemote: githubOnly,
       });
-      expect(result?.name).toBe("alpha");
+      expect(remote?.name).toBe("alpha");
     });
 
     it("does not special-case a remote merely named 'github'", () => {
       // gh ranks a `github`-named remote third; Daintree is forge-neutral, so
       // hostname matching decides instead.
-      const result = resolveForgeRemote({
+      const { remote } = resolveForgeRemote({
         remotes: [
           { name: "github", fetchUrl: INTERNAL },
-          { name: "origin", fetchUrl: GITHUB },
+          { name: "zed", fetchUrl: GITHUB },
         ],
         forgeRemote: null,
         isSupportedRemote: githubOnly,
       });
-      expect(result?.name).toBe("origin");
+      expect(remote?.name).toBe("zed");
     });
   });
 
   describe("no provider match", () => {
     it("still returns a remote so the provider chain reports the failure", () => {
-      const result = resolveForgeRemote({
+      const { remote } = resolveForgeRemote({
         remotes: [
           { name: "mirror", fetchUrl: INTERNAL },
           { name: "origin", fetchUrl: INTERNAL },
@@ -155,29 +188,29 @@ describe("resolveForgeRemote", () => {
         forgeRemote: null,
         isSupportedRemote: () => false,
       });
-      expect(result?.name).toBe("origin");
+      expect(remote?.name).toBe("origin");
     });
 
     it("ranks by name when no predicate is supplied", () => {
-      const result = resolveForgeRemote({
+      const { remote } = resolveForgeRemote({
         remotes: [
-          { name: "origin", fetchUrl: FORK },
           { name: "upstream", fetchUrl: GITHUB },
+          { name: "origin", fetchUrl: FORK },
         ],
         forgeRemote: null,
       });
-      expect(result?.name).toBe("upstream");
+      expect(remote?.name).toBe("origin");
     });
 
     it("treats a throwing predicate as no match rather than propagating", () => {
-      const result = resolveForgeRemote({
+      const { remote } = resolveForgeRemote({
         remotes: [{ name: "origin", fetchUrl: GITHUB }],
         forgeRemote: null,
         isSupportedRemote: () => {
           throw new Error("registry exploded");
         },
       });
-      expect(result?.name).toBe("origin");
+      expect(remote?.name).toBe("origin");
     });
   });
 });

--- a/shared/utils/__tests__/forgeRemoteSelection.test.ts
+++ b/shared/utils/__tests__/forgeRemoteSelection.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from "vitest";
+import { resolveForgeRemote } from "../forgeRemoteSelection.js";
+
+const GITHUB = "https://github.com/acme/widgets.git";
+const FORK = "https://github.com/me/widgets.git";
+const INTERNAL = "https://git.internal.example/acme/widgets.git";
+
+/** Stands in for a registry that only knows github.com. */
+const githubOnly = (url: string) => url.includes("github.com");
+
+describe("resolveForgeRemote", () => {
+  it("returns null when there are no remotes", () => {
+    expect(resolveForgeRemote({ remotes: [], forgeRemote: null })).toBeNull();
+  });
+
+  it("ignores remotes with an empty fetch URL", () => {
+    const result = resolveForgeRemote({
+      remotes: [
+        { name: "origin", fetchUrl: "" },
+        { name: "upstream", fetchUrl: GITHUB },
+      ],
+      forgeRemote: null,
+    });
+    expect(result?.name).toBe("upstream");
+  });
+
+  it("returns null when every remote has an empty fetch URL", () => {
+    const result = resolveForgeRemote({
+      remotes: [{ name: "origin", fetchUrl: "" }],
+      forgeRemote: null,
+    });
+    expect(result).toBeNull();
+  });
+
+  describe("explicit forgeRemote setting", () => {
+    it("wins over name preference and provider matching", () => {
+      const result = resolveForgeRemote({
+        remotes: [
+          { name: "origin", fetchUrl: GITHUB },
+          { name: "upstream", fetchUrl: GITHUB },
+          { name: "mirror", fetchUrl: INTERNAL },
+        ],
+        forgeRemote: "mirror",
+        isSupportedRemote: githubOnly,
+      });
+      expect(result).toEqual({ name: "mirror", fetchUrl: INTERNAL });
+    });
+
+    it("selects a non-origin remote — the issue's reported case", () => {
+      const result = resolveForgeRemote({
+        remotes: [
+          { name: "origin", fetchUrl: FORK },
+          { name: "upstream", fetchUrl: GITHUB },
+        ],
+        forgeRemote: "upstream",
+        isSupportedRemote: githubOnly,
+      });
+      expect(result?.fetchUrl).toBe(GITHUB);
+    });
+
+    it("falls through to auto-detect when the named remote no longer exists", () => {
+      // A renamed or deleted remote must not silently disable forge
+      // affordances — that is the failure this resolver exists to prevent.
+      const result = resolveForgeRemote({
+        remotes: [{ name: "origin", fetchUrl: GITHUB }],
+        forgeRemote: "deleted-remote",
+        isSupportedRemote: githubOnly,
+      });
+      expect(result?.name).toBe("origin");
+    });
+
+    it("treats an empty-string setting as unset", () => {
+      const result = resolveForgeRemote({
+        remotes: [
+          { name: "origin", fetchUrl: GITHUB },
+          { name: "upstream", fetchUrl: GITHUB },
+        ],
+        forgeRemote: "",
+      });
+      expect(result?.name).toBe("upstream");
+    });
+  });
+
+  describe("auto-detect", () => {
+    it("prefers a provider-matching remote over a better-named unmatched one", () => {
+      const result = resolveForgeRemote({
+        remotes: [
+          { name: "origin", fetchUrl: INTERNAL },
+          { name: "backup", fetchUrl: GITHUB },
+        ],
+        forgeRemote: null,
+        isSupportedRemote: githubOnly,
+      });
+      expect(result?.name).toBe("backup");
+    });
+
+    it("prefers upstream over origin when both match a provider", () => {
+      const result = resolveForgeRemote({
+        remotes: [
+          { name: "origin", fetchUrl: FORK },
+          { name: "upstream", fetchUrl: GITHUB },
+        ],
+        forgeRemote: null,
+        isSupportedRemote: githubOnly,
+      });
+      expect(result?.name).toBe("upstream");
+    });
+
+    it("prefers origin over an arbitrarily-named remote", () => {
+      const result = resolveForgeRemote({
+        remotes: [
+          { name: "fork", fetchUrl: FORK },
+          { name: "origin", fetchUrl: GITHUB },
+        ],
+        forgeRemote: null,
+        isSupportedRemote: githubOnly,
+      });
+      expect(result?.name).toBe("origin");
+    });
+
+    it("falls back to git's listing order when no name is preferred", () => {
+      const result = resolveForgeRemote({
+        remotes: [
+          { name: "alpha", fetchUrl: GITHUB },
+          { name: "beta", fetchUrl: GITHUB },
+        ],
+        forgeRemote: null,
+        isSupportedRemote: githubOnly,
+      });
+      expect(result?.name).toBe("alpha");
+    });
+
+    it("does not special-case a remote merely named 'github'", () => {
+      // gh ranks a `github`-named remote third; Daintree is forge-neutral, so
+      // hostname matching decides instead.
+      const result = resolveForgeRemote({
+        remotes: [
+          { name: "github", fetchUrl: INTERNAL },
+          { name: "origin", fetchUrl: GITHUB },
+        ],
+        forgeRemote: null,
+        isSupportedRemote: githubOnly,
+      });
+      expect(result?.name).toBe("origin");
+    });
+  });
+
+  describe("no provider match", () => {
+    it("still returns a remote so the provider chain reports the failure", () => {
+      const result = resolveForgeRemote({
+        remotes: [
+          { name: "mirror", fetchUrl: INTERNAL },
+          { name: "origin", fetchUrl: INTERNAL },
+        ],
+        forgeRemote: null,
+        isSupportedRemote: () => false,
+      });
+      expect(result?.name).toBe("origin");
+    });
+
+    it("ranks by name when no predicate is supplied", () => {
+      const result = resolveForgeRemote({
+        remotes: [
+          { name: "origin", fetchUrl: FORK },
+          { name: "upstream", fetchUrl: GITHUB },
+        ],
+        forgeRemote: null,
+      });
+      expect(result?.name).toBe("upstream");
+    });
+
+    it("treats a throwing predicate as no match rather than propagating", () => {
+      const result = resolveForgeRemote({
+        remotes: [{ name: "origin", fetchUrl: GITHUB }],
+        forgeRemote: null,
+        isSupportedRemote: () => {
+          throw new Error("registry exploded");
+        },
+      });
+      expect(result?.name).toBe("origin");
+    });
+  });
+});

--- a/shared/utils/forgeRemoteSelection.ts
+++ b/shared/utils/forgeRemoteSelection.ts
@@ -1,0 +1,86 @@
+export interface ForgeRemoteCandidate {
+  name: string;
+  fetchUrl: string;
+}
+
+export interface ResolveForgeRemoteInputs {
+  /** The repo's remote table (`git remote -v`), in git's own listing order. */
+  remotes: readonly ForgeRemoteCandidate[];
+  /** Per-project `forgeRemote` setting — a remote *name*, not a URL. */
+  forgeRemote: string | null | undefined;
+  /**
+   * "Could a registered forge provider parse this URL?" — the Daintree
+   * equivalent of `gh`'s known-host eligibility test. Injected rather than
+   * imported because the two call sites answer it from different tables:
+   * main asks `listMatchingProviders`, the workspace-host asks its relayed
+   * `forgeProviderMatchers`. Omitted (or always-false) degrades to plain
+   * name-order preference, which is still better than blind `origin`.
+   */
+  isSupportedRemote?: (url: string) => boolean;
+}
+
+/**
+ * Pick which git remote the forge integration should talk to. Pure function —
+ * no I/O, no registry import, no main-process bindings — so the workspace-host
+ * UtilityProcess can import it directly (same constraint as
+ * `forgeProviderResolver`, issue #8316).
+ *
+ * Precedence (issue #11408):
+ *
+ *   1. The `forgeRemote` setting, matched by exact name. The whole point of
+ *      the setting is that the user has already answered this question.
+ *   2. Remotes a registered provider can actually parse, ranked by
+ *      `NAME_PREFERENCE` then git's listing order.
+ *   3. The same ranking over all remotes, when nothing is parseable (or no
+ *      predicate was supplied) — preserves the pre-fix behavior of handing a
+ *      URL back and letting the provider chain reject it.
+ *
+ * Returns `null` only when there are no remotes at all.
+ *
+ * A `forgeRemote` naming a remote that no longer exists falls through to
+ * auto-detect rather than resolving to nothing: a renamed or removed remote
+ * would otherwise silently disable every forge affordance, which is the exact
+ * failure this issue exists to fix.
+ */
+export function resolveForgeRemote(inputs: ResolveForgeRemoteInputs): ForgeRemoteCandidate | null {
+  const { remotes, forgeRemote, isSupportedRemote } = inputs;
+
+  const usable = remotes.filter((r) => typeof r.fetchUrl === "string" && r.fetchUrl.length > 0);
+  if (usable.length === 0) return null;
+
+  if (typeof forgeRemote === "string" && forgeRemote.length > 0) {
+    const named = usable.find((r) => r.name === forgeRemote);
+    if (named) return named;
+  }
+
+  if (isSupportedRemote) {
+    const supported = usable.filter((r) => {
+      try {
+        return isSupportedRemote(r.fetchUrl);
+      } catch {
+        // A throwing matcher must not take down remote selection.
+        return false;
+      }
+    });
+    if (supported.length > 0) return preferByName(supported);
+  }
+
+  return preferByName(usable);
+}
+
+/**
+ * `upstream` before `origin` before everything else, mirroring `gh` and
+ * Magit/Forge. Deliberately omits `gh`'s literal `github` tier: Daintree is
+ * forge-neutral, so a Gitea remote is as likely to be named `gitea`, and
+ * hostname matching (step 2 above) already does that job properly.
+ */
+const NAME_PREFERENCE = ["upstream", "origin"];
+
+function preferByName(remotes: readonly ForgeRemoteCandidate[]): ForgeRemoteCandidate {
+  for (const name of NAME_PREFERENCE) {
+    const match = remotes.find((r) => r.name === name);
+    if (match) return match;
+  }
+  // Non-null: every caller has already checked for a non-empty list.
+  return remotes[0]!;
+}

--- a/shared/utils/forgeRemoteSelection.ts
+++ b/shared/utils/forgeRemoteSelection.ts
@@ -11,18 +11,30 @@ export interface ResolveForgeRemoteInputs {
   /**
    * "Could a registered forge provider parse this URL?" — the Daintree
    * equivalent of `gh`'s known-host eligibility test. Injected rather than
-   * imported because the two call sites answer it from different tables:
-   * main asks `listMatchingProviders`, the workspace-host asks its relayed
-   * `forgeProviderMatchers`. Omitted (or always-false) degrades to plain
-   * name-order preference, which is still better than blind `origin`.
+   * imported because the call sites answer it from different tables: main asks
+   * `listMatchingProviders`, the workspace-host asks its relayed
+   * `forgeProviderMatchers`, the Settings panel asks the provider list it has
+   * already loaded. Omitted (or always-false) degrades to plain name
+   * preference, which is still better than blind `origin`.
    */
   isSupportedRemote?: (url: string) => boolean;
+}
+
+export interface ForgeRemoteSelection {
+  /** The remote to route through, or `null` when none can be selected. */
+  remote: ForgeRemoteCandidate | null;
+  /**
+   * Set to the configured name when `forgeRemote` named a remote that is not
+   * in the table. Callers MUST NOT substitute another remote in this case —
+   * see the fail-closed note on {@link resolveForgeRemote}.
+   */
+  missingConfiguredRemote: string | null;
 }
 
 /**
  * Pick which git remote the forge integration should talk to. Pure function —
  * no I/O, no registry import, no main-process bindings — so the workspace-host
- * UtilityProcess can import it directly (same constraint as
+ * UtilityProcess and the renderer can both import it (same constraint as
  * `forgeProviderResolver`, issue #8316).
  *
  * Precedence (issue #11408):
@@ -35,23 +47,27 @@ export interface ResolveForgeRemoteInputs {
  *      predicate was supplied) — preserves the pre-fix behavior of handing a
  *      URL back and letting the provider chain reject it.
  *
- * Returns `null` only when there are no remotes at all.
- *
- * A `forgeRemote` naming a remote that no longer exists falls through to
- * auto-detect rather than resolving to nothing: a renamed or removed remote
- * would otherwise silently disable every forge affordance, which is the exact
- * failure this issue exists to fix.
+ * Fails CLOSED when `forgeRemote` names a remote that is not in the table:
+ * returns `{ remote: null, missingConfiguredRemote: name }` rather than
+ * quietly auto-detecting. `resolveForCwd` backs mutations (assign, close,
+ * merge), so substituting a different repository for the one the user named
+ * would let a renamed remote silently redirect a write to a fork — exactly the
+ * "no silent fallback defaults" rule in CLAUDE.md. A dark toolbar is a visible
+ * prompt to fix the setting; a write to the wrong repo is not recoverable.
  */
-export function resolveForgeRemote(inputs: ResolveForgeRemoteInputs): ForgeRemoteCandidate | null {
+export function resolveForgeRemote(inputs: ResolveForgeRemoteInputs): ForgeRemoteSelection {
   const { remotes, forgeRemote, isSupportedRemote } = inputs;
 
   const usable = remotes.filter((r) => typeof r.fetchUrl === "string" && r.fetchUrl.length > 0);
-  if (usable.length === 0) return null;
 
   if (typeof forgeRemote === "string" && forgeRemote.length > 0) {
     const named = usable.find((r) => r.name === forgeRemote);
-    if (named) return named;
+    return named
+      ? { remote: named, missingConfiguredRemote: null }
+      : { remote: null, missingConfiguredRemote: forgeRemote };
   }
+
+  if (usable.length === 0) return { remote: null, missingConfiguredRemote: null };
 
   if (isSupportedRemote) {
     const supported = usable.filter((r) => {
@@ -62,19 +78,28 @@ export function resolveForgeRemote(inputs: ResolveForgeRemoteInputs): ForgeRemot
         return false;
       }
     });
-    if (supported.length > 0) return preferByName(supported);
+    if (supported.length > 0) {
+      return { remote: preferByName(supported), missingConfiguredRemote: null };
+    }
   }
 
-  return preferByName(usable);
+  return { remote: preferByName(usable), missingConfiguredRemote: null };
 }
 
 /**
- * `upstream` before `origin` before everything else, mirroring `gh` and
- * Magit/Forge. Deliberately omits `gh`'s literal `github` tier: Daintree is
- * forge-neutral, so a Gitea remote is as likely to be named `gitea`, and
- * hostname matching (step 2 above) already does that job properly.
+ * `origin` before `upstream` before everything else.
+ *
+ * Deliberately NOT `gh`'s `upstream → github → origin`: `PullRequestService`
+ * and the built-in GitHub context both auto-detect origin-first, and a resolver
+ * that preferred `upstream` would make the toolbar read the canonical repo
+ * while the worktree PR badges read the fork. Preferring origin keeps every
+ * consumer on the same repository whenever origin is usable, so this fix
+ * changes behavior only in the case the issue actually reports — origin absent
+ * or unparseable. `gh`'s literal `github` tier is omitted for a second reason:
+ * Daintree is forge-neutral, so a Gitea remote is as likely to be named
+ * `gitea`, and provider matching above already does that job properly.
  */
-const NAME_PREFERENCE = ["upstream", "origin"];
+const NAME_PREFERENCE = ["origin", "upstream"];
 
 function preferByName(remotes: readonly ForgeRemoteCandidate[]): ForgeRemoteCandidate {
   for (const name of NAME_PREFERENCE) {

--- a/src/components/Project/CodeForgeTab.tsx
+++ b/src/components/Project/CodeForgeTab.tsx
@@ -109,7 +109,7 @@ export function CodeForgeTab({
         <label className="block text-sm font-medium text-daintree-text mb-1">Forge remote</label>
         <p className="text-xs text-daintree-text/60 mb-2">
           Select which git remote to use for forge integration (issues, PRs, and pulse data).
-          Auto-detect prefers a remote a forge provider recognises, favouring upstream over origin.
+          Auto-detect prefers origin, then any other remote a forge provider recognises.
         </p>
         {loading ? (
           <div className="text-sm text-daintree-text/60">Loading remotes...</div>

--- a/src/components/Project/CodeForgeTab.tsx
+++ b/src/components/Project/CodeForgeTab.tsx
@@ -108,7 +108,8 @@ export function CodeForgeTab({
       <div>
         <label className="block text-sm font-medium text-daintree-text mb-1">Forge remote</label>
         <p className="text-xs text-daintree-text/60 mb-2">
-          Select which git remote to use for forge integration (issues, PRs, and pulse data)
+          Select which git remote to use for forge integration (issues, PRs, and pulse data).
+          Auto-detect prefers a remote a forge provider recognises, favouring upstream over origin.
         </p>
         {loading ? (
           <div className="text-sm text-daintree-text/60">Loading remotes...</div>
@@ -120,7 +121,7 @@ export function CodeForgeTab({
             onChange={(e) => onForgeRemoteChange(e.target.value || undefined)}
             className="w-full px-3 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-sm text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent"
           >
-            <option value="">Auto-detect (origin)</option>
+            <option value="">Auto-detect</option>
             {remotes.map((r) => (
               <option key={r.name} value={r.name}>
                 {r.name}

--- a/src/components/Project/CodeForgeTab.tsx
+++ b/src/components/Project/CodeForgeTab.tsx
@@ -97,6 +97,8 @@ export function CodeForgeTab({
 
   if (!projectPath) return null;
 
+  const savedRemoteKnown = !forgeRemote || remotes.some((r) => r.name === forgeRemote);
+
   const savedProviderKnown =
     forgeProviderOverride === null ||
     providers.some(
@@ -109,7 +111,7 @@ export function CodeForgeTab({
         <label className="block text-sm font-medium text-daintree-text mb-1">Forge remote</label>
         <p className="text-xs text-daintree-text/60 mb-2">
           Select which git remote to use for forge integration (issues, PRs, and pulse data).
-          Auto-detect prefers origin, then any other remote a forge provider recognises.
+          Auto-detect prefers origin, then any other remote a forge provider recognizes.
         </p>
         {loading ? (
           <div className="text-sm text-daintree-text/60">Loading remotes...</div>
@@ -128,6 +130,9 @@ export function CodeForgeTab({
                 {r.parsedRepo ? ` — ${r.parsedRepo.owner}/${r.parsedRepo.repo}` : ""}
               </option>
             ))}
+            {!savedRemoteKnown && forgeRemote ? (
+              <option value={forgeRemote}>{forgeRemote} (unavailable)</option>
+            ) : null}
           </select>
         )}
       </div>

--- a/src/components/Project/__tests__/CodeForgeTab.test.tsx
+++ b/src/components/Project/__tests__/CodeForgeTab.test.tsx
@@ -2,16 +2,19 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, waitFor, act } from "@testing-library/react";
 import { CodeForgeTab } from "../CodeForgeTab";
+import type { RemoteInfo } from "@shared/types/ipc/forge";
 
 let provenanceCallbacks: Array<() => void>;
 let getForgeProvidersMock: ReturnType<typeof vi.fn>;
+let remotes: RemoteInfo[];
 
 beforeEach(() => {
   provenanceCallbacks = [];
+  remotes = [];
   getForgeProvidersMock = vi.fn(async () => []);
   window.electron = {
     project: {
-      listRemotes: vi.fn(async () => []),
+      listRemotes: vi.fn(async () => remotes),
     },
     plugin: {
       getForgeProviders: getForgeProvidersMock,
@@ -25,10 +28,10 @@ beforeEach(() => {
   } as unknown as typeof window.electron;
 });
 
-function renderCodeForgeTab() {
+function renderCodeForgeTab(forgeRemote?: string) {
   return render(
     <CodeForgeTab
-      forgeRemote={undefined}
+      forgeRemote={forgeRemote}
       onForgeRemoteChange={vi.fn()}
       forgeProviderOverride={null}
       onForgeProviderOverrideChange={vi.fn()}
@@ -37,12 +40,72 @@ function renderCodeForgeTab() {
   );
 }
 
+function makeRemote(name: string): RemoteInfo {
+  return { name, fetchUrl: `git@github.com:acme/${name}.git`, parsedRepo: null };
+}
+
+function remoteSelect(container: HTMLElement): HTMLSelectElement {
+  const select = container.querySelector("#project-code-forge-remote select");
+  if (!select) throw new Error("remote select not rendered");
+  return select as HTMLSelectElement;
+}
+
+function optionAt(select: HTMLSelectElement, index: number): HTMLOptionElement {
+  const option = select.options[index];
+  if (!option) throw new Error(`no option at index ${index}`);
+  return option;
+}
+
 describe("CodeForgeTab — DOM anchors for settings deep-links", () => {
   it("exposes the project-code-forge-remote anchor for settings deep-links", async () => {
     const { container } = renderCodeForgeTab();
     await waitFor(() => {
       expect(container.querySelector("#project-code-forge-remote")).not.toBeNull();
     });
+  });
+});
+
+describe("CodeForgeTab — stale forge remote", () => {
+  it("keeps a saved remote that no longer exists selectable and distinct from auto-detect", async () => {
+    remotes = [makeRemote("origin")];
+    const { container } = renderCodeForgeTab("upstream");
+
+    await waitFor(() => {
+      expect(remoteSelect(container).options).toHaveLength(3);
+    });
+
+    const select = remoteSelect(container);
+    // The stale name stays the selected value instead of silently collapsing
+    // onto the auto-detect option, and its label says why it can't be used.
+    expect(select.value).toBe("upstream");
+    const selected = optionAt(select, select.selectedIndex);
+    expect(selected.value).toBe("upstream");
+    expect(selected.textContent).not.toBe(optionAt(select, 0).textContent);
+    expect(selected.textContent).toContain("upstream");
+    expect(selected.textContent).toMatch(/unavailable/i);
+  });
+
+  it("adds no extra option when the saved remote is still present", async () => {
+    remotes = [makeRemote("origin"), makeRemote("upstream")];
+    const { container } = renderCodeForgeTab("upstream");
+
+    await waitFor(() => {
+      expect(remoteSelect(container).options).toHaveLength(3);
+    });
+
+    const select = remoteSelect(container);
+    expect(select.value).toBe("upstream");
+    expect(optionAt(select, select.selectedIndex).textContent).not.toMatch(/unavailable/i);
+  });
+
+  it("adds no extra option when no remote is saved", async () => {
+    remotes = [makeRemote("origin")];
+    const { container } = renderCodeForgeTab(undefined);
+
+    await waitFor(() => {
+      expect(remoteSelect(container).options).toHaveLength(2);
+    });
+    expect(remoteSelect(container).value).toBe("");
   });
 });
 

--- a/src/components/Settings/ForgeIntegrationsTab.tsx
+++ b/src/components/Settings/ForgeIntegrationsTab.tsx
@@ -14,6 +14,7 @@ import { useDohertyGate } from "@/hooks";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { makeForgeProviderId } from "@shared/utils/forgeProviderIds";
 import { resolveForgeRemote } from "@shared/utils/forgeRemoteSelection";
+import { extractHostname, hostnameMatchesAny } from "@shared/utils/forgeHostnames";
 import { logError } from "@/utils/logger";
 
 // Non-empty sentinel because Radix's `SelectItem` rejects an empty string value
@@ -36,17 +37,29 @@ interface RemoteRouting {
 /**
  * Which remote the project actually routes through (#11408) — the same
  * selection main and the workspace host run, replayed here so the panel can
- * label it. `isSupportedRemote` reuses the per-remote resolutions already
- * loaded above rather than re-deriving hostname matching.
+ * label it.
+ *
+ * `isSupportedRemote` must mirror main's `listMatchingProviders(url).length > 0`
+ * EXACTLY, which is a hostname match against the registered providers and
+ * nothing more. Using each row's full `resolved.entry` instead would be a
+ * stricter test (it also applies the override/global-default chain) and the
+ * panel would then label a different remote than main actually uses.
  */
-function findLiveRemoteName(rows: RemoteRouting[], forgeRemote: string | null): string | null {
-  const selected = resolveForgeRemote({
-    remotes: rows.map(({ remote }) => ({ name: remote.name, fetchUrl: remote.fetchUrl })),
+function findLiveRemoteName(
+  rows: RemoteRouting[],
+  forgeRemote: string | null,
+  providers: ForgeProviderEntry[]
+): string | null {
+  const { remote } = resolveForgeRemote({
+    remotes: rows.map(({ remote: r }) => ({ name: r.name, fetchUrl: r.fetchUrl })),
     forgeRemote,
-    isSupportedRemote: (url) =>
-      rows.some((row) => row.remote.fetchUrl === url && row.resolved.entry !== null),
+    isSupportedRemote: (url) => {
+      const hostname = extractHostname(url);
+      if (hostname === null) return false;
+      return providers.some((p) => hostnameMatchesAny(hostname, p.contribution.matches));
+    },
   });
-  return selected?.name ?? null;
+  return remote?.name ?? null;
 }
 
 const TOOLTIP_COPY: Record<ForgeProviderResolutionVia, string> = {
@@ -318,6 +331,7 @@ export function ForgeIntegrationsTab() {
           activeProjectName={activeProject?.name}
           activeProjectId={activeProjectId}
           providersInstalled={providers.length}
+          providers={providers}
           providersLoading={loading}
           remotes={remotes}
           forgeRemote={forgeRemote}
@@ -334,6 +348,8 @@ interface ProjectRoutingPanelProps {
   activeProjectName: string | undefined;
   activeProjectId: string | undefined;
   providersInstalled: number;
+  /** Registered providers, used to replay main's hostname-match test. */
+  providers: ForgeProviderEntry[];
   // Whether the top-level provider/settings load is still in flight. Used to
   // avoid asserting "no plugins installed" before the provider list resolves.
   providersLoading: boolean;
@@ -353,6 +369,7 @@ function ProjectRoutingPanel({
   activeProjectName,
   activeProjectId,
   providersInstalled,
+  providers,
   providersLoading,
   remotes,
   forgeRemote,
@@ -390,7 +407,7 @@ function ProjectRoutingPanel({
     );
   }
 
-  const liveRemoteName = findLiveRemoteName(remotes, forgeRemote);
+  const liveRemoteName = findLiveRemoteName(remotes, forgeRemote, providers);
 
   return (
     <div className="space-y-2">

--- a/src/components/Settings/ForgeIntegrationsTab.tsx
+++ b/src/components/Settings/ForgeIntegrationsTab.tsx
@@ -13,6 +13,7 @@ import { useProjectStore } from "@/store";
 import { useDohertyGate } from "@/hooks";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { makeForgeProviderId } from "@shared/utils/forgeProviderIds";
+import { resolveForgeRemote } from "@shared/utils/forgeRemoteSelection";
 import { logError } from "@/utils/logger";
 
 // Non-empty sentinel because Radix's `SelectItem` rejects an empty string value
@@ -30,6 +31,22 @@ const DEFAULT_SETTINGS: ForgeSettings = { defaultProviderId: null };
 interface RemoteRouting {
   remote: RemoteInfo;
   resolved: ResolvedForgeProvider;
+}
+
+/**
+ * Which remote the project actually routes through (#11408) — the same
+ * selection main and the workspace host run, replayed here so the panel can
+ * label it. `isSupportedRemote` reuses the per-remote resolutions already
+ * loaded above rather than re-deriving hostname matching.
+ */
+function findLiveRemoteName(rows: RemoteRouting[], forgeRemote: string | null): string | null {
+  const selected = resolveForgeRemote({
+    remotes: rows.map(({ remote }) => ({ name: remote.name, fetchUrl: remote.fetchUrl })),
+    forgeRemote,
+    isSupportedRemote: (url) =>
+      rows.some((row) => row.remote.fetchUrl === url && row.resolved.entry !== null),
+  });
+  return selected?.name ?? null;
 }
 
 const TOOLTIP_COPY: Record<ForgeProviderResolutionVia, string> = {
@@ -56,6 +73,7 @@ export function ForgeIntegrationsTab() {
   const activeProjectPath = activeProject?.path;
 
   const [remotes, setRemotes] = useState<RemoteRouting[]>([]);
+  const [forgeRemote, setForgeRemote] = useState<string | null>(null);
   const [remotesLoading, setRemotesLoading] = useState(false);
   const [remotesError, setRemotesError] = useState<string | null>(null);
   // Mirror project id + remotes into refs so a `reresolveRemotes` call that was
@@ -134,8 +152,16 @@ export function ForgeIntegrationsTab() {
         if (cancelled) return;
         if (loadedRemotes.length === 0) {
           setRemotes([]);
+          setForgeRemote(null);
           return;
         }
+        // Which remote this project routes through depends on its `forgeRemote`
+        // setting; a read failure just means "auto-detect" (#11408).
+        const projectSettings = await window.electron.project
+          .getSettings(activeProjectId)
+          .catch(() => null);
+        if (cancelled) return;
+        setForgeRemote(projectSettings?.forgeRemote ?? projectSettings?.githubRemote ?? null);
         const resolutions = await Promise.allSettled(
           loadedRemotes.map((remote) =>
             window.electron.forge.resolveProvider(activeProjectId, remote.fetchUrl)
@@ -294,6 +320,7 @@ export function ForgeIntegrationsTab() {
           providersInstalled={providers.length}
           providersLoading={loading}
           remotes={remotes}
+          forgeRemote={forgeRemote}
           loading={showRemotesLoading}
           pending={remotesPending}
           error={remotesError}
@@ -311,6 +338,8 @@ interface ProjectRoutingPanelProps {
   // avoid asserting "no plugins installed" before the provider list resolves.
   providersLoading: boolean;
   remotes: RemoteRouting[];
+  /** The project's selected forge remote name, or null for auto-detect. */
+  forgeRemote: string | null;
   loading: boolean;
   // Raw (un-gated) loading flag. `loading` is the Doherty-gated flag that only
   // flips true past the 400ms threshold; during the sub-400ms window a load is
@@ -326,6 +355,7 @@ function ProjectRoutingPanel({
   providersInstalled,
   providersLoading,
   remotes,
+  forgeRemote,
   loading,
   pending,
   error,
@@ -360,6 +390,8 @@ function ProjectRoutingPanel({
     );
   }
 
+  const liveRemoteName = findLiveRemoteName(remotes, forgeRemote);
+
   return (
     <div className="space-y-2">
       {providersInstalled === 0 && !providersLoading && (
@@ -377,6 +409,23 @@ function ProjectRoutingPanel({
             <div className="min-w-0 flex-1">
               <div className="flex items-baseline gap-2">
                 <span className="text-xs font-medium text-daintree-text">{remote.name}</span>
+                {remote.name === liveRemoteName && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span
+                        className="inline-flex items-center px-1.5 py-0.5 rounded-sm text-[10px] font-medium border border-daintree-border/60 text-daintree-text/70 cursor-default"
+                        tabIndex={0}
+                      >
+                        Active
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">
+                      {forgeRemote
+                        ? "This project is set to use this remote for issues, PRs, and pulse data."
+                        : "Auto-detected as this project's forge remote for issues, PRs, and pulse data."}
+                    </TooltipContent>
+                  </Tooltip>
+                )}
               </div>
               <p
                 className="text-xs text-daintree-text/50 font-mono truncate"

--- a/src/components/Settings/__tests__/ForgeIntegrationsTab.test.tsx
+++ b/src/components/Settings/__tests__/ForgeIntegrationsTab.test.tsx
@@ -150,12 +150,13 @@ describe("ForgeIntegrationsTab", () => {
     });
 
     it("marks the auto-detected remote when no setting is stored", async () => {
-      // Both match a provider, so name preference picks upstream over origin.
+      // Both match a provider, so origin-first name preference wins — the
+      // same answer PullRequestService reaches.
       renderWithBothRemotes(undefined);
 
       await waitFor(() => expect(screen.getByText("Active")).toBeTruthy());
-      expect(rowFor("upstream").textContent).toContain("Active");
-      expect(rowFor("origin").textContent).not.toContain("Active");
+      expect(rowFor("origin").textContent).toContain("Active");
+      expect(rowFor("upstream").textContent).not.toContain("Active");
     });
 
     it("marks exactly one remote", async () => {

--- a/src/components/Settings/__tests__/ForgeIntegrationsTab.test.tsx
+++ b/src/components/Settings/__tests__/ForgeIntegrationsTab.test.tsx
@@ -67,6 +67,8 @@ interface ForgeMockOptions {
   providers?: ForgeProviderEntry[];
   remotes?: RemoteInfo[] | Error;
   resolveByRemote?: Record<string, ResolvedForgeProvider>;
+  /** The project's stored forge remote name; undefined means auto-detect. */
+  forgeRemote?: string;
 }
 
 function installForgeMocks(opts: ForgeMockOptions = {}) {
@@ -87,6 +89,8 @@ function installForgeMocks(opts: ForgeMockOptions = {}) {
         if (opts.remotes instanceof Error) throw opts.remotes;
         return opts.remotes ?? [];
       }),
+      // Drives which remote the panel labels "Active" (#11408).
+      getSettings: vi.fn(async () => ({ forgeRemote: opts.forgeRemote })),
     },
   } as unknown as typeof window.electron;
   return { setDefault };
@@ -108,6 +112,59 @@ describe("ForgeIntegrationsTab", () => {
     });
     expect(screen.getByText(/Open a project to view its forge routing/i)).toBeTruthy();
     expect(window.electron.project.listRemotes).not.toHaveBeenCalled();
+  });
+
+  describe("active remote marker (#11408)", () => {
+    const github = makeProvider("builtin", "github", "GitHub", ["github.com"]);
+    const ORIGIN_URL = "git@github.com:me/fork.git";
+    const UPSTREAM_URL = "git@github.com:acme/canonical.git";
+
+    function renderWithBothRemotes(forgeRemote?: string) {
+      installForgeMocks({
+        providers: [github],
+        remotes: [makeRemote("origin", ORIGIN_URL), makeRemote("upstream", UPSTREAM_URL)],
+        resolveByRemote: {
+          [ORIGIN_URL]: { entry: github, resolvedVia: "hostname" },
+          [UPSTREAM_URL]: { entry: github, resolvedVia: "hostname" },
+        },
+        forgeRemote,
+      });
+      setProject({ id: "proj-1", path: "/repo", name: "Repo" } as Project);
+      render(<ForgeIntegrationsTab />);
+    }
+
+    /** The row `<li>` whose remote name cell matches. */
+    function rowFor(name: string): HTMLElement {
+      const cell = screen.getByText(name);
+      const row = cell.closest("li");
+      if (!row) throw new Error(`No routing row found for remote "${name}"`);
+      return row;
+    }
+
+    it("marks the remote named by the project setting", async () => {
+      renderWithBothRemotes("upstream");
+
+      await waitFor(() => expect(screen.getByText("Active")).toBeTruthy());
+      expect(rowFor("upstream").textContent).toContain("Active");
+      expect(rowFor("origin").textContent).not.toContain("Active");
+    });
+
+    it("marks the auto-detected remote when no setting is stored", async () => {
+      // Both match a provider, so name preference picks upstream over origin.
+      renderWithBothRemotes(undefined);
+
+      await waitFor(() => expect(screen.getByText("Active")).toBeTruthy());
+      expect(rowFor("upstream").textContent).toContain("Active");
+      expect(rowFor("origin").textContent).not.toContain("Active");
+    });
+
+    it("marks exactly one remote", async () => {
+      renderWithBothRemotes("origin");
+
+      await waitFor(() => expect(screen.getByText("Active")).toBeTruthy());
+      expect(screen.getAllByText("Active")).toHaveLength(1);
+      expect(rowFor("origin").textContent).toContain("Active");
+    });
   });
 
   it("renders a routing row per remote with the resolved provider badge", async () => {


### PR DESCRIPTION
## Summary

There's a per-project "Forge remote" setting, but the toolbar never actually checked it. Three sites only looked for a git remote literally named `origin`, so on a fork or mirror where the real forge remote has a different name, the toolbar silently hid issues and pull requests:

- `electron/ipc/handlers/forgeResolution.ts` `resolveForCwd`, the shared resolver behind both `forgeData` (list/get issues and PRs) and `forge` (open/assign)
- `electron/ipc/handlers/forgeSettings.ts` `FORGE_RESOLVE_PROVIDER`, the pill visibility gate behind `useResolvedForgeProvider`
- `electron/workspace-host/WorkspaceService.ts` `readForgeRemotes`, the worktree-card affordance

Resolves #11408

## Changes

- New pure resolver `shared/utils/forgeRemoteSelection.ts` (`resolveForgeRemote`). No I/O, no registry import, no Electron bindings, so main, the workspace-host `UtilityProcess`, and the renderer can all share one precedence chain. It takes an injected `isSupportedRemote` predicate because the host has no provider registry of its own, it matches against the relayed `forgeProviderMatchers` table instead.
- All three sites above now route through it.
- `forge:remote-changed` is broadcast when the setting changes, so the renderer drops its cached resolution instead of showing stale pills until a reload. The existing event only fired on `.git/config` changes, which a settings change never touches.
- The workspace host re-selects and fans out when the setting or the provider-matcher table changes, coalesced behind a trailing debounce and bounded by a retry budget.
- The Forge Integrations routing panel now marks which remote is actually live, replaying main's hostname predicate exactly.

## Safety: fail closed

A `forgeRemote` naming a remote that no longer resolves does not fall back to `origin`. `resolveForCwd` backs assign/close/merge, so silently substituting a different repository there could redirect a write to a fork. That's the "no silent fallback defaults" rule from `CLAUDE.md`. The same reasoning carries through to an unreadable project-settings row and to `GitHubRepoContext`, which backs issue creation.

## Design decisions worth a second look

1. Auto-detect prefers `origin`, then `upstream`, not gh's `upstream -> github -> origin`. `PullRequestService` and the built-in GitHub context both auto-detect origin-first, and preferring `upstream` here would point the toolbar at the canonical repo while the worktree PR badges keep reading the fork. This keeps every consumer on the same repository whenever `origin` is usable, so the only case that changes behavior is `origin` being absent or unparseable. gh's literal `github` name tier is left out too: Daintree is forge-neutral, a Gitea remote is just as likely to be named `gitea`, and hostname matching already covers that case.
2. A per-project provider override suppresses the hostname filter during selection. The override exists specifically to bypass hostname matching, so it can't be allowed to lose the self-hosted remote it's there to support.
3. `remote.<name>.gh-resolved` / Magit's `forge.remote` git-config interop is scoped out of this PR. It needs new async git-config I/O at three call sites, and the actual bug here is just that the existing setting was being ignored.

## Known limitations

Not regressions, flagging for follow-up:

- If a global default provider rejects the selected remote's hostname, the toolbar still hides even when a sibling remote would resolve. Pre-existing, it behaved identically before this fix when `origin` was always chosen. Fixing it properly means a joint remote-and-provider resolution, which is really a redesign.
- `PullRequestService` keeps its `origin` fallback when a configured remote misses. That's a deliberate, tested call from #8456, and the service is a read-only poller, so overturning it belongs in its own PR.

## Testing

New `shared/utils/__tests__/forgeRemoteSelection.test.ts`, plus extended coverage in `forgeResolution.test.ts`, `forgeSettings.handlers.test.ts`, `WorkspaceService.forgeRemote.test.ts`, and `ForgeIntegrationsTab.test.tsx`. 476 tests across the changed modules pass locally, plus the full 1556-test `electron/ipc/handlers/__tests__` suite. Own-file prettier and eslint are clean (0 errors).

Two pre-existing tests were updated because this fix deliberately inverts the contracts they encoded: settings are now read before the remote lookup, and a settings-read failure now fails closed instead of falling back.
