### PR TITLE
fix(palette): keep arrow and Enter navigation alive after Tab

### DIFF
--- a/src/components/PanelPalette/PanelPalette.tsx
+++ b/src/components/PanelPalette/PanelPalette.tsx
@@ -187,6 +187,11 @@ export function PanelPalette({
     return elements;
   };
 
+  const activeDescendant =
+    results.length > 0 && selectedIndex >= 0 && selectedIndex < results.length
+      ? `panel-option-${results[selectedIndex]!.id}`
+      : undefined;
+
   return (
     <AppPaletteDialog isOpen={isOpen} onClose={onClose} ariaLabel="Panel palette">
       <AppPaletteDialog.Header
@@ -204,15 +209,15 @@ export function PanelPalette({
           aria-haspopup="listbox"
           aria-label="Select panel type"
           aria-controls="panel-list"
-          aria-activedescendant={
-            results.length > 0 && selectedIndex >= 0 && selectedIndex < results.length
-              ? `panel-option-${results[selectedIndex]!.id}`
-              : undefined
-          }
+          aria-activedescendant={activeDescendant}
         />
       </AppPaletteDialog.Header>
 
-      <AppPaletteDialog.Body>
+      <AppPaletteDialog.Body
+        ariaLabel="Panel types"
+        activeDescendant={activeDescendant}
+        onNavigationKeyDown={handleKeyDown}
+      >
         {results.length === 0 ? (
           <AppPaletteDialog.Empty
             query={query}

--- a/src/components/PanelPalette/__tests__/PanelPalette.test.tsx
+++ b/src/components/PanelPalette/__tests__/PanelPalette.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { PanelPalette } from "../PanelPalette";
 import type { PanelKindOption } from "@/hooks/usePanelPalette";
@@ -96,5 +96,33 @@ describe("PanelPalette resume section", () => {
     expect(screen.queryByText("Resume Sessions")).toBeNull();
     // The options themselves still render.
     expect(screen.getByText("Resume: Fixing auth")).toBeTruthy();
+  });
+});
+
+describe("PanelPalette results region (#11431)", () => {
+  it("forwards navigation from the region and resolves its active option", () => {
+    const onSelectNext = vi.fn();
+    const onConfirm = vi.fn();
+    render(
+      <PanelPalette
+        {...baseProps}
+        query=""
+        results={resumeResults}
+        onSelectNext={onSelectNext}
+        onConfirm={onConfirm}
+      />
+    );
+    const region = screen.getByRole("group", { name: "Panel types" });
+
+    fireEvent.keyDown(region, { key: "ArrowDown" });
+    fireEvent.keyDown(region, { key: "Enter" });
+
+    expect(onSelectNext).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+
+    // A wrong id prefix here would silently break the announcement.
+    const activeDescendant = region.getAttribute("aria-activedescendant");
+    expect(activeDescendant).toBe(`panel-option-${resumeResults[0]!.id}`);
+    expect(document.getElementById(activeDescendant!)).not.toBeNull();
   });
 });

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -1095,6 +1095,7 @@ function ProjectPaletteInner({
   );
 
   const activeResult = results[selectedIndex];
+  const activeDescendant = activeResult ? `project-option-${activeResult.id}` : undefined;
 
   return (
     <>
@@ -1115,11 +1116,17 @@ function ProjectPaletteInner({
           aria-haspopup="listbox"
           aria-label="Search projects"
           aria-controls="project-list"
-          aria-activedescendant={activeResult ? `project-option-${activeResult.id}` : undefined}
+          aria-activedescendant={activeDescendant}
         />
       </AppPaletteDialog.Header>
 
-      <AppPaletteDialog.Body maxHeight={PALETTE_MAX_HEIGHT} className="p-0">
+      <AppPaletteDialog.Body
+        maxHeight={PALETTE_MAX_HEIGHT}
+        className="p-0"
+        ariaLabel="Projects"
+        activeDescendant={activeDescendant}
+        onNavigationKeyDown={handleKeyDown}
+      >
         <ProjectListContent
           results={results}
           selectedIndex={selectedIndex}

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
@@ -242,6 +242,26 @@ describe("ProjectSwitcherPalette keyboard navigation", () => {
     expect(defaultProps.onSelect).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps modifier shortcuts working from the results region", () => {
+    // The region forwards the raw event, so Meta+Enter must still reach the
+    // new-window branch rather than degrading to a plain switch.
+    const onSelectNewWindow = vi.fn();
+    render(<ProjectSwitcherPalette {...defaultProps} onSelectNewWindow={onSelectNewWindow} />);
+    fireEvent.keyDown(screen.getByTestId("palette-body"), { key: "Enter", metaKey: true });
+
+    expect(onSelectNewWindow).toHaveBeenCalledTimes(1);
+    expect(onSelectNewWindow).toHaveBeenCalledWith(defaultProps.results[0]);
+    expect(defaultProps.onSelect).not.toHaveBeenCalled();
+  });
+
+  it("closes the active project on Meta+Backspace from the results region", () => {
+    const onCloseProject = vi.fn();
+    render(<ProjectSwitcherPalette {...defaultProps} onCloseProject={onCloseProject} />);
+    fireEvent.keyDown(screen.getByTestId("palette-body"), { key: "Backspace", metaKey: true });
+
+    expect(onCloseProject).toHaveBeenCalledWith("p1");
+  });
+
   it("mirrors the input's active descendant onto the results region", () => {
     render(<ProjectSwitcherPalette {...defaultProps} selectedIndex={1} />);
     const activeDescendant = screen

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
@@ -59,8 +59,31 @@ vi.mock("@/components/ui/AppPaletteDialog", () => {
   }: React.InputHTMLAttributes<HTMLInputElement> & {
     inputRef?: React.Ref<HTMLInputElement>;
   }) => <input ref={inputRef} data-testid="palette-input" {...props} />;
-  const Body = ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="palette-body">{children}</div>
+  // Mirrors the real Body's focusable-region contract (role/label/active
+  // descendant/handler) so the palette's wiring is observable here. Key
+  // filtering itself is covered against the real component in
+  // src/components/ui/__tests__/AppPaletteDialog.test.tsx.
+  const Body = ({
+    children,
+    ariaLabel,
+    activeDescendant,
+    onNavigationKeyDown,
+  }: {
+    children: React.ReactNode;
+    ariaLabel?: string;
+    activeDescendant?: string;
+    onNavigationKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
+  }) => (
+    <div
+      data-testid="palette-body"
+      tabIndex={0}
+      role="group"
+      aria-label={ariaLabel}
+      aria-activedescendant={activeDescendant}
+      onKeyDown={onNavigationKeyDown}
+    >
+      {children}
+    </div>
   );
   const Footer = ({ children }: { children: React.ReactNode }) => (
     <div data-testid="palette-footer">{children}</div>
@@ -180,18 +203,57 @@ describe("ProjectSwitcherPalette keyboard navigation", () => {
     vi.restoreAllMocks();
   });
 
-  it("does not call onSelectNext when Tab is pressed on the input", () => {
+  // Tab must keep its native traversal so the controls rendered after the
+  // results list (the scratch section) stay keyboard-reachable. Remapping it
+  // to selection movement is what commit e7028aeb6 removed.
+  it("leaves Tab to native focus traversal instead of moving the selection", () => {
     render(<ProjectSwitcherPalette {...defaultProps} />);
     const input = screen.getByTestId("palette-input");
-    fireEvent.keyDown(input, { key: "Tab" });
+    const notCancelled = fireEvent.keyDown(input, { key: "Tab" });
     expect(defaultProps.onSelectNext).not.toHaveBeenCalled();
+    expect(notCancelled).toBe(true);
   });
 
-  it("does not call onSelectPrevious when Shift+Tab is pressed on the input", () => {
+  it("leaves Shift+Tab to native focus traversal instead of moving the selection", () => {
     render(<ProjectSwitcherPalette {...defaultProps} />);
     const input = screen.getByTestId("palette-input");
-    fireEvent.keyDown(input, { key: "Tab", shiftKey: true });
+    const notCancelled = fireEvent.keyDown(input, { key: "Tab", shiftKey: true });
     expect(defaultProps.onSelectPrevious).not.toHaveBeenCalled();
+    expect(notCancelled).toBe(true);
+  });
+
+  // #11431: Tab lands on the scrollable results region, so that region has to
+  // keep driving the same navigation the input does.
+  it("moves the selection when ArrowDown is pressed on the results region", () => {
+    render(<ProjectSwitcherPalette {...defaultProps} />);
+    fireEvent.keyDown(screen.getByTestId("palette-body"), { key: "ArrowDown" });
+    expect(defaultProps.onSelectNext).toHaveBeenCalledTimes(1);
+  });
+
+  it("moves the selection when ArrowUp is pressed on the results region", () => {
+    render(<ProjectSwitcherPalette {...defaultProps} />);
+    fireEvent.keyDown(screen.getByTestId("palette-body"), { key: "ArrowUp" });
+    expect(defaultProps.onSelectPrevious).toHaveBeenCalledTimes(1);
+  });
+
+  it("confirms the active project when Enter is pressed on the results region", () => {
+    render(<ProjectSwitcherPalette {...defaultProps} />);
+    fireEvent.keyDown(screen.getByTestId("palette-body"), { key: "Enter" });
+    expect(defaultProps.onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("mirrors the input's active descendant onto the results region", () => {
+    render(<ProjectSwitcherPalette {...defaultProps} selectedIndex={1} />);
+    const activeDescendant = screen
+      .getByTestId("palette-input")
+      .getAttribute("aria-activedescendant");
+
+    expect(activeDescendant).toBe("project-option-p2");
+    expect(screen.getByTestId("palette-body").getAttribute("aria-activedescendant")).toBe(
+      activeDescendant
+    );
+    // The IDREF has to resolve to a real option, or the mirror announces nothing.
+    expect(document.getElementById(activeDescendant!)).not.toBeNull();
   });
 
   it("still calls onSelectNext on ArrowDown", () => {

--- a/src/components/Terminal/ResumeSessionsPalette.tsx
+++ b/src/components/Terminal/ResumeSessionsPalette.tsx
@@ -163,6 +163,7 @@ export function ResumeSessionsPalette() {
   };
 
   const selected = selectedIndex >= 0 ? results[selectedIndex] : undefined;
+  const activeDescendant = selected ? `resume-session-option-${selected.id}` : undefined;
 
   return (
     <AppPaletteDialog isOpen={isOpen} onClose={close} ariaLabel="Resume session">
@@ -178,11 +179,15 @@ export function ResumeSessionsPalette() {
           aria-haspopup="listbox"
           aria-label="Search closed sessions"
           aria-controls="resume-session-list"
-          aria-activedescendant={selected ? `resume-session-option-${selected.id}` : undefined}
+          aria-activedescendant={activeDescendant}
         />
       </AppPaletteDialog.Header>
 
-      <AppPaletteDialog.Body>
+      <AppPaletteDialog.Body
+        ariaLabel="Closed sessions"
+        activeDescendant={activeDescendant}
+        onNavigationKeyDown={handleKeyDown}
+      >
         {results.length === 0 ? (
           isLoading ? null : (
             <AppPaletteDialog.Empty

--- a/src/components/TerminalPalette/NewTerminalPalette.tsx
+++ b/src/components/TerminalPalette/NewTerminalPalette.tsx
@@ -95,6 +95,7 @@ export function NewTerminalPalette({
 
   const selectedOption =
     selectedIndex >= 0 && selectedIndex < results.length ? results[selectedIndex] : null;
+  const activeDescendant = selectedOption ? `new-terminal-option-${selectedOption.id}` : undefined;
 
   return (
     <AppPaletteDialog isOpen={isOpen} onClose={onClose} ariaLabel="New terminal palette">
@@ -109,15 +110,15 @@ export function NewTerminalPalette({
           aria-expanded={isOpen}
           aria-label="Select terminal type"
           aria-controls="new-terminal-list"
-          aria-activedescendant={
-            results.length > 0 && selectedIndex >= 0 && selectedIndex < results.length
-              ? `new-terminal-option-${results[selectedIndex]!.id}`
-              : undefined
-          }
+          aria-activedescendant={activeDescendant}
         />
       </AppPaletteDialog.Header>
 
-      <AppPaletteDialog.Body>
+      <AppPaletteDialog.Body
+        ariaLabel="Terminal types"
+        activeDescendant={activeDescendant}
+        onNavigationKeyDown={handleKeyDown}
+      >
         <div role="status" aria-live="polite" className="sr-only">
           {results.length} terminal types
         </div>

--- a/src/components/TerminalPalette/__tests__/NewTerminalPalette.test.tsx
+++ b/src/components/TerminalPalette/__tests__/NewTerminalPalette.test.tsx
@@ -148,8 +148,8 @@ describe("NewTerminalPalette results region (#11431)", () => {
   it("omits the active descendant when there are no results", () => {
     const { getByRole } = renderPalette({ results: [], selectedIndex: -1 });
 
-    expect(getByRole("group", { name: "Terminal types" }).hasAttribute("aria-activedescendant")).toBe(
-      false
-    );
+    expect(
+      getByRole("group", { name: "Terminal types" }).hasAttribute("aria-activedescendant")
+    ).toBe(false);
   });
 });

--- a/src/components/TerminalPalette/__tests__/NewTerminalPalette.test.tsx
+++ b/src/components/TerminalPalette/__tests__/NewTerminalPalette.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render } from "@testing-library/react";
+import { render, fireEvent } from "@testing-library/react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 class ResizeObserverStub {
@@ -125,5 +125,31 @@ describe("NewTerminalPalette", () => {
     handler();
     expect(onQueryChange).not.toHaveBeenCalled();
     expect(onClose).toHaveBeenCalled();
+  });
+});
+
+describe("NewTerminalPalette results region (#11431)", () => {
+  it("forwards navigation from the region and resolves its active option", () => {
+    const { getByRole, props } = renderPalette();
+    const region = getByRole("group", { name: "Terminal types" });
+
+    fireEvent.keyDown(region, { key: "ArrowDown" });
+    fireEvent.keyDown(region, { key: "Enter" });
+
+    expect(props.onSelectNext).toHaveBeenCalledTimes(1);
+    expect(props.onConfirm).toHaveBeenCalledTimes(1);
+
+    // A wrong id prefix here would silently break the announcement.
+    const activeDescendant = region.getAttribute("aria-activedescendant");
+    expect(activeDescendant).toBe("new-terminal-option-a");
+    expect(document.getElementById(activeDescendant!)).not.toBeNull();
+  });
+
+  it("omits the active descendant when there are no results", () => {
+    const { getByRole } = renderPalette({ results: [], selectedIndex: -1 });
+
+    expect(getByRole("group", { name: "Terminal types" }).hasAttribute("aria-activedescendant")).toBe(
+      false
+    );
   });
 });

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -307,20 +307,67 @@ AppPaletteDialog.Header = function AppPaletteHeader({
   );
 };
 
+/**
+ * Keys the body forwards to the owning palette's keydown handler when the
+ * scroll container itself holds focus. Tab and Shift+Tab are deliberately
+ * absent: the container is a real tab stop (see `tabIndex` below) and palettes
+ * such as the project switcher render controls after it that must stay
+ * reachable by native traversal. PageUp/PageDown/Space are left to the
+ * browser so the region keeps its native scrolling.
+ */
+const BODY_NAVIGATION_KEYS = new Set(["ArrowUp", "ArrowDown", "Home", "End", "Enter"]);
+
 interface AppPaletteBodyProps {
   children: React.ReactNode;
   className?: string;
   maxHeight?: string;
+  /** Accessible name for the focusable results region. */
+  ariaLabel: string;
+  /**
+   * The same active-descendant IDREF the query input carries. Mirrored here so
+   * the active option keeps being announced once focus moves off the input —
+   * only the element holding DOM focus acts as the active-descendant owner, so
+   * carrying it on both is not a double-announcement.
+   */
+  activeDescendant?: string;
+  /**
+   * The palette's input keydown handler. Required rather than optional so a new
+   * consumer cannot silently reintroduce the dead-end scroll region that made
+   * arrow and Enter navigation stop working after Tab (#11431).
+   */
+  onNavigationKeyDown: React.KeyboardEventHandler<HTMLDivElement>;
 }
 
 AppPaletteDialog.Body = function AppPaletteBody({
   children,
   className,
   maxHeight = "max-h-[50vh]",
+  ariaLabel,
+  activeDescendant,
+  onNavigationKeyDown,
 }: AppPaletteBodyProps) {
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      // Only when the scroller itself owns focus. Palette bodies also host
+      // their own controls (the project switcher's scratch section), and Enter
+      // on one of those must activate the button, not confirm a result.
+      if (e.target !== e.currentTarget) return;
+      if (!BODY_NAVIGATION_KEYS.has(e.key)) return;
+      onNavigationKeyDown(e);
+    },
+    [onNavigationKeyDown]
+  );
+
   return (
     <ScrollShadow
+      // Load-bearing for axe's `scrollable-region-focusable` (WCAG 2.1.1): the
+      // overflow container must be reachable by keyboard. Removing it — or
+      // demoting it to -1 — reopens the violation fixed in 8ec243398.
       tabIndex={0}
+      role="group"
+      aria-label={ariaLabel}
+      aria-activedescendant={activeDescendant}
+      onKeyDown={handleKeyDown}
       className={cn(
         maxHeight,
         "min-h-32 transition-[height] motion-reduce:transition-none palette-body-height",

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -315,7 +315,18 @@ AppPaletteDialog.Header = function AppPaletteHeader({
  * reachable by native traversal. PageUp/PageDown/Space are left to the
  * browser so the region keeps its native scrolling.
  */
-const BODY_NAVIGATION_KEYS = new Set(["ArrowUp", "ArrowDown", "Home", "End", "Enter"]);
+const BODY_NAVIGATION_KEYS = new Set([
+  "ArrowUp",
+  "ArrowDown",
+  "Home",
+  "End",
+  "Enter",
+  // Palettes bind modified Backspace to a row action (the project switcher
+  // advertises ⌘⌫ to close a project). Forwarding it keeps the footer hint
+  // honest once focus is on the region; palettes that ignore the key are
+  // unaffected, and unmodified Backspace still falls through untouched.
+  "Backspace",
+]);
 
 interface AppPaletteBodyProps {
   children: React.ReactNode;

--- a/src/components/ui/SearchablePalette.tsx
+++ b/src/components/ui/SearchablePalette.tsx
@@ -234,15 +234,14 @@ export function SearchablePalette<T>({
 
   const hoverIndexHandler = onHoverIndex ?? noopHoverIndex;
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
-
-      if (onKeyDown) {
-        onKeyDown(e);
-        if (e.defaultPrevented) return;
-      }
-
+  /**
+   * List navigation shared by the query input and the focusable results region
+   * (`AppPaletteDialog.Body`), so arrow keys and Enter keep working after Tab
+   * moves focus off the input (#11431). Element-agnostic: it reads only
+   * key/modifier state, never `currentTarget`.
+   */
+  const handleNavigationKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLElement>) => {
       switch (e.key) {
         case "ArrowUp":
           e.preventDefault();
@@ -276,18 +275,36 @@ export function SearchablePalette<T>({
           e.stopPropagation();
           onConfirm();
           break;
-        case "Tab":
-          e.preventDefault();
-          e.stopPropagation();
-          if (e.shiftKey) {
-            onSelectPrevious();
-          } else {
-            onSelectNext();
-          }
-          break;
       }
     },
-    [onKeyDown, onSelectPrevious, onSelectNext, onConfirm, results.length, hoverIndexHandler]
+    [onSelectPrevious, onSelectNext, onConfirm, results.length, hoverIndexHandler]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
+
+      if (onKeyDown) {
+        onKeyDown(e);
+        if (e.defaultPrevented) return;
+      }
+
+      // Tab stays input-only: on the results region it must keep its native
+      // traversal so controls rendered after the list stay reachable.
+      if (e.key === "Tab") {
+        e.preventDefault();
+        e.stopPropagation();
+        if (e.shiftKey) {
+          onSelectPrevious();
+        } else {
+          onSelectNext();
+        }
+        return;
+      }
+
+      handleNavigationKeyDown(e);
+    },
+    [onKeyDown, onSelectPrevious, onSelectNext, handleNavigationKeyDown]
   );
 
   const activeDescendant =
@@ -367,7 +384,12 @@ export function SearchablePalette<T>({
         />
       </AppPaletteDialog.Header>
 
-      <AppPaletteDialog.Body className={bodyClassName}>
+      <AppPaletteDialog.Body
+        className={bodyClassName}
+        ariaLabel={label}
+        activeDescendant={activeDescendant}
+        onNavigationKeyDown={handleNavigationKeyDown}
+      >
         {renderBody ? (
           renderBody()
         ) : (

--- a/src/components/ui/__tests__/AppPaletteDialog.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteDialog.test.tsx
@@ -302,3 +302,75 @@ describe("AppPaletteDialog reduced-motion policy", () => {
     expect(getScrim().style.transitionTimingFunction).not.toBe("");
   });
 });
+
+describe("AppPaletteDialog.Body results region (#11431)", () => {
+  function renderBody(onNavigationKeyDown: (e: React.KeyboardEvent) => void) {
+    render(
+      <>
+        <Dispatcher />
+        <AppPaletteDialog isOpen onClose={() => {}} ariaLabel="Body palette">
+          <AppPaletteDialog.Body
+            ariaLabel="Results"
+            activeDescendant="option-b"
+            onNavigationKeyDown={onNavigationKeyDown}
+          >
+            <div role="listbox" aria-label="Results list">
+              <div id="option-a" role="option" aria-selected={false}>
+                A
+              </div>
+              <div id="option-b" role="option" aria-selected>
+                B
+              </div>
+            </div>
+            <button type="button">Nested control</button>
+          </AppPaletteDialog.Body>
+        </AppPaletteDialog>
+      </>
+    );
+    return screen.getByRole("group", { name: "Results" });
+  }
+
+  it("stays a tab stop so the scrollable region keeps keyboard access", () => {
+    // Load-bearing for axe's scrollable-region-focusable (WCAG 2.1.1).
+    expect(renderBody(vi.fn()).getAttribute("tabindex")).toBe("0");
+  });
+
+  it("mirrors the active descendant and resolves it to a real option", () => {
+    const region = renderBody(vi.fn());
+    const activeDescendant = region.getAttribute("aria-activedescendant");
+
+    expect(activeDescendant).toBe("option-b");
+    expect(document.getElementById(activeDescendant!)).not.toBeNull();
+  });
+
+  it.each(["ArrowUp", "ArrowDown", "Home", "End", "Enter"])(
+    "forwards %s to the palette's navigation handler",
+    (key) => {
+      const onNavigationKeyDown = vi.fn();
+      fireEvent.keyDown(renderBody(onNavigationKeyDown), { key });
+
+      expect(onNavigationKeyDown).toHaveBeenCalledTimes(1);
+      expect(onNavigationKeyDown.mock.calls[0]![0].key).toBe(key);
+    }
+  );
+
+  it.each(["Tab", "PageDown", "PageUp", " ", "Escape"])(
+    "leaves %s to its native behaviour",
+    (key) => {
+      const onNavigationKeyDown = vi.fn();
+      fireEvent.keyDown(renderBody(onNavigationKeyDown), { key });
+
+      expect(onNavigationKeyDown).not.toHaveBeenCalled();
+    }
+  );
+
+  it("ignores navigation keys raised by controls nested inside the region", () => {
+    // Enter on the scratch-section style buttons must activate the button, not
+    // confirm the palette's active result.
+    const onNavigationKeyDown = vi.fn();
+    renderBody(onNavigationKeyDown);
+    fireEvent.keyDown(screen.getByRole("button", { name: "Nested control" }), { key: "Enter" });
+
+    expect(onNavigationKeyDown).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/__tests__/AppPaletteDialog.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteDialog.test.tsx
@@ -354,15 +354,29 @@ describe("AppPaletteDialog.Body results region (#11431)", () => {
     }
   );
 
-  it.each(["Tab", "PageDown", "PageUp", " ", "Escape"])(
-    "leaves %s to its native behaviour",
-    (key) => {
-      const onNavigationKeyDown = vi.fn();
-      fireEvent.keyDown(renderBody(onNavigationKeyDown), { key });
+  it.each([
+    ["Tab", false],
+    ["Tab", true],
+    ["PageDown", false],
+    ["PageUp", false],
+    [" ", false],
+    ["Escape", false],
+  ])("leaves %s (shift: %s) to its native behaviour", (key, shiftKey) => {
+    const onNavigationKeyDown = vi.fn();
+    const notCancelled = fireEvent.keyDown(renderBody(onNavigationKeyDown), { key, shiftKey });
 
-      expect(onNavigationKeyDown).not.toHaveBeenCalled();
-    }
-  );
+    expect(onNavigationKeyDown).not.toHaveBeenCalled();
+    // Not merely unhandled — uncancelled, so Tab still traverses and
+    // Page/Space still scroll the region.
+    expect(notCancelled).toBe(true);
+  });
+
+  it("forwards modified Backspace so row shortcuts survive the focus move", () => {
+    const onNavigationKeyDown = vi.fn();
+    fireEvent.keyDown(renderBody(onNavigationKeyDown), { key: "Backspace", metaKey: true });
+
+    expect(onNavigationKeyDown).toHaveBeenCalledTimes(1);
+  });
 
   it("ignores navigation keys raised by controls nested inside the region", () => {
     // Enter on the scratch-section style buttons must activate the button, not

--- a/src/components/ui/__tests__/SearchablePalette.keyboard.test.tsx
+++ b/src/components/ui/__tests__/SearchablePalette.keyboard.test.tsx
@@ -191,3 +191,73 @@ describe("SearchablePalette keyboard navigation (non-composing)", () => {
     expect(prevented).toBe(false);
   });
 });
+
+describe("SearchablePalette Tab remap (input)", () => {
+  it("moves the selection forward on Tab and cancels native traversal", () => {
+    const onSelectNext = vi.fn();
+    renderPalette({ onSelectNext });
+    const notCancelled = fireEvent.keyDown(screen.getByRole("combobox"), { key: "Tab" });
+
+    expect(onSelectNext).toHaveBeenCalledTimes(1);
+    expect(notCancelled).toBe(false);
+  });
+
+  it("moves the selection backward on Shift+Tab and cancels native traversal", () => {
+    const onSelectPrevious = vi.fn();
+    renderPalette({ onSelectPrevious });
+    const notCancelled = fireEvent.keyDown(screen.getByRole("combobox"), {
+      key: "Tab",
+      shiftKey: true,
+    });
+
+    expect(onSelectPrevious).toHaveBeenCalledTimes(1);
+    expect(notCancelled).toBe(false);
+  });
+
+  it("lets the custom onKeyDown hook pre-empt the Tab remap", () => {
+    const onSelectNext = vi.fn();
+    const onKeyDown = vi.fn((e: React.KeyboardEvent) => e.preventDefault());
+    renderPalette({ onSelectNext, onKeyDown });
+    fireEvent.keyDown(screen.getByRole("combobox"), { key: "Tab" });
+
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+    expect(onSelectNext).not.toHaveBeenCalled();
+  });
+});
+
+describe("SearchablePalette results region (#11431)", () => {
+  function getRegion() {
+    return screen.getByRole("group", { name: "Test" });
+  }
+
+  it("drives the same navigation as the input while it owns focus", () => {
+    const onSelectNext = vi.fn();
+    const onSelectPrevious = vi.fn();
+    const onConfirm = vi.fn();
+    renderPalette({ onSelectNext, onSelectPrevious, onConfirm });
+    const region = getRegion();
+
+    fireEvent.keyDown(region, { key: "ArrowDown" });
+    fireEvent.keyDown(region, { key: "ArrowUp" });
+    fireEvent.keyDown(region, { key: "Enter" });
+
+    expect(onSelectNext).toHaveBeenCalledTimes(1);
+    expect(onSelectPrevious).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not remap Tab on the region, so focus can leave the list", () => {
+    const onSelectNext = vi.fn();
+    renderPalette({ onSelectNext });
+    const notCancelled = fireEvent.keyDown(getRegion(), { key: "Tab" });
+
+    expect(onSelectNext).not.toHaveBeenCalled();
+    expect(notCancelled).toBe(true);
+  });
+
+  it("omits the active descendant when there are no results", () => {
+    renderPalette({ results: [], selectedIndex: -1 });
+
+    expect(getRegion().hasAttribute("aria-activedescendant")).toBe(false);
+  });
+});


### PR DESCRIPTION
Resolves #11431

## The problem
Tab moved focus off the palette query input onto the scrollable results container, which is a tab stop because `AppPaletteDialog.Body` renders `<ScrollShadow tabIndex={0}>`. Arrow keys and Enter were only bound to the input's `onKeyDown`, so once focus landed on the container every navigation key was dead. Only Escape survived. Five palettes share that component, so they all had the same dead end.

## What I did NOT do, and why
The obvious fix is to remap Tab to next/previous selection, which four sibling palettes already do. That's wrong here: commit e7028aeb6 deliberately REMOVED exactly that case from the project switcher because it trapped focus in the list. The project switcher's body renders the scratch section, whose controls are real tab stops after the results list, and `ModalHostLayer` always passes `onCreateScratch` so that section is always mounted. Remapping Tab would make those controls keyboard-unreachable.

Also left `tabIndex={0}` alone. It's load-bearing: added in 8ec243398 to fix an axe-core `scrollable-region-focusable` (WCAG 2.1.1) violation, and axe's check is static, so removing it (or setting -1) just reopens the violation.

## The fix
The scroll container stops being a dead end instead. `AppPaletteDialog.Body` now takes `ariaLabel`, `activeDescendant` and `onNavigationKeyDown`, and the focusable region: keeps `tabIndex={0}`; gains `role="group"` + `aria-label`; mirrors the query input's `aria-activedescendant` (spec-valid on `group` per ARIA 1.2, and the referenced option is still a DOM descendant); forwards ArrowUp/ArrowDown/Home/End/Enter/Backspace to the palette's navigation handler, but only when the region itself owns focus, so Enter on nested controls still activates those controls. Tab, PageUp/PageDown and Space keep native behaviour, so traversal and scrolling are untouched. `onNavigationKeyDown` is required rather than optional so a new consumer can't silently reintroduce the dead end. All five consumers wired.

`SearchablePalette` needed its input-only handling (IME guard, `onKeyDown` escape hatch, Tab remap) split from the shared list navigation. Its escape hatch is typed for `HTMLInputElement`, and consumers like `ActionPalette` read `e.currentTarget.selectionStart`, so it must not receive a div-sourced event.

## Testing
935 tests pass locally; `npm run typecheck` clean; prettier + eslint clean on changed files (0 errors). New coverage: the real `AppPaletteDialog.Body` key filter and focus guard, non-forwarded keys asserted uncancelled (not merely unhandled), Meta+Enter/Meta+Backspace surviving the forward, SearchablePalette's Tab remap (previously guarded by no test at all), and active-descendant IDREF resolution for the Panel and New Terminal wiring. The two existing Tab tests were kept and strengthened rather than inverted. They're the e7028aeb6 regression guard.

## Known gaps (deliberate)
- No E2E for native Tab traversal: PR CI doesn't run E2E, and verifying locally needs a full Electron build, so it would land unverified and only fire at release. The fix itself is fully covered in jsdom; only browser-native traversal isn't.
- Plugin quick-pick multi-select: Cmd+Enter on the results region confirms the highlighted row instead of submitting the checked set, because that path lives in SearchablePalette's input-only `onKeyDown` hatch. Not a regression (it previously did nothing at all); fixing it properly needs new API surface, so it's left for follow-up.
- `LogLevelPalette` rows render plain divs with no option IDs, so its `aria-activedescendant` doesn't resolve. Pre-existing, now mirrored onto a second element. Worth a separate fix.
- `AppPaletteDialog`'s window-level Tab-wrap effect doesn't respect `defaultPrevented`, and `PanelPalette`/`ResumeSessionsPalette` call `preventDefault()` without `stopPropagation()` on their Tab remap. Pre-existing, orthogonal, left alone.
