### PR TITLE
fix(agents): make alt-screen mode force full-screen for Grok

### DIFF
--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -1004,22 +1004,37 @@ describe("blockAltScreen capabilities", () => {
 });
 
 describe("screen-mode flag capabilities (#11423)", () => {
+  // Select by property PRESENCE, not truthiness — filtering on the flag value
+  // would drop an agent declaring `""`, which is exactly what the non-empty
+  // assertion below exists to catch.
   const screenModeAgents = getAgentIds()
     .map((id) => ({ id, capabilities: getAgentConfig(id)?.capabilities }))
-    .filter((a) => a.capabilities?.inlineModeFlag ?? a.capabilities?.altScreenFlag);
+    .filter(
+      (a) =>
+        a.capabilities?.inlineModeFlag !== undefined ||
+        a.capabilities?.altScreenFlag !== undefined
+    );
 
   it("declares every screen-mode flag as a single non-empty token", () => {
-    // The launch path matches these by whole-token equality, so a value with
-    // whitespace could never be stripped and would leak into every snapshot.
+    // The launch path matches these by whole-token equality, so an empty or
+    // whitespace-bearing value could never be stripped and would leak into
+    // every persisted snapshot.
     expect(screenModeAgents.length).toBeGreaterThan(0);
     for (const { id, capabilities } of screenModeAgents) {
       for (const flag of [capabilities?.inlineModeFlag, capabilities?.altScreenFlag]) {
         if (flag === undefined) continue;
-        expect(`${id}:${flag}`).toBe(`${id}:${flag.trim()}`);
         expect(flag.length, `${id} declares an empty screen-mode flag`).toBeGreaterThan(0);
         expect(flag, `${id} declares a multi-token screen-mode flag`).not.toMatch(/\s/);
       }
     }
+  });
+
+  it("still ships at least one agent able to force alt screen", () => {
+    // Non-vacuity guard: every assertion in this block passes trivially if no
+    // agent declares `altScreenFlag`, which would mean #11423's fix went dead.
+    expect(
+      screenModeAgents.filter((a) => a.capabilities?.altScreenFlag !== undefined).length
+    ).toBeGreaterThan(0);
   });
 
   it("keeps the two polarities distinct for any agent declaring both", () => {

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -1011,8 +1011,7 @@ describe("screen-mode flag capabilities (#11423)", () => {
     .map((id) => ({ id, capabilities: getAgentConfig(id)?.capabilities }))
     .filter(
       (a) =>
-        a.capabilities?.inlineModeFlag !== undefined ||
-        a.capabilities?.altScreenFlag !== undefined
+        a.capabilities?.inlineModeFlag !== undefined || a.capabilities?.altScreenFlag !== undefined
     );
 
   it("declares every screen-mode flag as a single non-empty token", () => {

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -1003,6 +1003,48 @@ describe("blockAltScreen capabilities", () => {
   });
 });
 
+describe("screen-mode flag capabilities (#11423)", () => {
+  const screenModeAgents = getAgentIds()
+    .map((id) => ({ id, capabilities: getAgentConfig(id)?.capabilities }))
+    .filter((a) => a.capabilities?.inlineModeFlag ?? a.capabilities?.altScreenFlag);
+
+  it("declares every screen-mode flag as a single non-empty token", () => {
+    // The launch path matches these by whole-token equality, so a value with
+    // whitespace could never be stripped and would leak into every snapshot.
+    expect(screenModeAgents.length).toBeGreaterThan(0);
+    for (const { id, capabilities } of screenModeAgents) {
+      for (const flag of [capabilities?.inlineModeFlag, capabilities?.altScreenFlag]) {
+        if (flag === undefined) continue;
+        expect(`${id}:${flag}`).toBe(`${id}:${flag.trim()}`);
+        expect(flag.length, `${id} declares an empty screen-mode flag`).toBeGreaterThan(0);
+        expect(flag, `${id} declares a multi-token screen-mode flag`).not.toMatch(/\s/);
+      }
+    }
+  });
+
+  it("keeps the two polarities distinct for any agent declaring both", () => {
+    for (const { id, capabilities } of screenModeAgents) {
+      if (!capabilities?.inlineModeFlag || !capabilities?.altScreenFlag) continue;
+      expect(
+        capabilities.altScreenFlag,
+        `${id} declares the same token for both screen-mode polarities`
+      ).not.toBe(capabilities.inlineModeFlag);
+    }
+  });
+
+  it("never pairs a force-alt-screen flag with blockAltScreen", () => {
+    // Forcing the CLI into its full-screen TUI while the terminal strips the
+    // alt-screen escape sequences leaves the agent unusable.
+    for (const { id, capabilities } of screenModeAgents) {
+      if (!capabilities?.altScreenFlag) continue;
+      expect(
+        capabilities.blockAltScreen ?? false,
+        `${id} forces alt screen but also blocks it`
+      ).toBe(false);
+    }
+  });
+});
+
 describe("resume configuration", () => {
   it("session-id agents have a quitCommand and a sessionIdPattern", () => {
     const ids = getAgentIds();

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -454,6 +454,20 @@ export interface AgentConfig {
     /** CLI flag to disable alt-screen and use inline rendering (e.g., "--no-alt-screen") */
     inlineModeFlag?: string;
     /**
+     * CLI flag that forces the full-screen alternate buffer (e.g. "--fullscreen"),
+     * the opposite polarity of {@link inlineModeFlag}. Declare it for a CLI that
+     * picks inline on its own — via its own config file or terminal
+     * auto-detection — so choosing "Alt screen" is more than the absence of the
+     * inline flag (#11423). Omit it when the CLI already defaults to alt-screen;
+     * dropping `inlineModeFlag` is then enough.
+     *
+     * Both are single tokens and mutually exclusive: exactly one is injected per
+     * launch, and the launch path strips the other. Never pair this with
+     * `blockAltScreen: true` — forcing a full-screen TUI while the terminal
+     * strips its alt-screen escape sequences leaves the agent unusable.
+     */
+    altScreenFlag?: string;
+    /**
      * Default inline-mode state when the user hasn't chosen one. Agents with an
      * `inlineModeFlag` otherwise default to inline (`true`); set this to `false`
      * for a full-screen TUI that renders better on the alternate screen (clean

--- a/shared/config/agents/grok.ts
+++ b/shared/config/agents/grok.ts
@@ -80,14 +80,26 @@ export const config: AgentConfig = {
   capabilities: {
     scrollback: 10000,
     resizeStrategy: "default",
-    // Rust TUI that would otherwise take over the alternate screen. We default
-    // it inline (`--no-alt-screen`, grok's scrollback-native mode) so output
-    // flows into Daintree's own WebGL scrollback and stays selectable with our
-    // native text-selection layer instead of grok's mouse-grabbing full-screen
-    // TUI. No `defaultInlineMode` override: inline follows the global
-    // "Use alt-screen mode by default" switch (off ⇒ inline), so users can still
-    // flip back to alt-screen globally or per-agent.
+    // Rust TUI that would otherwise take over the alternate screen. Default it
+    // inline (`--no-alt-screen`) so output flows into Daintree's own WebGL
+    // scrollback and stays selectable with the native text-selection layer
+    // instead of grok's mouse-grabbing full-screen TUI. No `defaultInlineMode`
+    // override: inline follows the global "Use alt-screen mode by default"
+    // switch (off ⇒ inline), so users can still flip back globally or per-agent.
+    //
+    // `--no-alt-screen` controls the alternate buffer only — it is a separate
+    // axis from `--minimal`, which trims the chrome. Both polarities need an
+    // explicit flag here because grok picks inline on its own whenever
+    // `~/.grok/config.toml` sets `screen_mode` or terminal auto-detection says
+    // so, which made "Alt screen" a no-op when it merely omitted the inline flag
+    // (#11423). `--fullscreen` is session-scoped, so it overrides that config
+    // and the auto-detection without Daintree ever touching user-owned files.
+    //
+    // Provisional — `--fullscreen` is verified against grok 0.2.111 (issue
+    // author, first-hand); older builds may not accept it. Only users who
+    // actively pick "Alt screen" are exposed, since the default stays inline.
     inlineModeFlag: "--no-alt-screen",
+    altScreenFlag: "--fullscreen",
     supportsBracketedPaste: true,
     // Rust TUI reads the PTY buffer atomically, so the quit-command body and
     // Enter must be sent as separate writes (same rationale as Codex).

--- a/shared/config/agents/grok.ts
+++ b/shared/config/agents/grok.ts
@@ -87,17 +87,19 @@ export const config: AgentConfig = {
     // override: inline follows the global "Use alt-screen mode by default"
     // switch (off ⇒ inline), so users can still flip back globally or per-agent.
     //
-    // `--no-alt-screen` controls the alternate buffer only — it is a separate
-    // axis from `--minimal`, which trims the chrome. Both polarities need an
-    // explicit flag here because grok picks inline on its own whenever
-    // `~/.grok/config.toml` sets `screen_mode` or terminal auto-detection says
-    // so, which made "Alt screen" a no-op when it merely omitted the inline flag
-    // (#11423). `--fullscreen` is session-scoped, so it overrides that config
-    // and the auto-detection without Daintree ever touching user-owned files.
+    // Two axes: `--no-alt-screen` / `[terminal] alt_screen` pick the buffer,
+    // `--minimal` / `[ui] screen_mode` trim the chrome. Both polarities need an
+    // explicit flag here because grok also goes inline on its own whenever
+    // `~/.grok/config.toml` or terminal auto-detection says so, which made "Alt
+    // screen" a no-op when it merely omitted the inline flag (#11423).
     //
-    // Provisional — `--fullscreen` is verified against grok 0.2.111 (issue
-    // author, first-hand); older builds may not accept it. Only users who
-    // actively pick "Alt screen" are exposed, since the default stays inline.
+    // `--fullscreen` is the chrome-axis opposite of `--minimal`. Per `grok --help`
+    // (0.2.111) it is session-scoped — never writes config — but it overrides only
+    // `[ui] screen_mode = "minimal"`; the buffer still follows `[terminal]
+    // alt_screen` and auto-detection, so someone who set `alt_screen = false`
+    // stays inline even on "Alt screen". Collapsing both axes onto one flag pair
+    // is a deliberate simplification; older builds may not accept `--fullscreen`,
+    // and only users who actively pick "Alt screen" are exposed.
     inlineModeFlag: "--no-alt-screen",
     altScreenFlag: "--fullscreen",
     supportsBracketedPaste: true,

--- a/shared/types/__tests__/agentSettings.test.ts
+++ b/shared/types/__tests__/agentSettings.test.ts
@@ -1192,6 +1192,61 @@ describe("paired screen-mode polarities (#11423)", () => {
     expect(reconcileInlineModeFlag(flags, "neither-mode", true)).toEqual(flags);
     expect(reconcileInlineModeFlag(flags, "neither-mode", false)).toEqual(flags);
   });
+
+  it("injects into an empty snapshot, the shape the relaunch chokepoints pass", () => {
+    // restart.ts calls the reconciler with [] and uses the result only when it
+    // comes back non-empty, so a session launched before either polarity
+    // existed still picks up the current decision.
+    expect(reconcileInlineModeFlag([], "both-modes", false)).toEqual([ALT]);
+    expect(reconcileInlineModeFlag([], "both-modes", true)).toEqual([INLINE]);
+    expect(reconcileInlineModeFlag([], "alt-only", true)).toEqual([]);
+    expect(reconcileInlineModeFlag([], "neither-mode", false)).toEqual([]);
+  });
+
+  it("never mutates the input array", () => {
+    for (const agentId of ["inline-only", "alt-only", "both-modes", "neither-mode"]) {
+      for (const effectiveInline of [true, false]) {
+        const input = ["--keep", INLINE, ALT];
+        const snapshot = [...input];
+        reconcileInlineModeFlag(input, agentId, effectiveInline);
+        expect(input, `${agentId} mutated its input`).toEqual(snapshot);
+      }
+    }
+  });
+
+  it("is idempotent for every capability and direction combination", () => {
+    const inputs = [[], ["--keep"], [INLINE], [ALT], ["--keep", INLINE, ALT, INLINE]];
+    for (const agentId of ["inline-only", "alt-only", "both-modes", "neither-mode"]) {
+      for (const effectiveInline of [true, false]) {
+        for (const input of inputs) {
+          const once = reconcileInlineModeFlag(input, agentId, effectiveInline);
+          expect(
+            reconcileInlineModeFlag(once, agentId, effectiveInline),
+            `${agentId} inline=${effectiveInline} input=${JSON.stringify(input)}`
+          ).toEqual(once);
+        }
+      }
+    }
+  });
+
+  it("injects an alt-only agent's token through the generated command too", () => {
+    // The command builder must select from the same pair — a guard accidentally
+    // keyed on `inlineModeFlag` would silently skip an alt-only agent here.
+    const altScreen = generateAgentCommand("alt-only", { inlineMode: "off" }, "alt-only");
+    expect(altScreen).toContain(ALT);
+
+    const inline = generateAgentCommand("alt-only", { inlineMode: "on" }, "alt-only");
+    expect(inline).not.toContain(ALT);
+  });
+
+  it("keeps an alt-only agent's token out of a headless one-shot", () => {
+    // The interactive gate must cover the alt polarity independently: grok
+    // declares both, so it can't prove the gate isn't keyed on the inline flag.
+    const headless = generateAgentCommand("alt-only", { inlineMode: "off" }, "alt-only", {
+      interactive: false,
+    });
+    expect(headless).not.toContain(ALT);
+  });
 });
 
 describe("screen-mode reconciliation composed with bypass reconciliation (#11423)", () => {
@@ -1204,29 +1259,47 @@ describe("screen-mode reconciliation composed with bypass reconciliation (#11423
     agentId: string,
     effectiveBypass: boolean,
     effectiveInline: boolean
-  ) => reconcileInlineModeFlag(reconcileBypassFlags(flags, agentId, effectiveBypass), agentId, effectiveInline);
-
-  it("flips the screen-mode token while the bypass reconciler flips its own", () => {
-    // Grok carries both polarities; codex's bypass token is independent.
-    const withInline = reconcileBoth(["--no-alt-screen"], "grok", true, false);
-    expect(withInline).toContain("--fullscreen");
-    expect(withInline).not.toContain("--no-alt-screen");
-
-    // Flipping back leaves exactly one screen token and preserves the bypass
-    // decision the first reconciler made.
-    const backToInline = reconcileBoth(withInline, "grok", true, true);
-    expect(backToInline.filter((f) => f === "--no-alt-screen" || f === "--fullscreen")).toEqual([
-      "--no-alt-screen",
-    ]);
-    expect(backToInline.filter((f) => f.startsWith("--dangerously"))).toEqual(
-      withInline.filter((f) => f.startsWith("--dangerously"))
+  ) =>
+    reconcileInlineModeFlag(
+      reconcileBypassFlags(flags, agentId, effectiveBypass),
+      agentId,
+      effectiveInline
     );
+
+  // Grok's real bypass token, so the composition is exercised with a token the
+  // bypass reconciler actually owns rather than one it ignores.
+  const bypassToken = DEFAULT_DANGEROUS_ARGS.grok!;
+  const screenTokens = (flags: readonly string[]) =>
+    flags.filter((f) => f === "--no-alt-screen" || f === "--fullscreen");
+
+  it("flips the screen-mode token while the bypass reconciler keeps its own", () => {
+    const altScreen = reconcileBoth(["--no-alt-screen"], "grok", true, false);
+    expect(screenTokens(altScreen)).toEqual(["--fullscreen"]);
+    // The bypass reconciler injected its token into the same array.
+    expect(altScreen).toContain(bypassToken);
+
+    // Flipping screen mode back leaves exactly one screen token and does not
+    // disturb the bypass token the other reconciler owns.
+    const backToInline = reconcileBoth(altScreen, "grok", true, true);
+    expect(screenTokens(backToInline)).toEqual(["--no-alt-screen"]);
+    expect(backToInline.filter((f) => f === bypassToken)).toEqual([bypassToken]);
+  });
+
+  it("drops the bypass token without disturbing the screen-mode token", () => {
+    // The inverse direction: bypass off, screen mode unchanged. Proves neither
+    // reconciler claims the other's token.
+    const both = reconcileBoth([], "grok", true, false);
+    expect(both).toContain(bypassToken);
+
+    const bypassOff = reconcileBoth(both, "grok", false, false);
+    expect(bypassOff).not.toContain(bypassToken);
+    expect(screenTokens(bypassOff)).toEqual(["--fullscreen"]);
   });
 
   it("is idempotent under repeated composed reconciliation", () => {
     const once = reconcileBoth(["--model", "grok-build"], "grok", false, false);
-    expect(once).toEqual(reconcileBoth(once, "grok", false, false));
-    expect(once).toContain("--fullscreen");
+    expect(reconcileBoth(once, "grok", false, false)).toEqual(once);
+    expect(screenTokens(once)).toEqual(["--fullscreen"]);
   });
 });
 

--- a/shared/types/__tests__/agentSettings.test.ts
+++ b/shared/types/__tests__/agentSettings.test.ts
@@ -1143,7 +1143,11 @@ describe("paired screen-mode polarities (#11423)", () => {
 
   it("never lets both polarities coexist after reconciliation", () => {
     for (const effectiveInline of [true, false]) {
-      const reconciled = reconcileInlineModeFlag([INLINE, "--model", ALT], "both-modes", effectiveInline);
+      const reconciled = reconcileInlineModeFlag(
+        [INLINE, "--model", ALT],
+        "both-modes",
+        effectiveInline
+      );
       expect(reconciled).toEqual([effectiveInline ? INLINE : ALT, "--model"]);
     }
   });
@@ -1175,9 +1179,10 @@ describe("paired screen-mode polarities (#11423)", () => {
   });
 
   it("dedupes repeated managed tokens down to the wanted one", () => {
-    expect(
-      reconcileInlineModeFlag([INLINE, "--keep", INLINE, ALT], "both-modes", true)
-    ).toEqual([INLINE, "--keep"]);
+    expect(reconcileInlineModeFlag([INLINE, "--keep", INLINE, ALT], "both-modes", true)).toEqual([
+      INLINE,
+      "--keep",
+    ]);
   });
 
   it("strips the only declared token when the other direction has none", () => {

--- a/shared/types/__tests__/agentSettings.test.ts
+++ b/shared/types/__tests__/agentSettings.test.ts
@@ -1093,6 +1093,143 @@ describe("reconcileInlineModeFlag (resume trap, #10876)", () => {
   });
 });
 
+describe("paired screen-mode polarities (#11423)", () => {
+  // Sentinel tokens, not the real `--no-alt-screen`/`--fullscreen`: these cases
+  // pin the selection *mechanism* across the capability matrix, so they stay
+  // green if a shipped agent's flag spelling ever changes.
+  const INLINE = "--sentinel-inline";
+  const ALT = "--sentinel-alt";
+
+  const agent = (id: string, capabilities: AgentConfig["capabilities"]): AgentConfig => ({
+    id,
+    name: id,
+    command: id,
+    color: "#ffffff",
+    iconId: "custom",
+    supportsContextInjection: false,
+    capabilities,
+  });
+
+  beforeEach(() =>
+    setUserRegistry({
+      "inline-only": agent("inline-only", { inlineModeFlag: INLINE }),
+      "alt-only": agent("alt-only", { altScreenFlag: ALT }),
+      "both-modes": agent("both-modes", { inlineModeFlag: INLINE, altScreenFlag: ALT }),
+      "neither-mode": agent("neither-mode", { scrollback: 1000 }),
+    })
+  );
+  afterEach(() => setUserRegistry({}));
+
+  it("selects at most one token per direction across the capability matrix", () => {
+    // The gap #11423 closes: an agent declaring only `inlineModeFlag` still has
+    // NO way to force alt-screen (undefined row), which is why grok needed the
+    // opposite polarity added rather than a change to the resolver.
+    const cases: Array<[string, boolean, string | undefined]> = [
+      ["inline-only", true, INLINE],
+      ["inline-only", false, undefined],
+      ["alt-only", true, undefined],
+      ["alt-only", false, ALT],
+      ["both-modes", true, INLINE],
+      ["both-modes", false, ALT],
+      ["neither-mode", true, undefined],
+      ["neither-mode", false, undefined],
+    ];
+    for (const [agentId, effectiveInline, expected] of cases) {
+      const flags = buildAgentLaunchFlags({ inlineMode: effectiveInline ? "on" : "off" }, agentId);
+      const screenTokens = flags.filter((f) => f === INLINE || f === ALT);
+      expect(screenTokens).toEqual(expected ? [expected] : []);
+    }
+  });
+
+  it("never lets both polarities coexist after reconciliation", () => {
+    for (const effectiveInline of [true, false]) {
+      const reconciled = reconcileInlineModeFlag([INLINE, "--model", ALT], "both-modes", effectiveInline);
+      expect(reconciled).toEqual([effectiveInline ? INLINE : ALT, "--model"]);
+    }
+  });
+
+  it("flips a stale token in place rather than relocating it", () => {
+    // Position stability keeps an already-persisted snapshot's ordering intact
+    // so a flip rewrites one slot instead of churning the whole array.
+    expect(reconcileInlineModeFlag(["--a", INLINE, "--b"], "both-modes", false)).toEqual([
+      "--a",
+      ALT,
+      "--b",
+    ]);
+    expect(reconcileInlineModeFlag(["--a", ALT, "--b"], "both-modes", true)).toEqual([
+      "--a",
+      INLINE,
+      "--b",
+    ]);
+  });
+
+  it("upgrades a pre-#11423 snapshot that carried no screen-mode token", () => {
+    // The migration path: snapshots captured before `altScreenFlag` existed hold
+    // only the absence of the inline flag, which used to mean "alt screen" but
+    // actually left the CLI on its own default.
+    const legacy = ["--model", "grok-build"];
+    const upgraded = reconcileInlineModeFlag(legacy, "both-modes", false);
+    expect(upgraded).toEqual(["--model", "grok-build", ALT]);
+    // Reconciling the upgraded snapshot again must be a no-op.
+    expect(reconcileInlineModeFlag(upgraded, "both-modes", false)).toEqual(upgraded);
+  });
+
+  it("dedupes repeated managed tokens down to the wanted one", () => {
+    expect(
+      reconcileInlineModeFlag([INLINE, "--keep", INLINE, ALT], "both-modes", true)
+    ).toEqual([INLINE, "--keep"]);
+  });
+
+  it("strips the only declared token when the other direction has none", () => {
+    // An inline-only agent asked for alt-screen loses its inline flag and gains
+    // nothing — it falls back to the CLI's own default, unchanged from #10876.
+    expect(reconcileInlineModeFlag(["--a", INLINE], "inline-only", false)).toEqual(["--a"]);
+    expect(reconcileInlineModeFlag(["--a", ALT], "alt-only", true)).toEqual(["--a"]);
+  });
+
+  it("leaves an agent declaring neither polarity untouched", () => {
+    const flags = ["--a", INLINE, ALT];
+    expect(reconcileInlineModeFlag(flags, "neither-mode", true)).toEqual(flags);
+    expect(reconcileInlineModeFlag(flags, "neither-mode", false)).toEqual(flags);
+  });
+});
+
+describe("screen-mode reconciliation composed with bypass reconciliation (#11423)", () => {
+  // All three relaunch chokepoints (agentResume, panelRegistry/restart,
+  // stateHydration/statePatcher) compose the two reconcilers in this exact
+  // order. They own disjoint tokens, so neither may disturb the other's — this
+  // is the interaction the composition would hide if it regressed.
+  const reconcileBoth = (
+    flags: readonly string[],
+    agentId: string,
+    effectiveBypass: boolean,
+    effectiveInline: boolean
+  ) => reconcileInlineModeFlag(reconcileBypassFlags(flags, agentId, effectiveBypass), agentId, effectiveInline);
+
+  it("flips the screen-mode token while the bypass reconciler flips its own", () => {
+    // Grok carries both polarities; codex's bypass token is independent.
+    const withInline = reconcileBoth(["--no-alt-screen"], "grok", true, false);
+    expect(withInline).toContain("--fullscreen");
+    expect(withInline).not.toContain("--no-alt-screen");
+
+    // Flipping back leaves exactly one screen token and preserves the bypass
+    // decision the first reconciler made.
+    const backToInline = reconcileBoth(withInline, "grok", true, true);
+    expect(backToInline.filter((f) => f === "--no-alt-screen" || f === "--fullscreen")).toEqual([
+      "--no-alt-screen",
+    ]);
+    expect(backToInline.filter((f) => f.startsWith("--dangerously"))).toEqual(
+      withInline.filter((f) => f.startsWith("--dangerously"))
+    );
+  });
+
+  it("is idempotent under repeated composed reconciliation", () => {
+    const once = reconcileBoth(["--model", "grok-build"], "grok", false, false);
+    expect(once).toEqual(reconcileBoth(once, "grok", false, false));
+    expect(once).toContain("--fullscreen");
+  });
+});
+
 describe("global alt-screen threading through command generation (#10876)", () => {
   it("drops --no-alt-screen for an inherit agent when globalUseAltScreen is on", () => {
     // Codex inherits (no explicit choice, no registry default) → follows global.
@@ -1112,13 +1249,43 @@ describe("global alt-screen threading through command generation (#10876)", () =
 
   it("makes grok follow the global switch now that it has no curated default", () => {
     // Grok no longer pins a curated default, so it threads the global switch
-    // like any other inherit agent: inline when off, alt-screen when on.
-    expect(buildAgentLaunchFlags({}, "grok", { globalUseAltScreen: false })).toContain(
-      "--no-alt-screen"
-    );
-    expect(buildAgentLaunchFlags({}, "grok", { globalUseAltScreen: true })).not.toContain(
-      "--no-alt-screen"
-    );
+    // like any other inherit agent: inline when off, alt-screen when on. Grok
+    // declares BOTH polarities (#11423), so each direction is asserted
+    // positively — "alt screen" must inject the force-fullscreen token, not
+    // merely omit the inline one, or the setting is a no-op against grok's own
+    // config/auto-detected default.
+    const inline = buildAgentLaunchFlags({}, "grok", { globalUseAltScreen: false });
+    expect(inline).toContain("--no-alt-screen");
+    expect(inline).not.toContain("--fullscreen");
+
+    const altScreen = buildAgentLaunchFlags({}, "grok", { globalUseAltScreen: true });
+    expect(altScreen).toContain("--fullscreen");
+    expect(altScreen).not.toContain("--no-alt-screen");
+  });
+
+  it("threads both grok polarities through the generated command too", () => {
+    // generateAgentCommand and buildAgentLaunchFlags are dual representations
+    // (#9654) — a fix applied to only one silently drops the flag on restart.
+    const inline = generateAgentCommand("grok", {}, "grok", { globalUseAltScreen: false });
+    expect(inline).toContain("--no-alt-screen");
+    expect(inline).not.toContain("--fullscreen");
+
+    const altScreen = generateAgentCommand("grok", {}, "grok", { globalUseAltScreen: true });
+    expect(altScreen).toContain("--fullscreen");
+    expect(altScreen).not.toContain("--no-alt-screen");
+  });
+
+  it("omits both screen-mode polarities for a headless one-shot", () => {
+    // Screen mode configures the interactive TUI only, so neither token may
+    // reach a non-interactive invocation in either direction.
+    for (const globalUseAltScreen of [true, false]) {
+      const command = generateAgentCommand("grok", {}, "grok", {
+        globalUseAltScreen,
+        interactive: false,
+      });
+      expect(command).not.toContain("--fullscreen");
+      expect(command).not.toContain("--no-alt-screen");
+    }
   });
 
   it("lets an explicit per-agent choice veto the global switch", () => {

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -14,9 +14,11 @@ export type DangerousMode = "inherit" | "on" | "off";
 /**
  * Tri-state alt-screen intent, stored on the `inlineMode` field. `"on"` =
  * inline rendering (inject the agent's `inlineModeFlag`, e.g. `--no-alt-screen`);
- * `"off"` = full-screen alternate buffer (no flag); `"inherit"` defers to the
- * next level up (preset → agent registry default → the global "Use alt-screen
- * mode by default" switch). Value polarity intentionally matches the legacy
+ * `"off"` = full-screen alternate buffer (inject the agent's `altScreenFlag`,
+ * e.g. `--fullscreen`, or no flag when it declares none and rides its own CLI
+ * default); `"inherit"` defers to the next level up (preset → agent registry
+ * default → the global "Use alt-screen mode by default" switch). Value polarity
+ * intentionally matches the legacy
  * `inlineMode` boolean (`true` was inline), so a persisted boolean maps
  * literally — `true → "on"`, `false → "off"` (see {@link resolveInlineMode}).
  * The UI labels are decoupled from these values (the Settings control presents
@@ -267,8 +269,9 @@ export function combineInlineModes(agentMode: InlineMode, presetMode?: InlineMod
  * preset-merged) entry's tri-state mode. Returns `true` when the agent should
  * render inline — i.e. when the agent's `inlineModeFlag` should be injected.
  *
- * - `"on"`  → inline (inject flag).
- * - `"off"` → alt-screen (no flag); an explicit veto that beats the global switch.
+ * - `"on"`  → inline (inject `inlineModeFlag`).
+ * - `"off"` → alt-screen (inject `altScreenFlag` when the agent declares one,
+ *   otherwise no flag); an explicit veto that beats the global switch.
  * - `"inherit"` → a curated per-agent registry `capabilities.defaultInlineMode`
  *   wins if declared (no shipped agent pins one today — they all follow the
  *   global switch so it stays user-overridable); otherwise defer to the global

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -295,36 +295,68 @@ export function resolveEffectiveInlineMode(
 }
 
 /**
+ * Picks the single screen-mode token a launch should carry, plus the full set
+ * of tokens the launch path owns (and must therefore strip when they're stale).
+ *
+ * The two capabilities are opposite polarities of one decision: `inlineModeFlag`
+ * (e.g. `--no-alt-screen`) forces inline, `altScreenFlag` (e.g. `--fullscreen`)
+ * forces the alternate buffer. An agent may declare either, both, or neither.
+ * `wanted` is `undefined` when the agent declares no flag for the resolved
+ * direction — it then rides its own CLI default, which is exactly the
+ * one-directional gap `altScreenFlag` exists to close (#11423).
+ */
+function resolveScreenModeTokens(
+  capabilities: { inlineModeFlag?: string; altScreenFlag?: string } | undefined,
+  effectiveInline: boolean
+): { wanted: string | undefined; managed: string[] } {
+  const inlineFlag = capabilities?.inlineModeFlag;
+  const altFlag = capabilities?.altScreenFlag;
+  const managed = [...new Set([inlineFlag, altFlag].filter((f): f is string => !!f))];
+  return { wanted: effectiveInline ? inlineFlag : altFlag, managed };
+}
+
+/**
  * Reconciles a persisted `agentLaunchFlags` snapshot against the current
  * effective inline-mode decision (#10876) — the alt-screen analog of
  * {@link reconcileBypassFlags}'s "resume trap" fix.
  *
- * The agent's canonical single-token `inlineModeFlag` (e.g. `--no-alt-screen`)
- * is baked into `agentLaunchFlags` by the same `buildAgentLaunchFlags` that
- * captures the bypass flag, so a snapshot can carry a stale `--no-alt-screen`
- * forward after the user (or the global switch) flips the decision. This strips
- * every occurrence of that flag and re-appends a single copy only when
- * `effectiveInline` is true, making every spawn/restart/restore/resume
- * idempotent. Agents with no `inlineModeFlag` are left untouched.
+ * The agent's canonical single-token screen-mode flags (`inlineModeFlag` and,
+ * since #11423, its opposite-polarity `altScreenFlag`) are baked into
+ * `agentLaunchFlags` by the same `buildAgentLaunchFlags` that captures the
+ * bypass flag, so a snapshot can carry a stale token forward after the user (or
+ * the global switch) flips the decision. Exactly one token survives: the first
+ * managed token found is rewritten in place to the wanted one (keeping its
+ * position so an already-correct snapshot is untouched), later managed tokens
+ * are dropped, and the wanted token is appended only when the snapshot carried
+ * none — which is also how a pre-#11423 snapshot picks up its first
+ * `--fullscreen`. Idempotent across every spawn/restart/restore/resume. Agents
+ * declaring neither flag are left untouched.
  */
 export function reconcileInlineModeFlag(
   flags: readonly string[],
   agentId: string,
   effectiveInline: boolean
 ): string[] {
-  const flag = getEffectiveAgentConfig(agentId)?.capabilities?.inlineModeFlag;
-  if (!flag) return [...flags];
-  if (!effectiveInline) return flags.filter((f) => f !== flag);
-  if (!flags.includes(flag)) return [...flags, flag];
-  // Wanted and already present: keep the first occurrence in place (preserving
-  // order so an already-correct snapshot is untouched), drop any duplicates.
-  let kept = false;
-  return flags.filter((f) => {
-    if (f !== flag) return true;
-    if (kept) return false;
-    kept = true;
-    return true;
-  });
+  const { wanted, managed } = resolveScreenModeTokens(
+    getEffectiveAgentConfig(agentId)?.capabilities,
+    effectiveInline
+  );
+  if (managed.length === 0) return [...flags];
+
+  const reconciled: string[] = [];
+  let placed = false;
+  for (const flag of flags) {
+    if (!managed.includes(flag)) {
+      reconciled.push(flag);
+      continue;
+    }
+    if (!placed && wanted) {
+      reconciled.push(wanted);
+      placed = true;
+    }
+  }
+  if (wanted && !placed) reconciled.push(wanted);
+  return reconciled;
 }
 
 /**
@@ -569,20 +601,19 @@ export function generateAgentCommand(
       }
     }
 
-    // Add inline mode flag when the resolved tri-state says inline and the agent
-    // supports it (#10876). resolveEffectiveInlineMode encodes the full chain:
-    // explicit on/off → preset (already baked onto the entry) → curated registry
-    // default → the global `globalUseAltScreen` switch. Inline rendering only
-    // applies to the interactive TUI, so a headless one-shot (`interactive:
-    // false` — e.g. opencode's `run` subcommand, which rejects `--mini`) must not
-    // carry the flag.
-    const inlineModeFlag = agentConfig?.capabilities?.inlineModeFlag;
-    if (
-      inlineModeFlag &&
-      (options?.interactive ?? true) &&
-      resolveEffectiveInlineMode(entry, agentId, options?.globalUseAltScreen)
-    ) {
-      parts.push(inlineModeFlag);
+    // Add the screen-mode flag matching the resolved tri-state, when the agent
+    // declares one for that direction (#10876, #11423). resolveEffectiveInlineMode
+    // encodes the full chain: explicit on/off → preset (already baked onto the
+    // entry) → curated registry default → the global `globalUseAltScreen` switch.
+    // Screen mode only applies to the interactive TUI, so a headless one-shot
+    // (`interactive: false` — e.g. opencode's `run` subcommand, which rejects
+    // `--mini`) must carry neither polarity.
+    if (options?.interactive ?? true) {
+      const { wanted: screenModeFlag } = resolveScreenModeTokens(
+        agentConfig?.capabilities,
+        resolveEffectiveInlineMode(entry, agentId, options?.globalUseAltScreen)
+      );
+      if (screenModeFlag) parts.push(screenModeFlag);
     }
   }
 
@@ -807,12 +838,15 @@ export function buildAgentLaunchFlags(
     flags.push(...agentConfig.args);
   }
 
-  // Inline mode flag when the resolved tri-state says inline and the agent
-  // supports it (#10876) — same resolution chain as generateAgentCommand.
-  const inlineModeFlag = agentConfig?.capabilities?.inlineModeFlag;
-  if (inlineModeFlag && resolveEffectiveInlineMode(entry, agentId, options?.globalUseAltScreen)) {
-    flags.push(inlineModeFlag);
-  }
+  // Screen-mode flag matching the resolved tri-state, when the agent declares
+  // one for that direction (#10876, #11423) — same resolution chain as
+  // generateAgentCommand. No interactive gate: these flags are persisted for the
+  // interactive restart/resume paths that replay them.
+  const { wanted: screenModeFlag } = resolveScreenModeTokens(
+    agentConfig?.capabilities,
+    resolveEffectiveInlineMode(entry, agentId, options?.globalUseAltScreen)
+  );
+  if (screenModeFlag) flags.push(screenModeFlag);
 
   // Model flag for per-panel model selection
   if (options?.modelId) {

--- a/src/components/Settings/AgentScopeEditor/BehavioralControls.tsx
+++ b/src/components/Settings/AgentScopeEditor/BehavioralControls.tsx
@@ -141,7 +141,7 @@ export function BehavioralControls({
         <div id="agents-inline-mode" className="space-y-1.5">
           <SettingsChoicebox<InlineMode>
             label="Alt-screen mode"
-            description="Alt screen uses the CLI's full-screen TUI; inline keeps output in Daintree's scrollback with cleaner resizing. Either choice overrides the global setting for this scope."
+            description="Alt screen uses the CLI's full-screen TUI; inline keeps output in Daintree's scrollback with cleaner resizing. Choosing Inline or Alt screen overrides the inherited setting for this scope."
             columns={3}
             value={inlineMode}
             onChange={onInlineModeChange}

--- a/src/components/Settings/AgentScopeEditor/BehavioralControls.tsx
+++ b/src/components/Settings/AgentScopeEditor/BehavioralControls.tsx
@@ -141,7 +141,7 @@ export function BehavioralControls({
         <div id="agents-inline-mode" className="space-y-1.5">
           <SettingsChoicebox<InlineMode>
             label="Alt-screen mode"
-            description="Alt screen matches the CLI's native full-screen TUI; inline is smoother (WebGL scrollback, clean resize). Off vetoes the global setting for this scope."
+            description="Alt screen uses the CLI's full-screen TUI; inline keeps output in Daintree's scrollback with cleaner resizing. Either choice overrides the global setting for this scope."
             columns={3}
             value={inlineMode}
             onChange={onInlineModeChange}

--- a/src/components/Settings/AgentScopeEditor/__tests__/useAgentScope.test.tsx
+++ b/src/components/Settings/AgentScopeEditor/__tests__/useAgentScope.test.tsx
@@ -125,7 +125,10 @@ describe("useAgentScope — inline-mode inherit origin label (#10894)", () => {
 });
 
 describe("useAgentScope — screen-mode control gating (#11423)", () => {
-  const withCapabilities = (id: string, capabilities: AgentConfig["capabilities"]): AgentConfig => ({
+  const withCapabilities = (
+    id: string,
+    capabilities: AgentConfig["capabilities"]
+  ): AgentConfig => ({
     id,
     name: id,
     command: id,

--- a/src/components/Settings/AgentScopeEditor/__tests__/useAgentScope.test.tsx
+++ b/src/components/Settings/AgentScopeEditor/__tests__/useAgentScope.test.tsx
@@ -123,3 +123,38 @@ describe("useAgentScope — inline-mode inherit origin label (#10894)", () => {
     expect(result.current.inlineInheritOriginLabel).toBe("agent default");
   });
 });
+
+describe("useAgentScope — screen-mode control gating (#11423)", () => {
+  const withCapabilities = (id: string, capabilities: AgentConfig["capabilities"]): AgentConfig => ({
+    id,
+    name: id,
+    command: id,
+    color: "#ffffff",
+    iconId: "custom",
+    supportsContextInjection: false,
+    capabilities,
+  });
+
+  beforeEach(() => {
+    useAgentSettingsStore.setState({ settings: DEFAULT_AGENT_SETTINGS });
+    setUserRegistry({
+      "inline-only": withCapabilities("inline-only", { inlineModeFlag: "--sentinel-inline" }),
+      "alt-only": withCapabilities("alt-only", { altScreenFlag: "--sentinel-alt" }),
+      "neither-mode": withCapabilities("neither-mode", { scrollback: 1000 }),
+    });
+  });
+  afterEach(() => {
+    setUserRegistry({});
+  });
+
+  it("shows the control for either polarity and hides it only when neither is declared", () => {
+    // An agent declaring only `altScreenFlag` can still force full-screen, so
+    // gating on `inlineModeFlag` alone would hide a control that works.
+    const supports = (agentId: string) =>
+      renderHook(() => useAgentScope(makeProps(agentId))).result.current.supportsInlineMode;
+
+    expect(supports("inline-only")).toBe(true);
+    expect(supports("alt-only")).toBe(true);
+    expect(supports("neither-mode")).toBe(false);
+  });
+});

--- a/src/components/Settings/AgentScopeEditor/useAgentScope.ts
+++ b/src/components/Settings/AgentScopeEditor/useAgentScope.ts
@@ -73,9 +73,8 @@ export function useAgentScope({
   // declare only `altScreenFlag` (forces full-screen) or only `inlineModeFlag`
   // (forces inline) and still ride its CLI default in the other direction
   // (#11423). Gating on `inlineModeFlag` alone would hide a working control.
-  const supportsInlineMode = !!(
-    agentCfg?.capabilities?.inlineModeFlag ?? agentCfg?.capabilities?.altScreenFlag
-  );
+  const supportsInlineMode =
+    !!agentCfg?.capabilities?.inlineModeFlag || !!agentCfg?.capabilities?.altScreenFlag;
 
   const agentDefaultCustomFlags = activeEntry.customFlags ?? "";
 

--- a/src/components/Settings/AgentScopeEditor/useAgentScope.ts
+++ b/src/components/Settings/AgentScopeEditor/useAgentScope.ts
@@ -69,7 +69,13 @@ export function useAgentScope({
   }, [scopeKind, selectedPreset]);
 
   const agentCfg = getAgentConfig(agentId);
-  const supportsInlineMode = !!agentCfg?.capabilities?.inlineModeFlag;
+  // Either polarity is enough to make the control do something: an agent may
+  // declare only `altScreenFlag` (forces full-screen) or only `inlineModeFlag`
+  // (forces inline) and still ride its CLI default in the other direction
+  // (#11423). Gating on `inlineModeFlag` alone would hide a working control.
+  const supportsInlineMode = !!(
+    agentCfg?.capabilities?.inlineModeFlag ?? agentCfg?.capabilities?.altScreenFlag
+  );
 
   const agentDefaultCustomFlags = activeEntry.customFlags ?? "";
 

--- a/src/components/Settings/settingsTabRegistry.tsx
+++ b/src/components/Settings/settingsTabRegistry.tsx
@@ -1045,7 +1045,7 @@ export const SETTINGS_REGISTRY = [
         subtabLabel: "Claude",
         section: "Agent runtime settings",
         title: "Alt-screen mode",
-        description: "Choose inline rendering or the CLI's fullscreen TUI per agent",
+        description: "Choose inline rendering or the CLI's full-screen TUI per agent",
         keywords: ["inline", "mode", "tui", "fullscreen", "alt screen", "resize", "tty"],
       },
       {

--- a/src/components/Settings/settingsTabRegistry.tsx
+++ b/src/components/Settings/settingsTabRegistry.tsx
@@ -1044,7 +1044,7 @@ export const SETTINGS_REGISTRY = [
         subtab: "claude",
         subtabLabel: "Claude",
         section: "Agent runtime settings",
-        title: "Inline mode",
+        title: "Alt-screen mode",
         description: "Choose inline rendering or the CLI's fullscreen TUI per agent",
         keywords: ["inline", "mode", "tui", "fullscreen", "alt screen", "resize", "tty"],
       },

--- a/src/components/Settings/settingsTabRegistry.tsx
+++ b/src/components/Settings/settingsTabRegistry.tsx
@@ -1045,8 +1045,8 @@ export const SETTINGS_REGISTRY = [
         subtabLabel: "Claude",
         section: "Agent runtime settings",
         title: "Inline mode",
-        description: "Disable fullscreen TUI for better resize handling and scrollback",
-        keywords: ["inline", "mode", "tui", "fullscreen", "resize", "tty"],
+        description: "Choose inline rendering or the CLI's fullscreen TUI per agent",
+        keywords: ["inline", "mode", "tui", "fullscreen", "alt screen", "resize", "tty"],
       },
       {
         id: "agents-clipboard",

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -8,7 +8,7 @@ const getMergedPresetMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/config/agents", () => ({
   isRegisteredAgent: (type: string) =>
-    ["claude", "gemini", "antigravity", "codex", "opencode"].includes(type),
+    ["claude", "gemini", "antigravity", "codex", "opencode", "grok"].includes(type),
   getAgentConfig: (id: string) => ({
     command: id,
     name: id.charAt(0).toUpperCase() + id.slice(1),
@@ -1067,6 +1067,59 @@ describe("buildArgsForRespawn", () => {
     ]);
     // ...but the stored snapshot is not synthesized from nothing.
     expect(result.agentLaunchFlags).toEqual([]);
+  });
+
+  it("injects the force-alt-screen flag into an empty snapshot at resume (#11423)", () => {
+    // The live crash-recovery boundary: this file runs the REAL reconciler, so
+    // it proves the chokepoint actually threads the resolved decision through
+    // rather than merely that the reconciler works in isolation. A session
+    // captured before #11423 has no screen-mode token at all, and alt-screen
+    // used to mean "inject nothing" — which left grok on its own inline default.
+    buildResumeCommandMock.mockClear();
+    const result = buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "terminal" as const,
+        agentId: "grok",
+        cwd: "/p",
+        location: "grid",
+        agentSessionId: "sess-1",
+        agentLaunchFlags: [],
+      },
+      "agent",
+      "/p",
+      { agents: { grok: {} }, globalUseAltScreen: true },
+      false,
+      undefined
+    );
+    expect(buildResumeCommandMock).toHaveBeenCalledWith("grok", "sess-1", ["--fullscreen"]);
+    expect(result.agentLaunchFlags).toEqual([]);
+  });
+
+  it("flips a stale inline token to force-alt-screen on resume (#11423)", () => {
+    buildResumeCommandMock.mockClear();
+    buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "terminal" as const,
+        agentId: "grok",
+        cwd: "/p",
+        location: "grid",
+        agentSessionId: "sess-1",
+        // Captured while the global switch said inline.
+        agentLaunchFlags: ["--no-alt-screen", "--model", "grok-build"],
+      },
+      "agent",
+      "/p",
+      { agents: { grok: {} }, globalUseAltScreen: true },
+      false,
+      undefined
+    );
+    expect(buildResumeCommandMock).toHaveBeenCalledWith("grok", "sess-1", [
+      "--fullscreen",
+      "--model",
+      "grok-build",
+    ]);
   });
 
   it("prefers primary buildResumeCommand over resume-latest when session ID is present", () => {


### PR DESCRIPTION
## Summary

- The per-agent Alt-screen mode setting was one-directional: `resolveEffectiveInlineMode()` returns a boolean, and the launch path could only add or omit `capabilities.inlineModeFlag` (`--no-alt-screen` for Grok).
- Choosing "Alt screen" just meant we weren't adding the inline flag, so Grok fell back to its own default, which is inline or minimal whenever `~/.grok/config.toml` sets `screen_mode` or terminal auto-detection picks inline. The setting was a no-op for Grok.
- This adds an opposite-polarity `capabilities.altScreenFlag` and declares Grok's session-scoped `--fullscreen` flag, so "Alt screen" injects a real flag instead of relying on the absence of another one.

Resolves #11423

## The fix

Per precedent #4100, nothing here reads or writes the user's `~/.grok/config.toml`. The fix is purely a flag on Daintree's own spawn command.

`reconcileInlineModeFlag` was extended in place to manage both tokens, so all three relaunch code paths (`agentResume`, `panelRegistry` restart, `stateHydration` statePatcher) pick up the behavior with zero call-site changes. Exactly one token survives: the first managed token is flipped in place, later ones are dropped, and the wanted token is appended only when none existed. That's also how a pre-fix snapshot upgrades on restart, resume, or crash recovery.

Both dual representations were updated (`generateAgentCommand` and `buildAgentLaunchFlags`), per the lesson from #9654 that editing only one silently drops the flag on restart.

The Settings control gate was widened to either polarity, so an agent declaring only `altScreenFlag` doesn't end up with a hidden but functional control.

## Changes

- `shared/config/agentRegistry.ts`, `shared/config/agents/grok.ts`: add `capabilities.altScreenFlag`, declare `--fullscreen` for Grok
- `shared/types/agentSettings.ts`: extend `reconcileInlineModeFlag` to manage both tokens
- `src/components/Settings/AgentScopeEditor/useAgentScope.ts`, `BehavioralControls.tsx`: widen the control gate to either polarity
- `src/components/Settings/settingsTabRegistry.tsx`: wiring for the widened gate
- Tests: `shared/types/__tests__/agentSettings.test.ts`, `shared/config/__tests__/agentRegistry.test.ts`, `src/components/Settings/AgentScopeEditor/__tests__/useAgentScope.test.tsx`, `src/utils/stateHydration/__tests__/statePatcher.test.ts`

## Testing

868 tests pass locally across `agentSettings`, `agentRegistry`, `useAgentScope`, `BehavioralControls`, `restartTerminal`, `statePatcher`, `agentResume`, `agents-adversarial`, `recipeStore`, and `panelSpawning`. eslint reports 0 errors, prettier is clean on all changed files.

## Known limitations (deliberately out of scope)

1. `--fullscreen` is corroborated by the issue author's first-hand check on `grok 0.2.111`, but external documentation verification was inconclusive, so the registry comment marks it as provisional. Older Grok builds may reject the flag, but exposure is limited to users who actively select "Alt screen" since the default stays inline.
2. Preset or custom flags that manually duplicate a screen-mode token still behave differently on first launch vs. restart (first launch keeps both tokens, restart canonicalizes to one). This is a pre-existing precedence asymmetry that also affected `--no-alt-screen` before this fix. Fixing it needs argument provenance tracking and belongs in a separate change.
