### PR TITLE
feat(file-viewer): play audio files inline

### DIFF
--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -2132,9 +2132,7 @@ describe("createDaintreeFileProtocolHandler — video streaming (#11382)", () =>
       );
 
       expect(response.status).toBe(206);
-      expect(response.headers.get("Content-Range")).toBe(
-        `bytes 4-9/${String(VIDEO_BYTES.length)}`
-      );
+      expect(response.headers.get("Content-Range")).toBe(`bytes 4-9/${String(VIDEO_BYTES.length)}`);
       expect(await response.text()).toBe("456789");
     });
 

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -2069,6 +2069,12 @@ describe("createDaintreeFileProtocolHandler — video streaming (#11382)", () =>
     vi.mocked(fs.open).mockResolvedValue(
       makeVideoHandle() as unknown as Awaited<ReturnType<typeof fs.open>>
     );
+    // Pinned here rather than inherited: clearAllMocks keeps implementations,
+    // so a stat left over from an earlier describe would silently decide the
+    // buffered-fallback cases below.
+    vi.mocked(fs.stat).mockResolvedValue({
+      size: VIDEO_BYTES.length,
+    } as Awaited<ReturnType<typeof fs.stat>>);
     const appProtocol = await import("../../utils/appProtocol.js");
     vi.mocked(appProtocol.getMimeType).mockReturnValue("video/mp4");
   });
@@ -2132,23 +2138,69 @@ describe("createDaintreeFileProtocolHandler — video streaming (#11382)", () =>
       expect(await response.text()).toBe("456789");
     });
 
-    it("falls back to the buffered path when an audio name resolves to a non-media file", async () => {
-      // The canonical-path recheck is what stops an `.mp3` symlink pointed at a
-      // huge text file from being streamed uncapped under an audio MIME.
+    it("routes an audio-suffixed alias of a non-media file through the buffered path", async () => {
+      // On Windows O_NOFOLLOW is a no-op, so an in-root `track.mp3 → notes.txt`
+      // symlink opens fine — classification must follow the canonical target so
+      // the read stays capped instead of streaming uncapped under an audio MIME.
       const fs = await import("fs/promises");
-      vi.mocked(fs.realpath).mockResolvedValue("/project/notes.txt");
       const appProtocol = await import("../../utils/appProtocol.js");
+      const alias = path.normalize("/project/track.mp3");
+      const target = path.normalize("/project/notes.txt");
+      vi.mocked(fs.realpath).mockImplementation((p) =>
+        Promise.resolve(p === alias ? target : (p as string))
+      );
       vi.mocked(appProtocol.getMimeType).mockImplementation((p: string) =>
         p.endsWith(".mp3") ? "audio/mpeg" : "text/plain"
       );
-      const handle = makeVideoHandle(VIDEO_BYTES);
-      await installHandle(handle);
+      vi.mocked(fs.stat).mockResolvedValue({ size: 4 } as Awaited<ReturnType<typeof fs.stat>>);
+      const bufferedHandle = {
+        readFile: vi.fn().mockResolvedValue(Buffer.from("data")),
+        close: vi.fn().mockResolvedValue(undefined),
+      };
+      vi.mocked(fs.open).mockResolvedValue(
+        bufferedHandle as unknown as Awaited<ReturnType<typeof fs.open>>
+      );
 
       const handler = await captureHandler();
       const response = await handler(makeVideoRequest("/project/track.mp3", "/project"));
 
-      expect(handle.createReadStream).not.toHaveBeenCalled();
+      // A 200 with the canonical text MIME — not a 500 from an unconfigured
+      // buffered handle, which would let this pass without proving anything.
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Content-Type")).toBe("text/plain");
       expect(response.headers.get("Accept-Ranges")).toBeNull();
+      expect(bufferedHandle.readFile).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects an oversize audio alias of a text file with 413 before opening it", async () => {
+      // The cap is the whole point of routing the alias back to the buffered
+      // core; a size past it must be refused rather than read.
+      const fs = await import("fs/promises");
+      const appProtocol = await import("../../utils/appProtocol.js");
+      const alias = path.normalize("/project/track.mp3");
+      const target = path.normalize("/project/notes.txt");
+      vi.mocked(fs.realpath).mockImplementation((p) =>
+        Promise.resolve(p === alias ? target : (p as string))
+      );
+      vi.mocked(appProtocol.getMimeType).mockImplementation((p: string) =>
+        p.endsWith(".mp3") ? "audio/mpeg" : "text/plain"
+      );
+      vi.mocked(fs.stat).mockResolvedValue({
+        size: 5 * 1024 * 1024,
+      } as Awaited<ReturnType<typeof fs.stat>>);
+      const bufferedHandle = {
+        readFile: vi.fn(),
+        close: vi.fn().mockResolvedValue(undefined),
+      };
+      vi.mocked(fs.open).mockResolvedValue(
+        bufferedHandle as unknown as Awaited<ReturnType<typeof fs.open>>
+      );
+
+      const handler = await captureHandler();
+      const response = await handler(makeVideoRequest("/project/track.mp3", "/project"));
+
+      expect(response.status).toBe(413);
+      expect(bufferedHandle.readFile).not.toHaveBeenCalled();
     });
   });
 

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -2095,6 +2095,63 @@ describe("createDaintreeFileProtocolHandler — video streaming (#11382)", () =>
     });
   });
 
+  describe("audio streaming (#11425)", () => {
+    // Audio joined the streaming route because the buffered core caps normal
+    // files at 512 KB — every real track would have 413'd before reaching the
+    // renderer.
+    it("streams an audio file far past the buffered cap instead of 413ing", async () => {
+      const size = 8 * 1024 * 1024;
+      const handle = makeVideoHandle(VIDEO_BYTES, { size });
+      await installHandle(handle);
+      const appProtocol = await import("../../utils/appProtocol.js");
+      vi.mocked(appProtocol.getMimeType).mockReturnValue("audio/mpeg");
+
+      const handler = await captureHandler();
+      const response = await handler(makeVideoRequest("/project/track.mp3", "/project"));
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Content-Length")).toBe(String(size));
+      expect(response.headers.get("Content-Type")).toBe("audio/mpeg");
+      expect(response.headers.get("Accept-Ranges")).toBe("bytes");
+      expect(handle.readFile).not.toHaveBeenCalled();
+    });
+
+    it("serves a ranged audio request from the same stream path", async () => {
+      const appProtocol = await import("../../utils/appProtocol.js");
+      vi.mocked(appProtocol.getMimeType).mockReturnValue("audio/flac");
+
+      const handler = await captureHandler();
+      const response = await handler(
+        makeVideoRequest("/project/track.flac", "/project", { range: "bytes=4-9" })
+      );
+
+      expect(response.status).toBe(206);
+      expect(response.headers.get("Content-Range")).toBe(
+        `bytes 4-9/${String(VIDEO_BYTES.length)}`
+      );
+      expect(await response.text()).toBe("456789");
+    });
+
+    it("falls back to the buffered path when an audio name resolves to a non-media file", async () => {
+      // The canonical-path recheck is what stops an `.mp3` symlink pointed at a
+      // huge text file from being streamed uncapped under an audio MIME.
+      const fs = await import("fs/promises");
+      vi.mocked(fs.realpath).mockResolvedValue("/project/notes.txt");
+      const appProtocol = await import("../../utils/appProtocol.js");
+      vi.mocked(appProtocol.getMimeType).mockImplementation((p: string) =>
+        p.endsWith(".mp3") ? "audio/mpeg" : "text/plain"
+      );
+      const handle = makeVideoHandle(VIDEO_BYTES);
+      await installHandle(handle);
+
+      const handler = await captureHandler();
+      const response = await handler(makeVideoRequest("/project/track.mp3", "/project"));
+
+      expect(handle.createReadStream).not.toHaveBeenCalled();
+      expect(response.headers.get("Accept-Ranges")).toBeNull();
+    });
+  });
+
   describe("CORS gate (blob-URL playback fetch)", () => {
     // corsEnabled on the scheme only makes cross-origin fetch possible;
     // these pin the actual grant: ACAO echoed solely for the trusted app

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -522,7 +522,7 @@ async function readContainedDaintreeFile(
 /**
  * The origin allowed to read this daintree-file:// response via cross-origin
  * fetch(), or null for everyone else. The scheme is corsEnabled so the file
- * viewer can fetch() video bytes for blob-URL playback, but eligibility alone
+ * viewer can fetch() media bytes for blob-URL playback, but eligibility alone
  * must not grant reads: a browser panel hosting an arbitrary remote site
  * shares the scheme registration, and echoing its origin here would hand it
  * the user's local files. Only the trusted app document qualifies — app:// in

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -223,7 +223,7 @@ function buildDaintreeFileErrorHeaders(): Record<string, string> {
   };
 }
 
-// Videos are streamed, not buffered, so the whole-file caps above don't apply —
+// Media is streamed, not buffered, so the whole-file caps above don't apply —
 // no response ever holds more than a stream chunk in memory (the caps exist to
 // bound buffered bytes reaching the renderer, a model that doesn't fit ranged
 // streaming; see maxBytesForFile). Every range form is served exactly as
@@ -233,8 +233,11 @@ function buildDaintreeFileErrorHeaders(): Record<string, string> {
 // issues follow-up ranges), so a server-side chunk clamp truncates playback at
 // the clamp — verified against Electron 42 / Chromium 148. Backpressure on the
 // response stream keeps main-process memory chunk-bounded regardless of size.
-function isVideoMimeType(mimeType: string): boolean {
-  return mimeType.startsWith("video/");
+// Audio rides the same path as video: a 4 MB podcast episode would 413 against
+// the 512 KB buffered cap, and the renderer plays both through the same
+// fetch-to-blob flow (#11425).
+function isMediaMimeType(mimeType: string): boolean {
+  return mimeType.startsWith("video/") || mimeType.startsWith("audio/");
 }
 
 type ParsedByteRange = { start: number; end: number } | "unsatisfiable" | null;
@@ -243,7 +246,7 @@ type ParsedByteRange = { start: number; end: number } | "unsatisfiable" | null;
  * Parse a single-range `Range: bytes=…` header against a known file size.
  * Null means "serve the whole file as 200": header absent, non-bytes unit,
  * syntactically malformed, multi-range, or inverted — RFC 9110 permits
- * ignoring all of these, and Chromium's <video> only sends single ranges.
+ * ignoring all of these, and Chromium's media elements only send single ranges.
  * "unsatisfiable" means a well-formed range no byte can satisfy (416).
  */
 function parseByteRange(rangeHeader: string | null, size: number): ParsedByteRange {
@@ -280,10 +283,10 @@ function parseByteRange(rangeHeader: string | null, size: number): ParsedByteRan
 }
 
 /**
- * Serve an already-containment-checked video file as a Range-aware stream.
+ * Serve an already-containment-checked media file as a Range-aware stream.
  *
  * Bypasses readContainedDaintreeFile's buffer-and-cap core deliberately:
- * <video> seeks via byte ranges and a multi-hundred-MB recording must never be
+ * media seeks via byte ranges and a multi-hundred-MB recording must never be
  * read whole. The open-and-stream flow keeps the same TOCTOU discipline as
  * diffMedia.ts's readWorkingSide — O_NOFOLLOW rejects a final-component
  * symlink swap after the realpath check, O_NONBLOCK (no-op on Windows) keeps a
@@ -291,7 +294,7 @@ function parseByteRange(rangeHeader: string | null, size: number): ParsedByteRan
  * stat rejects anything that isn't a regular file. Range bounds derive from
  * that fd stat, so they describe the exact file that was opened.
  */
-async function streamContainedVideoFile(
+async function streamContainedMediaFile(
   normalizedFile: string,
   mimeType: string,
   request: GlobalRequest
@@ -598,21 +601,21 @@ function createDaintreeFileRequestCore() {
       const normalizedRoot = path.normalize(rootPath);
       const normalizedFile = path.normalize(filePath);
 
-      // Videos take the streaming path instead of the buffer-and-cap core.
-      // Classification must come from the canonical path, not the request
+      // Audio and video take the streaming path instead of the buffer-and-cap
+      // core. Classification must come from the canonical path, not the request
       // path: on Windows O_NOFOLLOW is a no-op, so a final-component symlink
       // (`clip.mp4` → `notes.txt`) opens fine, and request-path routing would
-      // stream a non-video uncapped under a video MIME. On POSIX ELOOP rejects
-      // that symlink at open, so the two spellings agree either way.
-      if (isVideoMimeType(getMimeType(normalizedFile))) {
+      // stream a non-media file uncapped under a media MIME. On POSIX ELOOP
+      // rejects that symlink at open, so the two spellings agree either way.
+      if (isMediaMimeType(getMimeType(normalizedFile))) {
         const contained = await resolveContainedRealPath(normalizedRoot, normalizedFile);
         if (contained instanceof Response) return contained;
         const realMimeType = getMimeType(contained.realFile);
-        if (isVideoMimeType(realMimeType)) {
-          return await streamContainedVideoFile(normalizedFile, realMimeType, request);
+        if (isMediaMimeType(realMimeType)) {
+          return await streamContainedMediaFile(normalizedFile, realMimeType, request);
         }
-        // A video-suffixed alias of a non-video — fall through to the buffered
-        // path, which redoes containment and applies its usual caps.
+        // A media-suffixed alias of a non-media file — fall through to the
+        // buffered path, which redoes containment and applies its usual caps.
       }
 
       const result = await readContainedDaintreeFile(normalizedRoot, normalizedFile, true);

--- a/electron/utils/__tests__/appProtocol.test.ts
+++ b/electron/utils/__tests__/appProtocol.test.ts
@@ -45,6 +45,37 @@ describe("appProtocol utilities", () => {
       expect(getMimeType("CLIP.MP4")).toBe("video/mp4");
     });
 
+    it("should return audio MIME types Chromium accepts for playable formats", () => {
+      // Same routing + nosniff stakes as video above. `audio/flac` is the
+      // spelling Chromium answers canPlayType for — the `audio/x-flac` alias
+      // returns "" and would leave the file unplayable.
+      expect(getMimeType("track.mp3")).toBe("audio/mpeg");
+      expect(getMimeType("track.wav")).toBe("audio/wav");
+      expect(getMimeType("track.flac")).toBe("audio/flac");
+      expect(getMimeType("track.ogg")).toBe("audio/ogg");
+      expect(getMimeType("track.oga")).toBe("audio/ogg");
+      expect(getMimeType("track.m4a")).toBe("audio/mp4");
+      expect(getMimeType("track.aac")).toBe("audio/aac");
+      expect(getMimeType("TRACK.FLAC")).toBe("audio/flac");
+    });
+
+    it("should declare .opus without a codecs parameter", () => {
+      // The extension names the Ogg container, not what is inside it, so
+      // promising codecs="opus" would misdescribe a mislabelled Vorbis file.
+      expect(getMimeType("track.opus")).toBe("audio/ogg");
+    });
+
+    it("should not map audio Chromium can't decode to an audio MIME", () => {
+      // Mapping these would route them into the streaming path and hand the
+      // pane an <audio> element that can only fail.
+      expect(getMimeType("track.wma")).toBe("application/octet-stream");
+      expect(getMimeType("track.aiff")).toBe("application/octet-stream");
+      expect(getMimeType("track.aif")).toBe("application/octet-stream");
+      expect(getMimeType("track.mid")).toBe("application/octet-stream");
+      expect(getMimeType("track.midi")).toBe("application/octet-stream");
+      expect(getMimeType("track.amr")).toBe("application/octet-stream");
+    });
+
     it("should not map containers Chromium can't demux to a video MIME", () => {
       // mov/mkv/avi/wmv are excluded from the playable set — mapping them to
       // video/* would route them into the streaming path and a broken <video>.

--- a/electron/utils/appProtocol.ts
+++ b/electron/utils/appProtocol.ts
@@ -63,9 +63,19 @@ const MIME_TYPES: Record<string, string> = {
   ".ttf": "font/ttf",
   ".eot": "application/vnd.ms-fontobject",
   ".wasm": "application/wasm",
+  // Spellings Chromium actually accepts: canPlayType("audio/flac") is
+  // "probably" while "audio/x-flac" is "" — and daintree-file:// serves
+  // nosniff, so a legacy alias here would leave the file unplayable. `.m4a`
+  // and `.opus` stay bare (no codecs= parameter): the extension names the
+  // container, not what's inside it, so promising a codec could be a lie.
   ".wav": "audio/wav",
   ".mp3": "audio/mpeg",
   ".ogg": "audio/ogg",
+  ".oga": "audio/ogg",
+  ".opus": "audio/ogg",
+  ".flac": "audio/flac",
+  ".m4a": "audio/mp4",
+  ".aac": "audio/aac",
   ".mp4": "video/mp4",
   ".m4v": "video/mp4",
   ".webm": "video/webm",

--- a/src/components/FileViewer/FileAudioPreview.tsx
+++ b/src/components/FileViewer/FileAudioPreview.tsx
@@ -1,0 +1,93 @@
+import { Skeleton, SkeletonBone, SkeletonHint } from "@/components/ui/Skeleton";
+import { useMediaBlobUrl } from "./useMediaBlobUrl";
+import type { MediaPreviewError } from "./useMediaBlobUrl";
+
+// Matches the video ceiling: the blob sits in Chromium's blob storage either
+// way, and an hour of 48kHz/24-bit stereo PCM lands just under 1GiB, so a
+// tighter cap would reject whole-session lossless recordings for no gain.
+const AUDIO_PREVIEW_MAX_BYTES = 1024 * 1024 * 1024;
+
+/** Why a preview couldn't play, split so callers can render a headline and a way forward. */
+export type AudioPreviewError = MediaPreviewError;
+
+const AUDIO_TOO_LARGE_ERROR: MediaPreviewError = {
+  title: "This audio file is too large to preview",
+  description: "Open it outside Daintree to listen to it.",
+  code: "FILE_TOO_LARGE",
+};
+
+interface FileAudioPreviewProps {
+  /** Absolute path of the audio file being previewed. */
+  filePath: string;
+  /** Known root the `daintree-file://` protocol resolves the path against. */
+  rootPath: string;
+  /** Accessible label — the file name, so a failed track still names its file. */
+  label: string;
+  /**
+   * Changed to force a fresh media request for the same path — the protocol
+   * serves `no-store`, but the blob is a byte-snapshot of the fetch, so a
+   * rewritten file needs a new URL to show new bytes.
+   */
+  reloadKey?: string | number;
+  /** Called when the audio can't be fetched or played; an error overrides the caller's generic copy. */
+  onError?: (error?: AudioPreviewError) => void;
+}
+
+/**
+ * Renders an inline audio player for the formats Chromium decodes natively.
+ *
+ * The audio sibling of `FileVideoPreview`, sharing its fetch-to-blob contract
+ * via `useMediaBlobUrl` so both surfaces stream from `daintree-file://` the
+ * same way. Deliberately has no `maxHeightClassName`: the native control is a
+ * fixed-height bar, so a height cap would mean nothing.
+ */
+export function FileAudioPreview({
+  filePath,
+  rootPath,
+  label,
+  reloadKey,
+  onError,
+}: FileAudioPreviewProps) {
+  const { objectUrl, fetching } = useMediaBlobUrl({
+    filePath,
+    rootPath,
+    reloadKey,
+    maxBytes: AUDIO_PREVIEW_MAX_BYTES,
+    tooLargeError: AUDIO_TOO_LARGE_ERROR,
+    onError,
+  });
+
+  return (
+    // Chromium's native audio control drops its scrubber and volume slider
+    // below ~300px, and a docked pane can be narrower than that. The floor
+    // keeps the control whole and lets the wrapper scroll instead — the same
+    // floor applies to the skeleton so settling doesn't shift the layout.
+    <div className="flex items-center justify-center overflow-x-auto p-6">
+      {objectUrl ? (
+        <audio
+          // Keyed by the object URL so switching files (or reloading) remounts
+          // the element rather than continuing playback of the previous source.
+          key={objectUrl}
+          src={objectUrl}
+          controls
+          preload="metadata"
+          aria-label={label}
+          className="w-full max-w-md min-w-[300px]"
+          onError={() => onError?.()}
+        />
+      ) : fetching ? (
+        // The whole file downloads before playback starts, so a long recording
+        // pushes this past the Doherty gate — a skeleton in the control's
+        // shape, not a spinner. `SkeletonBone` carries the 400ms gate.
+        <div className="flex w-full max-w-md min-w-[300px] flex-col items-center gap-3">
+          <Skeleton label="Loading audio" className="w-full">
+            <SkeletonBone className="h-[54px] w-full rounded-full" />
+          </Skeleton>
+          {/* Sibling, never nested: the wrapper's aria-busy silences mutations
+              inside its own subtree. */}
+          <SkeletonHint />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/FileViewer/FileVideoPreview.tsx
+++ b/src/components/FileViewer/FileVideoPreview.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useEffectEvent, useMemo, useState } from "react";
-import type { FileReadErrorCode } from "@shared/types/ipc/files";
 import { Skeleton, SkeletonBone, SkeletonHint } from "@/components/ui/Skeleton";
-import { buildDaintreeFileUrl } from "./filePreviewKinds";
+import { useMediaBlobUrl } from "./useMediaBlobUrl";
+import type { MediaPreviewError } from "./useMediaBlobUrl";
 
 // Blob previews hold the whole file in Chromium's blob storage (memory, then
 // disk-backed), so cap what one preview may pull in. A 4K screen recording
@@ -9,16 +8,9 @@ import { buildDaintreeFileUrl } from "./filePreviewKinds";
 const VIDEO_PREVIEW_MAX_BYTES = 1024 * 1024 * 1024;
 
 /** Why a preview couldn't play, split so callers can render a headline and a way forward. */
-export interface VideoPreviewError {
-  /** Names what happened. Callers with a titled error surface use it as the title. */
-  title: string;
-  /** Second line naming the next action. */
-  description?: string;
-  /** Read-error code for panes that gate their error surface on one. */
-  code?: FileReadErrorCode;
-}
+export type VideoPreviewError = MediaPreviewError;
 
-const VIDEO_TOO_LARGE_ERROR: VideoPreviewError = {
+const VIDEO_TOO_LARGE_ERROR: MediaPreviewError = {
   title: "This video is too large to preview",
   description: "Open it outside Daintree to watch it.",
   code: "FILE_TOO_LARGE",
@@ -48,16 +40,8 @@ interface FileVideoPreviewProps {
  *
  * Shared by `FilePane`, `FileBrowserViewer`, and `DiffPane` so every surface
  * plays the same files the same way — mirroring `FileImagePreview`'s role for
- * images.
- *
- * The bytes are fetch()ed from the `daintree-file://` protocol into a Blob and
- * played through an object URL rather than pointing `<video src>` at the
- * protocol directly. Chromium's custom-scheme media loader is single-shot: it
- * cannot consume any follow-up range request for the same resource, so every
- * video whose moov atom trails the mdat (the default mp4 layout from most
- * recorders) dies with a demuxer error moments after playback starts
- * (electron/electron#51442; verified against Electron 42). fetch() doesn't go
- * through the media loader, and a blob URL is fully seekable in-renderer.
+ * images. `useMediaBlobUrl` owns the fetch-to-blob contract this and
+ * `FileAudioPreview` both depend on.
  */
 export function FileVideoPreview({
   filePath,
@@ -67,67 +51,14 @@ export function FileVideoPreview({
   onError,
   maxHeightClassName = "max-h-[70vh]",
 }: FileVideoPreviewProps) {
-  const src = useMemo(() => {
-    const url = buildDaintreeFileUrl(filePath, rootPath);
-    // Cache-busting query param only — the protocol handler ignores it.
-    // Null-checked, not truthiness: a numeric key of 0 is a valid value.
-    return reloadKey != null ? `${url}&v=${encodeURIComponent(reloadKey)}` : url;
-  }, [filePath, rootPath, reloadKey]);
-
-  const [objectUrl, setObjectUrl] = useState<string | null>(null);
-  const [fetching, setFetching] = useState(true);
-
-  // Effect events so the fetch effect keys on `src` alone — callers pass
-  // inline closures, and refetching the file on every parent render would
-  // discard playback position each time anything else in the pane changes.
-  const reportError = useEffectEvent((error?: VideoPreviewError) => onError?.(error));
-
-  useEffect(() => {
-    const controller = new AbortController();
-    let url: string | null = null;
-    setFetching(true);
-    setObjectUrl(null);
-
-    void fetch(src, { signal: controller.signal })
-      .then(async (response) => {
-        // Guarded before any state write: an already-settled fetch promise can
-        // run this reaction after cleanup aborted it, and reporting then would
-        // clear the skeleton / flag an error on the file shown NEXT.
-        if (controller.signal.aborted) return;
-        if (!response.ok) throw new Error(`daintree-file responded ${response.status}`);
-        const declaredLength = Number(response.headers.get("content-length"));
-        if (Number.isFinite(declaredLength) && declaredLength > VIDEO_PREVIEW_MAX_BYTES) {
-          // Drop the unread body so the protocol stream (and its fd) closes
-          // now rather than when the response gets collected.
-          void response.body?.cancel().catch(() => {});
-          setFetching(false);
-          reportError(VIDEO_TOO_LARGE_ERROR);
-          return;
-        }
-        const blob = await response.blob();
-        if (controller.signal.aborted) return;
-        if (blob.size > VIDEO_PREVIEW_MAX_BYTES) {
-          setFetching(false);
-          reportError(VIDEO_TOO_LARGE_ERROR);
-          return;
-        }
-        url = URL.createObjectURL(blob);
-        setObjectUrl(url);
-        setFetching(false);
-      })
-      .catch(() => {
-        if (controller.signal.aborted) return;
-        setFetching(false);
-        reportError();
-      });
-
-    return () => {
-      controller.abort();
-      // Safe while the <video> below is unmounting with it: revoking detaches
-      // the URL from the blob for new loads; the element is gone either way.
-      if (url) URL.revokeObjectURL(url);
-    };
-  }, [src]);
+  const { objectUrl, fetching } = useMediaBlobUrl({
+    filePath,
+    rootPath,
+    reloadKey,
+    maxBytes: VIDEO_PREVIEW_MAX_BYTES,
+    tooLargeError: VIDEO_TOO_LARGE_ERROR,
+    onError,
+  });
 
   return (
     <div className="flex items-center justify-center p-6 min-h-[300px]">

--- a/src/components/FileViewer/__tests__/FileAudioPreview.test.tsx
+++ b/src/components/FileViewer/__tests__/FileAudioPreview.test.tsx
@@ -1,0 +1,239 @@
+// @vitest-environment jsdom
+/**
+ * Shared audio preview (#11425).
+ *
+ * jsdom does not decode media, so these tests pin the fetch→blob→object-URL
+ * contract — Chromium's custom-scheme media loader can't consume follow-up
+ * range requests (electron#51442), so the component must never point the
+ * <audio> at daintree-file:// directly — and dispatch the error event manually
+ * rather than waiting on playback.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { FileAudioPreview } from "../FileAudioPreview";
+
+const fetchMock = vi.fn();
+const createObjectURL = vi.fn();
+const revokeObjectURL = vi.fn();
+
+function respondWith(blob: Blob, headers: Record<string, string> = {}) {
+  fetchMock.mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Headers(headers),
+    blob: () => Promise.resolve(blob),
+  });
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  let nextUrl = 0;
+  createObjectURL.mockImplementation(() => `blob:app://daintree/${nextUrl++}`);
+  URL.createObjectURL = createObjectURL;
+  URL.revokeObjectURL = revokeObjectURL;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  fetchMock.mockReset();
+  createObjectURL.mockReset();
+  revokeObjectURL.mockReset();
+});
+
+describe("FileAudioPreview", () => {
+  it("fetches from the daintree-file protocol and plays through a blob object URL", async () => {
+    respondWith(new Blob(["x"]));
+    const { container } = render(
+      <FileAudioPreview filePath="/repo/track.mp3" rootPath="/repo" label="track.mp3" />
+    );
+
+    await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+    expect(fetchMock).toHaveBeenCalledWith(
+      "daintree-file://load?path=%2Frepo%2Ftrack.mp3&root=%2Frepo",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+    const audio = container.querySelector("audio");
+    expect(audio?.getAttribute("src")).toMatch(/^blob:/);
+    expect(audio?.hasAttribute("controls")).toBe(true);
+    expect(audio?.getAttribute("aria-label")).toBe("track.mp3");
+  });
+
+  it("holds a skeleton surface while the whole file downloads", () => {
+    fetchMock.mockImplementation(() => new Promise(() => {}));
+    const { container, getByRole } = render(
+      <FileAudioPreview filePath="/repo/track.mp3" rootPath="/repo" label="track.mp3" />
+    );
+
+    expect(getByRole("status").getAttribute("aria-busy")).toBe("true");
+    expect(container.querySelector("audio")).toBeNull();
+  });
+
+  it("refetches with the cache-busting param when the reload key changes", async () => {
+    respondWith(new Blob(["x"]));
+    const { rerender, container } = render(
+      <FileAudioPreview
+        filePath="/repo/track.mp3"
+        rootPath="/repo"
+        label="track.mp3"
+        reloadKey={1}
+      />
+    );
+    await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+    expect(fetchMock.mock.calls[0]?.[0]).toContain("&v=1");
+
+    rerender(
+      <FileAudioPreview
+        filePath="/repo/track.mp3"
+        rootPath="/repo"
+        label="track.mp3"
+        reloadKey={2}
+      />
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(fetchMock.mock.calls[1]?.[0]).toContain("&v=2");
+  });
+
+  it("revokes the object URL when the source changes", async () => {
+    respondWith(new Blob(["x"]));
+    const { rerender, container } = render(
+      <FileAudioPreview
+        filePath="/repo/track.mp3"
+        rootPath="/repo"
+        label="track.mp3"
+        reloadKey={1}
+      />
+    );
+    await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+    const firstUrl = container.querySelector("audio")?.getAttribute("src");
+
+    rerender(
+      <FileAudioPreview
+        filePath="/repo/track.mp3"
+        rootPath="/repo"
+        label="track.mp3"
+        reloadKey={2}
+      />
+    );
+
+    await waitFor(() => expect(revokeObjectURL).toHaveBeenCalledWith(firstUrl));
+  });
+
+  it("reports a fetch failure to onError without naming a reason", async () => {
+    fetchMock.mockRejectedValue(new Error("boom"));
+    const onError = vi.fn();
+    render(
+      <FileAudioPreview
+        filePath="/repo/track.mp3"
+        rootPath="/repo"
+        label="track.mp3"
+        onError={onError}
+      />
+    );
+
+    await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+    // No specific message — callers fall back to their generic copy.
+    expect(onError.mock.calls[0]?.[0]).toBeUndefined();
+  });
+
+  it("rejects an over-cap file by declared length without reading the body", async () => {
+    const blobSpy = vi.fn(() => Promise.resolve(new Blob(["x"])));
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-length": String(2 * 1024 * 1024 * 1024) }),
+      blob: blobSpy,
+    });
+    const onError = vi.fn();
+    render(
+      <FileAudioPreview
+        filePath="/repo/huge.wav"
+        rootPath="/repo"
+        label="huge.wav"
+        onError={onError}
+      />
+    );
+
+    // A distinct titled reason (not the callers' generic "couldn't be played"
+    // copy), with the description carrying the next action.
+    await waitFor(() =>
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: expect.any(String),
+          description: expect.any(String),
+          code: "FILE_TOO_LARGE",
+        })
+      )
+    );
+    expect(blobSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects an over-cap file by blob size when no length was declared", async () => {
+    const oversized = new Blob(["x"]);
+    Object.defineProperty(oversized, "size", { value: 2 * 1024 * 1024 * 1024 });
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      blob: () => Promise.resolve(oversized),
+    });
+    const onError = vi.fn();
+    render(
+      <FileAudioPreview
+        filePath="/repo/huge.wav"
+        rootPath="/repo"
+        label="huge.wav"
+        onError={onError}
+      />
+    );
+
+    await waitFor(() =>
+      expect(onError).toHaveBeenCalledWith(expect.objectContaining({ title: expect.any(String) }))
+    );
+  });
+
+  it("does not report an error when unmounted mid-fetch", async () => {
+    let resolveFetch: (value: unknown) => void = () => {};
+    fetchMock.mockImplementation(
+      (_url: string, opts: { signal: AbortSignal }) =>
+        new Promise((resolve, reject) => {
+          resolveFetch = resolve;
+          opts.signal.addEventListener("abort", () => reject(new DOMException("", "AbortError")));
+        })
+    );
+    const onError = vi.fn();
+    const { unmount } = render(
+      <FileAudioPreview
+        filePath="/repo/track.mp3"
+        rootPath="/repo"
+        label="track.mp3"
+        onError={onError}
+      />
+    );
+
+    unmount();
+    resolveFetch(undefined);
+    // Flush any queued reactions before asserting silence.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onError).not.toHaveBeenCalled();
+    expect(createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it("forwards media element errors to onError", async () => {
+    respondWith(new Blob(["x"]));
+    const onError = vi.fn();
+    const { container } = render(
+      <FileAudioPreview
+        filePath="/repo/track.mp3"
+        rootPath="/repo"
+        label="track.mp3"
+        onError={onError}
+      />
+    );
+
+    await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+    fireEvent.error(container.querySelector("audio")!);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/FileViewer/__tests__/filePreviewKinds.test.ts
+++ b/src/components/FileViewer/__tests__/filePreviewKinds.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   buildDaintreeFileUrl,
+  isAudioFilePath,
   isImageFilePath,
   isSvgFilePath,
+  isUnsupportedAudioFilePath,
   isUnsupportedVideoFilePath,
   isVideoFilePath,
 } from "../filePreviewKinds";
@@ -94,6 +96,76 @@ describe("filePreviewKinds", () => {
     it("is disjoint from the playable set", () => {
       for (const path of ["clip.mp4", "clip.webm", "clip.m4v", "clip.ogv"]) {
         expect(isUnsupportedVideoFilePath(path)).toBe(false);
+      }
+    });
+  });
+
+  describe("isAudioFilePath", () => {
+    it.each([
+      "track.mp3",
+      "track.wav",
+      "track.flac",
+      "track.ogg",
+      "track.oga",
+      "track.opus",
+      // m4a/aac ride the same proprietary-codec build that makes mp4 play.
+      "track.m4a",
+      "track.aac",
+      "TRACK.MP3",
+      "a/b/c.take 2.flac",
+    ])("accepts %s", (path) => {
+      expect(isAudioFilePath(path)).toBe(true);
+    });
+
+    it.each([
+      "track.wma",
+      "track.aiff",
+      "track.mid",
+      "track.mp3.txt",
+      "track",
+      "photo.png",
+      "notes.md",
+    ])("rejects %s", (path) => {
+      expect(isAudioFilePath(path)).toBe(false);
+    });
+
+    it("claims .ogg while video keeps .ogv", () => {
+      // The two Ogg spellings are split across the classifiers; overlapping
+      // them would make the pane's branch order decide which player appears.
+      expect(isAudioFilePath("sound.ogg")).toBe(true);
+      expect(isVideoFilePath("sound.ogg")).toBe(false);
+      expect(isVideoFilePath("clip.ogv")).toBe(true);
+      expect(isAudioFilePath("clip.ogv")).toBe(false);
+    });
+
+    it("never overlaps the image or video classifiers", () => {
+      for (const path of ["track.mp3", "track.flac", "track.m4a", "track.opus"]) {
+        expect(isImageFilePath(path)).toBe(false);
+        expect(isSvgFilePath(path)).toBe(false);
+        expect(isVideoFilePath(path)).toBe(false);
+      }
+    });
+  });
+
+  describe("isUnsupportedAudioFilePath", () => {
+    it.each(["track.wma", "track.aiff", "track.aif", "track.mid", "track.midi", "TRACK.WMA"])(
+      "accepts %s",
+      (path) => {
+        expect(isUnsupportedAudioFilePath(path)).toBe(true);
+      }
+    );
+
+    it("is disjoint from the playable set", () => {
+      for (const path of ["track.mp3", "track.wav", "track.flac", "track.m4a", "track.aac"]) {
+        expect(isUnsupportedAudioFilePath(path)).toBe(false);
+      }
+    });
+
+    it("does not overlap the unsupported video set", () => {
+      // Both feed the same "can't play this format" branch, so an extension in
+      // both would make the pane's copy depend on check order.
+      for (const path of ["clip.mov", "clip.mkv", "clip.avi", "clip.wmv"]) {
+        expect(isUnsupportedAudioFilePath(path)).toBe(false);
       }
     });
   });

--- a/src/components/FileViewer/__tests__/filePreviewKinds.test.ts
+++ b/src/components/FileViewer/__tests__/filePreviewKinds.test.ts
@@ -148,16 +148,33 @@ describe("filePreviewKinds", () => {
   });
 
   describe("isUnsupportedAudioFilePath", () => {
-    it.each(["track.wma", "track.aiff", "track.aif", "track.mid", "track.midi", "TRACK.WMA"])(
-      "accepts %s",
-      (path) => {
-        expect(isUnsupportedAudioFilePath(path)).toBe(true);
-      }
-    );
+    it.each([
+      "track.wma",
+      "track.aiff",
+      "track.aif",
+      "track.mid",
+      "track.midi",
+      "track.amr",
+      "TRACK.WMA",
+    ])("accepts %s", (path) => {
+      expect(isUnsupportedAudioFilePath(path)).toBe(true);
+    });
 
-    it("is disjoint from the playable set", () => {
+    it("is disjoint from the playable set in both directions", () => {
+      // An extension in both sets would make the pane's branch order decide
+      // between a working player and a "can't play" message.
       for (const path of ["track.mp3", "track.wav", "track.flac", "track.m4a", "track.aac"]) {
         expect(isUnsupportedAudioFilePath(path)).toBe(false);
+      }
+      for (const path of [
+        "track.wma",
+        "track.aiff",
+        "track.aif",
+        "track.mid",
+        "track.midi",
+        "track.amr",
+      ]) {
+        expect(isAudioFilePath(path)).toBe(false);
       }
     });
 

--- a/src/components/FileViewer/__tests__/useMediaBlobUrl.test.tsx
+++ b/src/components/FileViewer/__tests__/useMediaBlobUrl.test.tsx
@@ -43,15 +43,26 @@ function Probe({
   );
 }
 
+const realCreateObjectURL = URL.createObjectURL;
+const realRevokeObjectURL = URL.revokeObjectURL;
+
 beforeEach(() => {
   vi.stubGlobal("fetch", fetchMock);
-  URL.createObjectURL = vi.fn(() => "blob:app://daintree/0");
+  // Unique per call, never a constant: the stale-response tests below assert
+  // that an abandoned request can't replace the current URL, and a fixed
+  // return value would make an overwrite indistinguishable from the guard
+  // working.
+  let nextUrl = 0;
+  URL.createObjectURL = vi.fn(() => `blob:app://daintree/${nextUrl++}`);
   URL.revokeObjectURL = vi.fn();
 });
 
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
+  // unstubAllGlobals doesn't restore a directly assigned method.
+  URL.createObjectURL = realCreateObjectURL;
+  URL.revokeObjectURL = realRevokeObjectURL;
   fetchMock.mockReset();
 });
 
@@ -133,17 +144,13 @@ describe("useMediaBlobUrl", () => {
     expect(getByTestId("probe").dataset.fetching).toBe("false");
   });
 
-  it("lets a superseded request neither overwrite nor error over the current one", async () => {
-    // The stale-response race: switching files while the first fetch is in
-    // flight must not let the old bytes land on the new source.
+  it("drops a superseded response that settles after its request was abandoned", async () => {
+    // The stale-response race the guards exist for: a fetch that had already
+    // settled runs its reaction AFTER cleanup aborted it. Deliberately no
+    // abort listener — a rejecting promise would short-circuit to the catch
+    // path and never reach the guard on the fulfilled path.
     const deferred: Array<(value: unknown) => void> = [];
-    fetchMock.mockImplementation(
-      (_url: string, opts: { signal: AbortSignal }) =>
-        new Promise((resolve, reject) => {
-          deferred.push(resolve);
-          opts.signal.addEventListener("abort", () => reject(new DOMException("", "AbortError")));
-        })
-    );
+    fetchMock.mockImplementation(() => new Promise((resolve) => deferred.push(resolve)));
     const onError = vi.fn();
     const { rerender, getByTestId } = render(
       <Probe onError={onError} label="first" reloadKey={1} />
@@ -153,23 +160,62 @@ describe("useMediaBlobUrl", () => {
     rerender(<Probe onError={onError} label="second" reloadKey={2} />);
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
 
-    // Settle the SECOND request, then the abandoned first one.
-    const secondBlob = new Blob(["new"]);
     deferred[1]?.({
       ok: true,
       status: 200,
       headers: new Headers(),
-      blob: () => Promise.resolve(secondBlob),
+      blob: () => Promise.resolve(new Blob(["new"])),
     });
     await waitFor(() => expect(getByTestId("probe").dataset.url).toMatch(/^blob:/));
     const currentUrl = getByTestId("probe").dataset.url;
+    const staleBlob = vi.fn(() => Promise.resolve(new Blob(["stale"])));
 
-    deferred[0]?.({
+    deferred[0]?.({ ok: true, status: 200, headers: new Headers(), blob: staleBlob });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // The guard returns before the body is even read, so the stale bytes never
+    // become a URL and can't replace what is playing.
+    expect(staleBlob).not.toHaveBeenCalled();
+    expect(getByTestId("probe").dataset.url).toBe(currentUrl);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("drops a superseded response abandoned while its body was being read", async () => {
+    // The second guard: abort lands during `await response.blob()`, so the
+    // reaction resumes past the first check with a blob nothing wants.
+    let resolveFirstFetch: (value: unknown) => void = () => {};
+    let resolveFirstBlob: (value: Blob) => void = () => {};
+    let call = 0;
+    fetchMock.mockImplementation(() => {
+      call += 1;
+      if (call === 1) return new Promise((resolve) => (resolveFirstFetch = resolve));
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        blob: () => Promise.resolve(new Blob(["new"])),
+      });
+    });
+    const onError = vi.fn();
+    const { rerender, getByTestId } = render(
+      <Probe onError={onError} label="first" reloadKey={1} />
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    // Let the first request get past the ok/length checks and into blob().
+    resolveFirstFetch({
       ok: true,
       status: 200,
       headers: new Headers(),
-      blob: () => Promise.resolve(new Blob(["stale"])),
+      blob: () => new Promise<Blob>((resolve) => (resolveFirstBlob = resolve)),
     });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    rerender(<Probe onError={onError} label="second" reloadKey={2} />);
+    await waitFor(() => expect(getByTestId("probe").dataset.url).toMatch(/^blob:/));
+    const currentUrl = getByTestId("probe").dataset.url;
+
+    resolveFirstBlob(new Blob(["stale"]));
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(getByTestId("probe").dataset.url).toBe(currentUrl);

--- a/src/components/FileViewer/__tests__/useMediaBlobUrl.test.tsx
+++ b/src/components/FileViewer/__tests__/useMediaBlobUrl.test.tsx
@@ -16,15 +16,31 @@ const fetchMock = vi.fn();
 
 const TOO_LARGE: MediaPreviewError = { title: "Too large", code: "FILE_TOO_LARGE" };
 
-function Probe({ onError, label }: { onError?: (error?: MediaPreviewError) => void; label: string }) {
-  const { objectUrl } = useMediaBlobUrl({
+function Probe({
+  onError,
+  label,
+  reloadKey,
+}: {
+  onError?: (error?: MediaPreviewError) => void;
+  label: string;
+  reloadKey?: string | number;
+}) {
+  const { objectUrl, fetching } = useMediaBlobUrl({
     filePath: "/repo/track.mp3",
     rootPath: "/repo",
+    reloadKey,
     maxBytes: 1024,
     tooLargeError: TOO_LARGE,
     onError,
   });
-  return <div data-testid="probe" data-url={objectUrl ?? ""} data-label={label} />;
+  return (
+    <div
+      data-testid="probe"
+      data-url={objectUrl ?? ""}
+      data-label={label}
+      data-fetching={String(fetching)}
+    />
+  );
 }
 
 beforeEach(() => {
@@ -81,5 +97,102 @@ describe("useMediaBlobUrl", () => {
     // Without the cancel the protocol keeps streaming a file nothing will read.
     expect(cancel).toHaveBeenCalledTimes(1);
     expect(blobSpy).not.toHaveBeenCalled();
+  });
+
+  it("reports a non-ok protocol response as a generic failure", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 404,
+      headers: new Headers(),
+      blob: () => Promise.resolve(new Blob(["x"])),
+    });
+    const onError = vi.fn();
+
+    const { getByTestId } = render(<Probe onError={onError} label="missing" />);
+
+    await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+    // Undefined, not the too-large reason — the caller supplies its own copy.
+    expect(onError.mock.calls[0]?.[0]).toBeUndefined();
+    // The skeleton has to clear, or the pane waits forever on a dead request.
+    expect(getByTestId("probe").dataset.fetching).toBe("false");
+    expect(getByTestId("probe").dataset.url).toBe("");
+  });
+
+  it("reports a blob() rejection rather than hanging on the skeleton", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      blob: () => Promise.reject(new Error("read failed")),
+    });
+    const onError = vi.fn();
+
+    const { getByTestId } = render(<Probe onError={onError} label="unreadable" />);
+
+    await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+    expect(getByTestId("probe").dataset.fetching).toBe("false");
+  });
+
+  it("lets a superseded request neither overwrite nor error over the current one", async () => {
+    // The stale-response race: switching files while the first fetch is in
+    // flight must not let the old bytes land on the new source.
+    const deferred: Array<(value: unknown) => void> = [];
+    fetchMock.mockImplementation(
+      (_url: string, opts: { signal: AbortSignal }) =>
+        new Promise((resolve, reject) => {
+          deferred.push(resolve);
+          opts.signal.addEventListener("abort", () => reject(new DOMException("", "AbortError")));
+        })
+    );
+    const onError = vi.fn();
+    const { rerender, getByTestId } = render(
+      <Probe onError={onError} label="first" reloadKey={1} />
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    rerender(<Probe onError={onError} label="second" reloadKey={2} />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    // Settle the SECOND request, then the abandoned first one.
+    const secondBlob = new Blob(["new"]);
+    deferred[1]?.({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      blob: () => Promise.resolve(secondBlob),
+    });
+    await waitFor(() => expect(getByTestId("probe").dataset.url).toMatch(/^blob:/));
+    const currentUrl = getByTestId("probe").dataset.url;
+
+    deferred[0]?.({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      blob: () => Promise.resolve(new Blob(["stale"])),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(getByTestId("probe").dataset.url).toBe(currentUrl);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("recovers on a reload after a failure", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("boom")).mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      blob: () => Promise.resolve(new Blob(["x"])),
+    });
+    const onError = vi.fn();
+    const { rerender, getByTestId } = render(
+      <Probe onError={onError} label="failed" reloadKey={1} />
+    );
+    await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+
+    rerender(<Probe onError={onError} label="retried" reloadKey={2} />);
+
+    // A failed attempt must not latch — the next source gets a clean run.
+    await waitFor(() => expect(getByTestId("probe").dataset.url).toMatch(/^blob:/));
+    expect(onError).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/FileViewer/__tests__/useMediaBlobUrl.test.tsx
+++ b/src/components/FileViewer/__tests__/useMediaBlobUrl.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+/**
+ * Shared media fetch contract (#11425).
+ *
+ * `FileVideoPreview` and `FileAudioPreview` both cover the happy path through
+ * their own suites. These pin the two invariants neither component test can
+ * observe from the outside: that the effect keys on the source alone (so an
+ * inline `onError` closure can't restart playback), and that an over-cap
+ * declared length releases the protocol stream instead of leaving its fd open.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup, waitFor } from "@testing-library/react";
+import { useMediaBlobUrl, type MediaPreviewError } from "../useMediaBlobUrl";
+
+const fetchMock = vi.fn();
+
+const TOO_LARGE: MediaPreviewError = { title: "Too large", code: "FILE_TOO_LARGE" };
+
+function Probe({ onError, label }: { onError?: (error?: MediaPreviewError) => void; label: string }) {
+  const { objectUrl } = useMediaBlobUrl({
+    filePath: "/repo/track.mp3",
+    rootPath: "/repo",
+    maxBytes: 1024,
+    tooLargeError: TOO_LARGE,
+    onError,
+  });
+  return <div data-testid="probe" data-url={objectUrl ?? ""} data-label={label} />;
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  URL.createObjectURL = vi.fn(() => "blob:app://daintree/0");
+  URL.revokeObjectURL = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  fetchMock.mockReset();
+});
+
+describe("useMediaBlobUrl", () => {
+  it("does not refetch when only the error callback identity changes", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      blob: () => Promise.resolve(new Blob(["x"])),
+    });
+
+    // A fresh arrow per render is exactly how the three panes pass onError.
+    const { rerender, getByTestId } = render(<Probe onError={() => {}} label="first" />);
+    await waitFor(() => expect(getByTestId("probe").dataset.url).toMatch(/^blob:/));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    rerender(<Probe onError={() => {}} label="second" />);
+    rerender(<Probe onError={() => {}} label="third" />);
+
+    // Re-running the effect would abort the fetch and drop the blob, which the
+    // user experiences as playback restarting whenever the pane re-renders.
+    await waitFor(() => expect(getByTestId("probe").dataset.label).toBe("third"));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(getByTestId("probe").dataset.url).toMatch(/^blob:/);
+  });
+
+  it("cancels the unread body when the declared length exceeds the cap", async () => {
+    const cancel = vi.fn(() => Promise.resolve());
+    const blobSpy = vi.fn(() => Promise.resolve(new Blob(["x"])));
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-length": "4096" }),
+      body: { cancel },
+      blob: blobSpy,
+    });
+    const onError = vi.fn();
+
+    render(<Probe onError={onError} label="oversize" />);
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith(TOO_LARGE));
+    // Without the cancel the protocol keeps streaming a file nothing will read.
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(blobSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/FileViewer/filePreviewKinds.ts
+++ b/src/components/FileViewer/filePreviewKinds.ts
@@ -35,6 +35,18 @@ const VIDEO_EXTENSIONS = new Set(["mp4", "m4v", "webm", "ogv"]);
 // falling through to the text path's misleading size/binary errors.
 const UNSUPPORTED_VIDEO_EXTENSIONS = new Set(["mov", "mkv", "avi", "wmv"]);
 
+// Audio Chromium decodes natively. m4a/aac are in because stock Electron builds
+// ffmpeg with proprietary codecs (the same reason mp4/m4v play above) —
+// canPlayType("audio/mp4; codecs=\"mp4a.40.2\"") answers "probably" on
+// Electron 42 / Chromium 148. `ogg` is audio, not video: the video side claims
+// `ogv`, so the two never collide.
+const AUDIO_EXTENSIONS = new Set(["mp3", "wav", "flac", "ogg", "oga", "opus", "m4a", "aac"]);
+
+// Audio Chromium has no decoder for, at any MIME spelling. Classified so the
+// viewer says "can't play this format" rather than falling through to the text
+// path's "Binary file — cannot display".
+const UNSUPPORTED_AUDIO_EXTENSIONS = new Set(["wma", "aiff", "aif", "mid", "midi", "amr"]);
+
 function extensionOf(filePath: string): string {
   return filePath.split(".").pop()?.toLowerCase() ?? "";
 }
@@ -63,6 +75,20 @@ export function isUnsupportedVideoFilePath(filePath: string): boolean {
 /** Copy for containers in the unsupported set — shared so both panes say the same thing. */
 export const UNSUPPORTED_VIDEO_MESSAGE =
   "Can't play this video format — only MP4, WebM, and Ogg are supported";
+
+/** Audio Chromium plays natively — served via daintree-file:// to an <audio> element. */
+export function isAudioFilePath(filePath: string): boolean {
+  return AUDIO_EXTENSIONS.has(extensionOf(filePath));
+}
+
+/** Audio formats Chromium can't decode — recognized only to explain why they won't play. */
+export function isUnsupportedAudioFilePath(filePath: string): boolean {
+  return UNSUPPORTED_AUDIO_EXTENSIONS.has(extensionOf(filePath));
+}
+
+/** Copy for audio in the unsupported set — shared so every pane says the same thing. */
+export const UNSUPPORTED_AUDIO_MESSAGE =
+  "Can't play this audio format — only MP3, WAV, FLAC, Ogg, Opus, M4A, and AAC are supported";
 
 /**
  * URL for the custom `daintree-file://` protocol, which serves a file from

--- a/src/components/FileViewer/filePreviewKinds.ts
+++ b/src/components/FileViewer/filePreviewKinds.ts
@@ -86,7 +86,11 @@ export function isUnsupportedAudioFilePath(filePath: string): boolean {
   return UNSUPPORTED_AUDIO_EXTENSIONS.has(extensionOf(filePath));
 }
 
-/** Copy for audio in the unsupported set — shared so every pane says the same thing. */
+/**
+ * Copy for audio in the unsupported set, shared by the panes that classify it.
+ * DiffPane deliberately doesn't: like unsupported video, it leaves these to the
+ * diff view's own binary fallback rather than claiming a player it won't show.
+ */
 export const UNSUPPORTED_AUDIO_MESSAGE =
   "Can't play this audio format — only MP3, WAV, FLAC, Ogg, Opus, M4A, and AAC are supported";
 

--- a/src/components/FileViewer/useMediaBlobUrl.ts
+++ b/src/components/FileViewer/useMediaBlobUrl.ts
@@ -66,9 +66,10 @@ export function useMediaBlobUrl({
   const [objectUrl, setObjectUrl] = useState<string | null>(null);
   const [fetching, setFetching] = useState(true);
 
-  // Effect events so the fetch effect keys on `src` alone — callers pass
-  // inline closures, and refetching the file on every parent render would
-  // discard playback position each time anything else in the pane changes.
+  // Effect events so the fetch effect keys on the source and cap alone (both
+  // stable) — callers pass inline closures, and refetching the file on every
+  // parent render would discard playback position each time anything else in
+  // the pane changes.
   const reportError = useEffectEvent(() => onError?.());
   const reportTooLarge = useEffectEvent(() => onError?.(tooLargeError));
 

--- a/src/components/FileViewer/useMediaBlobUrl.ts
+++ b/src/components/FileViewer/useMediaBlobUrl.ts
@@ -1,0 +1,124 @@
+import { useEffect, useEffectEvent, useMemo, useState } from "react";
+import type { FileReadErrorCode } from "@shared/types/ipc/files";
+import { buildDaintreeFileUrl } from "./filePreviewKinds";
+
+/** Why a preview couldn't play, split so callers can render a headline and a way forward. */
+export interface MediaPreviewError {
+  /** Names what happened. Callers with a titled error surface use it as the title. */
+  title: string;
+  /** Second line naming the next action. */
+  description?: string;
+  /** Read-error code for panes that gate their error surface on one. */
+  code?: FileReadErrorCode;
+}
+
+interface UseMediaBlobUrlOptions {
+  /** Absolute path of the media being previewed. */
+  filePath: string;
+  /** Known root the `daintree-file://` protocol resolves the path against. */
+  rootPath: string;
+  /**
+   * Changed to force a fresh media request for the same path — the protocol
+   * serves `no-store`, but the blob is a byte-snapshot of the fetch, so a
+   * rewritten file needs a new URL to show new bytes.
+   */
+  reloadKey?: string | number;
+  /** Ceiling for a single preview, enforced against both the declared length and the blob. */
+  maxBytes: number;
+  /** Reported instead of the generic failure when the file exceeds `maxBytes`. */
+  tooLargeError: MediaPreviewError;
+  /** Called when the media can't be fetched; an error overrides the caller's generic copy. */
+  onError?: (error?: MediaPreviewError) => void;
+}
+
+/**
+ * Fetches a file from `daintree-file://` into a Blob and hands back an object
+ * URL for a media element to play.
+ *
+ * Shared by `FileVideoPreview` and `FileAudioPreview` so the fetch, size caps,
+ * abort sequencing, and object-URL lifetime have exactly one owner — the parts
+ * that are easy to get subtly wrong and impossible to notice when they drift.
+ *
+ * The bytes are fetch()ed into a Blob rather than pointing the element's `src`
+ * at the protocol directly. Chromium's custom-scheme media loader is
+ * single-shot: it cannot consume any follow-up range request for the same
+ * resource, so every file whose index trails its payload (the default mp4
+ * layout from most recorders) dies with a demuxer error moments after playback
+ * starts (electron/electron#51442; verified against Electron 42). fetch()
+ * doesn't go through the media loader, and a blob URL is fully seekable
+ * in-renderer.
+ */
+export function useMediaBlobUrl({
+  filePath,
+  rootPath,
+  reloadKey,
+  maxBytes,
+  tooLargeError,
+  onError,
+}: UseMediaBlobUrlOptions): { objectUrl: string | null; fetching: boolean } {
+  const src = useMemo(() => {
+    const url = buildDaintreeFileUrl(filePath, rootPath);
+    // Cache-busting query param only — the protocol handler ignores it.
+    // Null-checked, not truthiness: a numeric key of 0 is a valid value.
+    return reloadKey != null ? `${url}&v=${encodeURIComponent(reloadKey)}` : url;
+  }, [filePath, rootPath, reloadKey]);
+
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+  const [fetching, setFetching] = useState(true);
+
+  // Effect events so the fetch effect keys on `src` alone — callers pass
+  // inline closures, and refetching the file on every parent render would
+  // discard playback position each time anything else in the pane changes.
+  const reportError = useEffectEvent(() => onError?.());
+  const reportTooLarge = useEffectEvent(() => onError?.(tooLargeError));
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let url: string | null = null;
+    setFetching(true);
+    setObjectUrl(null);
+
+    void fetch(src, { signal: controller.signal })
+      .then(async (response) => {
+        // Guarded before any state write: an already-settled fetch promise can
+        // run this reaction after cleanup aborted it, and reporting then would
+        // clear the skeleton / flag an error on the file shown NEXT.
+        if (controller.signal.aborted) return;
+        if (!response.ok) throw new Error(`daintree-file responded ${response.status}`);
+        const declaredLength = Number(response.headers.get("content-length"));
+        if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+          // Drop the unread body so the protocol stream (and its fd) closes
+          // now rather than when the response gets collected.
+          void response.body?.cancel().catch(() => {});
+          setFetching(false);
+          reportTooLarge();
+          return;
+        }
+        const blob = await response.blob();
+        if (controller.signal.aborted) return;
+        if (blob.size > maxBytes) {
+          setFetching(false);
+          reportTooLarge();
+          return;
+        }
+        url = URL.createObjectURL(blob);
+        setObjectUrl(url);
+        setFetching(false);
+      })
+      .catch(() => {
+        if (controller.signal.aborted) return;
+        setFetching(false);
+        reportError();
+      });
+
+    return () => {
+      controller.abort();
+      // Safe while the media element below is unmounting with it: revoking
+      // detaches the URL from the blob for new loads; the element is gone
+      // either way.
+      if (url) URL.revokeObjectURL(url);
+    };
+  }, [src, maxBytes]);
+
+  return { objectUrl, fetching };
+}

--- a/src/panels/diff/DiffPane.tsx
+++ b/src/panels/diff/DiffPane.tsx
@@ -21,8 +21,9 @@ import { FileViewerToolbar } from "@/components/FileViewer/FileViewerToolbar";
 import { revealCopy } from "@/components/FileViewer/revealCopy";
 import { DiffFileSidebar } from "@/components/FileViewer/DiffFileSidebar";
 import { FileVideoPreview } from "@/components/FileViewer/FileVideoPreview";
-import type { VideoPreviewError } from "@/components/FileViewer/FileVideoPreview";
-import { isVideoFilePath } from "@/components/FileViewer/filePreviewKinds";
+import { FileAudioPreview } from "@/components/FileViewer/FileAudioPreview";
+import type { MediaPreviewError } from "@/components/FileViewer/useMediaBlobUrl";
+import { isAudioFilePath, isVideoFilePath } from "@/components/FileViewer/filePreviewKinds";
 import { ImageDiffViewer, isImageDiffCandidate } from "@/components/FileViewer/ImageDiffViewer";
 import { DiffViewer, FULL_FILE_MAX_LINES } from "@/components/Worktree/DiffViewer";
 import type { FullFileUnavailableReason } from "@/components/Worktree/DiffViewer";
@@ -65,9 +66,14 @@ const FULL_FILE_FALLBACK_MESSAGES: Record<FullFileUnavailableReason, string> = {
 
 // Used when the preview reports a failure it can't name — a decode error gives
 // the media element no detail beyond "this didn't play".
-const GENERIC_VIDEO_ERROR: VideoPreviewError = {
+const GENERIC_VIDEO_ERROR: MediaPreviewError = {
   title: "This video couldn't be played",
   description: "The container is supported but the codec may not be — Refresh to try again.",
+};
+
+const GENERIC_AUDIO_ERROR: MediaPreviewError = {
+  title: "This audio file couldn't be played",
+  description: "The format is supported but the codec may not be — Refresh to try again.",
 };
 
 // Mirrors the ladder the modal used, so the preference keeps meaning the same
@@ -269,19 +275,19 @@ export function DiffPane({
   const currentEntry = currentIndex === -1 ? undefined : changeSet?.[currentIndex];
   const isViewed = currentEntry ? viewedSet.has(currentEntry.viewedKey) : false;
 
-  // Forces a fresh media request in video mode — the diff content hooks don't
-  // carry video bytes, so Refresh has to re-request the protocol URL itself.
-  const [videoReloadNonce, setVideoReloadNonce] = useState(0);
+  // Forces a fresh media request in video/audio mode — the diff content hooks
+  // don't carry media bytes, so Refresh has to re-request the protocol URL.
+  const [mediaReloadNonce, setMediaReloadNonce] = useState(0);
   // An allowlisted container can still hold a codec Chromium lacks, or the
   // file may be unreadable — surface that instead of a dead native control.
   // Holds the preview's specific reason (e.g. too large) when it gives one.
-  const [videoPlaybackError, setVideoPlaybackError] = useState<VideoPreviewError | null>(null);
+  const [mediaPlaybackError, setMediaPlaybackError] = useState<MediaPreviewError | null>(null);
   useEffect(() => {
     // Any change to the playback attempt's identity — file, resolved root, or
     // an explicit refresh — gets a fresh attempt. absolutePath covers a
     // worktree move that filePath (relative) alone would miss.
-    setVideoPlaybackError(null);
-  }, [filePath, absolutePath, worktreePath, videoReloadNonce]);
+    setMediaPlaybackError(null);
+  }, [filePath, absolutePath, worktreePath, mediaReloadNonce]);
 
   const [pathCopied, setPathCopied] = useState(false);
   const handleCopyPath = useCallback(() => {
@@ -401,10 +407,12 @@ export function DiffPane({
   const isImageMode = Boolean(
     filePath && fileStatus && isImageDiffCandidate(filePath) && panel?.diffSource !== "base-branch"
   );
-  // Videos show only the current working-tree version (no side-by-side diff —
-  // the media pipeline has no cheap "old vs new frame" comparison), so unlike
+  // Media shows only the current working-tree version (no side-by-side diff —
+  // the media pipeline has no cheap "old vs new" comparison), so unlike
   // isImageMode this applies to every diff source, base-branch included.
   const isVideoMode = Boolean(filePath && isVideoFilePath(filePath));
+  const isAudioMode = Boolean(filePath && isAudioFilePath(filePath));
+  const isMediaMode = isVideoMode || isAudioMode;
   // Sentinels the viewer turns into empty states rather than a rendered diff.
   // `NO_CHANGES`/`ERROR` gate the pane's own branches below; the binary and
   // oversized ones matter to the full-file scope, which has nothing to expand
@@ -432,9 +440,11 @@ export function DiffPane({
       ? { available: false, reason: "This view already shows the whole image" }
       : isVideoMode
         ? { available: false, reason: "This view already shows the whole video" }
-        : !hasDiff
-          ? { available: false, reason: "There's no diff to expand yet" }
-          : { available: true };
+        : isAudioMode
+          ? { available: false, reason: "This view already shows the whole audio file" }
+          : !hasDiff
+            ? { available: false, reason: "There's no diff to expand yet" }
+            : { available: true };
 
   // The hunks and the file on disk must describe the same revision. Once the
   // store reports the file changed, they demonstrably don't: the check inside
@@ -470,10 +480,10 @@ export function DiffPane({
   // Only the diff is retried: clearing it drops `hasDiff`, which disables the
   // source hook and invalidates its read, and the source is fetched again when
   // the new diff lands. Retrying both here would issue that read twice. The
-  // video nonce bump is a no-op outside video mode (nothing renders it).
+  // media nonce bump is a no-op outside media mode (nothing renders it).
   const refreshAll = useCallback(() => {
     retry();
-    setVideoReloadNonce((nonce) => nonce + 1);
+    setMediaReloadNonce((nonce) => nonce + 1);
   }, [retry]);
 
   // One line explaining why a requested whole-file view isn't on screen. The
@@ -529,7 +539,7 @@ export function DiffPane({
   const toolbar = filePath ? (
     <>
       <FileViewerToolbar.Root>
-        {!isImageMode && !isVideoMode && (
+        {!isImageMode && !isMediaMode && (
           <div role="group" aria-label="Diff layout">
             <SegmentedToggle<DiffViewType>
               options={[
@@ -553,7 +563,7 @@ export function DiffPane({
         )}
         <FileViewerToolbar.Path path={filePath} copied={pathCopied} onCopy={handleCopyPath} />
         <FileViewerToolbar.Actions>
-          {!isImageMode && !isVideoMode && (
+          {!isImageMode && !isMediaMode && (
             <FileViewerToolbar.IconButton
               label="Wrap long lines"
               pressed={diffWrapLines}
@@ -742,37 +752,49 @@ export function DiffPane({
 
             {filePath &&
               subject &&
-              isVideoMode &&
+              isMediaMode &&
               (fileStatus === "deleted" || !absolutePath ? (
                 <div className="flex h-full w-full items-center justify-center p-6">
                   <EmptyState
                     variant="zero-data"
                     scale="canvas"
                     title="No working-tree version to play"
-                    description="This video was deleted, and the diff view can only play the current file."
+                    description={
+                      isAudioMode
+                        ? "This audio file was deleted, and the diff view can only play the current file."
+                        : "This video was deleted, and the diff view can only play the current file."
+                    }
                   />
                 </div>
-              ) : videoPlaybackError !== null ? (
+              ) : mediaPlaybackError !== null ? (
                 <div className="flex h-full w-full items-center justify-center p-6">
                   <EmptyState
                     variant="zero-data"
                     scale="canvas"
-                    title={videoPlaybackError.title}
-                    description={videoPlaybackError.description}
+                    title={mediaPlaybackError.title}
+                    description={mediaPlaybackError.description}
                   />
                 </div>
+              ) : isAudioMode ? (
+                <FileAudioPreview
+                  filePath={absolutePath}
+                  rootPath={worktreePath}
+                  label={fileName ?? filePath}
+                  reloadKey={mediaReloadNonce}
+                  onError={(error) => setMediaPlaybackError(error ?? GENERIC_AUDIO_ERROR)}
+                />
               ) : (
                 <FileVideoPreview
                   filePath={absolutePath}
                   rootPath={worktreePath}
                   label={fileName ?? filePath}
-                  reloadKey={videoReloadNonce}
-                  onError={(error) => setVideoPlaybackError(error ?? GENERIC_VIDEO_ERROR)}
+                  reloadKey={mediaReloadNonce}
+                  onError={(error) => setMediaPlaybackError(error ?? GENERIC_VIDEO_ERROR)}
                   maxHeightClassName="max-h-full"
                 />
               ))}
 
-            {filePath && subject && !isImageMode && !isVideoMode && content && (
+            {filePath && subject && !isImageMode && !isMediaMode && content && (
               <DiffViewer
                 diff={content}
                 viewType={diffViewType}
@@ -785,7 +807,7 @@ export function DiffPane({
               />
             )}
 
-            {filePath && subject && !isImageMode && !isVideoMode && !content && (
+            {filePath && subject && !isImageMode && !isMediaMode && !content && (
               <div className="p-4 space-y-3">
                 <Skeleton label="Loading diff">
                   <SkeletonBone className="h-7 w-3/4" />

--- a/src/panels/diff/__tests__/DiffPane.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.test.tsx
@@ -698,3 +698,112 @@ describe("DiffPane — video current-version mode (#11382)", () => {
     expect(titles).toContain("No working-tree version to play");
   });
 });
+
+describe("DiffPane — audio current-version mode (#11425)", () => {
+  // Same fetch/object-URL boundary as the video suite: audio shares the
+  // protocol path because electron#51442 covers <audio> too.
+  const audioFetchMock = vi.fn();
+  beforeEach(() => {
+    audioFetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      blob: () => Promise.resolve(new Blob(["x"])),
+    });
+    vi.stubGlobal("fetch", audioFetchMock);
+    let objectUrlSequence = 0;
+    URL.createObjectURL = vi.fn(() => `blob:app://daintree/audio-${objectUrlSequence++}`);
+    URL.revokeObjectURL = vi.fn();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    audioFetchMock.mockReset();
+  });
+
+  it("plays the working-tree version instead of rendering a diff", async () => {
+    seedPanel({
+      filePath: "media/track.mp3",
+      fileStatus: "modified",
+      changeSet: [entry("media/track.mp3")],
+    });
+    const { container } = renderPane();
+
+    await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+    expect(String(audioFetchMock.mock.calls[0]?.[0])).toContain(
+      encodeURIComponent("/repo/media/track.mp3")
+    );
+    expect(screen.queryByTestId("diff-viewer-mock")).toBeNull();
+  });
+
+  it("hides the text-diff layout controls in audio mode", () => {
+    seedPanel({
+      filePath: "media/track.mp3",
+      fileStatus: "modified",
+      changeSet: [entry("media/track.mp3")],
+    });
+    renderPane();
+
+    expect(screen.queryByRole("button", { name: "Unified" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Wrap long lines" })).toBeNull();
+  });
+
+  it("reloads the track from the toolbar Refresh (nonce-busted refetch)", async () => {
+    const retry = vi.fn();
+    useDiffContentMock.mockReturnValue({ content: "diff --git a/x b/x", stale: false, retry });
+    seedPanel({
+      filePath: "media/track.mp3",
+      fileStatus: "modified",
+      changeSet: [entry("media/track.mp3")],
+    });
+    const { container } = renderPane();
+    await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+    const before = container.querySelector("audio")?.getAttribute("src");
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+    await waitFor(() => expect(audioFetchMock).toHaveBeenCalledTimes(2));
+    expect(String(audioFetchMock.mock.calls[1]?.[0])).not.toBe(
+      String(audioFetchMock.mock.calls[0]?.[0])
+    );
+    await waitFor(() =>
+      expect(container.querySelector("audio")?.getAttribute("src")).not.toBe(before)
+    );
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses audio-specific copy on a playback failure, not the video wording", async () => {
+    seedPanel({
+      filePath: "media/track.mp3",
+      fileStatus: "modified",
+      changeSet: [entry("media/track.mp3")],
+    });
+    const { container } = renderPane();
+    await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+
+    fireEvent.error(container.querySelector("audio")!);
+
+    expect(container.querySelector("audio")).toBeNull();
+    const titles = Array.from(container.querySelectorAll('[data-testid="empty-state-mock"]')).map(
+      (el) => el.getAttribute("data-title")
+    );
+    expect(titles).toContain("This audio file couldn't be played");
+    expect(titles).not.toContain("This video couldn't be played");
+  });
+
+  it("shows a quiet empty state for a deleted audio file", () => {
+    seedPanel({
+      filePath: "media/track.mp3",
+      fileStatus: "deleted",
+      changeSet: [entry("media/track.mp3", "deleted")],
+    });
+    const { container } = renderPane();
+
+    expect(container.querySelector("audio")).toBeNull();
+    const descriptions = Array.from(
+      container.querySelectorAll('[data-testid="empty-state-mock"]')
+    ).map((el) => el.getAttribute("data-description"));
+    // The shared title is kind-agnostic; the description must name audio so it
+    // doesn't tell someone their track was a video.
+    expect(descriptions.some((d) => d?.includes("audio file was deleted"))).toBe(true);
+  });
+});

--- a/src/panels/diff/__tests__/DiffPane.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.test.tsx
@@ -790,6 +790,44 @@ describe("DiffPane — audio current-version mode (#11425)", () => {
     expect(titles).not.toContain("This video couldn't be played");
   });
 
+  it("headlines the preview's own refusal rather than the generic playback title", async () => {
+    audioFetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-length": String(2 * 1024 * 1024 * 1024) }),
+      blob: () => Promise.resolve(new Blob(["x"])),
+    });
+    seedPanel({
+      filePath: "media/track.wav",
+      fileStatus: "modified",
+      changeSet: [entry("media/track.wav")],
+    });
+    const { container } = renderPane();
+
+    await waitFor(() =>
+      expect(container.querySelector('[data-testid="empty-state-mock"]')).not.toBeNull()
+    );
+    const state = container.querySelector('[data-testid="empty-state-mock"]')!;
+    const title = state.getAttribute("data-title") ?? "";
+    const description = state.getAttribute("data-description") ?? "";
+    // Nothing failed to play, so the generic title would be wrong — and the
+    // description carries the way forward instead of restating the headline.
+    expect(title).not.toBe("This audio file couldn't be played");
+    expect(description).toBeTruthy();
+    expect(description).not.toContain(title);
+  });
+
+  it("keeps Full file visible but disabled, explaining audio already shows it all", () => {
+    seedPanel({
+      filePath: "media/track.mp3",
+      fileStatus: "modified",
+      changeSet: [entry("media/track.mp3")],
+    });
+    renderPane();
+
+    expect(screen.getByText(/already shows the whole audio file/i)).toBeTruthy();
+  });
+
   it("shows a quiet empty state for a deleted audio file", () => {
     seedPanel({
       filePath: "media/track.mp3",

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -16,11 +16,15 @@ import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { FileImagePreview } from "@/components/FileViewer/FileImagePreview";
 import { ZoomableImage } from "@/components/FileViewer/ZoomableImage";
 import { FileVideoPreview } from "@/components/FileViewer/FileVideoPreview";
+import { FileAudioPreview } from "@/components/FileViewer/FileAudioPreview";
 import {
   isImageFilePath,
   isSvgFilePath,
+  isAudioFilePath,
+  isUnsupportedAudioFilePath,
   isUnsupportedVideoFilePath,
   isVideoFilePath,
+  UNSUPPORTED_AUDIO_MESSAGE,
   UNSUPPORTED_VIDEO_MESSAGE,
 } from "@/components/FileViewer/filePreviewKinds";
 import { MarkdownViewer } from "@/components/Markdown/MarkdownViewer";
@@ -78,6 +82,7 @@ type ViewerState =
   | { status: "svg"; markup: string | null }
   | { status: "image" }
   | { status: "video" }
+  | { status: "audio" }
   | { status: "error"; message: string };
 
 // Markdown gets a Source/Rendered switch mirroring FilePane's toggle. Typed at
@@ -148,10 +153,21 @@ export function FileBrowserViewer({
       return;
     }
 
-    // Containers Chromium can't demux get a truthful "can't play" message
+    // Audio takes the same protocol-to-blob route as video.
+    if (isAudioFilePath(filePath)) {
+      setState({ status: "audio" });
+      return;
+    }
+
+    // Formats Chromium can't decode get a truthful "can't play" message
     // instead of falling through to the text path's size cap.
     if (isUnsupportedVideoFilePath(filePath)) {
       setState({ status: "error", message: UNSUPPORTED_VIDEO_MESSAGE });
+      return;
+    }
+
+    if (isUnsupportedAudioFilePath(filePath)) {
+      setState({ status: "error", message: UNSUPPORTED_AUDIO_MESSAGE });
       return;
     }
 
@@ -480,6 +496,26 @@ export function FileBrowserViewer({
                 })
               }
               maxHeightClassName="max-h-full"
+            />
+          </div>
+        );
+
+      case "audio":
+        return (
+          <div className="h-full w-full overflow-auto">
+            {/* Deliberately NOT keyed on `revision`, for the same reason as
+                video above: a worktree write elsewhere must not restart the
+                track someone is listening to. */}
+            <FileAudioPreview
+              filePath={filePath}
+              rootPath={rootPath}
+              label={fileName}
+              onError={(error) =>
+                setState({
+                  status: "error",
+                  message: error?.title ?? "This audio file couldn't be played",
+                })
+              }
             />
           </div>
         );

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -38,7 +38,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 
 function renderViewer(
   filePath: string | null,
-  opts: { sidebarCollapsed?: boolean; onToggleSidebar?: () => void } = {}
+  opts: { sidebarCollapsed?: boolean; onToggleSidebar?: () => void; revision?: string } = {}
 ) {
   const fileName = filePath ? (filePath.split("/").pop() ?? filePath) : "";
   return render(
@@ -48,7 +48,7 @@ function renderViewer(
         rootPath="/repo"
         fileName={fileName}
         relativePath={filePath ? fileName : null}
-        revision="r1"
+        revision={opts.revision ?? "r1"}
         sidebarCollapsed={opts.sidebarCollapsed ?? false}
         onToggleSidebar={opts.onToggleSidebar ?? vi.fn()}
         treeSidebarId="file-tree-column"
@@ -286,5 +286,62 @@ describe("FileBrowserViewer video preview (#11382)", () => {
     expect(container.querySelector("video")).toBeNull();
     expect(readMock).not.toHaveBeenCalled();
     expect(screen.getByText(/Can't play this video format/)).toBeTruthy();
+  });
+});
+
+describe("FileBrowserViewer audio preview (#11425)", () => {
+  // Same fetch/object-URL boundary as the video suite above.
+  const audioFetchMock = vi.fn();
+  beforeEach(() => {
+    audioFetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      blob: () => Promise.resolve(new Blob(["x"])),
+    });
+    vi.stubGlobal("fetch", audioFetchMock);
+    URL.createObjectURL = vi.fn(() => "blob:app://daintree/audio-preview");
+    URL.revokeObjectURL = vi.fn();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    audioFetchMock.mockReset();
+  });
+
+  it("renders an <audio> for a playable format without reading the file as text", async () => {
+    const { container } = renderViewer("/repo/media/track.flac");
+
+    await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+    expect(String(audioFetchMock.mock.calls[0]?.[0])).toContain("daintree-file://");
+    expect(container.querySelector("audio")?.getAttribute("src")).toMatch(/^blob:/);
+    expect(readMock).not.toHaveBeenCalled();
+  });
+
+  it("shows a format message for audio Chromium can't decode, not the binary error", async () => {
+    const { container } = renderViewer("/repo/media/track.mid");
+    await act(async () => {});
+
+    expect(container.querySelector("audio")).toBeNull();
+    expect(readMock).not.toHaveBeenCalled();
+    expect(screen.getByText(/Can't play this audio format/)).toBeTruthy();
+  });
+
+  it("keeps playing across a revision tick rather than refetching", async () => {
+    // `revision` bumps on every worktree write; keying the player on it would
+    // restart the track whenever an agent touches an unrelated file.
+    const { container, unmount } = renderViewer("/repo/media/track.mp3", { revision: "r1" });
+    await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+    const firstSrc = container.querySelector("audio")?.getAttribute("src");
+    expect(audioFetchMock).toHaveBeenCalledTimes(1);
+    unmount();
+    audioFetchMock.mockClear();
+
+    const bumped = renderViewer("/repo/media/track.mp3", { revision: "r2" });
+    await waitFor(() => expect(bumped.container.querySelector("audio")).not.toBeNull());
+
+    // A different revision must not change the media URL the player is given:
+    // the object URL is a snapshot of the fetch, not a function of revision.
+    expect(bumped.container.querySelector("audio")?.getAttribute("src")).toBe(firstSrc);
+    expect(String(audioFetchMock.mock.calls[0]?.[0])).not.toContain("r2");
   });
 });

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -326,22 +326,39 @@ describe("FileBrowserViewer audio preview (#11425)", () => {
     expect(screen.getByText(/Can't play this audio format/)).toBeTruthy();
   });
 
-  it("keeps playing across a revision tick rather than refetching", async () => {
+  it("keeps the same player across a revision tick rather than refetching", async () => {
     // `revision` bumps on every worktree write; keying the player on it would
-    // restart the track whenever an agent touches an unrelated file.
-    const { container, unmount } = renderViewer("/repo/media/track.mp3", { revision: "r1" });
+    // restart the track whenever an agent touches an unrelated file. Object
+    // URLs are unique here so a remount can't masquerade as continuity.
+    let objectUrlSequence = 0;
+    URL.createObjectURL = vi.fn(() => `blob:app://daintree/audio-${objectUrlSequence++}`);
+
+    const { container, rerender } = renderViewer("/repo/media/track.mp3", { revision: "r1" });
     await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
-    const firstSrc = container.querySelector("audio")?.getAttribute("src");
+    const firstNode = container.querySelector("audio");
+    const firstSrc = firstNode?.getAttribute("src");
     expect(audioFetchMock).toHaveBeenCalledTimes(1);
-    unmount();
-    audioFetchMock.mockClear();
 
-    const bumped = renderViewer("/repo/media/track.mp3", { revision: "r2" });
-    await waitFor(() => expect(bumped.container.querySelector("audio")).not.toBeNull());
+    rerender(
+      <TooltipProvider>
+        <FileBrowserViewer
+          filePath="/repo/media/track.mp3"
+          rootPath="/repo"
+          fileName="track.mp3"
+          relativePath="track.mp3"
+          revision="r2"
+          sidebarCollapsed={false}
+          onToggleSidebar={vi.fn()}
+          treeSidebarId="file-tree-column"
+        />
+      </TooltipProvider>
+    );
+    await act(async () => {});
 
-    // A different revision must not change the media URL the player is given:
-    // the object URL is a snapshot of the fetch, not a function of revision.
-    expect(bumped.container.querySelector("audio")?.getAttribute("src")).toBe(firstSrc);
-    expect(String(audioFetchMock.mock.calls[0]?.[0])).not.toContain("r2");
+    // The very same element, still on its original blob — not a fresh one that
+    // happens to look alike.
+    expect(container.querySelector("audio")).toBe(firstNode);
+    expect(container.querySelector("audio")?.getAttribute("src")).toBe(firstSrc);
+    expect(audioFetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -496,13 +496,16 @@ export function FilePane({
 
       // Formats Chromium can't decode get a truthful "can't play" message
       // instead of falling through to the text path's size cap.
-      if (isUnsupportedVideoFilePath(filePath) || isUnsupportedAudioFilePath(filePath)) {
+      const unsupportedMediaMessage = isUnsupportedVideoFilePath(filePath)
+        ? UNSUPPORTED_VIDEO_MESSAGE
+        : isUnsupportedAudioFilePath(filePath)
+          ? UNSUPPORTED_AUDIO_MESSAGE
+          : null;
+      if (unsupportedMediaMessage) {
         setContent(null);
         setSanitizedSvg(null);
         setErrorCode("BINARY_FILE");
-        setErrorMessage(
-          isUnsupportedVideoFilePath(filePath) ? UNSUPPORTED_VIDEO_MESSAGE : UNSUPPORTED_AUDIO_MESSAGE
-        );
+        setErrorMessage(unsupportedMediaMessage);
         setLoadState("error");
         return;
       }

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -28,11 +28,15 @@ import { FileViewerToolbar } from "@/components/FileViewer/FileViewerToolbar";
 import { revealCopy, type RevealCopy } from "@/components/FileViewer/revealCopy";
 import { FileImagePreview } from "@/components/FileViewer/FileImagePreview";
 import { FileVideoPreview } from "@/components/FileViewer/FileVideoPreview";
+import { FileAudioPreview } from "@/components/FileViewer/FileAudioPreview";
 import {
+  isAudioFilePath,
   isImageFilePath,
   isSvgFilePath,
+  isUnsupportedAudioFilePath,
   isUnsupportedVideoFilePath,
   isVideoFilePath,
+  UNSUPPORTED_AUDIO_MESSAGE,
   UNSUPPORTED_VIDEO_MESSAGE,
 } from "@/components/FileViewer/filePreviewKinds";
 import { sanitizeSvg } from "@shared/utils/svgSanitizer";
@@ -111,11 +115,11 @@ function isUnderRoot(filePath: string, rootPath: string): boolean {
   return toForwardSlashes(filePath).startsWith(root);
 }
 
-// "image", "svg", and "video" are terminal preview states: an image is handed
-// to the `daintree-file://` protocol as an <img> src, an SVG is read as text,
-// sanitized, then inlined, and a video streams from the same protocol into a
-// <video> element. None has readable text content.
-type LoadState = "idle" | "loading" | "loaded" | "error" | "image" | "svg" | "video";
+// "image", "svg", "video", and "audio" are terminal preview states: an image is
+// handed to the `daintree-file://` protocol as an <img> src, an SVG is read as
+// text, sanitized, then inlined, and video/audio are fetched from the same
+// protocol into a blob the media element plays. None has readable text content.
+type LoadState = "idle" | "loading" | "loaded" | "error" | "image" | "svg" | "video" | "audio";
 
 // Which external surface a toolbar action aims the current file at. `reveal` is
 // always offered; `browser`/`editor` is the mode-dependent open button.
@@ -475,13 +479,30 @@ export function FilePane({
         return;
       }
 
-      // Containers Chromium can't demux get a truthful "can't play" message
+      // Audio takes the same protocol-to-blob route as video — the text path
+      // would reject it with a misleading size/binary error.
+      if (isAudioFilePath(filePath)) {
+        setContent(null);
+        setSanitizedSvg(null);
+        // Only an explicit load (open, toolbar Refresh) re-requests the media —
+        // a silent background pass must not remount the player and reset
+        // playback while someone is listening.
+        if (!silent) setReloadNonce((nonce) => nonce + 1);
+        setLoadState("audio");
+        setErrorCode(null);
+        setErrorMessage(null);
+        return;
+      }
+
+      // Formats Chromium can't decode get a truthful "can't play" message
       // instead of falling through to the text path's size cap.
-      if (isUnsupportedVideoFilePath(filePath)) {
+      if (isUnsupportedVideoFilePath(filePath) || isUnsupportedAudioFilePath(filePath)) {
         setContent(null);
         setSanitizedSvg(null);
         setErrorCode("BINARY_FILE");
-        setErrorMessage(UNSUPPORTED_VIDEO_MESSAGE);
+        setErrorMessage(
+          isUnsupportedVideoFilePath(filePath) ? UNSUPPORTED_VIDEO_MESSAGE : UNSUPPORTED_AUDIO_MESSAGE
+        );
         setLoadState("error");
         return;
       }
@@ -901,9 +922,9 @@ export function FilePane({
             <p className="text-sm text-muted-foreground">
               {errorMessage ?? FILE_READ_ERROR_MESSAGES[errorCode]}
             </p>
-            {/* An unsupported container is deterministic — retrying the same
+            {/* An unsupported format is deterministic — retrying the same
                 extension can never succeed, so the action would be dead. */}
-            {!isUnsupportedVideoFilePath(filePath) && (
+            {!isUnsupportedVideoFilePath(filePath) && !isUnsupportedAudioFilePath(filePath) && (
               <button
                 type="button"
                 onClick={() => loadFile(false)}
@@ -944,6 +965,22 @@ export function FilePane({
               setLoadState("error");
             }}
             maxHeightClassName="max-h-full"
+          />
+        )}
+
+        {filePath && viewMode !== "diff" && loadState === "audio" && (
+          <FileAudioPreview
+            filePath={filePath}
+            rootPath={effectiveRootPath}
+            label={fileName ?? filePath}
+            reloadKey={reloadNonce}
+            onError={(error) => {
+              // An allowlisted extension can still hold a codec Chromium lacks;
+              // name that instead of implying the file is missing.
+              setErrorCode(error?.code ?? "BINARY_FILE");
+              setErrorMessage(error?.title ?? "This audio file couldn't be played");
+              setLoadState("error");
+            }}
           />
         )}
 

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import type { ReactNode } from "react";
-import { render, act, screen, waitFor } from "@testing-library/react";
+import { render, act, screen, waitFor, fireEvent } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // FilePane forwards a fixed prop list to ContentPanel; #10991 was a dropped
@@ -1057,6 +1057,8 @@ describe("FilePane diff mode (#11274)", () => {
     // Same fetch-to-blob boundary as video above: audio rides the identical
     // protocol path because electron#51442 covers <audio> too.
     const audioFetchMock = vi.fn();
+    let createObjectUrlSpy: ReturnType<typeof vi.spyOn<typeof URL, "createObjectURL">>;
+    let revokeObjectUrlSpy: ReturnType<typeof vi.spyOn<typeof URL, "revokeObjectURL">>;
     beforeEach(() => {
       audioFetchMock.mockResolvedValue({
         ok: true,
@@ -1065,11 +1067,17 @@ describe("FilePane diff mode (#11274)", () => {
         blob: () => Promise.resolve(new Blob(["x"])),
       });
       vi.stubGlobal("fetch", audioFetchMock);
-      URL.createObjectURL = vi.fn(() => "blob:app://daintree/audio-preview");
-      URL.revokeObjectURL = vi.fn();
+      // spyOn, not assignment: unstubAllGlobals doesn't restore a directly
+      // assigned URL method, and later describes in this file would inherit it.
+      createObjectUrlSpy = vi
+        .spyOn(URL, "createObjectURL")
+        .mockReturnValue("blob:app://daintree/audio-preview");
+      revokeObjectUrlSpy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
     });
     afterEach(() => {
       vi.unstubAllGlobals();
+      createObjectUrlSpy.mockRestore();
+      revokeObjectUrlSpy.mockRestore();
       audioFetchMock.mockReset();
     });
 
@@ -1096,6 +1104,23 @@ describe("FilePane diff mode (#11274)", () => {
 
       expect(screen.getByText(/Can't play this audio format/)).toBeTruthy();
       expect(screen.queryByText("Retry")).toBeNull();
+    });
+
+    it("names a decode failure and offers Retry, which reloads the player", async () => {
+      const { container } = await renderPane({ filePath: "/repo/media/track.mp3" });
+      await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+
+      // A playable extension can still hold a codec Chromium lacks; that's a
+      // real failure the pane must name rather than leaving a dead control.
+      fireEvent.error(container.querySelector("audio")!);
+
+      expect(container.querySelector("audio")).toBeNull();
+      expect(screen.getByText(/audio file couldn't be played/i)).toBeTruthy();
+
+      // Unlike an unsupported extension, this one CAN succeed on a retry.
+      fireEvent.click(screen.getByText("Retry"));
+      await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+      expect(audioFetchMock.mock.calls.length).toBeGreaterThan(1);
     });
   });
 

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -1053,6 +1053,52 @@ describe("FilePane diff mode (#11274)", () => {
     });
   });
 
+  describe("audio preview (#11425)", () => {
+    // Same fetch-to-blob boundary as video above: audio rides the identical
+    // protocol path because electron#51442 covers <audio> too.
+    const audioFetchMock = vi.fn();
+    beforeEach(() => {
+      audioFetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        blob: () => Promise.resolve(new Blob(["x"])),
+      });
+      vi.stubGlobal("fetch", audioFetchMock);
+      URL.createObjectURL = vi.fn(() => "blob:app://daintree/audio-preview");
+      URL.revokeObjectURL = vi.fn();
+    });
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      audioFetchMock.mockReset();
+    });
+
+    it("renders an <audio> for a playable format without reading the file as text", async () => {
+      const { container } = await renderPane({ filePath: "/repo/media/track.mp3" });
+
+      await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+      // The text-read IPC path is what produced "Binary file — cannot display".
+      expect(String(audioFetchMock.mock.calls[0]?.[0])).toContain("daintree-file://");
+      expect(container.querySelector("audio")?.getAttribute("src")).toMatch(/^blob:/);
+      expect(readMock).not.toHaveBeenCalled();
+    });
+
+    it("shows a format message for audio Chromium can't decode, not the binary error", async () => {
+      const { container } = await renderPane({ filePath: "/repo/media/track.wma" });
+
+      expect(container.querySelector("audio")).toBeNull();
+      expect(readMock).not.toHaveBeenCalled();
+      expect(screen.getByText(/Can't play this audio format/)).toBeTruthy();
+    });
+
+    it("hides Retry for an unsupported audio format, since it can never succeed", async () => {
+      await renderPane({ filePath: "/repo/media/track.aiff" });
+
+      expect(screen.getByText(/Can't play this audio format/)).toBeTruthy();
+      expect(screen.queryByText("Retry")).toBeNull();
+    });
+  });
+
   describe("change lookup", () => {
     it("matches a change stored as an absolute path", async () => {
       seedWorktree([{ path: "/repo/src/index.ts", status: "modified" }]);

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -1057,8 +1057,11 @@ describe("FilePane diff mode (#11274)", () => {
     // Same fetch-to-blob boundary as video above: audio rides the identical
     // protocol path because electron#51442 covers <audio> too.
     const audioFetchMock = vi.fn();
-    let createObjectUrlSpy: ReturnType<typeof vi.spyOn<typeof URL, "createObjectURL">>;
-    let revokeObjectUrlSpy: ReturnType<typeof vi.spyOn<typeof URL, "revokeObjectURL">>;
+    // Captured while the describe body runs, before any beforeEach has swapped
+    // them — vi.spyOn would hand back the video suite's own unrestored mock,
+    // and unstubAllGlobals never restores a directly assigned URL method.
+    const realCreateObjectURL = URL.createObjectURL;
+    const realRevokeObjectURL = URL.revokeObjectURL;
     beforeEach(() => {
       audioFetchMock.mockResolvedValue({
         ok: true,
@@ -1067,17 +1070,13 @@ describe("FilePane diff mode (#11274)", () => {
         blob: () => Promise.resolve(new Blob(["x"])),
       });
       vi.stubGlobal("fetch", audioFetchMock);
-      // spyOn, not assignment: unstubAllGlobals doesn't restore a directly
-      // assigned URL method, and later describes in this file would inherit it.
-      createObjectUrlSpy = vi
-        .spyOn(URL, "createObjectURL")
-        .mockReturnValue("blob:app://daintree/audio-preview");
-      revokeObjectUrlSpy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+      URL.createObjectURL = vi.fn(() => "blob:app://daintree/audio-preview");
+      URL.revokeObjectURL = vi.fn();
     });
     afterEach(() => {
       vi.unstubAllGlobals();
-      createObjectUrlSpy.mockRestore();
-      revokeObjectUrlSpy.mockRestore();
+      URL.createObjectURL = realCreateObjectURL;
+      URL.revokeObjectURL = realRevokeObjectURL;
       audioFetchMock.mockReset();
     });
 


### PR DESCRIPTION
Audio files fell through to the text-read path and reported "Binary file — cannot display". This gives them the same treatment #11385 gave video, across all three preview surfaces.

## What changed

- **Classification** (`filePreviewKinds.ts`): playable audio is `mp3, wav, flac, ogg, oga, opus, m4a, aac`; `wma, aiff, aif, mid, midi, amr` are recognized only so the viewer can say "can't play this audio format" instead of the misleading binary error. `.ogg` is audio, `.ogv` stays video — no collision.
- **Protocol routing** (`electron/setup/protocols.ts`): this was the actual blocker. `daintree-file://` streamed only `video/*`; everything else went through the buffered core capped at 512 KB, so a 4 MB podcast episode would have 413'd before reaching the renderer. `isVideoMimeType`/`streamContainedVideoFile` are now `isMediaMimeType`/`streamContainedMediaFile` and accept `audio/*` too. The canonical-path MIME recheck is untouched — a `track.mp3` symlink pointing at a large text file still falls back to the capped buffered path rather than streaming uncapped.
- **MIME map** (`appProtocol.ts`): added `flac, oga, opus, m4a, aac`. The spellings matter — the protocol serves `nosniff`, and `audio/x-flac` is not a type Chromium accepts.
- **Shared lifecycle** (`useMediaBlobUrl.ts`): the fetch → Blob → object-URL logic came out of `FileVideoPreview` into a hook both previews use, rather than duplicating ~100 lines of abort sequencing, size gates, and URL revocation into a second component where a fix to one would silently miss the other. `FileVideoPreview`'s props and behavior are unchanged and its existing tests pass untouched, which is the regression proof for the extraction.
- **`FileAudioPreview.tsx`** + wiring into `FilePane`, `DiffPane`, and `FileBrowserViewer`.

Audio uses the same fetch-to-Blob path as video rather than pointing `<audio src>` at the protocol: electron/electron#51442 (still open) means Chromium's custom-scheme media loader can't serve a follow-up range request, and `<audio>` rides the same `MultiBufferDataSource` as `<video>`.

## On the codec list

I probed `canPlayType` inside a real Electron 42.7.1 / Chromium 148 window from this repo's `node_modules` rather than trusting docs. Notable results: `audio/flac` → `probably` but `audio/x-flac` → unsupported; `audio/mp4; codecs="mp4a.40.2"` → `probably`, confirming m4a/aac work because Electron ships `proprietary_codecs=true` (same reason mp4/m4v already play); `wma`, `aiff`, `midi`, `amr` → unsupported. `.opus` and `.m4a` are declared with bare types, no `codecs=` parameter — the extension names the container, not what's inside it.

## Testing

430 tests across the 9 affected files. The two stale-response guards in the hook are mutation-checked: commenting them out fails exactly the two tests written for them.

## Deliberately not changed

These are all pre-existing behaviors that video already has, mirrored for parity rather than changed here:

- `DiffPane` has no unsupported-format branch (audio and video both fall to the diff view's binary state there).
- `FilePane`/`FileBrowserViewer` drop `MediaPreviewError.description`, and Retry stays offered for `FILE_TOO_LARGE` even though it can't succeed.
- A file named literally `.mp3` classifies as audio in the renderer but has no extension per `path.extname`, so the protocol serves it as octet-stream. Longstanding, and shared with the image/video classifiers.

There's also no Electron integration test that actually decodes an audio fixture — the repo has no file-viewer media E2E suite, and adding one is out of scope here.

Resolves #11425