### PR TITLE
fix(terminal): track terminal geometry for backgrounded project views

### DIFF
--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -3278,12 +3278,7 @@ _eventBusOn("window:reclaim-memory", () => {
   if (isE2EFaultMode) {
     performance.mark("daintree-e2e-reclaim-memory");
   }
-  // A cached project view is detached, not page-hidden — `visibilityState`
-  // stays "visible" for its whole background life (#11443), so the visibility
-  // check alone excluded exactly the views worth reclaiming. `_viewCached` is
-  // the latch this file already keeps for that; it clears on warm activation,
-  // so a reactivated view stops qualifying immediately.
-  if (!_viewCached && document.visibilityState !== "hidden") return;
+  if (document.visibilityState !== "hidden") return;
   const reclaim = () => (globalThis as unknown as { gc?: () => void }).gc?.();
   if (typeof requestIdleCallback === "function") {
     requestIdleCallback(reclaim, { timeout: 5_000 });

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -3278,7 +3278,12 @@ _eventBusOn("window:reclaim-memory", () => {
   if (isE2EFaultMode) {
     performance.mark("daintree-e2e-reclaim-memory");
   }
-  if (document.visibilityState !== "hidden") return;
+  // A cached project view is detached, not page-hidden — `visibilityState`
+  // stays "visible" for its whole background life (#11443), so the visibility
+  // check alone excluded exactly the views worth reclaiming. `_viewCached` is
+  // the latch this file already keeps for that; it clears on warm activation,
+  // so a reactivated view stops qualifying immediately.
+  if (!_viewCached && document.visibilityState !== "hidden") return;
   const reclaim = () => (globalThis as unknown as { gc?: () => void }).gc?.();
   if (typeof requestIdleCallback === "function") {
     requestIdleCallback(reclaim, { timeout: 5_000 });

--- a/src/hooks/app/__tests__/useBackgroundWindowResize.test.tsx
+++ b/src/hooks/app/__tests__/useBackgroundWindowResize.test.tsx
@@ -49,12 +49,12 @@ describe("useBackgroundWindowResize", () => {
   let lastCallback: ((payload: ResizePayload) => void) | null = null;
   let emitPhase: (phase: LifecyclePhase) => void;
   let unsubscribe: ReturnType<typeof vi.fn>;
-  let unsubscribeLifecycle: ReturnType<typeof vi.fn>;
+  let unsubscribeLifecycle: ReturnType<typeof vi.fn<() => void>>;
 
   beforeEach(() => {
     vi.clearAllMocks();
     unsubscribe = vi.fn();
-    unsubscribeLifecycle = vi.fn();
+    unsubscribeLifecycle = vi.fn<() => void>();
     lastCallback = null;
     const phaseHandlers: Array<(phase: LifecyclePhase) => void> = [];
     emitPhase = (phase) => phaseHandlers.forEach((handler) => handler(phase));

--- a/src/hooks/app/__tests__/useBackgroundWindowResize.test.tsx
+++ b/src/hooks/app/__tests__/useBackgroundWindowResize.test.tsx
@@ -11,6 +11,16 @@ const onBackgroundResizeMock = vi.hoisted(() =>
 const applyBackgroundWindowResizeMock = vi.hoisted(() => vi.fn());
 const resetBackgroundResizeBasisMock = vi.hoisted(() => vi.fn());
 
+type LifecyclePhase = "cached" | "active" | "revealed";
+
+const subscribeProjectViewLifecycleMock = vi.hoisted(() =>
+  vi.fn<(cb: (phase: LifecyclePhase) => void) => () => void>()
+);
+
+vi.mock("@/lib/viewCacheState", () => ({
+  subscribeProjectViewLifecycle: subscribeProjectViewLifecycleMock,
+}));
+
 vi.stubGlobal("window", {
   ...globalThis.window,
   electron: {
@@ -35,15 +45,24 @@ function setVisibility(state: "visible" | "hidden") {
 
 describe("useBackgroundWindowResize", () => {
   let lastCallback: ((payload: ResizePayload) => void) | null = null;
+  let emitPhase: (phase: LifecyclePhase) => void;
   let unsubscribe: ReturnType<typeof vi.fn>;
+  let unsubscribeLifecycle: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
     unsubscribe = vi.fn();
+    unsubscribeLifecycle = vi.fn();
     lastCallback = null;
+    const phaseHandlers: Array<(phase: LifecyclePhase) => void> = [];
+    emitPhase = (phase) => phaseHandlers.forEach((handler) => handler(phase));
     onBackgroundResizeMock.mockImplementation((cb) => {
       lastCallback = cb;
       return unsubscribe as () => void;
+    });
+    subscribeProjectViewLifecycleMock.mockImplementation((cb) => {
+      phaseHandlers.push(cb);
+      return unsubscribeLifecycle as () => void;
     });
     setVisibility("hidden");
   });
@@ -94,11 +113,38 @@ describe("useBackgroundWindowResize", () => {
     expect(resetBackgroundResizeBasisMock).not.toHaveBeenCalled();
   });
 
-  it("unsubscribes and removes the visibility listener on unmount", () => {
+  it("resets the basis on every reactivation phase, not just reveal", () => {
+    // A switch superseded mid-flight delivers warm-activated alone, so keying
+    // the reset on "revealed" would strand the anchor for that view.
+    renderHook(() => useBackgroundWindowResize());
+
+    act(() => {
+      emitPhase("active");
+    });
+    expect(resetBackgroundResizeBasisMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      emitPhase("revealed");
+    });
+    expect(resetBackgroundResizeBasisMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not reset the basis when the view is cached", () => {
+    renderHook(() => useBackgroundWindowResize());
+
+    act(() => {
+      emitPhase("cached");
+    });
+
+    expect(resetBackgroundResizeBasisMock).not.toHaveBeenCalled();
+  });
+
+  it("unsubscribes from both signals and removes the visibility listener on unmount", () => {
     const { unmount } = renderHook(() => useBackgroundWindowResize());
     unmount();
 
     expect(unsubscribe).toHaveBeenCalled();
+    expect(unsubscribeLifecycle).toHaveBeenCalled();
 
     setVisibility("visible");
     document.dispatchEvent(new Event("visibilitychange"));

--- a/src/hooks/app/__tests__/useBackgroundWindowResize.test.tsx
+++ b/src/hooks/app/__tests__/useBackgroundWindowResize.test.tsx
@@ -16,9 +16,11 @@ type LifecyclePhase = "cached" | "active" | "revealed";
 const subscribeProjectViewLifecycleMock = vi.hoisted(() =>
   vi.fn<(cb: (phase: LifecyclePhase) => void) => () => void>()
 );
+const isProjectViewCachedMock = vi.hoisted(() => vi.fn(() => false));
 
 vi.mock("@/lib/viewCacheState", () => ({
   subscribeProjectViewLifecycle: subscribeProjectViewLifecycleMock,
+  isProjectViewCached: isProjectViewCachedMock,
 }));
 
 vi.stubGlobal("window", {
@@ -62,8 +64,16 @@ describe("useBackgroundWindowResize", () => {
     });
     subscribeProjectViewLifecycleMock.mockImplementation((cb) => {
       phaseHandlers.push(cb);
-      return unsubscribeLifecycle as () => void;
+      return (() => {
+        // Model the real Set-based unsubscribe: a fake that only records the
+        // call would leave a live handler behind, so the unmount test could
+        // never catch a genuine leak (and would misreport StrictMode replay).
+        const index = phaseHandlers.indexOf(cb);
+        if (index !== -1) phaseHandlers.splice(index, 1);
+        unsubscribeLifecycle();
+      }) as () => void;
     });
+    isProjectViewCachedMock.mockReturnValue(false);
     setVisibility("hidden");
   });
 
@@ -139,6 +149,22 @@ describe("useBackgroundWindowResize", () => {
     expect(resetBackgroundResizeBasisMock).not.toHaveBeenCalled();
   });
 
+  it("ignores a restore that happens while the view is still cached", () => {
+    // Un-minimizing does not hand geometry back to real layout while this view
+    // is detached. Releasing the anchor there would re-snapshot the stale
+    // viewport against already-scaled terminal sizes and compound every later
+    // event, so the listener must match the service's own predicate.
+    renderHook(() => useBackgroundWindowResize());
+    isProjectViewCachedMock.mockReturnValue(true);
+
+    setVisibility("visible");
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(resetBackgroundResizeBasisMock).not.toHaveBeenCalled();
+  });
+
   it("unsubscribes from both signals and removes the visibility listener on unmount", () => {
     const { unmount } = renderHook(() => useBackgroundWindowResize());
     unmount();
@@ -146,6 +172,11 @@ describe("useBackgroundWindowResize", () => {
     expect(unsubscribe).toHaveBeenCalled();
     expect(unsubscribeLifecycle).toHaveBeenCalled();
 
+    // Behavioural, not bookkeeping: drive both signals and prove neither
+    // reaches the service any more.
+    act(() => {
+      emitPhase("active");
+    });
     setVisibility("visible");
     document.dispatchEvent(new Event("visibilitychange"));
     expect(resetBackgroundResizeBasisMock).not.toHaveBeenCalled();

--- a/src/hooks/app/useBackgroundWindowResize.ts
+++ b/src/hooks/app/useBackgroundWindowResize.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { subscribeProjectViewLifecycle } from "@/lib/viewCacheState";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 
 /**
@@ -9,14 +10,26 @@ import { terminalInstanceService } from "@/services/TerminalInstanceService";
  * detached WebContentsViews otherwise never learn the window size changed.
  * The geometry math lives in `terminalInstanceService.applyBackgroundWindowResize`.
  * Subscribes unconditionally on mount — PTY resize is idempotent and needs no
- * hydration gate. The visibilitychange listener resets the scaling basis when
- * the view returns to the foreground, where real layout owns geometry again.
+ * hydration gate.
+ *
+ * Two independent signals return the view to live layout, and each has to
+ * reset the scaling basis (#11443). `visibilitychange` covers a real window
+ * minimize/restore; it never fires for a cached child WebContentsView, so the
+ * project-view lifecycle covers the switch-back. `active` (warm-activated),
+ * not `revealed`, is the one that must clear it — a switch superseded
+ * mid-flight only ever gets warm-activated — with `revealed` kept as a
+ * defensive backstop. Resetting twice is harmless; the basis is re-snapshotted
+ * from the live viewport on the next background session.
  */
 export function useBackgroundWindowResize(): void {
   useEffect(() => {
     const unsubscribe = window.electron.project.onBackgroundResize((payload) => {
       if (!payload) return;
       terminalInstanceService.applyBackgroundWindowResize(payload.width, payload.height);
+    });
+    const unsubscribeLifecycle = subscribeProjectViewLifecycle((phase) => {
+      if (phase === "cached") return;
+      terminalInstanceService.resetBackgroundResizeBasis();
     });
     const onVisibilityChange = () => {
       if (document.visibilityState === "visible") {
@@ -26,6 +39,7 @@ export function useBackgroundWindowResize(): void {
     document.addEventListener("visibilitychange", onVisibilityChange);
     return () => {
       unsubscribe();
+      unsubscribeLifecycle();
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };
   }, []);

--- a/src/hooks/app/useBackgroundWindowResize.ts
+++ b/src/hooks/app/useBackgroundWindowResize.ts
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { subscribeProjectViewLifecycle } from "@/lib/viewCacheState";
+import { isProjectViewCached, subscribeProjectViewLifecycle } from "@/lib/viewCacheState";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 
 /**
@@ -32,7 +32,12 @@ export function useBackgroundWindowResize(): void {
       terminalInstanceService.resetBackgroundResizeBasis();
     });
     const onVisibilityChange = () => {
-      if (document.visibilityState === "visible") {
+      // Must match the service's own predicate exactly. Restoring a minimized
+      // window while this view is STILL cached is not a return to live layout:
+      // dropping the anchor there would re-snapshot the stale viewport while
+      // each terminal's `lastWidth` already holds an applied, scaled value, and
+      // every later event would compound off it.
+      if (!isProjectViewCached() && document.visibilityState === "visible") {
         terminalInstanceService.resetBackgroundResizeBasis();
       }
     };

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1,5 +1,6 @@
 import { Terminal, IBufferRange } from "@xterm/xterm";
 import { isMac } from "@/lib/platform";
+import { isProjectViewCached } from "@/lib/viewCacheState";
 import { terminalClient } from "@/clients";
 import { TerminalRefreshTier } from "@/types";
 import type { AgentState } from "@/types";
@@ -1707,9 +1708,17 @@ class TerminalInstanceService {
    * time it's seen. Every event computes absolute targets from that anchor,
    * so repeated resizes never compound and a terminal skipped in one pass
    * (resize-locked) still lands on the correct size in the next.
+   *
+   * Gated on `isProjectViewCached()` as well as page visibility (#11443).
+   * Caching a project view is `removeChildView` + `setVisible(false)`, and
+   * neither flips `document.visibilityState` for a child WebContentsView, so
+   * the original visibility-only guard early-returned for every genuinely
+   * backgrounded view — the one case this method exists to serve. The reset
+   * stays on the "not cached AND visible" branch: a cached view that still
+   * reports "visible" must keep its session anchor, not drop it.
    */
   applyBackgroundWindowResize(width: number, height: number): void {
-    if (document.visibilityState === "visible") {
+    if (!isProjectViewCached() && document.visibilityState === "visible") {
       // Queued delivery after reactivation — real layout owns geometry again.
       this.backgroundResizeSession = null;
       return;
@@ -1726,6 +1735,18 @@ class TerminalInstanceService {
     const heightRatio = height / session.basis.height;
     for (const [id, managed] of this.instances) {
       if (!managed.isOpened) continue;
+      // Never move the PTY out from under a live alt-screen TUI while the view
+      // is backgrounded (#11443). This path deliberately never reflows xterm,
+      // and the alternate buffer never reflows on resize anyway — so a
+      // PTY-only resize leaves the app painting a wider frame into a narrower
+      // grid, and that mangled frame is permanent: on reattach
+      // `applyDeferredResize` re-asserts the size the PTY already has, which
+      // dedupes into no second SIGWINCH, so the app never redraws to fix it.
+      // Main-buffer panes are safe — their reflow at wake re-wraps correctly.
+      // An alt pane keeps xterm and the PTY mutually consistent at the stale
+      // size until reattach, where the ResizeObserver-driven path resizes both
+      // together and delivers a genuine SIGWINCH.
+      if (managed.isAltBuffer) continue;
       let origin = session.origin.get(id);
       if (!origin) {
         if (managed.lastWidth <= 0 || managed.lastHeight <= 0) continue;

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1691,16 +1691,19 @@ class TerminalInstanceService {
   } | null = null;
 
   /**
-   * PTY-tracking resize for a backgrounded project view (#10415). A detached
+   * Window-ratio resize for a backgrounded project view (#10415). A detached
    * WebContentsView keeps its stale viewport until reattach — setBounds()
    * does not propagate while detached and ResizeObservers never fire in a
    * hidden page — so per-panel pixel sizes cannot be re-measured here.
    * Instead each terminal's host size is scaled by the window-bounds ratio,
    * which is exact for 1fr grid tracks and at worst off by ~1 col where
-   * fixed chrome doesn't scale. The PTY-only resize keeps agents wrapping
-   * at the right width the whole time; the wake path
-   * (`fullWakeForVisibilityRestore` → `applyDeferredResize`) reconciles
-   * xterm and corrects any residual error from real layout on reattach.
+   * fixed chrome doesn't scale. `applyBackgroundResize` moves xterm and the
+   * PTY together, so agents wrap at the right width the whole time and the
+   * parser never trails the grid the app is drawing for; alt-screen panes are
+   * excluded and both grids stay at their pre-background size. By reattach
+   * the wake path's `applyDeferredResize` therefore finds cache == current and
+   * early-returns; only `reconcileGeometryFresh` on reveal corrects the
+   * residual error between the scaled estimate and real layout.
    *
    * Scaling is anchored to a per-background-session snapshot: the basis is
    * the stale viewport (which all `lastWidth`/`lastHeight` measurements were

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1735,17 +1735,11 @@ class TerminalInstanceService {
     const heightRatio = height / session.basis.height;
     for (const [id, managed] of this.instances) {
       if (!managed.isOpened) continue;
-      // Never move the PTY out from under a live alt-screen TUI while the view
-      // is backgrounded (#11443). This path deliberately never reflows xterm,
-      // and the alternate buffer never reflows on resize anyway — so a
-      // PTY-only resize leaves the app painting a wider frame into a narrower
-      // grid, and that mangled frame is permanent: on reattach
-      // `applyDeferredResize` re-asserts the size the PTY already has, which
-      // dedupes into no second SIGWINCH, so the app never redraws to fix it.
-      // Main-buffer panes are safe — their reflow at wake re-wraps correctly.
-      // An alt pane keeps xterm and the PTY mutually consistent at the stale
-      // size until reattach, where the ResizeObserver-driven path resizes both
-      // together and delivers a genuine SIGWINCH.
+      // Never resize a live alt-screen TUI from here (#11443) — see the choke
+      // point in `applyBackgroundResize`. Skipping before the origin capture
+      // also keeps the anchor keyed to first eligibility, so a pane that leaves
+      // the alternate screen mid-session still scales from its pre-background
+      // size rather than a partially-applied one.
       if (managed.isAltBuffer) continue;
       let origin = session.origin.get(id);
       if (!origin) {
@@ -1753,7 +1747,7 @@ class TerminalInstanceService {
         origin = { width: managed.lastWidth, height: managed.lastHeight };
         session.origin.set(id, origin);
       }
-      this.resizeController.resizePtyOnly(
+      this.resizeController.applyBackgroundResize(
         id,
         origin.width * widthRatio,
         origin.height * heightRatio

--- a/src/services/terminal/TerminalReconciliationWatchdog.ts
+++ b/src/services/terminal/TerminalReconciliationWatchdog.ts
@@ -516,7 +516,6 @@ export class TerminalReconciliationWatchdog {
                   xtermRows: managed.terminal.rows,
                   proposedCols: proposal.cols,
                   proposedRows: proposal.rows,
-                  isAltBuffer: managed.isAltBuffer === true,
                 }
               );
             } else {
@@ -535,7 +534,6 @@ export class TerminalReconciliationWatchdog {
                   xtermRows: managed.terminal.rows,
                   proposedCols: proposal.cols,
                   proposedRows: proposal.rows,
-                  isAltBuffer: managed.isAltBuffer === true,
                 }
               );
               if (this.deps.reconcileRevealGeometry(id)) {

--- a/src/services/terminal/TerminalReconciliationWatchdog.ts
+++ b/src/services/terminal/TerminalReconciliationWatchdog.ts
@@ -453,14 +453,24 @@ export class TerminalReconciliationWatchdog {
     // (`terminal.cols/rows`) disagrees with what the container can hold
     // (`fitAddon.proposeDimensions()`) is rendering its buffer at the wrong width
     // — the exact "garbled line flow" users see after a warm switch-back, and the
-    // failure mode the watchdog previously only DIAGNOSED (DEV log) while
-    // excluding agent TUIs entirely. Now repair it for EVERY on-screen terminal,
-    // alt-buffer/DEC-2026 agents included, with the atomic alt-buffer-safe
-    // reconcile (no mid-block reflow). This is the verifier half: the divergence
-    // IS the proof the pane converged wrong, and the watchdog ticks until it
-    // matches. Bounded by the heavy-repair budget (== REVEAL_CONCURRENCY) so a
-    // grid that all diverges at once never lands as a single long task.
-    if (!inSynchronizedBlock && !resizeTransitioning) {
+    // failure mode the watchdog previously only DIAGNOSED (DEV log). This is the
+    // verifier half: the divergence IS the proof the pane converged wrong, and
+    // the watchdog ticks until it matches. Bounded by the heavy-repair budget
+    // (== REVEAL_CONCURRENCY) so a grid that all diverges at once never lands as
+    // a single long task.
+    //
+    // Main buffer only (#11443). `reconcileGeometryFresh` returns early for an
+    // alt-screen pane by design (#10805 — never reflow a live TUI's frame out
+    // from under its own SIGWINCH redraw), so the repair issued here is a
+    // structural no-op for one: the divergence can never close, every tick
+    // burns a heavy-budget slot another pane could use, and after
+    // WATCHDOG_MAX_GEOMETRY_REPAIR_ATTEMPTS the breaker latches
+    // `geometryRepairGaveUp` permanently — which then blocks the pane's
+    // legitimate main-buffer repairs once it leaves the alternate screen, since
+    // only genuine convergence or a re-attach re-arms it. An alt pane's geometry
+    // is owned by the ResizeObserver-driven applyResize path and the app's own
+    // redraw; the render-pause and WebGL layers below still cover it.
+    if (!managed.isAltBuffer && !inSynchronizedBlock && !resizeTransitioning) {
       const proposal = managed.fitAddon.proposeDimensions?.();
       if (proposal && proposal.cols > 1 && proposal.rows > 1) {
         const diverged =

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -485,8 +485,10 @@ export class TerminalResizeController {
 
   // Computes cols/rows from cached cell metrics with no DOM reads — a detached
   // view has no live layout to measure. Pure computation + state update; the
-  // caller applies the grid and delivers the PTY resize so each path picks its
-  // own strategy handling.
+  // caller decides whether to apply the grid. `applyBackgroundResize` reflows
+  // xterm and then resizes the PTY; `resize`'s background-unfocused branch
+  // sends the PTY resize only and leaves the content-visibility:hidden pane's
+  // xterm grid for wake reconciliation.
   private resizeGridFromCachedCellMetrics(
     managed: ManagedTerminal,
     width: number,

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -569,7 +569,10 @@ export class TerminalResizeController {
    *
    * @returns true once a fresh measurement landed (whether or not a resize was
    * needed); false when the box is not measurable yet (zero/occluded/transitional
-   * layout) so the reveal sweep retries on a later frame.
+   * layout) so the reveal sweep retries on a later frame. The boolean is
+   * measurability, NOT convergence — an alt-buffer pane reports true without
+   * touching geometry at all, so no caller may treat it as proof the grid now
+   * matches the container.
    */
   reconcileGeometryFresh(id: string): boolean {
     const managed = this.deps.getInstance(id);

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -190,7 +190,7 @@ export class TerminalResizeController {
       if (managed && managed.pendingBackgroundResize) {
         const { width, height } = managed.pendingBackgroundResize;
         managed.pendingBackgroundResize = undefined;
-        this.resizePtyOnly(id, width, height);
+        this.applyBackgroundResize(id, width, height);
       }
     }
   }
@@ -279,7 +279,7 @@ export class TerminalResizeController {
       return null;
     }
 
-    // Mirrors resizePtyOnly's guard: a non-finite box would otherwise poison the
+    // Mirrors applyBackgroundResize's guard: a non-finite box would otherwise poison the
     // pixel cache and deliver a garbage grid to the PTY.
     if (!Number.isFinite(width) || !Number.isFinite(height)) {
       return null;
@@ -312,7 +312,7 @@ export class TerminalResizeController {
       // read 0x0 from the DOM, so we compute cols/rows from cached cell
       // metrics instead. Settled agents still coalesce the PTY notification,
       // but the hidden xterm grid remains untouched until wake reconciliation.
-      const dims = this.resizePtyFromCachedCellMetrics(managed, width, height, wasAtBottom);
+      const dims = this.resizeGridFromCachedCellMetrics(managed, width, height, wasAtBottom);
       if (dims) {
         this.sendPtyOnlyResize(id, dims.cols, dims.rows);
       }
@@ -406,23 +406,46 @@ export class TerminalResizeController {
   }
 
   /**
-   * PTY-only resize from explicit pixel dimensions — never reflows xterm.
-   * Entry point for backgrounded project views (#10415), whose terminals may
-   * still carry `isVisible === true` from before the view was detached and
-   * would otherwise take the foreground path's xterm reflow while hidden.
-   * Delivers the PTY resize directly instead of through `sendPtyResize` —
-   * the settled-strategy timer would schedule a `terminal.resize()` in a
-   * hidden (possibly frozen) renderer, and the burst it coalesces was
-   * already debounced in Main. A pending settled timer is cleared since its
-   * stale geometry is superseded. The deferred xterm reflow is reconciled
-   * at wake via `applyDeferredResize`.
+   * Atomic xterm+PTY resize from explicit pixel dimensions. Entry point for
+   * backgrounded project views (#10415), whose terminals may still carry
+   * `isVisible === true` from before the view was detached. Delivers the PTY
+   * resize directly instead of through `sendPtyResize` — the settled-strategy
+   * timer would schedule a `terminal.resize()` in a hidden (possibly frozen)
+   * renderer, and the burst it coalesces was already debounced in Main. A
+   * pending settled timer is cleared since its stale geometry is superseded.
+   *
+   * Both grids move together (#11443). Resizing the PTY alone leaves the app
+   * emitting cursor-addressed output sized for the new width while the parser
+   * still holds the old grid, and the renderer keeps writing every byte while
+   * the view is cached — so those sequences land on the wrong rows. Nothing
+   * recovers them: reflow re-wraps text but cannot undo an erase applied to
+   * the wrong line, and the wake-time re-assert of a size the PTY already has
+   * dedupes in `TerminalProcess.resize`, so no corrective SIGWINCH ever
+   * arrives. This is the same pair `applyDeferredResize` used to run at wake,
+   * moved to the moment the geometry actually changes — identical work, off
+   * the switch-back critical path, with no window where the grids disagree.
    */
-  resizePtyOnly(id: string, width: number, height: number): { cols: number; rows: number } | null {
+  applyBackgroundResize(
+    id: string,
+    width: number,
+    height: number
+  ): { cols: number; rows: number } | null {
     if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
       return null;
     }
     const managed = this.deps.getInstance(id);
     if (!managed) return null;
+    // Choke point for the alt-screen exclusion: a live full-screen TUI paints an
+    // absolutely-positioned frame that xterm never reflows, and racing its own
+    // SIGWINCH redraw is the #10805/#10632 corruption. Leaving BOTH grids at the
+    // stale size keeps them consistent until real layout returns on reattach.
+    // Enforced here rather than only at the caller because a resize stashed in
+    // `pendingBackgroundResize` while main-buffer is replayed by `lockResize`
+    // long after the pane may have entered the alternate screen.
+    if (managed.isAltBuffer) {
+      managed.pendingBackgroundResize = undefined;
+      return null;
+    }
     if (this.isResizeLocked(id)) {
       managed.pendingBackgroundResize = { width, height };
       return null;
@@ -433,8 +456,8 @@ export class TerminalResizeController {
       // A foreground debounce/settled request updates the pixel and grid
       // caches before it commits. If backgrounding then supplies that same
       // box, cancelling the queued xterm work must not also discard the PTY
-      // half of the resize. Reassert the cached target directly; this entry
-      // point deliberately never reflows a hidden xterm.
+      // half of the resize. Reassert the cached target directly — the grid
+      // caches already describe this box, so xterm needs no further work.
       if (
         hadPendingResize &&
         Number.isInteger(managed.latestCols) &&
@@ -448,20 +471,23 @@ export class TerminalResizeController {
     }
     const buffer = managed.terminal.buffer.active;
     const wasAtBottom = buffer.viewportY >= buffer.baseY;
-    const dims = this.resizePtyFromCachedCellMetrics(managed, width, height, wasAtBottom);
+    const dims = this.resizeGridFromCachedCellMetrics(managed, width, height, wasAtBottom);
     if (dims) {
       this.clearSettledTimer(id);
+      // xterm first, then the PTY: the app must never receive SIGWINCH for a
+      // grid the parser has not adopted yet.
+      this.resizeTerminal(managed, dims.cols, dims.rows);
       terminalClient.resize(id, dims.cols, dims.rows);
+      this.pinToBottomAfterResize(managed);
     }
     return dims;
   }
 
-  // Computes cols/rows from cached cell metrics with no DOM reads and
-  // deliberately skips terminal.resize() — paint is paused for these
-  // terminals, so deferring the buffer reflow to wake time avoids work the
-  // user never sees. Pure computation + state update; the caller delivers
-  // the PTY resize so each path picks its own strategy handling.
-  private resizePtyFromCachedCellMetrics(
+  // Computes cols/rows from cached cell metrics with no DOM reads — a detached
+  // view has no live layout to measure. Pure computation + state update; the
+  // caller applies the grid and delivers the PTY resize so each path picks its
+  // own strategy handling.
+  private resizeGridFromCachedCellMetrics(
     managed: ManagedTerminal,
     width: number,
     height: number,

--- a/src/services/terminal/__tests__/TerminalInstanceService.backgroundResize.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.backgroundResize.test.ts
@@ -66,7 +66,7 @@ type BackgroundResizeTestService = {
   applyBackgroundWindowResize: (width: number, height: number) => void;
   resetBackgroundResizeBasis: () => void;
   resizeController: {
-    resizePtyOnly: (
+    applyBackgroundResize: (
       id: string,
       width: number,
       height: number
@@ -95,7 +95,7 @@ function setCached(cached: boolean) {
 
 describe("TerminalInstanceService applyBackgroundWindowResize", () => {
   let service: BackgroundResizeTestService;
-  let resizePtyOnlySpy: ReturnType<typeof vi.spyOn>;
+  let applyBackgroundResizeSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -105,14 +105,14 @@ describe("TerminalInstanceService applyBackgroundWindowResize", () => {
       });
     service.instances.clear();
     service.resetBackgroundResizeBasis();
-    resizePtyOnlySpy = vi
-      .spyOn(service.resizeController, "resizePtyOnly")
+    applyBackgroundResizeSpy = vi
+      .spyOn(service.resizeController, "applyBackgroundResize")
       .mockReturnValue(null) as ReturnType<typeof vi.spyOn>;
     // The production state this method exists to serve: main has detached and
     // hidden the view, but a child WebContentsView keeps reporting "visible"
-    // (#11443). Every case below therefore runs against visibilityState
-    // "visible" — under the old visibility-only guard the whole suite would
-    // no-op.
+    // (#11443). Cases that assert a resize is applied therefore only pass
+    // because the guard consults the cache signal — under the old
+    // visibility-only guard they would all no-op.
     setViewport(1000, 700, "visible");
     setCached(true);
   });
@@ -128,9 +128,9 @@ describe("TerminalInstanceService applyBackgroundWindowResize", () => {
 
     service.applyBackgroundWindowResize(1200, 840);
 
-    expect(resizePtyOnlySpy).toHaveBeenCalledTimes(2);
-    expect(resizePtyOnlySpy).toHaveBeenCalledWith("a", 800 * 1.2, 600 * 1.2);
-    expect(resizePtyOnlySpy).toHaveBeenCalledWith("b", 400 * 1.2, 300 * 1.2);
+    expect(applyBackgroundResizeSpy).toHaveBeenCalledTimes(2);
+    expect(applyBackgroundResizeSpy).toHaveBeenCalledWith("a", 800 * 1.2, 600 * 1.2);
+    expect(applyBackgroundResizeSpy).toHaveBeenCalledWith("b", 400 * 1.2, 300 * 1.2);
   });
 
   it("no-ops only once the view is neither cached nor page-hidden", () => {
@@ -139,18 +139,18 @@ describe("TerminalInstanceService applyBackgroundWindowResize", () => {
     setCached(false);
     setViewport(1000, 700, "visible");
     service.applyBackgroundWindowResize(1200, 840);
-    expect(resizePtyOnlySpy).not.toHaveBeenCalled();
+    expect(applyBackgroundResizeSpy).not.toHaveBeenCalled();
 
     // Either signal alone is enough to keep scaling: a minimized window that
     // was never cached, and a cached view that still reports "visible".
     setViewport(1000, 700, "hidden");
     service.applyBackgroundWindowResize(1200, 840);
-    expect(resizePtyOnlySpy).toHaveBeenCalledTimes(1);
+    expect(applyBackgroundResizeSpy).toHaveBeenCalledTimes(1);
 
     setCached(true);
     setViewport(1000, 700, "visible");
     service.applyBackgroundWindowResize(1200, 840);
-    expect(resizePtyOnlySpy).toHaveBeenCalledTimes(2);
+    expect(applyBackgroundResizeSpy).toHaveBeenCalledTimes(2);
   });
 
   it("skips alt-buffer panes so xterm and the PTY never split while backgrounded", () => {
@@ -165,7 +165,7 @@ describe("TerminalInstanceService applyBackgroundWindowResize", () => {
 
     service.applyBackgroundWindowResize(1200, 840);
 
-    expect(resizePtyOnlySpy.mock.calls.map((call) => call[0])).toEqual(["main"]);
+    expect(applyBackgroundResizeSpy.mock.calls.map((call) => call[0])).toEqual(["main"]);
   });
 
   it("scales a pane that leaves the alternate screen mid-session from its pre-background size", () => {
@@ -176,12 +176,12 @@ describe("TerminalInstanceService applyBackgroundWindowResize", () => {
     service.instances.set("a", managed);
 
     service.applyBackgroundWindowResize(1200, 840);
-    expect(resizePtyOnlySpy).not.toHaveBeenCalled();
+    expect(applyBackgroundResizeSpy).not.toHaveBeenCalled();
 
     managed.isAltBuffer = false;
     service.applyBackgroundWindowResize(1500, 700);
 
-    expect(resizePtyOnlySpy).toHaveBeenCalledWith("a", 800 * 1.5, 600 * 1.0);
+    expect(applyBackgroundResizeSpy).toHaveBeenCalledWith("a", 800 * 1.5, 600 * 1.0);
   });
 
   it("anchors repeated resizes to the session origin — targets are absolute, never compounded", () => {
@@ -192,21 +192,21 @@ describe("TerminalInstanceService applyBackgroundWindowResize", () => {
 
     // Both events scale the captured 800x600 origin against the 1000x700
     // viewport snapshot, regardless of what earlier events applied.
-    expect(resizePtyOnlySpy).toHaveBeenNthCalledWith(1, "a", 800 * 1.2, 600 * 1.2);
-    expect(resizePtyOnlySpy).toHaveBeenNthCalledWith(2, "a", 800 * 1.5, 600 * 1.0);
+    expect(applyBackgroundResizeSpy).toHaveBeenNthCalledWith(1, "a", 800 * 1.2, 600 * 1.2);
+    expect(applyBackgroundResizeSpy).toHaveBeenNthCalledWith(2, "a", 800 * 1.5, 600 * 1.0);
   });
 
   it("a terminal skipped in one pass still lands on the correct absolute size in the next", () => {
     const managed = makeManaged({ lastWidth: 800, lastHeight: 600 });
     service.instances.set("a", managed);
 
-    // First pass skipped (e.g. resize-locked) — resizePtyOnly returns null
+    // First pass skipped (e.g. resize-locked) — applyBackgroundResize returns null
     // and lastWidth is untouched. The origin snapshot must keep the second
     // pass anchored to the original viewport, not an advanced basis.
     service.applyBackgroundWindowResize(1200, 840);
     service.applyBackgroundWindowResize(1500, 1400);
 
-    expect(resizePtyOnlySpy).toHaveBeenLastCalledWith("a", 800 * 1.5, 600 * 2.0);
+    expect(applyBackgroundResizeSpy).toHaveBeenLastCalledWith("a", 800 * 1.5, 600 * 2.0);
   });
 
   it("resetBackgroundResizeBasis restores the live viewport as the basis", () => {
@@ -216,7 +216,7 @@ describe("TerminalInstanceService applyBackgroundWindowResize", () => {
     service.resetBackgroundResizeBasis();
     service.applyBackgroundWindowResize(1300, 770);
 
-    expect(resizePtyOnlySpy).toHaveBeenLastCalledWith("a", 800 * 1.3, 600 * 1.1);
+    expect(applyBackgroundResizeSpy).toHaveBeenLastCalledWith("a", 800 * 1.3, 600 * 1.1);
   });
 
   it("an uncached, visible delivery resets the basis for the next background session", () => {
@@ -230,13 +230,13 @@ describe("TerminalInstanceService applyBackgroundWindowResize", () => {
     setCached(false);
     setViewport(1300, 770, "visible");
     service.applyBackgroundWindowResize(1200, 840);
-    const callsBeforeNextSession = resizePtyOnlySpy.mock.calls.length;
+    const callsBeforeNextSession = applyBackgroundResizeSpy.mock.calls.length;
 
     setCached(true);
     service.applyBackgroundWindowResize(1560, 385);
 
-    expect(resizePtyOnlySpy).toHaveBeenLastCalledWith("a", 800 * 1.2, 600 * 0.5);
-    expect(resizePtyOnlySpy.mock.calls.length).toBe(callsBeforeNextSession + 1);
+    expect(applyBackgroundResizeSpy).toHaveBeenLastCalledWith("a", 800 * 1.2, 600 * 0.5);
+    expect(applyBackgroundResizeSpy.mock.calls.length).toBe(callsBeforeNextSession + 1);
   });
 
   it("keeps the anchor across a cached delivery that still reports visible", () => {
@@ -249,7 +249,7 @@ describe("TerminalInstanceService applyBackgroundWindowResize", () => {
     setViewport(1200, 840, "visible");
     service.applyBackgroundWindowResize(1500, 700);
 
-    expect(resizePtyOnlySpy).toHaveBeenLastCalledWith("a", 800 * 1.5, 600 * 1.0);
+    expect(applyBackgroundResizeSpy).toHaveBeenLastCalledWith("a", 800 * 1.5, 600 * 1.0);
   });
 
   it("skips unopened and never-measured terminals", () => {
@@ -259,8 +259,8 @@ describe("TerminalInstanceService applyBackgroundWindowResize", () => {
 
     service.applyBackgroundWindowResize(1200, 840);
 
-    expect(resizePtyOnlySpy).toHaveBeenCalledTimes(1);
-    expect(resizePtyOnlySpy).toHaveBeenCalledWith(
+    expect(applyBackgroundResizeSpy).toHaveBeenCalledTimes(1);
+    expect(applyBackgroundResizeSpy).toHaveBeenCalledWith(
       "eligible",
       expect.any(Number),
       expect.any(Number)
@@ -275,7 +275,7 @@ describe("TerminalInstanceService applyBackgroundWindowResize", () => {
     service.applyBackgroundWindowResize(0, 840);
     service.applyBackgroundWindowResize(-100, 840);
 
-    expect(resizePtyOnlySpy).not.toHaveBeenCalled();
+    expect(applyBackgroundResizeSpy).not.toHaveBeenCalled();
   });
 
   it("invalid bounds do not corrupt the session for a following valid event", () => {
@@ -284,7 +284,7 @@ describe("TerminalInstanceService applyBackgroundWindowResize", () => {
     service.applyBackgroundWindowResize(0, 0);
     service.applyBackgroundWindowResize(1200, 840);
 
-    expect(resizePtyOnlySpy).toHaveBeenCalledWith("a", 800 * 1.2, 600 * 1.2);
+    expect(applyBackgroundResizeSpy).toHaveBeenCalledWith("a", 800 * 1.2, 600 * 1.2);
   });
 
   it("captures the origin for a terminal measured only after the session started", () => {
@@ -292,13 +292,13 @@ describe("TerminalInstanceService applyBackgroundWindowResize", () => {
     service.instances.set("late", managed);
 
     service.applyBackgroundWindowResize(1200, 840);
-    expect(resizePtyOnlySpy).not.toHaveBeenCalled();
+    expect(applyBackgroundResizeSpy).not.toHaveBeenCalled();
 
     managed.lastWidth = 500;
     managed.lastHeight = 400;
     service.applyBackgroundWindowResize(1500, 700);
 
-    expect(resizePtyOnlySpy).toHaveBeenCalledWith("late", 500 * 1.5, 400 * 1.0);
+    expect(applyBackgroundResizeSpy).toHaveBeenCalledWith("late", 500 * 1.5, 400 * 1.0);
   });
 
   it("no-ops when the stale viewport reports zero dimensions", () => {
@@ -307,6 +307,6 @@ describe("TerminalInstanceService applyBackgroundWindowResize", () => {
 
     service.applyBackgroundWindowResize(1200, 840);
 
-    expect(resizePtyOnlySpy).not.toHaveBeenCalled();
+    expect(applyBackgroundResizeSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/services/terminal/__tests__/TerminalInstanceService.backgroundResize.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.backgroundResize.test.ts
@@ -2,6 +2,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ManagedTerminal } from "../types";
 
+// The service is re-imported under vi.resetModules() in beforeEach, so the
+// cache signal has to be a module mock rather than the preload-bridge stub the
+// controller suites use — a statically imported reset helper would operate on a
+// different module instance than the one the service under test binds to.
+// `viewCacheState.test.ts` owns the bridge-latch behaviour itself.
+const viewCacheState = vi.hoisted(() => ({
+  isProjectViewCached: vi.fn(() => false),
+  subscribeProjectViewLifecycle: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/lib/viewCacheState", () => viewCacheState);
+
 vi.mock("@/clients", () => ({
   terminalClient: {
     resize: vi.fn(),
@@ -77,6 +89,10 @@ function setViewport(width: number, height: number, visibility: "visible" | "hid
   Object.defineProperty(document, "visibilityState", { value: visibility, configurable: true });
 }
 
+function setCached(cached: boolean) {
+  viewCacheState.isProjectViewCached.mockReturnValue(cached);
+}
+
 describe("TerminalInstanceService applyBackgroundWindowResize", () => {
   let service: BackgroundResizeTestService;
   let resizePtyOnlySpy: ReturnType<typeof vi.spyOn>;
@@ -92,7 +108,13 @@ describe("TerminalInstanceService applyBackgroundWindowResize", () => {
     resizePtyOnlySpy = vi
       .spyOn(service.resizeController, "resizePtyOnly")
       .mockReturnValue(null) as ReturnType<typeof vi.spyOn>;
-    setViewport(1000, 700, "hidden");
+    // The production state this method exists to serve: main has detached and
+    // hidden the view, but a child WebContentsView keeps reporting "visible"
+    // (#11443). Every case below therefore runs against visibilityState
+    // "visible" — under the old visibility-only guard the whole suite would
+    // no-op.
+    setViewport(1000, 700, "visible");
+    setCached(true);
   });
 
   afterEach(() => {
@@ -111,13 +133,55 @@ describe("TerminalInstanceService applyBackgroundWindowResize", () => {
     expect(resizePtyOnlySpy).toHaveBeenCalledWith("b", 400 * 1.2, 300 * 1.2);
   });
 
-  it("no-ops when the document is visible — real layout owns geometry", () => {
-    setViewport(1000, 700, "visible");
+  it("no-ops only once the view is neither cached nor page-hidden", () => {
     service.instances.set("a", makeManaged());
+
+    setCached(false);
+    setViewport(1000, 700, "visible");
+    service.applyBackgroundWindowResize(1200, 840);
+    expect(resizePtyOnlySpy).not.toHaveBeenCalled();
+
+    // Either signal alone is enough to keep scaling: a minimized window that
+    // was never cached, and a cached view that still reports "visible".
+    setViewport(1000, 700, "hidden");
+    service.applyBackgroundWindowResize(1200, 840);
+    expect(resizePtyOnlySpy).toHaveBeenCalledTimes(1);
+
+    setCached(true);
+    setViewport(1000, 700, "visible");
+    service.applyBackgroundWindowResize(1200, 840);
+    expect(resizePtyOnlySpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips alt-buffer panes so xterm and the PTY never split while backgrounded", () => {
+    // A PTY-only resize would leave a live TUI painting a wider frame into a
+    // narrower alt grid, which never reflows — and the reattach resize dedupes
+    // to no SIGWINCH, so the app never redraws to correct it.
+    service.instances.set("main", makeManaged({ lastWidth: 800, lastHeight: 600 }));
+    service.instances.set(
+      "alt",
+      makeManaged({ lastWidth: 800, lastHeight: 600, isAltBuffer: true })
+    );
 
     service.applyBackgroundWindowResize(1200, 840);
 
+    expect(resizePtyOnlySpy.mock.calls.map((call) => call[0])).toEqual(["main"]);
+  });
+
+  it("scales a pane that leaves the alternate screen mid-session from its pre-background size", () => {
+    // The origin is captured on first eligibility, not on session start, so a
+    // pane skipped while alt-screen still lands on an absolute target anchored
+    // to the same basis rather than compounding off a partial resize.
+    const managed = makeManaged({ lastWidth: 800, lastHeight: 600, isAltBuffer: true });
+    service.instances.set("a", managed);
+
+    service.applyBackgroundWindowResize(1200, 840);
     expect(resizePtyOnlySpy).not.toHaveBeenCalled();
+
+    managed.isAltBuffer = false;
+    service.applyBackgroundWindowResize(1500, 700);
+
+    expect(resizePtyOnlySpy).toHaveBeenCalledWith("a", 800 * 1.5, 600 * 1.0);
   });
 
   it("anchors repeated resizes to the session origin — targets are absolute, never compounded", () => {
@@ -155,16 +219,37 @@ describe("TerminalInstanceService applyBackgroundWindowResize", () => {
     expect(resizePtyOnlySpy).toHaveBeenLastCalledWith("a", 800 * 1.3, 600 * 1.1);
   });
 
-  it("a visible-state delivery resets the basis for the next background session", () => {
+  it("an uncached, visible delivery resets the basis for the next background session", () => {
     service.instances.set("a", makeManaged({ lastWidth: 800, lastHeight: 600 }));
 
     service.applyBackgroundWindowResize(1200, 840);
-    setViewport(1000, 700, "visible");
-    service.applyBackgroundWindowResize(1200, 840);
-    setViewport(1000, 700, "hidden");
-    service.applyBackgroundWindowResize(1300, 770);
 
-    expect(resizePtyOnlySpy).toHaveBeenLastCalledWith("a", 800 * 1.3, 600 * 1.1);
+    // Reactivated: the delivery is dropped AND the anchor released. Real layout
+    // then re-measures the pane against a viewport the old basis knows nothing
+    // about — a stale basis would scale 1560/1000 instead of 1560/1300.
+    setCached(false);
+    setViewport(1300, 770, "visible");
+    service.applyBackgroundWindowResize(1200, 840);
+    const callsBeforeNextSession = resizePtyOnlySpy.mock.calls.length;
+
+    setCached(true);
+    service.applyBackgroundWindowResize(1560, 385);
+
+    expect(resizePtyOnlySpy).toHaveBeenLastCalledWith("a", 800 * 1.2, 600 * 0.5);
+    expect(resizePtyOnlySpy.mock.calls.length).toBe(callsBeforeNextSession + 1);
+  });
+
+  it("keeps the anchor across a cached delivery that still reports visible", () => {
+    // The reset must key off "not cached AND visible", not visibility alone —
+    // re-snapshotting mid-background would rebase every later event onto an
+    // already-scaled viewport and compound the targets.
+    service.instances.set("a", makeManaged({ lastWidth: 800, lastHeight: 600 }));
+
+    service.applyBackgroundWindowResize(1200, 840);
+    setViewport(1200, 840, "visible");
+    service.applyBackgroundWindowResize(1500, 700);
+
+    expect(resizePtyOnlySpy).toHaveBeenLastCalledWith("a", 800 * 1.5, 600 * 1.0);
   });
 
   it("skips unopened and never-measured terminals", () => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.backgroundResize.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.backgroundResize.test.ts
@@ -95,7 +95,13 @@ function setCached(cached: boolean) {
 
 describe("TerminalInstanceService applyBackgroundWindowResize", () => {
   let service: BackgroundResizeTestService;
-  let applyBackgroundResizeSpy: ReturnType<typeof vi.spyOn>;
+  // Typed rather than the bare vi.spyOn return so `.mock.calls` stays tuple-typed
+  // — an untyped spy makes every destructured call argument an implicit any.
+  let applyBackgroundResizeSpy: ReturnType<
+    typeof vi.fn<
+      (id: string, width: number, height: number) => { cols: number; rows: number } | null
+    >
+  >;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -107,7 +113,7 @@ describe("TerminalInstanceService applyBackgroundWindowResize", () => {
     service.resetBackgroundResizeBasis();
     applyBackgroundResizeSpy = vi
       .spyOn(service.resizeController, "applyBackgroundResize")
-      .mockReturnValue(null) as ReturnType<typeof vi.spyOn>;
+      .mockReturnValue(null);
     // The production state this method exists to serve: main has detached and
     // hidden the view, but a child WebContentsView keeps reporting "visible"
     // (#11443). Cases that assert a resize is applied therefore only pass

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -662,33 +662,46 @@ describe("TerminalReconciliationWatchdog", () => {
       setRenderPaused(alt, false);
       setGrid(alt, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
       instances.set("alt", alt);
+      // Diverged main-buffer controls, iterated after the alt pane. If the alt
+      // pane merely skipped the call while still consuming a heavy-repair slot,
+      // one control would be starved every tick.
+      const controls: ManagedTerminal[] = [];
+      for (let i = 0; i < WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK; i++) {
+        const control = makeManaged({ isAltBuffer: false });
+        setRenderPaused(control, false);
+        setGrid(control, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
+        instances.set(`control${i}`, control);
+        controls.push(control);
+      }
       const deps = makeDeps(instances);
       watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      // Every control was repaired on the first tick — the alt pane took none
+      // of the per-tick allowance.
+      expect(vi.mocked(deps.reconcileRevealGeometry).mock.calls.map(([id]) => id).sort()).toEqual(
+        controls.map((_, i) => `control${i}`)
+      );
 
       // Far more ticks than the breaker needs to trip on a diverged pane.
       for (let i = 0; i < 12; i++) vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
 
-      expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
+      expect(vi.mocked(deps.reconcileRevealGeometry).mock.calls.some(([id]) => id === "alt")).toBe(
+        false
+      );
       expect(alt.geometryRepairAttempts ?? 0).toBe(0);
       expect(alt.geometryRepairGaveUp).toBeFalsy();
-      // The DEV diagnostic still reports the divergence — excluding the pane
-      // from the repair loop must not also blind the log — but the breaker,
-      // whose whole job is to stop a repair that keeps failing, must never
-      // record a failure for a repair that was never attempted.
-      expect(
-        vi.mocked(logWarn).mock.calls.some((call) => String(call[0]).includes("giving up"))
-      ).toBe(false);
-      expect(
-        vi
-          .mocked(logWarn)
-          .mock.calls.some((call) => String(call[0]).includes("divergence for on-screen terminal"))
-      ).toBe(false);
+      // The controls prove the breaker still works on panes that CAN be
+      // repaired, so the alt pane's clean counters aren't a dead watchdog.
+      expect(controls.every((control) => control.geometryRepairGaveUp === true)).toBe(true);
 
       // Leaving the alternate screen restores repair eligibility, proving the
       // exclusion is keyed on live buffer mode and left no latched state.
       alt.isAltBuffer = false;
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
-      expect(deps.reconcileRevealGeometry).toHaveBeenCalledWith("alt");
+      expect(vi.mocked(deps.reconcileRevealGeometry).mock.calls.some(([id]) => id === "alt")).toBe(
+        true
+      );
       expect(alt.geometryRepairAttempts).toBe(1);
     });
 

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -560,7 +560,7 @@ describe("TerminalReconciliationWatchdog", () => {
 
   describe("geometry convergence (#10632)", () => {
     it("defers geometry diagnosis and repair during a coordinated resize, then repairs once stable", () => {
-      const managed = makeManaged({ isAltBuffer: true });
+      const managed = makeManaged({ isAltBuffer: false });
       setRenderPaused(managed, false);
       (managed.terminal as unknown as { cols: number; rows: number }).cols = 137;
       (managed.terminal as unknown as { cols: number; rows: number }).rows = 40;
@@ -634,12 +634,12 @@ describe("TerminalReconciliationWatchdog", () => {
       expect(deps.forceReflow).toHaveBeenCalledWith(managed.terminal.element);
     });
 
-    it("reconciles an on-screen agent TUI whose grid disagrees with the container (garbled wrapping)", () => {
+    it("reconciles an on-screen terminal whose grid disagrees with the container (garbled wrapping)", () => {
       // The exact switch-back failure: while backgrounded the container narrowed
-      // (137 → 100 cols) but the alt-buffer agent's xterm grid stayed at the old
-      // width, so its buffer wraps at the wrong column. The watchdog now repairs
-      // this for agent TUIs, which it previously only DIAGNOSED while excluding.
-      const managed = makeManaged({ isAltBuffer: true });
+      // (137 → 100 cols) but the xterm grid stayed at the old width, so the
+      // buffer wraps at the wrong column. The watchdog repairs this, which it
+      // previously only DIAGNOSED.
+      const managed = makeManaged({ isAltBuffer: false });
       setRenderPaused(managed, false);
       setGrid(managed, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
       instances.set("t1", managed);
@@ -651,8 +651,49 @@ describe("TerminalReconciliationWatchdog", () => {
       expect(managed.lastWatchdogRepairAt).toBeGreaterThan(0);
     });
 
+    it("never spends a geometry repair on an alt-buffer pane, whose repair cannot converge (#11443)", () => {
+      // reconcileGeometryFresh returns before touching geometry for an
+      // alt-screen pane (#10805), so issuing the repair here can never close
+      // the divergence. Left in the loop it burns a heavy-budget slot every
+      // cooldown window and then latches the breaker permanently — which would
+      // bar the pane's legitimate main-buffer repairs after it leaves the
+      // alternate screen. An identical main-buffer pane is the control.
+      const alt = makeManaged({ isAltBuffer: true });
+      setRenderPaused(alt, false);
+      setGrid(alt, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
+      instances.set("alt", alt);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      // Far more ticks than the breaker needs to trip on a diverged pane.
+      for (let i = 0; i < 12; i++) vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+
+      expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
+      expect(alt.geometryRepairAttempts ?? 0).toBe(0);
+      expect(alt.geometryRepairGaveUp).toBeFalsy();
+      // The DEV diagnostic still reports the divergence — excluding the pane
+      // from the repair loop must not also blind the log — but the breaker,
+      // whose whole job is to stop a repair that keeps failing, must never
+      // record a failure for a repair that was never attempted.
+      expect(
+        vi.mocked(logWarn).mock.calls.some((call) => String(call[0]).includes("giving up"))
+      ).toBe(false);
+      expect(
+        vi
+          .mocked(logWarn)
+          .mock.calls.some((call) => String(call[0]).includes("divergence for on-screen terminal"))
+      ).toBe(false);
+
+      // Leaving the alternate screen restores repair eligibility, proving the
+      // exclusion is keyed on live buffer mode and left no latched state.
+      alt.isAltBuffer = false;
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.reconcileRevealGeometry).toHaveBeenCalledWith("alt");
+      expect(alt.geometryRepairAttempts).toBe(1);
+    });
+
     it("does not reconcile geometry while a synchronized-output block is open", () => {
-      const managed = makeManaged({ isAltBuffer: true });
+      const managed = makeManaged({ isAltBuffer: false });
       (
         managed.terminal as unknown as { modes: { synchronizedOutputMode: boolean } }
       ).modes.synchronizedOutputMode = true;
@@ -667,7 +708,7 @@ describe("TerminalReconciliationWatchdog", () => {
 
     it("caps geometry reconciles per tick at the heavy budget (== REVEAL_CONCURRENCY)", () => {
       for (let i = 0; i < WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK + 1; i++) {
-        const managed = makeManaged({ isAltBuffer: true });
+        const managed = makeManaged({ isAltBuffer: false });
         setGrid(managed, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
         instances.set(`t${i}`, managed);
       }
@@ -692,7 +733,7 @@ describe("TerminalReconciliationWatchdog", () => {
     // returning true (box measurable) but the grid never actually converges —
     // the exact stable off-by-one that made the watchdog re-wrap forever.
     function makeDivergedTerminal(): ManagedTerminal {
-      const managed = makeManaged({ isAltBuffer: true });
+      const managed = makeManaged({ isAltBuffer: false });
       setRenderPaused(managed, false);
       setGrid(managed, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
       return managed;
@@ -775,7 +816,7 @@ describe("TerminalReconciliationWatchdog", () => {
     it("does not count a budget-deferred tick as a repair attempt", () => {
       const panes: ManagedTerminal[] = [];
       for (let i = 0; i < WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK + 1; i++) {
-        const managed = makeManaged({ isAltBuffer: true });
+        const managed = makeManaged({ isAltBuffer: false });
         setGrid(managed, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
         instances.set(`t${i}`, managed);
         panes.push(managed);
@@ -857,11 +898,17 @@ describe("TerminalReconciliationWatchdog", () => {
       expect(deps.forceReflow).toHaveBeenCalledWith(managed.terminal.element);
     });
 
-    it("still repairs a streaming ALT-buffer pane (quiescence gate is main-buffer only)", () => {
-      // reconcileGeometryFresh never re-wraps an alt-buffer pane (its guard
-      // returns before the quiescence gate), so deferring alt-buffer repairs
-      // for writes would only starve the reveal repair with no safety gain.
-      const managed = makeDivergedTerminal();
+    it("still issues the reveal-pending repair for a streaming ALT-buffer pane (quiescence gate is main-buffer only)", () => {
+      // The geometry branch excludes alt panes outright (#11443), but the
+      // reveal-pending obligation still belongs to them: its repair also
+      // restores the WebGL atlas and unpauses the renderer, and
+      // reconcileGeometryFresh's quiescence gate sits after the alt early
+      // return, so writes must not defer it.
+      const managed = makeManaged({ isAltBuffer: true });
+      setRenderPaused(managed, false);
+      setGrid(managed, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
+      managed.revealPendingRepair = true;
+      managed.revealPendingGeneration = managed.attachGeneration;
       instances.set("t1", managed);
       const deps = makeDeps(instances);
       watchdog = new TerminalReconciliationWatchdog(deps);
@@ -869,11 +916,14 @@ describe("TerminalReconciliationWatchdog", () => {
       managed.lastWriteAt = Date.now() + WATCHDOG_INTERVAL_MS;
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
       expect(deps.reconcileRevealGeometry).toHaveBeenCalledTimes(1);
-      expect(managed.geometryRepairAttempts).toBe(1);
+      expect(managed.revealPendingRepair).toBe(false);
+      // The reveal obligation is not a convergence repair — it must not spend a
+      // breaker attempt the alt pane can never win back.
+      expect(managed.geometryRepairAttempts ?? 0).toBe(0);
     });
 
     it("neither advances nor resets the breaker while a synchronized-output block stays open", () => {
-      const managed = makeManaged({ isAltBuffer: true });
+      const managed = makeManaged({ isAltBuffer: false });
       (
         managed.terminal as unknown as { modes: { synchronizedOutputMode: boolean } }
       ).modes.synchronizedOutputMode = true;

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -679,9 +679,12 @@ describe("TerminalReconciliationWatchdog", () => {
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
       // Every control was repaired on the first tick — the alt pane took none
       // of the per-tick allowance.
-      expect(vi.mocked(deps.reconcileRevealGeometry).mock.calls.map(([id]) => id).sort()).toEqual(
-        controls.map((_, i) => `control${i}`)
-      );
+      expect(
+        vi
+          .mocked(deps.reconcileRevealGeometry)
+          .mock.calls.map(([id]) => id)
+          .sort()
+      ).toEqual(controls.map((_, i) => `control${i}`));
 
       // Far more ticks than the breaker needs to trip on a diverged pane.
       for (let i = 0; i < 12; i++) vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);

--- a/src/services/terminal/__tests__/TerminalResizeController.fitParity.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.fitParity.test.ts
@@ -414,7 +414,7 @@ describe("TerminalResizeController ↔ FitAddon column parity (#11095)", () => {
     const controller = makeController(managed);
 
     const proposal = fitAddon.proposeDimensions();
-    const applied = controller.resizePtyOnly("t1", CONTAINER.width, CONTAINER.height);
+    const applied = controller.applyBackgroundResize("t1", CONTAINER.width, CONTAINER.height);
 
     expect(applied).toEqual({ cols: proposal!.cols, rows: proposal!.rows });
   });

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -1446,7 +1446,7 @@ describe("TerminalResizeController", () => {
       expect(resizeMock).toHaveBeenCalledWith("term-1", 140, 45);
     });
 
-    it("a PTY-only target supersedes an older debounce job without reflowing xterm", () => {
+    it("a background target supersedes an older debounce job and lands exactly once", () => {
       const managed = createManagedTerminal();
       managed.isFocused = false;
       managed.terminal.buffer.active.length = 300;
@@ -1457,10 +1457,13 @@ describe("TerminalResizeController", () => {
       });
 
       controller.resize("term-1", 1200, 800);
-      controller.resizePtyOnly("term-1", 1500, 800);
+      controller.applyBackgroundResize("term-1", 1500, 800);
       vi.advanceTimersByTime(100);
 
-      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      // The superseded 1200px job must not fire afterwards: both grids sit at
+      // the newer target, applied once.
+      expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
+      expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1500), 40);
       expect(resizeMock).toHaveBeenCalledTimes(1);
       expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1500), 40);
     });
@@ -1705,7 +1708,7 @@ describe("TerminalResizeController", () => {
     });
   });
 
-  describe("resizePtyOnly", () => {
+  describe("applyBackgroundResize", () => {
     function makeController(managed: ReturnType<typeof createManagedTerminal> | undefined) {
       return new TerminalResizeController({
         getInstance: vi.fn(() => managed),
@@ -1718,7 +1721,12 @@ describe("TerminalResizeController", () => {
       });
     }
 
-    it("resizes the PTY without reflowing xterm, even for a visible focused terminal", () => {
+    it("moves xterm and the PTY to the same grid, xterm first", () => {
+      // The grids must never disagree while the view is cached: bytes keep
+      // being written, so a PTY-only resize would land the app's
+      // cursor-addressed output on the wrong rows (#11443). Ordering matters
+      // too — SIGWINCH must not reach the app for a grid the parser hasn't
+      // adopted. No DOM measurement is involved; a detached view has none.
       const managed = createManagedTerminal();
       managed.isFocused = true;
       managed.isVisible = true;
@@ -1727,22 +1735,83 @@ describe("TerminalResizeController", () => {
         _core: { _renderService: { dimensions: { css: { cell: { width: 10, height: 20 } } } } },
       });
 
+      const order: string[] = [];
+      vi.mocked(managed.terminal.resize).mockImplementation(() => {
+        order.push("xterm");
+      });
+      resizeMock.mockImplementation(() => {
+        order.push("pty");
+      });
+
       const controller = makeController(managed);
-      const result = controller.resizePtyOnly("term-1", 1600, 800);
+      const result = controller.applyBackgroundResize("term-1", 1600, 800);
 
       expect(result).toEqual({ cols: colsFor(1600), rows: 40 });
-      expect(managed.terminal.resize).not.toHaveBeenCalled();
-      expect(managed.fitAddon.fit).not.toHaveBeenCalled();
+      expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1600), 40);
       expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
+      expect(order).toEqual(["xterm", "pty"]);
+      expect(managed.fitAddon.fit).not.toHaveBeenCalled();
       expect(managed.latestCols).toBe(colsFor(1600));
       expect(managed.latestRows).toBe(40);
       expect(managed.lastWidth).toBe(1600);
       expect(managed.lastHeight).toBe(800);
     });
 
+    it("refuses an alt-screen pane outright, leaving both grids untouched", () => {
+      const managed = createManagedTerminal();
+      managed.isAltBuffer = true;
+      Object.assign(managed.terminal, {
+        _core: { _renderService: { dimensions: { css: { cell: { width: 10, height: 20 } } } } },
+      });
+
+      const controller = makeController(managed);
+
+      expect(controller.applyBackgroundResize("term-1", 1600, 800)).toBeNull();
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).not.toHaveBeenCalled();
+      expect(managed.lastWidth).toBe(800);
+      expect(managed.lastHeight).toBe(600);
+    });
+
+    it("drops a lock-stashed resize when the pane entered the alternate screen meanwhile", () => {
+      // The stash outlives the buffer-mode change, so re-checking only at the
+      // caller would replay a resize onto a live TUI at unlock (#11443).
+      const managed = createManagedTerminal();
+      Object.assign(managed.terminal, {
+        _core: { _renderService: { dimensions: { css: { cell: { width: 10, height: 20 } } } } },
+      });
+      const controller = makeController(managed);
+
+      controller.lockResize("term-1", true);
+      expect(controller.applyBackgroundResize("term-1", 1600, 800)).toBeNull();
+      expect(managed.pendingBackgroundResize).toEqual({ width: 1600, height: 800 });
+
+      managed.isAltBuffer = true;
+      controller.lockResize("term-1", false);
+
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).not.toHaveBeenCalled();
+      expect(managed.pendingBackgroundResize).toBeUndefined();
+    });
+
+    it("replays a lock-stashed resize for a pane still on the main buffer", () => {
+      const managed = createManagedTerminal();
+      Object.assign(managed.terminal, {
+        _core: { _renderService: { dimensions: { css: { cell: { width: 10, height: 20 } } } } },
+      });
+      const controller = makeController(managed);
+
+      controller.lockResize("term-1", true);
+      controller.applyBackgroundResize("term-1", 1600, 800);
+      controller.lockResize("term-1", false);
+
+      expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1600), 40);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
+    });
+
     it("returns null for a missing instance", () => {
       const controller = makeController(undefined);
-      expect(controller.resizePtyOnly("term-1", 1600, 800)).toBeNull();
+      expect(controller.applyBackgroundResize("term-1", 1600, 800)).toBeNull();
       expect(resizeMock).not.toHaveBeenCalled();
     });
 
@@ -1754,7 +1823,7 @@ describe("TerminalResizeController", () => {
       const controller = makeController(managed);
       controller.lockResize("term-1", true);
 
-      expect(controller.resizePtyOnly("term-1", 1600, 800)).toBeNull();
+      expect(controller.applyBackgroundResize("term-1", 1600, 800)).toBeNull();
       expect(resizeMock).not.toHaveBeenCalled();
     });
 
@@ -1765,10 +1834,10 @@ describe("TerminalResizeController", () => {
       });
       const controller = makeController(managed);
 
-      controller.resizePtyOnly("term-1", 1600, 800);
+      controller.applyBackgroundResize("term-1", 1600, 800);
       expect(resizeMock).toHaveBeenCalledTimes(1);
 
-      expect(controller.resizePtyOnly("term-1", 1600, 800)).toBeNull();
+      expect(controller.applyBackgroundResize("term-1", 1600, 800)).toBeNull();
       expect(resizeMock).toHaveBeenCalledTimes(1);
     });
 
@@ -1788,7 +1857,7 @@ describe("TerminalResizeController", () => {
       expect(controller.hasPendingResize("term-1")).toBe(true);
       expect(resizeMock).not.toHaveBeenCalled();
 
-      expect(controller.resizePtyOnly("term-1", 1600, 800)).toBeNull();
+      expect(controller.applyBackgroundResize("term-1", 1600, 800)).toBeNull();
 
       expect(controller.hasPendingResize("term-1")).toBe(false);
       expect(managed.terminal.resize).not.toHaveBeenCalled();
@@ -1805,7 +1874,7 @@ describe("TerminalResizeController", () => {
       });
       const controller = makeController(managed);
 
-      controller.resizePtyOnly("term-1", 1600, 800);
+      controller.applyBackgroundResize("term-1", 1600, 800);
       expect(resizeMock).toHaveBeenCalledTimes(1);
 
       // Grow the container to the widest pixel that still yields the same column
@@ -1817,7 +1886,7 @@ describe("TerminalResizeController", () => {
       const subCellWidth = 1600 + (CELL.width - 1 - ((1600 - SCROLLBAR_PX) % CELL.width));
       expect(colsFor(subCellWidth)).toBe(colsFor(1600));
 
-      const second = controller.resizePtyOnly("term-1", subCellWidth, 800);
+      const second = controller.applyBackgroundResize("term-1", subCellWidth, 800);
       expect(second).toBeNull();
       expect(resizeMock).toHaveBeenCalledTimes(1);
       expect(managed.lastWidth).toBe(subCellWidth);
@@ -1827,7 +1896,7 @@ describe("TerminalResizeController", () => {
       const managed = createManagedTerminal();
       const controller = makeController(managed);
 
-      expect(controller.resizePtyOnly("term-1", 1600, 800)).toBeNull();
+      expect(controller.applyBackgroundResize("term-1", 1600, 800)).toBeNull();
       expect(resizeMock).not.toHaveBeenCalled();
       expect(managed.lastWidth).toBe(800);
       expect(managed.lastHeight).toBe(600);
@@ -1840,10 +1909,10 @@ describe("TerminalResizeController", () => {
       });
       const controller = makeController(managed);
 
-      expect(controller.resizePtyOnly("term-1", Number.NaN, 800)).toBeNull();
-      expect(controller.resizePtyOnly("term-1", 1600, Number.POSITIVE_INFINITY)).toBeNull();
-      expect(controller.resizePtyOnly("term-1", 0, 800)).toBeNull();
-      expect(controller.resizePtyOnly("term-1", -100, 800)).toBeNull();
+      expect(controller.applyBackgroundResize("term-1", Number.NaN, 800)).toBeNull();
+      expect(controller.applyBackgroundResize("term-1", 1600, Number.POSITIVE_INFINITY)).toBeNull();
+      expect(controller.applyBackgroundResize("term-1", 0, 800)).toBeNull();
+      expect(controller.applyBackgroundResize("term-1", -100, 800)).toBeNull();
       expect(resizeMock).not.toHaveBeenCalled();
       expect(managed.lastWidth).toBe(800);
       expect(managed.latestCols).toBe(80);
@@ -1861,15 +1930,18 @@ describe("TerminalResizeController", () => {
       });
 
       const controller = makeController(managed);
-      const result = controller.resizePtyOnly("term-1", 1600, 800);
+      const result = controller.applyBackgroundResize("term-1", 1600, 800);
 
       expect(result).toEqual({ cols: colsFor(1600), rows: 40 });
-      // Direct delivery — not deferred behind the settled 500ms timer, which
-      // would also reflow xterm in a hidden (possibly frozen) renderer.
+      // Direct delivery — not deferred behind the settled 500ms timer, whose
+      // whole purpose (coalescing a live drag) is moot for a burst Main has
+      // already debounced to resize-end.
       expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
+      expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
 
+      // Nothing lands a second time when the settled window elapses.
       vi.advanceTimersByTime(500);
-      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
       expect(resizeMock).toHaveBeenCalledTimes(1);
     });
 
@@ -1889,13 +1961,14 @@ describe("TerminalResizeController", () => {
       controller.sendPtyResize("term-1", 120, 30);
       expect(resizeMock).not.toHaveBeenCalled();
 
-      controller.resizePtyOnly("term-1", 1600, 800);
+      controller.applyBackgroundResize("term-1", 1600, 800);
       expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
 
       vi.advanceTimersByTime(500);
-      // The stale timer must not fire its 120x30 resize or reflow xterm.
+      // The stale timer must not fire its 120x30 resize into either grid.
       expect(resizeMock).toHaveBeenCalledTimes(1);
-      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
+      expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1600), 40);
     });
   });
 
@@ -2224,7 +2297,7 @@ describe("TerminalResizeController", () => {
       const controller = makeCtl(managed);
 
       controller.lockResize("term-1", true);
-      const result = controller.resizePtyOnly("term-1", 1600, 800);
+      const result = controller.applyBackgroundResize("term-1", 1600, 800);
 
       // Locked: the PTY is not resized now, but the geometry is preserved.
       expect(result).toBeNull();
@@ -2237,7 +2310,7 @@ describe("TerminalResizeController", () => {
       const controller = makeCtl(managed);
 
       controller.lockResize("term-1", true);
-      controller.resizePtyOnly("term-1", 1600, 800);
+      controller.applyBackgroundResize("term-1", 1600, 800);
       expect(resizeMock).not.toHaveBeenCalled();
 
       controller.lockResize("term-1", false);

--- a/src/services/terminal/__tests__/TerminalSwitchBackRedraw.regression.test.ts
+++ b/src/services/terminal/__tests__/TerminalSwitchBackRedraw.regression.test.ts
@@ -5,12 +5,18 @@
 // the closed-loop watchdog recovery converges it WITHOUT a manual Redraw.
 //
 // It drives the REAL TerminalReconciliationWatchdog against a deterministic fake
-// of a live agent TUI (alt-buffer + DEC 2026 synchronized output — the same
-// class of process the deleted `e2e/fixtures/fake-claude-agent.cjs` modelled).
-// The fake's container CHANGES COLUMN COUNT while the project is backgrounded,
-// so on switch-back its xterm grid wraps at the wrong width (the "garbled line
-// flow") and its renderer is left paused — exactly the two halves a manual
-// Redraw fixes.
+// of a live agent CLI (DEC 2026 synchronized output, optionally on the alternate
+// screen — the same class of process the deleted
+// `e2e/fixtures/fake-claude-agent.cjs` modelled). The fake's container CHANGES
+// COLUMN COUNT while the project is backgrounded, so on switch-back its xterm
+// grid wraps at the wrong width (the "garbled line flow") and its renderer is
+// left paused — exactly the two halves a manual Redraw fixes.
+//
+// Buffer mode splits the recovery lanes (#11443): a main-buffer pane is re-fit
+// by the geometry-convergence branch, while an alt-screen pane is excluded from
+// it (reconcileGeometryFresh refuses to reflow a live TUI) and gets only the
+// paint half here, with its grid owned by the app's SIGWINCH redraw and the
+// ResizeObserver-driven resize on reattach.
 //
 // The `reconcileRevealGeometry` / `forceReflow` deps mirror what the real
 // TerminalInstanceService does, INCLUDING the present-ordering guarantee:
@@ -78,7 +84,7 @@ function newAgent(): FakeAgent {
   };
 }
 
-function buildManaged(agent: FakeAgent): ManagedTerminal {
+function buildManaged(agent: FakeAgent, isAltBuffer: boolean): ManagedTerminal {
   const hostElement = document.createElement("div");
   const termEl = document.createElement("div");
   hostElement.appendChild(termEl);
@@ -136,10 +142,11 @@ function buildManaged(agent: FakeAgent): ManagedTerminal {
     isDetached: false,
     isResizeSuppressed: false,
     isUserScrolledBack: false,
-    // The defining trait of the panes that break: a live agent TUI on the alt
-    // buffer using DEC 2026 synchronized output — exactly what the watchdog used
-    // to exclude from recovery.
-    isAltBuffer: true,
+    // Buffer mode decides which recovery lane owns the pane: a main-buffer CLI
+    // converges through the geometry-convergence branch, while a live alt-screen
+    // agent TUI is excluded from it (#11443) and recovers via the reveal-pending
+    // obligation plus its own SIGWINCH redraw.
+    isAltBuffer,
     lastActiveTime: Date.now(),
     lastWidth: 0,
     lastHeight: 0,
@@ -200,9 +207,15 @@ function buildDeps(
       const agent = agents.get(id);
       if (!agent) return false;
       if (!agent.onScreen) return false; // present-ordering guarantee
+      agent.atlasRepairs += 1;
+      // reconcileGeometryFresh takes its alt-buffer early return BEFORE any
+      // measurement (#10805): the atlas/paint half still runs and the boolean
+      // still reports measurability, but the grid is deliberately untouched. A
+      // fake that converged here would hide the fact that the geometry lane is
+      // structurally a no-op for these panes.
+      if (instances.get(id)?.isAltBuffer) return true;
       agent.cols = agent.containerCols;
       agent.rows = agent.containerRows;
-      agent.atlasRepairs += 1;
       return true;
     }),
     isStoreBackgrounded: vi.fn(() => false),
@@ -241,14 +254,14 @@ describe("#10632 switch-back redraw — closed-loop convergence", () => {
     vi.clearAllMocks();
   });
 
-  function mount(id: string): FakeAgent {
+  function mount(id: string, { altBuffer = false } = {}): FakeAgent {
     const agent = newAgent();
     agents.set(id, agent);
-    instances.set(id, buildManaged(agent));
+    instances.set(id, buildManaged(agent, altBuffer));
     return agent;
   }
 
-  it("path A (warm view swap): converges a garbled, paused agent TUI on switch-back with no manual Redraw", () => {
+  it("path A (warm view swap): converges a garbled, paused main-buffer CLI on switch-back with no manual Redraw", () => {
     const agent = mount("claude");
     deps = buildDeps(instances, agents);
     watchdog = new TerminalReconciliationWatchdog(deps);
@@ -293,6 +306,53 @@ describe("#10632 switch-back redraw — closed-loop convergence", () => {
     expect(agent.cols).toBe(90); // grid converged to the container — no garble
     expect(agent.paused).toBe(false); // renderer resumed
     expect(agent.atlasRepairs).toBeGreaterThan(0); // local atlas repaired (WebGL path stand-in)
+  });
+
+  it("path A (alt-screen TUI): recovers paint without the geometry lane, and never latches the breaker (#11443)", () => {
+    // Same switch-back as path A, but the pane is a live alt-screen TUI. Its
+    // grid is NOT the watchdog's to re-fit — reconcileGeometryFresh returns
+    // before measuring so the app's own SIGWINCH redraw and the
+    // ResizeObserver-driven resize own it. What the watchdog must still deliver
+    // is the paint half, and what it must never do is spend a convergence
+    // budget it cannot win: a latched give-up would outlive the alternate
+    // screen and bar the pane's later main-buffer repairs.
+    const agent = mount("opencode", { altBuffer: true });
+    const managed = instances.get("opencode")!;
+    deps = buildDeps(instances, agents);
+    watchdog = new TerminalReconciliationWatchdog(deps);
+
+    agent.onScreen = false;
+    agent.containerCols = 90;
+    agent.paused = true;
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+
+    agent.onScreen = true;
+    managed.attachGeneration += 1;
+    managed.revealPendingRepair = true;
+    managed.revealPendingGeneration = managed.attachGeneration;
+
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+
+    // Paint recovered, obligation discharged.
+    expect(agent.paused).toBe(false);
+    expect(agent.atlasRepairs).toBeGreaterThan(0);
+    expect(managed.revealPendingRepair).toBe(false);
+    // Grid left to the app and real layout — the watchdog did not re-fit it.
+    expect(agent.cols).toBe(120);
+
+    // The divergence outlives the reveal, but no amount of ticking may burn the
+    // breaker on a repair that structurally cannot converge.
+    const callsAfterReveal = vi.mocked(deps.reconcileRevealGeometry).mock.calls.length;
+    for (let i = 0; i < 12; i++) vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+    expect(vi.mocked(deps.reconcileRevealGeometry).mock.calls.length).toBe(callsAfterReveal);
+    expect(managed.geometryRepairAttempts ?? 0).toBe(0);
+    expect(managed.geometryRepairGaveUp).toBeFalsy();
+
+    // Leaving the alternate screen hands the pane back to the geometry lane,
+    // which converges it on the next tick — proving nothing latched.
+    managed.isAltBuffer = false;
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+    expect(agent.cols).toBe(90);
   });
 
   it("path B (long dwell): the guaranteed redraw obligation survives the off-screen dead zone and discharges on foreground", () => {


### PR DESCRIPTION
Resolves #11443.

## The bug

`applyBackgroundWindowResize` guarded on `document.visibilityState === "visible"`. Caching a project view is `removeChildView` + `setVisible(false)`, and neither flips page visibility for a child `WebContentsView` — Chromium tracks occlusion at the `BrowserWindow` level, so a cached view reports `"visible"` forever. The guard therefore early-returned every time, and the whole #10415 background-resize mechanism has never run in production. Backgrounded agents kept wrapping at the pre-resize width until something else re-measured them.

The same dead signal appeared twice more in the same feature: the hook released the scaling anchor from a `visibilitychange` listener that never fires for a cached view, and the reconciliation watchdog burned its geometry-repair budget on alt-screen panes.

## What changed

**Gate on the cache signal, not just visibility.** `applyBackgroundWindowResize` now bails only when the view is neither cached nor page-hidden, matching how `TerminalReconciliationWatchdog`, `TerminalReflowController` and `TerminalWriteController` already consume `isProjectViewCached()`. The session anchor is released on the same predicate — a cached view that still reports `"visible"` keeps it.

**Move both grids together.** This is the part that grew past the original diagnosis. The renderer keeps parsing every byte into xterm while a view is cached, so a PTY-only resize leaves the app emitting cursor-addressed output sized for the new width while the parser still holds the old grid, and those sequences land on the wrong rows. Nothing recovers them: reflow re-wraps text but can't undo an erase applied to the wrong line, and the wake-time re-assert of a size the PTY already has dedupes in `TerminalProcess.resize`, so no corrective SIGWINCH ever arrives. It's not hypothetical — Codex CLI runs with `blockAltScreen: true`, so it's main-buffer *and* cursor-addressed.

So `resizePtyOnly` became `applyBackgroundResize` and now resizes xterm before notifying the PTY. It's the same pair `applyDeferredResize` used to run at wake, moved to the moment the geometry actually changes: identical work, off the switch-back critical path, with no window where the two grids disagree.

**Leave alt-screen panes alone entirely**, enforced at the controller choke point rather than at the caller — a resize stashed in `pendingBackgroundResize` while a pane was on the main buffer was being replayed onto a live TUI when `lockResize` released. Both grids stay at the stale size until real layout returns on reattach, which keeps them consistent.

**Stop alt-screen panes tripping the geometry circuit breaker.** `reconcileGeometryFresh` returns early for them by design (#10805 — never reflow a live TUI out from under its own SIGWINCH redraw), so the watchdog was issuing a repair that structurally could not converge: it spent a heavy-budget slot every cooldown window and then latched `geometryRepairGaveUp` permanently, which barred the pane's legitimate main-buffer repairs once it left the alternate screen. The DEV divergence diagnostic still fires; only the repair loop excludes them.

## Notes

The `window:reclaim-memory` preload listener has the identical stale-visibility guard, but both senders route through `getAppWebContents`, which never resolves a cached view — fixing the guard alone would have been inert and misleading. Worth its own issue alongside the `terminal:reduce-scrollback` / `terminal:restore-scrollback` channels, which the renderer fully consumes but main never sends.

Not covered here, worth follow-ups: there's no preload harness to test the reclaim predicate; `PaintFabricCompositor`'s fan-out of these two methods is untested; and alt-screen convergence on reveal still rests on the `XtermAdapter` ResizeObserver, which really wants an E2E rather than a unit test.

## Verification

- `npm run typecheck`, `npm run lint:ratchet` (warnings −3), prettier clean on changed files
- 3653 tests green across `src/services/terminal/__tests__/`, `src/hooks/app/__tests__/`, `src/lib/__tests__/viewCacheState*`, `electron/window/__tests__/`, `electron/services/pty/__tests__/`
- The background-resize suite now runs against `visibilityState: "visible"` with the view cached — the real production state, which the old guard would have no-opped on
- `TerminalSwitchBackRedraw.regression.test.ts`'s fake no longer converges an alt-buffer grid, so it models the production early return instead of hiding it