### PR TITLE
feat(copytree): adopt CopyTree 0.16 in CopyTreeService

### DIFF
--- a/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
@@ -205,7 +205,6 @@ describe("copyTree handlers", () => {
       const testConfig = vi.fn().mockResolvedValue({
         includedFiles: 1,
         includedSize: 1,
-        excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
       });
       // Re-register so the channel resolves to a handler whose worktreeService
       // is live; clear ipcMain.handle first so getInvokeHandler finds this one.
@@ -305,7 +304,6 @@ describe("copyTree handlers", () => {
       const testConfig = vi.fn().mockResolvedValue({
         includedFiles: 1,
         includedSize: 1,
-        excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
       });
       const generateContext = vi.fn().mockResolvedValue({ content: "", fileCount: 1 });
 

--- a/electron/ipc/handlers/copyTree.ts
+++ b/electron/ipc/handlers/copyTree.ts
@@ -458,7 +458,12 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
 
       // Content was written to the temp file; renderer callers read only
       // fileCount/stats/error, so drop it to avoid cloning a second copy.
-      return { content: "", fileCount: result.fileCount, stats: result.stats };
+      return {
+        content: "",
+        fileCount: result.fileCount,
+        stats: result.stats,
+        outputFormatVersion: result.outputFormatVersion,
+      };
     } catch (error) {
       const errorMessage = formatErrorMessage(error, "Failed to copy context file");
       console.error(`[${traceId}] Failed to save/copy context file:`, errorMessage);
@@ -466,6 +471,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
         content: "",
         fileCount: result.fileCount,
         stats: result.stats,
+        outputFormatVersion: result.outputFormatVersion,
         error: `Failed to copy file to clipboard: ${errorMessage}`,
       };
     }
@@ -612,7 +618,12 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       console.log(`[${traceId}] CopyTree inject completed successfully`);
       // The renderer reads only fileCount/stats; drop the (possibly multi-MB)
       // content so the contextBridge doesn't clone a second copy into the heap.
-      return { content: "", fileCount: result.fileCount, stats: result.stats };
+      return {
+        content: "",
+        fileCount: result.fileCount,
+        stats: result.stats,
+        outputFormatVersion: result.outputFormatVersion,
+      };
     } finally {
       contextInjectionTracker.finishInjection(validated.terminalId, injectionId);
     }
@@ -706,7 +717,6 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       return {
         includedFiles: 0,
         includedSize: 0,
-        excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
         error: "Invalid payload",
       };
     }
@@ -717,7 +727,6 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       return {
         includedFiles: 0,
         includedSize: 0,
-        excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
         error: "Workspace client not initialized",
       };
     }
@@ -734,7 +743,6 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       return {
         includedFiles: 0,
         includedSize: 0,
-        excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
         error: `Worktree not found: ${validated.worktreeId}`,
       };
     }

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -526,9 +526,6 @@ export const CopyTreeProgressSchema = z.object({
   stage: z.string(),
   progress: z.number().min(0).max(1),
   message: z.string(),
-  filesProcessed: z.number().int().nonnegative().optional(),
-  totalFiles: z.number().int().nonnegative().optional(),
-  currentFile: z.string().optional(),
   traceId: z.string().optional(),
 });
 

--- a/electron/services/CopyTreeService.ts
+++ b/electron/services/CopyTreeService.ts
@@ -2,8 +2,37 @@ import type { CopyResult, CopyOptions as SdkCopyOptions, ProgressEvent } from "c
 import * as path from "path";
 import * as fs from "fs/promises";
 import type { CopyTreeOptions, CopyTreeResult, CopyTreeProgress } from "../types/index.js";
+import type {
+  CopyTreeBudgetStats,
+  CopyTreeExclusionReason,
+  CopyTreeExclusionSummary,
+} from "../../shared/types/ipc/copyTree.js";
 import { logWarn } from "../utils/logger.js";
-import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+
+/**
+ * Renderer-visible text for the SDK's stable error codes. SDK messages can
+ * carry absolute paths and raw option values, so nothing from the error itself
+ * reaches the renderer — only these static strings.
+ */
+const ERROR_CODE_MESSAGES: Record<string, string> = {
+  ERR_PATH_NOT_FOUND: "Project path is unavailable",
+  ERR_NOT_A_DIRECTORY: "Project path isn't a directory",
+  ERR_SCOPE_OUTSIDE_ROOT: "Selected paths must stay inside the project",
+  ERR_SYMLINK_OUTSIDE_ROOT: "Selected paths must stay inside the project",
+  ERR_INVALID_OPTION: "Context settings are invalid",
+  ERR_INVALID_FORMAT: "Context settings are invalid",
+  ERR_CONFIG_INVALID: "Context configuration couldn't be loaded",
+  ERR_NO_FILES_MATCHED: "No files matched the current context settings",
+  ERR_SECRETS_DETECTED: "Context generation stopped because secrets were detected",
+  ERR_ABORTED: "Context generation cancelled",
+  ENOENT: "Project path is unavailable",
+  EACCES: "Can't read the project files",
+};
+
+const CANCELLED_MESSAGE = "Context generation cancelled";
+const CONFIG_FAILED_MESSAGE = "Context configuration couldn't be loaded";
+const GENERATE_FAILED_MESSAGE = "Failed to generate context";
+const TEST_CONFIG_FAILED_MESSAGE = "Failed to test context settings";
 
 // Lazy-load copytree so its module graph (ajv, xmlbuilder2, fast-glob, lodash, …)
 // stays off the workspace-host readiness path; it resolves on first use.
@@ -67,71 +96,41 @@ class CopyTreeService {
       const controller = new AbortController();
       this.activeOperations.set(opId, controller);
 
-      const { copy, ConfigManager } = await getCopytree();
+      const { copy } = await getCopytree();
       this.throwIfAborted(controller.signal);
 
-      let config;
-      try {
-        config = await ConfigManager.create();
-      } catch (error) {
-        logWarn(
-          "Failed to load default config (likely missing configuration files in bundle), proceeding with defaults",
-          { error }
-        );
-      }
-
+      const config = await this.createConfig();
       this.throwIfAborted(controller.signal);
 
       const sdkOptions: SdkCopyOptions = {
-        signal: controller.signal,
-        display: false,
-        clipboard: false,
-        format: options.format || "xml",
-
-        filter: options.includePaths || options.filter || undefined,
-        exclude: options.exclude || undefined,
-        always: options.always,
-
-        modified: options.modified,
-        changed: options.changed,
-
-        charLimit: options.charLimit,
-        addLineNumbers: options.withLineNumbers,
-        maxFileSize: options.maxFileSize,
-        maxTotalSize: options.maxTotalSize,
-        maxFileCount: options.maxFileCount,
-        sort: options.sort,
-
+        ...this.buildSdkOptions(options, controller.signal),
+        config,
         onProgress: onProgress
           ? (event: ProgressEvent) => {
               if (controller.signal.aborted) return;
 
-              const progress: CopyTreeProgress = {
-                stage: event.stage || "Processing",
+              onProgress({
+                stage: event.stage || "unknown",
                 progress: Math.max(0, Math.min(100, event.percent || 0)) / 100,
-                message: event.message || `Processing: ${event.stage || "files"}`,
-                filesProcessed: event.filesProcessed,
-                totalFiles: event.totalFiles,
-                currentFile: event.currentFile,
+                message: event.message || "Processing files",
                 traceId: effectiveTraceId,
-              };
-              onProgress(progress);
+              });
             }
           : undefined,
         progressThrottleMs: 100,
       };
-      if (config) {
-        sdkOptions.config = config;
-      }
 
       const result: CopyResult = await copy(rootPath, sdkOptions);
+      this.logScanErrors(result);
 
       return {
         content: result.output,
         fileCount: result.stats.totalFiles,
+        outputFormatVersion: result.outputFormatVersion,
         stats: {
           totalSize: result.stats.totalSize,
           duration: result.stats.duration,
+          ...this.mapBudgetStats(result),
         },
       };
     } catch (error: unknown) {
@@ -153,7 +152,6 @@ class CopyTreeService {
         return {
           includedFiles: 0,
           includedSize: 0,
-          excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
           error: "rootPath must be an absolute path",
         };
       }
@@ -164,7 +162,6 @@ class CopyTreeService {
         return {
           includedFiles: 0,
           includedSize: 0,
-          excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
           error: `Path does not exist or is not accessible: ${rootPath}`,
         };
       }
@@ -172,72 +169,38 @@ class CopyTreeService {
       const controller = new AbortController();
       this.activeOperations.set(opId, controller);
 
-      const { copy, ConfigManager } = await getCopytree();
+      const { copy } = await getCopytree();
       this.throwIfAborted(controller.signal);
 
-      let config;
-      try {
-        config = await ConfigManager.create();
-      } catch (error) {
-        logWarn(
-          "Failed to load default config (likely missing configuration files in bundle), proceeding with defaults",
-          { error }
-        );
-      }
-
+      const config = await this.createConfig();
       this.throwIfAborted(controller.signal);
 
       const sdkOptions: SdkCopyOptions = {
-        signal: controller.signal,
-        display: false,
-        clipboard: false,
-        format: options.format || "xml",
+        ...this.buildSdkOptions(options, controller.signal),
+        config,
         dryRun: true,
-
-        filter: options.includePaths || options.filter || undefined,
-        exclude: options.exclude || undefined,
-        always: options.always,
-
-        modified: options.modified,
-        changed: options.changed,
-
-        charLimit: options.charLimit,
-        addLineNumbers: options.withLineNumbers,
-        maxFileSize: options.maxFileSize,
-        maxTotalSize: options.maxTotalSize,
-        maxFileCount: options.maxFileCount,
-        sort: options.sort,
       };
-      if (config) {
-        sdkOptions.config = config;
-      }
 
       const result: CopyResult = await copy(rootPath, sdkOptions);
+      this.logScanErrors(result);
+
+      // The 0.16 manifest reports every file's outcome, not just the kept ones,
+      // so the preview has to drop anything that wouldn't actually be included.
+      const included = (result.manifest ?? [])
+        .filter((entry) => entry.outcome === "included")
+        .map((entry) => ({ path: entry.path, size: entry.size }));
 
       return {
-        includedFiles: result.stats.totalFiles,
-        includedSize: result.stats.totalSize,
-        excluded: {
-          byTruncation: 0,
-          bySize: 0,
-          byPattern: 0,
-        },
-        files: result.manifest ?? [],
+        includedFiles: included.length,
+        includedSize: included.reduce((total, entry) => total + entry.size, 0),
+        files: included,
+        ...this.mapBudgetStats(result),
       };
     } catch (error: unknown) {
-      if (error instanceof Error && error.name === "AbortError") {
-        return {
-          includedFiles: 0,
-          includedSize: 0,
-          excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
-          error: "Context generation cancelled",
-        };
-      }
       return {
         includedFiles: 0,
         includedSize: 0,
-        excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
-        error: formatErrorMessage(error, "Failed to generate context"),
+        error: this.errorMessageFor(error, TEST_CONFIG_FAILED_MESSAGE),
       };
     } finally {
       this.activeOperations.delete(opId);
@@ -263,50 +226,115 @@ class CopyTreeService {
 
   private throwIfAborted(signal: AbortSignal): void {
     if (signal.aborted) {
-      throw Object.assign(new Error("Context generation cancelled"), { name: "AbortError" });
+      throw Object.assign(new Error(CANCELLED_MESSAGE), { name: "AbortError" });
     }
   }
 
-  private handleError(error: unknown): CopyTreeResult {
-    if (error instanceof Error && error.name === "AbortError") {
-      return {
-        content: "",
-        fileCount: 0,
-        error: "Context generation cancelled",
-      };
+  /**
+   * Load configuration from the packaged defaults only.
+   *
+   * `userConfig` would let `~/.copytree/config/copytree.js` — arbitrary code on
+   * a machine we don't control — run inside the host process, and would make a
+   * project's context depend on a file outside it. Failure is fatal rather than
+   * degraded: since 0.16 the config carries the exclusions, so running without
+   * it would sweep `node_modules`, media and build output into the context.
+   */
+  private async createConfig() {
+    const { ConfigManager } = await getCopytree();
+    try {
+      return await ConfigManager.create({ userConfig: false, strict: true });
+    } catch (error) {
+      logWarn("Failed to load CopyTree configuration; refusing to run without exclusions", {
+        error,
+      });
+      throw Object.assign(new Error(CONFIG_FAILED_MESSAGE), { code: "ERR_CONFIG_INVALID" });
     }
+  }
 
+  private buildSdkOptions(options: CopyTreeOptions, signal: AbortSignal): SdkCopyOptions {
+    return {
+      signal,
+      display: false,
+      clipboard: false,
+      quiet: true,
+      format: options.format || "xml",
+
+      filter: options.includePaths || options.filter || undefined,
+      exclude: options.exclude || undefined,
+      always: options.always,
+      respectGitignore: true,
+
+      modified: options.modified,
+      changed: options.changed,
+
+      charLimit: options.charLimit,
+      addLineNumbers: options.withLineNumbers,
+      // The user-facing "max file size" is a per-file gate that `always`
+      // patterns are meant to override, which is `sizeGate` — not the SDK's
+      // `maxFileSize` memory ceiling, which nothing lifts. Left unset the gate
+      // is disabled rather than falling back to the SDK's 256KB default, so
+      // existing projects keep the files they had before this upgrade.
+      sizeGate: options.maxFileSize ?? false,
+      maxTotalSize: options.maxTotalSize,
+      maxFileCount: options.maxFileCount,
+      sort: options.sort,
+      // Budgets keep the head of the sorted list, so "recently modified first"
+      // only holds descending.
+      sortOrder: options.sort === "modified" ? "desc" : undefined,
+
+      // Redaction runs by default from 0.16 and still misfires on ordinary
+      // source, which would silently corrupt the context handed to an agent.
+      secretsGuard: false,
+    };
+  }
+
+  private mapBudgetStats(result: CopyResult): CopyTreeBudgetStats {
+    const stats = result.stats;
+    return {
+      estimatedOutputChars: stats.estimatedOutputChars,
+      estimatedTokens: stats.estimatedTokens,
+      noFilesMatched: stats.noFilesMatched,
+      excluded: this.mapExclusions(stats.excluded),
+      truncated: stats.truncated,
+      truncatedCount: stats.truncatedCount,
+      truncatedBy: stats.truncatedBy,
+    };
+  }
+
+  private mapExclusions(excluded: CopyResult["stats"]["excluded"]): CopyTreeExclusionSummary {
+    const byReason: Partial<Record<CopyTreeExclusionReason, number>> = excluded?.byReason ?? {};
+    return { total: excluded?.total ?? 0, byReason };
+  }
+
+  /**
+   * Unreadable files are already accounted for as exclusions, so a scan error
+   * is a logged detail rather than a reason to fail the whole run.
+   */
+  private logScanErrors(result: CopyResult): void {
+    const scanErrors = result.stats.scanErrors;
+    if (scanErrors && scanErrors.length > 0) {
+      logWarn("CopyTree reported scan errors", { count: scanErrors.length });
+    }
+  }
+
+  private errorMessageFor(error: unknown, fallback: string): string {
     if (error instanceof Error) {
-      const errorName = error.name;
-      const errorCode = (error as Error & { code?: string }).code;
+      if (error.name === "AbortError") return CANCELLED_MESSAGE;
 
-      if (errorName === "ValidationError") {
-        return {
-          content: "",
-          fileCount: 0,
-          error: `Validation Error: ${error.message}`,
-        };
-      }
-
-      if (errorName === "CopyTreeError" || errorCode) {
-        return {
-          content: "",
-          fileCount: 0,
-          error: `CopyTree Error${errorCode ? ` [${errorCode}]` : ""}: ${error.message}`,
-        };
-      }
-
-      return {
-        content: "",
-        fileCount: 0,
-        error: `CopyTree Error: ${error.message}`,
-      };
+      const code = (error as Error & { code?: string }).code;
+      if (code && ERROR_CODE_MESSAGES[code]) return ERROR_CODE_MESSAGES[code];
+      if (error.name === "ValidationError") return "Context settings are invalid";
     }
 
+    logWarn("CopyTree operation failed", { error });
+    return fallback;
+  }
+
+  private handleError(error: unknown): CopyTreeResult {
     return {
       content: "",
       fileCount: 0,
-      error: `CopyTree Error: ${String(error)}`,
+      error: this.errorMessageFor(error, GENERATE_FAILED_MESSAGE),
     };
   }
 

--- a/electron/services/CopyTreeService.ts
+++ b/electron/services/CopyTreeService.ts
@@ -89,7 +89,7 @@ class CopyTreeService {
         return {
           content: "",
           fileCount: 0,
-          error: `Path does not exist or is not accessible: ${rootPath}`,
+          error: ERROR_CODE_MESSAGES.ENOENT,
         };
       }
 
@@ -99,7 +99,7 @@ class CopyTreeService {
       const { copy } = await getCopytree();
       this.throwIfAborted(controller.signal);
 
-      const config = await this.createConfig();
+      const config = await this.createConfig(controller.signal);
       this.throwIfAborted(controller.signal);
 
       const sdkOptions: SdkCopyOptions = {
@@ -162,7 +162,7 @@ class CopyTreeService {
         return {
           includedFiles: 0,
           includedSize: 0,
-          error: `Path does not exist or is not accessible: ${rootPath}`,
+          error: ERROR_CODE_MESSAGES.ENOENT,
         };
       }
 
@@ -172,7 +172,7 @@ class CopyTreeService {
       const { copy } = await getCopytree();
       this.throwIfAborted(controller.signal);
 
-      const config = await this.createConfig();
+      const config = await this.createConfig(controller.signal);
       this.throwIfAborted(controller.signal);
 
       const sdkOptions: SdkCopyOptions = {
@@ -184,10 +184,12 @@ class CopyTreeService {
       const result: CopyResult = await copy(rootPath, sdkOptions);
       this.logScanErrors(result);
 
-      // The 0.16 manifest reports every file's outcome, not just the kept ones,
-      // so the preview has to drop anything that wouldn't actually be included.
+      // The 0.16 manifest reports every file's outcome, not just the kept ones.
+      // Everything that isn't `excluded:*` reaches the output in some form —
+      // truncated content, a structure-only lock file and a binary placeholder
+      // all still occupy a slot — so only the excluded entries are dropped.
       const included = (result.manifest ?? [])
-        .filter((entry) => entry.outcome === "included")
+        .filter((entry) => !entry.outcome.startsWith("excluded:"))
         .map((entry) => ({ path: entry.path, size: entry.size }));
 
       return {
@@ -239,11 +241,20 @@ class CopyTreeService {
    * degraded: since 0.16 the config carries the exclusions, so running without
    * it would sweep `node_modules`, media and build output into the context.
    */
-  private async createConfig() {
+  private async createConfig(signal: AbortSignal) {
     const { ConfigManager } = await getCopytree();
     try {
-      return await ConfigManager.create({ userConfig: false, strict: true });
+      const config = await ConfigManager.create({ userConfig: false, strict: true });
+      // `strict` only throws when a source errors. A config directory that is
+      // simply absent resolves successfully and empty, which carries none of
+      // the exclusion lists — the case this flag exists to expose.
+      if (!config.isDefaultsLoaded) {
+        throw new Error("CopyTree default configuration is missing");
+      }
+      return config;
     } catch (error) {
+      // A cancel that lands while config is loading is a cancel, not a failure.
+      this.throwIfAborted(signal);
       logWarn("Failed to load CopyTree configuration; refusing to run without exclusions", {
         error,
       });
@@ -271,10 +282,12 @@ class CopyTreeService {
       addLineNumbers: options.withLineNumbers,
       // The user-facing "max file size" is a per-file gate that `always`
       // patterns are meant to override, which is `sizeGate` — not the SDK's
-      // `maxFileSize` memory ceiling, which nothing lifts. Left unset the gate
-      // is disabled rather than falling back to the SDK's 256KB default, so
-      // existing projects keep the files they had before this upgrade.
-      sizeGate: options.maxFileSize ?? false,
+      // `maxFileSize` memory ceiling, which nothing lifts. Left unset (or set to
+      // a non-positive value) the gate is disabled rather than falling back to
+      // the SDK's 256KB default, so existing projects keep the files they had
+      // before this upgrade.
+      sizeGate:
+        options.maxFileSize !== undefined && options.maxFileSize > 0 ? options.maxFileSize : false,
       maxTotalSize: options.maxTotalSize,
       maxFileCount: options.maxFileCount,
       sort: options.sort,
@@ -298,6 +311,7 @@ class CopyTreeService {
       truncated: stats.truncated,
       truncatedCount: stats.truncatedCount,
       truncatedBy: stats.truncatedBy,
+      budgetExceeded: stats.budgetExceeded,
     };
   }
 
@@ -321,8 +335,13 @@ class CopyTreeService {
     if (error instanceof Error) {
       if (error.name === "AbortError") return CANCELLED_MESSAGE;
 
+      // Own-property check only: an error carrying `code: "constructor"` would
+      // otherwise resolve to an inherited function and fail structured clone on
+      // its way to the renderer.
       const code = (error as Error & { code?: string }).code;
-      if (code && ERROR_CODE_MESSAGES[code]) return ERROR_CODE_MESSAGES[code];
+      if (typeof code === "string" && Object.hasOwn(ERROR_CODE_MESSAGES, code)) {
+        return ERROR_CODE_MESSAGES[code];
+      }
       if (error.name === "ValidationError") return "Context settings are invalid";
     }
 

--- a/electron/services/__tests__/CopyTreeService.adversarial.test.ts
+++ b/electron/services/__tests__/CopyTreeService.adversarial.test.ts
@@ -115,44 +115,44 @@ describe("CopyTreeService adversarial", () => {
       expect(emitters.length).toBe(1);
     });
 
-    emitters[0]({ stage: "before", percent: 10 } as ProgressEvent);
+    emitters[0]({ stage: "discover", percent: 10, message: "Discovering" });
     copyTreeService.cancel("op-p");
-    emitters[0]({ stage: "after", percent: 90 } as ProgressEvent);
+    emitters[0]({ stage: "format", percent: 90, message: "Formatting" });
 
     await pending;
 
-    expect(progressCalls).toEqual(["before"]);
+    expect(progressCalls).toEqual(["discover"]);
   });
 
-  it("ENOENT error from copy is mapped to a stable CopyTree Error code", async () => {
+  it("ENOENT error from copy is mapped to a stable user-facing message", async () => {
     const err = new Error("missing file") as Error & { code?: string };
     err.code = "ENOENT";
     copyMock.mockRejectedValue(err);
 
     const result = await copyTreeService.generate(tempDir);
 
-    expect(result.error).toBe("CopyTree Error [ENOENT]: missing file");
+    expect(result.error).toBe("Project path is unavailable");
     expect(result.content).toBe("");
     expect(result.fileCount).toBe(0);
   });
 
-  it("EACCES error from copy is mapped to a stable CopyTree Error code", async () => {
+  it("EACCES error from copy is mapped to a stable user-facing message", async () => {
     const err = new Error("permission denied") as Error & { code?: string };
     err.code = "EACCES";
     copyMock.mockRejectedValue(err);
 
     const result = await copyTreeService.generate(tempDir);
 
-    expect(result.error).toBe("CopyTree Error [EACCES]: permission denied");
+    expect(result.error).toBe("Can't read the project files");
   });
 
-  it("non-Error thrown value is still wrapped into a CopyTree Error", async () => {
+  it("non-Error thrown value does not reach the renderer verbatim", async () => {
     copyMock.mockRejectedValue("unexpected string");
 
     const result = await copyTreeService.generate(tempDir);
 
-    expect(result.error).toContain("CopyTree Error");
-    expect(result.error).toContain("unexpected string");
+    expect(result.error).toBe("Failed to generate context");
+    expect(result.error).not.toContain("unexpected string");
   });
 
   it("activeOperations map is drained on success so future cancels return false", async () => {

--- a/electron/services/__tests__/CopyTreeService.adversarial.test.ts
+++ b/electron/services/__tests__/CopyTreeService.adversarial.test.ts
@@ -22,7 +22,7 @@ describe("CopyTreeService adversarial", () => {
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-copytree-adv-"));
     vi.clearAllMocks();
-    configCreateMock.mockResolvedValue(undefined);
+    configCreateMock.mockResolvedValue({ isDefaultsLoaded: true });
   });
 
   afterEach(async () => {

--- a/electron/services/__tests__/CopyTreeService.lazy-import.test.ts
+++ b/electron/services/__tests__/CopyTreeService.lazy-import.test.ts
@@ -67,12 +67,13 @@ describe("CopyTreeService lazy copytree import", () => {
 
     expect(result.content).toBe("");
     expect(result.fileCount).toBe(0);
-    expect(result.error).toMatch(/^CopyTree Error: /);
+    expect(result.error).toBe("Failed to generate context");
+    expect(result.error).not.toContain("module load failed");
     expect(copyTreeService.cancel("trace-import-fail")).toBe(false);
 
     const retry = await copyTreeService.generate(tempDir);
 
-    expect(retry.error).toMatch(/^CopyTree Error: /);
+    expect(retry.error).toBe("Failed to generate context");
     expect(factory).toHaveBeenCalledTimes(1);
   });
 

--- a/electron/services/__tests__/CopyTreeService.lazy-import.test.ts
+++ b/electron/services/__tests__/CopyTreeService.lazy-import.test.ts
@@ -9,7 +9,7 @@ function mockCopytreeModule() {
       output: "<context />",
       stats: { totalFiles: 1, totalSize: 10, duration: 5 },
     }),
-    ConfigManager: { create: vi.fn().mockResolvedValue(undefined) },
+    ConfigManager: { create: vi.fn().mockResolvedValue({ isDefaultsLoaded: true }) },
   };
 }
 
@@ -102,7 +102,7 @@ describe("CopyTreeService lazy copytree import", () => {
       await gate;
       return {
         copy: copyMock,
-        ConfigManager: { create: vi.fn().mockResolvedValue(undefined) },
+        ConfigManager: { create: vi.fn().mockResolvedValue({ isDefaultsLoaded: true }) },
       };
     });
 

--- a/electron/services/__tests__/CopyTreeService.sdk-contract.test.ts
+++ b/electron/services/__tests__/CopyTreeService.sdk-contract.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+// Deliberately NOT mocked: every other CopyTreeService suite stubs `copytree`,
+// so they only prove the adapter matches our assumptions about the SDK. This
+// one runs the installed package, which is what catches an assumption that was
+// wrong in the first place.
+import { copyTreeService } from "../CopyTreeService.js";
+
+describe("CopyTreeService against the installed CopyTree", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-copytree-sdk-"));
+    await fs.writeFile(path.join(tempDir, "small.ts"), "export const a = 1;\n");
+  });
+
+  afterEach(async () => {
+    copyTreeService.cancelAll();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function writeSized(name: string, bytes: number) {
+    await fs.writeFile(path.join(tempDir, name), "x".repeat(bytes));
+  }
+
+  it("loads the packaged configuration and generates a versioned document", async () => {
+    const result = await copyTreeService.generate(tempDir);
+
+    expect(result.error).toBeUndefined();
+    expect(result.content).toContain("small.ts");
+    // Proves ConfigManager.create({ userConfig: false, strict: true }) resolved
+    // with real defaults — the fail-closed path would have errored instead.
+    expect(result.outputFormatVersion).toBeTruthy();
+    expect(result.stats?.estimatedTokens).toBeGreaterThan(0);
+  });
+
+  it("keeps a file larger than the SDK's 256KB default gate when no limit is set", async () => {
+    await writeSized("big.ts", 300 * 1024);
+
+    const result = await copyTreeService.testConfig(tempDir);
+
+    expect(result.error).toBeUndefined();
+    expect(result.files?.map((file) => file.path)).toContain("big.ts");
+  });
+
+  it("drops a file above an explicit max file size and says why", async () => {
+    await writeSized("big.ts", 300 * 1024);
+
+    const result = await copyTreeService.testConfig(tempDir, { maxFileSize: 100 * 1024 });
+
+    expect(result.files?.map((file) => file.path)).not.toContain("big.ts");
+    expect(result.excluded?.byReason.sizeGate).toBeGreaterThan(0);
+  });
+
+  it("lets an always pattern override the max file size gate", async () => {
+    await writeSized("big.ts", 300 * 1024);
+
+    const result = await copyTreeService.testConfig(tempDir, {
+      maxFileSize: 100 * 1024,
+      always: ["big.ts"],
+    });
+
+    expect(result.files?.map((file) => file.path)).toContain("big.ts");
+  });
+
+  it("does not redact a secret-shaped string, since the guard is off", async () => {
+    const secret = "AKIAIOSFODNN7EXAMPLE";
+    await fs.writeFile(path.join(tempDir, "config.ts"), `export const key = "${secret}";\n`);
+
+    const result = await copyTreeService.generate(tempDir);
+
+    expect(result.error).toBeUndefined();
+    expect(result.content).toContain(secret);
+  });
+
+  it("reports gitignored files as excluded rather than silently omitting them", async () => {
+    await fs.writeFile(path.join(tempDir, ".gitignore"), "ignored.ts\n");
+    await fs.writeFile(path.join(tempDir, "ignored.ts"), "export const b = 2;\n");
+
+    const result = await copyTreeService.testConfig(tempDir);
+
+    expect(result.files?.map((file) => file.path)).not.toContain("ignored.ts");
+    expect(result.excluded?.total).toBeGreaterThan(0);
+  });
+
+  it("counts every previewed file the real run also emits", async () => {
+    await fs.writeFile(path.join(tempDir, "package-lock.json"), JSON.stringify({ a: 1 }));
+    await fs.writeFile(path.join(tempDir, "logo.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00]));
+
+    const preview = await copyTreeService.testConfig(tempDir);
+    const real = await copyTreeService.generate(tempDir);
+
+    expect(preview.error).toBeUndefined();
+    expect(real.error).toBeUndefined();
+    // The preview list drives the "N files would be included" headline, so every
+    // entry in it has to actually appear in the generated document.
+    for (const file of preview.files ?? []) {
+      expect(real.content).toContain(file.path);
+    }
+    expect(preview.includedFiles).toBe(preview.files?.length);
+  });
+
+  it("reports truncation when a character budget bites", async () => {
+    await writeSized("wide.ts", 20_000);
+
+    const result = await copyTreeService.testConfig(tempDir, { charLimit: 500 });
+
+    expect(result.error).toBeUndefined();
+    expect(result.truncated).toBe(true);
+  });
+});

--- a/electron/services/__tests__/CopyTreeService.test.ts
+++ b/electron/services/__tests__/CopyTreeService.test.ts
@@ -24,14 +24,23 @@ describe("CopyTreeService", () => {
     configCreateMock.mockResolvedValue(undefined);
     copyMock.mockResolvedValue({
       output: "<context />",
+      outputFormatVersion: "copytree-xml@1",
       manifest: [],
       stats: {
         totalFiles: 1,
         totalSize: 10,
         duration: 5,
+        estimatedOutputChars: 400,
+        estimatedTokens: 100,
+        noFilesMatched: false,
+        excluded: { total: 0, byReason: {} },
       },
     });
   });
+
+  function sdkOptions() {
+    return copyMock.mock.calls[0][1] as Record<string, unknown>;
+  }
 
   afterEach(async () => {
     copyTreeService.cancelAll();
@@ -63,9 +72,10 @@ describe("CopyTreeService", () => {
 
     expect(result).toEqual(
       expect.objectContaining({
-        error: "Validation Error: Bad include pattern",
+        error: "Context settings are invalid",
       })
     );
+    expect(result.error).not.toContain("Bad include pattern");
   });
 
   it("cancels a specific in-flight operation by trace id", async () => {
@@ -215,9 +225,9 @@ describe("CopyTreeService", () => {
   describe("testConfig", () => {
     it("returns files populated from the SDK manifest", async () => {
       const manifest = [
-        { path: "src/index.ts", size: 1024 },
-        { path: "src/utils.ts", size: 512 },
-        { path: "README.md", size: 256 },
+        { path: "src/index.ts", size: 1024, outcome: "included" },
+        { path: "src/utils.ts", size: 512, outcome: "included" },
+        { path: "README.md", size: 256, outcome: "included" },
       ];
       copyMock.mockResolvedValue({
         output: "",
@@ -239,14 +249,25 @@ describe("CopyTreeService", () => {
       }
     });
 
-    it("maps stats onto includedFiles and includedSize", async () => {
-      const stats = { totalFiles: 7, totalSize: 4096, duration: 5, dryRun: true };
-      copyMock.mockResolvedValue({ output: "", manifest: [], stats });
+    it("keeps includedFiles and includedSize consistent with the previewed files", async () => {
+      // stats.totalFiles counts everything the run processed, which in 0.16
+      // includes outcomes that never reach the output, so the headline numbers
+      // are derived from the same list the preview renders.
+      copyMock.mockResolvedValue({
+        output: "",
+        manifest: [
+          { path: "kept.ts", size: 1024, outcome: "included" },
+          { path: "gone.mp4", size: 3072, outcome: "excluded:binaryExtension" },
+        ],
+        stats: { totalFiles: 7, totalSize: 4096, duration: 5, dryRun: true },
+      });
 
       const result = await copyTreeService.testConfig(tempDir);
 
-      expect(result.includedFiles).toBe(stats.totalFiles);
-      expect(result.includedSize).toBe(stats.totalSize);
+      expect(result.includedFiles).toBe(result.files?.length);
+      expect(result.includedSize).toBe(result.files?.reduce((sum, file) => sum + file.size, 0));
+      expect(result.includedFiles).toBe(1);
+      expect(result.includedSize).toBe(1024);
     });
 
     it("returns an empty files array when the manifest is empty", async () => {
@@ -285,14 +306,205 @@ describe("CopyTreeService", () => {
     });
   });
 
-  it("omits config from sdkOptions when ConfigManager.create() fails", async () => {
-    configCreateMock.mockRejectedValue(new Error("No config"));
+  describe("configuration loading", () => {
+    it("loads configuration without the user config directory", async () => {
+      await copyTreeService.generate(tempDir);
 
-    await copyTreeService.generate(tempDir);
+      expect(configCreateMock).toHaveBeenCalledWith(expect.objectContaining({ userConfig: false }));
+    });
 
-    expect(copyMock).toHaveBeenCalledTimes(1);
-    const sdkOptions = copyMock.mock.calls[0][1] as Record<string, unknown>;
-    expect(sdkOptions).not.toHaveProperty("config");
-    expect("config" in sdkOptions).toBe(false);
+    it("refuses to run when config fails, rather than generating without exclusions", async () => {
+      configCreateMock.mockRejectedValue(new Error("No config"));
+
+      const result = await copyTreeService.generate(tempDir);
+
+      expect(copyMock).not.toHaveBeenCalled();
+      expect(result.error).toBe("Context configuration couldn't be loaded");
+      expect(result.content).toBe("");
+    });
+
+    it("fails the dry run closed when config cannot be loaded", async () => {
+      configCreateMock.mockRejectedValue(new Error("No config"));
+
+      const result = await copyTreeService.testConfig(tempDir);
+
+      expect(copyMock).not.toHaveBeenCalled();
+      expect(result.error).toBe("Context configuration couldn't be loaded");
+      expect(result.includedFiles).toBe(0);
+    });
+  });
+
+  describe("SDK option policy", () => {
+    it("disables the per-file gate when the user set no max file size", async () => {
+      await copyTreeService.generate(tempDir);
+
+      expect(sdkOptions().sizeGate).toBe(false);
+    });
+
+    it("routes the user's max file size to the overridable gate, not the memory ceiling", async () => {
+      await copyTreeService.generate(tempDir, { maxFileSize: 50_000 });
+
+      const options = sdkOptions();
+      expect(options.sizeGate).toBe(50_000);
+      // maxFileSize is the SDK's memory ceiling and cannot be lifted by
+      // `always`, so the user-facing limit must not be routed there.
+      expect(options.maxFileSize).toBeUndefined();
+    });
+
+    it("keeps redaction off so it cannot rewrite source handed to an agent", async () => {
+      await copyTreeService.generate(tempDir);
+
+      expect(sdkOptions().secretsGuard).toBe(false);
+    });
+
+    it("orders a modified-first run descending so budgets keep the newest files", async () => {
+      await copyTreeService.generate(tempDir, { sort: "modified" });
+
+      expect(sdkOptions()).toMatchObject({ sort: "modified", sortOrder: "desc" });
+    });
+
+    it("leaves sort order unset for non-modified strategies", async () => {
+      await copyTreeService.generate(tempDir, { sort: "path" });
+
+      expect(sdkOptions().sortOrder).toBeUndefined();
+    });
+
+    it("passes the remaining budgets through untouched", async () => {
+      await copyTreeService.generate(tempDir, {
+        maxTotalSize: 1234,
+        maxFileCount: 7,
+        charLimit: 99,
+      });
+
+      expect(sdkOptions()).toMatchObject({
+        maxTotalSize: 1234,
+        maxFileCount: 7,
+        charLimit: 99,
+      });
+    });
+  });
+
+  describe("result mapping", () => {
+    it("forwards budget estimates and the format version to the renderer", async () => {
+      const result = await copyTreeService.generate(tempDir);
+
+      expect(result.outputFormatVersion).toBe("copytree-xml@1");
+      expect(result.stats).toMatchObject({
+        estimatedTokens: 100,
+        estimatedOutputChars: 400,
+        noFilesMatched: false,
+      });
+    });
+
+    it("counts only files the dry run would actually include", async () => {
+      copyMock.mockResolvedValue({
+        output: "",
+        outputFormatVersion: null,
+        manifest: [
+          { path: "a.ts", size: 10, outcome: "included" },
+          { path: "big.bin", size: 900, outcome: "excluded:sizeGate" },
+          { path: "lock.json", size: 40, outcome: "structure-only" },
+          { path: "b.ts", size: 20, outcome: "included" },
+        ],
+        stats: {
+          totalFiles: 4,
+          totalSize: 970,
+          duration: 1,
+          estimatedOutputChars: 0,
+          estimatedTokens: 0,
+          noFilesMatched: false,
+          excluded: { total: 1, byReason: { sizeGate: 1 } },
+        },
+      });
+
+      const result = await copyTreeService.testConfig(tempDir);
+
+      expect(result.files).toEqual([
+        { path: "a.ts", size: 10 },
+        { path: "b.ts", size: 20 },
+      ]);
+      expect(result.includedFiles).toBe(2);
+      expect(result.includedSize).toBe(30);
+      expect(result.excluded).toEqual({ total: 1, byReason: { sizeGate: 1 } });
+    });
+
+    it("surfaces which budget truncated the run", async () => {
+      copyMock.mockResolvedValue({
+        output: "",
+        outputFormatVersion: null,
+        manifest: [],
+        stats: {
+          totalFiles: 0,
+          totalSize: 0,
+          duration: 1,
+          estimatedOutputChars: 0,
+          estimatedTokens: 0,
+          noFilesMatched: false,
+          excluded: { total: 3, byReason: { totalSizeBudget: 3 } },
+          truncated: true,
+          truncatedCount: 3,
+          truncatedBy: "maxTotalSize",
+        },
+      });
+
+      const result = await copyTreeService.testConfig(tempDir);
+
+      expect(result).toMatchObject({
+        truncated: true,
+        truncatedCount: 3,
+        truncatedBy: "maxTotalSize",
+      });
+    });
+
+    it("does not fail a run that reported recoverable scan errors", async () => {
+      copyMock.mockResolvedValue({
+        output: "<context />",
+        outputFormatVersion: "copytree-xml@1",
+        manifest: [],
+        stats: {
+          totalFiles: 2,
+          totalSize: 20,
+          duration: 1,
+          estimatedOutputChars: 0,
+          estimatedTokens: 0,
+          noFilesMatched: false,
+          excluded: { total: 1, byReason: { unreadable: 1 } },
+          scanErrors: ["EACCES: locked.txt"],
+        },
+      });
+
+      const result = await copyTreeService.generate(tempDir);
+
+      expect(result.error).toBeUndefined();
+      expect(result.fileCount).toBe(2);
+    });
+  });
+
+  describe("error message sanitization", () => {
+    it.each([
+      ["ERR_PATH_NOT_FOUND", "Project path is unavailable"],
+      ["ERR_SCOPE_OUTSIDE_ROOT", "Selected paths must stay inside the project"],
+      ["ERR_NO_FILES_MATCHED", "No files matched the current context settings"],
+      ["ERR_CONFIG_INVALID", "Context configuration couldn't be loaded"],
+    ])("maps %s to a static message", async (code, expected) => {
+      copyMock.mockRejectedValue(
+        Object.assign(new Error(`/Users/someone/secret/path exploded`), { code })
+      );
+
+      const result = await copyTreeService.generate(tempDir);
+
+      expect(result.error).toBe(expected);
+    });
+
+    it("never leaks an unrecognized SDK message to the renderer", async () => {
+      copyMock.mockRejectedValue(
+        Object.assign(new Error("/Users/someone/private/repo is bad"), { code: "ERR_WAT" })
+      );
+
+      const result = await copyTreeService.generate(tempDir);
+
+      expect(result.error).toBe("Failed to generate context");
+      expect(result.error).not.toContain("/Users/someone");
+    });
   });
 });

--- a/electron/services/__tests__/CopyTreeService.test.ts
+++ b/electron/services/__tests__/CopyTreeService.test.ts
@@ -21,7 +21,7 @@ describe("CopyTreeService", () => {
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-copytree-service-"));
     vi.clearAllMocks();
-    configCreateMock.mockResolvedValue(undefined);
+    configCreateMock.mockResolvedValue({ isDefaultsLoaded: true });
     copyMock.mockResolvedValue({
       output: "<context />",
       outputFormatVersion: "copytree-xml@1",
@@ -59,7 +59,10 @@ describe("CopyTreeService", () => {
 
     const result = await copyTreeService.generate(missingPath);
 
-    expect(result.error).toContain("does not exist or is not accessible");
+    expect(result.error).toBe("Project path is unavailable");
+    // The path itself is the user's filesystem layout and must not cross to the
+    // renderer with the error.
+    expect(result.error).not.toContain(missingPath);
     expect(copyMock).not.toHaveBeenCalled();
   });
 
@@ -257,7 +260,7 @@ describe("CopyTreeService", () => {
         output: "",
         manifest: [
           { path: "kept.ts", size: 1024, outcome: "included" },
-          { path: "gone.mp4", size: 3072, outcome: "excluded:binaryExtension" },
+          { path: "gone.mp4", size: 3072, outcome: "excluded:configExclude" },
         ],
         stats: { totalFiles: 7, totalSize: 4096, duration: 5, dryRun: true },
       });
@@ -332,6 +335,32 @@ describe("CopyTreeService", () => {
       expect(result.error).toBe("Context configuration couldn't be loaded");
       expect(result.includedFiles).toBe(0);
     });
+
+    it.each([
+      ["generate", () => copyTreeService.generate(tempDir)],
+      ["testConfig", () => copyTreeService.testConfig(tempDir)],
+    ])(
+      "refuses to run %s when config resolved without the exclusion defaults",
+      async (_name, run) => {
+        // strict only throws when a source errors; an absent config directory
+        // resolves successfully and empty, carrying no exclusion lists at all.
+        configCreateMock.mockResolvedValue({ isDefaultsLoaded: false });
+
+        const result = await run();
+
+        expect(copyMock).not.toHaveBeenCalled();
+        expect(result.error).toBe("Context configuration couldn't be loaded");
+      }
+    );
+
+    it("proceeds when the defaults did load", async () => {
+      configCreateMock.mockResolvedValue({ isDefaultsLoaded: true });
+
+      const result = await copyTreeService.generate(tempDir);
+
+      expect(copyMock).toHaveBeenCalledTimes(1);
+      expect(result.error).toBeUndefined();
+    });
   });
 
   describe("SDK option policy", () => {
@@ -349,6 +378,12 @@ describe("CopyTreeService", () => {
       // maxFileSize is the SDK's memory ceiling and cannot be lifted by
       // `always`, so the user-facing limit must not be routed there.
       expect(options.maxFileSize).toBeUndefined();
+    });
+
+    it.each([0, -1])("treats a non-positive max file size (%i) as no gate", async (maxFileSize) => {
+      await copyTreeService.generate(tempDir, { maxFileSize });
+
+      expect(sdkOptions().sizeGate).toBe(false);
     });
 
     it("keeps redaction off so it cannot rewrite source handed to an agent", async () => {
@@ -396,7 +431,9 @@ describe("CopyTreeService", () => {
       });
     });
 
-    it("counts only files the dry run would actually include", async () => {
+    it("drops excluded entries but keeps every outcome that reaches the output", async () => {
+      // truncated / structure-only / binary-placeholder files all still occupy a
+      // slot in the generated context, so the preview must count them.
       copyMock.mockResolvedValue({
         output: "",
         outputFormatVersion: null,
@@ -404,28 +441,32 @@ describe("CopyTreeService", () => {
           { path: "a.ts", size: 10, outcome: "included" },
           { path: "big.bin", size: 900, outcome: "excluded:sizeGate" },
           { path: "lock.json", size: 40, outcome: "structure-only" },
-          { path: "b.ts", size: 20, outcome: "included" },
+          { path: "logo.png", size: 60, outcome: "binary-placeholder" },
+          { path: "long.md", size: 80, outcome: "truncated" },
+          { path: "vendored.js", size: 500, outcome: "excluded:gitignore" },
         ],
         stats: {
-          totalFiles: 4,
-          totalSize: 970,
+          totalFiles: 6,
+          totalSize: 1590,
           duration: 1,
           estimatedOutputChars: 0,
           estimatedTokens: 0,
           noFilesMatched: false,
-          excluded: { total: 1, byReason: { sizeGate: 1 } },
+          excluded: { total: 2, byReason: { sizeGate: 1, gitignore: 1 } },
         },
       });
 
       const result = await copyTreeService.testConfig(tempDir);
 
-      expect(result.files).toEqual([
-        { path: "a.ts", size: 10 },
-        { path: "b.ts", size: 20 },
+      expect(result.files?.map((file) => file.path)).toEqual([
+        "a.ts",
+        "lock.json",
+        "logo.png",
+        "long.md",
       ]);
-      expect(result.includedFiles).toBe(2);
-      expect(result.includedSize).toBe(30);
-      expect(result.excluded).toEqual({ total: 1, byReason: { sizeGate: 1 } });
+      expect(result.includedFiles).toBe(4);
+      expect(result.includedSize).toBe(190);
+      expect(result.excluded).toEqual({ total: 2, byReason: { sizeGate: 1, gitignore: 1 } });
     });
 
     it("surfaces which budget truncated the run", async () => {

--- a/electron/services/workspace-client/WorkspaceCopyTreeClient.ts
+++ b/electron/services/workspace-client/WorkspaceCopyTreeClient.ts
@@ -75,7 +75,6 @@ export class WorkspaceCopyTreeClient {
       return {
         includedFiles: 0,
         includedSize: 0,
-        excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
         error: "No workspace host for path",
       };
     }
@@ -103,7 +102,6 @@ export class WorkspaceCopyTreeClient {
       return {
         includedFiles: 0,
         includedSize: 0,
-        excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
         error: formatErrorMessage(error, "Failed to generate context"),
       };
     } finally {

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -732,7 +732,6 @@ port.on("message", async (rawMsg: any) => {
             result: {
               includedFiles: 0,
               includedSize: 0,
-              excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
               error: formatErrorMessage(error, "Failed to test CopyTree config"),
             },
           });

--- a/electron/workspace-host/__tests__/CopytreeWorkerClient.test.ts
+++ b/electron/workspace-host/__tests__/CopytreeWorkerClient.test.ts
@@ -32,7 +32,6 @@ const inlineResult = { content: "inline", fileCount: 1 };
 const inlineTestResult = {
   includedFiles: 2,
   includedSize: 10,
-  excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
 };
 
 beforeEach(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "archiver": "^8.0.0",
         "avr-vad": "^1.0.10",
         "better-sqlite3": "^13.0.1",
-        "copytree": "^0.14.2",
+        "copytree": "^0.16.0",
         "httpxy": "^0.5.3",
         "ipaddr.js": "^2.4.0",
         "js-yaml": "^4.1.1",
@@ -205,9 +205,9 @@
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.2.5.tgz",
-      "integrity": "sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.3.0.tgz",
+      "integrity": "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.1",
@@ -2954,334 +2954,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@inquirer/ansi": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
-      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-      }
-    },
-    "node_modules/@inquirer/checkbox": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.1.tgz",
-      "integrity": "sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^11.2.1",
-        "@inquirer/figures": "^2.0.7",
-        "@inquirer/type": "^4.0.7"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/confirm": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
-      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^11.2.1",
-        "@inquirer/type": "^4.0.7"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/core": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
-      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/figures": "^2.0.7",
-        "@inquirer/type": "^4.0.7",
-        "cli-width": "^4.1.0",
-        "fast-wrap-ansi": "^0.2.0",
-        "mute-stream": "^3.0.0",
-        "signal-exit": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/editor": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.2.2.tgz",
-      "integrity": "sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^11.2.1",
-        "@inquirer/external-editor": "^3.0.3",
-        "@inquirer/type": "^4.0.7"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/expand": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.1.tgz",
-      "integrity": "sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^11.2.1",
-        "@inquirer/type": "^4.0.7"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/external-editor": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.3.tgz",
-      "integrity": "sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==",
-      "license": "MIT",
-      "dependencies": {
-        "chardet": "^2.1.1",
-        "iconv-lite": "^0.7.2"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/figures": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
-      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-      }
-    },
-    "node_modules/@inquirer/input": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.2.tgz",
-      "integrity": "sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^11.2.1",
-        "@inquirer/type": "^4.0.7"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/number": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.1.1.tgz",
-      "integrity": "sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^11.2.1",
-        "@inquirer/type": "^4.0.7"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/password": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.1.1.tgz",
-      "integrity": "sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^11.2.1",
-        "@inquirer/type": "^4.0.7"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/prompts": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.5.2.tgz",
-      "integrity": "sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/checkbox": "^5.2.1",
-        "@inquirer/confirm": "^6.1.1",
-        "@inquirer/editor": "^5.2.2",
-        "@inquirer/expand": "^5.1.1",
-        "@inquirer/input": "^5.1.2",
-        "@inquirer/number": "^4.1.1",
-        "@inquirer/password": "^5.1.1",
-        "@inquirer/rawlist": "^5.3.1",
-        "@inquirer/search": "^4.2.1",
-        "@inquirer/select": "^5.2.1"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/rawlist": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.1.tgz",
-      "integrity": "sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^11.2.1",
-        "@inquirer/type": "^4.0.7"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/search": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.2.1.tgz",
-      "integrity": "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^11.2.1",
-        "@inquirer/figures": "^2.0.7",
-        "@inquirer/type": "^4.0.7"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/select": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.1.tgz",
-      "integrity": "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^11.2.1",
-        "@inquirer/figures": "^2.0.7",
-        "@inquirer/type": "^4.0.7"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/type": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
-      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
       }
     },
     "node_modules/@isaacs/fs-minipass": {
@@ -7349,7 +7021,7 @@
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
       "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -7359,7 +7031,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/prismjs": {
@@ -9336,12 +9008,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/chardet": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
-      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
-      "license": "MIT"
-    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -9442,12 +9108,12 @@
       }
     },
     "node_modules/cli-boxes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
-      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-4.0.1.tgz",
+      "integrity": "sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=18.20 <19 || >=20.10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9481,28 +9147,19 @@
       }
     },
     "node_modules/cli-truncate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
-      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-6.1.1.tgz",
+      "integrity": "sha512-06p9vyLahLa4zkGcgsGxU6iEkSOiuI4fhCH6Emhe2lPAcoUv73n72DnODsnHA+5wwXGnV0n9M9/qOQJSjYhFhw==",
       "license": "MIT",
       "dependencies": {
-        "slice-ansi": "^8.0.0",
+        "slice-ansi": "^9.0.0",
         "string-width": "^8.2.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-width": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/clipboard-image": {
@@ -9524,9 +9181,9 @@
       }
     },
     "node_modules/clipboardy": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-5.3.1.tgz",
-      "integrity": "sha512-fPWgBqpp9ctiOQCkE5yjYGzv11ZU55g6ahEgr3COiio6dXdt1mbchCPXQrSR2Y9sZqfi8L7QD3+UosgXVIuPdg==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-5.3.2.tgz",
+      "integrity": "sha512-R35PENCHFCw6lsd5SjYPuAVV3Zawr74mKc7ogFNzoDPoQsmWDoJgUNNnWCk/czeqdZGZs8Y0M8zkOlVoySfHEQ==",
       "license": "MIT",
       "dependencies": {
         "clipboard-image": "^0.1.0",
@@ -9926,36 +9583,36 @@
       }
     },
     "node_modules/copytree": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/copytree/-/copytree-0.14.2.tgz",
-      "integrity": "sha512-HyL57mQafgQiGGgDWMHvYZKDCwZdKF8eGPGHC9cFokoVOKb7iAmDB5ob86EWpvHxeMCaw3360r5V+sC4oN/imA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/copytree/-/copytree-0.16.0.tgz",
+      "integrity": "sha512-x0k76Rr11U9rV6o1g0//ahWz2R0cWgEDwEt0bY1CWG+qFEMMx4WXfXvIIcTvSs6nAcUiHHLZ771yCCEAXr/0JQ==",
       "license": "MIT",
       "dependencies": {
-        "ajv": "^8.18.0",
+        "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
         "chalk": "^5.6.2",
-        "clipboardy": "^5.3.0",
-        "commander": "^14.0.3",
+        "clipboardy": "^5.3.2",
+        "commander": "^15.0.0",
         "fast-glob": "^3.3.3",
-        "fs-extra": "^11.3.3",
-        "ignore": "^5.3.2",
-        "ink": "^6.7.0",
+        "fs-extra": "^11.4.0",
+        "ignore": "^7.0.6",
+        "ink": "^7.1.1",
         "ink-spinner": "^5.0.0",
-        "inquirer": "^13.2.4",
-        "js-yaml": "^4.1.1",
-        "lodash": "^4.17.23",
-        "minimatch": "^10.2.0",
-        "ora": "^9.3.0",
-        "p-limit": "^7.3.0",
-        "react": "^19.2.4",
-        "simple-git": "^3.31.1",
+        "js-yaml": "^4.3.0",
+        "lodash": "^4.18.1",
+        "micromatch": "^4.0.8",
+        "minimatch": "^10.2.5",
+        "ora": "^9.4.1",
+        "p-limit": "^7.3.1",
+        "react": "^19.2.8",
+        "simple-git": "^3.36.0",
         "xmlbuilder2": "^4.0.3"
       },
       "bin": {
         "copytree": "bin/copytree.js"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/copytree/node_modules/chalk": {
@@ -9968,6 +9625,24 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/copytree/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/copytree/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/core-js-compat": {
@@ -12404,21 +12079,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-string-truncated-width": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
-      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
-      "license": "MIT"
-    },
-    "node_modules/fast-string-width": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
-      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-string-truncated-width": "^3.0.2"
-      }
-    },
     "node_modules/fast-uri": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
@@ -12434,15 +12094,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fast-wrap-ansi": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
-      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-string-width": "^3.0.2"
-      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -12853,9 +12504,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
-      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -13532,6 +13183,7 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -13568,6 +13220,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -13629,43 +13282,43 @@
       "license": "ISC"
     },
     "node_modules/ink": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/ink/-/ink-6.8.0.tgz",
-      "integrity": "sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-7.1.1.tgz",
+      "integrity": "sha512-Y43xxa1ZSPvpmfLHcN5o+OdP8Rf8ykkNJEuKYOUNZKT8wXVNLFTtEm1nSDMQkfBH+YANF4Xuu0hhZ4ejqAtN2w==",
       "license": "MIT",
       "dependencies": {
-        "@alcalzone/ansi-tokenize": "^0.2.4",
+        "@alcalzone/ansi-tokenize": "^0.3.0",
         "ansi-escapes": "^7.3.0",
-        "ansi-styles": "^6.2.1",
+        "ansi-styles": "^6.2.3",
         "auto-bind": "^5.0.1",
-        "chalk": "^5.6.0",
-        "cli-boxes": "^3.0.0",
+        "chalk": "^5.6.2",
+        "cli-boxes": "^4.0.1",
         "cli-cursor": "^4.0.0",
-        "cli-truncate": "^5.1.1",
+        "cli-truncate": "^6.0.0",
         "code-excerpt": "^4.0.0",
-        "es-toolkit": "^1.39.10",
+        "es-toolkit": "^1.45.1",
         "indent-string": "^5.0.0",
         "is-in-ci": "^2.0.0",
         "patch-console": "^2.0.0",
         "react-reconciler": "^0.33.0",
         "scheduler": "^0.27.0",
         "signal-exit": "^3.0.7",
-        "slice-ansi": "^8.0.0",
+        "slice-ansi": "^9.0.0",
         "stack-utils": "^2.0.6",
-        "string-width": "^8.1.1",
+        "string-width": "^8.2.0",
         "terminal-size": "^4.0.1",
-        "type-fest": "^5.4.1",
+        "type-fest": "^5.5.0",
         "widest-line": "^6.0.0",
-        "wrap-ansi": "^9.0.0",
-        "ws": "^8.18.0",
+        "wrap-ansi": "^10.0.0",
+        "ws": "^8.20.0",
         "yoga-layout": "~3.2.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "peerDependencies": {
-        "@types/react": ">=19.0.0",
-        "react": ">=19.0.0",
+        "@types/react": ">=19.2.0",
+        "react": ">=19.2.0",
         "react-devtools-core": ">=6.1.2"
       },
       "peerDependenciesMeta": {
@@ -13723,38 +13376,29 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
+    "node_modules/ink/node_modules/wrap-ansi": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/inquirer": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.4.3.tgz",
-      "integrity": "sha512-EPd3IqieHSavSOXh+LZhrIkdQcOELWeRblLT6kslQr+cF9XTh/HxZdSt1YkHH1iq4dvqBnV42uwg2YlorgOy6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^2.0.5",
-        "@inquirer/core": "^11.1.10",
-        "@inquirer/prompts": "^8.4.3",
-        "@inquirer/type": "^4.0.5",
-        "mute-stream": "^3.0.0",
-        "run-async": "^4.0.6",
-        "rxjs": "^7.8.2"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
@@ -16066,15 +15710,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/mute-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
-      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -18344,15 +17979,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/run-async": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
-      "integrity": "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/run-jxa": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/run-jxa/-/run-jxa-3.0.0.tgz",
@@ -18493,6 +18119,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -18554,6 +18181,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {
@@ -19011,16 +18639,16 @@
       }
     },
     "node_modules/slice-ansi": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
-      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-9.0.0.tgz",
+      "integrity": "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.3",
         "is-fullwidth-code-point": "^5.1.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
@@ -21648,6 +21276,7 @@
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
       "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.1",
@@ -21665,6 +21294,7 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -21677,12 +21307,14 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi/node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^10.3.0",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "archiver": "^8.0.0",
     "avr-vad": "^1.0.10",
     "better-sqlite3": "^13.0.1",
-    "copytree": "^0.14.2",
+    "copytree": "^0.16.0",
     "httpxy": "^0.5.3",
     "ipaddr.js": "^2.4.0",
     "js-yaml": "^4.1.1",

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -135,6 +135,10 @@ export type {
   CopyTreeTestConfigResult,
   CopyTreeResult,
   CopyTreeProgress,
+  CopyTreeExclusionReason,
+  CopyTreeExclusionSummary,
+  CopyTreeBudgetStats,
+  CopyTreeTruncatedBy,
   FileTreeNode,
   // Worktree IPC types
   WorktreeRemovePayload,

--- a/shared/types/ipc/copyTree.ts
+++ b/shared/types/ipc/copyTree.ts
@@ -16,13 +16,18 @@ export interface CopyTreeOptions {
   /** Git filtering - only include files changed since specified commit/branch */
   changed?: string;
 
-  /** Size limits */
+  /**
+   * Per-file size gate in bytes. Files above it are never opened and are
+   * reported under `excluded.byReason.sizeGate`. `always` patterns override it.
+   * Left unset, no per-file gate applies.
+   */
   maxFileSize?: number;
   maxTotalSize?: number;
   maxFileCount?: number;
 
   /** Formatting */
   withLineNumbers?: boolean;
+  /** Character budget across all file content, not per file */
   charLimit?: number;
 
   /** Sorting strategy for file selection when limits are exceeded */
@@ -79,21 +84,70 @@ export interface CopyTreeTestConfigPayload {
   options?: CopyTreeTestConfigOptions;
 }
 
+/**
+ * Why a file did not make it into the context. Mirrors the SDK's stable
+ * exclusion reason keys — machine-readable, never prose, and additive.
+ */
+export type CopyTreeExclusionReason =
+  | "gitignore"
+  | "copytreeignore"
+  | "globalGitignore"
+  | "gitInfoExclude"
+  | "configExclude"
+  | "optionExclude"
+  | "filterPattern"
+  | "testExclude"
+  | "binaryExtension"
+  | "sizeGate"
+  | "totalSizeBudget"
+  | "fileCountBudget"
+  | "charBudget"
+  | "scopeFilter"
+  | "gitFilter"
+  | "duplicate"
+  | "unreadable";
+
+/**
+ * Exclusion accounting for a run. A pruned directory counts as a single
+ * exclusion standing in for its whole subtree.
+ */
+export interface CopyTreeExclusionSummary {
+  /** How many entries were excluded */
+  total: number;
+  /** Counts keyed by reason */
+  byReason: Partial<Record<CopyTreeExclusionReason, number>>;
+}
+
+/** Which budget dropped files first */
+export type CopyTreeTruncatedBy = "maxFileCount" | "maxTotalSize" | "charLimit";
+
+/** Budget and estimate reporting shared by real runs and dry runs */
+export interface CopyTreeBudgetStats {
+  /**
+   * Output characters. Measured on a real run, estimated on a dry run where
+   * the estimate is biased high.
+   */
+  estimatedOutputChars?: number;
+  /** Rough token count (chars/4), accurate to roughly ±20% */
+  estimatedTokens?: number;
+  /** True when nothing matched — a valid outcome, not an error */
+  noFilesMatched?: boolean;
+  /** What didn't make it, and why */
+  excluded?: CopyTreeExclusionSummary;
+  /** Whether a budget dropped files */
+  truncated?: boolean;
+  /** How many files a budget dropped */
+  truncatedCount?: number;
+  /** Which budget bit first */
+  truncatedBy?: CopyTreeTruncatedBy;
+}
+
 /** Result from CopyTree dry run test */
-export interface CopyTreeTestConfigResult {
+export interface CopyTreeTestConfigResult extends CopyTreeBudgetStats {
   /** Number of files that would be included */
   includedFiles: number;
   /** Total size of included files in bytes */
   includedSize: number;
-  /** Number of files excluded (broken down by reason) */
-  excluded: {
-    /** Files excluded by age/size truncation */
-    byTruncation: number;
-    /** Files excluded by size limit */
-    bySize: number;
-    /** Files excluded by patterns */
-    byPattern: number;
-  };
   /** Optional list of included file paths (for detailed preview) */
   files?: Array<{ path: string; size: number }>;
   /** Error message if dry run failed */
@@ -115,8 +169,13 @@ export interface CopyTreeResult {
   fileCount: number;
   /** Error message if generation failed */
   error?: string;
+  /**
+   * Version of the emitted format, e.g. `copytree-xml@1`. The output shape is a
+   * compatibility surface agents are prompted against, so it is versioned.
+   */
+  outputFormatVersion?: string | null;
   /** Generation statistics */
-  stats?: {
+  stats?: CopyTreeBudgetStats & {
     totalSize: number;
     duration: number;
   };
@@ -124,18 +183,16 @@ export interface CopyTreeResult {
 
 /** Progress update during CopyTree generation */
 export interface CopyTreeProgress {
-  /** Current stage name (e.g., 'FileDiscoveryStage', 'FormatterStage') */
+  /**
+   * Stage label. SDK-sourced events carry a stable pipeline identifier
+   * ('discover', 'load', 'format', …) and fall back to 'unknown'; the renderer
+   * also synthesizes its own local states before generation starts.
+   */
   stage: string;
   /** Progress percentage (0-1) */
   progress: number;
   /** Human-readable progress message */
   message: string;
-  /** Files processed so far (if known) */
-  filesProcessed?: number;
-  /** Total files estimated (if known) */
-  totalFiles?: number;
-  /** Current file being processed (if known) */
-  currentFile?: string;
   /** Optional trace ID to track event chains */
   traceId?: string;
 }

--- a/shared/types/ipc/copyTree.ts
+++ b/shared/types/ipc/copyTree.ts
@@ -19,7 +19,8 @@ export interface CopyTreeOptions {
   /**
    * Per-file size gate in bytes. Files above it are never opened and are
    * reported under `excluded.byReason.sizeGate`. `always` patterns override it.
-   * Left unset, no per-file gate applies.
+   * Left unset no configurable gate applies, but CopyTree's own 10MB
+   * memory-safety ceiling still does and nothing lifts that.
    */
   maxFileSize?: number;
   maxTotalSize?: number;
@@ -136,10 +137,16 @@ export interface CopyTreeBudgetStats {
   excluded?: CopyTreeExclusionSummary;
   /** Whether a budget dropped files */
   truncated?: boolean;
-  /** How many files a budget dropped */
+  /** How many files a budget dropped or cut short */
   truncatedCount?: number;
-  /** Which budget bit first */
+  /** Which budget bit first — not necessarily the only one that bit */
   truncatedBy?: CopyTreeTruncatedBy;
+  /**
+   * The retained set is larger than `maxTotalSize`. Happens when the first file
+   * alone exceeds the budget and is kept anyway, so it can be true even when
+   * nothing was truncated.
+   */
+  budgetExceeded?: boolean;
 }
 
 /** Result from CopyTree dry run test */

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -444,7 +444,7 @@ export interface RunCommand {
 export interface CopyTreeSettings {
   /** Maximum total context size in bytes. Undefined falls back to CopyTree's 100MB ceiling */
   maxContextSize?: number;
-  /** Maximum individual file size in bytes. Undefined means no per-file limit */
+  /** Per-file size gate in bytes. CopyTree's unliftable 10MB ceiling applies regardless */
   maxFileSize?: number;
   /** Character budget across all file content, not per file */
   charLimit?: number;

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -442,15 +442,15 @@ export interface RunCommand {
 
 /** CopyTree context generation settings */
 export interface CopyTreeSettings {
-  /** Maximum total context size in bytes (e.g., 1MB, 5MB, 10MB). Undefined = unlimited */
+  /** Maximum total context size in bytes. Undefined falls back to CopyTree's 100MB ceiling */
   maxContextSize?: number;
-  /** Maximum individual file size in bytes. Files larger are skipped */
+  /** Maximum individual file size in bytes. Undefined means no per-file limit */
   maxFileSize?: number;
-  /** Character limit per file for truncation. Files exceeding this will be truncated */
+  /** Character budget across all file content, not per file */
   charLimit?: number;
-  /** Truncation strategy: "all" (no truncation) or "modified" (newest first when limits hit) */
+  /** Retention order when a budget drops files: "all" (path order) or "modified" (newest first) */
   strategy?: "all" | "modified";
-  /** Glob patterns to always include, even if old */
+  /** Glob patterns to always include, overriding excludes and the per-file size limit */
   alwaysInclude?: string[];
   /** Glob patterns to always exclude from context */
   alwaysExclude?: string[];

--- a/src/components/Project/ContextTab.tsx
+++ b/src/components/Project/ContextTab.tsx
@@ -23,14 +23,23 @@ function formatBytes(bytes: number): string {
   return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + " " + sizes[i];
 }
 
-/** Token counts are a ±20% heuristic, so they read better rounded than exact. */
+/**
+ * Token counts are a ±20% heuristic, so they read better rounded than exact.
+ * Thresholds are picked off the *rounded* value so it can never print "1000k",
+ * and so the one-decimal form stops before it would round up to two digits.
+ */
 function formatTokenEstimate(tokens: number): string {
-  if (tokens < 1000) return String(tokens);
-  if (tokens < 1_000_000) return `${(tokens / 1000).toFixed(tokens < 10_000 ? 1 : 0)}k`;
+  if (tokens < 1000) return String(Math.round(tokens));
+  if (tokens < 999_500) {
+    const thousands = tokens / 1000;
+    return thousands < 9.95 ? `${thousands.toFixed(1)}k` : `${Math.round(thousands)}k`;
+  }
   return `${(tokens / 1_000_000).toFixed(1)}M`;
 }
 
-const EXCLUSION_LABELS: Partial<Record<CopyTreeExclusionReason, string>> = {
+// Keyed loosely on purpose: exclusion reasons are additive upstream, and an
+// unrecognized one falls back to showing its own key rather than nothing.
+const EXCLUSION_LABELS: Record<string, string | undefined> = {
   gitignore: "gitignore",
   copytreeignore: "copytreeignore",
   globalGitignore: "global gitignore",
@@ -51,12 +60,24 @@ const EXCLUSION_LABELS: Partial<Record<CopyTreeExclusionReason, string>> = {
 };
 
 const TRUNCATION_LABELS: Record<CopyTreeTruncatedBy, string> = {
-  maxFileCount: "file count",
-  maxTotalSize: "total size",
-  charLimit: "character budget",
+  maxFileCount: "the file count limit",
+  maxTotalSize: "the total size limit",
+  charLimit: "the character budget",
 };
 
 const EXCLUSION_REASON_PREVIEW_COUNT = 3;
+
+/**
+ * `truncatedBy` names the budget that bit first, not the only one that bit, and
+ * the count mixes files cut short with files left out entirely — so the notice
+ * says what is certain and attributes the cause only when the SDK reported one.
+ */
+function formatTruncationNotice(count?: number, by?: CopyTreeTruncatedBy): string {
+  const subject =
+    count === undefined ? "Some files were" : count === 1 ? "1 file was" : `${count} files were`;
+  const cause = by ? ` — ${TRUNCATION_LABELS[by]} was reached first` : "";
+  return `${subject} truncated or left out${cause}`;
+}
 
 /** Names the biggest exclusion reasons so the count isn't an unexplained number. */
 function describeTopExclusions(byReason: Partial<Record<CopyTreeExclusionReason, number>>): string {
@@ -64,7 +85,7 @@ function describeTopExclusions(byReason: Partial<Record<CopyTreeExclusionReason,
     .filter(([, count]) => (count ?? 0) > 0)
     .sort(([, a], [, b]) => (b ?? 0) - (a ?? 0))
     .slice(0, EXCLUSION_REASON_PREVIEW_COUNT)
-    .map(([reason]) => EXCLUSION_LABELS[reason as CopyTreeExclusionReason] ?? reason);
+    .map(([reason]) => EXCLUSION_LABELS[reason] ?? reason);
 
   return top.length > 0 ? ` — ${top.join(", ")}` : "";
 }
@@ -279,7 +300,7 @@ export function ContextTab({
                   setTestConfigResult(null);
                 }}
                 min={1}
-                placeholder="Default (no limit)"
+                placeholder="Default (up to 10 MB)"
                 className="w-full bg-daintree-sidebar border border-daintree-border rounded px-2 py-1 text-sm text-daintree-text font-mono focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30"
               />
               <p className="text-xs text-daintree-text/40 mt-1">Skip files larger than this</p>
@@ -335,8 +356,8 @@ export function ContextTab({
               Always include (glob patterns)
             </label>
             <p className="text-xs text-daintree-text/40 mb-2">
-              Files matching these patterns will always be included, even if they would otherwise be
-              excluded
+              Files matching these patterns are included even when an exclude rule or the max file
+              size would drop them
             </p>
             <div className="space-y-2">
               {(copyTreeSettings.alwaysInclude || []).map((pattern, index) => (
@@ -487,7 +508,11 @@ export function ContextTab({
             )}
 
             {testConfigResult && !showTestingSkeleton && (
+              // The skeleton this replaces is a live status, so the outcome has
+              // to be announced too — focus stays on the button either way.
               <div
+                role={testConfigResult.error ? "alert" : "status"}
+                aria-live={testConfigResult.error ? "assertive" : "polite"}
                 className={cn(
                   "mt-4 p-4 rounded-[var(--radius-md)] border",
                   testConfigResult.error
@@ -502,32 +527,55 @@ export function ContextTab({
                   </div>
                 ) : (
                   <div className="space-y-3">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <Check className="h-4 w-4 text-status-success" />
-                      <span className="text-sm font-medium text-daintree-text">
-                        {testConfigResult.includedFiles} files would be included
-                      </span>
-                      <span className="text-xs text-daintree-text/60">
-                        ({formatBytes(testConfigResult.includedSize)})
-                      </span>
-                      {testConfigResult.estimatedTokens !== undefined && (
-                        <span className="text-xs text-daintree-text/60">
-                          ~{formatTokenEstimate(testConfigResult.estimatedTokens)} tokens
+                    {testConfigResult.noFilesMatched ? (
+                      <p className="text-sm text-daintree-text">
+                        No files match these settings — loosen the excluded paths or size limits
+                      </p>
+                    ) : (
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <Check className="h-4 w-4 text-status-success" />
+                        <span className="text-sm font-medium text-daintree-text">
+                          {testConfigResult.includedFiles} files would be included
                         </span>
-                      )}
-                    </div>
+                        <span className="text-xs text-daintree-text/60">
+                          ({formatBytes(testConfigResult.includedSize)})
+                        </span>
+                        {testConfigResult.estimatedTokens !== undefined && (
+                          <span className="text-xs text-daintree-text/60">
+                            ~{formatTokenEstimate(testConfigResult.estimatedTokens)} tokens
+                          </span>
+                        )}
+                      </div>
+                    )}
                     {testConfigResult.excluded && testConfigResult.excluded.total > 0 && (
                       <p className="text-xs text-daintree-text/60">
                         {testConfigResult.excluded.total} excluded
                         {describeTopExclusions(testConfigResult.excluded.byReason)}
                       </p>
                     )}
+                    {copyTreeSettings.charLimit !== undefined && (
+                      // The dry run plans the character budget from byte sizes
+                      // without reading content, so this preview is an estimate.
+                      <p className="text-xs text-daintree-text/40">
+                        Estimated — the character budget is planned from file sizes
+                      </p>
+                    )}
                     {testConfigResult.truncated && (
                       <div className="flex items-start gap-2">
                         <AlertTriangle className="h-4 w-4 text-status-warning mt-0.5 shrink-0" />
                         <p className="text-xs text-daintree-text/80">
-                          {testConfigResult.truncatedCount ?? 0} files were dropped by the{" "}
-                          {TRUNCATION_LABELS[testConfigResult.truncatedBy ?? "maxTotalSize"]} limit
+                          {formatTruncationNotice(
+                            testConfigResult.truncatedCount,
+                            testConfigResult.truncatedBy
+                          )}
+                        </p>
+                      </div>
+                    )}
+                    {testConfigResult.budgetExceeded && !testConfigResult.truncated && (
+                      <div className="flex items-start gap-2">
+                        <AlertTriangle className="h-4 w-4 text-status-warning mt-0.5 shrink-0" />
+                        <p className="text-xs text-daintree-text/80">
+                          The first file alone is over the total size limit, so it was kept anyway
                         </p>
                       </div>
                     )}

--- a/src/components/Project/ContextTab.tsx
+++ b/src/components/Project/ContextTab.tsx
@@ -6,7 +6,13 @@ import { useSkeletonGate, useSkeletonFloor } from "@/hooks/useDeferredLoading";
 import { cn } from "@/lib/utils";
 import { copyTreeClient } from "@/clients/copyTreeClient";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
-import type { CopyTreeSettings, CopyTreeTestConfigResult, Worktree } from "@/types";
+import type {
+  CopyTreeExclusionReason,
+  CopyTreeSettings,
+  CopyTreeTestConfigResult,
+  CopyTreeTruncatedBy,
+  Worktree,
+} from "@/types";
 import { logError } from "@/utils/logger";
 
 function formatBytes(bytes: number): string {
@@ -15,6 +21,52 @@ function formatBytes(bytes: number): string {
   const sizes = ["B", "KB", "MB", "GB", "TB"];
   const i = Math.floor(Math.log(bytes) / Math.log(k));
   return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + " " + sizes[i];
+}
+
+/** Token counts are a ±20% heuristic, so they read better rounded than exact. */
+function formatTokenEstimate(tokens: number): string {
+  if (tokens < 1000) return String(tokens);
+  if (tokens < 1_000_000) return `${(tokens / 1000).toFixed(tokens < 10_000 ? 1 : 0)}k`;
+  return `${(tokens / 1_000_000).toFixed(1)}M`;
+}
+
+const EXCLUSION_LABELS: Partial<Record<CopyTreeExclusionReason, string>> = {
+  gitignore: "gitignore",
+  copytreeignore: "copytreeignore",
+  globalGitignore: "global gitignore",
+  gitInfoExclude: "git exclude file",
+  configExclude: "built-in excludes",
+  optionExclude: "excluded paths",
+  filterPattern: "filter patterns",
+  testExclude: "test excludes",
+  binaryExtension: "binary files",
+  sizeGate: "max file size",
+  totalSizeBudget: "total size limit",
+  fileCountBudget: "file count limit",
+  charBudget: "character budget",
+  scopeFilter: "scope",
+  gitFilter: "git filter",
+  duplicate: "duplicates",
+  unreadable: "unreadable files",
+};
+
+const TRUNCATION_LABELS: Record<CopyTreeTruncatedBy, string> = {
+  maxFileCount: "file count",
+  maxTotalSize: "total size",
+  charLimit: "character budget",
+};
+
+const EXCLUSION_REASON_PREVIEW_COUNT = 3;
+
+/** Names the biggest exclusion reasons so the count isn't an unexplained number. */
+function describeTopExclusions(byReason: Partial<Record<CopyTreeExclusionReason, number>>): string {
+  const top = Object.entries(byReason)
+    .filter(([, count]) => (count ?? 0) > 0)
+    .sort(([, a], [, b]) => (b ?? 0) - (a ?? 0))
+    .slice(0, EXCLUSION_REASON_PREVIEW_COUNT)
+    .map(([reason]) => EXCLUSION_LABELS[reason as CopyTreeExclusionReason] ?? reason);
+
+  return top.length > 0 ? ` — ${top.join(", ")}` : "";
 }
 
 const FILE_PREVIEW_COUNT = 10;
@@ -69,7 +121,6 @@ export function ContextTab({
       setTestConfigResult({
         includedFiles: 0,
         includedSize: 0,
-        excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
         error: "No worktree available to test configuration",
       });
       return;
@@ -110,7 +161,6 @@ export function ContextTab({
       setTestConfigResult({
         includedFiles: 0,
         includedSize: 0,
-        excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
         error: formatErrorMessage(error, "Failed to test configuration"),
       });
     } finally {
@@ -211,7 +261,7 @@ export function ContextTab({
                   setTestConfigResult(null);
                 }}
                 min={1}
-                placeholder="Default (unlimited)"
+                placeholder="Default (100 MB)"
                 className="w-full bg-daintree-sidebar border border-daintree-border rounded px-2 py-1 text-sm text-daintree-text font-mono focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30"
               />
               <p className="text-xs text-daintree-text/40 mt-1">Total size limit for all files</p>
@@ -229,7 +279,7 @@ export function ContextTab({
                   setTestConfigResult(null);
                 }}
                 min={1}
-                placeholder="Default (50KB)"
+                placeholder="Default (no limit)"
                 className="w-full bg-daintree-sidebar border border-daintree-border rounded px-2 py-1 text-sm text-daintree-text font-mono focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30"
               />
               <p className="text-xs text-daintree-text/40 mt-1">Skip files larger than this</p>
@@ -239,9 +289,7 @@ export function ContextTab({
           {/* Truncation Strategy */}
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-xs text-daintree-text/60 mb-1">
-                Char limit (per file)
-              </label>
+              <label className="block text-xs text-daintree-text/60 mb-1">Character budget</label>
               <input
                 type="number"
                 value={copyTreeSettings.charLimit ?? ""}
@@ -255,7 +303,7 @@ export function ContextTab({
                 className="w-full bg-daintree-sidebar border border-daintree-border rounded px-2 py-1 text-sm text-daintree-text font-mono focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30"
               />
               <p className="text-xs text-daintree-text/40 mt-1">
-                Truncate each file to this many characters
+                Total characters across all files
               </p>
             </div>
             <div>
@@ -454,7 +502,7 @@ export function ContextTab({
                   </div>
                 ) : (
                   <div className="space-y-3">
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 flex-wrap">
                       <Check className="h-4 w-4 text-status-success" />
                       <span className="text-sm font-medium text-daintree-text">
                         {testConfigResult.includedFiles} files would be included
@@ -462,7 +510,27 @@ export function ContextTab({
                       <span className="text-xs text-daintree-text/60">
                         ({formatBytes(testConfigResult.includedSize)})
                       </span>
+                      {testConfigResult.estimatedTokens !== undefined && (
+                        <span className="text-xs text-daintree-text/60">
+                          ~{formatTokenEstimate(testConfigResult.estimatedTokens)} tokens
+                        </span>
+                      )}
                     </div>
+                    {testConfigResult.excluded && testConfigResult.excluded.total > 0 && (
+                      <p className="text-xs text-daintree-text/60">
+                        {testConfigResult.excluded.total} excluded
+                        {describeTopExclusions(testConfigResult.excluded.byReason)}
+                      </p>
+                    )}
+                    {testConfigResult.truncated && (
+                      <div className="flex items-start gap-2">
+                        <AlertTriangle className="h-4 w-4 text-status-warning mt-0.5 shrink-0" />
+                        <p className="text-xs text-daintree-text/80">
+                          {testConfigResult.truncatedCount ?? 0} files were dropped by the{" "}
+                          {TRUNCATION_LABELS[testConfigResult.truncatedBy ?? "maxTotalSize"]} limit
+                        </p>
+                      </div>
+                    )}
                     {testConfigResult.files && testConfigResult.files.length > 0 && (
                       <div className="space-y-1">
                         <ul className="max-h-60 overflow-y-auto space-y-1">

--- a/src/components/Project/__tests__/ContextTab.test.tsx
+++ b/src/components/Project/__tests__/ContextTab.test.tsx
@@ -31,7 +31,7 @@ function renderTab(overrides: Partial<React.ComponentProps<typeof ContextTab>> =
 const successResult: CopyTreeTestConfigResult = {
   includedFiles: 5,
   includedSize: 2048,
-  excluded: { byTruncation: 1, bySize: 2, byPattern: 3 },
+  excluded: { total: 6, byReason: { gitignore: 4, sizeGate: 2 } },
 };
 
 beforeEach(() => {
@@ -52,7 +52,7 @@ describe("ContextTab copy", () => {
     expect(screen.getByText("Test configuration")).toBeTruthy();
     expect(screen.getByText("Max context size (bytes)")).toBeTruthy();
     expect(screen.getByText("Max file size (bytes)")).toBeTruthy();
-    expect(screen.getByText("Char limit (per file)")).toBeTruthy();
+    expect(screen.getByText("Character budget")).toBeTruthy();
     expect(screen.getByText("File priority strategy")).toBeTruthy();
     expect(screen.getByText("Always include (glob patterns)")).toBeTruthy();
     expect(screen.getByText("Always exclude (glob patterns)")).toBeTruthy();
@@ -202,12 +202,68 @@ describe("ContextTab test-config button", () => {
     });
     expect(screen.queryByRole("status", { name: "Running test configuration" })).toBeNull();
   });
+});
+
+describe("ContextTab dry-run reporting", () => {
+  async function runWith(result: Partial<CopyTreeTestConfigResult>) {
+    testConfigMock.mockResolvedValue({ ...successResult, ...result });
+    renderTab();
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Test config" }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText("5 files would be included")).toBeTruthy();
+    });
+  }
+
+  it("abbreviates large token estimates and leaves small ones exact", async () => {
+    await runWith({ estimatedTokens: 78_400 });
+    expect(screen.getByText("~78k tokens")).toBeTruthy();
+  });
+
+  it("shows an exact count below a thousand tokens", async () => {
+    await runWith({ estimatedTokens: 640 });
+    expect(screen.getByText("~640 tokens")).toBeTruthy();
+  });
+
+  it("omits the token estimate when the dry run did not report one", async () => {
+    await runWith({ estimatedTokens: undefined });
+    expect(screen.queryByText(/tokens/)).toBeNull();
+  });
+
+  it("names the largest exclusion reasons behind the excluded count", async () => {
+    await runWith({
+      excluded: { total: 12, byReason: { gitignore: 7, sizeGate: 4, duplicate: 1 } },
+    });
+
+    const line = screen.getByText(/12 excluded/).textContent ?? "";
+    expect(line).toContain("gitignore");
+    expect(line).toContain("max file size");
+    // Ordered by count, so the largest reason leads.
+    expect(line.indexOf("gitignore")).toBeLessThan(line.indexOf("max file size"));
+  });
+
+  it("stays quiet when nothing was excluded", async () => {
+    await runWith({ excluded: { total: 0, byReason: {} } });
+    expect(screen.queryByText(/\d+ excluded/)).toBeNull();
+  });
+
+  it("warns which budget dropped files when the run truncated", async () => {
+    await runWith({ truncated: true, truncatedCount: 9, truncatedBy: "charLimit" });
+
+    const warning = screen.getByText(/9 files were dropped/).textContent ?? "";
+    expect(warning).toContain("character budget");
+  });
+
+  it("shows no truncation warning on an untruncated run", async () => {
+    await runWith({ truncated: false });
+    expect(screen.queryByText(/were dropped by/)).toBeNull();
+  });
 
   it("renders an error card when the dry-run fails", async () => {
     testConfigMock.mockResolvedValue({
       includedFiles: 0,
       includedSize: 0,
-      excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
       error: "Boom",
     } satisfies CopyTreeTestConfigResult);
     renderTab();
@@ -289,7 +345,6 @@ describe("ContextTab file-list preview", () => {
     return {
       includedFiles: files.length,
       includedSize: files.reduce((sum, file) => sum + file.size, 0),
-      excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
       files,
     };
   }

--- a/src/components/Project/__tests__/ContextTab.test.tsx
+++ b/src/components/Project/__tests__/ContextTab.test.tsx
@@ -81,9 +81,9 @@ describe("ContextTab copy", () => {
     expect(excludedSubtitle?.endsWith(").")).toBe(false);
 
     const includeSubtitle = screen
-      .getByText(/Files matching these patterns will always be included/)
+      .getByText(/Files matching these patterns are included/)
       .textContent?.trim();
-    expect(includeSubtitle?.endsWith("excluded")).toBe(true);
+    expect(includeSubtitle?.endsWith("them")).toBe(true);
 
     const excludeSubtitle = screen
       .getByText(/Additional exclusion patterns beyond the default excluded paths above/)
@@ -205,25 +205,38 @@ describe("ContextTab test-config button", () => {
 });
 
 describe("ContextTab dry-run reporting", () => {
-  async function runWith(result: Partial<CopyTreeTestConfigResult>) {
+  async function runWith(
+    result: Partial<CopyTreeTestConfigResult>,
+    settledText: string | RegExp = "5 files would be included"
+  ) {
     testConfigMock.mockResolvedValue({ ...successResult, ...result });
     renderTab();
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "Test config" }));
     });
     await waitFor(() => {
-      expect(screen.getByText("5 files would be included")).toBeTruthy();
+      expect(screen.getByText(settledText)).toBeTruthy();
     });
   }
 
-  it("abbreviates large token estimates and leaves small ones exact", async () => {
-    await runWith({ estimatedTokens: 78_400 });
-    expect(screen.getByText("~78k tokens")).toBeTruthy();
+  it.each([
+    [999, "~999 tokens"],
+    [1_000, "~1.0k tokens"],
+    [9_949, "~9.9k tokens"],
+    [10_000, "~10k tokens"],
+    [78_400, "~78k tokens"],
+    // Must roll over to M rather than printing a malformed "1000k".
+    [999_500, "~1.0M tokens"],
+    [1_000_000, "~1.0M tokens"],
+    [2_400_000, "~2.4M tokens"],
+  ])("formats a %i token estimate as %s", async (tokens, expected) => {
+    await runWith({ estimatedTokens: tokens });
+    expect(screen.getByText(expected)).toBeTruthy();
   });
 
-  it("shows an exact count below a thousand tokens", async () => {
-    await runWith({ estimatedTokens: 640 });
-    expect(screen.getByText("~640 tokens")).toBeTruthy();
+  it("never renders a four-digit thousands abbreviation", async () => {
+    await runWith({ estimatedTokens: 999_499 });
+    expect(screen.queryByText(/~\d{4}k tokens/)).toBeNull();
   });
 
   it("omits the token estimate when the dry run did not report one", async () => {
@@ -248,16 +261,47 @@ describe("ContextTab dry-run reporting", () => {
     expect(screen.queryByText(/\d+ excluded/)).toBeNull();
   });
 
-  it("warns which budget dropped files when the run truncated", async () => {
+  it("names the budget that bit first without claiming it was the only cause", async () => {
     await runWith({ truncated: true, truncatedCount: 9, truncatedBy: "charLimit" });
 
-    const warning = screen.getByText(/9 files were dropped/).textContent ?? "";
-    expect(warning).toContain("character budget");
+    const warning = screen.getByText(/9 files were truncated or left out/).textContent ?? "";
+    expect(warning).toContain("the character budget");
+    expect(warning).toContain("reached first");
+  });
+
+  it("uses singular grammar for a single truncated file", async () => {
+    await runWith({ truncated: true, truncatedCount: 1, truncatedBy: "maxTotalSize" });
+
+    expect(screen.getByText(/^1 file was truncated or left out/)).toBeTruthy();
+  });
+
+  it("attributes no cause when the SDK reported none", async () => {
+    await runWith({ truncated: true, truncatedCount: 4, truncatedBy: undefined });
+
+    const warning = screen.getByText(/4 files were truncated or left out/).textContent ?? "";
+    expect(warning).not.toContain("reached first");
   });
 
   it("shows no truncation warning on an untruncated run", async () => {
     await runWith({ truncated: false });
-    expect(screen.queryByText(/were dropped by/)).toBeNull();
+    expect(screen.queryByText(/truncated or left out/)).toBeNull();
+  });
+
+  it("warns when an oversized first file pushed the run past the total size limit", async () => {
+    await runWith({ truncated: false, budgetExceeded: true });
+
+    expect(screen.getByText(/first file alone is over the total size limit/)).toBeTruthy();
+  });
+
+  it("reports a no-match run as an empty state rather than a success", async () => {
+    await runWith(
+      { noFilesMatched: true, includedFiles: 0, files: [] },
+      /No files match these settings/
+    );
+
+    // The success headline carries a count; the static tab subtitle also says
+    // "files would be included", so match only the counted form.
+    expect(screen.queryByText(/^\d+ files would be included$/)).toBeNull();
   });
 
   it("renders an error card when the dry-run fails", async () => {


### PR DESCRIPTION
Bumps `copytree` from 0.14.2 to 0.16.0 and reworks the SDK adapter so the new capabilities are actually used and the behaviour changes are handled deliberately rather than silently.

The headline is that this is as much a bug fix as a version bump. Upstream PR #125 (written against a requirements doc we filed) puts it plainly: "Budgets were accepted and then ignored. `maxFileSize`, `maxTotalSize`, `maxFileCount` and `charLimit` were documented, typed, and threaded into `FileDiscoveryStage`, whose constructor never stored them." Three of the four controls the Context tab presents have done nothing in production all along, and config media exclusions never applied on the SDK path either. They work now.

## The size-limit decision

0.16 adds `sizeGate`, a per-file gate defaulting to 256KB, applied before `maxFileSize`. Left alone it would silently drop every file between 256KB and whatever limit the user configured.

Our "Max file size" control maps to `sizeGate`, not the SDK's `maxFileSize`. The SDK is explicit that `maxFileSize` is a memory ceiling nothing lifts, while `always` patterns *can* lift `sizeGate` — and the Context tab promises exactly that. Unset, the gate is disabled rather than inheriting the 256KB default, so existing projects keep the files they had. The 10MB memory ceiling still applies underneath and nothing lifts it; the UI copy now says so instead of claiming "no limit".

## Other behaviour changes

- `sort: "modified"` now pairs with `sortOrder: "desc"`. Budgets keep the head of the sorted list, so "Recently modified first" was keeping the *oldest* files. Invisible until budgets started working.
- Config loads hermetically via `ConfigManager.create({ userConfig: false, strict: true })` and fails closed. `~/.copytree/config/copytree.js` is arbitrary code that was running in our main process. Failing closed matters now because in 0.14.2 a missing config was harmless — in 0.16 it means no exclusions at all, so `node_modules` and media flood the context. `strict` alone isn't enough: an absent config directory resolves successfully and empty, so we check `isDefaultsLoaded` too.
- `secretsGuard: false` is set explicitly. 0.16 turned redaction on by default for the programmatic API and it still misfires on ordinary source, which would quietly corrupt what an agent receives.
- Errors map through stable codes to static strings. We were interpolating raw SDK messages, which carry absolute paths.
- `filesProcessed`/`totalFiles`/`currentFile` are gone from `CopyTreeProgress` — the 0.16 tracker only ever emits `percent`, `message` and a stable stage id, so we were declaring fields nothing populated.

## The dry run tells the truth now

`testConfig()` used to hardcode `excluded: { byTruncation: 0, bySize: 0, byPattern: 0 }` on every return path, because 0.14.2 had no breakdown to report. That fake shape existed in 15 places and was never rendered. It's replaced with the SDK's real `{ total, byReason }` accounting across 17 stable reasons.

The preview counts every manifest outcome that reaches the output, not just `included` — `truncated`, `structure-only` and `binary-placeholder` all occupy a slot, and filtering them out under-reported what the context would contain. The count and the file list are derived from the same filtered list, so they can't disagree.

The Context tab now shows the token estimate, what was excluded and why, and which budget bit first — worded so it doesn't claim a single budget dropped everything when `truncatedBy` only names the one that hit first.

## Not included

`includePaths` is still mapped to `filter` rather than the new `scope` option. The action schema documents a published contract that agents are prompted against ("a folder needs a glob: pass `src/panels/**`, not `src/panels`"), and the migration is all-or-nothing — literal paths handed to a glob matcher match nothing. It's worth doing as its own change, with the file picker and MCP contract moved together.

## Testing

205 tests pass across the affected suites. Added `CopyTreeService.sdk-contract.test.ts`, which runs the real installed package rather than a mock — every other suite mocks `copytree`, so they only prove the adapter matches our assumptions. That suite caught nothing new only because it was written after the assumption it would have caught was already fixed.

Resolves #11437