### PR TITLE
feat(terminal): make file:// URLs in terminal output clickable

### DIFF
--- a/src/services/terminal/FileLinksAddon.ts
+++ b/src/services/terminal/FileLinksAddon.ts
@@ -9,9 +9,11 @@ import { formatErrorMessage } from "@shared/utils/errorMessage";
 import {
   DIR_PATH_REGEX,
   FILE_PATH_REGEX,
+  FILE_URL_REGEX,
   isPathExcluded,
   resolveDirPathCandidate,
   resolveFilePathCandidate,
+  resolveFileUrlCandidate,
 } from "./filePathDetection";
 import { fileBrowserClient } from "@/clients/fileBrowserClient";
 import type { TerminalLink } from "./types";
@@ -208,6 +210,46 @@ export class FileLinksAddon implements ILinkProvider {
     // re-matches a file token (`src/file.ts` satisfies both regexes) is
     // dropped instead of stacking a second link on the same characters.
     const claimed: Array<[number, number]> = [];
+
+    // `file://` URLs are scanned first so their ranges are claimed before the
+    // bare-path and directory passes. Gated on a substring test rather than
+    // run unconditionally: provideLinks is pointer-driven across every visible
+    // terminal, and virtually no line carries a scheme at all. `://` (not
+    // `file://`) keeps the guard case-insensitive without a lowercase copy.
+    if (lineText.includes("://")) {
+      for (const match of lineText.matchAll(FILE_URL_REGEX)) {
+        const url = match[1];
+        if (url === undefined) continue;
+
+        const resolved = resolveFileUrlCandidate(url);
+        if (!resolved) continue;
+
+        // Indexed off the capture, not `match[0]`: the match also spans the
+        // leading boundary character and any trailing sentence punctuation,
+        // neither of which the link should underline or own.
+        const startIndex = match.index + match[0]!.indexOf(url);
+        claimed.push([startIndex, startIndex + url.length]);
+
+        const range: IBufferRange = {
+          start: { x: startIndex + 1, y: bufferLineNumber },
+          end: { x: startIndex + url.length, y: bufferLineNumber },
+        };
+
+        // No line/col: `resolveFileUrlCandidate` deliberately doesn't peel a
+        // `:line` suffix off a URL, so there is none to forward.
+        links.push(
+          new FileLink(
+            range,
+            url,
+            resolved.absolutePath,
+            undefined,
+            undefined,
+            this._getCwd(),
+            this._onHover
+          )
+        );
+      }
+    }
 
     // matchAll on the module-scope global regex clones it internally (per spec)
     // and never mutates lastIndex, so the regex is reused across hover calls

--- a/src/services/terminal/FileLinksAddon.ts
+++ b/src/services/terminal/FileLinksAddon.ts
@@ -153,10 +153,14 @@ interface ScopedDirCandidate extends DirCandidate {
 /** A soft-wrapped run of buffer rows, rejoined into the line the user sees. */
 interface LogicalLine {
   text: string;
-  /** 0-based buffer index of the first row in the run. */
+  /** 0-based buffer index of the first row in the window. */
   startRow: number;
   /** Where each row's text begins in `text`, indexed from `startRow`. */
   rowOffsets: number[];
+  /** The budget, not a real line start, ended the window — `^` is a lie here. */
+  clippedStart: boolean;
+  /** The budget, not a real line end, ended the window — `$` is a lie here. */
+  clippedEnd: boolean;
 }
 
 // Matches xterm's own web-link provider: a rejoin budget that keeps a pathological
@@ -231,13 +235,21 @@ export class FileLinksAddon implements ILinkProvider {
 
     const lineText = line.translateToString(true);
 
+    // A row that continues, or is continued by, another holds only part of a
+    // logical line, so nothing about it can be decided from its own text.
+    const partOfWrappedLine =
+      line.isWrapped === true ||
+      this._terminal.buffer.active.getLine(bufferLineNumber)?.isWrapped === true;
+
     // Fast path: every FILE_PATH_REGEX alternative requires a path separator
     // ('/' or '\'), so a line with neither can never contain a file path. Most
     // agent output (code without imports, prose, prompts) hits this and skips
     // the regex entirely. provideLinks is pointer-driven (xterm Linkifier2
     // _activeLine cache, fires when the pointer crosses a new row), so this is
-    // scroll-feel regex/GC cost, not write throughput.
-    if (!lineText.includes("/") && !lineText.includes("\\")) {
+    // scroll-feel regex/GC cost, not write throughput. A wrapped row is exempt:
+    // the tail of `file:///tmp/long/` + `shot.png` carries no separator of its
+    // own, and skipping it would leave half the URL unclickable.
+    if (!partOfWrappedLine && !lineText.includes("/") && !lineText.includes("\\")) {
       callback(undefined);
       return;
     }
@@ -253,12 +265,10 @@ export class FileLinksAddon implements ILinkProvider {
     // continued can't be hiding the rest of one. provideLinks is pointer-driven
     // across every visible terminal, so the common line still does no work.
     // `://` (not `file://`) keeps the guard case-insensitive without a copy.
-    const partOfWrappedLine =
-      line.isWrapped === true ||
-      this._terminal.buffer.active.getLine(bufferLineNumber)?.isWrapped === true;
-    if (lineText.includes("://") || partOfWrappedLine) {
-      this._collectUrlLinks(bufferLineNumber, lineText, links, claimed);
-    }
+    const urlScanText =
+      lineText.includes("://") || partOfWrappedLine
+        ? this._collectUrlLinks(bufferLineNumber, lineText, links, claimed)
+        : null;
 
     // matchAll on the module-scope global regex clones it internally (per spec)
     // and never mutates lastIndex, so the regex is reused across hover calls
@@ -337,6 +347,13 @@ export class FileLinksAddon implements ILinkProvider {
           callback(undefined);
           return;
         }
+        // A URL link can span rows this check never looks at, so re-read the
+        // whole window it was computed from: rewriting only the continuation
+        // row would otherwise leave a link to the path the URL used to name.
+        if (urlScanText !== null && this._readLogicalLine(bufferLineNumber - 1)?.text !== urlScanText) {
+          callback(undefined);
+          return;
+        }
         for (const candidate of confirmed) {
           const range: IBufferRange = {
             start: { x: candidate.startIndex + 1, y: bufferLineNumber },
@@ -374,20 +391,23 @@ export class FileLinksAddon implements ILinkProvider {
    *
    * Spans are claimed for every syntactic match, resolved or not: a rejected
    * remote URL must still shield its own characters from the bare-path pass.
+   *
+   * Returns the rejoined text it scanned, so a deferred reply can tell whether
+   * any contributing row changed underneath it, or null if there was no line.
    */
   private _collectUrlLinks(
     bufferLineNumber: number,
     lineText: string,
     links: ILink[],
     claimed: Array<[number, number]>
-  ): void {
+  ): string | null {
     const logical = this._readLogicalLine(bufferLineNumber - 1);
-    if (!logical) return;
+    if (!logical) return null;
     // The current row's offset into the joined text, for translating a match
     // back into `lineText` coordinates — that's the space `claimed` and the
-    // single-row bare-path and directory passes all speak.
-    const rowOffset = logical.rowOffsets[bufferLineNumber - 1 - logical.startRow];
-    if (rowOffset === undefined) return;
+    // single-row bare-path and directory passes all speak. The window is
+    // anchored on this row, so the lookup always lands.
+    const rowOffset = logical.rowOffsets[bufferLineNumber - 1 - logical.startRow]!;
 
     for (const match of logical.text.matchAll(FILE_URL_REGEX)) {
       const url = match[1];
@@ -399,13 +419,26 @@ export class FileLinksAddon implements ILinkProvider {
       const startIndex = match.index + match[0]!.indexOf(url);
       const endIndex = startIndex + url.length;
 
+      // Only URLs touching THIS row are ours to report. xterm projects a
+      // returned range onto the requested row and evicts lower-priority links
+      // that intersect it, so handing back a sibling row's link would blank a
+      // web link the user can actually see.
       const localStart = startIndex - rowOffset;
       const localEnd = endIndex - rowOffset;
-      // A URL wholly on a sibling row still surfaces here (xterm's own web-link
-      // provider behaves the same way, and its range keeps it inert until the
-      // pointer reaches it) — but it owns no characters on this row to claim.
-      if (localEnd > 0 && localStart < lineText.length) {
-        claimed.push([Math.max(0, localStart), Math.min(lineText.length, localEnd)]);
+      if (localEnd <= 0 || localStart >= lineText.length) continue;
+      claimed.push([Math.max(0, localStart), Math.min(lineText.length, localEnd)]);
+
+      // A token touching a clipped edge may continue past it, and the regex's
+      // `^`/`$` would read the budget cutoff as a boundary — the same lie a row
+      // edge tells. Claim it anyway (claiming only ever suppresses links) but
+      // never link it. A token starting entirely outside the window stays
+      // invisible; bounding the rejoin is what makes hover affordable, and that
+      // needs a logical line past 2048 columns to reach.
+      if (
+        (logical.clippedStart && startIndex === 0) ||
+        (logical.clippedEnd && endIndex === logical.text.length)
+      ) {
+        continue;
       }
 
       const resolved = resolveFileUrlCandidate(url);
@@ -434,31 +467,72 @@ export class FileLinksAddon implements ILinkProvider {
         )
       );
     }
+    return logical.text;
   }
 
   /**
    * Rejoin the soft-wrapped rows around `rowIndex` into the logical line the
    * user actually sees, remembering where each row's text starts so matches
    * can be mapped back to buffer coordinates.
+   *
+   * The window is anchored on `rowIndex` and grows outward on a shared budget,
+   * rather than starting at the logical line's first row: a run longer than
+   * the budget would otherwise stop before reaching the hovered row, leaving
+   * it unclaimed and its characters free for the bare-path pass to mis-link.
+   * Whichever end the budget cuts is reported as clipped, because a match
+   * touching an artificial edge can't be trusted to be whole.
    */
   private _readLogicalLine(rowIndex: number): LogicalLine | null {
     const buffer = this._terminal.buffer.active;
+    const current = buffer.getLine(rowIndex);
+    if (!current) return null;
+
+    // trimRight is deliberately OFF for the rejoin. A wrapped row is full by
+    // definition, so trimming can only delete real trailing spaces — and those
+    // spaces are what separate a URL from the next token, so dropping them
+    // fuses `file:///tmp/a.png` and a following path into one bogus target.
+    // The cost is the inverse of xterm's tradeoff: a wide char that wrapped
+    // early leaves a placeholder space mid-token, so that (rare, ASCII-free)
+    // URL goes unlinked. Missing a link beats linking the wrong file.
+    const texts = [current.translateToString(false)];
     let startRow = rowIndex;
-    // `isWrapped` marks a row as the CONTINUATION of the one above it, so walk
-    // up while that holds to find where the logical line begins.
-    while (startRow > 0 && buffer.getLine(startRow)?.isWrapped === true) startRow--;
+    let budget = MAX_LOGICAL_LINE_LENGTH - texts[0]!.length;
+    let clippedStart = false;
+    let clippedEnd = false;
+
+    // `isWrapped` marks a row as the CONTINUATION of the one above it.
+    while (startRow > 0 && buffer.getLine(startRow)?.isWrapped === true) {
+      const above = buffer.getLine(startRow - 1);
+      if (!above) break;
+      const text = above.translateToString(false);
+      if (text.length > budget) {
+        clippedStart = true;
+        break;
+      }
+      budget -= text.length;
+      texts.unshift(text);
+      startRow--;
+    }
+
+    for (let row = rowIndex + 1; ; row++) {
+      const below = buffer.getLine(row);
+      if (!below || below.isWrapped !== true) break;
+      const text = below.translateToString(false);
+      if (text.length > budget) {
+        clippedEnd = true;
+        break;
+      }
+      budget -= text.length;
+      texts.push(text);
+    }
 
     const rowOffsets: number[] = [];
     let text = "";
-    for (let row = startRow; text.length < MAX_LOGICAL_LINE_LENGTH; row++) {
-      const line = buffer.getLine(row);
-      if (!line) break;
-      if (row > startRow && line.isWrapped !== true) break;
+    for (const rowText of texts) {
       rowOffsets.push(text.length);
-      text += line.translateToString(true);
+      text += rowText;
     }
-    if (rowOffsets.length === 0) return null;
-    return { text, startRow, rowOffsets };
+    return { text, startRow, rowOffsets, clippedStart, clippedEnd };
   }
 
   private _collectDirCandidates(

--- a/src/services/terminal/FileLinksAddon.ts
+++ b/src/services/terminal/FileLinksAddon.ts
@@ -350,7 +350,10 @@ export class FileLinksAddon implements ILinkProvider {
         // A URL link can span rows this check never looks at, so re-read the
         // whole window it was computed from: rewriting only the continuation
         // row would otherwise leave a link to the path the URL used to name.
-        if (urlScanText !== null && this._readLogicalLine(bufferLineNumber - 1)?.text !== urlScanText) {
+        if (
+          urlScanText !== null &&
+          this._readLogicalLine(bufferLineNumber - 1)?.text !== urlScanText
+        ) {
           callback(undefined);
           return;
         }

--- a/src/services/terminal/FileLinksAddon.ts
+++ b/src/services/terminal/FileLinksAddon.ts
@@ -150,6 +150,42 @@ interface ScopedDirCandidate extends DirCandidate {
   relativePath: string;
 }
 
+/** A soft-wrapped run of buffer rows, rejoined into the line the user sees. */
+interface LogicalLine {
+  text: string;
+  /** 0-based buffer index of the first row in the run. */
+  startRow: number;
+  /** Where each row's text begins in `text`, indexed from `startRow`. */
+  rowOffsets: number[];
+}
+
+// Matches xterm's own web-link provider: a rejoin budget that keeps a pathological
+// unwrapped paste from turning every hover into a megabyte of string building.
+const MAX_LOGICAL_LINE_LENGTH = 2048;
+
+function overlapsClaimed(
+  claimed: ReadonlyArray<[number, number]>,
+  startIndex: number,
+  endIndex: number
+): boolean {
+  return claimed.some(([start, end]) => startIndex < end && endIndex > start);
+}
+
+/** Map an index in a rejoined logical line back to its buffer row and column. */
+function mapToRow(logical: LogicalLine, index: number): { row: number; column: number } {
+  let offsetIndex = 0;
+  while (
+    offsetIndex + 1 < logical.rowOffsets.length &&
+    logical.rowOffsets[offsetIndex + 1]! <= index
+  ) {
+    offsetIndex++;
+  }
+  return {
+    row: logical.startRow + offsetIndex,
+    column: index - logical.rowOffsets[offsetIndex]!,
+  };
+}
+
 /**
  * Cheap validation memo for directory candidates, keyed
  * `worktreeId\nrelativePath`. Hover re-fires for the same line constantly, so
@@ -211,44 +247,17 @@ export class FileLinksAddon implements ILinkProvider {
     // dropped instead of stacking a second link on the same characters.
     const claimed: Array<[number, number]> = [];
 
-    // `file://` URLs are scanned first so their ranges are claimed before the
-    // bare-path and directory passes. Gated on a substring test rather than
-    // run unconditionally: provideLinks is pointer-driven across every visible
-    // terminal, and virtually no line carries a scheme at all. `://` (not
-    // `file://`) keeps the guard case-insensitive without a lowercase copy.
-    if (lineText.includes("://")) {
-      for (const match of lineText.matchAll(FILE_URL_REGEX)) {
-        const url = match[1];
-        if (url === undefined) continue;
-
-        const resolved = resolveFileUrlCandidate(url);
-        if (!resolved) continue;
-
-        // Indexed off the capture, not `match[0]`: the match also spans the
-        // leading boundary character and any trailing sentence punctuation,
-        // neither of which the link should underline or own.
-        const startIndex = match.index + match[0]!.indexOf(url);
-        claimed.push([startIndex, startIndex + url.length]);
-
-        const range: IBufferRange = {
-          start: { x: startIndex + 1, y: bufferLineNumber },
-          end: { x: startIndex + url.length, y: bufferLineNumber },
-        };
-
-        // No line/col: `resolveFileUrlCandidate` deliberately doesn't peel a
-        // `:line` suffix off a URL, so there is none to forward.
-        links.push(
-          new FileLink(
-            range,
-            url,
-            resolved.absolutePath,
-            undefined,
-            undefined,
-            this._getCwd(),
-            this._onHover
-          )
-        );
-      }
+    // `file://` URLs are scanned first so their spans are claimed before the
+    // bare-path and directory passes. Two gates, both O(1)-ish: a line with no
+    // scheme can't start a URL, and a line that neither continues nor is
+    // continued can't be hiding the rest of one. provideLinks is pointer-driven
+    // across every visible terminal, so the common line still does no work.
+    // `://` (not `file://`) keeps the guard case-insensitive without a copy.
+    const partOfWrappedLine =
+      line.isWrapped === true ||
+      this._terminal.buffer.active.getLine(bufferLineNumber)?.isWrapped === true;
+    if (lineText.includes("://") || partOfWrappedLine) {
+      this._collectUrlLinks(bufferLineNumber, lineText, links, claimed);
     }
 
     // matchAll on the module-scope global regex clones it internally (per spec)
@@ -267,6 +276,14 @@ export class FileLinksAddon implements ILinkProvider {
       }
 
       const startIndex = match.index + match[0]!.indexOf(fullMatch);
+      // A `(` is legal inside a file URL and is also this regex's boundary
+      // character, so `file:///tmp/(src/foo.ts` offers `src/foo.ts` as a bare
+      // path — which would resolve against the cwd and link a different file
+      // than the URL names. Every URL span is claimed whether or not it
+      // resolved, so a rejected remote URL can't leak a local link either.
+      if (overlapsClaimed(claimed, startIndex, startIndex + fullMatch.length)) {
+        continue;
+      }
       claimed.push([startIndex, startIndex + fullMatch.length]);
 
       const range: IBufferRange = {
@@ -345,6 +362,105 @@ export class FileLinksAddon implements ILinkProvider {
     );
   }
 
+  /**
+   * Scan the logical line for `file://` URLs, appending links and claiming the
+   * spans they occupy on `bufferLineNumber`'s own row.
+   *
+   * Rows are rejoined first because xterm soft-wraps mid-token and the
+   * motivating URL — an agent's generated-image path — is long enough to wrap
+   * in any tiled terminal. Scanning one row would capture the prefix that
+   * happens to end at the margin, and a truncated `file://` URL still parses,
+   * so it would link to a real-but-wrong path instead of failing.
+   *
+   * Spans are claimed for every syntactic match, resolved or not: a rejected
+   * remote URL must still shield its own characters from the bare-path pass.
+   */
+  private _collectUrlLinks(
+    bufferLineNumber: number,
+    lineText: string,
+    links: ILink[],
+    claimed: Array<[number, number]>
+  ): void {
+    const logical = this._readLogicalLine(bufferLineNumber - 1);
+    if (!logical) return;
+    // The current row's offset into the joined text, for translating a match
+    // back into `lineText` coordinates — that's the space `claimed` and the
+    // single-row bare-path and directory passes all speak.
+    const rowOffset = logical.rowOffsets[bufferLineNumber - 1 - logical.startRow];
+    if (rowOffset === undefined) return;
+
+    for (const match of logical.text.matchAll(FILE_URL_REGEX)) {
+      const url = match[1];
+      if (url === undefined) continue;
+
+      // Indexed off the capture, not `match[0]`: the match also spans the
+      // leading boundary character and any trailing sentence punctuation,
+      // neither of which the link should underline or own.
+      const startIndex = match.index + match[0]!.indexOf(url);
+      const endIndex = startIndex + url.length;
+
+      const localStart = startIndex - rowOffset;
+      const localEnd = endIndex - rowOffset;
+      // A URL wholly on a sibling row still surfaces here (xterm's own web-link
+      // provider behaves the same way, and its range keeps it inert until the
+      // pointer reaches it) — but it owns no characters on this row to claim.
+      if (localEnd > 0 && localStart < lineText.length) {
+        claimed.push([Math.max(0, localStart), Math.min(lineText.length, localEnd)]);
+      }
+
+      const resolved = resolveFileUrlCandidate(url);
+      if (!resolved) continue;
+
+      const start = mapToRow(logical, startIndex);
+      const end = mapToRow(logical, endIndex - 1);
+      const range: IBufferRange = {
+        // xterm rows are 1-based and the end column is inclusive, so `end`
+        // addresses the URL's last character rather than the one past it.
+        start: { x: start.column + 1, y: start.row + 1 },
+        end: { x: end.column + 1, y: end.row + 1 },
+      };
+
+      // No line/col: `resolveFileUrlCandidate` deliberately doesn't peel a
+      // `:line` suffix off a URL, so there is none to forward.
+      links.push(
+        new FileLink(
+          range,
+          url,
+          resolved.absolutePath,
+          undefined,
+          undefined,
+          this._getCwd(),
+          this._onHover
+        )
+      );
+    }
+  }
+
+  /**
+   * Rejoin the soft-wrapped rows around `rowIndex` into the logical line the
+   * user actually sees, remembering where each row's text starts so matches
+   * can be mapped back to buffer coordinates.
+   */
+  private _readLogicalLine(rowIndex: number): LogicalLine | null {
+    const buffer = this._terminal.buffer.active;
+    let startRow = rowIndex;
+    // `isWrapped` marks a row as the CONTINUATION of the one above it, so walk
+    // up while that holds to find where the logical line begins.
+    while (startRow > 0 && buffer.getLine(startRow)?.isWrapped === true) startRow--;
+
+    const rowOffsets: number[] = [];
+    let text = "";
+    for (let row = startRow; text.length < MAX_LOGICAL_LINE_LENGTH; row++) {
+      const line = buffer.getLine(row);
+      if (!line) break;
+      if (row > startRow && line.isWrapped !== true) break;
+      rowOffsets.push(text.length);
+      text += line.translateToString(true);
+    }
+    if (rowOffsets.length === 0) return null;
+    return { text, startRow, rowOffsets };
+  }
+
   private _collectDirCandidates(
     lineText: string,
     claimed: Array<[number, number]>
@@ -356,7 +472,7 @@ export class FileLinksAddon implements ILinkProvider {
 
       const startIndex = match.index + match[0]!.indexOf(fullMatch);
       const endIndex = startIndex + fullMatch.length;
-      if (claimed.some(([start, end]) => startIndex < end && endIndex > start)) continue;
+      if (overlapsClaimed(claimed, startIndex, endIndex)) continue;
 
       const absolutePath = resolveDirPathCandidate(fullMatch, this._getCwd());
       if (!absolutePath) continue;

--- a/src/services/terminal/__tests__/FileLinksAddon.directories.test.ts
+++ b/src/services/terminal/__tests__/FileLinksAddon.directories.test.ts
@@ -106,6 +106,46 @@ describe("FileLinksAddon directory links", () => {
     expect(fileBrowserClient.statPaths).not.toHaveBeenCalled();
   });
 
+  it("ships a file:// link alongside a stat-validated directory on one line", async () => {
+    const root = nextRoot();
+    bindWorktrees(new Map([[root, { id: root, path: root }]]));
+    vi.mocked(fileBrowserClient.statPaths).mockResolvedValue(["directory"]);
+
+    // The URL resolves synchronously but the directory doesn't, so delivery of
+    // both moves behind the deferred validation callback.
+    const addon = new FileLinksAddon(
+      makeTerminal(["wrote file:///tmp/a.png under src/generated"]),
+      () => root
+    );
+    const links = await provide(addon);
+
+    expect(links).toHaveLength(2);
+    expect(links!.map((link) => (link as ILink & { kind: string }).kind)).toEqual([
+      "file",
+      "directory",
+    ]);
+    expect((links![0] as ILink & { absolutePath: string }).absolutePath).toBe("/tmp/a.png");
+    expect(fileBrowserClient.statPaths).toHaveBeenCalledWith({
+      worktreeId: root,
+      paths: ["src/generated"],
+    });
+  });
+
+  it("keeps the file:// link when directory validation fails", async () => {
+    const root = nextRoot();
+    bindWorktrees(new Map([[root, { id: root, path: root }]]));
+    vi.mocked(fileBrowserClient.statPaths).mockRejectedValue(new Error("view evicted"));
+
+    const addon = new FileLinksAddon(
+      makeTerminal(["wrote file:///tmp/a.png under src/generated"]),
+      () => root
+    );
+    const links = await provide(addon);
+
+    expect(links).toHaveLength(1);
+    expect((links![0] as ILink & { absolutePath: string }).absolutePath).toBe("/tmp/a.png");
+  });
+
   it("keeps file links when validation fails", async () => {
     const root = nextRoot();
     bindWorktrees(new Map([[root, { id: root, path: root }]]));

--- a/src/services/terminal/__tests__/FileLinksAddon.directories.test.ts
+++ b/src/services/terminal/__tests__/FileLinksAddon.directories.test.ts
@@ -187,6 +187,43 @@ describe("FileLinksAddon directory links", () => {
     expect(await provide(addon)).toBeUndefined();
   });
 
+  it("drops the reply when only a wrapped URL's continuation row was rewritten", async () => {
+    const root = nextRoot();
+    bindWorktrees(new Map([[root, { id: root, path: root }]]));
+    let release: (value: Array<"directory" | "file" | null>) => void = () => {};
+    vi.mocked(fileBrowserClient.statPaths).mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve;
+      })
+    );
+
+    // The hovered row never changes, so the single-row guard sees nothing —
+    // only the rejoined window reveals that the URL now names another file.
+    const rows = ["src/generated file:///tmp/renders/", "a.png"];
+    const terminal = {
+      buffer: {
+        active: {
+          getLine: vi.fn((index: number): IBufferLine | undefined => {
+            const text = rows[index];
+            if (text === undefined) return undefined;
+            return {
+              translateToString: (trimRight?: boolean) => (trimRight ? text.trimEnd() : text),
+              isWrapped: index > 0,
+            } as IBufferLine;
+          }),
+        },
+      },
+    } as unknown as Terminal;
+
+    const addon = new FileLinksAddon(terminal, () => root);
+    const callback = vi.fn();
+    addon.provideLinks(1, callback);
+    rows[1] = "b.png";
+    release(["directory"]);
+    await vi.waitFor(() => expect(callback).toHaveBeenCalled());
+    expect(callback).toHaveBeenCalledWith(undefined);
+  });
+
   it("stays silent after disposal", async () => {
     const root = nextRoot();
     bindWorktrees(new Map([[root, { id: root, path: root }]]));

--- a/src/services/terminal/__tests__/FileLinksAddon.test.ts
+++ b/src/services/terminal/__tests__/FileLinksAddon.test.ts
@@ -295,6 +295,110 @@ describe("FileLinksAddon", () => {
     });
   });
 
+  describe("file:// URLs (#11419)", () => {
+    const CODEX_URL =
+      "file:///Users/gpriday/.codex/generated_images/019f92d9-d4b8-7de3-b1c3-56ce778ef00b/call_H5WWfuc4aUo8pAYO4a5eYRZ5.png";
+
+    const linksFor = (lineText: string, cwd = "/home/user/project"): Promise<ILink[] | undefined> =>
+      new Promise((resolve) => {
+        const terminal = createMockTerminal();
+        vi.mocked(terminal.buffer.active.getLine).mockReturnValue(createMockLine(lineText));
+        new FileLinksAddon(terminal, () => cwd).provideLinks(1, resolve);
+      });
+
+    const readLink = (link: ILink) =>
+      link as unknown as { kind: string; text: string; absolutePath: string };
+
+    it("turns an agent's generated-image URL into a single file link", async () => {
+      const links = await linksFor(`Saved image to ${CODEX_URL}`);
+      expect(links).toHaveLength(1);
+      const link = readLink(links![0]!);
+      expect(link.kind).toBe("file");
+      expect(link.text).toBe(CODEX_URL);
+      expect(link.absolutePath).toBe(
+        "/Users/gpriday/.codex/generated_images/019f92d9-d4b8-7de3-b1c3-56ce778ef00b/call_H5WWfuc4aUo8pAYO4a5eYRZ5.png"
+      );
+    });
+
+    it("spans exactly the URL's columns", async () => {
+      const prefix = "Saved to ";
+      const url = "file:///tmp/a.png";
+      const links = await linksFor(`${prefix}${url}.`);
+      expect(links).toHaveLength(1);
+      // xterm columns are 1-based and the end is inclusive, so the range covers
+      // the URL alone — not the leading space, not the sentence period.
+      expect(links![0]!.range).toEqual({
+        start: { x: prefix.length + 1, y: 1 },
+        end: { x: prefix.length + url.length, y: 1 },
+      });
+    });
+
+    it("keeps query and fragment in the link text but out of the resolved path", async () => {
+      const links = await linksFor("open file:///tmp/a.png?download=1#preview");
+      expect(links).toHaveLength(1);
+      const link = readLink(links![0]!);
+      expect(link.text).toBe("file:///tmp/a.png?download=1#preview");
+      expect(link.absolutePath).toBe("/tmp/a.png");
+    });
+
+    it("decodes the Windows drive spellings a URL can carry", async () => {
+      for (const url of ["file:///C:/Users/me/x.png", "file:///C|/Users/me/x.png"]) {
+        const links = await linksFor(`open ${url}`);
+        expect(links).toHaveLength(1);
+        expect(readLink(links![0]!).absolutePath).toBe("C:/Users/me/x.png");
+      }
+    });
+
+    it("produces no link for a URL that isn't a viewable local file", async () => {
+      const rejected = [
+        "file://someserver/share/x.png",
+        "file:////someserver/share/x.png",
+        "file:///tmp/a%2Fb.png",
+        "file:///tmp/a%zz.png",
+        "file:///",
+        "file:///tmp/renders/",
+      ];
+      for (const url of rejected) {
+        expect(await linksFor(`open ${url}`)).toBeUndefined();
+      }
+    });
+
+    it("links a URL and a bare path on the same line without overlapping", async () => {
+      const links = await linksFor("wrote file:///tmp/a.png from src/App.tsx:10");
+      expect(links).toHaveLength(2);
+      expect(links!.map((link) => readLink(link).absolutePath)).toEqual([
+        "/tmp/a.png",
+        "/home/user/project/src/App.tsx",
+      ]);
+      const [first, second] = links!;
+      expect(first!.range.end.x).toBeLessThan(second!.range.start.x);
+    });
+
+    it("opens in the in-app viewer rather than the OS default app", async () => {
+      vi.mocked(actionService.dispatch).mockReset();
+      vi.mocked(systemClient.openPath).mockReset();
+      vi.mocked(actionService.dispatch).mockResolvedValue({ ok: true, value: { panelId: "p1" } });
+
+      const links = await linksFor(`Saved image to ${CODEX_URL}`);
+      links![0]!.activate(
+        { metaKey: false, ctrlKey: false } as unknown as MouseEvent,
+        links![0]!.text
+      );
+      await vi.waitFor(() => expect(actionService.dispatch).toHaveBeenCalledTimes(1));
+
+      expect(actionService.dispatch).toHaveBeenCalledWith(
+        "file.view",
+        expect.objectContaining({
+          path: "/Users/gpriday/.codex/generated_images/019f92d9-d4b8-7de3-b1c3-56ce778ef00b/call_H5WWfuc4aUo8pAYO4a5eYRZ5.png",
+          line: undefined,
+          col: undefined,
+        }),
+        { source: "user" }
+      );
+      expect(systemClient.openPath).not.toHaveBeenCalled();
+    });
+  });
+
   describe("path resolution", () => {
     it("should resolve relative paths against cwd", () => {
       return new Promise<void>((resolve) => {

--- a/src/services/terminal/__tests__/FileLinksAddon.test.ts
+++ b/src/services/terminal/__tests__/FileLinksAddon.test.ts
@@ -262,7 +262,7 @@ describe("FileLinksAddon", () => {
   });
 
   describe("exclusions", () => {
-    it("should not match URLs with protocols", () => {
+    it("should not match non-file protocol URLs", () => {
       return new Promise<void>((resolve) => {
         const terminal = createMockTerminal();
         const getCwd = () => "/home/user/project";
@@ -306,6 +306,21 @@ describe("FileLinksAddon", () => {
         new FileLinksAddon(terminal, () => cwd).provideLinks(1, resolve);
       });
 
+    /** Rows as xterm stores them: row 0 plus soft-wrapped continuations. */
+    const linksForWrapped = (rows: string[], hoveredRow: number): Promise<ILink[] | undefined> =>
+      new Promise((resolve) => {
+        const terminal = createMockTerminal();
+        vi.mocked(terminal.buffer.active.getLine).mockImplementation((index: number) => {
+          const text = rows[index];
+          if (text === undefined) return undefined;
+          return { translateToString: () => text, isWrapped: index > 0 } as IBufferLine;
+        });
+        new FileLinksAddon(terminal, () => "/home/user/project").provideLinks(
+          hoveredRow + 1,
+          resolve
+        );
+      });
+
     const readLink = (link: ILink) =>
       link as unknown as { kind: string; text: string; absolutePath: string };
 
@@ -331,6 +346,57 @@ describe("FileLinksAddon", () => {
         start: { x: prefix.length + 1, y: 1 },
         end: { x: prefix.length + url.length, y: 1 },
       });
+      expect(readLink(links![0]!).absolutePath).toBe("/tmp/a.png");
+    });
+
+    it("links a URL that fills the whole line", async () => {
+      const links = await linksFor("file:///tmp/a.png");
+      expect(links).toHaveLength(1);
+      expect(readLink(links![0]!).absolutePath).toBe("/tmp/a.png");
+    });
+
+    it("links a URL delimited by backticks or angle brackets", async () => {
+      for (const line of ["saved to `file:///tmp/a.png`", "saved to <file:///tmp/a.png>"]) {
+        const links = await linksFor(line);
+        expect(links).toHaveLength(1);
+        expect(readLink(links![0]!).text).toBe("file:///tmp/a.png");
+      }
+    });
+
+    it("accepts a mixed-case scheme and a localhost authority", async () => {
+      for (const url of ["FILE:///tmp/a.png", "file://localhost/tmp/a.png"]) {
+        const links = await linksFor(`saved to ${url}`);
+        expect(links).toHaveLength(1);
+        expect(readLink(links![0]!).absolutePath).toBe("/tmp/a.png");
+      }
+    });
+
+    it("rejoins a soft-wrapped URL instead of linking the truncated prefix", async () => {
+      // The motivating URL is 116 chars, so it wraps in any tiled terminal. The
+      // prefix ending at the margin still parses as a valid URL — linking it
+      // would silently open a real-but-wrong path.
+      const rows = ["Saved image to file:///Users/gpriday/.codex/generated_", "images/shot.png"];
+      for (const hoveredRow of [0, 1]) {
+        const links = await linksForWrapped(rows, hoveredRow);
+        expect(links).toHaveLength(1);
+        const link = links![0]!;
+        expect(readLink(link).absolutePath).toBe("/Users/gpriday/.codex/generated_images/shot.png");
+        // One link spanning both rows — 1-based rows, inclusive end column.
+        expect(link.range.start).toEqual({ x: "Saved image to ".length + 1, y: 1 });
+        expect(link.range.end).toEqual({ x: "images/shot.png".length, y: 2 });
+      }
+    });
+
+    it("does not let a literal ( in a URL leak a bare-path link", async () => {
+      // `(` is legal in a file URL and is also FILE_PATH_REGEX's boundary
+      // character, so the tail would otherwise resolve against the cwd.
+      const links = await linksFor("open file:///tmp/(src/foo.ts");
+      expect(links).toHaveLength(1);
+      expect(readLink(links![0]!).absolutePath).toBe("/tmp/(src/foo.ts");
+    });
+
+    it("does not let a rejected remote URL leak a bare-path link", async () => {
+      expect(await linksFor("open file://someserver/(share/x.png")).toBeUndefined();
     });
 
     it("keeps query and fragment in the link text but out of the resolved path", async () => {
@@ -374,28 +440,63 @@ describe("FileLinksAddon", () => {
       expect(first!.range.end.x).toBeLessThan(second!.range.start.x);
     });
 
-    it("opens in the in-app viewer rather than the OS default app", async () => {
-      vi.mocked(actionService.dispatch).mockReset();
-      vi.mocked(systemClient.openPath).mockReset();
-      vi.mocked(actionService.dispatch).mockResolvedValue({ ok: true, value: { panelId: "p1" } });
-
-      const links = await linksFor(`Saved image to ${CODEX_URL}`);
-      links![0]!.activate(
-        { metaKey: false, ctrlKey: false } as unknown as MouseEvent,
-        links![0]!.text
+    it("reports hover and leave like any other file link", async () => {
+      const terminal = createMockTerminal();
+      vi.mocked(terminal.buffer.active.getLine).mockReturnValue(
+        createMockLine(`Saved image to ${CODEX_URL}`)
       );
-      await vi.waitFor(() => expect(actionService.dispatch).toHaveBeenCalledTimes(1));
+      const seen: Array<unknown> = [];
+      const addon = new FileLinksAddon(terminal, () => "/p", (link) => seen.push(link));
 
-      expect(actionService.dispatch).toHaveBeenCalledWith(
-        "file.view",
-        expect.objectContaining({
-          path: "/Users/gpriday/.codex/generated_images/019f92d9-d4b8-7de3-b1c3-56ce778ef00b/call_H5WWfuc4aUo8pAYO4a5eYRZ5.png",
-          line: undefined,
-          col: undefined,
-        }),
-        { source: "user" }
+      const link = await new Promise<ILink>((resolve) =>
+        addon.provideLinks(1, (links) => resolve(links![0]!))
       );
-      expect(systemClient.openPath).not.toHaveBeenCalled();
+      const event = new Event("mousemove") as unknown as MouseEvent;
+      link.hover?.(event, link.text);
+      link.leave?.(event, link.text);
+      expect(seen).toEqual([link, null]);
+    });
+
+    describe("activation", () => {
+      const DECODED =
+        "/Users/gpriday/.codex/generated_images/019f92d9-d4b8-7de3-b1c3-56ce778ef00b/call_H5WWfuc4aUo8pAYO4a5eYRZ5.png";
+
+      beforeEach(() => {
+        vi.mocked(actionService.dispatch).mockReset();
+        vi.mocked(systemClient.openPath).mockReset();
+        vi.mocked(systemClient.openInEditor).mockReset();
+        vi.mocked(actionService.dispatch).mockResolvedValue({
+          ok: true,
+          result: { panelId: "p1" },
+        });
+      });
+
+      const activateUrlLink = async (modifiers: MouseEventInit) => {
+        const links = await linksFor(`Saved image to ${CODEX_URL}`);
+        const link = links![0]!;
+        link.activate({ metaKey: false, ctrlKey: false, ...modifiers } as MouseEvent, link.text);
+        await vi.waitFor(() => expect(actionService.dispatch).toHaveBeenCalledTimes(1));
+      };
+
+      it("opens in the in-app viewer rather than the OS default app", async () => {
+        await activateUrlLink({});
+        expect(actionService.dispatch).toHaveBeenCalledWith(
+          "file.view",
+          expect.objectContaining({ path: DECODED, line: undefined, col: undefined }),
+          { source: "user" }
+        );
+        expect(systemClient.openPath).not.toHaveBeenCalled();
+      });
+
+      it("sends the decoded path to the external editor on a modified click", async () => {
+        await activateUrlLink({ metaKey: true });
+        expect(actionService.dispatch).toHaveBeenCalledWith(
+          "file.openInEditor",
+          expect.objectContaining({ path: DECODED, line: undefined, col: undefined }),
+          { source: "user" }
+        );
+        expect(systemClient.openInEditor).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/src/services/terminal/__tests__/FileLinksAddon.test.ts
+++ b/src/services/terminal/__tests__/FileLinksAddon.test.ts
@@ -306,14 +306,22 @@ describe("FileLinksAddon", () => {
         new FileLinksAddon(terminal, () => cwd).provideLinks(1, resolve);
       });
 
-    /** Rows as xterm stores them: row 0 plus soft-wrapped continuations. */
+    /**
+     * Rows as xterm stores them: row 0 plus soft-wrapped continuations. Rows
+     * are given with their real trailing spaces, and `translateToString`
+     * honours `trimRight` the way xterm does — that difference is what decides
+     * whether a rejoin fuses two tokens together.
+     */
     const linksForWrapped = (rows: string[], hoveredRow: number): Promise<ILink[] | undefined> =>
       new Promise((resolve) => {
         const terminal = createMockTerminal();
         vi.mocked(terminal.buffer.active.getLine).mockImplementation((index: number) => {
           const text = rows[index];
           if (text === undefined) return undefined;
-          return { translateToString: () => text, isWrapped: index > 0 } as IBufferLine;
+          return {
+            translateToString: (trimRight?: boolean) => (trimRight ? text.trimEnd() : text),
+            isWrapped: index > 0,
+          } as IBufferLine;
         });
         new FileLinksAddon(terminal, () => "/home/user/project").provideLinks(
           hoveredRow + 1,
@@ -385,6 +393,38 @@ describe("FileLinksAddon", () => {
         expect(link.range.start).toEqual({ x: "Saved image to ".length + 1, y: 1 });
         expect(link.range.end).toEqual({ x: "images/shot.png".length, y: 2 });
       }
+    });
+
+    it("links a continuation row that carries no separator of its own", async () => {
+      // `shot.png` alone would hit the '/'-or-'\' fast path and never be
+      // scanned, leaving the tail of a wrapped URL dead to the pointer.
+      const links = await linksForWrapped(["file:///tmp/long/", "shot.png"], 1);
+      expect(links).toHaveLength(1);
+      expect(readLink(links![0]!).absolutePath).toBe("/tmp/long/shot.png");
+    });
+
+    it("keeps the spaces that separate a wrapped URL from the next token", async () => {
+      // Row one is full to the margin with real spaces. Trimming them on
+      // rejoin would fuse the two tokens into `/tmp/a.pngsrc/foo.ts`.
+      const links = await linksForWrapped(["file:///tmp/a.png   ", "src/foo.ts"], 0);
+      expect(links).toHaveLength(1);
+      expect(readLink(links![0]!).absolutePath).toBe("/tmp/a.png");
+    });
+
+    it("ignores a URL that lies entirely on a sibling row", async () => {
+      // xterm evicts lower-priority links intersecting a returned range, so a
+      // link the pointer can't reach on this row must not be reported at all.
+      expect(await linksForWrapped(["no separator here", "file:///tmp/a.png"], 0)).toBeUndefined();
+    });
+
+    it("refuses to link a URL clipped by the rejoin budget", async () => {
+      // Past the budget the window's edge is not a token boundary, and a
+      // truncated file URL still parses — the original wrapping bug.
+      const rows: string[] = [];
+      const huge = `file:///tmp/${"a".repeat(2500)}.png`;
+      for (let i = 0; i < huge.length; i += 80) rows.push(huge.slice(i, i + 80));
+      expect(await linksForWrapped(rows, 0)).toBeUndefined();
+      expect(await linksForWrapped(rows, rows.length - 1)).toBeUndefined();
     });
 
     it("does not let a literal ( in a URL leak a bare-path link", async () => {
@@ -486,6 +526,18 @@ describe("FileLinksAddon", () => {
           { source: "user" }
         );
         expect(systemClient.openPath).not.toHaveBeenCalled();
+      });
+
+      it("falls back to the OS opener only after the in-app viewer refuses", async () => {
+        // Deliberate: a file:// URL and its bare-path spelling must behave the
+        // same way once file.view has failed. The issue's constraint is about
+        // which linkifier owns the token, not about the recovery path.
+        vi.mocked(actionService.dispatch).mockResolvedValue({
+          ok: false,
+          error: { code: "EXECUTION_ERROR", message: "no panel" },
+        });
+        await activateUrlLink({});
+        await vi.waitFor(() => expect(systemClient.openPath).toHaveBeenCalledWith(DECODED));
       });
 
       it("sends the decoded path to the external editor on a modified click", async () => {

--- a/src/services/terminal/__tests__/FileLinksAddon.test.ts
+++ b/src/services/terminal/__tests__/FileLinksAddon.test.ts
@@ -486,7 +486,11 @@ describe("FileLinksAddon", () => {
         createMockLine(`Saved image to ${CODEX_URL}`)
       );
       const seen: Array<unknown> = [];
-      const addon = new FileLinksAddon(terminal, () => "/p", (link) => seen.push(link));
+      const addon = new FileLinksAddon(
+        terminal,
+        () => "/p",
+        (link) => seen.push(link)
+      );
 
       const link = await new Promise<ILink>((resolve) =>
         addon.provideLinks(1, (links) => resolve(links![0]!))

--- a/src/services/terminal/__tests__/filePathDetection.test.ts
+++ b/src/services/terminal/__tests__/filePathDetection.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect } from "vitest";
 import {
   DIR_PATH_REGEX,
   FILE_PATH_REGEX,
+  FILE_URL_REGEX,
   isPathExcluded,
   resolveDirPathCandidate,
   resolveFilePathCandidate,
+  resolveFileUrlCandidate,
   resolveSelectedFilePath,
 } from "../filePathDetection";
 
@@ -106,6 +108,169 @@ describe("resolveSelectedFilePath", () => {
 
   it("rejects a bare filename with no separator", () => {
     expect(resolveSelectedFilePath("foo.ts", "/p")).toBeNull();
+  });
+
+  it("accepts a selection that is exactly one file:// URL", () => {
+    expect(resolveSelectedFilePath("file:///tmp/renders/a.png", "/p")?.absolutePath).toBe(
+      "/tmp/renders/a.png"
+    );
+    expect(resolveSelectedFilePath("  file:///tmp/renders/a.png \n", "/p")?.absolutePath).toBe(
+      "/tmp/renders/a.png"
+    );
+  });
+
+  it("resolves a selected file:// URL the same way a click on it would", () => {
+    const url = "file:///tmp/my%20render.png";
+    expect(resolveSelectedFilePath(url, "/p")).toEqual(resolveFileUrlCandidate(url));
+  });
+
+  it("rejects a file:// URL embedded in prose or paired with another", () => {
+    expect(resolveSelectedFilePath("see file:///tmp/a.png for details", "/p")).toBeNull();
+    expect(resolveSelectedFilePath("file:///tmp/a.png file:///tmp/b.png", "/p")).toBeNull();
+  });
+
+  it("rejects a file:// URL that resolves to nothing viewable", () => {
+    expect(resolveSelectedFilePath("file://someserver/share/a.png", "/p")).toBeNull();
+    expect(resolveSelectedFilePath("file:///", "/p")).toBeNull();
+  });
+});
+
+describe("resolveFileUrlCandidate", () => {
+  const CODEX_URL =
+    "file:///Users/gpriday/.codex/generated_images/019f92d9-d4b8-7de3-b1c3-56ce778ef00b/call_H5WWfuc4aUo8pAYO4a5eYRZ5.png";
+
+  it("decodes the URL an agent CLI prints for a generated image", () => {
+    expect(resolveFileUrlCandidate(CODEX_URL)).toEqual({
+      absolutePath:
+        "/Users/gpriday/.codex/generated_images/019f92d9-d4b8-7de3-b1c3-56ce778ef00b/call_H5WWfuc4aUo8pAYO4a5eYRZ5.png",
+    });
+  });
+
+  it("percent-decodes spaces without treating + as one", () => {
+    expect(resolveFileUrlCandidate("file:///tmp/my%20render+v2.png")?.absolutePath).toBe(
+      "/tmp/my render+v2.png"
+    );
+  });
+
+  it("decodes non-ASCII without re-normalizing the Unicode form", () => {
+    // NFD "café": the combining acute stays a separate code point. Forcing NFC
+    // would rewrite the name the filesystem actually holds.
+    const decomposed = "/tmp/cafe\u0301.png";
+    const resolved = resolveFileUrlCandidate("file:///tmp/cafe%CC%81.png")?.absolutePath;
+    expect(resolved).toBe(decomposed);
+    expect(resolved).not.toBe(decomposed.normalize("NFC"));
+  });
+
+  it("drops a query string and a fragment", () => {
+    expect(resolveFileUrlCandidate("file:///tmp/a.png?download=1#preview")?.absolutePath).toBe(
+      "/tmp/a.png"
+    );
+  });
+
+  it("accepts an empty and a localhost authority alike", () => {
+    expect(resolveFileUrlCandidate("file:///tmp/a.png")?.absolutePath).toBe("/tmp/a.png");
+    expect(resolveFileUrlCandidate("file://localhost/tmp/a.png")?.absolutePath).toBe("/tmp/a.png");
+    expect(resolveFileUrlCandidate("file://LOCALHOST/tmp/a.png")?.absolutePath).toBe("/tmp/a.png");
+  });
+
+  it("rejects a remote authority", () => {
+    expect(resolveFileUrlCandidate("file://someserver/share/x.png")).toBeNull();
+  });
+
+  it("rejects a four-slash URL whose empty host hides a UNC path", () => {
+    expect(resolveFileUrlCandidate("file:////someserver/share/x.png")).toBeNull();
+  });
+
+  it("strips the drive's leading slash and preserves the letter's case", () => {
+    expect(resolveFileUrlCandidate("file:///C:/Users/me/x.png")?.absolutePath).toBe(
+      "C:/Users/me/x.png"
+    );
+    expect(resolveFileUrlCandidate("file:///d:/Users/me/x.png")?.absolutePath).toBe(
+      "d:/Users/me/x.png"
+    );
+  });
+
+  it("accepts the bar and backslash spellings of a Windows drive URL", () => {
+    expect(resolveFileUrlCandidate("file:///C|/Users/me/x.png")?.absolutePath).toBe(
+      "C:/Users/me/x.png"
+    );
+    expect(resolveFileUrlCandidate("file:///C:\\Users\\me\\x.png")?.absolutePath).toBe(
+      "C:/Users/me/x.png"
+    );
+  });
+
+  it("rejects encoded path separators in either case", () => {
+    expect(resolveFileUrlCandidate("file:///tmp/a%2Fb.png")).toBeNull();
+    expect(resolveFileUrlCandidate("file:///tmp/a%2fb.png")).toBeNull();
+    expect(resolveFileUrlCandidate("file:///tmp/a%5Cb.png")).toBeNull();
+    expect(resolveFileUrlCandidate("file:///C:/a%5cb.png")).toBeNull();
+  });
+
+  it("rejects a malformed percent escape instead of throwing", () => {
+    expect(() => resolveFileUrlCandidate("file:///tmp/a%zz.png")).not.toThrow();
+    expect(resolveFileUrlCandidate("file:///tmp/a%zz.png")).toBeNull();
+  });
+
+  it("rejects roots and directory-shaped URLs", () => {
+    expect(resolveFileUrlCandidate("file://")).toBeNull();
+    expect(resolveFileUrlCandidate("file:///")).toBeNull();
+    expect(resolveFileUrlCandidate("file:///C:/")).toBeNull();
+    expect(resolveFileUrlCandidate("file:///C:")).toBeNull();
+    expect(resolveFileUrlCandidate("file:///tmp/renders/")).toBeNull();
+  });
+
+  it("rejects a non-file scheme and unparseable text", () => {
+    expect(resolveFileUrlCandidate("https://example.com/a.png")).toBeNull();
+    expect(resolveFileUrlCandidate("not a url")).toBeNull();
+  });
+
+  it("rejects a URL carrying an escape sequence", () => {
+    expect(resolveFileUrlCandidate("file:///tmp/\x1b[0m/a.png")).toBeNull();
+  });
+
+  it("keeps no line or column — a file URL names an exact resource", () => {
+    // `:2024` is a legal POSIX filename ending; peeling it would retarget the
+    // link at a file the URL never named.
+    expect(resolveFileUrlCandidate("file:///tmp/render:2024")).toEqual({
+      absolutePath: "/tmp/render:2024",
+    });
+  });
+});
+
+describe("FILE_URL_REGEX (terminal line scanning)", () => {
+  const scan = (line: string) => [...line.matchAll(FILE_URL_REGEX)].map((m) => m[1]);
+
+  it("captures a bare URL and one wrapped in parentheses", () => {
+    expect(scan("saved to file:///tmp/a.png")).toEqual(["file:///tmp/a.png"]);
+    expect(scan("![shot](file:///tmp/a.png)")).toEqual(["file:///tmp/a.png"]);
+  });
+
+  it("leaves trailing sentence punctuation out of the capture", () => {
+    expect(scan("wrote file:///tmp/a.png.")).toEqual(["file:///tmp/a.png"]);
+    expect(scan("wrote file:///tmp/a.png, then stopped")).toEqual(["file:///tmp/a.png"]);
+  });
+
+  it("never truncates at a Windows bar or a bracket", () => {
+    // A truncated `file:///C` still parses as a URL, so a partial capture would
+    // silently link to the wrong path rather than to nothing.
+    expect(scan("open file:///C|/Users/me/x.png")).toEqual(["file:///C|/Users/me/x.png"]);
+    expect(scan("open file:///tmp/shot[1].png")).toEqual(["file:///tmp/shot[1].png"]);
+    expect(scan("open file:///C:\\Users\\me\\x.png")).toEqual(["file:///C:\\Users\\me\\x.png"]);
+  });
+
+  it("requires a boundary before the scheme", () => {
+    expect(scan("xfile:///tmp/a.png")).toEqual([]);
+  });
+
+  it("matches an uppercase scheme", () => {
+    expect(scan("FILE:///tmp/a.png")).toEqual(["FILE:///tmp/a.png"]);
+  });
+
+  it("finds every URL on a line", () => {
+    expect(scan("file:///tmp/a.png and file:///tmp/b.png")).toEqual([
+      "file:///tmp/a.png",
+      "file:///tmp/b.png",
+    ]);
   });
 });
 

--- a/src/services/terminal/__tests__/filePathDetection.test.ts
+++ b/src/services/terminal/__tests__/filePathDetection.test.ts
@@ -291,6 +291,7 @@ describe("FILE_URL_REGEX (terminal line scanning)", () => {
       ["'", "'"],
       ["<", ">"],
       ["[", "]"],
+      ["{", "}"],
     ]) {
       expect(scan(`saved to ${open}file:///tmp/a.png${close}`)).toEqual(["file:///tmp/a.png"]);
     }

--- a/src/services/terminal/__tests__/filePathDetection.test.ts
+++ b/src/services/terminal/__tests__/filePathDetection.test.ts
@@ -92,8 +92,9 @@ describe("resolveSelectedFilePath", () => {
     expect(resolveSelectedFilePath("a/one.ts b/two.ts", "/p")).toBeNull();
   });
 
-  it("rejects a URL that looks path-like", () => {
+  it("rejects a non-file URL that looks path-like", () => {
     expect(resolveSelectedFilePath("https://example.com/a/b.ts", "/p")).toBeNull();
+    expect(resolveSelectedFilePath("ssh://host/a/b.ts", "/p")).toBeNull();
   });
 
   it("rejects slash-commands with no extension", () => {
@@ -121,7 +122,9 @@ describe("resolveSelectedFilePath", () => {
 
   it("resolves a selected file:// URL the same way a click on it would", () => {
     const url = "file:///tmp/my%20render.png";
-    expect(resolveSelectedFilePath(url, "/p")).toEqual(resolveFileUrlCandidate(url));
+    const viaSelection = resolveSelectedFilePath(url, "/p");
+    expect(viaSelection?.absolutePath).toBe("/tmp/my render.png");
+    expect(viaSelection).toEqual(resolveFileUrlCandidate(url));
   });
 
   it("rejects a file:// URL embedded in prose or paired with another", () => {
@@ -207,8 +210,25 @@ describe("resolveFileUrlCandidate", () => {
   });
 
   it("rejects a malformed percent escape instead of throwing", () => {
-    expect(() => resolveFileUrlCandidate("file:///tmp/a%zz.png")).not.toThrow();
     expect(resolveFileUrlCandidate("file:///tmp/a%zz.png")).toBeNull();
+  });
+
+  it("rejects a decoded NUL byte", () => {
+    expect(resolveFileUrlCandidate("file:///tmp/a%00.png")).toBeNull();
+  });
+
+  it("resolves an encoded drive letter and colon like their literal spellings", () => {
+    const literal = resolveFileUrlCandidate("file:///C:/Users/me/x.png")?.absolutePath;
+    expect(resolveFileUrlCandidate("file:///C%3A/Users/me/x.png")?.absolutePath).toBe(literal);
+    expect(resolveFileUrlCandidate("file:///%43:/Users/me/x.png")?.absolutePath).toBe(literal);
+  });
+
+  it("keeps a drive-relative pathname absolute rather than joining it to a cwd", () => {
+    // `/C:foo.png` has no slash after the colon, so it isn't a drive-absolute
+    // path — it's a POSIX file literally named `C:foo.png` at the root.
+    // Stripping the slash would hand `file.view` a relative path to join.
+    expect(resolveFileUrlCandidate("file:///C:foo.png")?.absolutePath).toBe("/C:foo.png");
+    expect(resolveFileUrlCandidate("file:///%43:")).toBeNull();
   });
 
   it("rejects roots and directory-shaped URLs", () => {
@@ -260,6 +280,20 @@ describe("FILE_URL_REGEX (terminal line scanning)", () => {
 
   it("requires a boundary before the scheme", () => {
     expect(scan("xfile:///tmp/a.png")).toEqual([]);
+  });
+
+  it("unwraps the delimiters agent output puts around a URL", () => {
+    // Symmetry matters: the closing side already terminated on these, so a
+    // one-sided set would linkify on click but not on selection, or vice versa.
+    for (const [open, close] of [
+      ["`", "`"],
+      ['"', '"'],
+      ["'", "'"],
+      ["<", ">"],
+      ["[", "]"],
+    ]) {
+      expect(scan(`saved to ${open}file:///tmp/a.png${close}`)).toEqual(["file:///tmp/a.png"]);
+    }
   });
 
   it("matches an uppercase scheme", () => {

--- a/src/services/terminal/filePathDetection.ts
+++ b/src/services/terminal/filePathDetection.ts
@@ -25,12 +25,20 @@ const WINDOWS_ABS = /^(?:[a-zA-Z]:[\\/]|\\\\)/;
 // still parses as a URL and would link somewhere else entirely. Trailing
 // sentence punctuation is consumed OUTSIDE group 1, and the lookahead demands
 // a real token terminator so a partial match can never pose as the whole URL.
+//
+// The opening and closing delimiter sets are deliberately symmetric: a URL in
+// backticks or quotes has to linkify the same way the selection path resolves
+// it, or right-click "View file" and a click disagree about the same token.
+// `$`/`^` mean logical-line ends, so callers scanning a terminal buffer must
+// rejoin soft-wrapped rows first — a row boundary is not a token boundary.
 export const FILE_URL_REGEX =
-  /(?:^|[\s(])(file:\/\/[^\s<>"'`]*[^\s<>"'`:,.!?;)\]}])[,:.;!?)\]}]*(?=$|[\s<>"'`])/gi;
+  /(?:^|[\s("'`<[])(file:\/\/[^\s<>"'`]*[^\s<>"'`:,.!?;)\]}])[,:.;!?)\]}]*(?=$|[\s<>"'`])/gi;
 
-// A `file:` pathname carrying a Windows drive arrives as `/C:/…`. Positional,
-// not a WINDOWS_ABS reuse: that regex expects the leading slash already gone.
-const WINDOWS_DRIVE_PATHNAME = /^\/[A-Za-z]:/;
+// A `file:` pathname carrying a Windows drive arrives as `/C:/…`. Matched
+// against the DECODED path so `%43`/`%3A` spellings resolve identically, and
+// the trailing `/`-or-end keeps drive-relative `/C:foo.png` (a legitimate
+// POSIX path, not a drive) from losing its leading slash.
+const WINDOWS_DRIVE_PATHNAME = /^\/[A-Za-z]:(?:\/|$)/;
 const WINDOWS_DRIVE_ONLY = /^[A-Za-z]:$/;
 
 // Directory-shaped tokens: multi-segment paths with NO extension requirement,
@@ -150,10 +158,13 @@ export function resolveFileUrlCandidate(text: string): ResolvedFilePath | null {
     // link on the line, so a bad token simply isn't a link.
     return null;
   }
+  // No filesystem accepts a NUL, and the files IPC rejects one at its schema —
+  // a link that can only ever fail is worse than no link.
+  if (decoded.includes("\0")) return null;
 
   // Strip the drive's leading slash by position, never touching the letter's
   // case — Node doesn't either, and callers on case-sensitive volumes care.
-  const absolutePath = WINDOWS_DRIVE_PATHNAME.test(encodedPath) ? decoded.slice(1) : decoded;
+  const absolutePath = WINDOWS_DRIVE_PATHNAME.test(decoded) ? decoded.slice(1) : decoded;
 
   // File-only feature: a root, a drive root, or a trailing-slash directory URL
   // has no file to view, and `file:///` would otherwise link the filesystem
@@ -162,6 +173,11 @@ export function resolveFileUrlCandidate(text: string): ResolvedFilePath | null {
   if (!absolutePath || absolutePath.endsWith("/") || WINDOWS_DRIVE_ONLY.test(absolutePath)) {
     return null;
   }
+  // Last gate before the path reaches `file.view`, which joins anything
+  // relative onto the terminal's cwd — silently opening a file the URL never
+  // named. Nothing that survives the steps above should be relative, so this
+  // is the backstop for a spelling none of them anticipated.
+  if (!isAbsolute(absolutePath)) return null;
 
   return { absolutePath };
 }

--- a/src/services/terminal/filePathDetection.ts
+++ b/src/services/terminal/filePathDetection.ts
@@ -16,6 +16,23 @@ export const FILE_PATH_REGEX =
 
 const WINDOWS_ABS = /^(?:[a-zA-Z]:[\\/]|\\\\)/;
 
+// Matches a `file://` URL token inside arbitrary text — agent CLIs print
+// generated images this way (`file:///Users/me/.codex/generated_images/x.png`).
+// The body class is deliberately permissive about `|`, `\` and brackets: real
+// Windows file URLs carry them (`file:///C|/x.png`, `file:///C:\Users\x.png`,
+// both of which WHATWG normalizes to `/C:/…`), and excluding them the way
+// xterm's web-links regex does would capture a truncated `file:///C` — which
+// still parses as a URL and would link somewhere else entirely. Trailing
+// sentence punctuation is consumed OUTSIDE group 1, and the lookahead demands
+// a real token terminator so a partial match can never pose as the whole URL.
+export const FILE_URL_REGEX =
+  /(?:^|[\s(])(file:\/\/[^\s<>"'`]*[^\s<>"'`:,.!?;)\]}])[,:.;!?)\]}]*(?=$|[\s<>"'`])/gi;
+
+// A `file:` pathname carrying a Windows drive arrives as `/C:/…`. Positional,
+// not a WINDOWS_ABS reuse: that regex expects the leading slash already gone.
+const WINDOWS_DRIVE_PATHNAME = /^\/[A-Za-z]:/;
+const WINDOWS_DRIVE_ONLY = /^[A-Za-z]:$/;
+
 // Directory-shaped tokens: multi-segment paths with NO extension requirement,
 // optionally slash-terminated. Deliberately loose — `and/or` matches — because
 // candidates are validated against the filesystem before they ever become
@@ -82,6 +99,74 @@ export function resolveFilePathCandidate(text: string, cwd: string): ResolvedFil
 }
 
 /**
+ * Turn a `file://` URL token into an absolute filesystem path, mirroring
+ * Node's `fileURLToPath`. Hand-rolled on the WHATWG `URL` global because the
+ * renderer is sandboxed and has no Node builtins — the same reason
+ * `@shared/utils/path` exists.
+ *
+ * No `cwd`: a file URL is absolute by definition. No `:line[:col]` peeling
+ * either — a file URL names an exact resource, and `:42` is a legal POSIX
+ * filename ending, so peeling would silently retarget `/tmp/render:2024` at
+ * `/tmp/render`. Bare tokens keep their suffix handling because a bare
+ * `foo.ts:42` really is a source location.
+ */
+export function resolveFileUrlCandidate(text: string): ResolvedFilePath | null {
+  if (text.includes("\x1b")) return null;
+
+  let url: URL;
+  try {
+    url = new URL(text);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "file:") return null;
+  // Anything but a local authority is someone else's machine. WHATWG already
+  // folds a `localhost` host to "" for file URLs (in any case), so this single
+  // check covers both accepted spellings and rejects `file://server/share`.
+  if (url.hostname !== "") return null;
+
+  // Percent-encoded and query/fragment-free: the parser split those off, and
+  // it already normalized `\` and `|` into `/` and `:`.
+  const encodedPath = url.pathname;
+  // `file:////server/share/x.png` slips past the host check with an empty
+  // hostname but yields a `//`-prefixed pathname, which `@shared/utils/path`
+  // reads as a UNC root. Reject the shape rather than let the empty-host form
+  // smuggle a remote link past the local-authority rule.
+  if (encodedPath.startsWith("//")) return null;
+
+  // Encoded separators are rejected BEFORE decoding, as Node does: one that
+  // survived into the decoded string would invent a path component the URL's
+  // structure never had. Node only rejects `%5c` for Windows because its POSIX
+  // path module treats `\` as an ordinary character — ours doesn't, since
+  // `normalize()` rewrites every `\` to `/`, so here it's the same hazard as
+  // `%2f` on both platforms.
+  if (/%2f/i.test(encodedPath) || /%5c/i.test(encodedPath)) return null;
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(encodedPath);
+  } catch {
+    // Malformed escape (`%zz`). A link provider that throws takes down every
+    // link on the line, so a bad token simply isn't a link.
+    return null;
+  }
+
+  // Strip the drive's leading slash by position, never touching the letter's
+  // case — Node doesn't either, and callers on case-sensitive volumes care.
+  const absolutePath = WINDOWS_DRIVE_PATHNAME.test(encodedPath) ? decoded.slice(1) : decoded;
+
+  // File-only feature: a root, a drive root, or a trailing-slash directory URL
+  // has no file to view, and `file:///` would otherwise link the filesystem
+  // root. A directory URL with no trailing slash falls through and fails
+  // through the viewer's existing error path.
+  if (!absolutePath || absolutePath.endsWith("/") || WINDOWS_DRIVE_ONLY.test(absolutePath)) {
+    return null;
+  }
+
+  return { absolutePath };
+}
+
+/**
  * Detect a file path from a user's text *selection* (terminal or composer). The
  * whole trimmed selection must be a single path token — a path embedded in
  * prose ("see src/foo.ts for details") is intentionally rejected so the "View
@@ -89,7 +174,19 @@ export function resolveFilePathCandidate(text: string, cwd: string): ResolvedFil
  */
 export function resolveSelectedFilePath(selection: string, cwd: string): ResolvedFilePath | null {
   const trimmed = selection.trim();
-  if (!trimmed || isPathExcluded(trimmed)) return null;
+  if (!trimmed) return null;
+
+  // `file://` is checked ahead of `isPathExcluded` rather than by loosening
+  // it: the blanket `://` rejection still has to kill `http://` and `ssh://`,
+  // so this is a scheme-specific carve-out in front of it, not a hole in it.
+  // The whole-selection rule is identical to the bare-path branch below, which
+  // is what keeps the context menu and a click on the same token in agreement.
+  const urlMatches = [...trimmed.matchAll(FILE_URL_REGEX)];
+  if (urlMatches.length === 1 && urlMatches[0]?.[1] === trimmed) {
+    return resolveFileUrlCandidate(trimmed);
+  }
+
+  if (isPathExcluded(trimmed)) return null;
   const matches = [...trimmed.matchAll(FILE_PATH_REGEX)];
   if (matches.length !== 1) return null;
   const [match] = matches;

--- a/src/services/terminal/filePathDetection.ts
+++ b/src/services/terminal/filePathDetection.ts
@@ -32,7 +32,7 @@ const WINDOWS_ABS = /^(?:[a-zA-Z]:[\\/]|\\\\)/;
 // `$`/`^` mean logical-line ends, so callers scanning a terminal buffer must
 // rejoin soft-wrapped rows first — a row boundary is not a token boundary.
 export const FILE_URL_REGEX =
-  /(?:^|[\s("'`<[])(file:\/\/[^\s<>"'`]*[^\s<>"'`:,.!?;)\]}])[,:.;!?)\]}]*(?=$|[\s<>"'`])/gi;
+  /(?:^|[\s("'`<[{])(file:\/\/[^\s<>"'`]*[^\s<>"'`:,.!?;)\]}])[,:.;!?)\]}]*(?=$|[\s<>"'`])/gi;
 
 // A `file:` pathname carrying a Windows drive arrives as `/C:/…`. Matched
 // against the DECODED path so `%43`/`%3A` spellings resolve identically, and


### PR DESCRIPTION
Agent CLIs print generated images as `file:///Users/me/.codex/generated_images/<uuid>/call_<id>.png`, and nothing linkified them. `WebLinksAddon`'s regex is scheme-locked to `http(s)`, and `FileLinksAddon` never saw the token because `isPathExcluded()` drops anything containing `://`.

This lands the handling in the file-link path, as the issue asks — activation goes through the existing `file.view` dispatch, so it inherits `files:read`'s realpath + O_NOFOLLOW containment and opens in the in-app viewer rather than the OS default app. Out-of-project paths work without special handling: `FilePane` already falls back to the file's parent directory as its containment root.

What's in it:
- `resolveFileUrlCandidate()` in `filePathDetection.ts` — mirrors Node's `fileURLToPath` on the WHATWG `URL` global, since the sandboxed renderer has no `node:url`. Percent-decoding, `?query`/`#fragment` stripping, Windows `file:///C:/…` including the `C|` and backslash spellings, and empty-or-`localhost` authorities only.
- A `FILE_URL_REGEX` scan in `FileLinksAddon.provideLinks`, ahead of the bare-path pass so URL spans are claimed first.
- The same rules on the right-click "View file" selection path (`resolveSelectedFilePath`), so selection and click never disagree about a token.

Most of the work went into not producing a *wrong* link, since a truncated `file://` URL still parses and would open a real-but-different file:
- Soft-wrapped rows are rejoined before scanning. The motivating URL is 116 characters and wraps in any tiled terminal; scanning one row would have linked the prefix ending at the margin. The rejoin window is anchored on the hovered row and bounded, and a match touching a clipped edge is claimed but never linked.
- Rejoined rows aren't trimmed — trimming deletes the real spaces separating a URL from the next token and fuses them into a path the URL never named.
- Every syntactic URL span is claimed before resolution, and the bare-path pass now skips claimed ranges. `(` is legal in a file URL and is also the bare-path regex's boundary character, so `file:///tmp/(src/foo.ts` would otherwise have leaked a second link resolved against the cwd.
- Rejected: remote authorities, the `file:////server/share` empty-host UNC smuggle, `%2f`/`%5c` (both, not just Windows — `normalize()` rewrites every `\` to `/` here), malformed escapes, NUL bytes, roots, and trailing-slash directory URLs.

No `:line:col` peeling for URLs: a file URL names an exact resource and `:2024` is a legal POSIX filename ending. Bare paths keep their suffix handling.

Known boundary: a URL starting entirely outside the 2048-character rejoin window is invisible to the scan. Bounding the rejoin is what keeps hover affordable, and reaching it takes a single logical line past ~2048 columns.

Verified locally: 211 tests across the terminal link suites and both `resolveSelectedFilePath` consumers, typecheck, eslint, the per-rule lint ratchet, and prettier.

Resolves #11419