### PR TITLE
feat(worktree): identify worktrees outside the project directory

### DIFF
--- a/electron/workspace-host/SnapshotBuilder.ts
+++ b/electron/workspace-host/SnapshotBuilder.ts
@@ -66,6 +66,7 @@ export interface SnapshotBuilderHost {
   readonly fetchNetworkFailed: boolean;
   readonly isFetchInFlight: boolean;
   readonly matchedForgeProviderId: string | null;
+  readonly isExternal: boolean | undefined;
   readonly isWslPath: boolean;
   readonly wslDistro: string | undefined;
   readonly wslPosixPath: string | undefined;
@@ -176,6 +177,10 @@ export class SnapshotBuilder {
       // serializes the correct value, never a stale cached copy.
       isFetchInFlight: this.host.isFetchInFlight || undefined,
       matchedForgeProviderId: this.host.matchedForgeProviderId ?? undefined,
+      // Passed through verbatim rather than `|| undefined` like the flags above:
+      // false ("inside the boundary") and undefined ("boundary unknown") are
+      // distinct states, and collapsing them would lose that.
+      isExternal: this.host.isExternal,
       isWslPath: this.host.isWslPath || undefined,
       wslDistro: this.host.wslDistro,
       wslPosixPath: this.host.wslPosixPath,

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -824,6 +824,7 @@ export class WorkspaceService {
           existingMonitor.name = wt.name;
           existingMonitor.isCurrent = isActive;
           existingMonitor.isMainWorktree = wt.isMainWorktree ?? false;
+          existingMonitor.isExternal = wt.isExternal;
           // Keep the base-branch divergence fallback fresh if the main worktree
           // switched branches since this monitor was created.
           existingMonitor.setMainBranch(this.mainBranch);
@@ -2637,6 +2638,9 @@ export class WorkspaceService {
         isDetached: false,
         isCurrent: false,
         isMainWorktree: false,
+        // `assertWorktreePathContained` ran above, so this path is provably
+        // inside the boundary — no need to re-derive it from the root here.
+        isExternal: false,
         gitDir: (await getGitDir(canonicalPath)) || undefined,
       };
       const canonicalWorktreeId = createdWorktree.id;

--- a/electron/workspace-host/WorktreeListService.ts
+++ b/electron/workspace-host/WorktreeListService.ts
@@ -197,28 +197,36 @@ export class WorktreeListService {
   }
 
   /**
-   * Base for resolving a relative porcelain path. Git 2.48+'s
-   * `worktree.useRelativePaths` emits linked worktrees relative to the
-   * repository while the main worktree entry stays absolute, so that entry —
-   * not `projectRootPath`, which may itself be a linked worktree — is the
-   * correct base. Bare `pathResolve` would resolve against the host process
-   * cwd and mint a bogus worktree id.
+   * The main worktree is the project's own by definition and is never external,
+   * whatever the path math says. That matters when the opened project IS a
+   * linked worktree: the boundary is then that worktree's parent, which the
+   * repo's main worktree legitimately sits outside of. Deriving the flag purely
+   * from paths would badge the project's own main worktree as external — the
+   * failure mode #2251 was reverted for.
+   *
+   * A relative porcelain path stays unclassified. Git 2.48+'s
+   * `worktree.useRelativePaths` records linked worktrees relative to
+   * `$GIT_COMMON_DIR/worktrees/<id>/`, an admin directory whose id the porcelain
+   * output doesn't carry, so `normalizedPath` is untrustworthy here and the
+   * honest answer is "unknown" rather than a badge derived from a bad path.
    */
-  private static getRelativePathBase(rawWorktrees: RawWorktreeRecord[]): string | undefined {
-    const mainEntry = rawWorktrees.find((wt) => wt.isMainWorktree);
-    return mainEntry && isAbsolute(mainEntry.path) ? mainEntry.path : undefined;
+  private static classifyExternal(
+    wt: RawWorktreeRecord,
+    normalizedPath: string,
+    boundary: string | undefined
+  ): boolean | undefined {
+    if (boundary === undefined) return undefined;
+    if (wt.isMainWorktree) return false;
+    if (!isAbsolute(wt.path)) return undefined;
+    return !isPathInside(normalizedPath, boundary);
   }
 
   mapToWorktrees(rawWorktrees: RawWorktreeRecord[]): Promise<Worktree[]> {
     const boundary = this.getContainmentBoundary();
-    const relativeBase = WorktreeListService.getRelativePathBase(rawWorktrees);
 
     return Promise.all(
       rawWorktrees.map(async (wt) => {
-        const normalizedPath =
-          isAbsolute(wt.path) || !relativeBase
-            ? pathResolve(wt.path)
-            : pathResolve(relativeBase, wt.path);
+        const normalizedPath = pathResolve(wt.path);
         let name: string;
         if (wt.isMainWorktree) {
           name = normalizedPath.split(/[/\\]/).pop() || "Main";
@@ -239,7 +247,7 @@ export class WorktreeListService {
           isDetached: wt.isDetached,
           isCurrent: false,
           isMainWorktree: wt.isMainWorktree,
-          isExternal: boundary === undefined ? undefined : !isPathInside(normalizedPath, boundary),
+          isExternal: WorktreeListService.classifyExternal(wt, normalizedPath, boundary),
           gitDir: (await getGitDir(normalizedPath)) || undefined,
           isLocked: wt.isLocked,
           lockReason: wt.lockReason,

--- a/electron/workspace-host/WorktreeListService.ts
+++ b/electron/workspace-host/WorktreeListService.ts
@@ -1,6 +1,7 @@
-import { resolve as pathResolve } from "path";
+import { dirname, isAbsolute, resolve as pathResolve } from "path";
 import type { SimpleGit } from "simple-git";
 import type { Worktree } from "../../shared/types/worktree.js";
+import { isPathInside } from "../../shared/utils/path.js";
 import { getGitDir } from "../utils/gitUtils.js";
 
 const WORKTREE_LIST_CACHE_TTL_MS = 15_000;
@@ -180,10 +181,44 @@ export class WorktreeListService {
     }
   }
 
+  /**
+   * Directory every Daintree-created worktree is confined to, used to classify
+   * `isExternal`. Returns undefined when no boundary can be trusted: no project
+   * root, or a repo at the filesystem root (where the parent is the root itself
+   * and would accept every path on the system — same rejection as
+   * `assertWorktreePathContained`). Undefined means "unknown", so callers leave
+   * `isExternal` unset rather than flagging every worktree (#2251).
+   */
+  private getContainmentBoundary(): string | undefined {
+    if (!this.projectRootPath) return undefined;
+    const resolvedRoot = pathResolve(this.projectRootPath);
+    const parentDir = dirname(resolvedRoot);
+    return parentDir === resolvedRoot ? undefined : parentDir;
+  }
+
+  /**
+   * Base for resolving a relative porcelain path. Git 2.48+'s
+   * `worktree.useRelativePaths` emits linked worktrees relative to the
+   * repository while the main worktree entry stays absolute, so that entry —
+   * not `projectRootPath`, which may itself be a linked worktree — is the
+   * correct base. Bare `pathResolve` would resolve against the host process
+   * cwd and mint a bogus worktree id.
+   */
+  private static getRelativePathBase(rawWorktrees: RawWorktreeRecord[]): string | undefined {
+    const mainEntry = rawWorktrees.find((wt) => wt.isMainWorktree);
+    return mainEntry && isAbsolute(mainEntry.path) ? mainEntry.path : undefined;
+  }
+
   mapToWorktrees(rawWorktrees: RawWorktreeRecord[]): Promise<Worktree[]> {
+    const boundary = this.getContainmentBoundary();
+    const relativeBase = WorktreeListService.getRelativePathBase(rawWorktrees);
+
     return Promise.all(
       rawWorktrees.map(async (wt) => {
-        const normalizedPath = pathResolve(wt.path);
+        const normalizedPath =
+          isAbsolute(wt.path) || !relativeBase
+            ? pathResolve(wt.path)
+            : pathResolve(relativeBase, wt.path);
         let name: string;
         if (wt.isMainWorktree) {
           name = normalizedPath.split(/[/\\]/).pop() || "Main";
@@ -204,6 +239,7 @@ export class WorktreeListService {
           isDetached: wt.isDetached,
           isCurrent: false,
           isMainWorktree: wt.isMainWorktree,
+          isExternal: boundary === undefined ? undefined : !isPathInside(normalizedPath, boundary),
           gitDir: (await getGitDir(normalizedPath)) || undefined,
           isLocked: wt.isLocked,
           lockReason: wt.lockReason,

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -246,6 +246,10 @@ export class WorktreeMonitor {
   private _pendingPollPromise: Promise<void> | null = null;
   private _pollAbortController: AbortController = new AbortController();
 
+  // Tri-state on purpose: undefined means the containment boundary was unknown,
+  // which must stay distinct from a confirmed-internal false.
+  private _isExternal: boolean | undefined;
+
   // WSL routing state (Windows only)
   private _isWslPath: boolean = false;
   private _wslDistro: string | undefined;
@@ -292,6 +296,7 @@ export class WorktreeMonitor {
     this._gitDir = worktree.gitDir;
     this._isCurrent = worktree.isCurrent;
     this._isMainWorktree = Boolean(worktree.isMainWorktree);
+    this._isExternal = worktree.isExternal;
     this._isDetached = Boolean(worktree.isDetached);
     this._head = worktree.head;
     this.gitWatchEnabled = config.gitWatchEnabled ?? true;
@@ -570,6 +575,9 @@ export class WorktreeMonitor {
       },
       get matchedForgeProviderId() {
         return monitor._matchedForgeProviderId;
+      },
+      get isExternal() {
+        return monitor._isExternal;
       },
       get isWslPath() {
         return monitor._isWslPath;
@@ -1026,6 +1034,14 @@ export class WorktreeMonitor {
 
   set isMainWorktree(value: boolean) {
     this._isMainWorktree = value;
+  }
+
+  get isExternal(): boolean | undefined {
+    return this._isExternal;
+  }
+
+  set isExternal(value: boolean | undefined) {
+    this._isExternal = value;
   }
 
   get isRunning(): boolean {

--- a/electron/workspace-host/__tests__/SnapshotBuilder.test.ts
+++ b/electron/workspace-host/__tests__/SnapshotBuilder.test.ts
@@ -57,6 +57,7 @@ function makeHost(overrides: Partial<SnapshotBuilderHost> = {}): SnapshotBuilder
     fetchNetworkFailed: false,
     isFetchInFlight: false,
     matchedForgeProviderId: null,
+    isExternal: undefined,
     isWslPath: false,
     wslDistro: undefined,
     wslPosixPath: undefined,
@@ -211,5 +212,15 @@ describe("SnapshotBuilder", () => {
 
     const stamped = makeHost({ workingTreeChangedAt: 1_725_000_000_000 });
     expect(new SnapshotBuilder(stamped).build().workingTreeChangedAt).toBe(1_725_000_000_000);
+  });
+
+  it("passes isExternal through without collapsing false into undefined", () => {
+    // Unlike the neighbouring `|| undefined` flags, false ("inside the boundary")
+    // and undefined ("boundary unknown") are distinct states downstream.
+    expect(new SnapshotBuilder(makeHost({ isExternal: true })).build().isExternal).toBe(true);
+    expect(new SnapshotBuilder(makeHost({ isExternal: false })).build().isExternal).toBe(false);
+    expect(
+      new SnapshotBuilder(makeHost({ isExternal: undefined })).build().isExternal
+    ).toBeUndefined();
   });
 });

--- a/electron/workspace-host/__tests__/WorktreeListService.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeListService.test.ts
@@ -324,6 +324,35 @@ describe("WorktreeListService", () => {
       expect(worktrees[1].isExternal).toBe(true);
     });
 
+    it("never flags the main worktree, even when it sits outside the boundary", async () => {
+      // Opening a linked worktree as the project puts the boundary at that
+      // worktree's parent, which the repo's own main worktree legitimately sits
+      // outside of. The project's main worktree is never "outside the project".
+      const linkedRoot = path.resolve("/projects/my-repo-worktrees/feature-a");
+      service.setGit(mockGit, linkedRoot);
+      const raw = [
+        {
+          path: path.resolve("/projects/my-repo"),
+          branch: "main",
+          bare: false,
+          isMainWorktree: true,
+        },
+        { path: linkedRoot, branch: "feature/a", bare: false, isMainWorktree: false },
+        {
+          path: path.resolve("/var/tmp/scratch/bench-baseline"),
+          branch: "develop",
+          bare: false,
+          isMainWorktree: false,
+        },
+      ];
+
+      const worktrees = await service.mapToWorktrees(raw);
+
+      expect(worktrees[0].isExternal).toBe(false);
+      expect(worktrees[1].isExternal).toBe(false);
+      expect(worktrees[2].isExternal).toBe(true);
+    });
+
     it("treats worktrees anywhere under the parent directory as internal", async () => {
       service.setGit(mockGit, projectRoot);
       const parentDir = path.dirname(projectRoot);
@@ -404,14 +433,15 @@ describe("WorktreeListService", () => {
       expect(worktrees.every((w) => w.isExternal === undefined)).toBe(true);
     });
 
-    it("resolves a relative porcelain path against the main worktree, not the host cwd", async () => {
-      // Git 2.48+ `worktree.useRelativePaths` emits linked worktrees relative to
-      // the repository while the main entry stays absolute.
+    it("leaves a relative porcelain path unclassified rather than guessing", async () => {
+      // Git 2.48+ `worktree.useRelativePaths` records linked worktrees relative
+      // to `$GIT_COMMON_DIR/worktrees/<id>/`, an admin dir the porcelain output
+      // doesn't name — so the resolved path can't be trusted to classify against.
       service.setGit(mockGit, projectRoot);
       const raw = [
         { path: projectRoot, branch: "main", bare: false, isMainWorktree: true },
         {
-          path: path.join("..", "my-repo-worktrees", "feature-a"),
+          path: path.join("..", "..", "..", "my-repo-worktrees", "feature-a"),
           branch: "feature/a",
           bare: false,
           isMainWorktree: false,
@@ -420,21 +450,8 @@ describe("WorktreeListService", () => {
 
       const worktrees = await service.mapToWorktrees(raw);
 
-      expect(worktrees[1].id).toBe(
-        path.resolve(projectRoot, "..", "my-repo-worktrees", "feature-a")
-      );
-      expect(worktrees[1].path).toBe(worktrees[1].id);
-      expect(worktrees[1].isExternal).toBe(false);
-    });
-
-    it("falls back to cwd resolution for a relative path with no absolute main entry", async () => {
-      service.setGit(mockGit, projectRoot);
-      const relative = path.join("detached", "worktree");
-      const raw = [{ path: relative, branch: "feature/a", bare: false, isMainWorktree: false }];
-
-      const worktrees = await service.mapToWorktrees(raw);
-
-      expect(worktrees[0].id).toBe(path.resolve(relative));
+      expect(worktrees[0].isExternal).toBe(false);
+      expect(worktrees[1].isExternal).toBeUndefined();
     });
   });
 });

--- a/electron/workspace-host/__tests__/WorktreeListService.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeListService.test.ts
@@ -302,4 +302,139 @@ describe("WorktreeListService", () => {
       expect(worktrees[1].prunableReason).toBe("stale");
     });
   });
+
+  describe("mapToWorktrees external classification", () => {
+    const projectRoot = path.resolve("/projects/my-repo");
+
+    it("flags a worktree outside the repository's parent directory", async () => {
+      service.setGit(mockGit, projectRoot);
+      const raw = [
+        { path: projectRoot, branch: "main", bare: false, isMainWorktree: true },
+        {
+          path: path.resolve("/var/tmp/scratch/bench-baseline"),
+          branch: "develop",
+          bare: false,
+          isMainWorktree: false,
+        },
+      ];
+
+      const worktrees = await service.mapToWorktrees(raw);
+
+      expect(worktrees[0].isExternal).toBe(false);
+      expect(worktrees[1].isExternal).toBe(true);
+    });
+
+    it("treats worktrees anywhere under the parent directory as internal", async () => {
+      service.setGit(mockGit, projectRoot);
+      const parentDir = path.dirname(projectRoot);
+      const raw = [
+        { path: projectRoot, branch: "main", bare: false, isMainWorktree: true },
+        {
+          path: path.join(parentDir, "my-repo-worktrees", "feature-a"),
+          branch: "feature/a",
+          bare: false,
+          isMainWorktree: false,
+        },
+        {
+          path: path.join(parentDir, "somewhere", "deeply", "nested"),
+          branch: "feature/b",
+          bare: false,
+          isMainWorktree: false,
+        },
+      ];
+
+      const worktrees = await service.mapToWorktrees(raw);
+
+      expect(worktrees.map((w) => w.isExternal)).toEqual([false, false, false]);
+    });
+
+    it("does not admit a sibling whose name merely extends the parent directory", async () => {
+      service.setGit(mockGit, projectRoot);
+      const parentDir = path.dirname(projectRoot);
+      const raw = [
+        { path: projectRoot, branch: "main", bare: false, isMainWorktree: true },
+        {
+          path: `${parentDir}-other${path.sep}feature`,
+          branch: "feature/a",
+          bare: false,
+          isMainWorktree: false,
+        },
+      ];
+
+      const worktrees = await service.mapToWorktrees(raw);
+
+      expect(worktrees[1].isExternal).toBe(true);
+    });
+
+    it("leaves classification unset for every worktree when projectRootPath is null", async () => {
+      service.setGit(mockGit, null);
+      const raw = [
+        { path: projectRoot, branch: "main", bare: false, isMainWorktree: true },
+        {
+          path: path.resolve("/var/tmp/scratch/bench-baseline"),
+          branch: "develop",
+          bare: false,
+          isMainWorktree: false,
+        },
+      ];
+
+      const worktrees = await service.mapToWorktrees(raw);
+
+      // Unknown boundary must never resolve to "everything is external" (#2251).
+      expect(worktrees.every((w) => w.isExternal === undefined)).toBe(true);
+    });
+
+    it("leaves classification unset when the repository sits at the filesystem root", async () => {
+      // The parent of a filesystem-root repo is the root itself, which would
+      // accept every path on the system — the same case `assertWorktreePathContained`
+      // refuses rather than degrading to an open boundary.
+      service.setGit(mockGit, path.resolve("/"));
+      const raw = [
+        { path: path.resolve("/"), branch: "main", bare: false, isMainWorktree: true },
+        {
+          path: path.resolve("/var/tmp/scratch/bench-baseline"),
+          branch: "develop",
+          bare: false,
+          isMainWorktree: false,
+        },
+      ];
+
+      const worktrees = await service.mapToWorktrees(raw);
+
+      expect(worktrees.every((w) => w.isExternal === undefined)).toBe(true);
+    });
+
+    it("resolves a relative porcelain path against the main worktree, not the host cwd", async () => {
+      // Git 2.48+ `worktree.useRelativePaths` emits linked worktrees relative to
+      // the repository while the main entry stays absolute.
+      service.setGit(mockGit, projectRoot);
+      const raw = [
+        { path: projectRoot, branch: "main", bare: false, isMainWorktree: true },
+        {
+          path: path.join("..", "my-repo-worktrees", "feature-a"),
+          branch: "feature/a",
+          bare: false,
+          isMainWorktree: false,
+        },
+      ];
+
+      const worktrees = await service.mapToWorktrees(raw);
+
+      expect(worktrees[1].id).toBe(
+        path.resolve(projectRoot, "..", "my-repo-worktrees", "feature-a")
+      );
+      expect(worktrees[1].path).toBe(worktrees[1].id);
+      expect(worktrees[1].isExternal).toBe(false);
+    });
+
+    it("falls back to cwd resolution for a relative path with no absolute main entry", async () => {
+      service.setGit(mockGit, projectRoot);
+      const relative = path.join("detached", "worktree");
+      const raw = [{ path: relative, branch: "feature/a", bare: false, isMainWorktree: false }];
+
+      const worktrees = await service.mapToWorktrees(raw);
+
+      expect(worktrees[0].id).toBe(path.resolve(relative));
+    });
+  });
 });

--- a/electron/workspace-host/__tests__/WorktreeMonitor.snapshotState.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.snapshotState.test.ts
@@ -973,4 +973,47 @@ describe("WorktreeMonitor", () => {
       monitor.stop();
     });
   });
+
+  describe("external classification (#11434)", () => {
+    // The monitor copies selected Worktree fields into private state rather than
+    // retaining the object, so a field it doesn't copy never reaches a snapshot.
+    it("carries the constructor's classification into the snapshot", () => {
+      const external = new WorktreeMonitor(
+        { ...TEST_WORKTREE, isExternal: true },
+        TEST_CONFIG,
+        makeCallbacks(),
+        "main"
+      );
+      const internal = new WorktreeMonitor(
+        { ...TEST_WORKTREE, isExternal: false },
+        TEST_CONFIG,
+        makeCallbacks(),
+        "main"
+      );
+
+      expect(external.getSnapshot().isExternal).toBe(true);
+      expect(internal.getSnapshot().isExternal).toBe(false);
+    });
+
+    it("keeps an unknown classification unknown rather than coercing it to false", () => {
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, makeCallbacks(), "main");
+
+      expect(monitor.getSnapshot().isExternal).toBeUndefined();
+    });
+
+    it("reflects a reconciled classification through the setter", () => {
+      const monitor = new WorktreeMonitor(
+        { ...TEST_WORKTREE, isExternal: false },
+        TEST_CONFIG,
+        makeCallbacks(),
+        "main"
+      );
+
+      monitor.isExternal = true;
+      expect(monitor.getSnapshot().isExternal).toBe(true);
+
+      monitor.isExternal = undefined;
+      expect(monitor.getSnapshot().isExternal).toBeUndefined();
+    });
+  });
 });

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -91,9 +91,9 @@ export interface WorktreeSnapshot {
   isCurrent: boolean;
   /**
    * Whether this is the main worktree (project permanent worktree).
-   * Determined by canonical path match with project root, not git primary status.
+   * Taken from git's first `worktree list --porcelain` entry, which is always
+   * the main worktree — not a path match against the project root (#2251).
    * Main worktrees are protected from deletion and cleanup operations.
-   * False when project root path is unavailable (no protection applied).
    */
   isMainWorktree?: boolean;
   gitDir?: string;
@@ -244,6 +244,13 @@ export interface WorktreeSnapshot {
 
   /** Cached display label for the environment (e.g., "Docker", "Akash") */
   worktreeEnvironmentLabel?: string;
+
+  /**
+   * True when the worktree lives outside `dirname(projectRootPath)` — git
+   * reports it, but Daintree did not place it (mirrors `Worktree.isExternal`).
+   * `undefined` when the boundary is unknown; only `true` means external.
+   */
+  isExternal?: boolean;
 
   /** True when the worktree path is mounted via \\wsl$\ or \\wsl.localhost\. */
   isWslPath?: boolean;

--- a/shared/types/worktree.ts
+++ b/shared/types/worktree.ts
@@ -134,9 +134,11 @@ export interface Worktree {
 
   /**
    * Whether this is the main worktree (project permanent worktree).
-   * Determined by canonical path match with project root, not git primary status.
+   * Taken from git's first `worktree list --porcelain` entry, which is always
+   * the main worktree — not a path match against the project root (#2251: the
+   * path-canonicalization variant failed closed and dropped delete protection
+   * for every row when the root was unavailable).
    * Main worktrees are protected from deletion and cleanup operations.
-   * False when project root path is unavailable (no protection applied).
    */
   isMainWorktree?: boolean;
 
@@ -329,6 +331,17 @@ export interface Worktree {
 
   /** Cached display label for the environment (e.g., "Docker", "Akash") */
   worktreeEnvironmentLabel?: string;
+
+  /**
+   * True when `path` falls outside `dirname(projectRootPath)` — the boundary
+   * every Daintree-created worktree is structurally confined to, since
+   * `validatePathPattern` rejects any pattern that escapes `{parent-dir}` and
+   * `assertWorktreePathContained` enforces it on create. Marks a worktree git
+   * reports but Daintree did not place (e.g. an agent's scratch worktree).
+   * `undefined` when the boundary can't be determined; consumers must treat
+   * only `true` as external so an unresolvable root can never flag the list.
+   */
+  isExternal?: boolean;
 
   /**
    * True when the worktree path is mounted via WSL (\\wsl$\… or

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -79,6 +79,7 @@ import {
   sortWorktreesByRelevance,
   groupByType,
   findIntegrationWorktree,
+  isExternalWorktree,
   scoreWorktree,
   computeChipCounts,
   type DerivedWorktreeMeta,
@@ -1259,6 +1260,9 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const sidebarItems = useMemo<SidebarFlatItem[]>(() => {
     const items: SidebarFlatItem[] = [];
     const pinnedSet = new Set(pinnedWorktrees);
+    // External worktrees sort below the pinned area regardless of a leftover pin
+    // entry, so their rows must not claim pinned affordances either (#11434).
+    const isRowPinned = (w: WorktreeState) => pinnedSet.has(w.id) && !isExternalWorktree(w);
     let nextRowIndex = firstScrollableRowIndex;
 
     // Deleted worktrees anchor their row to the live neighbour it sat above
@@ -1311,7 +1315,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
             worktreeId: w.id,
             ariaRowIndex: nextRowIndex++,
             rowIndex: orderIndex.get(w.id) ?? -1,
-            isPinned: pinnedSet.has(w.id),
+            isPinned: isRowPinned(w),
             mode: "static",
           });
         }
@@ -1335,7 +1339,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         worktreeId: w.id,
         ariaRowIndex: nextRowIndex++,
         rowIndex: i,
-        isPinned: pinnedSet.has(w.id),
+        isPinned: isRowPinned(w),
         mode: "sortable",
       });
     }

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -29,6 +29,7 @@ import { actionService } from "@/services/ActionService";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { cn } from "../../lib/utils";
+import { isExternalWorktree } from "@/lib/worktreeFilters";
 import { getAgentConfig, getAgentIds } from "@/config/agents";
 import { isAssistantOnlyAgentId } from "@shared/config/agentIds";
 import { getAgentSettingsEntry } from "@/types";
@@ -186,9 +187,15 @@ export function WorktreeCard({
       ? resourceEnvironments?.[worktree.worktreeMode]?.icon
       : undefined;
 
-  const isPinned = useWorktreeFilterStore((state) => state.pinnedWorktrees.includes(worktree.id));
+  const isPinnedStored = useWorktreeFilterStore((state) =>
+    state.pinnedWorktrees.includes(worktree.id)
+  );
   const pinWorktree = useWorktreeFilterStore((state) => state.pinWorktree);
   const unpinWorktree = useWorktreeFilterStore((state) => state.unpinWorktree);
+  const isExternal = isExternalWorktree(worktree);
+  // Pinning can't lift an external worktree out of the bottom partition, so a
+  // leftover pin entry must not render as pinned either (#11434).
+  const isPinned = isPinnedStored && !isExternal;
 
   const isCollapsed = useWorktreeFilterStore((state) =>
     state.collapsedWorktrees.includes(worktree.id)
@@ -747,7 +754,7 @@ export function WorktreeCard({
     onCompareDiff: () => useWorktreeSelectionStore.getState().openCrossWorktreeDiff(worktree.id),
     onRunRecipe: (recipeId) => void handleRunRecipe(recipeId),
     onSaveLayout,
-    onTogglePin: handleTogglePin,
+    onTogglePin: isExternal ? undefined : handleTogglePin,
     onToggleCollapse: canCollapse ? () => toggleWorktreeCollapsed(worktree.id) : undefined,
     isCollapsed: effectiveIsCollapsed,
     onLaunchAgent,

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -7,6 +7,7 @@ import { STATE_LABELS, STATE_PRIORITY } from "../terminalStateConfig";
 import { BranchLabel } from "../BranchLabel";
 import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
 import { Sprout, Pin, BellOff, RefreshCw } from "lucide-react";
+import { FolderOutput } from "@/components/icons";
 import type { AggregateCounts } from "./MainWorktreeSummaryRows";
 import { IssueBadge } from "./IssueBadge";
 import { PRBadge } from "./PRBadge";
@@ -14,7 +15,7 @@ import { EnvironmentPopover } from "./EnvironmentPopover";
 import { DevServerIndicator } from "./DevServerIndicator";
 import { CollapsedSessionIndicators } from "./CollapsedSessionIndicators";
 import { CollapsedAlarmPill } from "./CollapsedAlarmPill";
-import { isLiveDevServerStatus } from "@/lib/worktreeFilters";
+import { isExternalWorktree, isLiveDevServerStatus } from "@/lib/worktreeFilters";
 import type { DevPreviewSessionState } from "@shared/types/ipc/devPreview";
 import { WorktreeActionsToolbar } from "./WorktreeActionsToolbar";
 import { MainWorktreeSecondaryRow } from "./MainWorktreeSecondaryRow";
@@ -220,6 +221,7 @@ export function WorktreeHeader({
     (worktree.matchedForgeProviderId != null || worktree.linked?.providerId != null)
   );
   const isMainStandardLayout = !!(isMainOnStandardBranch && !hasDisplayTitle);
+  const isExternal = isExternalWorktree(worktree);
 
   const prState = worktree.linked?.pr?.state;
   const isPrLive = prState !== undefined && prState !== "closed" && prState !== "declined";
@@ -321,6 +323,7 @@ export function WorktreeHeader({
         </div>
 
         {((isPinned && !isMainWorktree) ||
+          isExternal ||
           isProjectNotificationsMuted ||
           (worktree.worktreeMode && worktree.worktreeMode !== "local") ||
           resourceStatusLabel ||
@@ -333,6 +336,28 @@ export function WorktreeHeader({
                 className="w-3.5 h-3.5 text-daintree-text/40 shrink-0 pointer-events-none"
                 aria-label="Pinned"
               />
+            )}
+            {isExternal && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    role="img"
+                    aria-label={`External worktree at ${worktree.path}`}
+                    className="shrink-0 leading-none"
+                  >
+                    <FolderOutput
+                      className="w-3.5 h-3.5 text-daintree-text/40"
+                      aria-hidden="true"
+                    />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="max-w-xs">
+                  <span className="block">Outside the project directory</span>
+                  <span className="mt-0.5 block font-mono text-[11px] break-all">
+                    {worktree.path}
+                  </span>
+                </TooltipContent>
+              </Tooltip>
             )}
             {isProjectNotificationsMuted && (
               <BellOff

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -1543,3 +1543,39 @@ describe("WorktreeHeader blocking-op passive indicator (#10921)", () => {
     expect(screen.queryByRole("button", { name: /^Abort / })).toBeNull();
   });
 });
+
+describe("WorktreeHeader external indicator", () => {
+  const externalPath = "/private/tmp/claude-501/session/scratchpad/bench-baseline";
+  const externalWorktree: WorktreeState = {
+    ...baseWorktree,
+    path: externalPath,
+    isExternal: true,
+  };
+
+  it("names the worktree's location so 'where' is discoverable, not just 'that'", () => {
+    renderHeader({ worktree: externalWorktree });
+
+    const indicator = screen.getByRole("img", { name: /external worktree/i });
+    expect(indicator.getAttribute("aria-label")).toContain(externalPath);
+  });
+
+  it("stays visible on a collapsed card", () => {
+    renderHeader({ worktree: externalWorktree, isCollapsed: true });
+
+    expect(screen.getByRole("img", { name: /external worktree/i })).toBeDefined();
+  });
+
+  it("stays visible in the grid variant", () => {
+    renderHeader({ worktree: externalWorktree, variant: "grid" });
+
+    expect(screen.getByRole("img", { name: /external worktree/i })).toBeDefined();
+  });
+
+  it("is absent for an internal worktree and for unknown classification", () => {
+    renderHeader({ worktree: { ...baseWorktree, isExternal: false } });
+    expect(screen.queryByRole("img", { name: /external worktree/i })).toBeNull();
+
+    renderHeader({ worktree: { ...baseWorktree, isExternal: undefined } });
+    expect(screen.queryByRole("img", { name: /external worktree/i })).toBeNull();
+  });
+});

--- a/src/components/Worktree/WorktreeMenuItems.tsx
+++ b/src/components/Worktree/WorktreeMenuItems.tsx
@@ -50,6 +50,7 @@ import {
   Zap,
 } from "lucide-react";
 import { Folders, Workflow } from "@/components/icons";
+import { isExternalWorktree } from "@/lib/worktreeFilters";
 import { PluginContextMenuSection } from "@/components/Plugin/PluginContextMenuSection";
 import type { PluginContextMenuItemEntry } from "@/hooks/usePluginContextMenuItems";
 
@@ -530,7 +531,7 @@ export function WorktreeMenuItems({
         Copy Path
       </C.Item>
 
-      {onTogglePin && !worktree.isMainWorktree && (
+      {onTogglePin && !worktree.isMainWorktree && !isExternalWorktree(worktree) && (
         <C.Item onSelect={onTogglePin}>
           {isPinned ? (
             <>

--- a/src/components/Worktree/__tests__/WorktreeMenuItems.pin.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeMenuItems.pin.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type * as React from "react";
+import { render, screen, cleanup } from "@testing-library/react";
+import type { WorktreeState } from "../../../types";
+import { WorktreeMenuItems, type WorktreeMenuComponents } from "../WorktreeMenuItems";
+
+vi.mock("@/components/Plugin/PluginContextMenuSection", () => ({
+  PluginContextMenuSection: () => null,
+}));
+
+afterEach(cleanup);
+
+const components: WorktreeMenuComponents = {
+  Item: ({ children, onSelect }: { children?: React.ReactNode; onSelect?: () => void }) => (
+    <button type="button" onClick={onSelect}>
+      {children}
+    </button>
+  ),
+  Label: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  Separator: () => <hr />,
+  Shortcut: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
+  Sub: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  SubTrigger: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  SubContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+};
+
+function makeWorktree(overrides: Partial<WorktreeState> = {}): WorktreeState {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- WorktreeState has ~60 fields and this render layer reads four of them; the sibling WorktreeMenuItems test builds its fixture the same way.
+  return {
+    id: "wt-1",
+    name: "feature",
+    path: "/repo/wt-1",
+    branch: "feature",
+    ...overrides,
+  } as WorktreeState;
+}
+
+function renderMenu(worktree: WorktreeState, onTogglePin?: () => void, isPinned = false) {
+  return render(
+    <WorktreeMenuItems
+      worktree={worktree}
+      components={components}
+      launchAgents={[]}
+      recipes={[]}
+      runningRecipeId={null}
+      counts={{ grid: 0, dock: 0, active: 0, completed: 0, all: 0, waiting: 0, working: 0 }}
+      onCopyContextFull={vi.fn()}
+      onCopyContextModified={vi.fn()}
+      onCopyPath={vi.fn()}
+      onOpenEditor={vi.fn()}
+      onRevealInFinder={vi.fn()}
+      onRunRecipe={vi.fn()}
+      onDockAll={vi.fn()}
+      onMaximizeAll={vi.fn()}
+      onResetRenderers={vi.fn()}
+      onSelectAllAgents={vi.fn()}
+      onSelectWaitingAgents={vi.fn()}
+      onSelectWorkingAgents={vi.fn()}
+      onCloseAll={vi.fn()}
+      onTerminateAll={vi.fn()}
+      onClearHistory={vi.fn()}
+      onTogglePin={onTogglePin}
+      isPinned={isPinned}
+    />
+  );
+}
+
+describe("WorktreeMenuItems — pin suppression for external worktrees (#11434)", () => {
+  it("offers the pin action for an internal non-main worktree", () => {
+    renderMenu(makeWorktree(), vi.fn());
+
+    expect(screen.queryByText("Pin to Top")).not.toBeNull();
+  });
+
+  it("withholds the pin action for an external worktree even when a callback is supplied", () => {
+    // Sorting already sinks external worktrees below the pinned area, so an
+    // offered pin command would be a no-op the user can't explain.
+    renderMenu(makeWorktree({ isExternal: true }), vi.fn());
+
+    expect(screen.queryByText("Pin to Top")).toBeNull();
+  });
+
+  it("withholds the unpin action for an external worktree carrying a stale pin", () => {
+    renderMenu(makeWorktree({ isExternal: true }), vi.fn(), true);
+
+    expect(screen.queryByText("Unpin")).toBeNull();
+  });
+
+  it("keeps offering the pin action when classification is unknown", () => {
+    renderMenu(makeWorktree({ isExternal: undefined }), vi.fn());
+
+    expect(screen.queryByText("Pin to Top")).not.toBeNull();
+  });
+});

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -13,6 +13,7 @@ export {
   FileText, // view selected file path in the read-only file viewer
   FolderGit2, // git worktree (single)
   FolderOpen, // reveal in file manager (Finder / Explorer / file manager)
+  FolderOutput, // worktree living outside the project directory (external)
   Folders, // copy tree / file hierarchy capture (two overlapping folders)
   GitPullRequest, // forge provider / code-host plugin category
   History, // resume closed session / session history

--- a/src/lib/__tests__/worktreeCyclingOrder.test.ts
+++ b/src/lib/__tests__/worktreeCyclingOrder.test.ts
@@ -114,6 +114,45 @@ describe("getVisibleWorktreesForCycling", () => {
     expect(ordered.map((w) => w.id)).toEqual(["main", "dev", "wt-a", "wt-b"]);
   });
 
+  it("cycles to external worktrees last and never into the integration slot (#11434)", () => {
+    // Keyboard cycling must match the rendered order, and an external worktree
+    // on develop must not claim the integration slot ahead of everything else.
+    setWorktrees([
+      createSnapshot({
+        id: "ext",
+        name: "bench-baseline",
+        branch: "develop",
+        path: "/private/tmp/scratch/bench-baseline",
+        isExternal: true,
+        createdAt: 300,
+      }),
+      createSnapshot({ id: "main", name: "main", branch: "main", isMainWorktree: true }),
+      createSnapshot({ id: "wt-a", name: "alpha", branch: "feature/alpha", createdAt: 200 }),
+    ]);
+
+    const ordered = getVisibleWorktreesForCycling();
+
+    expect(ordered.map((w) => w.id)).toEqual(["main", "wt-a", "ext"]);
+  });
+
+  it("keeps external worktrees last in grouped mode", () => {
+    useWorktreeFilterStore.setState({ groupByType: true, orderBy: "alpha" });
+    setWorktrees([
+      createSnapshot({ id: "main", name: "main", branch: "main", isMainWorktree: true }),
+      createSnapshot({
+        id: "ext-feat",
+        name: "aaa-scratch",
+        branch: "feature/scratch",
+        isExternal: true,
+      }),
+      createSnapshot({ id: "int-bug", name: "zzz-bug", branch: "bugfix/z" }),
+    ]);
+
+    const ordered = getVisibleWorktreesForCycling();
+
+    expect(ordered.map((w) => w.id)).toEqual(["main", "int-bug", "ext-feat"]);
+  });
+
   it("sorts non-main worktrees alphabetically when orderBy is alpha", () => {
     useWorktreeFilterStore.setState({ orderBy: "alpha" });
     setWorktrees([

--- a/src/lib/__tests__/worktreeFilters.test.ts
+++ b/src/lib/__tests__/worktreeFilters.test.ts
@@ -16,9 +16,11 @@ import {
   compareWorktreeNames,
   matchesDevServerFilter,
   isLiveDevServerStatus,
+  isExternalWorktree,
   type DerivedWorktreeMeta,
   type FilterState,
 } from "../worktreeFilters";
+import type { OrderBy } from "@/store/worktreeFilterStore";
 import type { Worktree } from "@shared/types/worktree";
 import type {
   StatusFilter,
@@ -407,6 +409,54 @@ describe("sortWorktreesByRelevance", () => {
     // Both score 4 (name starts-with), main first via sortWorktrees tiebreaker
     expect(result[0]!.id).toBe("1");
     expect(result[1]!.id).toBe("2");
+  });
+
+  it("keeps external worktrees last even when they score higher", () => {
+    const worktrees = [
+      // Scores higher: issueTitle starts-with "auth" beats a mere contains match.
+      createMockWorktree({
+        id: "ext",
+        name: "scratch",
+        issueTitle: "Auth rewrite",
+        isExternal: true,
+      }),
+      createMockWorktree({ id: "int", name: "feature", issueTitle: "Fix database auth" }),
+    ];
+
+    const result = sortWorktreesByRelevance(worktrees, "auth", "alpha");
+
+    expect(result.map((w) => w.id)).toEqual(["int", "ext"]);
+  });
+
+  it("still ranks external worktrees among themselves by score", () => {
+    const worktrees = [
+      createMockWorktree({
+        id: "ext-low",
+        name: "scratch",
+        issueTitle: "Fix database auth",
+        isExternal: true,
+      }),
+      createMockWorktree({
+        id: "ext-high",
+        name: "bench",
+        issueTitle: "Auth rewrite",
+        isExternal: true,
+      }),
+      createMockWorktree({ id: "int", name: "feature", issueTitle: "Unrelated" }),
+    ];
+
+    const result = sortWorktreesByRelevance(worktrees, "auth", "alpha");
+
+    expect(result.map((w) => w.id)).toEqual(["int", "ext-high", "ext-low"]);
+  });
+});
+
+describe("isExternalWorktree", () => {
+  it("treats only an explicit true as external", () => {
+    expect(isExternalWorktree(createMockWorktree({ isExternal: true }))).toBe(true);
+    expect(isExternalWorktree(createMockWorktree({ isExternal: false }))).toBe(false);
+    expect(isExternalWorktree(createMockWorktree({ isExternal: undefined }))).toBe(false);
+    expect(isExternalWorktree(createMockWorktree())).toBe(false);
   });
 });
 
@@ -914,6 +964,89 @@ describe("sortWorktrees", () => {
       expect(sorted.map((w) => w.name)).toEqual(["a", "b"]);
     });
   });
+
+  describe("external worktrees", () => {
+    const orderModes: OrderBy[] = ["alpha", "created", "recent", "manual"];
+
+    it.each(orderModes)("sinks external worktrees below internal ones (%s)", (orderBy) => {
+      const worktrees = [
+        createMockWorktree({
+          id: "ext",
+          name: "a-external",
+          isExternal: true,
+          createdAt: 9000,
+          lastActivityTimestamp: 9000,
+        }),
+        createMockWorktree({
+          id: "int",
+          name: "z-internal",
+          createdAt: 1000,
+          lastActivityTimestamp: 1000,
+        }),
+      ];
+
+      const sorted = sortWorktrees(worktrees, orderBy, [], ["ext", "int"]);
+
+      expect(sorted.map((w) => w.id)).toEqual(["int", "ext"]);
+    });
+
+    it("keeps the main worktree above external worktrees", () => {
+      const worktrees = [
+        createMockWorktree({ id: "ext", name: "a-external", isExternal: true }),
+        createMockWorktree({ id: "main", name: "z-main", isMainWorktree: true }),
+      ];
+
+      const sorted = sortWorktrees(worktrees, "alpha", []);
+
+      expect(sorted.map((w) => w.id)).toEqual(["main", "ext"]);
+    });
+
+    it("ignores a pin entry on an external worktree", () => {
+      const worktrees = [
+        createMockWorktree({ id: "ext", name: "a-external", isExternal: true }),
+        createMockWorktree({ id: "int", name: "z-internal" }),
+      ];
+
+      const sorted = sortWorktrees(worktrees, "alpha", ["ext"]);
+
+      expect(sorted.map((w) => w.id)).toEqual(["int", "ext"]);
+    });
+
+    it("keeps pin ordering among internal worktrees while external stays last", () => {
+      const worktrees = [
+        createMockWorktree({ id: "ext", name: "a-external", isExternal: true }),
+        createMockWorktree({ id: "int-a", name: "b-internal" }),
+        createMockWorktree({ id: "int-b", name: "c-internal" }),
+      ];
+
+      const sorted = sortWorktrees(worktrees, "alpha", ["int-b"]);
+
+      expect(sorted.map((w) => w.id)).toEqual(["int-b", "int-a", "ext"]);
+    });
+
+    it("orders external worktrees among themselves by the active sort mode", () => {
+      const worktrees = [
+        createMockWorktree({ id: "ext-z", name: "z-external", isExternal: true }),
+        createMockWorktree({ id: "ext-a", name: "a-external", isExternal: true }),
+        createMockWorktree({ id: "int", name: "m-internal" }),
+      ];
+
+      const sorted = sortWorktrees(worktrees, "alpha", []);
+
+      expect(sorted.map((w) => w.id)).toEqual(["int", "ext-a", "ext-z"]);
+    });
+
+    it("does not demote a worktree whose classification is unknown", () => {
+      const worktrees = [
+        createMockWorktree({ id: "unknown", name: "a-unknown", isExternal: undefined }),
+        createMockWorktree({ id: "internal", name: "z-internal", isExternal: false }),
+      ];
+
+      const sorted = sortWorktrees(worktrees, "alpha", []);
+
+      expect(sorted.map((w) => w.id)).toEqual(["unknown", "internal"]);
+    });
+  });
 });
 
 describe("sortWorktrees manual order", () => {
@@ -1027,6 +1160,46 @@ describe("groupByType", () => {
     expect(groups.length).toBe(1);
     expect(groups.every((g) => g.worktrees.length > 0)).toBe(true);
   });
+
+  it("collects external worktrees into a trailing section instead of their branch type", () => {
+    // Section order outranks the per-group comparator, so leaving an external
+    // feature worktree in "Features" would render it above internal bugfixes.
+    const worktrees = [
+      createMockWorktree({ id: "ext-feat", branch: "feature/scratch", isExternal: true }),
+      createMockWorktree({ id: "int-bug", branch: "bugfix/b" }),
+      createMockWorktree({ id: "int-feat", branch: "feature/a" }),
+    ];
+
+    const groups = groupByType(worktrees, "alpha");
+
+    const lastSection = groups[groups.length - 1]!;
+    expect(lastSection.worktrees.map((w) => w.id)).toEqual(["ext-feat"]);
+    expect(groups.slice(0, -1).flatMap((g) => g.worktrees.map((w) => w.id))).toEqual([
+      "int-feat",
+      "int-bug",
+    ]);
+  });
+
+  it("omits the external section when nothing is external", () => {
+    const worktrees = [
+      createMockWorktree({ id: "1", branch: "feature/a" }),
+      createMockWorktree({ id: "2", branch: "bugfix/b", isExternal: false }),
+    ];
+
+    const groups = groupByType(worktrees, "alpha");
+
+    expect(groups.some((g) => g.type === "external")).toBe(false);
+  });
+
+  it("keeps the branch type of an external worktree reportable independently", () => {
+    const external = createMockWorktree({ id: "ext", branch: "feature/scratch", isExternal: true });
+
+    const groups = groupByType([external], "alpha");
+
+    // Grouped into the location bucket, but the branch taxonomy is untouched.
+    expect(groups.map((g) => g.type)).toEqual(["external"]);
+    expect(getWorktreeType(external)).toBe("feature");
+  });
 });
 
 describe("hasAnyFilters", () => {
@@ -1124,6 +1297,27 @@ describe("findIntegrationWorktree", () => {
     const worktrees = [createMockWorktree({ id: "main", branch: "develop", isMainWorktree: true })];
     const result = findIntegrationWorktree(worktrees, "main");
     expect(result).toBeNull();
+  });
+
+  it("skips an external worktree on an integration branch", () => {
+    // The integration slot renders above the divider, so admitting an external
+    // worktree there would pin it to the top — the exact #11434 repro.
+    const worktrees = [
+      createMockWorktree({ id: "main", branch: "main", isMainWorktree: true }),
+      createMockWorktree({ id: "ext-dev", branch: "develop", isExternal: true }),
+    ];
+    const result = findIntegrationWorktree(worktrees, "main");
+    expect(result).toBeNull();
+  });
+
+  it("still finds a later internal integration worktree past an external one", () => {
+    const worktrees = [
+      createMockWorktree({ id: "main", branch: "main", isMainWorktree: true }),
+      createMockWorktree({ id: "ext-dev", branch: "develop", isExternal: true }),
+      createMockWorktree({ id: "int-dev", branch: "develop" }),
+    ];
+    const result = findIntegrationWorktree(worktrees, "main");
+    expect(result?.id).toBe("int-dev");
   });
 
   it("returns the first match when multiple integration branches exist", () => {

--- a/src/lib/worktreeFilters.ts
+++ b/src/lib/worktreeFilters.ts
@@ -271,6 +271,15 @@ export function matchesFilters(
   return true;
 }
 
+/**
+ * Only an explicit `true` counts. `undefined` means the workspace host couldn't
+ * determine the containment boundary, and treating that as external would demote
+ * every worktree in the project on a transient path-resolution failure (#2251).
+ */
+export function isExternalWorktree(worktree: Worktree | WorktreeState): boolean {
+  return worktree.isExternal === true;
+}
+
 export function sortWorktrees<T extends Worktree | WorktreeState>(
   worktrees: T[],
   orderBy: OrderBy,
@@ -286,9 +295,17 @@ export function sortWorktrees<T extends Worktree | WorktreeState>(
     if (a.isMainWorktree && !b.isMainWorktree) return -1;
     if (!a.isMainWorktree && b.isMainWorktree) return 1;
 
+    // Worktrees git reports from outside the project sink below everything the
+    // project owns. Ahead of the pin check on purpose: a stale pin entry (or one
+    // added before the worktree was classified) must not lift an external
+    // worktree into the pinned area at the top (#11434).
+    const aExternal = isExternalWorktree(a);
+    const bExternal = isExternalWorktree(b);
+    if (aExternal !== bExternal) return aExternal ? 1 : -1;
+
     // Pinned worktrees come before unpinned (after main)
-    const aPinned = pinnedIndex.has(a.id);
-    const bPinned = pinnedIndex.has(b.id);
+    const aPinned = pinnedIndex.has(a.id) && !aExternal;
+    const bPinned = pinnedIndex.has(b.id) && !bExternal;
     if (aPinned && !bPinned) return -1;
     if (!aPinned && bPinned) return 1;
 
@@ -343,12 +360,26 @@ export function sortWorktreesByRelevance<T extends Worktree | WorktreeState>(
   if (!query.trim()) return sorted;
 
   const scores = new Map(sorted.map((w) => [w.id, scoreWorktree(w, query)]));
-  // Stable sort preserves sortWorktrees order as tiebreaker
-  return [...sorted].sort((a, b) => scores.get(b.id)! - scores.get(a.id)!);
+  // Stable sort preserves sortWorktrees order as tiebreaker. The external
+  // partition is re-applied as the primary key: a strong query match must not
+  // pull an outside-the-project worktree back above the project's own (#11434).
+  return [...sorted].sort((a, b) => {
+    const aExternal = isExternalWorktree(a);
+    const bExternal = isExternalWorktree(b);
+    if (aExternal !== bExternal) return aExternal ? 1 : -1;
+    return scores.get(b.id)! - scores.get(a.id)!;
+  });
 }
 
+/**
+ * Section identity for grouped mode. `"external"` is a location bucket, not a
+ * branch type — `getWorktreeType` never returns it, so it stays outside
+ * `WorktreeTypeId` (which the type filters and display-name table exhaust).
+ */
+export type WorktreeGroupId = WorktreeTypeId | "external";
+
 export interface GroupedSection<T> {
-  type: WorktreeTypeId;
+  type: WorktreeGroupId;
   displayName: string;
   worktrees: T[];
 }
@@ -395,8 +426,16 @@ export function groupByType<T extends Worktree | WorktreeState>(
   pinnedWorktrees: string[] = []
 ): GroupedSection<T>[] {
   const groups = new Map<WorktreeTypeId, T[]>();
+  // Pulled out before branch grouping: section order outranks the per-group
+  // comparator, so an external feature worktree left in "Features" would still
+  // render above the project's own bugfixes (#11434).
+  const external: T[] = [];
 
   for (const worktree of worktrees) {
+    if (isExternalWorktree(worktree)) {
+      external.push(worktree);
+      continue;
+    }
     const type = getWorktreeType(worktree);
     const existing = groups.get(type) ?? [];
     existing.push(worktree);
@@ -419,6 +458,14 @@ export function groupByType<T extends Worktree | WorktreeState>(
         worktrees: items,
       });
     }
+  }
+
+  if (external.length > 0) {
+    sections.push({
+      type: "external",
+      displayName: "Outside the project",
+      worktrees: sortWorktrees(external, orderBy, pinnedWorktrees),
+    });
   }
 
   return sections;
@@ -473,6 +520,7 @@ export function findIntegrationWorktree<T extends Worktree | WorktreeState>(
       (w) =>
         w.id !== mainWorktreeId &&
         !w.isMainWorktree &&
+        !isExternalWorktree(w) &&
         w.branch != null &&
         (INTEGRATION_BRANCH_NAMES as readonly string[]).includes(w.branch.toLowerCase())
     ) ?? null

--- a/src/store/__tests__/createWorktreeStore.external.test.ts
+++ b/src/store/__tests__/createWorktreeStore.external.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import type { WorktreeSnapshot, WorktreeEventVersion } from "@shared/types";
+import { createWorktreeStore } from "@/store/createWorktreeStore";
+
+// `snapshotsEqual` compares snapshot fields by hand, so a field it doesn't
+// compare is a field whose changes never reach the renderer (#11434). These
+// tests pin `isExternal` into that comparison.
+
+const TEST_EPOCH = "test-epoch";
+let _seq = 0;
+function nextV(): WorktreeEventVersion {
+  return { epoch: TEST_EPOCH, seq: ++_seq };
+}
+
+function makeSnapshot(id: string, extra: Partial<WorktreeSnapshot> = {}): WorktreeSnapshot {
+  return {
+    id,
+    worktreeId: id,
+    name: id,
+    branch: "main",
+    path: `/repo/${id}`,
+    isCurrent: false,
+    isMainWorktree: false,
+    modifiedCount: 0,
+    summary: "",
+    gitDir: "",
+    ...extra,
+  };
+}
+
+describe("createWorktreeStore — external classification updates", () => {
+  it("surfaces an update whose only change is isExternal", () => {
+    const store = createWorktreeStore();
+    store.getState().applyUpdate(makeSnapshot("wt-1", { isExternal: false }), nextV());
+    const mapBefore = store.getState().worktrees;
+
+    store.getState().applyUpdate(makeSnapshot("wt-1", { isExternal: true }), nextV());
+
+    expect(store.getState().worktrees).not.toBe(mapBefore);
+    expect(store.getState().worktrees.get("wt-1")?.isExternal).toBe(true);
+  });
+
+  it("distinguishes unknown classification from a confirmed internal one", () => {
+    const store = createWorktreeStore();
+    store.getState().applyUpdate(makeSnapshot("wt-1", { isExternal: undefined }), nextV());
+    const mapBefore = store.getState().worktrees;
+
+    store.getState().applyUpdate(makeSnapshot("wt-1", { isExternal: false }), nextV());
+
+    expect(store.getState().worktrees).not.toBe(mapBefore);
+    expect(store.getState().worktrees.get("wt-1")?.isExternal).toBe(false);
+  });
+
+  it("does not churn the map identity when classification is unchanged", () => {
+    const store = createWorktreeStore();
+    store.getState().applyUpdate(makeSnapshot("wt-1", { isExternal: true }), nextV());
+    const mapBefore = store.getState().worktrees;
+
+    store.getState().applyUpdate(makeSnapshot("wt-1", { isExternal: true }), nextV());
+
+    expect(store.getState().worktrees).toBe(mapBefore);
+  });
+});

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -1773,6 +1773,7 @@ function snapshotsEqual(a: WorktreeSnapshot, b: WorktreeSnapshot): boolean {
     a.hasResumeCommand === b.hasResumeCommand &&
     a.hasTeardownCommand === b.hasTeardownCommand &&
     a.resourceConnectCommand === b.resourceConnectCommand &&
+    a.isExternal === b.isExternal &&
     a.isWslPath === b.isWslPath &&
     a.wslDistro === b.wslDistro &&
     a.wslPosixPath === b.wslPosixPath &&


### PR DESCRIPTION
## Summary

Git reports every worktree it knows about, including ones a coding agent creates in its own scratch directory. Those were rendering as ordinary project worktree cards, with nothing to indicate where they actually lived.

This adds a derived `isExternal` flag that distinguishes them: sorted below the project's own worktrees, and kept out of the pinned area. It doesn't hide them, because it's still worth knowing when an agent has left a worktree behind.

Resolves #11434

## How "external" is defined

`validatePathPattern` rejects any worktree path pattern that escapes `{parent-dir}`, and `assertWorktreePathContained` enforces that same boundary on create. So every worktree Daintree itself can produce lives under `dirname(projectRootPath)`.

External means not under that boundary. No need to predict a specific worktrees directory from the pattern config, which was the mistake #11278 fixed.

## Why the flag is tri-state

Only `true` activates external behaviour. `undefined` means the boundary couldn't be determined. That direction matters: #2251/#3946 was a revert of exactly the opposite failure, where deriving `isMainWorktree` from path matching failed closed and cleared the flag for every row.

Three cases deliberately return `undefined`/`false`:

- No project root, or a repo at the filesystem root: the boundary is unknown.
- The main worktree: it's the project's own by definition. This matters when the opened project is itself a linked worktree, where the boundary becomes that worktree's parent and the repo's main worktree legitimately sits outside it.
- A relative porcelain path from git 2.48's `worktree.useRelativePaths`: recorded relative to `$GIT_COMMON_DIR/worktrees/<id>/`, an admin directory whose id porcelain never carries, so the resolved path can't be trusted to classify against.

## Plumbing

A field set only in `mapToWorktrees` doesn't reach the renderer. `WorktreeMonitor` copies selected fields into private state rather than keeping the whole `Worktree` object, `SnapshotBuilder` rebuilds `WorktreeSnapshot` field by field, and `snapshotsEqual` compares fields by hand, so it would have been dropped three times over. All three now carry the flag.

## Sorting and pinning

There are actually two pinned areas, not one. Besides the user pin array, there's a separate hardcoded slot for a worktree on develop, trunk, or next, rendered above the divider. The issue's own reproduction, an external worktree on develop, lands in that second slot, so `findIntegrationWorktree` now excludes external worktrees too.

In `sortWorktrees`, the external partition sits ahead of the pin check, so a stale pin entry can't lift an external worktree to the top. The pin affordance is withheld rather than left as a no-op.

Counts are deliberately unchanged: external worktrees still count towards the quick-state and chip counts, because it's real state the user should see. Grouped mode gets a trailing "Outside the project" section, since section order outranks the per-group comparator and an external feature worktree would otherwise sit above the project's own bugfixes.

## Testing

3071 tests pass across the workspace-host suites, the worktree filter/sort/cycling suites, the worktree store suites, and the Worktree/Sidebar component suites. `npm run typecheck` is clean and eslint adds no new warnings, verified against the per-rule ratchet baseline.

New coverage includes:

- The classification matrix (outside, inside, sibling-prefix, null-root, filesystem-root, linked-worktree-as-project, relative-path).
- Tri-state passthrough through the monitor and snapshot builder.
- An `isExternal`-only store update proving `snapshotsEqual` propagates it.
- Ordering across all four sort modes, plus query and grouped modes with a stale external pin.
- Integration-slot exclusion.
- The header indicator's accessible name carrying the absolute path.

The existing `e2e/full/worktree/core-worktree-external.spec.ts` is unaffected: its "external" means externally-created, and its worktrees live under the fixture's parent directory, so they're internal by this definition.
