### PR TITLE
feat(project): open any folder as a lightweight workspace without git

### DIFF
--- a/electron/ipc/handlers/__tests__/project.addOptions.test.ts
+++ b/electron/ipc/handlers/__tests__/project.addOptions.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import os from "os";
+
+vi.mock("electron", () => ({
+  ipcMain: {
+    handle: vi.fn(),
+    removeHandler: vi.fn(),
+  },
+  dialog: {
+    showOpenDialog: vi.fn(),
+    showErrorBox: vi.fn(),
+  },
+  shell: {
+    openPath: vi.fn(),
+    openExternal: vi.fn(),
+  },
+  app: {
+    getPath: vi.fn().mockReturnValue(os.tmpdir()),
+  },
+  BrowserWindow: {
+    getAllWindows: () => [],
+  },
+}));
+
+const addProjectMock = vi.fn(async (projectPath: string, _options?: unknown) => ({
+  id: "p1",
+  path: projectPath,
+  name: "p1",
+  emoji: "🌲",
+  lastOpened: 0,
+}));
+
+vi.mock("../../../services/ProjectStore.js", () => ({
+  projectStore: {
+    addProject: (...args: unknown[]) =>
+      addProjectMock(...(args as Parameters<typeof addProjectMock>)),
+    getCurrentProjectId: vi.fn(),
+    getProjectById: vi.fn(),
+    setCurrentProject: vi.fn(),
+    getProjectState: vi.fn(),
+    saveProjectState: vi.fn(),
+    getAllProjects: vi.fn(() => []),
+    getCurrentProject: vi.fn(() => null),
+    updateProjectStatus: vi.fn(),
+  },
+}));
+
+vi.mock("../../../services/ProjectSwitchService.js", () => ({
+  ProjectSwitchService: class MockProjectSwitchService {
+    onSwitch = vi.fn();
+    switchProject = vi.fn();
+    reopenProject = vi.fn();
+  },
+}));
+
+vi.mock("../../../services/RunCommandDetector.js", () => ({
+  runCommandDetector: { detect: vi.fn().mockResolvedValue([]) },
+}));
+
+vi.mock("../../../window/webContentsRegistry.js", () => ({
+  getWindowForWebContents: vi.fn(() => null),
+  getProjectForWebContents: vi.fn(() => null),
+  getAllAppWebContents: vi.fn(() => []),
+}));
+
+vi.mock("../../../window/portDistribution.js", () => ({
+  distributePortsToView: vi.fn(),
+}));
+
+import { ipcMain } from "electron";
+import { CHANNELS } from "../../channels.js";
+import { registerProjectCrudHandlers } from "../projectCrud/index.js";
+import type { HandlerDependencies } from "../../types.js";
+
+const EVENT = { sender: { id: 1 } };
+
+function getHandler(channel: string): (...args: unknown[]) => unknown {
+  for (const call of (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls) {
+    if (call[0] === channel) return call[1] as (...args: unknown[]) => unknown;
+  }
+  throw new Error(`No handler registered for ${channel}`);
+}
+
+/** The options object `project:add` actually handed the store. */
+function forwardedOptions(): Record<string, unknown> | undefined {
+  const call = addProjectMock.mock.calls.at(-1);
+  return call?.[1] as Record<string, unknown> | undefined;
+}
+
+/**
+ * `project:add`'s second argument carries two independently-validated things:
+ * the lightweight-workspace opt-out (#11405) and the creation identity
+ * (#11404). The identity validator drops a malformed payload WHOLE, so any
+ * refactor that folds `gitBacked` in beside `name`/`emoji` would make an
+ * "Open without git" add fail that gate and be discarded in silence — the
+ * dialog would then reopen forever with nothing to show for it. Nothing else
+ * in the suite covers that, so these assertions are the guard.
+ */
+describe("project:add options", () => {
+  let handler: (...args: unknown[]) => unknown;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const deps = {
+      mainWindow: { id: 1 } as unknown,
+      windowRegistry: {
+        getPrimary: () => undefined,
+        getByWindowId: () => undefined,
+        getByWebContentsId: () => undefined,
+        all: () => [],
+        size: 0,
+      },
+    } as unknown as HandlerDependencies;
+
+    registerProjectCrudHandlers(deps);
+    handler = getHandler(CHANNELS.PROJECT_ADD);
+  });
+
+  it("carries gitBacked:false through to the store on its own", async () => {
+    await handler(EVENT, "/tmp/plain-folder", { gitBacked: false });
+
+    expect(addProjectMock).toHaveBeenCalledTimes(1);
+    expect(addProjectMock.mock.calls[0]![0]).toBe("/tmp/plain-folder");
+    expect(forwardedOptions()).toMatchObject({ gitBacked: false });
+  });
+
+  it("keeps gitBacked:false when no identity accompanies it", async () => {
+    // The identity half being absent must not take the mode half down with it.
+    await handler(EVENT, "/tmp/plain-folder", { gitBacked: false });
+
+    const options = forwardedOptions();
+    expect(options?.gitBacked).toBe(false);
+    expect(options?.identity).toBeUndefined();
+  });
+
+  it("keeps gitBacked:false when the identity alongside it is malformed", async () => {
+    await handler(EVENT, "/tmp/plain-folder", {
+      gitBacked: false,
+      identity: { name: "Only half" },
+    });
+
+    const options = forwardedOptions();
+    expect(options?.gitBacked).toBe(false);
+    expect(options?.identity).toBeUndefined();
+  });
+
+  it("carries a well-formed identity through, trimmed", async () => {
+    await handler(EVENT, "/tmp/repo", { identity: { name: "  Chosen  ", emoji: " 🚀 " } });
+
+    const options = forwardedOptions();
+    expect(options?.identity).toEqual({ name: "Chosen", emoji: "🚀" });
+    expect(options?.gitBacked).toBeUndefined();
+  });
+
+  it("carries both halves when both are supplied", async () => {
+    await handler(EVENT, "/tmp/plain-folder", {
+      gitBacked: false,
+      identity: { name: "Downloads", emoji: "📦" },
+    });
+
+    expect(forwardedOptions()).toMatchObject({
+      gitBacked: false,
+      identity: { name: "Downloads", emoji: "📦" },
+    });
+  });
+
+  it("never lets a caller assert that a folder IS git-backed", async () => {
+    // Only `addProject` — which actually looked for a repository — may decide
+    // that. `true` is narrowed away rather than forwarded.
+    await handler(EVENT, "/tmp/repo", { gitBacked: true });
+
+    expect(forwardedOptions()?.gitBacked).toBeUndefined();
+  });
+
+  it("forwards nothing meaningful for a plain add", async () => {
+    await handler(EVENT, "/tmp/repo");
+
+    const options = forwardedOptions();
+    expect(options?.gitBacked).toBeUndefined();
+    expect(options?.identity).toBeUndefined();
+  });
+});

--- a/electron/ipc/handlers/__tests__/project.openDialog.test.ts
+++ b/electron/ipc/handlers/__tests__/project.openDialog.test.ts
@@ -112,7 +112,6 @@ describe("handleProjectOpenDialog", () => {
     expect(dialog.showOpenDialog).toHaveBeenCalledWith(
       fakeWindow,
       expect.objectContaining({
-        title: "Open Git Repository",
         properties: ["openDirectory", "createDirectory"],
       })
     );
@@ -129,15 +128,27 @@ describe("handleProjectOpenDialog", () => {
     const fakeEvent = { sender: { id: 99 } };
     const result = await handler(fakeEvent);
 
-    expect(dialog.showOpenDialog).toHaveBeenCalledWith(
-      expect.objectContaining({
-        title: "Open Git Repository",
-      })
-    );
     // Should NOT have been called with a window as first arg
     const callArgs = (dialog.showOpenDialog as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(callArgs).toHaveLength(1); // only opts, no window
     expect(result).toBe("/projects/fallback");
+  });
+
+  it("does not present the picker as requiring a repository (#11405)", async () => {
+    // A folder without git is openable now, so the picker must not imply
+    // otherwise — the choice about git comes after, not at selection time.
+    mockGetWindowForWebContents.mockReturnValue({ id: 1 });
+    (dialog.showOpenDialog as ReturnType<typeof vi.fn>).mockResolvedValue({
+      canceled: true,
+      filePaths: [],
+    });
+
+    await handler({ sender: { id: 1 } });
+
+    const opts = (dialog.showOpenDialog as ReturnType<typeof vi.fn>).mock
+      .calls[0]![1] as Electron.OpenDialogOptions;
+    expect(opts.title).toBeTruthy();
+    expect(opts.title).not.toMatch(/git|repositor/i);
   });
 
   it("returns null when dialog is canceled", async () => {

--- a/electron/ipc/handlers/projectCrud/crud.ts
+++ b/electron/ipc/handlers/projectCrud/crud.ts
@@ -12,7 +12,7 @@ import { projectRelocationCoordinator } from "../../../services/ProjectRelocatio
 import { resolveScopedProjectForIpcContext } from "../../projectContext.js";
 import { refreshProjectMenuState } from "../../../projectMenuState.js";
 import type { HandlerDependencies } from "../../types.js";
-import type { Project } from "../../../types/index.js";
+import type { Project, ProjectAddOptions } from "../../../types/index.js";
 import type { ProjectCreationIdentity } from "../../../../shared/types/project.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import { AppError } from "../../../utils/errorTypes.js";
@@ -42,7 +42,7 @@ const PROJECT_VISIBLE_MESSAGE =
  */
 export async function addProjectByPath(
   projectPath: string,
-  identity?: ProjectCreationIdentity
+  options?: ProjectAddOptions
 ): Promise<Project> {
   if (typeof projectPath !== "string" || !projectPath) {
     throw new Error("Invalid project path");
@@ -50,7 +50,17 @@ export async function addProjectByPath(
   if (!path.isAbsolute(projectPath)) {
     throw new Error("Project path must be absolute");
   }
-  const project = await projectStore.addProject(projectPath, normalizeCreationIdentity(identity));
+  // The two halves are validated independently and stay separate keys.
+  // `normalizeCreationIdentity` drops a malformed identity WHOLE, so folding
+  // `gitBacked` in alongside `name`/`emoji` would make a lightweight-open
+  // payload fail the identity gate and be discarded in silence.
+  const project = await projectStore.addProject(projectPath, {
+    // Narrowed rather than forwarded: a caller may only ever ask to *drop* the
+    // git requirement. Anything else would let it assert a mode the folder
+    // doesn't have, and `addProject` alone decides that a repository was found.
+    ...(options?.gitBacked === false ? { gitBacked: false } : {}),
+    identity: normalizeCreationIdentity(options?.identity),
+  });
   broadcastToRenderer(CHANNELS.PROJECT_UPDATED, project);
   return project;
 }
@@ -93,8 +103,8 @@ function normalizeCreationIdentity(
 }
 
 export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () => void {
-  const handleProjectAdd = async (projectPath: string, identity?: ProjectCreationIdentity) =>
-    addProjectByPath(projectPath, identity);
+  const handleProjectAdd = async (projectPath: string, options?: ProjectAddOptions) =>
+    addProjectByPath(projectPath, options);
 
   const handlers: Array<() => void> = [];
 
@@ -183,12 +193,16 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
     // renderer that could rewrite its own project's path to a sibling's would
     // point that resolution at the sibling's host. Path changes stay exclusive
     // to the main-owned relocation flow (#11282).
+    // `gitBacked` joins them: it decides whether the workspace host enumerates
+    // worktrees at all, and only `addProject` — which actually looked for a
+    // repository — may set it (#11405).
     const {
       id: _id,
       path: _path,
       inRepoSettings: _inRepo,
       frecencyScore: _fs,
       lastAccessedAt: _lat,
+      gitBacked: _gitBacked,
       ...safeUpdates
     } = updates;
     const updated = projectStore.updateProject(projectId, safeUpdates);
@@ -219,7 +233,9 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
     const senderWindow = getWindowForWebContents(ctx.event.sender);
     const dialogOpts = {
       properties: ["openDirectory" as const, "createDirectory" as const],
-      title: "Open Git Repository",
+      // Not "Open Git Repository": a folder without one is now openable too,
+      // and the picker shouldn't imply a requirement it no longer has (#11405).
+      title: "Open Folder",
     };
     const result = senderWindow
       ? await dialog.showOpenDialog(senderWindow, dialogOpts)

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -84,7 +84,7 @@ import { buildTerminalConfigPreloadBindings } from "./ipc/handlers/terminalConfi
 
 import type {
   Project,
-  ProjectCreationIdentity,
+  ProjectAddOptions,
   ProjectSettings,
   TerminalSpawnOptions,
   CopyTreeOptions,
@@ -1709,11 +1709,11 @@ function buildElectronApi(): ElectronAPI {
 
       getCurrent: () => _unwrappingInvoke(CHANNELS.PROJECT_GET_CURRENT),
 
-      // Forward the optional identity only when present — an open-existing-repo
+      // Forward the optional options bag only when present — an open-existing-repo
       // add stays a one-argument invoke, byte-identical to before.
-      add: (path: string, identity?: ProjectCreationIdentity) =>
-        identity
-          ? _unwrappingInvoke(CHANNELS.PROJECT_ADD, path, identity)
+      add: (path: string, options?: ProjectAddOptions) =>
+        options
+          ? _unwrappingInvoke(CHANNELS.PROJECT_ADD, path, options)
           : _unwrappingInvoke(CHANNELS.PROJECT_ADD, path),
 
       remove: (projectId: string) => _unwrappingInvoke(CHANNELS.PROJECT_REMOVE, projectId),

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -1,6 +1,7 @@
 // eager-import-allow: reads/writes the project list via sync fs during startup
 import type {
   Project,
+  ProjectAddOptions,
   ProjectRepoStats,
   ProjectState,
   ProjectSettings,
@@ -8,7 +9,6 @@ import type {
   TerminalRecipe,
   RecipeNameCollision,
 } from "../types/index.js";
-import type { ProjectCreationIdentity } from "../../shared/types/project.js";
 import type { NotificationSettings } from "../../shared/types/ipc/api.js";
 import type { AgentPreset } from "../../shared/config/agentRegistry.js";
 import path from "path";
@@ -137,6 +137,8 @@ function rowToProject(row: ProjectRow): Project {
     typeof row.frecencyScore === "number" ? row.frecencyScore : FRECENCY_COLD_START;
   project.lastAccessedAt = typeof row.lastAccessedAt === "number" ? row.lastAccessedAt : 0;
   if (typeof row.autoParkedAt === "number") project.autoParkedAt = row.autoParkedAt;
+  // Only `false` is carried: null means git-backed, and so does absence.
+  if (row.gitBacked === false) project.gitBacked = false;
   const lastKnownStats = rowToRepoStats(row);
   if (lastKnownStats) project.lastKnownStats = lastKnownStats;
   return project;
@@ -377,16 +379,19 @@ export class ProjectStore {
   }
 
   /**
-   * `creationIdentity` is the name/emoji chosen in a creation dialog. It is
+   * `options.identity` is the name/emoji chosen in a creation dialog. It is
    * consulted only where a brand-new row is minted below — every earlier return
    * (already-registered path, adopted move, lost insert race) keeps the
    * identity it already has, so re-adding a folder can never rename it.
    * In-repo `.daintree/project.json` still wins field-wise.
+   *
+   * `options.gitBacked === false` adopts a folder that has no repository at
+   * all; anything else keeps the strict git-root requirement. The two options
+   * are read independently — a lightweight open carries no identity, and an
+   * identity never implies a mode.
    */
-  async addProject(
-    projectPath: string,
-    creationIdentity?: ProjectCreationIdentity
-  ): Promise<Project> {
+  async addProject(projectPath: string, options?: ProjectAddOptions): Promise<Project> {
+    const creationIdentity = options?.identity;
     let gitRoot: string;
     try {
       gitRoot = await this.getGitRoot(projectPath);
@@ -411,6 +416,18 @@ export class ProjectStore {
       }
 
       if (lower.includes("not a git repository")) {
+        // The folder has no repository. Adopt it as a lightweight workspace when
+        // the caller asked for that explicitly, or when it is already registered
+        // as one — the latter is what lets Recents, Dock drops, Open With and the
+        // CLI reopen it without re-prompting (#11405). Anything else keeps
+        // today's behavior and drives the choice dialog.
+        const lightweight = await this.resolveLightweightPath(projectPath);
+        if (lightweight) {
+          const existing = await this.getProjectByPath(lightweight);
+          if (existing) return this.touchExistingProject(existing, { gitBacked: false });
+          if (options?.gitBacked === false) return this.insertLightweightProject(lightweight);
+        }
+
         throw new AppError({
           code: "NOT_A_GIT_REPO",
           message: `Not a git repository: ${projectPath}`,
@@ -443,23 +460,9 @@ export class ProjectStore {
 
     const existing = await this.getProjectByPath(normalizedPath);
     if (existing) {
-      const now = Date.now();
-      // Skip frecency churn under disk pressure — these are non-critical
-      // ranking-signal writes. `lastOpened` is also non-critical here (the
-      // existing project row is unchanged for the user's purposes).
-      if (getWritesSuppressed()) {
-        return existing;
-      }
-      const newScore = computeFrecencyScore(
-        existing.frecencyScore ?? FRECENCY_COLD_START,
-        existing.lastAccessedAt ?? 0,
-        now
-      );
-      return this.updateProject(existing.id, {
-        lastOpened: now,
-        frecencyScore: newScore,
-        lastAccessedAt: now,
-      });
+      // A git root resolved, so promote a row that was adopted without one —
+      // this is what `git init` on a lightweight workspace lands on (#11405).
+      return this.touchExistingProject(existing, { gitBacked: true });
     }
 
     const inRepo = await this.readInRepoProjectIdentity(normalizedPath);
@@ -508,6 +511,100 @@ export class ProjectStore {
         inRepoSettings: project.inRepoSettings ?? null,
         frecencyScore: FRECENCY_COLD_START,
         lastAccessedAt: now,
+      })
+      .run();
+
+    return project;
+  }
+
+  /**
+   * Reopen an already-registered project: bump its ranking signals and reconcile
+   * its git-backed mode.
+   *
+   * The mode flip is written even while disk-pressure suppression is on. Frecency
+   * and `lastOpened` are non-critical ranking churn and are rightly dropped under
+   * pressure, but the mode decides whether the workspace host enumerates
+   * worktrees at all — losing it would leave the row describing the wrong kind of
+   * workspace until the next uncontended open.
+   */
+  private touchExistingProject(existing: Project, mode: { gitBacked: boolean }): Project {
+    // Stored as null rather than 1 for a repository, so a git-backed row is
+    // indistinguishable from every row predating the column.
+    const nextGitBacked = mode.gitBacked ? undefined : false;
+    const modeChanged = existing.gitBacked !== nextGitBacked;
+
+    const now = Date.now();
+    if (getWritesSuppressed()) {
+      return modeChanged ? this.updateProject(existing.id, { gitBacked: nextGitBacked }) : existing;
+    }
+
+    const newScore = computeFrecencyScore(
+      existing.frecencyScore ?? FRECENCY_COLD_START,
+      existing.lastAccessedAt ?? 0,
+      now
+    );
+    return this.updateProject(existing.id, {
+      lastOpened: now,
+      frecencyScore: newScore,
+      lastAccessedAt: now,
+      ...(modeChanged ? { gitBacked: nextGitBacked } : {}),
+    });
+  }
+
+  /**
+   * Canonical registry path for a folder with no repository, or `null` when it
+   * isn't a usable directory.
+   *
+   * Git-backed projects register their repository root; a lightweight workspace
+   * has none, so the adopted folder itself is the identity. Symlinks are resolved
+   * and the result NFC-normalized to match {@link addProject}'s dedup rules.
+   */
+  private async resolveLightweightPath(projectPath: string): Promise<string | null> {
+    try {
+      const canonical = await fs.realpath(projectPath);
+      const stats = await fs.stat(canonical);
+      if (!stats.isDirectory()) return null;
+      return path.normalize(canonical).normalize("NFC");
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Register a folder that has no repository.
+   *
+   * Deliberately skips `.daintree/project.json`: reading identity from an
+   * arbitrary folder would let a downloaded archive carrying a stray anchor
+   * either rename itself after an unrelated project or, through
+   * {@link tryAdoptMovedProject}, take over that project's id and inherit its
+   * panels, settings and Assistant history.
+   */
+  private insertLightweightProject(normalizedPath: string): Project {
+    const now = Date.now();
+    const project: Project = {
+      id: mintProjectId(normalizedPath, (candidate) => this.isProjectIdTaken(candidate)),
+      path: normalizedPath,
+      name: path.basename(normalizedPath),
+      emoji: DEFAULT_PROJECT_EMOJI,
+      lastOpened: now,
+      status: "closed",
+      frecencyScore: FRECENCY_COLD_START,
+      lastAccessedAt: now,
+      gitBacked: false,
+    };
+
+    getSharedDb()
+      .insert(projectsTable)
+      .values({
+        id: project.id,
+        path: project.path,
+        name: project.name,
+        emoji: project.emoji,
+        lastOpened: project.lastOpened,
+        status: project.status ?? null,
+        frecencyScore: FRECENCY_COLD_START,
+        lastAccessedAt: now,
+        gitBacked: false,
       })
       .run();
 
@@ -647,6 +744,7 @@ export class ProjectStore {
       frecencyScore: number;
       lastAccessedAt: number;
       autoParkedAt: number | null;
+      gitBacked: boolean | null;
     }> = {};
     if (updates.name !== undefined) set.name = updates.name;
     if (updates.path !== undefined) set.path = updates.path;
@@ -661,6 +759,10 @@ export class ProjectStore {
     if (updates.frecencyScore !== undefined) set.frecencyScore = updates.frecencyScore;
     if (updates.lastAccessedAt !== undefined) set.lastAccessedAt = updates.lastAccessedAt;
     if ("autoParkedAt" in updates) set.autoParkedAt = updates.autoParkedAt ?? null;
+    // Keyed on presence, not on `!== undefined`: promoting a lightweight
+    // workspace clears the flag by passing `undefined`, which an existence-blind
+    // check would silently drop and leave the row lightweight forever.
+    if ("gitBacked" in updates) set.gitBacked = updates.gitBacked ?? null;
 
     if (Object.keys(set).length > 0) {
       db.update(projectsTable).set(set).where(eq(projectsTable.id, projectId)).run();

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -421,11 +421,23 @@ export class ProjectStore {
         // as one — the latter is what lets Recents, Dock drops, Open With and the
         // CLI reopen it without re-prompting (#11405). Anything else keeps
         // today's behavior and drives the choice dialog.
+        //
+        // A registered *git-backed* row is deliberately not demoted on its own:
+        // git failing to see a repository at a path we recorded as one is an
+        // anomaly (an unmounted volume, a permissions blip, a `.git` deleted out
+        // from under us), and silently rewriting the row would lose that project's
+        // git identity for good. It falls through to the choice dialog, where
+        // demotion becomes the user's explicit decision.
         const lightweight = await this.resolveLightweightPath(projectPath);
         if (lightweight) {
           const existing = await this.getProjectByPath(lightweight);
-          if (existing) return this.touchExistingProject(existing, { gitBacked: false });
-          if (options?.gitBacked === false) return this.insertLightweightProject(lightweight);
+          if (existing) {
+            if (existing.gitBacked === false || options?.gitBacked === false) {
+              return this.touchExistingProject(existing, { gitBacked: false });
+            }
+          } else if (options?.gitBacked === false) {
+            return this.insertLightweightProject(lightweight);
+          }
         }
 
         throw new AppError({

--- a/electron/services/__tests__/ProjectStore.autoParkedAt.test.ts
+++ b/electron/services/__tests__/ProjectStore.autoParkedAt.test.ts
@@ -27,7 +27,8 @@ const CREATE_TABLES_SQL = `
     stats_issue_count INTEGER,
     stats_pr_count INTEGER,
     stats_provider_id TEXT,
-    stats_last_updated INTEGER
+    stats_last_updated INTEGER,
+    git_backed INTEGER
   );
   CREATE TABLE IF NOT EXISTS app_state (
     key TEXT PRIMARY KEY,

--- a/electron/services/__tests__/ProjectStore.diskPressure.test.ts
+++ b/electron/services/__tests__/ProjectStore.diskPressure.test.ts
@@ -26,7 +26,8 @@ const CREATE_TABLES_SQL = `
     stats_issue_count INTEGER,
     stats_pr_count INTEGER,
     stats_provider_id TEXT,
-    stats_last_updated INTEGER
+    stats_last_updated INTEGER,
+    git_backed INTEGER
   );
   CREATE TABLE IF NOT EXISTS app_state (
     key TEXT PRIMARY KEY,

--- a/electron/services/__tests__/ProjectStore.identity.test.ts
+++ b/electron/services/__tests__/ProjectStore.identity.test.ts
@@ -25,7 +25,8 @@ const CREATE_TABLES_SQL = `
     stats_issue_count INTEGER,
     stats_pr_count INTEGER,
     stats_provider_id TEXT,
-    stats_last_updated INTEGER
+    stats_last_updated INTEGER,
+    git_backed INTEGER
   );
   CREATE TABLE IF NOT EXISTS app_state (
     key TEXT PRIMARY KEY,
@@ -211,7 +212,7 @@ describe("project identity across folder moves", () => {
     it("applies the chosen name and emoji when a new row is minted", async () => {
       const dir = await makeDir("fresh");
 
-      const created = await store.addProject(dir, { name: "Chosen", emoji: "🚀" });
+      const created = await store.addProject(dir, { identity: { name: "Chosen", emoji: "🚀" } });
 
       expect(created.name).toBe("Chosen");
       expect(created.emoji).toBe("🚀");
@@ -228,9 +229,9 @@ describe("project identity across folder moves", () => {
 
     it("cannot rename an already-registered project by re-adding it", async () => {
       const dir = await makeDir("existing");
-      const first = await store.addProject(dir, { name: "First", emoji: "🚀" });
+      const first = await store.addProject(dir, { identity: { name: "First", emoji: "🚀" } });
 
-      const second = await store.addProject(dir, { name: "Hijacked", emoji: "💀" });
+      const second = await store.addProject(dir, { identity: { name: "Hijacked", emoji: "💀" } });
 
       expect(second.id).toBe(first.id);
       expect(second.name).toBe("First");
@@ -240,14 +241,14 @@ describe("project identity across folder moves", () => {
 
     it("cannot rename an adopted moved project by supplying an identity", async () => {
       const original = await makeDir("original");
-      const registered = await store.addProject(original, { name: "Original", emoji: "🚀" });
+      const registered = await store.addProject(original, { identity: { name: "Original", emoji: "🚀" } });
       await writeAnchor(original, registered.id);
 
       const moved = path.join(tmpRoot, "renamed");
       await fs.promises.rename(original, moved);
       const canonicalMoved = await fs.promises.realpath(moved);
 
-      const reopened = await store.addProject(canonicalMoved, { name: "Hijacked", emoji: "💀" });
+      const reopened = await store.addProject(canonicalMoved, { identity: { name: "Hijacked", emoji: "💀" } });
 
       expect(reopened.id).toBe(registered.id);
       expect(reopened.emoji).not.toBe("💀");
@@ -261,7 +262,7 @@ describe("project identity across folder moves", () => {
       const link = path.join(tmpRoot, "linked-repo");
       await fs.promises.symlink(real, link);
 
-      const created = await store.addProject(link, { name: "Chosen", emoji: "🚀" });
+      const created = await store.addProject(link, { identity: { name: "Chosen", emoji: "🚀" } });
 
       expect(created.path).toBe(real);
       expect(created.name).toBe("Chosen");
@@ -272,8 +273,7 @@ describe("project identity across folder moves", () => {
       const dir = await makeDir("trailing");
 
       const created = await store.addProject(`${dir}${path.sep}`, {
-        name: "Chosen",
-        emoji: "🚀",
+        identity: { name: "Chosen", emoji: "🚀" },
       });
 
       expect(created.name).toBe("Chosen");
@@ -288,7 +288,7 @@ describe("project identity across folder moves", () => {
       const child = await makeDir("repo-root/child");
       repositoryRootOverride = root;
 
-      const created = await store.addProject(child, { name: "Child", emoji: "🚀" });
+      const created = await store.addProject(child, { identity: { name: "Child", emoji: "🚀" } });
 
       expect(created.path).toBe(root);
       expect(created.name).toBe(path.basename(root));

--- a/electron/services/__tests__/ProjectStore.identity.test.ts
+++ b/electron/services/__tests__/ProjectStore.identity.test.ts
@@ -241,14 +241,18 @@ describe("project identity across folder moves", () => {
 
     it("cannot rename an adopted moved project by supplying an identity", async () => {
       const original = await makeDir("original");
-      const registered = await store.addProject(original, { identity: { name: "Original", emoji: "🚀" } });
+      const registered = await store.addProject(original, {
+        identity: { name: "Original", emoji: "🚀" },
+      });
       await writeAnchor(original, registered.id);
 
       const moved = path.join(tmpRoot, "renamed");
       await fs.promises.rename(original, moved);
       const canonicalMoved = await fs.promises.realpath(moved);
 
-      const reopened = await store.addProject(canonicalMoved, { identity: { name: "Hijacked", emoji: "💀" } });
+      const reopened = await store.addProject(canonicalMoved, {
+        identity: { name: "Hijacked", emoji: "💀" },
+      });
 
       expect(reopened.id).toBe(registered.id);
       expect(reopened.emoji).not.toBe("💀");

--- a/electron/services/__tests__/ProjectStore.lightweight.test.ts
+++ b/electron/services/__tests__/ProjectStore.lightweight.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import * as schema from "../persistence/schema.js";
+
+const CREATE_TABLES_SQL = `
+  CREATE TABLE IF NOT EXISTS projects (
+    id TEXT PRIMARY KEY,
+    path TEXT NOT NULL,
+    name TEXT NOT NULL,
+    emoji TEXT NOT NULL,
+    last_opened INTEGER NOT NULL,
+    color TEXT,
+    status TEXT,
+    daintree_config_present INTEGER,
+    in_repo_settings INTEGER,
+    pinned INTEGER NOT NULL DEFAULT 0,
+    frecency_score REAL NOT NULL DEFAULT 3.0,
+    last_accessed_at INTEGER NOT NULL DEFAULT 0,
+    auto_parked_at INTEGER,
+    stats_commit_count INTEGER,
+    stats_issue_count INTEGER,
+    stats_pr_count INTEGER,
+    stats_provider_id TEXT,
+    stats_last_updated INTEGER,
+    git_backed INTEGER
+  );
+  CREATE TABLE IF NOT EXISTS app_state (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+  );
+`;
+
+let sqlite: Database.Database;
+let db: ReturnType<typeof drizzle<typeof schema>>;
+let tmpRoot: string;
+
+/** Paths this fake treats as repositories; anything else throws like real git. */
+const repoPaths = new Set<string>();
+const getRepositoryRoot = vi.fn(async (p: string) => {
+  if (!repoPaths.has(p)) {
+    throw new Error(`fatal: not a git repository (or any of the parent directories): .git`);
+  }
+  return p;
+});
+
+vi.mock("../persistence/db.js", () => ({
+  getSharedDb: () => db,
+  openDb: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  app: { getPath: () => "/tmp/daintree-lightweight-test" },
+}));
+
+vi.mock("../GitService.js", () => ({
+  GitService: class {
+    async getRepositoryRoot(p: string): Promise<string> {
+      return getRepositoryRoot(p);
+    }
+    repairWorktrees() {}
+  },
+}));
+
+vi.mock("../ProjectSettingsManager.js", () => ({
+  ProjectSettingsManager: class {
+    deleteAllEnvForProject() {}
+    migrateEnvForProject() {}
+    getEffectiveNotificationSettings() {
+      return {};
+    }
+  },
+}));
+
+vi.mock("../ProjectStateManager.js", () => ({
+  ProjectStateManager: class {
+    invalidateProjectStateCache() {}
+    enqueueProjectStateUpdate() {}
+  },
+}));
+
+vi.mock("../ProjectFileStore.js", () => ({ ProjectFileStore: class {} }));
+vi.mock("../GlobalFileStore.js", () => ({ GlobalFileStore: class {} }));
+vi.mock("../projectQuarantineCleanup.js", () => ({
+  cleanupQuarantinedProjectFiles: vi.fn(),
+}));
+
+import { ProjectStore } from "../ProjectStore.js";
+import { ProjectIdentityFiles } from "../ProjectIdentityFiles.js";
+import { setWritesSuppressed, resetWritesSuppressedForTesting } from "../diskPressureState.js";
+
+async function makeDir(name: string): Promise<string> {
+  const dir = path.join(tmpRoot, name);
+  await fs.promises.mkdir(dir, { recursive: true });
+  return fs.promises.realpath(dir);
+}
+
+describe("opening a folder without git (#11405)", () => {
+  let store: ProjectStore;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.promises.realpath(
+      fs.mkdtempSync(path.join(os.tmpdir(), "daintree-lightweight-"))
+    );
+    sqlite = new Database(":memory:");
+    sqlite.exec(CREATE_TABLES_SQL);
+    db = drizzle(sqlite, { schema });
+    repoPaths.clear();
+    getRepositoryRoot.mockClear();
+    resetWritesSuppressedForTesting();
+    store = new ProjectStore();
+  });
+
+  afterEach(() => {
+    sqlite.close();
+    resetWritesSuppressedForTesting();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("rejects a folder with no repository unless the caller opted in", async () => {
+    const folder = await makeDir("downloads");
+
+    await expect(store.addProject(folder)).rejects.toMatchObject({ code: "NOT_A_GIT_REPO" });
+    expect(store.getAllProjects()).toHaveLength(0);
+  });
+
+  it("adopts the folder when the caller opted in, flagged as not git-backed", async () => {
+    const folder = await makeDir("downloads");
+
+    const project = await store.addProject(folder, { gitBacked: false });
+
+    expect(project.path).toBe(folder);
+    expect(project.name).toBe(path.basename(folder));
+    expect(project.gitBacked).toBe(false);
+    expect(store.getProjectById(project.id)?.gitBacked).toBe(false);
+  });
+
+  it("reopens a known lightweight folder without opting in again", async () => {
+    const folder = await makeDir("downloads");
+    const first = await store.addProject(folder, { gitBacked: false });
+
+    // No options: what Recents, a Dock drop, Open With and the CLI all send.
+    const reopened = await store.addProject(folder);
+
+    expect(reopened.id).toBe(first.id);
+    expect(reopened.gitBacked).toBe(false);
+    expect(store.getAllProjects()).toHaveLength(1);
+  });
+
+  it("leaves a repository-backed project undiscriminated", async () => {
+    const folder = await makeDir("repo");
+    repoPaths.add(folder);
+
+    const project = await store.addProject(folder);
+
+    expect(project.gitBacked).toBeUndefined();
+    expect(sqlite.prepare("SELECT git_backed FROM projects WHERE id = ?").get(project.id)).toEqual({
+      git_backed: null,
+    });
+  });
+
+  it("promotes the same row once the folder becomes a repository", async () => {
+    const folder = await makeDir("adopted");
+    const lightweight = await store.addProject(folder, { gitBacked: false });
+
+    repoPaths.add(folder);
+    const promoted = await store.addProject(folder);
+
+    expect(promoted.id).toBe(lightweight.id);
+    expect(promoted.gitBacked).toBeUndefined();
+    expect(store.getAllProjects()).toHaveLength(1);
+  });
+
+  it("persists a mode change even while writes are suppressed", async () => {
+    const folder = await makeDir("adopted");
+    const lightweight = await store.addProject(folder, { gitBacked: false });
+
+    repoPaths.add(folder);
+    setWritesSuppressed(true);
+    const promoted = await store.addProject(folder);
+
+    expect(promoted.gitBacked).toBeUndefined();
+    // Ranking churn is still correctly dropped under pressure.
+    expect(promoted.lastOpened).toBe(lightweight.lastOpened);
+  });
+
+  it("ignores an in-repo identity anchor a downloaded folder happens to carry", async () => {
+    const original = await makeDir("original");
+    repoPaths.add(original);
+    const owner = await store.addProject(original);
+
+    // A copy of that project's `.daintree/project.json`, as an archive would carry.
+    const copy = await makeDir("copy");
+    await new ProjectIdentityFiles().writeInRepoProjectIdentity(copy, {
+      id: owner.id,
+      name: "Anchored",
+    });
+
+    const adopted = await store.addProject(copy, { gitBacked: false });
+
+    expect(adopted.id).not.toBe(owner.id);
+    expect(adopted.name).toBe(path.basename(copy));
+    expect(store.getProjectById(owner.id)?.path).toBe(original);
+  });
+
+  it("refuses a path that is not a directory", async () => {
+    const file = path.join(tmpRoot, "note.txt");
+    await fs.promises.writeFile(file, "hi");
+
+    await expect(store.addProject(file, { gitBacked: false })).rejects.toMatchObject({
+      code: "NOT_A_GIT_REPO",
+    });
+  });
+
+  it("does not consult git when reopening a known lightweight folder", async () => {
+    const folder = await makeDir("downloads");
+    await store.addProject(folder, { gitBacked: false });
+    const callsAfterAdd = getRepositoryRoot.mock.calls.length;
+
+    await store.addProject(folder);
+
+    // One probe to learn there is still no repository, and nothing beyond it.
+    expect(getRepositoryRoot.mock.calls.length).toBe(callsAfterAdd + 1);
+  });
+});

--- a/electron/services/__tests__/ProjectStore.lightweight.test.ts
+++ b/electron/services/__tests__/ProjectStore.lightweight.test.ts
@@ -206,6 +206,32 @@ describe("opening a folder without git (#11405)", () => {
     expect(store.getProjectById(owner.id)?.path).toBe(original);
   });
 
+  it("does not demote a registered repository whose git metadata went missing", async () => {
+    const folder = await makeDir("repo");
+    repoPaths.add(folder);
+    const project = await store.addProject(folder);
+
+    // An unmounted volume, a permissions blip, or a `.git` deleted externally.
+    // Rewriting the row here would lose the project's git identity for good, so
+    // the anomaly surfaces and demotion stays the user's explicit decision.
+    repoPaths.delete(folder);
+    await expect(store.addProject(folder)).rejects.toMatchObject({ code: "NOT_A_GIT_REPO" });
+
+    expect(store.getProjectById(project.id)?.gitBacked).toBeUndefined();
+  });
+
+  it("demotes a registered repository only when the user explicitly asks", async () => {
+    const folder = await makeDir("repo");
+    repoPaths.add(folder);
+    const project = await store.addProject(folder);
+
+    repoPaths.delete(folder);
+    const demoted = await store.addProject(folder, { gitBacked: false });
+
+    expect(demoted.id).toBe(project.id);
+    expect(demoted.gitBacked).toBe(false);
+  });
+
   it("refuses a path that is not a directory", async () => {
     const file = path.join(tmpRoot, "note.txt");
     await fs.promises.writeFile(file, "hi");

--- a/electron/services/__tests__/ProjectStore.mruSwitch.test.ts
+++ b/electron/services/__tests__/ProjectStore.mruSwitch.test.ts
@@ -26,7 +26,8 @@ const CREATE_TABLES_SQL = `
     stats_issue_count INTEGER,
     stats_pr_count INTEGER,
     stats_provider_id TEXT,
-    stats_last_updated INTEGER
+    stats_last_updated INTEGER,
+    git_backed INTEGER
   );
   CREATE TABLE IF NOT EXISTS app_state (
     key TEXT PRIMARY KEY,

--- a/electron/services/__tests__/ProjectStore.repoStats.test.ts
+++ b/electron/services/__tests__/ProjectStore.repoStats.test.ts
@@ -28,7 +28,8 @@ const CREATE_TABLES_SQL = `
     stats_issue_count INTEGER,
     stats_pr_count INTEGER,
     stats_provider_id TEXT,
-    stats_last_updated INTEGER
+    stats_last_updated INTEGER,
+    git_backed INTEGER
   );
   CREATE TABLE IF NOT EXISTS app_state (
     key TEXT PRIMARY KEY,

--- a/electron/services/__tests__/ProjectStore.test.ts
+++ b/electron/services/__tests__/ProjectStore.test.ts
@@ -574,7 +574,8 @@ const CREATE_TABLES_SQL = `
     stats_issue_count INTEGER,
     stats_pr_count INTEGER,
     stats_provider_id TEXT,
-    stats_last_updated INTEGER
+    stats_last_updated INTEGER,
+    git_backed INTEGER
   );
   CREATE TABLE IF NOT EXISTS app_state (
     key TEXT PRIMARY KEY,

--- a/electron/services/persistence/__tests__/db.openDb.test.ts
+++ b/electron/services/persistence/__tests__/db.openDb.test.ts
@@ -392,30 +392,31 @@ describe("openDb (integration)", () => {
     for (const entry of applied) ins.run(entry.tag, entry.when);
     seed.close();
 
-    // The final migration's effect must be absent before the upgrade for the test
-    // to mean anything — the seed `projects` table was created without them, and
-    // the final migration (0007) adds the stats_* columns (#11078).
+    // Read the newest migration's own effect out of its SQL rather than naming
+    // columns here, so this stays a real assertion about migration application
+    // instead of a copy of whichever migration happens to be last today.
+    const finalTag = journal[journal.length - 1].tag;
+    const finalSql = fs.readFileSync(path.join(migrationsFolder, `${finalTag}.sql`), "utf8");
+    const addedColumns = [...finalSql.matchAll(/ALTER TABLE `projects` ADD `([a-z_]+)`/g)].map(
+      (m) => m[1]
+    );
+    expect(addedColumns.length).toBeGreaterThan(0);
+
+    // Those columns must be absent before the upgrade for the test to mean
+    // anything — the seed `projects` table was created without them.
     const preCheck = new Database(dbPath, { readonly: true });
     const seededColumns = (preCheck.prepare("PRAGMA table_info(projects)").all() as ColInfo[]).map(
       (c) => c.name
     );
     preCheck.close();
-    expect(seededColumns).not.toContain("stats_commit_count");
+    for (const column of addedColumns) expect(seededColumns).not.toContain(column);
 
     const { sqlite } = openDb(dbPath, migrationsFolder);
     try {
       const projectColumns = (sqlite.pragma("table_info(projects)") as ColInfo[]).map(
         (c) => c.name
       );
-      expect(projectColumns).toEqual(
-        expect.arrayContaining([
-          "stats_commit_count",
-          "stats_issue_count",
-          "stats_pr_count",
-          "stats_provider_id",
-          "stats_last_updated",
-        ])
-      );
+      expect(projectColumns).toEqual(expect.arrayContaining(addedColumns));
 
       // The skipped migration is now recorded — total equals the full journal.
       const migrations = sqlite.prepare("SELECT id FROM __drizzle_migrations").all();

--- a/electron/services/persistence/migrations/0008_add_project_git_backed.sql
+++ b/electron/services/persistence/migrations/0008_add_project_git_backed.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `projects` ADD `git_backed` integer;

--- a/electron/services/persistence/migrations/meta/_journal.json
+++ b/electron/services/persistence/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1783900000000,
       "tag": "0007_add_project_stats",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1784500000000,
+      "tag": "0008_add_project_git_backed",
+      "breakpoints": true
     }
   ]
 }

--- a/electron/services/persistence/schema.ts
+++ b/electron/services/persistence/schema.ts
@@ -20,6 +20,10 @@ export const projects = sqliteTable(
     // "Suspended to free memory" label in the project switcher. Cleared when the
     // project is reopened (`setCurrentProject`).
     autoParkedAt: integer("auto_parked_at"),
+    // False for a folder adopted without git (issue #11405). Null for every
+    // legacy row and every repository-backed project — absence means
+    // git-backed, so no backfill is needed.
+    gitBacked: integer("git_backed", { mode: "boolean" }),
     // Last-known repository counts (issue #11078), so switch-back can seed the
     // toolbar pills from real numbers instead of em-dashes that resize once a
     // poll lands. All nullable: absent until the project's first clean stats

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -226,6 +226,12 @@ export class WorkspaceService {
   private forgeConfigPollTimer: NodeJS.Timeout | null = null;
   private forgeConfigFingerprint: string | null = null;
   private git: SimpleGit | null = null;
+  /**
+   * Whether the loaded folder is a git repository, as observed by `loadProject`.
+   * `null` before the first load. `false` keeps every worktree monitor, the
+   * topology watcher and forge detection permanently off for this host (#11405).
+   */
+  private gitBacked: boolean | null = null;
   private pollingEnabled: boolean = true;
   private projectRootPath: string | null = null;
   // Immutable project id threaded from main via load-project (#11282). The host
@@ -634,8 +640,6 @@ export class WorkspaceService {
       }
       this.projectRootPath = projectRootPath;
       this.projectId = projectId;
-      // Backstop for a disabled or silently-degraded git watcher (#11155).
-      this.startForgeRemoteDetection();
       if (wslGitByWorktree && typeof wslGitByWorktree === "object") {
         // Merge instead of replacing: a `set-wsl-opt-in` message arriving
         // during this load-project's async work would otherwise be silently
@@ -650,6 +654,28 @@ export class WorkspaceService {
       const projectEnvVars = await this.loadProjectEnvVars(projectId);
       this.projectEnvVars = { ...(globalEnvVars ?? {}), ...projectEnvVars };
       this.git = await createHardenedGit(projectRootPath, this._shutdownController.signal);
+
+      // A folder opened without git has no worktrees to enumerate and must never
+      // be polled: `getWorktreeChangesWithStats` turns "not a git repository"
+      // into a `WorktreeRemovedError`, which `GitStatusPass` reads as an external
+      // deletion and answers by removing the workspace from the sidebar. So the
+      // gate has to be here — ahead of prune, list, syncMonitors, the topology
+      // watcher and forge detection — because the hazard is a monitor *existing*,
+      // not a monitor misbehaving (#11405).
+      //
+      // Probed rather than passed in: the folder is the authority. A project
+      // registered as a repository whose `.git` was since deleted reaches this
+      // same branch and is spared the self-deletion too, which trusting a
+      // persisted flag would not do.
+      if (!(await this.isGitRepository())) {
+        this.gitBacked = false;
+        this.sendEvent({ type: "load-project-result", requestId, success: true });
+        return;
+      }
+      this.gitBacked = true;
+
+      // Backstop for a disabled or silently-degraded git watcher (#11155).
+      this.startForgeRemoteDetection();
       this.listService.setGit(this.git, projectRootPath);
 
       // #6669: prune at startup so externally-deleted worktrees (kept in
@@ -2276,8 +2302,29 @@ export class WorkspaceService {
     }
   }
 
+  /**
+   * Whether the loaded folder is a git repository.
+   *
+   * `checkIsRepo` rejects rather than returning false for permission denials,
+   * a missing git binary and other environment faults, so every failure is
+   * treated as "no repository" — the conservative answer, since it only ever
+   * withholds git features rather than pointing the status poller at a path
+   * that cannot serve it.
+   */
+  private async isGitRepository(): Promise<boolean> {
+    if (!this.git) return false;
+    try {
+      return await this.git.checkIsRepo();
+    } catch {
+      return false;
+    }
+  }
+
   private async discoverAndSyncWorktrees(): Promise<void> {
-    if (!this.git) {
+    // Backstop for the `loadProject` gate: a topology reconcile or an explicit
+    // refresh must not be the thing that mints the first monitor for a folder
+    // with no repository (#11405).
+    if (!this.git || this.gitBacked === false) {
       return;
     }
 
@@ -3358,6 +3405,10 @@ ${lines.map((l) => "+" + l).join("\n")}`;
       for (const monitor of this.monitors.values()) {
         monitor.pausePolling();
       }
+    } else if (this.gitBacked === false) {
+      // Foregrounding must not start the topology watcher for a workspace with
+      // no repository — `loadProject` deliberately never started it, and this is
+      // the one path that would otherwise revive it (#11405).
     } else {
       for (const monitor of this.monitors.values()) {
         monitor.resumePolling();

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -745,6 +745,15 @@ export class WorkspaceService {
     monitorConfig?: MonitorConfig,
     skipInitialGitStatus: boolean = false
   ): Promise<void> {
+    // The only place a monitor is ever constructed, and therefore the only
+    // place that can arm the self-deletion hazard for a folder with no
+    // repository: a monitor's first `GitStatusPass` tick there raises
+    // `WorktreeRemovedError`, which the pass answers by removing the workspace.
+    // Guarding here rather than only at the callers covers the `sync` host
+    // message, which arrives with a caller-supplied worktree list and is
+    // fanned out to every live host by `WorkspaceClient.sync` (#11405).
+    if (this.gitBacked === false) return;
+
     // Derive the repository's main/integration branch from the actual main
     // worktree rather than trusting the caller. The legacy `mainBranch`
     // argument is never populated with a real value — internal callers pass

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -3486,6 +3486,11 @@ ${lines.map((l) => "+" + l).join("\n")}`;
    * fingerprint and signature gates: neither moved, only the choice did.
    */
   private scheduleForgeReselect(): void {
+    // A folder with no repository has no remotes to reselect from, and
+    // `forgeProbeCwd` falls back to the project root — so without this the
+    // matcher relay would spawn `git remote -v` there and, on its bounded
+    // re-arm, up to three more times per registry change (#11405 × #11408).
+    if (this.gitBacked === false) return;
     if (this._shutdownController.signal.aborted) return;
     if (this.forgeReselectTimer) return;
     this.forgeReselectTimer = setTimeout(() => {
@@ -3495,6 +3500,9 @@ ${lines.map((l) => "+" + l).join("\n")}`;
   }
 
   private async reselectForgeRemote(): Promise<void> {
+    // Guarded here as well as in `scheduleForgeReselect`: `updateForgeSettings`
+    // calls this one directly, so the debounced path is not the only way in.
+    if (this.gitBacked === false) return;
     const cwd = this.forgeProbeCwd();
     if (!cwd) return;
     // Its OWN sequence — it only makes two rapid setting changes land in order.

--- a/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
@@ -219,6 +219,28 @@ describe("WorkspaceService adversarial", () => {
       expect(monitorCount()).toBe(0);
     });
 
+    it("ignores a sync carrying worktrees from main", async () => {
+      await service.loadProject("req-plain", "/downloads", "ws-plain");
+
+      // `WorkspaceClient.sync` fans out to every live host, so a lightweight
+      // one can be handed another project's worktree list. Accepting it would
+      // arm a monitor whose first poll deletes this workspace.
+      await service.syncMonitors(
+        [
+          {
+            id: "wt-1",
+            path: "/downloads",
+            branch: "main",
+            isMainWorktree: true,
+          } as unknown as Parameters<typeof service.syncMonitors>[0][number],
+        ],
+        "wt-1",
+        "main"
+      );
+
+      expect(monitorCount()).toBe(0);
+    });
+
     it("treats a throwing repository probe as no repository", async () => {
       // simple-git rejects rather than answering false on permission denials
       // and other environment faults.

--- a/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
@@ -8,6 +8,7 @@ import type { WorkspaceHostEvent } from "../../../shared/types/workspace-host.js
 
 const mockSimpleGit = {
   raw: vi.fn(),
+  checkIsRepo: vi.fn().mockResolvedValue(true),
   branch: vi.fn().mockResolvedValue({ current: "main" }),
 };
 
@@ -90,6 +91,7 @@ describe("WorkspaceService adversarial", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     mockSimpleGit.raw.mockResolvedValue(undefined);
+    mockSimpleGit.checkIsRepo.mockResolvedValue(true);
     waitForPathExistsMock.mockResolvedValue(undefined);
 
     sentEvents = [];
@@ -147,6 +149,90 @@ describe("WorkspaceService adversarial", () => {
     // assignment the failure event would still fire, but the dead path would
     // be primed and the polling loops would resume. Pin the ordering.
     expect(service["projectRootPath"]).toBeNull();
+  });
+
+  describe("a folder with no git repository (#11405)", () => {
+    /**
+     * Every monitor is a `GitStatusPass` poller, and its first tick against a
+     * non-repo raises `WorktreeRemovedError` — which the pass answers by
+     * removing the workspace. So the invariant under test is that none is ever
+     * created, not that they cope.
+     */
+    function monitorCount(): number {
+      return (service["monitors"] as Map<string, unknown>).size;
+    }
+
+    beforeEach(() => {
+      mockSimpleGit.checkIsRepo.mockResolvedValue(false);
+    });
+
+    it("loads successfully instead of surfacing a worktree-load failure", async () => {
+      await service.loadProject("req-plain", "/downloads", "ws-plain");
+
+      expect(sentEvents).toContainEqual({
+        type: "load-project-result",
+        requestId: "req-plain",
+        success: true,
+      });
+      expect(sentEvents.some((e) => e.type === "load-project-result" && !e.success)).toBe(false);
+    });
+
+    it("starts no worktree monitor, watcher, or enumeration", async () => {
+      const listService = service["listService"] as unknown as { list: Mock };
+      listService.list = vi.fn();
+      const startWatcher = vi.spyOn(
+        service["topologyWatcher"] as unknown as { startWatcher: () => Promise<void> },
+        "startWatcher"
+      );
+
+      await service.loadProject("req-plain", "/downloads", "ws-plain");
+
+      expect(monitorCount()).toBe(0);
+      expect(listService.list).not.toHaveBeenCalled();
+      expect(startWatcher).not.toHaveBeenCalled();
+      // `worktree prune` writes into `.git`; a folder Daintree merely adopted
+      // must never be written to.
+      expect(mockSimpleGit.raw).not.toHaveBeenCalled();
+    });
+
+    it("stays inert when the workspace is foregrounded again", async () => {
+      await service.loadProject("req-plain", "/downloads", "ws-plain");
+      const startWatcher = vi.spyOn(
+        service["topologyWatcher"] as unknown as { startWatcher: () => Promise<void> },
+        "startWatcher"
+      );
+
+      service.pause();
+      service.resume();
+
+      expect(startWatcher).not.toHaveBeenCalled();
+      expect(monitorCount()).toBe(0);
+    });
+
+    it("does not mint a monitor on a later topology reconcile", async () => {
+      await service.loadProject("req-plain", "/downloads", "ws-plain");
+
+      await (service as unknown as { discoverAndSyncWorktrees: () => Promise<void> })[
+        "discoverAndSyncWorktrees"
+      ]();
+
+      expect(monitorCount()).toBe(0);
+    });
+
+    it("treats a throwing repository probe as no repository", async () => {
+      // simple-git rejects rather than answering false on permission denials
+      // and other environment faults.
+      mockSimpleGit.checkIsRepo.mockRejectedValue(new Error("EACCES"));
+
+      await service.loadProject("req-denied", "/downloads", "ws-plain");
+
+      expect(sentEvents).toContainEqual({
+        type: "load-project-result",
+        requestId: "req-denied",
+        success: true,
+      });
+      expect(monitorCount()).toBe(0);
+    });
   });
 
   it("returns a failure when git worktree add hits index.lock contention", async () => {

--- a/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
@@ -5,6 +5,7 @@ import type { WorkspaceService } from "../WorkspaceService.js";
 
 const mockSimpleGit = {
   raw: vi.fn().mockResolvedValue(undefined),
+  checkIsRepo: vi.fn().mockResolvedValue(true),
   branch: vi.fn().mockResolvedValue({ current: "main" }),
   branchLocal: vi.fn().mockResolvedValue({ all: [], current: "", branches: {}, detached: false }),
 };
@@ -175,6 +176,7 @@ describe("WorkspaceService.createWorktree", () => {
     // the second test onwards, which the createWorktree pre-flight handles
     // via try/catch — but the fallback masks real test failures.
     mockSimpleGit.raw.mockResolvedValue(undefined);
+    mockSimpleGit.checkIsRepo.mockResolvedValue(true);
     mockSimpleGit.branch.mockResolvedValue({ current: "main" });
     mockSimpleGit.branchLocal.mockResolvedValue({
       all: [],
@@ -1456,6 +1458,8 @@ describe("WorkspaceService.loadProject performance behavior", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    mockSimpleGit.raw.mockResolvedValue(undefined);
+    mockSimpleGit.checkIsRepo.mockResolvedValue(true);
     mockSendEvent = vi.fn();
     const WorkspaceServiceModule = await import("../WorkspaceService.js");
     service = new WorkspaceServiceModule.WorkspaceService(

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -82,9 +82,11 @@ export type {
 export type { BrowserHistory } from "./browser.js";
 
 // Project types
+export { isGitBackedProject } from "./project.js";
 export type {
   ProjectStatus,
   Project,
+  ProjectAddOptions,
   ProjectCreationIdentity,
   ProjectRepoStats,
   TerminalSnapshot,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -5,7 +5,7 @@ import type { TabGroup } from "../panel.js";
 import type { WorktreeState } from "../worktree.js";
 import type {
   Project,
-  ProjectCreationIdentity,
+  ProjectAddOptions,
   ProjectSettings,
   RecipeNameCollision,
   RunCommand,
@@ -536,7 +536,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
   project: {
     getAll(): Promise<Project[]>;
     getCurrent(): Promise<Project | null>;
-    add(path: string, identity?: ProjectCreationIdentity): Promise<Project>;
+    add(path: string, options?: ProjectAddOptions): Promise<Project>;
     remove(projectId: string): Promise<void>;
     update(projectId: string, updates: Partial<Project>): Promise<Project>;
     switch(

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -3,7 +3,7 @@ import type { AgentId } from "../agent.js";
 import type { VoiceInputError, VoiceInputStatus } from "../voice.js";
 import type {
   Project,
-  ProjectCreationIdentity,
+  ProjectAddOptions,
   ProjectSettings,
   RecipeNameCollision,
   RunCommand,
@@ -591,7 +591,7 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     result: Project | null;
   };
   "project:add": {
-    args: [path: string, identity?: ProjectCreationIdentity];
+    args: [path: string, options?: ProjectAddOptions];
     result: Project;
   };
   "project:remove": {

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -56,11 +56,11 @@ export interface ProjectRepoStats {
   lastUpdated: number | null;
 }
 
-/** Project (Git repository) managed by Daintree */
+/** Workspace managed by Daintree — a git repository, or a plain folder. */
 export interface Project {
   /** Unique identifier (UUID or path hash) */
   id: string;
-  /** Git repository root path */
+  /** Git repository root, or the adopted folder itself when {@link Project.gitBacked} is false */
   path: string;
   /** User-editable display name */
   name: string;
@@ -95,6 +95,41 @@ export interface Project {
    * the write; absent until the project's first clean stats poll.
    */
   lastKnownStats?: ProjectRepoStats;
+  /**
+   * `false` for a folder opened without git (issue #11405) — worktrees, review,
+   * and diffs don't apply to it. Absent on every repository-backed project and
+   * every row predating the field, so absence means git-backed. Read it through
+   * {@link isGitBackedProject} rather than testing the field directly.
+   */
+  gitBacked?: boolean;
+}
+
+/** Options for registering a folder as a workspace. */
+export interface ProjectAddOptions {
+  /**
+   * `false` adopts a folder that isn't a git repository. Omitted keeps the
+   * strict git-root requirement, so an unknown non-repo still fails with
+   * `NOT_A_GIT_REPO` and drives the choice dialog.
+   */
+  gitBacked?: boolean;
+  /**
+   * Name/emoji chosen in a creation dialog, applied only where a brand-new row
+   * is minted. Kept as its own key rather than flattened alongside
+   * {@link ProjectAddOptions.gitBacked}: the main-process validator drops a
+   * creation identity whole unless both halves are present, so a flattened
+   * payload carrying only `gitBacked` would be discarded silently.
+   */
+  identity?: ProjectCreationIdentity;
+}
+
+/**
+ * Whether git-backed surfaces (worktrees, review, diffs, branch labels) apply.
+ * Absence means git-backed — legacy rows carry no discriminator.
+ */
+export function isGitBackedProject(
+  project: Pick<Project, "gitBacked"> | null | undefined
+): boolean {
+  return project?.gitBacked !== false;
 }
 
 /**

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -181,6 +181,8 @@ function AppInner() {
   const gitInitIdentity = useProjectStore((state) => state.gitInitIdentity);
   const closeGitInitDialog = useProjectStore((state) => state.closeGitInitDialog);
   const handleGitInitSuccess = useProjectStore((state) => state.handleGitInitSuccess);
+  const gitInitDialogStep = useProjectStore((state) => state.gitInitDialogStep);
+  const openWithoutGit = useProjectStore((state) => state.openWithoutGit);
   const createFolderDialogOpen = useProjectStore((state) => state.createFolderDialogOpen);
   const closeCreateFolderDialog = useProjectStore((state) => state.closeCreateFolderDialog);
 
@@ -600,7 +602,9 @@ function AppInner() {
                 shouldMountGitInitDialog={shouldMountGitInitDialog}
                 effectiveGitInitPath={effectiveGitInitPath}
                 effectiveGitInitIdentity={effectiveGitInitIdentity}
+                gitInitDialogStep={gitInitDialogStep}
                 handleGitInitSuccess={handleGitInitSuccess}
+                openWithoutGit={openWithoutGit}
                 closeGitInitDialog={closeGitInitDialog}
                 createFolderDialogOpen={createFolderDialogOpen}
                 shouldMountCreateFolderDialog={shouldMountCreateFolderDialog}

--- a/src/ModalHostLayer.tsx
+++ b/src/ModalHostLayer.tsx
@@ -15,6 +15,7 @@ import type { ReEntrySummaryState } from "./hooks/useReEntrySummary";
 import type { UseAgentLauncherReturn } from "./hooks/useAgentLauncher";
 import type { PluginDeepLinkState } from "./hooks/app";
 import type { SettingsTab } from "./components/Settings";
+import type { NonGitFolderStep } from "./components/Project/NonGitFolderDialog";
 import type { BuiltInPanelKind } from "./types";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { ConfirmDialog } from "./components/ui/ConfirmDialog";
@@ -138,7 +139,9 @@ interface ModalHostLayerProps {
   shouldMountGitInitDialog: boolean;
   effectiveGitInitPath: string | null;
   effectiveGitInitIdentity: ProjectCreationIdentity | null;
+  gitInitDialogStep: NonGitFolderStep;
   handleGitInitSuccess: (identity?: ProjectCreationIdentity) => Promise<void>;
+  openWithoutGit: () => Promise<void>;
   closeGitInitDialog: () => void;
   createFolderDialogOpen: boolean;
   shouldMountCreateFolderDialog: boolean;
@@ -230,7 +233,9 @@ export function ModalHostLayer({
   shouldMountGitInitDialog,
   effectiveGitInitPath,
   effectiveGitInitIdentity,
+  gitInitDialogStep,
   handleGitInitSuccess,
+  openWithoutGit,
   closeGitInitDialog,
   createFolderDialogOpen,
   shouldMountCreateFolderDialog,
@@ -761,7 +766,7 @@ export function ModalHostLayer({
 
       <ErrorBoundary
         variant="component"
-        componentName="GitInitDialog"
+        componentName="NonGitFolderDialog"
         resetKeys={[Number(gitInitDialogOpen)]}
       >
         {shouldMountGitInitDialog && effectiveGitInitPath && (
@@ -769,8 +774,10 @@ export function ModalHostLayer({
             <LazyGitInitDialog
               isOpen={gitInitDialogOpen}
               directoryPath={effectiveGitInitPath}
+              initialStep={gitInitDialogStep}
               initialIdentity={effectiveGitInitIdentity}
-              onSuccess={handleGitInitSuccess}
+              onOpenWithoutGit={openWithoutGit}
+              onInitSuccess={handleGitInitSuccess}
               onCancel={closeGitInitDialog}
             />
           </Suspense>

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -1,6 +1,6 @@
 import type {
   Project,
-  ProjectCreationIdentity,
+  ProjectAddOptions,
   ProjectSettings,
   RunCommand,
   ProjectCloseResult,
@@ -112,8 +112,8 @@ export const projectClient = {
     return inflight;
   },
 
-  add: (path: string, identity?: ProjectCreationIdentity): Promise<Project> => {
-    return window.electron.project.add(path, identity);
+  add: (path: string, options?: ProjectAddOptions): Promise<Project> => {
+    return window.electron.project.add(path, options);
   },
 
   remove: (projectId: string): Promise<void> => {

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -93,6 +93,7 @@ import { useNotificationHistoryStore } from "@/store/slices/notificationHistoryS
 import { agentStateDotColor } from "@/components/Worktree/AgentStatusIndicator";
 import { notify } from "@/lib/notify";
 import type { CliAvailability, AgentSettings, AgentState } from "@shared/types";
+import { isGitBackedProject } from "@shared/types";
 import type { ForgeRepositoryStats } from "@shared/types/ipc/forge";
 import { isAgentToolbarVisible } from "../../../shared/utils/agentPinned";
 import { projectClient } from "@/clients";
@@ -971,8 +972,11 @@ export function Toolbar({
         // local git data). Placeholder (not removal) when no project: the
         // slot's no-drag rectangle must exist on first paint regardless
         // (PROJECT_SCOPED_TOOLBAR_IDS).
+        // A workspace with no repository has no commits, issues or PRs to
+        // report, so it takes the placeholder too — which also keeps the
+        // button's stats polling from ever starting for it (#11405).
         render: () =>
-          currentProject ? (
+          currentProject && isGitBackedProject(currentProject) ? (
             <ForgeStatsToolbarButton
               key="forge-stats"
               ref={forgeStatsRef}
@@ -1470,7 +1474,11 @@ export function Toolbar({
 
   const activeSearchableProject = projectSwitcher.activeProject;
   const truncatedBranchName = branchName ? middleTruncate(branchName, 24) : undefined;
-  const chipState = branchChipState(workspaceIdentity.kind, branchName);
+  const chipState = branchChipState(
+    workspaceIdentity.kind,
+    branchName,
+    isGitBackedProject(currentProject)
+  );
   const { copy: copyPillPath } = useCopyWithFeedback({ announcement: "Path copied" });
   const handleCopyProjectPath = useCallback(() => {
     if (!currentProject) return;

--- a/src/components/Project/NonGitFolderDialog.tsx
+++ b/src/components/Project/NonGitFolderDialog.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { AppDialog } from "@/components/ui/AppDialog";
+import { FolderOpen } from "@/components/icons";
+import { GitInitDialog } from "./GitInitDialog";
+import type { ProjectCreationIdentity } from "@shared/types";
+
+export type NonGitFolderStep = "choice" | "initialize";
+
+interface NonGitFolderDialogProps {
+  isOpen: boolean;
+  directoryPath: string;
+  /** `"initialize"` skips straight to git setup, for the sidebar's upgrade CTA. */
+  initialStep: NonGitFolderStep;
+  /**
+   * Identity chosen one dialog earlier in the create-project flow, forwarded
+   * verbatim to git setup. Absent when the folder was opened directly, which is
+   * what lets {@link GitInitDialog} derive a suggestion from the folder name.
+   */
+  initialIdentity?: ProjectCreationIdentity | null;
+  onOpenWithoutGit: () => void;
+  onInitSuccess: (identity: ProjectCreationIdentity) => void;
+  onCancel: () => void;
+}
+
+function folderName(directoryPath: string): string {
+  const segments = directoryPath.split(/[/\\]/).filter(Boolean);
+  return segments[segments.length - 1] ?? directoryPath;
+}
+
+/**
+ * What a folder with no repository offers: adopt it as-is, or set git up first.
+ *
+ * The initialize branch defers entirely to {@link GitInitDialog}, and is mounted
+ * only once chosen — its progress subscription and auto-close timer should not
+ * be live while the user is still deciding.
+ */
+export function NonGitFolderDialog({
+  isOpen,
+  directoryPath,
+  initialStep,
+  initialIdentity,
+  onOpenWithoutGit,
+  onInitSuccess,
+  onCancel,
+}: NonGitFolderDialogProps) {
+  const [step, setStep] = useState<NonGitFolderStep>(initialStep);
+
+  // Re-arm on close rather than on open: the dialog animates out while still
+  // mounted, and resetting the step on the way in would swap the body back to
+  // the choice screen underneath a closing initialize step.
+  useEffect(() => {
+    if (!isOpen) setStep(initialStep);
+  }, [isOpen, initialStep]);
+
+  if (step === "initialize") {
+    return (
+      <GitInitDialog
+        isOpen={isOpen}
+        directoryPath={directoryPath}
+        initialIdentity={initialIdentity}
+        onSuccess={onInitSuccess}
+        onCancel={onCancel}
+      />
+    );
+  }
+
+  return (
+    <AppDialog isOpen={isOpen} onClose={onCancel} size="md">
+      <AppDialog.Header>
+        <AppDialog.Title icon={<FolderOpen className="h-5 w-5 text-daintree-text/70" />}>
+          Open &lsquo;{folderName(directoryPath)}&rsquo;?
+        </AppDialog.Title>
+        <AppDialog.CloseButton />
+      </AppDialog.Header>
+
+      <AppDialog.Body className="space-y-3">
+        <div className="text-sm text-muted-foreground truncate">{directoryPath}</div>
+        <p className="text-sm text-daintree-text/70">
+          This folder isn&rsquo;t a git repository. Open it as-is and terminals, agents, recipes,
+          and the file browser all work — worktrees, review, and diffs stay unavailable until it
+          becomes a repository. Nothing in the folder is changed either way.
+        </p>
+      </AppDialog.Body>
+
+      <AppDialog.Footer>
+        <Button variant="outline" onClick={() => setStep("initialize")}>
+          Initialize repository
+        </Button>
+        <Button onClick={onOpenWithoutGit}>Open without git</Button>
+      </AppDialog.Footer>
+    </AppDialog>
+  );
+}

--- a/src/components/Project/__tests__/NonGitFolderDialog.test.tsx
+++ b/src/components/Project/__tests__/NonGitFolderDialog.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { ReactNode, ButtonHTMLAttributes } from "react";
+
+const gitInitDialogSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("../GitInitDialog", () => ({
+  GitInitDialog: (props: { directoryPath: string }) => {
+    gitInitDialogSpy(props);
+    return <div data-testid="git-init-dialog" />;
+  },
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/AppDialog", () => {
+  interface AppDialogMockProps {
+    isOpen: boolean;
+    children: ReactNode;
+    onClose: () => void;
+  }
+  interface SectionProps {
+    children: ReactNode;
+  }
+
+  const AppDialog = ({ isOpen, children, onClose }: AppDialogMockProps) =>
+    isOpen ? (
+      <div data-testid="app-dialog">
+        <button type="button" onClick={onClose}>
+          dialog-close
+        </button>
+        {children}
+      </div>
+    ) : null;
+
+  AppDialog.Header = ({ children }: SectionProps) => <div>{children}</div>;
+  AppDialog.Title = ({ children }: SectionProps) => <h2>{children}</h2>;
+  AppDialog.CloseButton = () => <button type="button">close</button>;
+  AppDialog.Body = ({ children }: SectionProps) => <div>{children}</div>;
+  AppDialog.Footer = ({ children }: SectionProps) => <div>{children}</div>;
+
+  return { AppDialog };
+});
+
+import { NonGitFolderDialog } from "../NonGitFolderDialog";
+
+const DIRECTORY = "/Users/someone/Downloads/archive";
+
+function renderDialog(overrides: Partial<Parameters<typeof NonGitFolderDialog>[0]> = {}) {
+  const props = {
+    isOpen: true,
+    directoryPath: DIRECTORY,
+    initialStep: "choice" as const,
+    onOpenWithoutGit: vi.fn(),
+    onInitSuccess: vi.fn(),
+    onCancel: vi.fn(),
+    ...overrides,
+  };
+  return { props, ...render(<NonGitFolderDialog {...props} />) };
+}
+
+describe("NonGitFolderDialog (#11405)", () => {
+  beforeEach(() => {
+    gitInitDialogSpy.mockClear();
+  });
+
+  it("names the folder being opened", () => {
+    renderDialog();
+
+    expect(screen.getByRole("heading").textContent).toContain("archive");
+  });
+
+  it("offers both paths without initializing anything yet", () => {
+    renderDialog();
+
+    expect(screen.getByText("Open without git")).toBeTruthy();
+    expect(screen.getByText("Initialize repository")).toBeTruthy();
+    // Mounting git setup early would start its progress subscription and
+    // auto-close timer while the user is still deciding.
+    expect(gitInitDialogSpy).not.toHaveBeenCalled();
+  });
+
+  it("adopts the folder when the user opens it without git", () => {
+    const { props } = renderDialog();
+
+    fireEvent.click(screen.getByText("Open without git"));
+
+    expect(props.onOpenWithoutGit).toHaveBeenCalledTimes(1);
+    expect(props.onInitSuccess).not.toHaveBeenCalled();
+  });
+
+  it("hands the same folder to git setup when that is chosen", () => {
+    renderDialog();
+
+    fireEvent.click(screen.getByText("Initialize repository"));
+
+    expect(screen.getByTestId("git-init-dialog")).toBeTruthy();
+    expect(gitInitDialogSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ directoryPath: DIRECTORY })
+    );
+  });
+
+  it("opens straight into git setup when asked to (sidebar upgrade)", () => {
+    renderDialog({ initialStep: "initialize" });
+
+    expect(screen.getByTestId("git-init-dialog")).toBeTruthy();
+    expect(screen.queryByText("Open without git")).toBeNull();
+  });
+
+  it("keeps the chosen step until the dialog has closed", () => {
+    const { rerender, props } = renderDialog();
+    fireEvent.click(screen.getByText("Initialize repository"));
+
+    // Closing animates out while still mounted; swapping the body back to the
+    // choice screen mid-exit would flash the wrong content.
+    rerender(<NonGitFolderDialog {...props} isOpen={false} />);
+    rerender(<NonGitFolderDialog {...props} isOpen={true} />);
+
+    expect(screen.getByText("Open without git")).toBeTruthy();
+  });
+});

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -20,6 +20,8 @@ import {
 } from "react-virtuoso";
 import { AlertTriangle, FolderOpen, LayoutGrid, Plus, RefreshCw, Zap } from "lucide-react";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { Button } from "@/components/ui/button";
+import { isGitBackedProject } from "@shared/types";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { Skeleton, SkeletonBone, SkeletonHint } from "@/components/ui/Skeleton";
 import { ScrollIndicator } from "@/components/Worktree/ScrollIndicator";
@@ -1520,6 +1522,51 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       }}
     />
   );
+
+  // A workspace opened without git has no worktrees to wait for or fail at, so
+  // it takes neither the skeleton nor the "Open a Git repository" nudge. Paired
+  // with the empty list rather than read alone: a folder that has since been
+  // initialized externally loads worktrees normally, and those must win over a
+  // flag that is only reconciled the next time the folder is opened (#11405).
+  if (!isGitBackedProject(currentProject) && worktrees.length === 0) {
+    return (
+      <>
+        <div className="flex flex-col h-full">
+          <div className="flex items-center px-4 py-2 border-b border-divider shrink-0">
+            <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Worktrees</h2>
+          </div>
+          <EmptyState
+            variant="zero-data"
+            scale="sidebar"
+            icon={<FolderOpen />}
+            title="Initialize a repository to use worktrees"
+            action={
+              <div className="flex flex-col items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    if (currentProject) {
+                      useProjectStore
+                        .getState()
+                        .openGitInitDialog(currentProject.path, { step: "initialize" });
+                    }
+                  }}
+                >
+                  Initialize repository
+                </Button>
+                <span className="text-xs text-daintree-text/50">
+                  Terminals, agents, and recipes work without one
+                </span>
+              </div>
+            }
+            className="flex-1"
+          />
+        </div>
+        {restartConfirmDialog}
+      </>
+    );
+  }
 
   if (isLoading && worktrees.length === 0) {
     return (

--- a/src/components/Sidebar/__tests__/SidebarContent.lightweight.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.lightweight.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+
+const SIDEBAR_CONTENT_PATH = path.resolve(__dirname, "../SidebarContent.tsx");
+
+/**
+ * The sidebar's branches are ordered early-returns, so what matters for a
+ * workspace opened without git (#11405) is *where* its branch sits relative to
+ * the loading skeleton and the "Open a Git repository" nudge — both of which
+ * would otherwise claim the same zero-worktree state and mislead.
+ */
+describe("SidebarContent — workspace opened without git (#11405)", () => {
+  let source: string;
+
+  beforeAll(async () => {
+    source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
+  });
+
+  it("decides on the project's mode, not on the absence of worktrees alone", () => {
+    // Reading the flag alone would misreport a folder initialized externally,
+    // whose host does load worktrees; those must win over a stale flag.
+    expect(source).toMatch(/!isGitBackedProject\(currentProject\)\s*&&\s*worktrees\.length === 0/);
+  });
+
+  it("answers before the loading skeleton, which would otherwise never resolve", () => {
+    const gate = source.indexOf("!isGitBackedProject(currentProject)");
+    const skeleton = source.indexOf("if (isLoading && worktrees.length === 0)");
+    expect(gate).toBeGreaterThan(-1);
+    expect(skeleton).toBeGreaterThan(-1);
+    expect(gate).toBeLessThan(skeleton);
+  });
+
+  it("answers before the zero-worktree branch that nudges toward opening a repository", () => {
+    const gate = source.indexOf("!isGitBackedProject(currentProject)");
+    const zeroWorktrees = source.indexOf("if (worktrees.length === 0)");
+    expect(zeroWorktrees).toBeGreaterThan(-1);
+    expect(gate).toBeLessThan(zeroWorktrees);
+  });
+
+  it("offers the upgrade at the initialize step rather than re-asking the choice", () => {
+    expect(source).toMatch(
+      /openGitInitDialog\(\s*currentProject\.path,\s*\{\s*step:\s*"initialize"\s*\}\s*\)/
+    );
+  });
+});

--- a/src/hooks/app/__tests__/useEmptyCanvasContent.test.tsx
+++ b/src/hooks/app/__tests__/useEmptyCanvasContent.test.tsx
@@ -3,7 +3,15 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, renderHook } from "@testing-library/react";
 
 const h = vi.hoisted(() => ({
-  projectState: { currentProject: null as { id: string; name: string; path: string } | null },
+  projectState: {
+    currentProject: null as {
+      id: string;
+      name: string;
+      path: string;
+      emoji?: string;
+      gitBacked?: boolean;
+    } | null,
+  },
   scratchState: {
     currentScratch: null as { id: string; name: string; path: string } | null,
   },
@@ -116,6 +124,61 @@ describe("useEmptyCanvasContent", () => {
 
       expect(result.emptyContent).toBeUndefined();
       expect(result.workspaceId).toBe(project.id);
+    });
+  });
+
+  describe("with a project opened without git (#11405)", () => {
+    const lightweight = {
+      id: "project-2",
+      name: "downloads",
+      path: "/Users/someone/Downloads",
+      emoji: "🌳",
+      gitBacked: false,
+    };
+
+    beforeEach(() => {
+      h.projectState.currentProject = lightweight;
+    });
+
+    // Deferring would hand the grid `hasLaunchTarget: ctx.hasActiveWorktree`,
+    // and there is no worktree — so the folder the user just opened would offer
+    // no way to start an agent in it.
+    it("supplies the launcher instead of deferring to worktree-derived context", () => {
+      render(<>{renderContent().current.emptyContent}</>);
+
+      expect(emptyStateProps().hasLaunchTarget).toBe(true);
+    });
+
+    it("launches into the folder itself", () => {
+      render(<>{renderContent().current.emptyContent}</>);
+
+      const props = emptyStateProps();
+      expect(props.defaultCwd).toBe(lightweight.path);
+      expect(props.activeWorktreePath).toBe(lightweight.path);
+      expect(props.workspaceName).toBe(lightweight.name);
+    });
+
+    it("keeps the project affordances a scratch lacks", () => {
+      render(<>{renderContent().current.emptyContent}</>);
+
+      // It is a real project row, so settings and recipes apply — unlike a
+      // scratch, which has neither.
+      expect(emptyStateProps().hasProjectContext).toBe(true);
+    });
+
+    it("claims no worktrees and no git-derived pulse", () => {
+      render(<>{renderContent().current.emptyContent}</>);
+
+      const props = emptyStateProps();
+      expect(props.hasWorktrees).toBe(false);
+      expect(props.isWorktreeInitialized).toBe(false);
+      expect(props.showProjectPulse).toBe(false);
+    });
+
+    it("still defers for a git-backed project", () => {
+      h.projectState.currentProject = { ...lightweight, gitBacked: undefined };
+
+      expect(renderContent().current.emptyContent).toBeUndefined();
     });
   });
 

--- a/src/hooks/app/useEmptyCanvasContent.tsx
+++ b/src/hooks/app/useEmptyCanvasContent.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import type { GettingStartedChecklistState } from "@/hooks/app/useGettingStartedChecklist";
+import { isGitBackedProject } from "@shared/types";
 import { useProjectStore } from "@/store";
 import { useScratchStore } from "@/store/scratchStore";
 import { ContentGridEmptyState } from "@/components/Terminal/ContentGridEmptyState";
@@ -15,6 +16,12 @@ import { LazyWelcomeScreen } from "@/lazyPanels";
  * has no worktree, branch, recipes or project settings, so those affordances
  * stay off. A project returns `undefined`, deferring to the grid's own
  * context-driven empty state.
+ *
+ * A project opened without git (#11405) is the third case: the grid derives its
+ * launch target from the active worktree, and this one has none, so deferring
+ * would leave the user no way to start an agent in the folder they just opened.
+ * It supplies the target explicitly like a scratch does, but keeps the project
+ * affordances a scratch lacks — it has real settings and recipes.
  */
 export function useEmptyCanvasContent(gettingStarted: GettingStartedChecklistState): {
   emptyContent: React.ReactNode | undefined;
@@ -26,6 +33,24 @@ export function useEmptyCanvasContent(gettingStarted: GettingStartedChecklistSta
   const canvas = resolveEmptyCanvas(currentProject, currentScratch);
 
   if (canvas.kind === "project") {
+    if (currentProject && !isGitBackedProject(currentProject)) {
+      return {
+        emptyContent: (
+          <ContentGridEmptyState
+            hasLaunchTarget
+            hasProjectContext
+            hasWorktrees={false}
+            isWorktreeInitialized={false}
+            workspaceName={currentProject.name}
+            projectEmoji={currentProject.emoji}
+            activeWorktreePath={currentProject.path}
+            showProjectPulse={false}
+            defaultCwd={currentProject.path}
+          />
+        ),
+        workspaceId: currentProject.id,
+      };
+    }
     return { emptyContent: undefined, workspaceId: currentProject?.id ?? null };
   }
 

--- a/src/lazyPanels.ts
+++ b/src/lazyPanels.ts
@@ -104,10 +104,10 @@ export const LazyProjectSwitcherPalette = lazy(() =>
 );
 
 export function preloadGitInitDialog() {
-  return import("./components/Project/GitInitDialog");
+  return import("./components/Project/NonGitFolderDialog");
 }
 export const LazyGitInitDialog = lazy(() =>
-  preloadGitInitDialog().then((m) => ({ default: m.GitInitDialog }))
+  preloadGitInitDialog().then((m) => ({ default: m.NonGitFolderDialog }))
 );
 
 export function preloadCloneRepoDialog() {

--- a/src/lib/__tests__/workspaceIdentity.test.ts
+++ b/src/lib/__tests__/workspaceIdentity.test.ts
@@ -84,6 +84,22 @@ describe("branchChipState", () => {
     expect(branchChipState("none", "feature/x")).toBe("reserved");
   });
 
+  it("drops the chip for a project opened without git — issue #11405", () => {
+    // Same reasoning as a scratch: no repository means no branch is ever coming,
+    // so holding the width would leave a permanently blank chip.
+    expect(branchChipState("project", undefined, false)).toBe("hidden");
+  });
+
+  it("drops the chip for a git-free project even if a stale branch is selected", () => {
+    expect(branchChipState("project", "feature/x", false)).toBe("hidden");
+  });
+
+  it("treats an unspecified mode as git-backed, preserving existing callers", () => {
+    expect(branchChipState("project", "feature/x")).toBe(
+      branchChipState("project", "feature/x", true)
+    );
+  });
+
   it("never shows a branch outside a project", () => {
     const outsideProject = (["scratch", "none"] as const).map((kind) =>
       branchChipState(kind, "feature/x")

--- a/src/lib/workspaceIdentity.ts
+++ b/src/lib/workspaceIdentity.ts
@@ -34,8 +34,9 @@ export function activeWorkspaceIdentity(
 /**
  * How the toolbar pill's git-branch chip should render.
  *
- * - `hidden` — not mounted at all. A scratch workspace is never a git repo, so a
- *   faded chip would only reserve blank width beside the name (issue #11084).
+ * - `hidden` — not mounted at all. A scratch workspace is never a git repo, and
+ *   neither is a folder opened without one (#11405), so a faded chip would only
+ *   reserve blank width beside the name (issue #11084).
  * - `reserved` — mounted but transparent, holding the chip's width. A project's
  *   branch can arrive late (a view first-paints before its project binds) or never
  *   (detached HEAD); collapsing the pill then would shift the titlebar's no-drag
@@ -46,9 +47,10 @@ export type BranchChipState = "hidden" | "reserved" | "visible";
 
 export function branchChipState(
   kind: ActiveWorkspaceIdentity["kind"],
-  branchName: string | null | undefined
+  branchName: string | null | undefined,
+  gitBacked: boolean = true
 ): BranchChipState {
-  if (kind === "scratch") return "hidden";
+  if (kind === "scratch" || !gitBacked) return "hidden";
   // `branchName` rides the worktree selection, which closing a project does not
   // clear — so it can outlive `currentProject`. Requiring a project keeps a closed
   // project's branch from lingering beside the "Open project" empty state.

--- a/src/store/__tests__/projectStore.addProject.test.ts
+++ b/src/store/__tests__/projectStore.addProject.test.ts
@@ -31,6 +31,10 @@ const terminalClientMock = {
   getSharedBuffers: vi.fn().mockResolvedValue({ visualBuffers: [], signalBuffer: null }),
 };
 
+const worktreeClientMock = {
+  retryProjectLoad: vi.fn().mockResolvedValue(undefined),
+};
+
 const notifyMock = vi.fn().mockReturnValue("");
 
 const actionServiceDispatchMock = vi.fn().mockResolvedValue({ ok: true });
@@ -43,6 +47,7 @@ vi.mock("@/clients", () => ({
   projectClient: projectClientMock,
   appClient: appClientMock,
   terminalClient: terminalClientMock,
+  worktreeClient: worktreeClientMock,
 }));
 
 vi.mock("@/lib/notify", () => ({
@@ -119,8 +124,7 @@ describe("projectStore addProject", () => {
       .handleCloneSuccess("/tmp/cloned", { name: "cloned", emoji: "📦" });
 
     expect(projectClientMock.add).toHaveBeenCalledWith("/tmp/cloned", {
-      name: "cloned",
-      emoji: "📦",
+      identity: { name: "cloned", emoji: "📦" },
     });
   });
 
@@ -229,7 +233,9 @@ describe("projectStore addProject", () => {
   });
 
   it("clears the carried identity together with the path on close", () => {
-    useProjectStore.getState().openGitInitDialog("/tmp/repo", { name: "N", emoji: "🚀" });
+    useProjectStore
+      .getState()
+      .openGitInitDialog("/tmp/repo", { identity: { name: "N", emoji: "🚀" } });
     expect(useProjectStore.getState().gitInitIdentity).toEqual({ name: "N", emoji: "🚀" });
 
     useProjectStore.getState().closeGitInitDialog();
@@ -392,6 +398,60 @@ describe("projectStore addProject", () => {
         (call) => (call[0] as { title?: string }).title === "Couldn't add project"
       );
       expect(genericToasts.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("opening a folder without git (#11405)", () => {
+    const LIGHTWEIGHT = { id: "p-light", path: "/tmp/downloads", name: "downloads" };
+
+    beforeEach(() => {
+      useProjectStore.setState({ gitInitDirectoryPath: "/tmp/downloads" });
+      projectClientMock.add.mockResolvedValue(LIGHTWEIGHT);
+      projectClientMock.getAll.mockResolvedValue([LIGHTWEIGHT]);
+    });
+
+    it("opens the choice screen first when a folder has no repository", async () => {
+      projectClientMock.openDialog.mockResolvedValueOnce("/tmp/not-a-repo");
+      projectClientMock.add.mockRejectedValueOnce(
+        new Error("Not a git repository: /tmp/not-a-repo")
+      );
+
+      await useProjectStore.getState().addProject();
+
+      expect(useProjectStore.getState().gitInitDialogStep).toBe("choice");
+    });
+
+    it("asks main to drop the git requirement when the user opens without git", async () => {
+      await useProjectStore.getState().openWithoutGit();
+
+      expect(projectClientMock.add).toHaveBeenCalledWith("/tmp/downloads", { gitBacked: false });
+      expect(useProjectStore.getState().gitInitDialogOpen).toBe(false);
+    });
+
+    it("keeps the git requirement on an ordinary add", async () => {
+      await useProjectStore.getState().addProjectByPath("/tmp/some-repo");
+
+      expect(projectClientMock.add).toHaveBeenCalledWith("/tmp/some-repo", undefined);
+    });
+
+    it("reloads the workspace after initializing git in the open workspace", async () => {
+      useProjectStore.setState({
+        currentProject: { ...LIGHTWEIGHT, emoji: "🌳", lastOpened: 0, gitBacked: false },
+      });
+
+      await useProjectStore.getState().handleGitInitSuccess();
+
+      // The host loaded this folder with no repository and enumerated nothing;
+      // without a reload the sidebar would stay empty until the next switch.
+      expect(worktreeClientMock.retryProjectLoad).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not reload when git was initialized in some other folder", async () => {
+      useProjectStore.setState({ currentProject: null });
+
+      await useProjectStore.getState().handleGitInitSuccess();
+
+      expect(worktreeClientMock.retryProjectLoad).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -1,7 +1,13 @@
 import { create, type StateCreator } from "zustand";
 import { persist, subscribeWithSelector } from "zustand/middleware";
-import type { Project, ProjectCloseResult, ProjectCreationIdentity } from "@shared/types";
-import { projectClient } from "@/clients";
+import type {
+  Project,
+  ProjectAddOptions,
+  ProjectCloseResult,
+  ProjectCreationIdentity,
+} from "@shared/types";
+import { projectClient, worktreeClient } from "@/clients";
+import type { NonGitFolderStep } from "@/components/Project/NonGitFolderDialog";
 import { notify } from "@/lib/notify";
 import { actionService } from "@/services/ActionService";
 import { logErrorWithContext } from "@/utils/errorContext";
@@ -166,6 +172,8 @@ interface ProjectState {
    * derives its own suggestion. Cleared with the path, in the same set().
    */
   gitInitIdentity: ProjectCreationIdentity | null;
+  /** Which screen the non-git folder dialog opens on. */
+  gitInitDialogStep: NonGitFolderStep;
   createFolderDialogOpen: boolean;
   cloneRepoDialogOpen: boolean;
 
@@ -174,7 +182,11 @@ interface ProjectState {
   addProject: () => Promise<void>;
   addProjectByPath: (
     path: string,
-    options?: { skipDubiousOwnershipRetry?: boolean; identity?: ProjectCreationIdentity }
+    options?: {
+      skipDubiousOwnershipRetry?: boolean;
+      gitBacked?: boolean;
+      identity?: ProjectCreationIdentity;
+    }
   ) => Promise<void>;
   createProjectFolder: (parentPath: string, folderName: string, emoji?: string) => Promise<void>;
   switchProject: (
@@ -195,9 +207,13 @@ interface ProjectState {
   reopenProject: (projectId: string) => Promise<void>;
   checkMissingProjects: () => Promise<void>;
   locateProject: (projectId: string) => Promise<void>;
-  openGitInitDialog: (directoryPath: string, identity?: ProjectCreationIdentity) => void;
+  openGitInitDialog: (
+    directoryPath: string,
+    options?: { step?: NonGitFolderStep; identity?: ProjectCreationIdentity }
+  ) => void;
   closeGitInitDialog: () => void;
   handleGitInitSuccess: (identity?: ProjectCreationIdentity) => Promise<void>;
+  openWithoutGit: () => Promise<void>;
   openCreateFolderDialog: () => void;
   closeCreateFolderDialog: () => void;
   openCloneRepoDialog: () => void;
@@ -431,6 +447,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
   gitInitDialogOpen: false,
   gitInitDirectoryPath: null,
   gitInitIdentity: null,
+  gitInitDialogStep: "choice",
   createFolderDialogOpen: false,
   cloneRepoDialogOpen: false,
   error: null,
@@ -446,7 +463,18 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
         return;
       }
 
-      const newProject = await projectClient.add(resolvedPath, options?.identity);
+      // Built as two independent keys rather than one flattened payload: main
+      // validates the creation identity as a whole and drops it unless both
+      // halves are present, so a lightweight open carrying only `gitBacked`
+      // must not be routed through that gate.
+      const addOptions: ProjectAddOptions = {
+        ...(options?.gitBacked === false ? { gitBacked: false } : {}),
+        ...(options?.identity ? { identity: options.identity } : {}),
+      };
+      const newProject = await projectClient.add(
+        resolvedPath,
+        Object.keys(addOptions).length > 0 ? addOptions : undefined
+      );
 
       await get().loadProjects();
       await get().switchProject(newProject.id);
@@ -471,7 +499,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
           resolvedPath || path.trim() || errorMessage.match(/Not a git repository: (.+)/)?.[1];
         if (gitInitPath && isAbsolutePath(gitInitPath)) {
           set({ isLoading: false });
-          get().openGitInitDialog(gitInitPath, options?.identity);
+          get().openGitInitDialog(gitInitPath, { identity: options?.identity });
           return;
         }
       }
@@ -973,11 +1001,15 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     }
   },
 
-  openGitInitDialog: (directoryPath: string, identity?: ProjectCreationIdentity) => {
+  openGitInitDialog: (
+    directoryPath: string,
+    options?: { step?: NonGitFolderStep; identity?: ProjectCreationIdentity }
+  ) => {
     set({
       gitInitDialogOpen: true,
       gitInitDirectoryPath: directoryPath,
-      gitInitIdentity: identity ?? null,
+      gitInitDialogStep: options?.step ?? "choice",
+      gitInitIdentity: options?.identity ?? null,
     });
   },
 
@@ -991,8 +1023,31 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     const directoryPath = get().gitInitDirectoryPath;
     const carried = identity ?? get().gitInitIdentity ?? undefined;
     get().closeGitInitDialog();
+    if (!directoryPath) return;
+    // The folder is a repository now, so this add resolves a git root and clears
+    // any lightweight flag the row was carrying. A workspace host already loaded
+    // for it enumerated no worktrees, so it needs a reload to pick the new
+    // repository up (#11405).
+    const wasCurrent = get().currentProject?.path === directoryPath;
+    await get().addProjectByPath(directoryPath, { identity: carried });
+    if (wasCurrent) {
+      try {
+        await worktreeClient.retryProjectLoad();
+      } catch (error) {
+        logErrorWithContext(error, {
+          operation: "reload_after_git_init",
+          component: "projectStore",
+          details: { path: directoryPath },
+        });
+      }
+    }
+  },
+
+  openWithoutGit: async () => {
+    const directoryPath = get().gitInitDirectoryPath;
+    get().closeGitInitDialog();
     if (directoryPath) {
-      await get().addProjectByPath(directoryPath, { identity: carried });
+      await get().addProjectByPath(directoryPath, { gitBacked: false });
     }
   },
 


### PR DESCRIPTION
## Summary

- Opening a folder that isn't a git repository used to dead-end: `ProjectStore.addProject` resolved the git toplevel and threw `NOT_A_GIT_REPO`, and every entry point (the folder picker, Dock drop, Open With, the `daintree` CLI) funnelled through it, so the only way forward was letting Daintree run `git init` on the folder, the wrong move for something like `~/Downloads`.
- Now a folder can be adopted as-is: it opens as a lightweight workspace, shows up in the project switcher and recents, and Daintree never touches it, no `git init`, no auto-delete, no modification.
- Git init stays available as an explicit upgrade path, and the sidebar degrades to a not-applicable state instead of an error when there's no repository to read.

Resolves #11405

## Changes

**Persistence**: a nullable `git_backed` column, added via a hand-written migration `0008` (`db:generate` is frozen against a stale snapshot), plus a `Project.gitBacked` field. Absence of the value means git-backed, so no legacy row needs a backfill. Code reads it through an `isGitBackedProject` helper rather than testing the raw field.

**Decision logic**, all in `ProjectStore.addProject`:
- An explicit opt-in adopts a folder with no repository.
- An already-registered lightweight row reopens without re-prompting, that's what makes Recents, Dock, and the CLI work.
- A resolving git root promotes the row in place, which is what `git init` lands on.
- A registered repository whose git metadata is momentarily unreadable is never auto-demoted. An unmounted volume or a permissions blip would otherwise rewrite the row for good.

**The hazard this is built around**: `getWorktreeChangesWithStats` turns "not a git repository" into a `WorktreeRemovedError`, and `GitStatusPass` responds by calling `host.stop()` and `host.onRemoved()`, the path that deletes a workspace from the sidebar. Point a single monitor at a non-repo folder and it self-deletes the user's workspace on its first poll. The guard sits on `syncMonitors`, the only place a monitor gets constructed, rather than on its callers, because the `sync` host message arrives with a caller-supplied worktree list and `WorkspaceClient.sync` fans out to every live host.

**Host detection is a probe, not a flag**: `WorkspaceService.loadProject` asks the folder itself via `checkIsRepo()` in a try/catch (it rejects rather than returns false on permission denials). That avoids threading a mode value through `WorkspaceHostPool` and replacing hosts on transitions, and it fails safe: a row claiming git-backed whose `.git` folder vanished is spared the self-deletion too, which trusting a persisted flag wouldn't achieve.

**UI**:
- The non-git dialog becomes a choice: "Initialize repository" (the existing `GitInitDialog`, unchanged) or "Open without git".
- The sidebar shows a not-applicable state with an upgrade call-to-action instead of "Couldn't load worktrees".
- The branch chip hides (same precedent as scratch, #11084), and forge stats take their existing placeholder, which also stops the poll.
- The empty canvas supplies an explicit launch target. The grid normally derives one from the active worktree, and a lightweight workspace has none; without it, the folder you just opened offers no way to start an agent.
- The folder picker is retitled "Open Folder".

**Scope note**: scratch machinery is deliberately not reused. Scratches are app-managed folders under `userData/scratches/{uuid}`, and `ScratchCleanupService` deletes idle ones, pointing that at a user's real folder would be destructive. These are ordinary `Project` rows instead, so nothing ever auto-deletes or modifies the adopted folder.

## Testing

- 15,586 tests pass across every module this branch touches: `electron/services`, `electron/workspace-host`, `electron/services/persistence`, `electron/ipc/handlers`, and the renderer store/component/hook/lib suites.
- Composite `npm run typecheck` is clean, `lint:ratchet` reports no new warnings on any rule, `format:check` is clean, `db:check` is clean.
- All IPC and codegen guards pass: `check:channels`, `check:ipc`, `check:ipc-renderer`, `check:ipc-handwritten`, `check:api-surface`, `check:confirm-wiring`, `check:plugin-manifests`, `check:keybindings`.
- New test files: `ProjectStore.lightweight.test.ts`, `NonGitFolderDialog.test.tsx`, `SidebarContent.lightweight.test.ts`, plus a new describe block in `WorkspaceService.adversarial.test.ts` pinning that zero monitors are ever created, including against a `sync` call carrying another project's worktrees.
- No new E2E spec, deliberately: a spec that can't be run locally is a red CI risk, so the invariants are unit-tested instead.