### PR TITLE
fix(file-browser): let rendered markdown scroll in the preview

### DIFF
--- a/e2e/full/panels/core-file-browser.spec.ts
+++ b/e2e/full/panels/core-file-browser.spec.ts
@@ -1,0 +1,207 @@
+import path from "path";
+import { writeFileSync } from "fs";
+import { test, expect, type Locator, type Page } from "@playwright/test";
+import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
+import { createFixtureRepo } from "../../helpers/fixtures";
+import { openAndOnboardProject } from "../../helpers/project";
+import { SEL } from "../../helpers/selectors";
+import { T_SHORT, T_MEDIUM, T_LONG } from "../../helpers/timeouts";
+
+let ctx: AppContext;
+let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
+
+// Tall enough to overflow the preview in both source and rendered mode.
+// Blank-line separated so the rendered document is a stack of real <p>
+// elements rather than one wrapped paragraph.
+const TALL_MARKDOWN =
+  "# Tall browser document\n\n" +
+  Array.from(
+    { length: 300 },
+    (_, i) => `Paragraph ${String(i + 1).padStart(3, "0")} lorem ipsum dolor sit amet.`
+  ).join("\n\n") +
+  "\n\n## file-browser-end\n";
+
+const SHORT_MARKDOWN = "# Short browser document\n\nOne paragraph, nowhere near a screenful.\n";
+
+interface DispatchResult {
+  ok?: boolean;
+  error?: { message?: string };
+  result?: { worktrees?: Array<{ id: string; isMain?: boolean }> };
+}
+
+async function dispatchAction(
+  page: Page,
+  actionId: string,
+  args?: unknown
+): Promise<DispatchResult> {
+  return page.evaluate(
+    ([id, a]) =>
+      (
+        window as unknown as {
+          __daintreeDispatchAction: (id: string, a?: unknown) => Promise<DispatchResult>;
+        }
+      ).__daintreeDispatchAction(id, a),
+    [actionId, args] as const
+  );
+}
+
+/**
+ * Opens the browser through the real action rather than driving the
+ * virtualized tree: `revealPath` seeds the selection, so the preview renders
+ * the file without a click that depends on row virtualization.
+ */
+async function openFileBrowser(page: Page, revealPath: string) {
+  const listed = await dispatchAction(page, "worktree.list");
+  if (!listed.ok) throw new Error(`worktree.list failed: ${listed.error?.message ?? "unknown"}`);
+  const worktrees = listed.result?.worktrees ?? [];
+  const target = worktrees.find((w) => w.isMain) ?? worktrees[0];
+  if (!target) throw new Error("no worktree to browse");
+
+  await dispatchAction(page, "worktree.openFileBrowser", {
+    worktreeId: target.id,
+    revealPath,
+    revealKind: "file",
+  });
+
+  const dialog = page.locator(SEL.fileViewer.dialog);
+  await expect(dialog).toBeVisible({ timeout: T_MEDIUM });
+  return dialog;
+}
+
+async function closeDialog(page: Page) {
+  await page.locator(SEL.fileViewer.closeButton).first().click();
+  await expect(page.locator(SEL.fileViewer.dialog)).not.toBeVisible({ timeout: T_SHORT });
+}
+
+/**
+ * #11441: neither markdown surface brings its own scroller — MarkdownDocument
+ * carries no overflow class, and CodeViewer forces `.cm-scroller` visible — so
+ * without a scroll owner in the preview everything past the first screenful
+ * was unreachable. Mirrors `expectScrollsWithinDialog` in core-file-viewer.
+ */
+async function expectPreviewScrolls(scrollRoot: Locator) {
+  await expect
+    .poll(
+      () =>
+        scrollRoot.evaluate((el) => {
+          const dialogRect = el.closest('[data-testid="panel-dialog"]')?.getBoundingClientRect();
+          return {
+            scrollsInternally: el.scrollHeight > el.clientHeight,
+            // A real scrollbar, not merely programmatic scrollability: an
+            // `overflow: hidden` element still accepts a `scrollTop` write, so
+            // the scroll check below would pass on a clipped preview.
+            scrollable: ["auto", "scroll"].includes(getComputedStyle(el).overflowY),
+            // The preview stays inside the dialog surface. A pane that sizes to
+            // the document instead fits the window while having its bottom edge
+            // — and its scrollbar — clipped away.
+            withinDialog:
+              dialogRect !== undefined &&
+              el.getBoundingClientRect().bottom <= dialogRect.bottom + 1,
+            // The content is the preview's own child, not a nested scrollport
+            // that would trap the wheel and leave the outer one at zero.
+            childDelegatesScroll:
+              el.firstElementChild instanceof HTMLElement &&
+              el.firstElementChild.scrollHeight <= el.firstElementChild.clientHeight + 1,
+          };
+        }),
+      { timeout: T_MEDIUM }
+    )
+    .toEqual({
+      scrollsInternally: true,
+      scrollable: true,
+      withinDialog: true,
+      childDelegatesScroll: true,
+    });
+
+  // Content past the first screen is reachable, and scrolling lands on the real
+  // bottom rather than some intermediate clamp.
+  const scroll = await scrollRoot.evaluate((el) => {
+    el.scrollTop = el.scrollHeight;
+    return { reached: el.scrollTop, max: el.scrollHeight - el.clientHeight };
+  });
+  expect(scroll.reached).toBeGreaterThan(0);
+  expect(scroll.reached).toBeGreaterThanOrEqual(scroll.max - 2);
+}
+
+test.describe.serial("Core: File browser preview", () => {
+  test.beforeAll(async () => {
+    const { dir, cleanup } = createFixtureRepo({ name: "file-browser" });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
+    writeFileSync(path.join(dir, "tall.md"), TALL_MARKDOWN);
+    writeFileSync(path.join(dir, "short.md"), SHORT_MARKDOWN);
+    ctx = await launchApp();
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "File Browser");
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
+  });
+
+  test("rendered markdown taller than the preview scrolls inside it", async () => {
+    const dialog = await openFileBrowser(ctx.window, "tall.md");
+
+    // Rendered is the browser's default markdown mode.
+    const document = dialog.locator(".markdown-document");
+    await expect(document).toContainText("Paragraph 001", { timeout: T_LONG });
+
+    const scrollRoot = dialog.getByTestId("file-browser-markdown-scroll");
+    await expectPreviewScrolls(scrollRoot);
+
+    // The user-visible symptom: the tail of the document was unreachable.
+    await scrollRoot.evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+    await expect(dialog.getByRole("heading", { name: /file-browser-end/ })).toBeInViewport({
+      timeout: T_MEDIUM,
+    });
+
+    await closeDialog(ctx.window);
+  });
+
+  test("markdown source mode scrolls in the same preview scroll root", async () => {
+    const dialog = await openFileBrowser(ctx.window, "tall.md");
+    await expect(dialog.locator(".markdown-document")).toBeVisible({ timeout: T_LONG });
+
+    await dialog.getByRole("button", { name: "Source" }).click();
+    await expect(dialog.locator(".cm-content")).toContainText("# Tall browser document", {
+      timeout: T_LONG,
+    });
+
+    // CodeViewer's root carries `overflow-auto` by default, so this also proves
+    // the two scrollports don't fight: with no definite height it grows with
+    // CodeMirror and delegates the scroll up to the preview wrapper.
+    await expectPreviewScrolls(dialog.getByTestId("file-browser-markdown-scroll"));
+
+    await closeDialog(ctx.window);
+  });
+
+  test("a short markdown document fills the preview instead of stopping at its own height", async () => {
+    const dialog = await openFileBrowser(ctx.window, "short.md");
+    await expect(dialog.locator(".markdown-document")).toContainText("One paragraph", {
+      timeout: T_LONG,
+    });
+
+    // `min-h-full` rather than no class at all: the document reaches the bottom
+    // of the preview so its background doesn't stop mid-pane, and rather than
+    // `h-full`, which would clamp it and re-break the tall case above.
+    await expect
+      .poll(
+        () =>
+          dialog.getByTestId("file-browser-markdown-scroll").evaluate((el) => {
+            const document = el.firstElementChild;
+            return {
+              fillsPreview:
+                document instanceof HTMLElement && document.offsetHeight >= el.clientHeight - 1,
+              noSpuriousOverflow: el.scrollHeight <= el.clientHeight + 1,
+            };
+          }),
+        { timeout: T_MEDIUM }
+      )
+      .toEqual({ fillsPreview: true, noSpuriousOverflow: true });
+
+    await closeDialog(ctx.window);
+  });
+});

--- a/e2e/full/panels/core-file-browser.spec.ts
+++ b/e2e/full/panels/core-file-browser.spec.ts
@@ -11,11 +11,14 @@ let ctx: AppContext;
 let fixtureDir: string;
 let fixtureCleanup: (() => void) | undefined;
 
-// Tall enough to overflow the preview in both source and rendered mode.
-// Blank-line separated so the rendered document is a stack of real <p>
-// elements rather than one wrapped paragraph.
+// Tall enough to overflow the preview in both modes. Blank-line separated so
+// the rendered document is a stack of real <p> elements rather than one
+// wrapped paragraph. The long unbroken line matters for source mode, where
+// CodeViewer defaults `wrapLines` to false: it forces horizontal overflow, so
+// the spec can prove which element owns that axis.
 const TALL_MARKDOWN =
   "# Tall browser document\n\n" +
+  `    const wide = "${"x".repeat(600)}";\n\n` +
   Array.from(
     { length: 300 },
     (_, i) => `Paragraph ${String(i + 1).padStart(3, "0")} lorem ipsum dolor sit amet.`
@@ -46,82 +49,102 @@ async function dispatchAction(
   );
 }
 
+// Scoped to the file browser's own marker rather than a bare `panel-dialog`:
+// that host is shared, so an unrelated dialog must not satisfy this.
+const BROWSER_DIALOG = `${SEL.fileViewer.dialog}:has([data-testid="file-browser-sidebar-toggle"])`;
+
 /**
  * Opens the browser through the real action rather than driving the
  * virtualized tree: `revealPath` seeds the selection, so the preview renders
  * the file without a click that depends on row virtualization.
  */
 async function openFileBrowser(page: Page, revealPath: string) {
-  const listed = await dispatchAction(page, "worktree.list");
-  if (!listed.ok) throw new Error(`worktree.list failed: ${listed.error?.message ?? "unknown"}`);
-  const worktrees = listed.result?.worktrees ?? [];
-  const target = worktrees.find((w) => w.isMain) ?? worktrees[0];
-  if (!target) throw new Error("no worktree to browse");
+  // Polled rather than read once: the project's worktree readiness gate is
+  // best-effort, so a loaded runner can briefly answer with an empty list.
+  let worktreeId: string | undefined;
+  await expect
+    .poll(
+      async () => {
+        const listed = await dispatchAction(page, "worktree.list");
+        worktreeId = (listed.result?.worktrees ?? []).find((w) => w.isMain)?.id;
+        return worktreeId ?? null;
+      },
+      { timeout: T_MEDIUM }
+    )
+    .not.toBeNull();
 
-  await dispatchAction(page, "worktree.openFileBrowser", {
-    worktreeId: target.id,
+  const opened = await dispatchAction(page, "worktree.openFileBrowser", {
+    worktreeId,
     revealPath,
     revealKind: "file",
   });
+  if (opened.ok === false) {
+    throw new Error(`openFileBrowser failed: ${opened.error?.message ?? "unknown"}`);
+  }
 
-  const dialog = page.locator(SEL.fileViewer.dialog);
+  const dialog = page.locator(BROWSER_DIALOG);
   await expect(dialog).toBeVisible({ timeout: T_MEDIUM });
   return dialog;
 }
 
 async function closeDialog(page: Page) {
-  await page.locator(SEL.fileViewer.closeButton).first().click();
-  await expect(page.locator(SEL.fileViewer.dialog)).not.toBeVisible({ timeout: T_SHORT });
+  await page.locator(BROWSER_DIALOG).locator(SEL.fileViewer.closeButton).first().click();
+  await expect(page.locator(BROWSER_DIALOG)).not.toBeVisible({ timeout: T_SHORT });
 }
 
 /**
- * #11441: neither markdown surface brings its own scroller — MarkdownDocument
- * carries no overflow class, and CodeViewer forces `.cm-scroller` visible — so
- * without a scroll owner in the preview everything past the first screenful
- * was unreachable. Mirrors `expectScrollsWithinDialog` in core-file-viewer.
+ * Vertical scroll ownership: the element scrolls, and its scrollbar is on
+ * screen.
+ *
+ * The containment check measures the dialog SURFACE, not `panel-dialog` — that
+ * test id sits on AppDialog's inset-0 backdrop, so measuring against it would
+ * only prove the pane ends before the window bottom. The bounded surface is the
+ * backdrop's first child; without that, a pane clipped by the surface's own
+ * overflow-hidden still passes.
  */
-async function expectPreviewScrolls(scrollRoot: Locator) {
+async function expectOwnsVerticalScroll(scrollOwner: Locator) {
   await expect
     .poll(
       () =>
-        scrollRoot.evaluate((el) => {
-          const dialogRect = el.closest('[data-testid="panel-dialog"]')?.getBoundingClientRect();
+        scrollOwner.evaluate((el) => {
+          const surfaceRect = el
+            .closest('[data-testid="panel-dialog"]')
+            ?.firstElementChild?.getBoundingClientRect();
+          const rect = el.getBoundingClientRect();
           return {
-            scrollsInternally: el.scrollHeight > el.clientHeight,
+            // A collapsed root with overflowing content would otherwise satisfy
+            // the overflow check below while showing nothing.
+            hasHeight: el.clientHeight > 0,
+            scrollsVertically: el.scrollHeight > el.clientHeight,
             // A real scrollbar, not merely programmatic scrollability: an
-            // `overflow: hidden` element still accepts a `scrollTop` write, so
-            // the scroll check below would pass on a clipped preview.
+            // `overflow: hidden` element still accepts a `scrollTop` write.
             scrollable: ["auto", "scroll"].includes(getComputedStyle(el).overflowY),
-            // The preview stays inside the dialog surface. A pane that sizes to
-            // the document instead fits the window while having its bottom edge
-            // — and its scrollbar — clipped away.
-            withinDialog:
-              dialogRect !== undefined &&
-              el.getBoundingClientRect().bottom <= dialogRect.bottom + 1,
-            // The content is the preview's own child, not a nested scrollport
-            // that would trap the wheel and leave the outer one at zero.
-            childDelegatesScroll:
-              el.firstElementChild instanceof HTMLElement &&
-              el.firstElementChild.scrollHeight <= el.firstElementChild.clientHeight + 1,
+            withinSurface:
+              surfaceRect !== undefined &&
+              rect.bottom <= surfaceRect.bottom + 1 &&
+              rect.top >= surfaceRect.top - 1,
           };
         }),
       { timeout: T_MEDIUM }
     )
     .toEqual({
-      scrollsInternally: true,
+      hasHeight: true,
+      scrollsVertically: true,
       scrollable: true,
-      withinDialog: true,
-      childDelegatesScroll: true,
+      withinSurface: true,
     });
 
   // Content past the first screen is reachable, and scrolling lands on the real
-  // bottom rather than some intermediate clamp.
-  const scroll = await scrollRoot.evaluate((el) => {
+  // bottom rather than some intermediate clamp. Reset afterwards so a later
+  // assertion starts from a known position.
+  const vertical = await scrollOwner.evaluate((el) => {
     el.scrollTop = el.scrollHeight;
-    return { reached: el.scrollTop, max: el.scrollHeight - el.clientHeight };
+    const reached = el.scrollTop;
+    el.scrollTop = 0;
+    return { reached, max: el.scrollHeight - el.clientHeight };
   });
-  expect(scroll.reached).toBeGreaterThan(0);
-  expect(scroll.reached).toBeGreaterThanOrEqual(scroll.max - 2);
+  expect(vertical.reached).toBeGreaterThan(0);
+  expect(vertical.reached).toBeGreaterThanOrEqual(vertical.max - 2);
 }
 
 test.describe.serial("Core: File browser preview", () => {
@@ -144,36 +167,89 @@ test.describe.serial("Core: File browser preview", () => {
     const dialog = await openFileBrowser(ctx.window, "tall.md");
 
     // Rendered is the browser's default markdown mode.
-    const document = dialog.locator(".markdown-document");
-    await expect(document).toContainText("Paragraph 001", { timeout: T_LONG });
+    await expect(dialog.locator(".markdown-document")).toContainText("Paragraph 001", {
+      timeout: T_LONG,
+    });
 
+    // #11441: MarkdownDocument brings no scroller of its own, so before the fix
+    // nothing between the pane and the document was a scroll container.
     const scrollRoot = dialog.getByTestId("file-browser-markdown-scroll");
-    await expectPreviewScrolls(scrollRoot);
+    await expectOwnsVerticalScroll(scrollRoot);
+
+    // The document grows instead of clamping to the wrapper — restoring
+    // `h-full` on the MarkdownViewer call fails right here.
+    await expect
+      .poll(
+        () =>
+          scrollRoot.evaluate((el) => {
+            const doc = el.firstElementChild;
+            return doc instanceof HTMLElement && doc.scrollHeight <= doc.clientHeight + 1;
+          }),
+        { timeout: T_MEDIUM }
+      )
+      .toBe(true);
 
     // The user-visible symptom: the tail of the document was unreachable.
+    // ratio 1 — a single visible pixel of the heading is not "readable".
     await scrollRoot.evaluate((el) => {
       el.scrollTop = el.scrollHeight;
     });
     await expect(dialog.getByRole("heading", { name: /file-browser-end/ })).toBeInViewport({
+      ratio: 1,
       timeout: T_MEDIUM,
     });
 
     await closeDialog(ctx.window);
   });
 
-  test("markdown source mode scrolls in the same preview scroll root", async () => {
+  test("markdown source mode keeps one scrollport that owns both axes", async () => {
     const dialog = await openFileBrowser(ctx.window, "tall.md");
     await expect(dialog.locator(".markdown-document")).toBeVisible({ timeout: T_LONG });
 
-    await dialog.getByRole("button", { name: "Source" }).click();
+    await dialog.getByRole("button", { name: "Source", exact: true }).click();
     await expect(dialog.locator(".cm-content")).toContainText("# Tall browser document", {
       timeout: T_LONG,
     });
 
-    // CodeViewer's root carries `overflow-auto` by default, so this also proves
-    // the two scrollports don't fight: with no definite height it grows with
-    // CodeMirror and delegates the scroll up to the preview wrapper.
-    await expectPreviewScrolls(dialog.getByTestId("file-browser-markdown-scroll"));
+    // Source mode is deliberately left unwrapped: CodeViewer at pane height is
+    // the single scrollport, which keeps its horizontal scrollbar on screen.
+    // Handing the vertical axis to an outer wrapper would let this element grow
+    // to content height, stranding the horizontal scrollbar below the fold.
+    await expect(dialog.getByTestId("file-browser-markdown-scroll")).toHaveCount(0);
+
+    // Resolved by walking up from the editor to the nearest scrollable
+    // ancestor: the invariant is about whichever element actually owns the
+    // scroll, not about a particular tag or test id.
+    await expect
+      .poll(
+        () =>
+          dialog.locator(".cm-editor").evaluate((cm) => {
+            let owner = cm.parentElement;
+            while (owner && !["auto", "scroll"].includes(getComputedStyle(owner).overflowY)) {
+              owner = owner.parentElement;
+            }
+            if (!owner) return { found: false };
+            const surfaceRect = owner
+              .closest('[data-testid="panel-dialog"]')
+              ?.firstElementChild?.getBoundingClientRect();
+            const rect = owner.getBoundingClientRect();
+            return {
+              found: true,
+              ownsVertical: owner.scrollHeight > owner.clientHeight,
+              ownsHorizontal: owner.scrollWidth > owner.clientWidth,
+              horizontalScrollable: ["auto", "scroll"].includes(getComputedStyle(owner).overflowX),
+              withinSurface: surfaceRect !== undefined && rect.bottom <= surfaceRect.bottom + 1,
+            };
+          }),
+        { timeout: T_MEDIUM }
+      )
+      .toEqual({
+        found: true,
+        ownsVertical: true,
+        ownsHorizontal: true,
+        horizontalScrollable: true,
+        withinSurface: true,
+      });
 
     await closeDialog(ctx.window);
   });
@@ -185,16 +261,15 @@ test.describe.serial("Core: File browser preview", () => {
     });
 
     // `min-h-full` rather than no class at all: the document reaches the bottom
-    // of the preview so its background doesn't stop mid-pane, and rather than
+    // of the preview so its background doesn't stop mid-pane — and rather than
     // `h-full`, which would clamp it and re-break the tall case above.
     await expect
       .poll(
         () =>
           dialog.getByTestId("file-browser-markdown-scroll").evaluate((el) => {
-            const document = el.firstElementChild;
+            const doc = el.firstElementChild;
             return {
-              fillsPreview:
-                document instanceof HTMLElement && document.offsetHeight >= el.clientHeight - 1,
+              fillsPreview: doc instanceof HTMLElement && doc.offsetHeight >= el.clientHeight - 1,
               noSpuriousOverflow: el.scrollHeight <= el.clientHeight + 1,
             };
           }),

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -545,13 +545,24 @@ export function FileBrowserViewer({
 
       case "text":
         return isMarkdownFilePath(filePath) ? (
-          <MarkdownViewer
-            content={state.content}
-            filePath={filePath}
-            rootPath={rootPath}
-            viewMode={markdownMode}
-            className="h-full"
-          />
+          // Neither markdown surface brings a scroller: MarkdownDocument's root
+          // carries no overflow class by design, and CodeViewer forces
+          // `.cm-scroller` visible so it delegates upward. The viewer column
+          // above only clips, so without this wrapper anything past the first
+          // screenful was unreachable (#11441). Same idiom as svg/video/audio.
+          <div data-testid="file-browser-markdown-scroll" className="h-full w-full overflow-auto">
+            {/* min-h-full, never h-full: a floor lets a tall document grow past
+                the wrapper and scroll it, while a short one still fills the
+                preview. It also twMerge-replaces MarkdownViewer's source-mode
+                min-h-[300px], which used to overflow a preview under 300px. */}
+            <MarkdownViewer
+              content={state.content}
+              filePath={filePath}
+              rootPath={rootPath}
+              viewMode={markdownMode}
+              className="min-h-full"
+            />
+          </div>
         ) : (
           <CodeViewer content={state.content} filePath={filePath} className="h-full" />
         );

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -544,17 +544,37 @@ export function FileBrowserViewer({
         );
 
       case "text":
-        return isMarkdownFilePath(filePath) ? (
-          // Neither markdown surface brings a scroller: MarkdownDocument's root
-          // carries no overflow class by design, and CodeViewer forces
-          // `.cm-scroller` visible so it delegates upward. The viewer column
-          // above only clips, so without this wrapper anything past the first
-          // screenful was unreachable (#11441). Same idiom as svg/video/audio.
+        if (!isMarkdownFilePath(filePath)) {
+          return <CodeViewer content={state.content} filePath={filePath} className="h-full" />;
+        }
+        // Source mode was never part of #11441: CodeViewer's root is already a
+        // scrollport, and at pane height it owns BOTH axes, so its horizontal
+        // scrollbar stays pinned to the bottom of the visible pane. Letting it
+        // grow to content height instead would hand the vertical axis to an
+        // outer wrapper and strand the horizontal scrollbar below the fold —
+        // lines here don't wrap (CodeViewer defaults `wrapLines` to false).
+        // `min-h-0` only replaces MarkdownViewer's min-h-[300px] floor, which
+        // used to overflow a preview shorter than 300px.
+        if (markdownMode === "source") {
+          return (
+            <MarkdownViewer
+              content={state.content}
+              filePath={filePath}
+              rootPath={rootPath}
+              viewMode={markdownMode}
+              className="h-full min-h-0"
+            />
+          );
+        }
+        return (
+          // Rendered markdown is the bug: MarkdownDocument's root carries no
+          // overflow class by design, and the viewer column above only clips,
+          // so anything past the first screenful was unreachable (#11441).
+          // Same local-wrapper idiom as the svg/video/audio branches.
           <div data-testid="file-browser-markdown-scroll" className="h-full w-full overflow-auto">
             {/* min-h-full, never h-full: a floor lets a tall document grow past
                 the wrapper and scroll it, while a short one still fills the
-                preview. It also twMerge-replaces MarkdownViewer's source-mode
-                min-h-[300px], which used to overflow a preview under 300px. */}
+                preview. h-full would clamp it and silently restore the bug. */}
             <MarkdownViewer
               content={state.content}
               filePath={filePath}
@@ -563,8 +583,6 @@ export function FileBrowserViewer({
               className="min-h-full"
             />
           </div>
-        ) : (
-          <CodeViewer content={state.content} filePath={filePath} className="h-full" />
         );
     }
   }


### PR DESCRIPTION
## Summary

The file browser's preview pane couldn't scroll rendered Markdown taller than the pane. Everything past the first screenful was unreachable. `MarkdownDocument`'s root carries no overflow class by design (scroll ownership is delegated to the caller), and the column above it in the viewer only clips, so nothing in the chain was a scroll container. Source mode was fine because `CodeViewer` brings its own scroller.

Resolves #11441

## The fix

`FileBrowserViewer.tsx`'s `renderBody()`, `case "text"`, now branches three ways:

- **Rendered markdown** gets a local `<div className="h-full w-full overflow-auto">` scroll owner (the same pattern the `svg`/`video`/`audio` branches in the same switch already use), plus `className="min-h-full"` on `MarkdownViewer`. `min-h-full` matters here, not `h-full`: a floor lets a tall document grow past the wrapper and scroll it, while a short one still fills the preview. `h-full` would clamp the document to the wrapper's exact height and quietly bring the bug back.
- **Markdown source** stays unwrapped and now gets `h-full min-h-0`. It was never part of the bug: `CodeViewer` at pane height is already a scrollport that owns both axes, and that's what keeps its horizontal scrollbar on screen. `min-h-0` replaces `MarkdownViewer`'s `min-h-[300px]` default via twMerge, which was the ticket's secondary issue: that floor used to overflow a preview shorter than 300px.
- **Non-markdown text** is untouched.

The two ancestor `overflow-hidden` columns (`FileBrowserPane.tsx:771`, `FileBrowserViewer.tsx:408`) are left alone on purpose. That `overflow-hidden` is what zeroes flexbox's automatic min-height and makes the sibling `min-h-0` work, so touching it would be a sizing change, not a clip/scroll toggle.

An earlier version of this branch gave both submodes `min-h-full`. Review caught that it broke source mode: `CodeViewer` defaults `wrapLines` to false, and this call site doesn't override it, so source lines overflow horizontally. Letting `CodeViewer` grow to content height handed the vertical axis to the wrapper while it kept the horizontal one, stranding the horizontal scrollbar well below the visible pane on a tall, wide file. That's why the two modes are split.

## Tests

Adds `e2e/full/panels/core-file-browser.spec.ts`, the first end-to-end coverage for the file-browser panel kind (it had none before). Three tests:

- Tall rendered markdown scrolls inside the preview and its last heading becomes reachable.
- Source mode keeps a single scrollport that owns both axes.
- A short document fills the preview instead of stopping at its intrinsic height.

They assert real layout geometry rather than class names, and all three fail against the pre-fix code. jsdom can't observe any of this since the existing unit suites mock both leaf viewers away.

## Verification

126 unit tests across the `FileBrowserViewer`/`FileBrowserPane`/`MarkdownViewer`/`FilePane` suites, `tsc --noEmit`, eslint (0 errors, the one warning in the file is pre-existing and unchanged from the parent commit), prettier, `npm run build`, and all 3 new e2e tests, all passing locally against a real Electron build.