### PR TITLE
feat(file-viewer): preview PDFs inline via Chromium's built-in viewer

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -25,6 +25,7 @@ import {
   registerAppProtocol,
   registerDaintreeFileProtocol,
   registerDaintreeHtmlProtocol,
+  registerDaintreePdfProtocol,
   registerDeepLinkProtocolClient,
   registerPluginProtocol,
   setupWebviewCSP,
@@ -149,6 +150,23 @@ protocol.registerSchemesAsPrivileged([
     scheme: "daintree-html",
     privileges: {
       standard: true,
+      secure: true,
+    },
+  },
+  {
+    // Inline PDF preview (#11427). Chromium's built-in PDFium viewer engages for
+    // any custom-scheme response typed `application/pdf` — verified against
+    // Electron 42 / Chromium 148 — so this scheme exists purely to give the
+    // viewer a `frame-src` allowance that can never resolve to anything but a
+    // PDF. Kept off daintree-file:// on purpose: that scheme serves arbitrary
+    // repo files under extension-derived MIME types and a `sandbox` response
+    // CSP, and a sandboxed document blocks PDFium (ERR_BLOCKED_BY_CLIENT).
+    // Deliberately minimal privileges: no `standard` (an opaque origin is more
+    // isolated, and the query-string URL shape needs no hierarchical parsing),
+    // and no supportFetchAPI/corsEnabled — the iframe navigates here, it never
+    // fetch()es.
+    scheme: "daintree-pdf",
+    privileges: {
       secure: true,
     },
   },
@@ -592,6 +610,7 @@ if (!gotTheLock) {
       registerAppProtocol(distPath, { allowDisplayCapture: isDemoMode });
       registerDaintreeFileProtocol();
       registerDaintreeHtmlProtocol();
+      registerDaintreePdfProtocol();
       // Register `plugin://` with a placeholder resolver that 404s every
       // request, keeping the heavy ~2900-line PluginService module off the
       // first-paint critical path (#10322). The handler must exist before

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -136,9 +136,11 @@ vi.mock("../../ipc/channels.js", () => ({
 }));
 
 import {
+  applyDaintreeAppCspToSession,
   createPluginProtocolHandler,
   registerAppProtocol,
   registerDaintreeFileProtocol,
+  registerDaintreePdfProtocol,
   registerPluginProtocol,
   registerProtocolsForSession,
   setPluginDirResolver,
@@ -1198,6 +1200,46 @@ describe("setupWebviewCSP — partition CSP wiring", () => {
     expect(vi.mocked(mergeCspHeaders)).toHaveBeenCalledTimes(1);
   });
 
+  it("passes daintree-pdf:// responses through without stamping a CSP on them (#11427)", async () => {
+    const { session } = await import("electron");
+    const { mergeCspHeaders } = await import("../../utils/webviewCsp.js");
+    const fromPartition = vi.mocked(session.fromPartition);
+    vi.mocked(mergeCspHeaders).mockClear();
+
+    let captured:
+      | ((details: unknown, callback: (r: { responseHeaders?: unknown }) => void) => void)
+      | undefined;
+    fromPartition.mockImplementation((partition: string) => {
+      const onHeadersReceived = vi.fn(
+        (
+          _filter: unknown,
+          listener: (details: unknown, callback: (r: { responseHeaders?: unknown }) => void) => void
+        ) => {
+          if (partition === "persist:daintree") captured = listener;
+        }
+      );
+      return { webRequest: { onHeadersReceived } } as unknown as Electron.Session;
+    });
+
+    setupWebviewCSP();
+    expect(captured).toBeDefined();
+
+    // A PDF document must reach PDFium carrying NO CSP: the app policy's
+    // frame-src omits chrome-extension:, so overlaying it would block the
+    // viewer frame PDFium installs inside the document.
+    const pdfHeaders = { "Content-Type": ["application/pdf"] };
+    let pdfResult: { responseHeaders?: unknown } | undefined;
+    captured!({ url: "daintree-pdf://load?path=%2Frepo%2Fa.pdf", responseHeaders: pdfHeaders }, (r) => {
+      pdfResult = r;
+    });
+    expect(pdfResult?.responseHeaders).toBe(pdfHeaders);
+    expect(vi.mocked(mergeCspHeaders)).not.toHaveBeenCalled();
+
+    // A normal app response still gets the overlay, so the bypass is scoped.
+    captured!({ url: "app://daintree/index.html", responseHeaders: {} }, () => {});
+    expect(vi.mocked(mergeCspHeaders)).toHaveBeenCalledTimes(1);
+  });
+
   it("attaches an onHeadersReceived listener for persist:daintree only (browser is excluded)", async () => {
     const { session } = await import("electron");
     const fromPartition = vi.mocked(session.fromPartition);
@@ -1420,10 +1462,14 @@ describe("protocol registration", () => {
     // plugin:// is skipped here — registerPluginProtocol hasn't been called yet
     // in this test. Production order is the opposite: registerPluginProtocol runs
     // in app.whenReady() before any per-project session is created.
-    expect(handle).toHaveBeenCalledTimes(3);
-    expect(handle).toHaveBeenCalledWith("app", expect.any(Function));
-    expect(handle).toHaveBeenCalledWith("daintree-file", expect.any(Function));
-    expect(handle).toHaveBeenCalledWith("daintree-html", expect.any(Function));
+    const schemes = handle.mock.calls.map((c) => c[0] as string);
+    expect(new Set(schemes)).toEqual(new Set(["app", "daintree-file", "daintree-html", "daintree-pdf"]));
+    // Each exactly once: a duplicate handle() for one scheme throws in Electron.
+    expect(schemes).toHaveLength(new Set(schemes).size);
+    expect(schemes).not.toContain("plugin");
+    for (const scheme of schemes) {
+      expect(handle).toHaveBeenCalledWith(scheme, expect.any(Function));
+    }
   });
 
   it("also registers plugin:// on per-project sessions after the resolver is cached", async () => {
@@ -1443,6 +1489,14 @@ describe("protocol registration", () => {
     registerDaintreeFileProtocol();
 
     expect(protocol.handle).toHaveBeenCalledWith("daintree-file", expect.any(Function));
+  });
+
+  it("registers the default-session daintree-pdf protocol", async () => {
+    const { protocol } = await import("electron");
+
+    registerDaintreePdfProtocol();
+
+    expect(protocol.handle).toHaveBeenCalledWith("daintree-pdf", expect.any(Function));
   });
 
   it("registers the default-session plugin protocol", async () => {
@@ -3373,5 +3427,283 @@ describe("createDaintreeHtmlProtocolHandler — sandboxed HTML preview (#11191)"
     const handler = await captureHandler();
     const response = await handler(makeRequest(token, "chart.png"));
     expect(response.status).toBe(413);
+  });
+});
+
+describe("createDaintreePdfProtocolHandler — inline PDF preview (#11427)", () => {
+  type ProtocolHandler = (request: GlobalRequest) => Promise<Response>;
+
+  async function captureHandler(): Promise<ProtocolHandler> {
+    const handle = vi.fn();
+    const mockSession = { protocol: { handle } } as unknown as Electron.Session;
+    registerProtocolsForSession(mockSession, "/tmp/dist");
+    const call = handle.mock.calls.find((c) => c[0] === "daintree-pdf");
+    if (!call) throw new Error("handler for daintree-pdf not registered");
+    return call[1] as ProtocolHandler;
+  }
+
+  function makeRequest(
+    filePath: string,
+    rootPath: string,
+    init?: RequestInit
+  ): GlobalRequest {
+    const url = new URL("daintree-pdf://load");
+    url.searchParams.set("path", filePath);
+    url.searchParams.set("root", rootPath);
+    return new Request(url.toString(), init) as GlobalRequest;
+  }
+
+  function makeFileHandle(content: string | Buffer = "%PDF-1.4 body") {
+    const buffer = typeof content === "string" ? Buffer.from(content) : content;
+    return {
+      readFile: vi.fn().mockResolvedValue(buffer),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const fs = await import("fs/promises");
+    vi.mocked(fs.realpath).mockImplementation((p) => Promise.resolve(p as string));
+    vi.mocked(fs.stat).mockResolvedValue({ size: 13 } as Awaited<ReturnType<typeof fs.stat>>);
+    vi.mocked(fs.open).mockResolvedValue(
+      makeFileHandle() as unknown as Awaited<ReturnType<typeof fs.open>>
+    );
+    const appProtocol = await import("../../utils/appProtocol.js");
+    vi.mocked(appProtocol.getMimeType).mockReturnValue("application/pdf");
+  });
+
+  it("serves a PDF with no CSP and no COEP so PDFium can install its viewer frame", async () => {
+    const handler = await captureHandler();
+    const response = await handler(makeRequest("/project/spec.pdf", "/project"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/pdf");
+    // Both headers are load-bearing by their ABSENCE: a `sandbox` CSP blocks
+    // PDFium outright, and a COEP makes the PDF an embedder whose own viewer
+    // frame is then blocked. The iframe carries `credentialless` instead.
+    expect(response.headers.get("Content-Security-Policy")).toBeNull();
+    expect(response.headers.get("Cross-Origin-Embedder-Policy")).toBeNull();
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("reports the byte length actually returned", async () => {
+    const fs = await import("fs/promises");
+    const bytes = Buffer.from("%PDF-1.7 a longer body than the stat claimed");
+    vi.mocked(fs.open).mockResolvedValue(
+      makeFileHandle(bytes) as unknown as Awaited<ReturnType<typeof fs.open>>
+    );
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest("/project/spec.pdf", "/project"));
+
+    expect(response.headers.get("Content-Length")).toBe(String(bytes.length));
+  });
+
+  it("names the download after the file, not the URL's `load` segment", async () => {
+    const handler = await captureHandler();
+    const response = await handler(makeRequest("/project/data sheet.pdf", "/project"));
+
+    const disposition = response.headers.get("Content-Disposition") ?? "";
+    expect(disposition.startsWith("inline")).toBe(true);
+    expect(disposition).toContain('filename="data sheet.pdf"');
+    expect(disposition).not.toContain("load");
+  });
+
+  it("opens the user-supplied path with O_NOFOLLOW", async () => {
+    const fs = await import("fs/promises");
+    const handler = await captureHandler();
+    await handler(makeRequest("/project/spec.pdf", "/project"));
+
+    expect(fs.open).toHaveBeenCalledWith(
+      path.normalize("/project/spec.pdf"),
+      fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW
+    );
+  });
+
+  it.each(["/project/spec.PDF", "/project/a.b.Pdf"])(
+    "accepts the case-insensitive extension %s",
+    async (filePath) => {
+      const handler = await captureHandler();
+      const response = await handler(makeRequest(filePath, "/project"));
+      expect(response.status).toBe(200);
+    }
+  );
+
+  it("rejects a non-PDF before reading any bytes", async () => {
+    const fs = await import("fs/promises");
+    const handler = await captureHandler();
+    const response = await handler(makeRequest("/project/notes.txt", "/project"));
+
+    expect(response.status).toBe(415);
+    // The gate must run before the read, or an arbitrary in-root file would be
+    // buffered under the PDF ceiling rather than the much tighter text cap.
+    expect(fs.open).not.toHaveBeenCalled();
+    expect(fs.stat).not.toHaveBeenCalled();
+  });
+
+  it("rejects a .pdf name whose canonical path is not a PDF", async () => {
+    // On Windows O_NOFOLLOW is a no-op, so a final-component symlink
+    // (`spec.pdf` -> `huge.bin`) would otherwise be served under the PDF cap.
+    const fs = await import("fs/promises");
+    vi.mocked(fs.realpath).mockImplementation((p) =>
+      Promise.resolve(
+        (p as string).endsWith("spec.pdf") ? path.normalize("/project/huge.bin") : (p as string)
+      )
+    );
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest("/project/spec.pdf", "/project"));
+
+    expect(response.status).toBe(415);
+    expect(fs.open).not.toHaveBeenCalled();
+  });
+
+  it("types a .pdf holding active HTML as a PDF rather than a document", async () => {
+    // This is what makes the `frame-src daintree-pdf:` allowance safe: the
+    // bytes reach PDFium and fail as a malformed PDF instead of executing.
+    const fs = await import("fs/promises");
+    vi.mocked(fs.open).mockResolvedValue(
+      makeFileHandle("<script>parent.pwned = true</script>") as unknown as Awaited<
+        ReturnType<typeof fs.open>
+      >
+    );
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest("/project/evil.pdf", "/project"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/pdf");
+  });
+
+  it("ignores a Range header and answers with the whole document", async () => {
+    // PDFium renders from a single buffered 200, so the video path's ranged
+    // streaming is deliberately not wired here.
+    const handler = await captureHandler();
+    const response = await handler(
+      makeRequest("/project/spec.pdf", "/project", { headers: { Range: "bytes=0-4" } })
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Range")).toBeNull();
+  });
+
+  it("allows a PDF larger than the raster-image ceiling but rejects one past its own", async () => {
+    const fs = await import("fs/promises");
+    const handler = await captureHandler();
+
+    // 30 MB clears the 25 MB image cap — proving PDFs get their own, larger
+    // ceiling rather than inheriting one of the existing limits.
+    vi.mocked(fs.stat).mockResolvedValue({ size: 30 * 1024 * 1024 } as Awaited<
+      ReturnType<typeof fs.stat>
+    >);
+    expect((await handler(makeRequest("/project/big.pdf", "/project"))).status).toBe(200);
+
+    vi.mocked(fs.stat).mockResolvedValue({ size: 512 * 1024 * 1024 } as Awaited<
+      ReturnType<typeof fs.stat>
+    >);
+    expect((await handler(makeRequest("/project/huge.pdf", "/project"))).status).toBe(413);
+  });
+
+  it("rejects a file outside the root", async () => {
+    const handler = await captureHandler();
+    const response = await handler(makeRequest("/elsewhere/secret.pdf", "/project"));
+    expect(response.status).toBe(404);
+  });
+
+  it.each([
+    ["relative paths", "project/spec.pdf", "/project"],
+    ["a NUL byte", "/project/spec\0.pdf", "/project"],
+  ])("rejects %s with 400", async (_label, filePath, rootPath) => {
+    const handler = await captureHandler();
+    const response = await handler(makeRequest(filePath, rootPath));
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects a request missing the path parameter", async () => {
+    const handler = await captureHandler();
+    const response = await handler(
+      new Request("daintree-pdf://load?root=%2Fproject") as GlobalRequest
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects a non-GET method", async () => {
+    const handler = await captureHandler();
+    const response = await handler(
+      makeRequest("/project/spec.pdf", "/project", { method: "POST" })
+    );
+    expect(response.status).toBe(405);
+  });
+
+  it("keeps error responses inert rather than serving them as PDFs", async () => {
+    const handler = await captureHandler();
+    const response = await handler(makeRequest("/project/notes.txt", "/project"));
+
+    expect(response.headers.get("Content-Type")).toBe("text/plain");
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("Content-Security-Policy")).toContain("sandbox");
+  });
+});
+
+describe("applyDaintreeAppCspToSession — preview response pass-through", () => {
+  // The second CSP overlay call site. It and setupWebviewCSP must agree about
+  // which preview responses keep their own headers; a bypass added to only one
+  // leaves paint-surface views silently broken (#11198).
+  async function captureListener() {
+    const { mergeCspHeaders } = await import("../../utils/webviewCsp.js");
+    vi.mocked(mergeCspHeaders).mockClear();
+
+    let captured:
+      | ((details: unknown, callback: (r: { responseHeaders?: unknown }) => void) => void)
+      | undefined;
+    const ses = {
+      webRequest: {
+        onHeadersReceived: vi.fn(
+          (
+            _filter: unknown,
+            listener: (
+              details: unknown,
+              callback: (r: { responseHeaders?: unknown }) => void
+            ) => void
+          ) => {
+            captured = listener;
+          }
+        ),
+      },
+    } as unknown as Electron.Session;
+
+    applyDaintreeAppCspToSession(ses);
+    if (!captured) throw new Error("no onHeadersReceived listener registered");
+    return { listener: captured, mergeCspHeaders: vi.mocked(mergeCspHeaders) };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ["daintree-pdf://load?path=%2Frepo%2Fa.pdf"],
+    ["daintree-html://tok/index.html"],
+  ])("passes %s through untouched", async (url) => {
+    const { listener, mergeCspHeaders } = await captureListener();
+    const headers = { "Content-Type": ["application/pdf"] };
+
+    let result: { responseHeaders?: unknown } | undefined;
+    listener({ url, responseHeaders: headers }, (r) => {
+      result = r;
+    });
+
+    expect(result?.responseHeaders).toBe(headers);
+    expect(mergeCspHeaders).not.toHaveBeenCalled();
+  });
+
+  it("still overlays the app CSP on ordinary responses", async () => {
+    const { listener, mergeCspHeaders } = await captureListener();
+
+    listener({ url: "app://daintree/index.html", responseHeaders: {} }, () => {});
+
+    expect(mergeCspHeaders).toHaveBeenCalledTimes(1);
   });
 });

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -1229,9 +1229,12 @@ describe("setupWebviewCSP — partition CSP wiring", () => {
     // viewer frame PDFium installs inside the document.
     const pdfHeaders = { "Content-Type": ["application/pdf"] };
     let pdfResult: { responseHeaders?: unknown } | undefined;
-    captured!({ url: "daintree-pdf://load?path=%2Frepo%2Fa.pdf", responseHeaders: pdfHeaders }, (r) => {
-      pdfResult = r;
-    });
+    captured!(
+      { url: "daintree-pdf://load?path=%2Frepo%2Fa.pdf", responseHeaders: pdfHeaders },
+      (r) => {
+        pdfResult = r;
+      }
+    );
     expect(pdfResult?.responseHeaders).toBe(pdfHeaders);
     expect(vi.mocked(mergeCspHeaders)).not.toHaveBeenCalled();
 
@@ -1463,7 +1466,9 @@ describe("protocol registration", () => {
     // in this test. Production order is the opposite: registerPluginProtocol runs
     // in app.whenReady() before any per-project session is created.
     const schemes = handle.mock.calls.map((c) => c[0] as string);
-    expect(new Set(schemes)).toEqual(new Set(["app", "daintree-file", "daintree-html", "daintree-pdf"]));
+    expect(new Set(schemes)).toEqual(
+      new Set(["app", "daintree-file", "daintree-html", "daintree-pdf"])
+    );
     // Each exactly once: a duplicate handle() for one scheme throws in Electron.
     expect(schemes).toHaveLength(new Set(schemes).size);
     expect(schemes).not.toContain("plugin");
@@ -3442,11 +3447,7 @@ describe("createDaintreePdfProtocolHandler — inline PDF preview (#11427)", () 
     return call[1] as ProtocolHandler;
   }
 
-  function makeRequest(
-    filePath: string,
-    rootPath: string,
-    init?: RequestInit
-  ): GlobalRequest {
+  function makeRequest(filePath: string, rootPath: string, init?: RequestInit): GlobalRequest {
     const url = new URL("daintree-pdf://load");
     url.searchParams.set("path", filePath);
     url.searchParams.set("root", rootPath);
@@ -3580,6 +3581,12 @@ describe("createDaintreePdfProtocolHandler — inline PDF preview (#11427)", () 
   it("ignores a Range header and answers with the whole document", async () => {
     // PDFium renders from a single buffered 200, so the video path's ranged
     // streaming is deliberately not wired here.
+    const fs = await import("fs/promises");
+    const bytes = Buffer.from("%PDF-1.4 the entire document body");
+    vi.mocked(fs.open).mockResolvedValue(
+      makeFileHandle(bytes) as unknown as Awaited<ReturnType<typeof fs.open>>
+    );
+
     const handler = await captureHandler();
     const response = await handler(
       makeRequest("/project/spec.pdf", "/project", { headers: { Range: "bytes=0-4" } })
@@ -3587,6 +3594,20 @@ describe("createDaintreePdfProtocolHandler — inline PDF preview (#11427)", () 
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Range")).toBeNull();
+    // Assert the bytes, not just the status: a truncated or empty 200 would
+    // otherwise satisfy this test while breaking the viewer.
+    expect(Buffer.from(await response.arrayBuffer())).toEqual(bytes);
+  });
+
+  it("answers HEAD with the metadata and no body", async () => {
+    const handler = await captureHandler();
+    const response = await handler(
+      makeRequest("/project/spec.pdf", "/project", { method: "HEAD" })
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/pdf");
+    expect((await response.arrayBuffer()).byteLength).toBe(0);
   });
 
   it("allows a PDF larger than the raster-image ceiling but rejects one past its own", async () => {
@@ -3600,10 +3621,49 @@ describe("createDaintreePdfProtocolHandler — inline PDF preview (#11427)", () 
     >);
     expect((await handler(makeRequest("/project/big.pdf", "/project"))).status).toBe(200);
 
-    vi.mocked(fs.stat).mockResolvedValue({ size: 512 * 1024 * 1024 } as Awaited<
+    // 60 MB must fail. Bracketing the ceiling between 30 and 60 pins it without
+    // restating the constant, so a tenfold relaxation can't slip through.
+    vi.mocked(fs.stat).mockResolvedValue({ size: 60 * 1024 * 1024 } as Awaited<
       ReturnType<typeof fs.stat>
     >);
     expect((await handler(makeRequest("/project/huge.pdf", "/project"))).status).toBe(413);
+  });
+
+  it("rejects bytes that grew past the ceiling between stat and read", async () => {
+    const fs = await import("fs/promises");
+    vi.mocked(fs.stat).mockResolvedValue({ size: 100 } as Awaited<ReturnType<typeof fs.stat>>);
+    // The pre-read stat is advisory — a writer can swap the file underneath it,
+    // so the bytes actually read are re-checked before they reach the renderer.
+    vi.mocked(fs.open).mockResolvedValue(
+      makeFileHandle(Buffer.alloc(60 * 1024 * 1024)) as unknown as Awaited<
+        ReturnType<typeof fs.open>
+      >
+    );
+
+    const handler = await captureHandler();
+    expect((await handler(makeRequest("/project/spec.pdf", "/project"))).status).toBe(413);
+  });
+
+  it("percent-encodes an extended filename so a conforming parser accepts it", async () => {
+    const handler = await captureHandler();
+    const response = await handler(makeRequest("/project/O'Brien (1)*.pdf", "/project"));
+
+    const disposition = response.headers.get("Content-Disposition") ?? "";
+    const extended = disposition.match(/filename\*=UTF-8''(.*)$/)?.[1] ?? "";
+    // RFC 8187 attr-char excludes ' ( ) * — none may survive unescaped, or the
+    // recipient discards the extended value and falls back to the lossy one.
+    expect(extended).not.toMatch(/['()*]/);
+    expect(decodeURIComponent(extended)).toBe("O'Brien (1)*.pdf");
+  });
+
+  it("strips control characters from the ASCII filename fallback", async () => {
+    const handler = await captureHandler();
+    const response = await handler(makeRequest('/project/a\r\nb"c.pdf', "/project"));
+
+    const disposition = response.headers.get("Content-Disposition") ?? "";
+    // A raw CR/LF or quote here would break out of the header value.
+    expect(disposition).not.toMatch(/[\r\n]/);
+    expect(disposition.match(/filename="([^"]*)"/)?.[1]).toBe("a__b_c.pdf");
   });
 
   it("rejects a file outside the root", async () => {
@@ -3683,21 +3743,21 @@ describe("applyDaintreeAppCspToSession — preview response pass-through", () =>
     vi.clearAllMocks();
   });
 
-  it.each([
-    ["daintree-pdf://load?path=%2Frepo%2Fa.pdf"],
-    ["daintree-html://tok/index.html"],
-  ])("passes %s through untouched", async (url) => {
-    const { listener, mergeCspHeaders } = await captureListener();
-    const headers = { "Content-Type": ["application/pdf"] };
+  it.each([["daintree-pdf://load?path=%2Frepo%2Fa.pdf"], ["daintree-html://tok/index.html"]])(
+    "passes %s through untouched",
+    async (url) => {
+      const { listener, mergeCspHeaders } = await captureListener();
+      const headers = { "Content-Type": ["application/pdf"] };
 
-    let result: { responseHeaders?: unknown } | undefined;
-    listener({ url, responseHeaders: headers }, (r) => {
-      result = r;
-    });
+      let result: { responseHeaders?: unknown } | undefined;
+      listener({ url, responseHeaders: headers }, (r) => {
+        result = r;
+      });
 
-    expect(result?.responseHeaders).toBe(headers);
-    expect(mergeCspHeaders).not.toHaveBeenCalled();
-  });
+      expect(result?.responseHeaders).toBe(headers);
+      expect(mergeCspHeaders).not.toHaveBeenCalled();
+    }
+  );
 
   it("still overlays the app CSP on ordinary responses", async () => {
     const { listener, mergeCspHeaders } = await captureListener();

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -185,12 +185,32 @@ const LARGE_IMAGE_MIME_TYPES = new Set([
   "image/x-icon",
 ]);
 
-// The size ceiling for a resolved file. Only the daintree-file:// viewer path
-// opts into the larger raster-image cap (allowLargeImages); daintree-html://
-// report assets stay at the tight cap so a script-driven preview can't turn the
-// allowance into an aggregate-memory DoS.
-function maxBytesForFile(realFile: string, allowLargeImages: boolean): number {
-  return allowLargeImages && LARGE_IMAGE_MIME_TYPES.has(getMimeType(realFile))
+// PDFium renders from a single buffered response (no Range/206 needed —
+// verified against Electron 42 / Chromium 148), so the whole document is held
+// in memory across the Node buffer, the Response, and the viewer. 50 MB is
+// double the raster-image allowance: enough for the specs, datasheets and
+// design exports repos actually carry, while still bounding a single preview.
+const DAINTREE_PDF_MAX_BYTES = 50 * 1024 * 1024;
+
+function isPdfPath(filePath: string): boolean {
+  return /\.pdf$/i.test(filePath);
+}
+
+/**
+ * Which scheme is doing the read — selects the size ceiling and any gate the
+ * canonical path must pass.
+ *
+ * `file`  daintree-file://, the viewer path that opts into the raster-image cap.
+ * `asset` daintree-html:// sibling assets — the tight cap, so a script-driven
+ *         preview can't turn the image allowance into an aggregate-memory DoS.
+ * `pdf`   daintree-pdf://, capped separately and restricted to real PDFs.
+ */
+type DaintreeReadKind = "file" | "asset" | "pdf";
+
+// The size ceiling for a resolved file, chosen from its canonical path.
+function maxBytesForFile(realFile: string, kind: DaintreeReadKind): number {
+  if (kind === "pdf") return DAINTREE_PDF_MAX_BYTES;
+  return kind === "file" && LARGE_IMAGE_MIME_TYPES.has(getMimeType(realFile))
     ? DAINTREE_IMAGE_MAX_BYTES
     : DAINTREE_FILE_MAX_BYTES;
 }
@@ -441,12 +461,12 @@ async function resolveContainedRealPath(
 }
 
 /**
- * Shared read core for daintree-file:// and daintree-html://: realpath
- * containment, a size cap (per maxBytesForFile — larger for raster images when
- * allowLargeImages is set), and O_RDONLY|O_NOFOLLOW open. Returns the file bytes
- * plus the canonical path (for MIME), or an error Response. Callers own the
- * success headers so each scheme sets its own CSP. The flow (realpath →
- * path.relative → stat → O_NOFOLLOW open) and its TOCTOU defenses are unchanged.
+ * Shared read core for daintree-file://, daintree-html:// and daintree-pdf://:
+ * realpath containment, a size cap (per maxBytesForFile, selected by `kind`),
+ * and O_RDONLY|O_NOFOLLOW open. Returns the file bytes plus the canonical path
+ * (for MIME), or an error Response. Callers own the success headers so each
+ * scheme sets its own CSP. The flow (realpath → path.relative → stat →
+ * O_NOFOLLOW open) and its TOCTOU defenses are unchanged.
  */
 // Return type is inferred, not annotated: annotating `buffer: Buffer` widens it
 // to `Buffer<ArrayBufferLike>`, which `new Response(...)` rejects as a BodyInit.
@@ -454,11 +474,22 @@ async function resolveContainedRealPath(
 async function readContainedDaintreeFile(
   normalizedRoot: string,
   normalizedFile: string,
-  allowLargeImages: boolean
+  kind: DaintreeReadKind
 ) {
   const contained = await resolveContainedRealPath(normalizedRoot, normalizedFile);
   if (contained instanceof Response) return contained;
   const { realFile } = contained;
+
+  // Gate on the CANONICAL path before any stat/open/read: routing on the
+  // request path would let `report.pdf` → `huge.bin` be buffered under the
+  // 50 MB PDF ceiling on Windows, where O_NOFOLLOW is a no-op. Rejecting here
+  // means a non-PDF never gets read under the PDF allowance at all.
+  if (kind === "pdf" && !isPdfPath(realFile)) {
+    return new Response("Unsupported Media Type", {
+      status: 415,
+      headers: buildDaintreeFileErrorHeaders(),
+    });
+  }
 
   // Stat the realpath-resolved path for an accurate size before any read.
   let fileStat: Awaited<ReturnType<typeof fs.stat>>;
@@ -471,7 +502,7 @@ async function readContainedDaintreeFile(
     });
   }
 
-  const maxBytes = maxBytesForFile(realFile, allowLargeImages);
+  const maxBytes = maxBytesForFile(realFile, kind);
   if (fileStat.size > maxBytes) {
     return new Response("Payload Too Large", {
       status: 413,
@@ -618,7 +649,7 @@ function createDaintreeFileRequestCore() {
         // buffered path, which redoes containment and applies its usual caps.
       }
 
-      const result = await readContainedDaintreeFile(normalizedRoot, normalizedFile, true);
+      const result = await readContainedDaintreeFile(normalizedRoot, normalizedFile, "file");
       if (result instanceof Response) return result;
 
       // Content-Length reflects the bytes actually returned. If the file
@@ -801,7 +832,7 @@ function createDaintreeHtmlProtocolHandler() {
       // Report assets keep the tight cap: a preview document can execute scripts
       // and request the same file many times, so the raster-image allowance is
       // scoped to the daintree-file:// viewer path only.
-      const result = await readContainedDaintreeFile(path.normalize(root), candidatePath, false);
+      const result = await readContainedDaintreeFile(path.normalize(root), candidatePath, "asset");
       if (result instanceof Response) return result;
 
       // Only navigable HTML documents get the loosened, token-scoped CSP;
@@ -814,6 +845,129 @@ function createDaintreeHtmlProtocolHandler() {
       return new Response(result.buffer, { status: 200, headers });
     } catch (err) {
       console.error("[MAIN] daintree-html protocol error:", err);
+      return new Response("Internal Server Error", {
+        status: 500,
+        headers: buildDaintreeFileErrorHeaders(),
+      });
+    }
+  };
+}
+
+/** True for any `daintree-pdf://…` request URL (the inline PDF preview scheme). */
+function isDaintreePdfPreviewUrl(url: string | undefined): boolean {
+  return typeof url === "string" && url.startsWith("daintree-pdf://");
+}
+
+/**
+ * Preview documents whose protocol-handler response headers must survive the
+ * session-wide CSP overlay untouched. Both schemes need the pass-through, for
+ * opposite reasons:
+ *   daintree-html:// carries a token-scoped CSP and a COEP that the overlay
+ *     would replace with the trusted app policy.
+ *   daintree-pdf:// carries NEITHER, and must not acquire either: a `sandbox`
+ *     CSP blocks PDFium outright (ERR_BLOCKED_BY_CLIENT), and a COEP header
+ *     makes the PDF document an embedder whose own internal viewer frame is
+ *     then blocked (ERR_BLOCKED_BY_RESPONSE). Both verified against
+ *     Electron 42 / Chromium 148.
+ */
+function shouldPreservePreviewResponseHeaders(url: string | undefined): boolean {
+  return isDaintreeHtmlPreviewUrl(url) || isDaintreePdfPreviewUrl(url);
+}
+
+/**
+ * `Content-Disposition` for a PDF response. The URL's own last segment is
+ * `load`, so without an explicit filename PDFium's download button and title
+ * would both use that. Ships a quoted ASCII fallback plus an RFC 5987
+ * `filename*` so non-ASCII names survive.
+ */
+function buildPdfContentDisposition(realFile: string): string {
+  const base = path.basename(realFile);
+  const ascii = base.replace(/[^\x20-\x7e]/g, "_").replace(/["\\]/g, "_");
+  return `inline; filename="${ascii}"; filename*=UTF-8''${encodeURIComponent(base)}`;
+}
+
+/**
+ * Response headers for a daintree-pdf:// document.
+ *
+ * Content-Type is hard-coded, never derived from the path: the canonical-path
+ * `.pdf` gate in the read core plus a fixed `application/pdf` here is what
+ * makes the `frame-src daintree-pdf:` allowance safe — a repo file holding
+ * active HTML under a `.pdf` name reaches PDFium as PDF bytes and fails as a
+ * malformed document rather than executing.
+ *
+ * Deliberately absent: `Content-Security-Policy` (a `sandbox` policy blocks
+ * PDFium) and `Cross-Origin-Embedder-Policy` (blocks PDFium's own viewer
+ * frame). The iframe carries `credentialless` instead, which is what lets a
+ * COEP-credentialless app shell embed a document that asserts no COEP at all.
+ */
+function buildDaintreePdfHeaders(realFile: string, contentLength: number): Record<string, string> {
+  return {
+    "Content-Type": "application/pdf",
+    "Content-Length": String(contentLength),
+    "Content-Disposition": buildPdfContentDisposition(realFile),
+    "Cross-Origin-Resource-Policy": "cross-origin",
+    "X-Content-Type-Options": "nosniff",
+    "Referrer-Policy": "no-referrer",
+    "Cache-Control": "no-store",
+  };
+}
+
+/**
+ * Create the daintree-pdf:// protocol handler — inline PDF preview (#11427).
+ * URL shape mirrors daintree-file://: `daintree-pdf://load?path=…&root=…`.
+ *
+ * Range headers are ignored: PDFium renders fine from a single buffered 200
+ * with an accurate Content-Length, so there is no reason to carry the video
+ * path's ranged-streaming machinery here.
+ */
+function createDaintreePdfProtocolHandler() {
+  return async (request: GlobalRequest) => {
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return new Response("Method Not Allowed", {
+        status: 405,
+        headers: buildDaintreeFileErrorHeaders(),
+      });
+    }
+
+    try {
+      const url = new URL(request.url);
+      const filePath = url.searchParams.get("path");
+      const rootPath = url.searchParams.get("root");
+
+      if (!filePath || !rootPath) {
+        return new Response("Missing path or root parameter", {
+          status: 400,
+          headers: buildDaintreeFileErrorHeaders(),
+        });
+      }
+
+      if (filePath.includes("\0") || rootPath.includes("\0")) {
+        return new Response("Invalid path", {
+          status: 400,
+          headers: buildDaintreeFileErrorHeaders(),
+        });
+      }
+
+      if (!path.isAbsolute(filePath) || !path.isAbsolute(rootPath)) {
+        return new Response("Paths must be absolute", {
+          status: 400,
+          headers: buildDaintreeFileErrorHeaders(),
+        });
+      }
+
+      const result = await readContainedDaintreeFile(
+        path.normalize(rootPath),
+        path.normalize(filePath),
+        "pdf"
+      );
+      if (result instanceof Response) return result;
+
+      return new Response(result.buffer, {
+        status: 200,
+        headers: buildDaintreePdfHeaders(result.realFile, result.buffer.length),
+      });
+    } catch (err) {
+      console.error("[MAIN] daintree-pdf protocol error:", err);
       return new Response("Internal Server Error", {
         status: 500,
         headers: buildDaintreeFileErrorHeaders(),
@@ -1063,7 +1217,8 @@ export function createPluginProtocolHandler(getPluginDir: GetPluginDir) {
 }
 
 /**
- * Register app://, daintree-file://, and plugin:// protocol handlers on a specific session.
+ * Register app://, daintree-file://, daintree-html://, daintree-pdf:// and
+ * plugin:// protocol handlers on a specific session.
  * Safe to call multiple times — skips sessions that are already configured.
  * Used for per-project session partitions that don't inherit the default session's handlers.
  *
@@ -1080,6 +1235,7 @@ export function registerProtocolsForSession(ses: Electron.Session, distPath: str
   ses.protocol.handle("app", createAppProtocolHandler(distPath));
   ses.protocol.handle("daintree-file", createDaintreeFileProtocolHandler());
   ses.protocol.handle("daintree-html", createDaintreeHtmlProtocolHandler());
+  ses.protocol.handle("daintree-pdf", createDaintreePdfProtocolHandler());
   if (cachedGetPluginDir) {
     ses.protocol.handle("plugin", createPluginProtocolHandler(resolvePluginDir));
   }
@@ -1124,6 +1280,10 @@ export function registerDaintreeFileProtocol(): void {
 
 export function registerDaintreeHtmlProtocol(): void {
   protocol.handle("daintree-html", createDaintreeHtmlProtocolHandler());
+}
+
+export function registerDaintreePdfProtocol(): void {
+  protocol.handle("daintree-pdf", createDaintreePdfProtocolHandler());
 }
 
 // Stable indirection so the live `plugin://` resolver can be swapped after the
@@ -1219,7 +1379,7 @@ export function applyDaintreeAppCspToSession(ses: Electron.Session): void {
   ses.webRequest.onHeadersReceived(
     { urls: ["<all_urls>"], types: ["mainFrame", "subFrame", "script"] },
     (details, callback) => {
-      if (isDaintreeHtmlPreviewUrl(details.url)) {
+      if (shouldPreservePreviewResponseHeaders(details.url)) {
         callback({ responseHeaders: details.responseHeaders });
         return;
       }
@@ -1265,13 +1425,15 @@ export function setupWebviewCSP(): void {
     ses.webRequest.onHeadersReceived(
       { urls: ["<all_urls>"], types: ["mainFrame", "subFrame", "script"] },
       (details, callback) => {
-        // A daintree-html:// preview iframe carries its own token-scoped CSP
-        // (buildDaintreeHtmlDocHeaders). protocol.handle responses DO flow
-        // through onHeadersReceived (Electron 42 / Chromium 148), so without
-        // this bypass mergeCspHeaders would replace that policy with the trusted
-        // app CSP — breaking the sandboxed page's scripts AND re-exposing
-        // connect-src daintree-file:. Pass it through untouched.
-        if (isDaintreeHtmlPreviewUrl(details.url)) {
+        // Preview documents own their response headers. protocol.handle
+        // responses DO flow through onHeadersReceived (Electron 42 /
+        // Chromium 148), so without this bypass mergeCspHeaders would replace
+        // a daintree-html:// page's token-scoped CSP with the trusted app CSP
+        // — breaking its scripts AND re-exposing connect-src daintree-file: —
+        // and would stamp that same policy onto a daintree-pdf:// document,
+        // whose `frame-src` omits chrome-extension: and would therefore block
+        // PDFium's internal viewer frame. Pass both through untouched.
+        if (shouldPreservePreviewResponseHeaders(details.url)) {
           callback({ responseHeaders: details.responseHeaders });
           return;
         }

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -882,8 +882,18 @@ function shouldPreservePreviewResponseHeaders(url: string | undefined): boolean 
  */
 function buildPdfContentDisposition(realFile: string): string {
   const base = path.basename(realFile);
+  // Drop everything outside printable ASCII (control chars, CR/LF) before
+  // neutralizing the quote and backslash that would otherwise escape the
+  // quoted-string.
   const ascii = base.replace(/[^\x20-\x7e]/g, "_").replace(/["\\]/g, "_");
-  return `inline; filename="${ascii}"; filename*=UTF-8''${encodeURIComponent(base)}`;
+  // encodeURIComponent leaves ' ( ) * unescaped, but RFC 8187 `attr-char`
+  // excludes them, so a conforming parser would reject the extended value and
+  // silently fall back to the lossy ASCII one.
+  const encoded = encodeURIComponent(base).replace(
+    /['()*]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`
+  );
+  return `inline; filename="${ascii}"; filename*=UTF-8''${encoded}`;
 }
 
 /**
@@ -962,9 +972,13 @@ function createDaintreePdfProtocolHandler() {
       );
       if (result instanceof Response) return result;
 
-      return new Response(result.buffer, {
+      const headers = buildDaintreePdfHeaders(result.realFile, result.buffer.length);
+      // HEAD answers with the metadata only. The bytes were already read to
+      // size the response honestly, but attaching a body up to the PDF cap to
+      // a request that discards it is pure waste.
+      return new Response(request.method === "HEAD" ? null : result.buffer, {
         status: 200,
-        headers: buildDaintreePdfHeaders(result.realFile, result.buffer.length),
+        headers,
       });
     } catch (err) {
       console.error("[MAIN] daintree-pdf protocol error:", err);

--- a/shared/config/__tests__/csp.test.ts
+++ b/shared/config/__tests__/csp.test.ts
@@ -124,6 +124,47 @@ describe("Daintree app CSP", () => {
     });
   });
 
+  describe("daintree-pdf: preview scheme in frame-src (#11427)", () => {
+    // The file viewer mounts a `daintree-pdf://load?…` iframe so Chromium's
+    // built-in PDFium viewer renders the document. The scheme exists purely to
+    // carry this allowance: its handler rejects any canonical path that isn't
+    // `.pdf` and answers with a hard-coded `application/pdf`.
+    const frameSrcOf = (csp: string) => csp.match(/frame-src ([^;]*);/)?.[1];
+
+    it("allows daintree-pdf: in frame-src in production", () => {
+      expect(frameSrcOf(getDaintreeAppProdCSP())).toContain("daintree-pdf:");
+    });
+
+    it("allows daintree-pdf: in frame-src in development", () => {
+      expect(frameSrcOf(getDaintreeAppDevCSP())).toContain("daintree-pdf:");
+    });
+
+    it("keeps daintree-file: out of frame-src in both modes", () => {
+      // The general file scheme serves arbitrary repo files under
+      // extension-derived MIME types, so framing it would let a repo-controlled
+      // document render as a live page. That is why the PDF scheme is separate.
+      for (const csp of [getDaintreeAppProdCSP(), getDaintreeAppDevCSP()]) {
+        expect(frameSrcOf(csp)).not.toContain("daintree-file:");
+      }
+    });
+
+    it("does not add daintree-pdf: to any fetch directive", () => {
+      // Navigation-only: the iframe navigates to the scheme, nothing fetches it.
+      const csp = getDaintreeAppProdCSP();
+      for (const directive of ["script-src", "connect-src", "img-src", "media-src"]) {
+        const value = csp.match(new RegExp(`${directive} ([^;]*);`))?.[1];
+        expect(value).not.toContain("daintree-pdf:");
+      }
+    });
+
+    it("keeps the existing frame-src entries alongside the new scheme", () => {
+      // Adding a scheme must widen the directive, not replace what was there.
+      const frameSrc = frameSrcOf(getDaintreeAppProdCSP());
+      expect(frameSrc).toContain("'self'");
+      expect(frameSrc).toContain("daintree-html:");
+    });
+  });
+
   describe("daintree-file: scheme in media-src (#11382)", () => {
     // The file viewer fetch()es video bytes from daintree-file:// and plays
     // them through a blob object URL (Chromium's custom-scheme media loader

--- a/shared/config/__tests__/csp.test.ts
+++ b/shared/config/__tests__/csp.test.ts
@@ -148,13 +148,20 @@ describe("Daintree app CSP", () => {
       }
     });
 
-    it("does not add daintree-pdf: to any fetch directive", () => {
+    it.each([
+      ["production", getDaintreeAppProdCSP],
+      ["development", getDaintreeAppDevCSP],
+    ])("confines daintree-pdf: to frame-src in %s", (_label, build) => {
       // Navigation-only: the iframe navigates to the scheme, nothing fetches it.
-      const csp = getDaintreeAppProdCSP();
-      for (const directive of ["script-src", "connect-src", "img-src", "media-src"]) {
-        const value = csp.match(new RegExp(`${directive} ([^;]*);`))?.[1];
-        expect(value).not.toContain("daintree-pdf:");
-      }
+      // Every directive is parsed rather than a hand-picked few, so the scheme
+      // can't leak into default-src, worker-src or anything added later.
+      const carriers = build()
+        .split(";")
+        .map((directive) => directive.trim())
+        .filter((directive) => directive.includes("daintree-pdf:"))
+        .map((directive) => directive.split(/\s+/)[0]);
+
+      expect(carriers).toEqual(["frame-src"]);
     });
 
     it("keeps the existing frame-src entries alongside the new scheme", () => {

--- a/shared/config/csp.ts
+++ b/shared/config/csp.ts
@@ -9,6 +9,15 @@ const FILE_SCHEMES = "daintree-file:";
 // protocol handler serves (scoped to its exact token authority), never this one.
 const HTML_PREVIEW_SCHEME = "daintree-html:";
 
+// Inline PDF preview (#11427). Only appears in `frame-src`, so the file viewer
+// can mount a `daintree-pdf://load?…` iframe that Chromium hands to its built-in
+// PDFium viewer. `daintree-file:` is deliberately NOT granted this: it serves
+// arbitrary repo files under extension-derived MIME types, so framing it would
+// let a repo-controlled document render as a live page. The PDF scheme's handler
+// rejects any canonical path that isn't `.pdf` and answers with a hard-coded
+// `application/pdf`, so this allowance can never resolve to anything else.
+const PDF_PREVIEW_SCHEME = "daintree-pdf:";
+
 // Plugin-served renderer modules. `plugin:` is a hardened first-party scheme
 // (`standard: true, secure: true`, no `bypassCSP`) — see
 // `electron/main.ts:120-130` — that resolves to the plugin's installed-on-disk
@@ -112,7 +121,7 @@ export function getDaintreeAppProdCSP(options?: DaintreeCspOptions): string {
     // for WebAudio-style consumers that stream media without the blob detour.
     `media-src 'self' ${FILE_SCHEMES} blob:`,
     "worker-src 'self' blob:",
-    `frame-src 'self' ${HTML_PREVIEW_SCHEME} ${FRAME_LOCALHOST}`,
+    `frame-src 'self' ${HTML_PREVIEW_SCHEME} ${PDF_PREVIEW_SCHEME} ${FRAME_LOCALHOST}`,
     "object-src 'none'",
     "base-uri 'self'",
     "form-action 'none'",
@@ -147,7 +156,7 @@ export function getDaintreeAppDevCSP(): string {
     // blob: mirrors the production policy — see getDaintreeAppProdCSP.
     `media-src 'self' ${FILE_SCHEMES} blob:`,
     "worker-src 'self' blob:",
-    `frame-src 'self' ${HTML_PREVIEW_SCHEME} ${FRAME_LOCALHOST}`,
+    `frame-src 'self' ${HTML_PREVIEW_SCHEME} ${PDF_PREVIEW_SCHEME} ${FRAME_LOCALHOST}`,
     "object-src 'none'",
     "base-uri 'self'",
     "form-action 'none'",

--- a/src/components/FileViewer/FilePdfPreview.tsx
+++ b/src/components/FileViewer/FilePdfPreview.tsx
@@ -1,0 +1,63 @@
+import { useMemo } from "react";
+import { buildDaintreePdfUrl } from "./filePreviewKinds";
+
+interface FilePdfPreviewProps {
+  /** Absolute path of the PDF being previewed. */
+  filePath: string;
+  /** Known root the `daintree-pdf://` protocol resolves the path against. */
+  rootPath: string;
+  /** Accessible name for the frame — the file name, so the document names its file. */
+  label: string;
+  /**
+   * Changed to force a fresh document request for the same path. The protocol
+   * serves `no-store`, but the frame won't re-navigate to an identical URL on
+   * its own, so an explicit refresh needs a new one.
+   */
+  reloadKey?: string | number;
+}
+
+/**
+ * Renders a PDF inline using Chromium's built-in PDFium viewer.
+ *
+ * Shared by `FilePane`, `FileBrowserViewer`, and `DiffPane` so every surface
+ * previews PDFs the same way — mirroring `FileImagePreview`/`FileVideoPreview`.
+ *
+ * Three details are load-bearing, all verified against Electron 42 /
+ * Chromium 148:
+ *
+ * 1. `credentialless`. The app shell is COEP `credentialless`, and such a
+ *    document may only embed a frame that asserts COEP itself — but a PDF
+ *    response carrying COEP makes the PDF an embedder whose own internal
+ *    viewer frame is then blocked (ERR_BLOCKED_BY_RESPONSE). The
+ *    `credentialless` attribute resolves the deadlock: the frame loads in an
+ *    ephemeral context, so the embedded document needs no COEP at all.
+ * 2. No `sandbox`. Unlike the `daintree-html://` preview, sandboxing kills
+ *    PDFium outright (ERR_BLOCKED_BY_CLIENT) — it needs same-origin
+ *    postMessage with the viewer frame it installs. Isolation comes from the
+ *    scheme instead: `daintree-pdf://` only ever emits `application/pdf`.
+ * 3. A direct `src`, not a blob. `FileVideoPreview` detours through a Blob
+ *    object URL to dodge the single-shot custom-scheme media loader, but
+ *    PDFium won't accept a `blob:` navigation — it needs a real URL serving
+ *    `application/pdf`, which is exactly what this scheme is for.
+ */
+export function FilePdfPreview({ filePath, rootPath, label, reloadKey }: FilePdfPreviewProps) {
+  const src = useMemo(() => {
+    const url = buildDaintreePdfUrl(filePath, rootPath);
+    // Cache-busting query param only — the protocol handler ignores it.
+    // Null-checked, not truthiness: a numeric key of 0 is a valid value.
+    return reloadKey != null ? `${url}&v=${encodeURIComponent(reloadKey)}` : url;
+  }, [filePath, rootPath, reloadKey]);
+
+  return (
+    <iframe
+      // Empty string, never {true}: React omits an unknown attribute given a
+      // boolean value, which would silently drop the credentialless behavior
+      // the COEP shell depends on.
+      credentialless=""
+      src={src}
+      title={label}
+      referrerPolicy="no-referrer"
+      className="h-full w-full border-0 bg-daintree-bg"
+    />
+  );
+}

--- a/src/components/FileViewer/__tests__/FilePdfPreview.test.tsx
+++ b/src/components/FileViewer/__tests__/FilePdfPreview.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+/**
+ * Shared inline PDF preview (#11427).
+ *
+ * jsdom has no PDFium, so these tests pin the frame contract the real viewer
+ * depends on — each assertion here stands in for a failure mode verified
+ * against Electron 42 / Chromium 148:
+ *   - a missing `credentialless` attribute => ERR_BLOCKED_BY_RESPONSE, blank frame
+ *   - a `sandbox` attribute                => ERR_BLOCKED_BY_CLIENT, blank frame
+ *   - a daintree-file:// src              => blocked by the app CSP's frame-src
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { FilePdfPreview } from "../FilePdfPreview";
+
+afterEach(cleanup);
+
+function renderPreview(props: Partial<React.ComponentProps<typeof FilePdfPreview>> = {}) {
+  const { container } = render(
+    <FilePdfPreview filePath="/repo/spec.pdf" rootPath="/repo" label="spec.pdf" {...props} />
+  );
+  const frame = container.querySelector("iframe");
+  if (!frame) throw new Error("expected an iframe");
+  return frame;
+}
+
+describe("FilePdfPreview", () => {
+  it("points the frame at the PDF-only scheme with the file and root as params", () => {
+    const url = new URL(renderPreview().getAttribute("src") ?? "");
+    expect(url.protocol).toBe("daintree-pdf:");
+    expect(url.searchParams.get("path")).toBe("/repo/spec.pdf");
+    expect(url.searchParams.get("root")).toBe("/repo");
+  });
+
+  it("marks the frame credentialless so a COEP shell can embed a COEP-less document", () => {
+    // Presence is what matters, and React omits unknown attributes given a
+    // boolean value — so assert the attribute actually reached the DOM rather
+    // than trusting the prop.
+    expect(renderPreview().hasAttribute("credentialless")).toBe(true);
+  });
+
+  it("never sandboxes the frame", () => {
+    // Unlike the daintree-html:// preview, a sandbox attribute stops PDFium
+    // from installing its viewer frame at all.
+    expect(renderPreview().hasAttribute("sandbox")).toBe(false);
+  });
+
+  it("names the frame with the file label and withholds the referrer", () => {
+    const frame = renderPreview({ label: "datasheet.pdf" });
+    expect(frame.getAttribute("title")).toBe("datasheet.pdf");
+    expect(frame.getAttribute("referrerpolicy")).toBe("no-referrer");
+  });
+
+  it("re-navigates to a new URL when the reload key changes", () => {
+    const first = renderPreview({ reloadKey: 1 }).getAttribute("src");
+    cleanup();
+    const second = renderPreview({ reloadKey: 2 }).getAttribute("src");
+    expect(second).not.toBe(first);
+  });
+
+  it("keeps the same URL across renders when the reload key does not change", () => {
+    // The protocol serves no-store, so a stable URL is what preserves the
+    // reader's page and zoom across an unrelated re-render.
+    const first = renderPreview({ reloadKey: 7 }).getAttribute("src");
+    cleanup();
+    const second = renderPreview({ reloadKey: 7 }).getAttribute("src");
+    expect(second).toBe(first);
+  });
+
+  it("treats a zero reload key as a real value rather than an absent one", () => {
+    const zero = renderPreview({ reloadKey: 0 }).getAttribute("src");
+    cleanup();
+    const absent = renderPreview().getAttribute("src");
+    expect(zero).not.toBe(absent);
+  });
+});

--- a/src/components/FileViewer/__tests__/FilePdfPreview.test.tsx
+++ b/src/components/FileViewer/__tests__/FilePdfPreview.test.tsx
@@ -52,19 +52,38 @@ describe("FilePdfPreview", () => {
   });
 
   it("re-navigates to a new URL when the reload key changes", () => {
-    const first = renderPreview({ reloadKey: 1 }).getAttribute("src");
-    cleanup();
-    const second = renderPreview({ reloadKey: 2 }).getAttribute("src");
-    expect(second).not.toBe(first);
+    const { container, rerender } = render(
+      <FilePdfPreview filePath="/repo/spec.pdf" rootPath="/repo" label="spec.pdf" reloadKey={1} />
+    );
+    const before = container.querySelector("iframe")?.getAttribute("src");
+
+    rerender(
+      <FilePdfPreview filePath="/repo/spec.pdf" rootPath="/repo" label="spec.pdf" reloadKey={2} />
+    );
+
+    expect(container.querySelector("iframe")?.getAttribute("src")).not.toBe(before);
   });
 
-  it("keeps the same URL across renders when the reload key does not change", () => {
-    // The protocol serves no-store, so a stable URL is what preserves the
-    // reader's page and zoom across an unrelated re-render.
-    const first = renderPreview({ reloadKey: 7 }).getAttribute("src");
-    cleanup();
-    const second = renderPreview({ reloadKey: 7 }).getAttribute("src");
-    expect(second).toBe(first);
+  it("keeps the same frame and URL when an unrelated prop changes", () => {
+    // The reader's page and zoom live in the frame. A re-render that changed
+    // the src — or remounted the element — would silently reset both.
+    const { container, rerender } = render(
+      <FilePdfPreview filePath="/repo/spec.pdf" rootPath="/repo" label="spec.pdf" reloadKey={7} />
+    );
+    const frame = container.querySelector("iframe");
+    const before = frame?.getAttribute("src");
+
+    rerender(
+      <FilePdfPreview
+        filePath="/repo/spec.pdf"
+        rootPath="/repo"
+        label="renamed.pdf"
+        reloadKey={7}
+      />
+    );
+
+    expect(container.querySelector("iframe")).toBe(frame);
+    expect(container.querySelector("iframe")?.getAttribute("src")).toBe(before);
   });
 
   it("treats a zero reload key as a real value rather than an absent one", () => {

--- a/src/components/FileViewer/__tests__/filePreviewKinds.test.ts
+++ b/src/components/FileViewer/__tests__/filePreviewKinds.test.ts
@@ -197,12 +197,9 @@ describe("filePreviewKinds", () => {
       }
     );
 
-    it.each(["spec.pdf.txt", "spec", "notes.md", "photo.png", "clip.mp4"])(
-      "rejects %s",
-      (path) => {
-        expect(isPdfFilePath(path)).toBe(false);
-      }
-    );
+    it.each(["spec.pdf.txt", "spec", "notes.md", "photo.png", "clip.mp4"])("rejects %s", (path) => {
+      expect(isPdfFilePath(path)).toBe(false);
+    });
 
     it("is disjoint from every other preview classifier", () => {
       // A PDF must not also route to the image/video branches — the panes check
@@ -231,13 +228,15 @@ describe("filePreviewKinds", () => {
       expect(url.searchParams.get("root")).toBe("/a dir");
     });
 
-    it("uses a different scheme than the general file URL for the same input", () => {
+    it("differs from the general file URL only by scheme", () => {
       // The PDF scheme is the only one allowed in frame-src, so routing a PDF
-      // through daintree-file:// would make the iframe fail CSP.
-      const pdf = buildDaintreePdfUrl("/repo/spec.pdf", "/repo");
-      const file = buildDaintreeFileUrl("/repo/spec.pdf", "/repo");
-      expect(pdf).not.toBe(file);
-      expect(pdf.startsWith("daintree-pdf://")).toBe(true);
+      // through daintree-file:// would make the iframe fail CSP. The rest of
+      // the URL must stay identical so both resolve the same file.
+      const pdf = new URL(buildDaintreePdfUrl("/repo/spec.pdf", "/repo"));
+      const file = new URL(buildDaintreeFileUrl("/repo/spec.pdf", "/repo"));
+
+      expect(pdf.protocol).not.toBe(file.protocol);
+      expect(pdf.search).toBe(file.search);
     });
   });
 });

--- a/src/components/FileViewer/__tests__/filePreviewKinds.test.ts
+++ b/src/components/FileViewer/__tests__/filePreviewKinds.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   buildDaintreeFileUrl,
+  buildDaintreePdfUrl,
   isAudioFilePath,
   isImageFilePath,
+  isPdfFilePath,
   isSvgFilePath,
   isUnsupportedAudioFilePath,
   isUnsupportedVideoFilePath,
@@ -187,10 +189,55 @@ describe("filePreviewKinds", () => {
     });
   });
 
+  describe("isPdfFilePath", () => {
+    it.each(["spec.pdf", "SPEC.PDF", "a/b/data.sheet.pdf", "/abs/path/report.Pdf"])(
+      "accepts %s",
+      (path) => {
+        expect(isPdfFilePath(path)).toBe(true);
+      }
+    );
+
+    it.each(["spec.pdf.txt", "spec", "notes.md", "photo.png", "clip.mp4"])(
+      "rejects %s",
+      (path) => {
+        expect(isPdfFilePath(path)).toBe(false);
+      }
+    );
+
+    it("is disjoint from every other preview classifier", () => {
+      // A PDF must not also route to the image/video branches — the panes check
+      // these in sequence, so an overlap would silently pick the wrong preview.
+      expect(isImageFilePath("spec.pdf")).toBe(false);
+      expect(isSvgFilePath("spec.pdf")).toBe(false);
+      expect(isVideoFilePath("spec.pdf")).toBe(false);
+      expect(isUnsupportedVideoFilePath("spec.pdf")).toBe(false);
+      expect(isAudioFilePath("spec.pdf")).toBe(false);
+      expect(isUnsupportedAudioFilePath("spec.pdf")).toBe(false);
+    });
+  });
+
   describe("buildDaintreeFileUrl", () => {
     it("encodes path and root as query params", () => {
       const url = buildDaintreeFileUrl("/a dir/clip.mp4", "/a dir");
       expect(url).toBe("daintree-file://load?path=%2Fa%20dir%2Fclip.mp4&root=%2Fa%20dir");
+    });
+  });
+
+  describe("buildDaintreePdfUrl", () => {
+    it("round-trips path and root through the query string", () => {
+      const url = new URL(buildDaintreePdfUrl("/a dir/spec #1.pdf", "/a dir"));
+      expect(url.protocol).toBe("daintree-pdf:");
+      expect(url.searchParams.get("path")).toBe("/a dir/spec #1.pdf");
+      expect(url.searchParams.get("root")).toBe("/a dir");
+    });
+
+    it("uses a different scheme than the general file URL for the same input", () => {
+      // The PDF scheme is the only one allowed in frame-src, so routing a PDF
+      // through daintree-file:// would make the iframe fail CSP.
+      const pdf = buildDaintreePdfUrl("/repo/spec.pdf", "/repo");
+      const file = buildDaintreeFileUrl("/repo/spec.pdf", "/repo");
+      expect(pdf).not.toBe(file);
+      expect(pdf.startsWith("daintree-pdf://")).toBe(true);
     });
   });
 });

--- a/src/components/FileViewer/filePreviewKinds.ts
+++ b/src/components/FileViewer/filePreviewKinds.ts
@@ -72,6 +72,11 @@ export function isUnsupportedVideoFilePath(filePath: string): boolean {
   return UNSUPPORTED_VIDEO_EXTENSIONS.has(extensionOf(filePath));
 }
 
+/** PDFs — framed from daintree-pdf:// and rendered by Chromium's built-in viewer. */
+export function isPdfFilePath(filePath: string): boolean {
+  return extensionOf(filePath) === "pdf";
+}
+
 /** Copy for containers in the unsupported set — shared so both panes say the same thing. */
 export const UNSUPPORTED_VIDEO_MESSAGE =
   "Can't play this video format — only MP4, WebM, and Ogg are supported";
@@ -101,4 +106,14 @@ export const UNSUPPORTED_AUDIO_MESSAGE =
  */
 export function buildDaintreeFileUrl(filePath: string, rootPath: string): string {
   return `daintree-file://load?path=${encodeURIComponent(filePath)}&root=${encodeURIComponent(rootPath)}`;
+}
+
+/**
+ * URL for the custom `daintree-pdf://` protocol — a PDF-only sibling of
+ * `daintree-file://`, kept separate because it is the one scheme allowed in
+ * `frame-src`. Used as an iframe `src` so Chromium's built-in PDFium viewer
+ * renders the document.
+ */
+export function buildDaintreePdfUrl(filePath: string, rootPath: string): string {
+  return `daintree-pdf://load?path=${encodeURIComponent(filePath)}&root=${encodeURIComponent(rootPath)}`;
 }

--- a/src/panels/diff/DiffPane.tsx
+++ b/src/panels/diff/DiffPane.tsx
@@ -22,8 +22,13 @@ import { revealCopy } from "@/components/FileViewer/revealCopy";
 import { DiffFileSidebar } from "@/components/FileViewer/DiffFileSidebar";
 import { FileVideoPreview } from "@/components/FileViewer/FileVideoPreview";
 import { FileAudioPreview } from "@/components/FileViewer/FileAudioPreview";
+import { FilePdfPreview } from "@/components/FileViewer/FilePdfPreview";
 import type { MediaPreviewError } from "@/components/FileViewer/useMediaBlobUrl";
-import { isAudioFilePath, isVideoFilePath } from "@/components/FileViewer/filePreviewKinds";
+import {
+  isAudioFilePath,
+  isPdfFilePath,
+  isVideoFilePath,
+} from "@/components/FileViewer/filePreviewKinds";
 import { ImageDiffViewer, isImageDiffCandidate } from "@/components/FileViewer/ImageDiffViewer";
 import { DiffViewer, FULL_FILE_MAX_LINES } from "@/components/Worktree/DiffViewer";
 import type { FullFileUnavailableReason } from "@/components/Worktree/DiffViewer";
@@ -275,9 +280,9 @@ export function DiffPane({
   const currentEntry = currentIndex === -1 ? undefined : changeSet?.[currentIndex];
   const isViewed = currentEntry ? viewedSet.has(currentEntry.viewedKey) : false;
 
-  // Forces a fresh media request in video/audio mode — the diff content hooks
-  // don't carry media bytes, so Refresh has to re-request the protocol URL.
-  const [mediaReloadNonce, setMediaReloadNonce] = useState(0);
+  // Forces a fresh request in video, audio and PDF mode — the diff content hooks
+  // don't carry those bytes, so Refresh has to re-request the protocol URL itself.
+  const [previewReloadNonce, setPreviewReloadNonce] = useState(0);
   // An allowlisted container can still hold a codec Chromium lacks, or the
   // file may be unreadable — surface that instead of a dead native control.
   // Holds the preview's specific reason (e.g. too large) when it gives one.
@@ -287,7 +292,7 @@ export function DiffPane({
     // an explicit refresh — gets a fresh attempt. absolutePath covers a
     // worktree move that filePath (relative) alone would miss.
     setMediaPlaybackError(null);
-  }, [filePath, absolutePath, worktreePath, mediaReloadNonce]);
+  }, [filePath, absolutePath, worktreePath, previewReloadNonce]);
 
   const [pathCopied, setPathCopied] = useState(false);
   const handleCopyPath = useCallback(() => {
@@ -413,6 +418,10 @@ export function DiffPane({
   const isVideoMode = Boolean(filePath && isVideoFilePath(filePath));
   const isAudioMode = Boolean(filePath && isAudioFilePath(filePath));
   const isMediaMode = isVideoMode || isAudioMode;
+  // PDFs likewise show only the current working-tree version: the built-in
+  // viewer renders a whole document, not a comparison, so like media this
+  // applies to every diff source.
+  const isPdfMode = Boolean(filePath && isPdfFilePath(filePath));
   // Sentinels the viewer turns into empty states rather than a rendered diff.
   // `NO_CHANGES`/`ERROR` gate the pane's own branches below; the binary and
   // oversized ones matter to the full-file scope, which has nothing to expand
@@ -442,9 +451,11 @@ export function DiffPane({
         ? { available: false, reason: "This view already shows the whole video" }
         : isAudioMode
           ? { available: false, reason: "This view already shows the whole audio file" }
-          : !hasDiff
-            ? { available: false, reason: "There's no diff to expand yet" }
-            : { available: true };
+          : isPdfMode
+            ? { available: false, reason: "This view already shows the whole PDF" }
+            : !hasDiff
+              ? { available: false, reason: "There's no diff to expand yet" }
+              : { available: true };
 
   // The hunks and the file on disk must describe the same revision. Once the
   // store reports the file changed, they demonstrably don't: the check inside
@@ -480,10 +491,10 @@ export function DiffPane({
   // Only the diff is retried: clearing it drops `hasDiff`, which disables the
   // source hook and invalidates its read, and the source is fetched again when
   // the new diff lands. Retrying both here would issue that read twice. The
-  // media nonce bump is a no-op outside media mode (nothing renders it).
+  // preview nonce bump is a no-op outside media/PDF mode (nothing renders it).
   const refreshAll = useCallback(() => {
     retry();
-    setMediaReloadNonce((nonce) => nonce + 1);
+    setPreviewReloadNonce((nonce) => nonce + 1);
   }, [retry]);
 
   // One line explaining why a requested whole-file view isn't on screen. The
@@ -539,7 +550,7 @@ export function DiffPane({
   const toolbar = filePath ? (
     <>
       <FileViewerToolbar.Root>
-        {!isImageMode && !isMediaMode && (
+        {!isImageMode && !isMediaMode && !isPdfMode && (
           <div role="group" aria-label="Diff layout">
             <SegmentedToggle<DiffViewType>
               options={[
@@ -563,7 +574,7 @@ export function DiffPane({
         )}
         <FileViewerToolbar.Path path={filePath} copied={pathCopied} onCopy={handleCopyPath} />
         <FileViewerToolbar.Actions>
-          {!isImageMode && !isMediaMode && (
+          {!isImageMode && !isMediaMode && !isPdfMode && (
             <FileViewerToolbar.IconButton
               label="Wrap long lines"
               pressed={diffWrapLines}
@@ -780,7 +791,7 @@ export function DiffPane({
                   filePath={absolutePath}
                   rootPath={worktreePath}
                   label={fileName ?? filePath}
-                  reloadKey={mediaReloadNonce}
+                  reloadKey={previewReloadNonce}
                   onError={(error) => setMediaPlaybackError(error ?? GENERIC_AUDIO_ERROR)}
                 />
               ) : (
@@ -788,13 +799,34 @@ export function DiffPane({
                   filePath={absolutePath}
                   rootPath={worktreePath}
                   label={fileName ?? filePath}
-                  reloadKey={mediaReloadNonce}
+                  reloadKey={previewReloadNonce}
                   onError={(error) => setMediaPlaybackError(error ?? GENERIC_VIDEO_ERROR)}
                   maxHeightClassName="max-h-full"
                 />
               ))}
 
-            {filePath && subject && !isImageMode && !isMediaMode && content && (
+            {filePath &&
+              subject &&
+              isPdfMode &&
+              (fileStatus === "deleted" || !absolutePath ? (
+                <div className="flex h-full w-full items-center justify-center p-6">
+                  <EmptyState
+                    variant="zero-data"
+                    scale="canvas"
+                    title="No working-tree version to preview"
+                    description="This PDF was deleted, and the diff view can only show the current file."
+                  />
+                </div>
+              ) : (
+                <FilePdfPreview
+                  filePath={absolutePath}
+                  rootPath={worktreePath}
+                  label={fileName ?? filePath}
+                  reloadKey={previewReloadNonce}
+                />
+              ))}
+
+            {filePath && subject && !isImageMode && !isMediaMode && !isPdfMode && content && (
               <DiffViewer
                 diff={content}
                 viewType={diffViewType}
@@ -807,7 +839,7 @@ export function DiffPane({
               />
             )}
 
-            {filePath && subject && !isImageMode && !isMediaMode && !content && (
+            {filePath && subject && !isImageMode && !isMediaMode && !isPdfMode && !content && (
               <div className="p-4 space-y-3">
                 <Skeleton label="Loading diff">
                   <SkeletonBone className="h-7 w-3/4" />

--- a/src/panels/diff/__tests__/DiffPane.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.test.tsx
@@ -845,3 +845,66 @@ describe("DiffPane — audio current-version mode (#11425)", () => {
     expect(descriptions.some((d) => d?.includes("audio file was deleted"))).toBe(true);
   });
 });
+
+describe("DiffPane — PDF current-version mode (#11427)", () => {
+  function pdfFrame(container: HTMLElement): HTMLIFrameElement | null {
+    return container.querySelector("iframe");
+  }
+
+  it("shows the working-tree PDF instead of rendering a diff", () => {
+    seedPanel({
+      filePath: "docs/spec.pdf",
+      fileStatus: "modified",
+      changeSet: [entry("docs/spec.pdf")],
+    });
+    const { container } = renderPane();
+
+    const src = new URL(pdfFrame(container)?.getAttribute("src") ?? "");
+    expect(src.protocol).toBe("daintree-pdf:");
+    // The absolute working-tree path rides the protocol URL, and no text diff
+    // is attempted for a binary document.
+    expect(src.searchParams.get("path")).toBe("/repo/docs/spec.pdf");
+    expect(screen.queryByTestId("diff-viewer-mock")).toBeNull();
+  });
+
+  it("hides the text-diff layout controls in PDF mode", () => {
+    seedPanel({
+      filePath: "docs/spec.pdf",
+      fileStatus: "modified",
+      changeSet: [entry("docs/spec.pdf")],
+    });
+    renderPane();
+
+    expect(screen.queryByRole("button", { name: "Unified" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Wrap long lines" })).toBeNull();
+  });
+
+  it("re-navigates the frame from the toolbar Refresh and still retries the diff", async () => {
+    const retry = vi.fn();
+    useDiffContentMock.mockReturnValue({ content: "diff --git a/x b/x", stale: false, retry });
+    seedPanel({
+      filePath: "docs/spec.pdf",
+      fileStatus: "modified",
+      changeSet: [entry("docs/spec.pdf")],
+    });
+    const { container } = renderPane();
+    const before = pdfFrame(container)?.getAttribute("src");
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+    await waitFor(() => expect(pdfFrame(container)?.getAttribute("src")).not.toBe(before));
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it("explains there is nothing to preview when the PDF was deleted", () => {
+    seedPanel({
+      filePath: "docs/spec.pdf",
+      fileStatus: "deleted",
+      changeSet: [entry("docs/spec.pdf", "deleted")],
+    });
+    const { container } = renderPane();
+
+    expect(pdfFrame(container)).toBeNull();
+    expect(screen.getByTestId("empty-state-mock")).toBeTruthy();
+  });
+});

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -17,8 +17,10 @@ import { FileImagePreview } from "@/components/FileViewer/FileImagePreview";
 import { ZoomableImage } from "@/components/FileViewer/ZoomableImage";
 import { FileVideoPreview } from "@/components/FileViewer/FileVideoPreview";
 import { FileAudioPreview } from "@/components/FileViewer/FileAudioPreview";
+import { FilePdfPreview } from "@/components/FileViewer/FilePdfPreview";
 import {
   isImageFilePath,
+  isPdfFilePath,
   isSvgFilePath,
   isAudioFilePath,
   isUnsupportedAudioFilePath,
@@ -83,6 +85,7 @@ type ViewerState =
   | { status: "image" }
   | { status: "video" }
   | { status: "audio" }
+  | { status: "pdf" }
   | { status: "error"; message: string };
 
 // Markdown gets a Source/Rendered switch mirroring FilePane's toggle. Typed at
@@ -156,6 +159,13 @@ export function FileBrowserViewer({
     // Audio takes the same protocol-to-blob route as video.
     if (isAudioFilePath(filePath)) {
       setState({ status: "audio" });
+      return;
+    }
+
+    // PDFs are framed from `daintree-pdf://` into Chromium's built-in viewer;
+    // the text path would reject them as a binary file.
+    if (isPdfFilePath(filePath)) {
+      setState({ status: "pdf" });
       return;
     }
 
@@ -518,6 +528,14 @@ export function FileBrowserViewer({
               }
             />
           </div>
+        );
+
+      case "pdf":
+        return (
+          // Same reasoning as the video case: no `revision` key. Remounting the
+          // frame on every worktree write would throw away the reader's page
+          // and zoom; a rewritten PDF shows new bytes on re-selection.
+          <FilePdfPreview filePath={filePath} rootPath={rootPath} label={fileName} />
         );
 
       case "html":

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -362,3 +362,28 @@ describe("FileBrowserViewer audio preview (#11425)", () => {
     expect(audioFetchMock).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("FileBrowserViewer PDF preview (#11427)", () => {
+  it("frames the PDF scheme without reading the file as text", async () => {
+    const { container } = renderViewer("/repo/docs/spec.pdf");
+    await act(async () => {});
+
+    const src = new URL(container.querySelector("iframe")?.getAttribute("src") ?? "");
+    expect(src.protocol).toBe("daintree-pdf:");
+    expect(src.searchParams.get("path")).toBe("/repo/docs/spec.pdf");
+    expect(src.searchParams.get("root")).toBe("/repo");
+    // The text-read IPC path is what produced "Binary file — cannot display".
+    expect(readMock).not.toHaveBeenCalled();
+  });
+
+  it("mounts the frame credentialless and unsandboxed", async () => {
+    const { container } = renderViewer("/repo/docs/spec.pdf");
+    await act(async () => {});
+
+    const frame = container.querySelector("iframe");
+    // Without credentialless the COEP shell blocks the document; with a sandbox
+    // attribute PDFium refuses to install its viewer frame.
+    expect(frame?.hasAttribute("credentialless")).toBe(true);
+    expect(frame?.hasAttribute("sandbox")).toBe(false);
+  });
+});

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -29,9 +29,11 @@ import { revealCopy, type RevealCopy } from "@/components/FileViewer/revealCopy"
 import { FileImagePreview } from "@/components/FileViewer/FileImagePreview";
 import { FileVideoPreview } from "@/components/FileViewer/FileVideoPreview";
 import { FileAudioPreview } from "@/components/FileViewer/FileAudioPreview";
+import { FilePdfPreview } from "@/components/FileViewer/FilePdfPreview";
 import {
   isAudioFilePath,
   isImageFilePath,
+  isPdfFilePath,
   isSvgFilePath,
   isUnsupportedAudioFilePath,
   isUnsupportedVideoFilePath,
@@ -115,11 +117,22 @@ function isUnderRoot(filePath: string, rootPath: string): boolean {
   return toForwardSlashes(filePath).startsWith(root);
 }
 
-// "image", "svg", "video", and "audio" are terminal preview states: an image is
-// handed to the `daintree-file://` protocol as an <img> src, an SVG is read as
-// text, sanitized, then inlined, and video/audio are fetched from the same
-// protocol into a blob the media element plays. None has readable text content.
-type LoadState = "idle" | "loading" | "loaded" | "error" | "image" | "svg" | "video" | "audio";
+// "image", "svg", "video", "audio", and "pdf" are terminal preview states: an
+// image is handed to the `daintree-file://` protocol as an <img> src, an SVG is
+// read as text, sanitized, then inlined, video/audio are fetched from the same
+// protocol into a blob the media element plays, and a PDF is framed from
+// `daintree-pdf://` into Chromium's built-in viewer. None has readable text
+// content.
+type LoadState =
+  | "idle"
+  | "loading"
+  | "loaded"
+  | "error"
+  | "image"
+  | "svg"
+  | "video"
+  | "audio"
+  | "pdf";
 
 // Which external surface a toolbar action aims the current file at. `reveal` is
 // always offered; `browser`/`editor` is the mode-dependent open button.
@@ -489,6 +502,21 @@ export function FilePane({
         // playback while someone is listening.
         if (!silent) setReloadNonce((nonce) => nonce + 1);
         setLoadState("audio");
+        setErrorCode(null);
+        setErrorMessage(null);
+        return;
+      }
+
+      // PDFs are framed straight from the protocol handler into Chromium's
+      // built-in viewer; the text path would reject them as a binary file.
+      if (isPdfFilePath(filePath)) {
+        setContent(null);
+        setSanitizedSvg(null);
+        // Only an explicit load (open, toolbar Refresh) re-requests the
+        // document — a silent background pass must not remount the frame and
+        // throw away the reader's page and zoom.
+        if (!silent) setReloadNonce((nonce) => nonce + 1);
+        setLoadState("pdf");
         setErrorCode(null);
         setErrorMessage(null);
         return;
@@ -984,6 +1012,15 @@ export function FilePane({
               setErrorMessage(error?.title ?? "This audio file couldn't be played");
               setLoadState("error");
             }}
+          />
+        )}
+
+        {filePath && viewMode !== "diff" && loadState === "pdf" && (
+          <FilePdfPreview
+            filePath={filePath}
+            rootPath={effectiveRootPath}
+            label={fileName ?? filePath}
+            reloadKey={reloadNonce}
           />
         )}
 

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -124,15 +124,7 @@ function isUnderRoot(filePath: string, rootPath: string): boolean {
 // `daintree-pdf://` into Chromium's built-in viewer. None has readable text
 // content.
 type LoadState =
-  | "idle"
-  | "loading"
-  | "loaded"
-  | "error"
-  | "image"
-  | "svg"
-  | "video"
-  | "audio"
-  | "pdf";
+  "idle" | "loading" | "loaded" | "error" | "image" | "svg" | "video" | "audio" | "pdf";
 
 // Which external surface a toolbar action aims the current file at. `reveal` is
 // always offered; `browser`/`editor` is the mode-dependent open button.

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -1152,9 +1152,17 @@ describe("FilePane diff mode (#11274)", () => {
       expect(frame.hasAttribute("sandbox")).toBe(false);
     });
 
-    it("never shows the binary-file error for a PDF", async () => {
-      await renderPane({ filePath: "/repo/docs/spec.pdf" });
+    it("never shows the binary-file error even when a text read would reject the file", async () => {
+      // Arm the read path with the exact rejection PDFs used to hit. If the
+      // classifier were removed the file would fall through and surface it, so
+      // this fails loudly rather than passing on an empty default read.
+      readMock.mockRejectedValueOnce(Object.assign(new Error("binary"), { code: "BINARY_FILE" }));
+
+      const { container } = await renderPane({ filePath: "/repo/docs/spec.pdf" });
+
+      await waitFor(() => expect(container.querySelector("iframe")).not.toBeNull());
       expect(screen.queryByText(/Binary file/)).toBeNull();
+      expect(readMock).not.toHaveBeenCalled();
     });
   });
 

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -1123,6 +1123,41 @@ describe("FilePane diff mode (#11274)", () => {
     });
   });
 
+  describe("PDF preview (#11427)", () => {
+    it("frames the PDF scheme instead of reading the file as text", async () => {
+      const { container } = await renderPane({ filePath: "/repo/docs/spec.pdf" });
+
+      const frame = await waitFor(() => {
+        const found = container.querySelector("iframe");
+        if (!found) throw new Error("no iframe yet");
+        return found;
+      });
+      // The text-read IPC path is what produced "Binary file — cannot display";
+      // a PDF must short-circuit before it ever runs.
+      expect(readMock).not.toHaveBeenCalled();
+      const src = new URL(frame.getAttribute("src") ?? "");
+      expect(src.protocol).toBe("daintree-pdf:");
+      expect(src.searchParams.get("path")).toBe("/repo/docs/spec.pdf");
+    });
+
+    it("mounts the frame credentialless and unsandboxed", async () => {
+      const { container } = await renderPane({ filePath: "/repo/docs/spec.pdf" });
+
+      const frame = await waitFor(() => {
+        const found = container.querySelector("iframe");
+        if (!found) throw new Error("no iframe yet");
+        return found;
+      });
+      expect(frame.hasAttribute("credentialless")).toBe(true);
+      expect(frame.hasAttribute("sandbox")).toBe(false);
+    });
+
+    it("never shows the binary-file error for a PDF", async () => {
+      await renderPane({ filePath: "/repo/docs/spec.pdf" });
+      expect(screen.queryByText(/Binary file/)).toBeNull();
+    });
+  });
+
   describe("change lookup", () => {
     it("matches a change stored as an absolute path", async () => {
       seedWorktree([{ path: "/repo/src/index.ts", status: "modified" }]);

--- a/src/types/credentialless.d.ts
+++ b/src/types/credentialless.d.ts
@@ -12,6 +12,9 @@
 import "react";
 
 declare module "react" {
+  // The type parameter is unused here but must match React's own declaration
+  // exactly — TypeScript rejects an interface merge whose type parameters differ.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface IframeHTMLAttributes<T> {
     credentialless?: "";
   }

--- a/src/types/credentialless.d.ts
+++ b/src/types/credentialless.d.ts
@@ -1,0 +1,18 @@
+// `credentialless` (Chrome 110+) loads an iframe in an ephemeral, credential-free
+// context. It is what lets the COEP `credentialless` app shell embed a document
+// that asserts no COEP of its own — the shape the inline PDF preview needs,
+// since PDFium breaks if its document carries either a COEP or a `sandbox` CSP.
+// React 19 has no typing for it.
+//
+// Typed as the empty string, not boolean, on purpose: React treats an unknown
+// attribute with a `true` value as a non-boolean it should omit, so
+// `credentialless={true}` silently renders nothing. `credentialless=""` is
+// emitted, and an empty string is a present attribute per the HTML spec.
+
+import "react";
+
+declare module "react" {
+  interface IframeHTMLAttributes<T> {
+    credentialless?: "";
+  }
+}


### PR DESCRIPTION
## Summary

PDFs fell through to the text read path and reported "Binary file — cannot display". They now render inline via Chromium's built-in PDFium viewer, alongside the existing image, SVG and video previews.

The issue's two starting premises turned out to be wrong, and a standalone Electron 42.7.1 / Chromium 148 spike (serving a real PDF from custom `protocol.handle` schemes, detecting PDFium by its `chrome-extension://mhjfbmdgcfjbbpaeojofohoefgiehjai` viewer frame) settled what actually matters:

- `webPreferences.plugins: true` is NOT required — the viewer engaged with `plugins: false`. No `webPreferences` change ships here.
- A `standard: true` scheme is NOT required — an opaque, `daintree-file`-shaped scheme rendered fine.
- The real blocker is COEP. The app shell is `Cross-Origin-Embedder-Policy: credentialless`. From that parent, a plain iframe to a PDF without COEP is blocked (`ERR_BLOCKED_BY_RESPONSE`), and *with* COEP the PDF loads but PDFium's own viewer frame is blocked instead. A `sandbox` attribute — the `daintree-html://` shape — breaks it a third way (`ERR_BLOCKED_BY_CLIENT`).
- The fix is the `credentialless` iframe attribute, which is purpose-built for this: the frame loads in an ephemeral context, so the embedded document needs no COEP at all.

## Changes

- A dedicated `daintree-pdf://` scheme, privileged with `{ secure: true }` only. It reuses the existing realpath + `O_NOFOLLOW` containment core, rejects any canonical path that isn't `.pdf` *before* reading a byte, and always answers with a hard-coded `application/pdf`. That MIME lock is what makes the `frame-src` allowance safe.
- `frame-src` gains `daintree-pdf:` and nothing else. `daintree-file:` stays out on purpose: it serves arbitrary repo files under extension-derived MIME types, so framing it would let a repo-controlled `.html` run as a live document — and its responses carry a `sandbox` CSP that breaks PDFium anyway.
- Both `onHeadersReceived` CSP overlays pass PDF responses through untouched. Without that the app CSP (whose `frame-src` excludes `chrome-extension:`) would be stamped onto the PDF document and silently block the viewer frame — the #11198 failure mode, which has already shipped broken twice on the structurally identical `daintree-html://` feature.
- A 50 MB cap, twice the raster-image allowance. No Range/206 needed — PDFium renders from a single buffered 200.
- Routed in `FilePane`, `FileBrowserViewer` and `DiffPane`, short-circuiting before the text read. `DiffPane` shows the working-tree document, mirroring how video already behaves.

Resolves #11427

## Testing

446 targeted tests pass, plus lint and a full typecheck. New coverage spans the protocol handler (canonical-extension gating, pre-read rejection, fixed MIME, absent CSP/COEP, HEAD, Range, size bracketing, RFC 8187 filename encoding, header-injection safety), both CSP overlay call sites, the CSP directive confinement, the preview component's frame contract, and the PDF path in all three panes.

**Not covered:** no end-to-end test was added — the Chromium-level behaviour was established by the spike rather than in-app, and the full-panels E2E bucket runs in the release pipeline.