### PR TITLE
feat(file-viewer): recognise AVIF and APNG as images

### DIFF
--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -1677,6 +1677,27 @@ describe("createDaintreeFileProtocolHandler — symlink containment", () => {
     expect(fs.open).toHaveBeenCalledTimes(1);
   });
 
+  it.each([
+    ["image/avif", "/project/big.avif"],
+    ["image/apng", "/project/big.apng"],
+  ])("extends the raster ceiling to %s", async (mimeType, filePath) => {
+    // Both decode to pixels like every other raster format, so they belong on
+    // the image ceiling — an animated APNG in particular passes 512 KB quickly.
+    const fs = await import("fs/promises");
+    vi.mocked(fs.realpath).mockImplementation((p) => Promise.resolve(p as string));
+    vi.mocked(fs.stat).mockResolvedValue({ size: 5 * 1024 * 1024 } as Awaited<
+      ReturnType<typeof fs.stat>
+    >);
+    const appProtocol = await import("../../utils/appProtocol.js");
+    vi.mocked(appProtocol.getMimeType).mockReturnValue(mimeType);
+
+    const handler = await captureHandler("daintree-file");
+    const response = await handler(makeRequest(filePath, "/project"));
+
+    expect(response.status).toBe(200);
+    expect(fs.open).toHaveBeenCalledTimes(1);
+  });
+
   it("still rejects an image beyond the image ceiling with 413", async () => {
     const fs = await import("fs/promises");
     vi.mocked(fs.realpath).mockImplementation((p) => Promise.resolve(p as string));

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -167,15 +167,19 @@ const DAINTREE_FILE_MAX_BYTES = 512 * 1024;
 // a normal screenshot or AI-generated PNG routinely runs to several MB. These
 // MIME types get a much larger ceiling (still bounded, and enforced against the
 // bytes actually read) so the inline file viewer can display them. The set
-// mirrors FileViewerModal's IMAGE_EXTENSIONS; SVG is deliberately excluded — the
+// mirrors filePreviewKinds' IMAGE_EXTENSIONS; SVG is deliberately excluded — the
 // viewer routes SVG through the sanitizing files:read path (its own 512 KB cap),
 // so serving multi-MB raw SVG here would be inconsistent and pointless.
 const DAINTREE_IMAGE_MAX_BYTES = 25 * 1024 * 1024;
 const LARGE_IMAGE_MIME_TYPES = new Set([
   "image/png",
+  // Animated PNG frames are stored close to raw, so an APNG clears 512 KB far
+  // sooner than a still image of the same dimensions.
+  "image/apng",
   "image/jpeg",
   "image/gif",
   "image/webp",
+  "image/avif",
   "image/bmp",
   "image/x-icon",
 ]);

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -174,7 +174,8 @@ const DAINTREE_IMAGE_MAX_BYTES = 25 * 1024 * 1024;
 const LARGE_IMAGE_MIME_TYPES = new Set([
   "image/png",
   // Animated PNG frames are stored close to raw, so an APNG clears 512 KB far
-  // sooner than a still image of the same dimensions.
+  // sooner than a still image of the same dimensions. Not a new exposure: the
+  // same bytes already got this ceiling whenever they were named .png.
   "image/apng",
   "image/jpeg",
   "image/gif",

--- a/electron/utils/__tests__/appProtocol.test.ts
+++ b/electron/utils/__tests__/appProtocol.test.ts
@@ -26,6 +26,15 @@ describe("appProtocol utilities", () => {
       expect(getMimeType("hero.avif")).toBe("image/avif");
     });
 
+    it("maps APNG to its own image type rather than the octet-stream fallback", () => {
+      // An .apng is a valid PNG, but nosniff on daintree-file:// means the
+      // declared type is final: falling back to application/octet-stream would
+      // stop Chromium decoding it in an <img> even though it can animate it.
+      expect(getMimeType("animation.apng")).toBe("image/apng");
+      expect(getMimeType("ANIMATION.APNG")).toBe("image/apng");
+      expect(getMimeType("PHOTO.AVIF")).toBe("image/avif");
+    });
+
     it("should return video MIME types for containers Chromium plays natively", () => {
       // Drives the daintree-file:// handler's video-vs-buffered routing AND the
       // Content-Type on streamed responses — nosniff makes a wrong type fatal.

--- a/electron/utils/appProtocol.ts
+++ b/electron/utils/appProtocol.ts
@@ -46,6 +46,10 @@ const MIME_TYPES: Record<string, string> = {
   ".css": "text/css",
   ".json": "application/json",
   ".png": "image/png",
+  // Distinct from image/png so nosniff doesn't block the load: an unmapped
+  // extension falls through to application/octet-stream below, which Chromium
+  // refuses to decode as an image once nosniff is set.
+  ".apng": "image/apng",
   ".jpg": "image/jpeg",
   ".jpeg": "image/jpeg",
   ".gif": "image/gif",

--- a/src/components/FileViewer/__tests__/filePreviewKinds.test.ts
+++ b/src/components/FileViewer/__tests__/filePreviewKinds.test.ts
@@ -8,6 +8,50 @@ import {
 } from "../filePreviewKinds";
 
 describe("filePreviewKinds", () => {
+  describe("isImageFilePath", () => {
+    it.each([
+      "photo.png",
+      "photo.jpg",
+      "photo.jpeg",
+      "photo.gif",
+      "photo.webp",
+      "photo.bmp",
+      "photo.ico",
+      "icon.svg",
+      // Chromium decodes and animates both natively; before #11426 they fell
+      // through to the text path and reported "Binary file — cannot display".
+      "photo.avif",
+      "animation.apng",
+      // Case is normalized before lookup, so a shouty extension still renders.
+      "PHOTO.AVIF",
+      "ANIMATION.APNG",
+      "a/b/c.render.avif",
+    ])("accepts %s", (path) => {
+      expect(isImageFilePath(path)).toBe(true);
+    });
+
+    it.each([
+      // Only the final extension counts — a lookalike suffix is still text.
+      "photo.avif.txt",
+      "animation.apng.txt",
+      "notes.md",
+      "clip.mp4",
+      "archive.zip",
+    ])("rejects %s", (path) => {
+      expect(isImageFilePath(path)).toBe(false);
+    });
+
+    it("treats the new raster formats as <img> sources, not sanitized SVG", () => {
+      // isSvgFilePath gates the read-as-text-and-sanitize branch; a raster
+      // format landing there would be read as a string and rejected as binary.
+      for (const path of ["photo.avif", "animation.apng"]) {
+        expect(isSvgFilePath(path)).toBe(false);
+        expect(isVideoFilePath(path)).toBe(false);
+        expect(isUnsupportedVideoFilePath(path)).toBe(false);
+      }
+    });
+  });
+
   describe("isVideoFilePath", () => {
     it.each(["clip.mp4", "clip.m4v", "clip.webm", "clip.ogv", "CLIP.MP4", "a/b/c.demo.webm"])(
       "accepts %s",

--- a/src/components/FileViewer/filePreviewKinds.ts
+++ b/src/components/FileViewer/filePreviewKinds.ts
@@ -6,7 +6,21 @@
  * meant opening an image in one worked and errored in the other.
  */
 
-const IMAGE_EXTENSIONS = new Set(["png", "jpg", "jpeg", "gif", "webp", "bmp", "ico"]);
+// apng is listed alongside png because the extension — not the container — is
+// what routes a file here: an .apng is a valid PNG, but without its own entry it
+// falls through to the text path and reports "Binary file". Chromium decodes and
+// animates both apng and avif natively in an <img>.
+const IMAGE_EXTENSIONS = new Set([
+  "png",
+  "apng",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "avif",
+  "bmp",
+  "ico",
+]);
 const SVG_EXTENSION = "svg";
 
 // Containers Chromium's media pipeline demuxes natively (stock Electron ships


### PR DESCRIPTION
## Summary

- The file viewer's image classifier in `filePreviewKinds.ts` didn't recognise `avif` or `apng` files, so they fell through to the text read path and reported `Binary file, cannot display`.
- Fixed this across all three places that needed to agree: the classifier, the protocol's MIME map, and the large-image size cap.
- Added direct test coverage for the classifier (it had none before) plus targeted cases for the other two files.

Resolves #11426

## Changes

1. `src/components/FileViewer/filePreviewKinds.ts`: added `avif` and `apng` to `IMAGE_EXTENSIONS`.
2. `electron/utils/appProtocol.ts`: added `apng` to `image/apng` in `MIME_TYPES` (`avif` was already mapped).
3. `electron/setup/protocols.ts`: added `image/avif` and `image/apng` to `LARGE_IMAGE_MIME_TYPES`, raising the cap from 512 KB to 25 MB for these formats. Also corrected a stale comment that referenced the deleted `FileViewerModal`, pointing it at `filePreviewKinds` instead.

All three were necessary together, not just the classifier. The `daintree-file://` protocol sets `X-Content-Type-Options: nosniff`, so an unmapped extension falls through `getMimeType()` to `application/octet-stream`, which Chromium refuses to decode in an `img` tag. Changing the classifier alone would have just swapped the "Binary file" message for a silently blank image. And without the size cap change, both formats would stay on the 512 KB text cap, which animated APNG files routinely exceed.

## Testing

- `src/components/FileViewer/__tests__/filePreviewKinds.test.ts`: new `isImageFilePath` describe block. The classifier previously had no direct accept/reject coverage at all, only an indirect video "never overlaps" cross-check. Now covers all existing formats plus `avif`/`apng`, uppercase normalisation, and suffix lookalikes.
- `electron/utils/__tests__/appProtocol.test.ts`: `.apng` to `image/apng` plus uppercase cases.
- `electron/setup/__tests__/protocols.test.ts`: an `it.each` cap test proving a 5 MB avif/apng file serves 200 rather than 413.
- Ran 440 tests across 10 files locally, covering the three changed modules plus consumers: `FilePane`, `FileBrowserViewer`, `FileImagePreview`, `ImageDiffViewer`, `FileVideoPreview`, `SurfaceViewManager`, `globalServicesInit`.
- `prettier --check` and `eslint` clean on all six changed files.
- Reviewed by two parallel automated passes, one for security/correctness and one for test quality. Both approved with no blockers.
- Verified separately that no CSP/COEP change was needed: the renderer's CSP `img-src` already permits `daintree-file:` in both production and development, the response's `sandbox; default-src 'none'` CSP doesn't affect an image subresource, and COEP `credentialless` plus CORP `cross-origin` already allow the `img` load.

## Follow-ups (out of scope here)

1. `shared/types/ipc/diffMedia.ts`'s `DIFF_MEDIA_IMAGE_MIME_BY_EXTENSION` still omits `avif`/`apng`, so a changed `.avif` file in a git diff still shows a binary content message in the image compare panel. That's a separate feature behind separate IPC with its own 8 MB per-side cap, and it wasn't regressed here, it was already broken.
2. There's no decoded pixel/frame/dimension guard anywhere on this path for any raster format, only the encoded byte size ceiling. Review rated this medium severity but not a new worst case: PNG, WebP, and GIF already carry the same 25 MB allowance, and APNG bytes already got it whenever a file happened to be named `.png`. Worth hardening across all raster formats, and `diffMedia`, as a future follow-up.