### PR TITLE
fix(terminal): stop the worktree card flashing on every keystroke

### DIFF
--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -691,10 +691,9 @@ function TerminalPaneComponent({
   // Calling it here too is redundant and breaks in React StrictMode (dev),
   // where the effect's cleanup captures the same generation as the active
   // mount, bypassing the stale-generation guard and hiding the terminal.
-  // Deliberately NOT keyed on attachEpoch: a bare observer re-arm would run
-  // this hook's cleanup while the pane is still mounted, and its captured
-  // generation would match the live attach — writing a spurious false.
-  useUnmountVisibilityCleanup(id, restartKey, updateVisibility);
+  // The epoch re-captures the generation this mount owns without re-running the
+  // cleanup itself — see the hook for why those two have to stay separate.
+  useUnmountVisibilityCleanup(id, restartKey, updateVisibility, attachEpoch);
 
   const handleReady = useCallback(() => {}, []);
 

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -4,6 +4,7 @@ import React, {
   useCallback,
   useEffect,
   useEffectEvent,
+  useReducer,
   useRef,
   useState,
 } from "react";
@@ -27,9 +28,8 @@ import { ArtifactOverlay } from "./ArtifactOverlay";
 import { TerminalSearchBar } from "./TerminalSearchBar";
 import { TerminalScrollIndicator } from "./TerminalScrollIndicator";
 import { useGridScrollRoot } from "./GridScrollRootContext";
-import { isStaleHiddenReading } from "./visibilityReadingGuard";
 import { useUnmountVisibilityCleanup } from "./useUnmountVisibilityCleanup";
-import { COMFORTABLE_PANEL_HEIGHT_PX } from "@/lib/terminalLayout";
+import { useTerminalVisibilityObserver } from "./useTerminalVisibilityObserver";
 import { FleetDraftingPill } from "@/components/Fleet/FleetDraftingPill";
 import { TerminalRestartStatusBanner } from "./TerminalRestartStatusBanner";
 import { InlineStatusBanner } from "./InlineStatusBanner";
@@ -660,14 +660,7 @@ function TerminalPaneComponent({
     };
   }, [isExited, exitBehavior, exitCode, isTrashedOrRemoved, isRestarting]);
 
-  // Track drag state in a ref to avoid useEffect cleanup timing issues.
-  // If isDragging is in the dependency array, cleanup runs on drag START
-  // with the OLD isDragging=false value, which would set visibility to false!
   const isDragging = useIsDragging();
-  const isDraggingRef = useRef(isDragging);
-  useEffect(() => {
-    isDraggingRef.current = isDragging;
-  }, [isDragging]);
 
   // Root the visibility observer at the panel grid's scroll container when this
   // pane is mounted inside the scrollable grid (#8805). Panes outside the grid
@@ -675,63 +668,22 @@ function TerminalPaneComponent({
   // context value, which is the correct default for those surfaces.
   const gridScrollRoot = useGridScrollRoot();
 
-  // Visibility observation - stable observer, ref-gated callback.
-  // Capture attach generation so stale IntersectionObserver callbacks from a
-  // previous mount site don't hide a terminal that has already been re-attached.
-  useEffect(() => {
-    if (!containerRef.current) return;
+  // Bumped by XtermAdapter the moment its async attach lands, so the observer
+  // re-arms against the generation that attach just produced rather than the
+  // one that happened to be current when this render's effects flushed
+  // (#11445). `useReducer`'s dispatch identity is stable, so handing it
+  // straight to XtermAdapter can't churn its attach effect.
+  const [attachEpoch, bumpAttachEpoch] = useReducer((epoch: number) => epoch + 1, 0);
 
-    const gen = terminalInstanceService.getAttachGeneration(id);
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        // Under load a single callback can batch multiple entries for the same
-        // element; only the most recent reading reflects current geometry.
-        const entry = entries[entries.length - 1];
-
-        // Don't update visibility during drag - CSS transforms cause false negatives
-        if (isDraggingRef.current || !entry) return;
-
-        // Suppress stale `false` readings that would freeze a visible terminal
-        // at the BACKGROUND tier (#9780). Confirm against fresh element and root
-        // geometry, read before any write to avoid a redundant layout reflow.
-        if (
-          isStaleHiddenReading(
-            entry,
-            () => containerRef.current?.getBoundingClientRect(),
-            () =>
-              gridScrollRoot?.getBoundingClientRect() ??
-              new DOMRect(0, 0, window.innerWidth, window.innerHeight)
-          )
-        )
-          return;
-
-        // A callback queued from a previous mount site (warm-swap reattach)
-        // must not write at all. setVisible already drops it via its
-        // generation guard — dropping the store write under the same
-        // condition keeps store and service from diverging permanently
-        // (#10416).
-        if (terminalInstanceService.getAttachGeneration(id) !== gen) return;
-
-        updateVisibility(id, entry.isIntersecting);
-        terminalInstanceService.setVisible(id, entry.isIntersecting, gen);
-      },
-      {
-        // Grid-scoped root: when mounted inside the grid, the pre-warm margin
-        // upgrades panels that are one comfortable row away from the viewport
-        // from BACKGROUND → VISIBLE before they paint. Sized to the comfortable
-        // row height so the pre-warm fires a full row ahead now that rows no
-        // longer shrink to the minimum. Outside the grid we fall back to the
-        // document viewport with no margin.
-        root: gridScrollRoot ?? null,
-        rootMargin: gridScrollRoot ? `${COMFORTABLE_PANEL_HEIGHT_PX}px 0px` : "0px",
-        threshold: 0.1,
-      }
-    );
-
-    observer.observe(containerRef.current);
-    return () => observer.disconnect();
-  }, [id, restartKey, updateVisibility, gridScrollRoot]);
+  useTerminalVisibilityObserver({
+    id,
+    restartKey,
+    attachEpoch,
+    isDragging,
+    gridScrollRoot,
+    containerRef,
+    updateVisibility,
+  });
 
   // Separate unmount cleanup — only update store visibility.
   // The service-level setVisible(false) is handled by XtermAdapter's own
@@ -739,6 +691,9 @@ function TerminalPaneComponent({
   // Calling it here too is redundant and breaks in React StrictMode (dev),
   // where the effect's cleanup captures the same generation as the active
   // mount, bypassing the stale-generation guard and hiding the terminal.
+  // Deliberately NOT keyed on attachEpoch: a bare observer re-arm would run
+  // this hook's cleanup while the pane is still mounted, and its captured
+  // generation would match the live attach — writing a spurious false.
   useUnmountVisibilityCleanup(id, restartKey, updateVisibility);
 
   const handleReady = useCallback(() => {}, []);
@@ -1461,6 +1416,7 @@ function TerminalPaneComponent({
                     onReady={handleReady}
                     onExit={handleExit}
                     onInput={handleInput}
+                    onAttached={bumpAttachEpoch}
                     className="absolute inset-0"
                     getRefreshTier={getRefreshTierCallback}
                     cwd={cwd}

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -32,6 +32,12 @@ export interface XtermAdapterProps {
   onReady?: () => void;
   onExit?: (exitCode: number) => void;
   onInput?: (data: string) => void;
+  /**
+   * Fired once per live `attach()`, after the service has been told the
+   * terminal is visible. Lets the owning pane re-arm anything that captured an
+   * attach generation before this async setup landed (#11445).
+   */
+  onAttached?: () => void;
   className?: string;
   getRefreshTier?: () => TerminalRefreshTier;
   cwd?: string;
@@ -51,6 +57,7 @@ export function XtermAdapter({
   onReady,
   onExit,
   onInput,
+  onAttached,
   className,
   getRefreshTier,
   cwd,
@@ -76,6 +83,7 @@ export function XtermAdapter({
   const onReadyRef = useRef(onReady);
   const onExitRef = useRef(onExit);
   const onInputRef = useRef(onInput);
+  const onAttachedRef = useRef(onAttached);
   const cwdRef = useRef(cwd);
 
   useLayoutEffect(() => {
@@ -84,8 +92,9 @@ export function XtermAdapter({
     onReadyRef.current = onReady;
     onExitRef.current = onExit;
     onInputRef.current = onInput;
+    onAttachedRef.current = onAttached;
     cwdRef.current = cwd;
-  }, [launchAgentId, detectedAgentId, onReady, onExit, onInput, cwd]);
+  }, [launchAgentId, detectedAgentId, onReady, onExit, onInput, onAttached, cwd]);
 
   const stableOnInput = useCallback((data: string) => {
     onInputRef.current?.(data);
@@ -286,6 +295,11 @@ export function XtermAdapter({
       // Force visibility immediately on mount - don't wait for IntersectionObserver.
       // This prevents data from being dropped during the brief window before the observer fires.
       terminalInstanceService.setVisible(terminalId, true);
+      // Announce the generation this attach produced. The pane's visibility
+      // observer captured one before this async setup resumed, and only the
+      // service flag was forced above — the store field it owns would otherwise
+      // stay frozen behind the stale capture (#11445).
+      onAttachedRef.current?.();
 
       if (!managed.keyHandlerInstalled) {
         const writeWordJump = (event: KeyboardEvent, sequence: string): boolean => {

--- a/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
+++ b/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
@@ -270,6 +270,51 @@ describe("XtermAdapter lifecycle", () => {
     expect((cwdProvider as () => string)()).toBe("/repo/next");
   });
 
+  it("announces each attach after forcing the service visible (#11445)", async () => {
+    const onAttached = vi.fn();
+
+    renderAdapter({ onAttached });
+
+    await waitFor(() => expect(onAttached).toHaveBeenCalledTimes(1));
+
+    // The pane re-arms its visibility observer on this signal, so it has to
+    // land after the attach that bumped the generation — and after the forced
+    // service-side visibility, so the two never disagree at the moment the
+    // observer re-captures.
+    const attachOrder = mocks.terminalInstanceService.attach.mock.invocationCallOrder[0]!;
+    const visibleOrder = mocks.terminalInstanceService.setVisible.mock.invocationCallOrder[0]!;
+    const attachedOrder = onAttached.mock.invocationCallOrder[0]!;
+    expect(attachedOrder).toBeGreaterThan(attachOrder);
+    expect(attachedOrder).toBeGreaterThan(visibleOrder);
+  });
+
+  it("does not re-announce an attach when only hot callbacks change (#11445)", async () => {
+    const onAttached = vi.fn();
+
+    const view = renderAdapter({ onAttached, onInput: vi.fn() });
+    await waitFor(() => expect(onAttached).toHaveBeenCalledTimes(1));
+
+    view.rerender(
+      <Suspense fallback={null}>
+        <XtermAdapter
+          terminalId="term-1"
+          launchAgentId="claude"
+          onReady={vi.fn()}
+          onExit={vi.fn()}
+          onInput={vi.fn()}
+          onAttached={onAttached}
+          getRefreshTier={() => TerminalRefreshTier.FOCUSED}
+          cwd="/repo/initial"
+        />
+      </Suspense>
+    );
+
+    // A re-announce with no attach behind it would re-arm the observer for
+    // nothing, and an identity-unstable callback would do it on every render.
+    expect(onAttached).toHaveBeenCalledTimes(1);
+    expect(mocks.terminalInstanceService.attach).toHaveBeenCalledTimes(1);
+  });
+
   it("uses the latest input and exit callbacks without reinstalling the terminal", async () => {
     const firstOnInput = vi.fn();
     const secondOnInput = vi.fn();

--- a/src/components/Terminal/__tests__/useTerminalVisibilityObserver.test.tsx
+++ b/src/components/Terminal/__tests__/useTerminalVisibilityObserver.test.tsx
@@ -28,6 +28,7 @@ class FakeIntersectionObserver implements IntersectionObserver {
   observed: Element[] = [];
   readonly root: Document | Element | null;
   readonly rootMargin: string;
+  readonly scrollMargin: string = "0px";
   readonly thresholds: readonly number[];
 
   constructor(

--- a/src/components/Terminal/__tests__/useTerminalVisibilityObserver.test.tsx
+++ b/src/components/Terminal/__tests__/useTerminalVisibilityObserver.test.tsx
@@ -169,6 +169,30 @@ describe("useTerminalVisibilityObserver", () => {
     expect(mocks.setVisible).toHaveBeenCalledWith("t1", true, 1);
   });
 
+  it("does not upgrade a parked pane whose box overlaps but renders nothing", () => {
+    const { updateVisibility, container } = setup({ containerRect: ON_SCREEN });
+    // The dock parks live panes in a fixed 0,0 box under
+    // content-visibility:hidden — full-size overlap, nothing drawn.
+    container.checkVisibility = () => false;
+
+    FakeIntersectionObserver.instances[0]!.deliver(false);
+
+    expect(updateVisibility).not.toHaveBeenCalled();
+    expect(mocks.setVisible).not.toHaveBeenCalled();
+  });
+
+  it("spends no layout on a superseded callback", () => {
+    const { container } = setup();
+    const measure = vi.spyOn(container, "getBoundingClientRect");
+
+    mocks.getAttachGeneration.mockReturnValue(2);
+    FakeIntersectionObserver.instances[0]!.deliver(false);
+
+    // The generation check runs first precisely so a dead mount site cannot
+    // force a reflow it will never use.
+    expect(measure).not.toHaveBeenCalled();
+  });
+
   it("resumes writing after an attach that landed post-capture (#11445)", () => {
     const { view, updateVisibility } = setup();
     const first = FakeIntersectionObserver.instances[0]!;

--- a/src/components/Terminal/__tests__/useTerminalVisibilityObserver.test.tsx
+++ b/src/components/Terminal/__tests__/useTerminalVisibilityObserver.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useTerminalVisibilityObserver } from "../useTerminalVisibilityObserver";
+
+const mocks = vi.hoisted(() => ({
+  getAttachGeneration: vi.fn(() => 1),
+  setVisible: vi.fn(),
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    getAttachGeneration: mocks.getAttachGeneration,
+    setVisible: mocks.setVisible,
+  },
+}));
+
+/**
+ * Retains every callback ever registered, including across `disconnect()`, so a
+ * superseded observer's queued reading can still be delivered by hand — the
+ * #10416 scenario the generation guard exists for.
+ */
+class FakeIntersectionObserver {
+  static instances: FakeIntersectionObserver[] = [];
+  disconnected = false;
+  observed: Element[] = [];
+
+  constructor(
+    private callback: IntersectionObserverCallback,
+    readonly options?: IntersectionObserverInit
+  ) {
+    FakeIntersectionObserver.instances.push(this);
+  }
+
+  observe(el: Element) {
+    this.observed.push(el);
+  }
+
+  disconnect() {
+    this.disconnected = true;
+  }
+
+  /** Deliver a reading as the browser would, batched entries and all. */
+  deliver(...isIntersecting: boolean[]) {
+    const entries = isIntersecting.map(
+      (flag) => ({ isIntersecting: flag }) as IntersectionObserverEntry
+    );
+    act(() => {
+      this.callback(entries, this as unknown as IntersectionObserver);
+    });
+  }
+}
+
+/** Overlaps jsdom's viewport, so a `false` reading reads as stale (#9780). */
+const ON_SCREEN = new DOMRect(0, 100, 400, 300);
+/** Far below the viewport, so a `false` reading is a genuine hide. */
+const OFF_SCREEN = new DOMRect(0, 5000, 400, 300);
+
+function setup(
+  overrides: {
+    gridScrollRoot?: HTMLElement | null;
+    containerRect?: DOMRect;
+    isDragging?: boolean;
+  } = {}
+) {
+  const container = document.createElement("div");
+  const rect = overrides.containerRect ?? ON_SCREEN;
+  container.getBoundingClientRect = () => rect;
+  // renderHook cannot attach a real ref, so hand the hook the same shape React
+  // would have populated by the time its effects run.
+  const containerRef = { current: container };
+
+  const updateVisibility = vi.fn();
+
+  const view = renderHook(
+    ({ attachEpoch }: { attachEpoch: number }) =>
+      useTerminalVisibilityObserver({
+        id: "t1",
+        restartKey: 0,
+        attachEpoch,
+        isDragging: overrides.isDragging ?? false,
+        gridScrollRoot: overrides.gridScrollRoot ?? null,
+        containerRef,
+        updateVisibility,
+      }),
+    { initialProps: { attachEpoch: 0 } }
+  );
+
+  return { view, updateVisibility, container };
+}
+
+describe("useTerminalVisibilityObserver", () => {
+  const RealIntersectionObserver = globalThis.IntersectionObserver;
+
+  beforeEach(() => {
+    FakeIntersectionObserver.instances = [];
+    globalThis.IntersectionObserver =
+      FakeIntersectionObserver as unknown as typeof IntersectionObserver;
+    mocks.getAttachGeneration.mockReturnValue(1);
+  });
+
+  afterEach(() => {
+    globalThis.IntersectionObserver = RealIntersectionObserver;
+    vi.clearAllMocks();
+  });
+
+  it("commits a reading while the captured generation is still live", () => {
+    const { updateVisibility } = setup();
+
+    FakeIntersectionObserver.instances[0]!.deliver(true);
+
+    expect(updateVisibility).toHaveBeenCalledWith("t1", true);
+    expect(mocks.setVisible).toHaveBeenCalledWith("t1", true, 1);
+  });
+
+  it("commits a genuine hide", () => {
+    const { updateVisibility } = setup({ containerRect: OFF_SCREEN });
+
+    FakeIntersectionObserver.instances[0]!.deliver(false);
+
+    expect(updateVisibility).toHaveBeenCalledWith("t1", false);
+    expect(mocks.setVisible).toHaveBeenCalledWith("t1", false, 1);
+  });
+
+  it("suppresses a stale hide for an element still on screen (#9780)", () => {
+    const { updateVisibility } = setup({ containerRect: ON_SCREEN });
+
+    FakeIntersectionObserver.instances[0]!.deliver(false);
+
+    expect(updateVisibility).not.toHaveBeenCalled();
+    expect(mocks.setVisible).not.toHaveBeenCalled();
+  });
+
+  it("resumes writing after an attach that landed post-capture (#11445)", () => {
+    const { view, updateVisibility } = setup();
+    const first = FakeIntersectionObserver.instances[0]!;
+
+    // XtermAdapter's async attach resumes after this effect already captured
+    // the pre-attach generation, so every further reading fails the guard.
+    mocks.getAttachGeneration.mockReturnValue(2);
+    first.deliver(true);
+    expect(updateVisibility).not.toHaveBeenCalled();
+    expect(mocks.setVisible).not.toHaveBeenCalled();
+
+    // The attach notification re-arms the observer against the live generation.
+    act(() => {
+      view.rerender({ attachEpoch: 1 });
+    });
+
+    const second = FakeIntersectionObserver.instances[1];
+    expect(second).toBeDefined();
+    expect(first.disconnected).toBe(true);
+
+    second!.deliver(true);
+    expect(updateVisibility).toHaveBeenCalledWith("t1", true);
+    expect(mocks.setVisible).toHaveBeenCalledWith("t1", true, 2);
+  });
+
+  it("still drops a superseded observer's retained callback (#10416)", () => {
+    const { view, updateVisibility } = setup();
+    const first = FakeIntersectionObserver.instances[0]!;
+
+    mocks.getAttachGeneration.mockReturnValue(2);
+    act(() => {
+      view.rerender({ attachEpoch: 1 });
+    });
+
+    // A visible reading, deliberately: it sails past the #9780 stale-hide guard,
+    // so reaching the store would prove the generation check had stopped
+    // holding. The old mount site keeps its own capture and must write nothing.
+    first.deliver(true);
+
+    expect(updateVisibility).not.toHaveBeenCalled();
+    expect(mocks.setVisible).not.toHaveBeenCalled();
+  });
+
+  it("re-arming does not itself write visibility", () => {
+    const { view, updateVisibility } = setup();
+
+    act(() => {
+      view.rerender({ attachEpoch: 1 });
+    });
+
+    // Only a delivered reading may write — the re-arm is an invalidation, not a
+    // visibility claim of its own.
+    expect(updateVisibility).not.toHaveBeenCalled();
+    expect(mocks.setVisible).not.toHaveBeenCalled();
+  });
+
+  it("keeps the last batched entry as the authoritative reading", () => {
+    const { updateVisibility } = setup({ containerRect: OFF_SCREEN });
+
+    // Under load one callback batches several entries for the same element;
+    // only the newest reflects current geometry.
+    FakeIntersectionObserver.instances[0]!.deliver(true, false);
+
+    expect(updateVisibility).toHaveBeenCalledTimes(1);
+    expect(updateVisibility).toHaveBeenCalledWith("t1", false);
+  });
+
+  it("ignores readings while a drag is in flight", () => {
+    const { updateVisibility } = setup({ isDragging: true, containerRect: OFF_SCREEN });
+
+    // CSS transforms during drag produce false negatives.
+    FakeIntersectionObserver.instances[0]!.deliver(false);
+
+    expect(updateVisibility).not.toHaveBeenCalled();
+  });
+
+  it("disconnects the live observer on unmount", () => {
+    const { view } = setup();
+
+    view.unmount();
+
+    expect(FakeIntersectionObserver.instances[0]!.disconnected).toBe(true);
+  });
+
+  it("roots at the grid scroll container when one is provided", () => {
+    const root = document.createElement("div");
+    setup({ gridScrollRoot: root });
+
+    const options = FakeIntersectionObserver.instances[0]!.options;
+    expect(options?.root).toBe(root);
+    // Outside the grid there is no pre-warm margin; inside it there must be one.
+    expect(options?.rootMargin).not.toBe("0px");
+  });
+});

--- a/src/components/Terminal/__tests__/useTerminalVisibilityObserver.test.tsx
+++ b/src/components/Terminal/__tests__/useTerminalVisibilityObserver.test.tsx
@@ -22,20 +22,32 @@ vi.mock("@/services/TerminalInstanceService", () => ({
  * superseded observer's queued reading can still be delivered by hand — the
  * #10416 scenario the generation guard exists for.
  */
-class FakeIntersectionObserver {
+class FakeIntersectionObserver implements IntersectionObserver {
   static instances: FakeIntersectionObserver[] = [];
   disconnected = false;
   observed: Element[] = [];
+  readonly root: Document | Element | null;
+  readonly rootMargin: string;
+  readonly thresholds: readonly number[];
 
   constructor(
     private callback: IntersectionObserverCallback,
-    readonly options?: IntersectionObserverInit
+    options?: IntersectionObserverInit
   ) {
+    this.root = options?.root ?? null;
+    this.rootMargin = options?.rootMargin ?? "0px";
+    this.thresholds = options?.threshold === undefined ? [0] : [options.threshold].flat();
     FakeIntersectionObserver.instances.push(this);
   }
 
   observe(el: Element) {
     this.observed.push(el);
+  }
+
+  unobserve() {}
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
   }
 
   disconnect() {
@@ -44,11 +56,23 @@ class FakeIntersectionObserver {
 
   /** Deliver a reading as the browser would, batched entries and all. */
   deliver(...isIntersecting: boolean[]) {
-    const entries = isIntersecting.map(
-      (flag) => ({ isIntersecting: flag }) as IntersectionObserverEntry
-    );
+    const target = this.observed[0] ?? document.createElement("div");
+    const entries = isIntersecting.map((flag) => {
+      // Only `isIntersecting` is read by the observer; the rest is filled in so
+      // the fixture is a real entry rather than a cast-away partial.
+      const rect = new DOMRect(0, 0, 0, 0);
+      return {
+        boundingClientRect: rect,
+        intersectionRatio: flag ? 1 : 0,
+        intersectionRect: rect,
+        isIntersecting: flag,
+        rootBounds: null,
+        target,
+        time: 0,
+      };
+    });
     act(() => {
-      this.callback(entries, this as unknown as IntersectionObserver);
+      this.callback(entries, this);
     });
   }
 }
@@ -96,8 +120,7 @@ describe("useTerminalVisibilityObserver", () => {
 
   beforeEach(() => {
     FakeIntersectionObserver.instances = [];
-    globalThis.IntersectionObserver =
-      FakeIntersectionObserver as unknown as typeof IntersectionObserver;
+    globalThis.IntersectionObserver = FakeIntersectionObserver;
     mocks.getAttachGeneration.mockReturnValue(1);
   });
 
@@ -124,13 +147,26 @@ describe("useTerminalVisibilityObserver", () => {
     expect(mocks.setVisible).toHaveBeenCalledWith("t1", false, 1);
   });
 
-  it("suppresses a stale hide for an element still on screen (#9780)", () => {
+  it("never commits a hide for an element fresh geometry puts on screen (#9780)", () => {
     const { updateVisibility } = setup({ containerRect: ON_SCREEN });
 
     FakeIntersectionObserver.instances[0]!.deliver(false);
 
-    expect(updateVisibility).not.toHaveBeenCalled();
-    expect(mocks.setVisible).not.toHaveBeenCalled();
+    expect(updateVisibility).not.toHaveBeenCalledWith("t1", false);
+    expect(mocks.setVisible).not.toHaveBeenCalledWith("t1", false, expect.anything());
+  });
+
+  it("repairs a store stuck hidden when geometry proves the pane on screen", () => {
+    const { updateVisibility } = setup({ containerRect: ON_SCREEN });
+
+    // The re-armed observer's first reading can itself be the Chromium
+    // false-negative. Dropping it would leave a store that entered hidden stuck
+    // there until some later threshold crossing — and nothing else repairs a
+    // focused pane.
+    FakeIntersectionObserver.instances[0]!.deliver(false);
+
+    expect(updateVisibility).toHaveBeenCalledWith("t1", true);
+    expect(mocks.setVisible).toHaveBeenCalledWith("t1", true, 1);
   });
 
   it("resumes writing after an attach that landed post-capture (#11445)", () => {
@@ -209,6 +245,43 @@ describe("useTerminalVisibilityObserver", () => {
     expect(updateVisibility).not.toHaveBeenCalled();
   });
 
+  it("tracks drag state changes without re-arming the observer", () => {
+    const container = document.createElement("div");
+    container.getBoundingClientRect = () => OFF_SCREEN;
+    const containerRef = { current: container };
+    const updateVisibility = vi.fn();
+
+    const view = renderHook(
+      ({ isDragging }: { isDragging: boolean }) =>
+        useTerminalVisibilityObserver({
+          id: "t1",
+          restartKey: 0,
+          attachEpoch: 0,
+          isDragging,
+          gridScrollRoot: null,
+          containerRef,
+          updateVisibility,
+        }),
+      { initialProps: { isDragging: false } }
+    );
+
+    act(() => {
+      view.rerender({ isDragging: true });
+    });
+    FakeIntersectionObserver.instances[0]!.deliver(false);
+    expect(updateVisibility).not.toHaveBeenCalled();
+
+    act(() => {
+      view.rerender({ isDragging: false });
+    });
+    FakeIntersectionObserver.instances[0]!.deliver(false);
+    expect(updateVisibility).toHaveBeenCalledWith("t1", false);
+
+    // Drag state must ride a ref: re-arming on it would run the observer's
+    // cleanup on drag START, which is what the mirrored ref exists to avoid.
+    expect(FakeIntersectionObserver.instances).toHaveLength(1);
+  });
+
   it("disconnects the live observer on unmount", () => {
     const { view } = setup();
 
@@ -221,9 +294,9 @@ describe("useTerminalVisibilityObserver", () => {
     const root = document.createElement("div");
     setup({ gridScrollRoot: root });
 
-    const options = FakeIntersectionObserver.instances[0]!.options;
-    expect(options?.root).toBe(root);
+    const observer = FakeIntersectionObserver.instances[0]!;
+    expect(observer.root).toBe(root);
     // Outside the grid there is no pre-warm margin; inside it there must be one.
-    expect(options?.rootMargin).not.toBe("0px");
+    expect(observer.rootMargin).not.toBe("0px");
   });
 });

--- a/src/components/Terminal/__tests__/useUnmountVisibilityCleanup.test.tsx
+++ b/src/components/Terminal/__tests__/useUnmountVisibilityCleanup.test.tsx
@@ -57,6 +57,42 @@ describe("useUnmountVisibilityCleanup", () => {
     expect(updateVisibility).toHaveBeenCalledWith("t1", false);
   });
 
+  it("still cleans up after this mount's own late attach advanced the generation", () => {
+    const updateVisibility = vi.fn();
+    const { rerender, unmount } = renderHook(
+      ({ attachEpoch }) => useUnmountVisibilityCleanup("t1", 0, updateVisibility, attachEpoch),
+      { initialProps: { attachEpoch: 0 } }
+    );
+
+    // XtermAdapter awaits getOrCreate, so this mount's own attach lands after
+    // the passive capture. Announcing it must re-capture, not be read as a
+    // warm-swap by someone else.
+    mocks.getAttachGeneration.mockReturnValue(2);
+    rerender({ attachEpoch: 1 });
+
+    // Re-capturing must not fire the cleanup while the pane is still mounted.
+    expect(updateVisibility).not.toHaveBeenCalled();
+
+    unmount();
+    expect(updateVisibility).toHaveBeenCalledTimes(1);
+    expect(updateVisibility).toHaveBeenCalledWith("t1", false);
+  });
+
+  it("still skips a genuinely superseded mount that never announced the attach", () => {
+    const updateVisibility = vi.fn();
+    const { unmount } = renderHook(
+      ({ attachEpoch }) => useUnmountVisibilityCleanup("t1", 0, updateVisibility, attachEpoch),
+      { initialProps: { attachEpoch: 0 } }
+    );
+
+    // A replacement pane attached — this mount's own epoch never moved, so the
+    // owned generation stays behind and the write must not land.
+    mocks.getAttachGeneration.mockReturnValue(2);
+    unmount();
+
+    expect(updateVisibility).not.toHaveBeenCalled();
+  });
+
   it("cleans up the outgoing id when the pane is reused for another terminal", () => {
     const updateVisibility = vi.fn();
     const { rerender } = renderHook(

--- a/src/components/Terminal/useTerminalVisibilityObserver.ts
+++ b/src/components/Terminal/useTerminalVisibilityObserver.ts
@@ -87,18 +87,33 @@ export function useTerminalVisibilityObserver({
             new DOMRect(0, 0, window.innerWidth, window.innerHeight)
         );
 
-        // Commit what that geometry established rather than dropping the
-        // callback: a stale hide is positive proof the pane IS on screen. When
-        // the store already agrees this is a no-op (both writes early-return on
-        // an unchanged value), so the only case it changes is a store stuck
-        // hidden — which nothing else repairs for a FOCUSED pane, since
-        // getTerminalRefreshTier answers FOCUSED before it ever consults
-        // isVisible and the reconciliation watchdog only repairs at BACKGROUND
-        // (#11445).
-        const isVisible = isStaleHide || entry.isIntersecting;
+        if (isStaleHide) {
+          // Overlapping geometry alone is NOT proof the pane renders: the dock
+          // parks live panes in a fixed 0,0 box under content-visibility:hidden
+          // (DockPanelOffscreenContainer), which overlaps the root at full size
+          // while drawing nothing. Ask the engine — the same checkVisibility
+          // gate the resize controller's fit() uses — before treating a stale
+          // hide as an upgrade; without that confirmation keep suppressing and
+          // wait for the next reading, exactly as before.
+          const el = containerRef.current;
+          const rendersNow =
+            el !== null && (typeof el.checkVisibility !== "function" || el.checkVisibility());
+          if (!rendersNow) return;
 
-        updateVisibility(id, isVisible);
-        terminalInstanceService.setVisible(id, isVisible, gen);
+          // Commit what the geometry established rather than dropping the
+          // callback. When the store already agrees this is a no-op (both
+          // writes early-return on an unchanged value), so the only case it
+          // changes is a store stuck hidden — which nothing else repairs for a
+          // FOCUSED pane, since getTerminalRefreshTier answers FOCUSED before
+          // it ever consults isVisible and the reconciliation watchdog only
+          // repairs at BACKGROUND (#11445).
+          updateVisibility(id, true);
+          terminalInstanceService.setVisible(id, true, gen);
+          return;
+        }
+
+        updateVisibility(id, entry.isIntersecting);
+        terminalInstanceService.setVisible(id, entry.isIntersecting, gen);
       },
       {
         // Grid-scoped root: when mounted inside the grid, the pre-warm margin

--- a/src/components/Terminal/useTerminalVisibilityObserver.ts
+++ b/src/components/Terminal/useTerminalVisibilityObserver.ts
@@ -1,0 +1,111 @@
+import { useEffect, useRef, type RefObject } from "react";
+import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import { isStaleHiddenReading } from "./visibilityReadingGuard";
+import { COMFORTABLE_PANEL_HEIGHT_PX } from "@/lib/terminalLayout";
+
+interface TerminalVisibilityObserverParams {
+  id: string;
+  restartKey: number;
+  /**
+   * Advances once per live `attach()` of this pane's terminal. Re-arming on it
+   * is what keeps the generation capture below honest: `attach()` runs inside
+   * XtermAdapter's async setup, so on a cold open (the lazy Unicode11 addon is
+   * awaited during construction) the passive effect here can capture the
+   * PRE-attach generation and then be superseded. Without the re-arm every
+   * later reading fails the guard at the write site and the pane's store
+   * visibility freezes at whatever value it already held — permanently, since
+   * nothing else re-runs this effect (#11445).
+   */
+  attachEpoch: number;
+  isDragging: boolean;
+  gridScrollRoot: HTMLElement | null;
+  containerRef: RefObject<HTMLDivElement | null>;
+  updateVisibility: (id: string, isVisible: boolean) => void;
+}
+
+/**
+ * Grid-rooted visibility observation for a terminal pane — stable observer,
+ * ref-gated callback, generation-guarded writes.
+ *
+ * Re-arming (rather than adopting a newer generation inside the callback) is
+ * deliberate: IntersectionObserver only reports threshold crossings after the
+ * initial observation, so a pane whose one callback landed before the attach
+ * may never be called again. A fresh `observe()` is the only thing that
+ * guarantees a delivery, and it re-captures the generation at the same time.
+ */
+export function useTerminalVisibilityObserver({
+  id,
+  restartKey,
+  attachEpoch,
+  isDragging,
+  gridScrollRoot,
+  containerRef,
+  updateVisibility,
+}: TerminalVisibilityObserverParams): void {
+  // Track drag state in a ref to avoid useEffect cleanup timing issues.
+  // If isDragging is in the dependency array, cleanup runs on drag START
+  // with the OLD isDragging=false value, which would set visibility to false!
+  const isDraggingRef = useRef(isDragging);
+  useEffect(() => {
+    isDraggingRef.current = isDragging;
+  }, [isDragging]);
+
+  // Capture attach generation so stale IntersectionObserver callbacks from a
+  // previous mount site don't hide a terminal that has already been re-attached.
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const gen = terminalInstanceService.getAttachGeneration(id);
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        // Under load a single callback can batch multiple entries for the same
+        // element; only the most recent reading reflects current geometry.
+        const entry = entries[entries.length - 1];
+
+        // Don't update visibility during drag - CSS transforms cause false negatives
+        if (isDraggingRef.current || !entry) return;
+
+        // Suppress stale `false` readings that would freeze a visible terminal
+        // at the BACKGROUND tier (#9780). Confirm against fresh element and root
+        // geometry, read before any write to avoid a redundant layout reflow.
+        if (
+          isStaleHiddenReading(
+            entry,
+            () => containerRef.current?.getBoundingClientRect(),
+            () =>
+              gridScrollRoot?.getBoundingClientRect() ??
+              new DOMRect(0, 0, window.innerWidth, window.innerHeight)
+          )
+        )
+          return;
+
+        // A callback queued from a previous mount site (warm-swap reattach)
+        // must not write at all. setVisible already drops it via its
+        // generation guard — dropping the store write under the same
+        // condition keeps store and service from diverging permanently
+        // (#10416). The live mount re-arms on `attachEpoch` instead of
+        // adopting the newer generation here, so a superseded observer's
+        // retained callback keeps failing this check.
+        if (terminalInstanceService.getAttachGeneration(id) !== gen) return;
+
+        updateVisibility(id, entry.isIntersecting);
+        terminalInstanceService.setVisible(id, entry.isIntersecting, gen);
+      },
+      {
+        // Grid-scoped root: when mounted inside the grid, the pre-warm margin
+        // upgrades panels that are one comfortable row away from the viewport
+        // from BACKGROUND → VISIBLE before they paint. Sized to the comfortable
+        // row height so the pre-warm fires a full row ahead now that rows no
+        // longer shrink to the minimum. Outside the grid we fall back to the
+        // document viewport with no margin.
+        root: gridScrollRoot ?? null,
+        rootMargin: gridScrollRoot ? `${COMFORTABLE_PANEL_HEIGHT_PX}px 0px` : "0px",
+        threshold: 0.1,
+      }
+    );
+
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, [id, restartKey, attachEpoch, updateVisibility, gridScrollRoot, containerRef]);
+}

--- a/src/components/Terminal/useTerminalVisibilityObserver.ts
+++ b/src/components/Terminal/useTerminalVisibilityObserver.ts
@@ -66,31 +66,39 @@ export function useTerminalVisibilityObserver({
         // Don't update visibility during drag - CSS transforms cause false negatives
         if (isDraggingRef.current || !entry) return;
 
-        // Suppress stale `false` readings that would freeze a visible terminal
-        // at the BACKGROUND tier (#9780). Confirm against fresh element and root
-        // geometry, read before any write to avoid a redundant layout reflow.
-        if (
-          isStaleHiddenReading(
-            entry,
-            () => containerRef.current?.getBoundingClientRect(),
-            () =>
-              gridScrollRoot?.getBoundingClientRect() ??
-              new DOMRect(0, 0, window.innerWidth, window.innerHeight)
-          )
-        )
-          return;
-
         // A callback queued from a previous mount site (warm-swap reattach)
         // must not write at all. setVisible already drops it via its
         // generation guard — dropping the store write under the same
         // condition keeps store and service from diverging permanently
         // (#10416). The live mount re-arms on `attachEpoch` instead of
         // adopting the newer generation here, so a superseded observer's
-        // retained callback keeps failing this check.
+        // retained callback keeps failing this check. Checked before the
+        // geometry reads below so a superseded callback costs no layout.
         if (terminalInstanceService.getAttachGeneration(id) !== gen) return;
 
-        updateVisibility(id, entry.isIntersecting);
-        terminalInstanceService.setVisible(id, entry.isIntersecting, gen);
+        // Stale `false` readings would freeze a visible terminal at the
+        // BACKGROUND tier (#9780). Confirm against fresh element and root
+        // geometry, read before any write to avoid a redundant layout reflow.
+        const isStaleHide = isStaleHiddenReading(
+          entry,
+          () => containerRef.current?.getBoundingClientRect(),
+          () =>
+            gridScrollRoot?.getBoundingClientRect() ??
+            new DOMRect(0, 0, window.innerWidth, window.innerHeight)
+        );
+
+        // Commit what that geometry established rather than dropping the
+        // callback: a stale hide is positive proof the pane IS on screen. When
+        // the store already agrees this is a no-op (both writes early-return on
+        // an unchanged value), so the only case it changes is a store stuck
+        // hidden — which nothing else repairs for a FOCUSED pane, since
+        // getTerminalRefreshTier answers FOCUSED before it ever consults
+        // isVisible and the reconciliation watchdog only repairs at BACKGROUND
+        // (#11445).
+        const isVisible = isStaleHide || entry.isIntersecting;
+
+        updateVisibility(id, isVisible);
+        terminalInstanceService.setVisible(id, isVisible, gen);
       },
       {
         // Grid-scoped root: when mounted inside the grid, the pre-warm margin

--- a/src/components/Terminal/useUnmountVisibilityCleanup.ts
+++ b/src/components/Terminal/useUnmountVisibilityCleanup.ts
@@ -1,9 +1,9 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 
 /**
  * Marks the panel hidden in the store when the pane unmounts — guarded by the
- * attach generation captured at mount. During a warm-swap the old pane's
+ * attach generation this mount owns. During a warm-swap the old pane's
  * cleanup can fire after the replacement pane has already re-attached (the
  * generation advanced); writing false then would poison store visibility
  * while the service stays visible, pinning the computed refresh tier at
@@ -11,6 +11,16 @@ import { terminalInstanceService } from "@/services/TerminalInstanceService";
  * (#10416). restartKey is in the deps because a restart re-attaches under a
  * new generation — without re-capturing, the final real unmount would be
  * mistaken for a stale cleanup and skipped.
+ *
+ * The owned generation is re-read on `attachEpoch` rather than in the cleanup
+ * effect's own deps, and the two are deliberately split. This mount's OWN
+ * attach lands asynchronously (XtermAdapter awaits `getOrCreate`), so a
+ * generation captured at mount is routinely one behind — and a cleanup
+ * comparing against it would read the pane's own attach as someone else's
+ * warm-swap and skip the write the real unmount needs (#11445). Re-capturing
+ * has to happen WITHOUT re-running the cleanup effect: adding the epoch to
+ * those deps would fire the cleanup mid-mount, where the freshly matching
+ * generation lets it write a spurious false.
  *
  * StrictMode double-invoke is safe: XtermAdapter's attach (useLayoutEffect,
  * generation bump) replays before this passive effect first runs, so the
@@ -21,12 +31,18 @@ import { terminalInstanceService } from "@/services/TerminalInstanceService";
 export function useUnmountVisibilityCleanup(
   id: string,
   restartKey: number,
-  updateVisibility: (id: string, isVisible: boolean) => void
+  updateVisibility: (id: string, isVisible: boolean) => void,
+  attachEpoch = 0
 ): void {
+  const ownedGenerationRef = useRef(0);
+
   useEffect(() => {
-    const gen = terminalInstanceService.getAttachGeneration(id);
+    ownedGenerationRef.current = terminalInstanceService.getAttachGeneration(id);
+  }, [id, restartKey, attachEpoch]);
+
+  useEffect(() => {
     return () => {
-      if (terminalInstanceService.getAttachGeneration(id) === gen) {
+      if (terminalInstanceService.getAttachGeneration(id) === ownedGenerationRef.current) {
         updateVisibility(id, false);
       }
     };

--- a/src/hooks/__tests__/useTypeAnywhere.test.tsx
+++ b/src/hooks/__tests__/useTypeAnywhere.test.tsx
@@ -58,10 +58,9 @@ vi.mock("@/components/Panel/panelFocusRegistry", () => ({
   focusPanelInput: (id: string) => focusPanelInput(id),
 }));
 
-import { useTypeAnywhere } from "../useTypeAnywhere";
+import { useTypeAnywhere, LOCATE_EPISODE_MS } from "../useTypeAnywhere";
 import { useTerminalInputStore } from "@/store/terminalInputStore";
 import { useTypingLocatorStore } from "@/store/typingLocatorStore";
-import { UI_TRANSIENT_HINT_DWELL_MS } from "@/lib/animationUtils";
 
 function agentPanel(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
@@ -432,7 +431,25 @@ describe("useTypeAnywhere", () => {
       expect(pingTerminal).toHaveBeenCalledTimes(2);
     });
 
-    it("re-locates a still-hidden pane once the locator has faded", () => {
+    it("keeps suppressing while the locator is still on screen", () => {
+      vi.useFakeTimers();
+      try {
+        setPanels([agentPanel("a1", { isVisible: false })]);
+        focusOffscreenTerminal("a1");
+        renderHook(() => useTypeAnywhere());
+
+        press("h");
+        // Still inside the pill's life, so the pane is already named on screen.
+        vi.advanceTimersByTime(LOCATE_EPISODE_MS - 1);
+        press("e");
+
+        expect(pingTerminal).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("re-locates a still-hidden pane once the locator has cleared", () => {
       vi.useFakeTimers();
       try {
         setPanels([agentPanel("a1", { isVisible: false })]);
@@ -443,10 +460,29 @@ describe("useTypeAnywhere", () => {
         press("e");
         expect(pingTerminal).toHaveBeenCalledTimes(1);
 
-        // Past the pill's dwell nothing on screen still names the pane, so a
-        // keystroke landing off-screen has earned a fresh locate.
-        vi.advanceTimersByTime(UI_TRANSIENT_HINT_DWELL_MS + 1);
+        // The pill has been cleared, so nothing on screen still names the pane
+        // and a keystroke landing off-screen has earned a fresh locate.
+        vi.advanceTimersByTime(LOCATE_EPISODE_MS);
         press("y");
+
+        expect(pingTerminal).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("starts a new episode after a backward wall-clock step", () => {
+      vi.useFakeTimers();
+      try {
+        setPanels([agentPanel("a1", { isVisible: false })]);
+        focusOffscreenTerminal("a1");
+        renderHook(() => useTypeAnywhere());
+
+        press("h");
+        // An NTP correction must not strand the pane un-locatable until real
+        // time catches back up to the episode stamp.
+        vi.setSystemTime(Date.now() - 60_000);
+        press("e");
 
         expect(pingTerminal).toHaveBeenCalledTimes(2);
       } finally {
@@ -465,9 +501,13 @@ describe("useTypeAnywhere", () => {
       press("h");
       focusOffscreenTerminal("a2");
       press("i");
+      // Coming straight back is a new context: the pill now names a2.
+      focusOffscreenTerminal("a1");
+      press("o");
 
       expect(pingTerminal).toHaveBeenNthCalledWith(1, "a1");
       expect(pingTerminal).toHaveBeenNthCalledWith(2, "a2");
+      expect(pingTerminal).toHaveBeenNthCalledWith(3, "a1");
     });
   });
 

--- a/src/hooks/__tests__/useTypeAnywhere.test.tsx
+++ b/src/hooks/__tests__/useTypeAnywhere.test.tsx
@@ -61,6 +61,7 @@ vi.mock("@/components/Panel/panelFocusRegistry", () => ({
 import { useTypeAnywhere } from "../useTypeAnywhere";
 import { useTerminalInputStore } from "@/store/terminalInputStore";
 import { useTypingLocatorStore } from "@/store/typingLocatorStore";
+import { UI_TRANSIENT_HINT_DWELL_MS } from "@/lib/animationUtils";
 
 function agentPanel(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
@@ -389,6 +390,84 @@ describe("useTypeAnywhere", () => {
 
       expect(pingTerminal).toHaveBeenCalledWith("sh");
       expect(useTypingLocatorStore.getState().label).toContain("zsh");
+    });
+
+    it("locates once per episode, not once per keystroke", () => {
+      setPanels([agentPanel("a1", { isVisible: false })]);
+      focusOffscreenTerminal("a1");
+      const host = document.querySelector<HTMLElement>('[data-panel-id="a1"]');
+      const scrollIntoView = vi.fn();
+      host!.scrollIntoView = scrollIntoView;
+      renderHook(() => useTypeAnywhere());
+      const revisionBefore = useTypingLocatorStore.getState().revision;
+
+      press("h");
+      press("e");
+      press("y");
+
+      // Each ping advances pingSeq, and the worktree card mounts a fresh receipt
+      // overlay per advance — three pings is three background flashes.
+      expect(pingTerminal).toHaveBeenCalledTimes(1);
+      expect(scrollIntoView).toHaveBeenCalledTimes(1);
+      expect(useTypingLocatorStore.getState().revision - revisionBefore).toBe(1);
+    });
+
+    it("starts a new episode once the pane has been seen on screen again", () => {
+      setPanels([agentPanel("a1", { isVisible: false })]);
+      focusOffscreenTerminal("a1");
+      renderHook(() => useTypeAnywhere());
+
+      press("h");
+      expect(pingTerminal).toHaveBeenCalledTimes(1);
+
+      // The reveal lands: a keystroke into the now-visible pane closes the
+      // episode without locating anything.
+      setPanels([agentPanel("a1", { isVisible: true })]);
+      press("e");
+      expect(pingTerminal).toHaveBeenCalledTimes(1);
+
+      // Scrolled away again — the user is typing blind once more.
+      setPanels([agentPanel("a1", { isVisible: false })]);
+      press("y");
+      expect(pingTerminal).toHaveBeenCalledTimes(2);
+    });
+
+    it("re-locates a still-hidden pane once the locator has faded", () => {
+      vi.useFakeTimers();
+      try {
+        setPanels([agentPanel("a1", { isVisible: false })]);
+        focusOffscreenTerminal("a1");
+        renderHook(() => useTypeAnywhere());
+
+        press("h");
+        press("e");
+        expect(pingTerminal).toHaveBeenCalledTimes(1);
+
+        // Past the pill's dwell nothing on screen still names the pane, so a
+        // keystroke landing off-screen has earned a fresh locate.
+        vi.advanceTimersByTime(UI_TRANSIENT_HINT_DWELL_MS + 1);
+        press("y");
+
+        expect(pingTerminal).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("locates each pane separately when focus moves between them", () => {
+      setPanels([
+        agentPanel("a1", { isVisible: false }),
+        agentPanel("a2", { isVisible: false, title: "Codex" }),
+      ]);
+      focusOffscreenTerminal("a1");
+      renderHook(() => useTypeAnywhere());
+
+      press("h");
+      focusOffscreenTerminal("a2");
+      press("i");
+
+      expect(pingTerminal).toHaveBeenNthCalledWith(1, "a1");
+      expect(pingTerminal).toHaveBeenNthCalledWith(2, "a2");
     });
   });
 

--- a/src/hooks/__tests__/useTypeAnywhere.test.tsx
+++ b/src/hooks/__tests__/useTypeAnywhere.test.tsx
@@ -490,6 +490,27 @@ describe("useTypeAnywhere", () => {
       }
     });
 
+    it("re-locates a pane the rescue branch renamed the locator away from", () => {
+      setPanels([agentPanel("a1", { isVisible: false })]);
+      focusOffscreenTerminal("a1");
+      renderHook(() => useTypeAnywhere());
+
+      press("h");
+      expect(pingTerminal).toHaveBeenCalledTimes(1);
+
+      // Focus leaves the terminal entirely and the rescue repoints the pill at
+      // its own target, so nothing on screen still names a1.
+      document.body.innerHTML += `<div id="elsewhere" tabindex="0"></div>`;
+      document.getElementById("elsewhere")?.focus();
+      press("e");
+      expect(useTypingLocatorStore.getState().label).toContain("Claude");
+
+      focusOffscreenTerminal("a1");
+      press("y");
+
+      expect(pingTerminal).toHaveBeenCalledTimes(2);
+    });
+
     it("locates each pane separately when focus moves between them", () => {
       setPanels([
         agentPanel("a1", { isVisible: false }),

--- a/src/hooks/useTypeAnywhere.ts
+++ b/src/hooks/useTypeAnywhere.ts
@@ -112,8 +112,8 @@ export function useTypeAnywhere(): void {
         // Locating is one action per episode, not per keystroke. Without this
         // the receipt flash on the worktree card re-fires for every character
         // (pingTerminal advances pingSeq unconditionally), which is the same
-        // per-keystroke flashing the card's border-accent guard already avoids
-        // (#11445).
+        // per-keystroke flashing the card's own border flash already guards
+        // against (#11445).
         const episode = locateEpisodeRef.current;
         const now = Date.now();
         const elapsed = episode === null ? 0 : now - episode.at;

--- a/src/hooks/useTypeAnywhere.ts
+++ b/src/hooks/useTypeAnywhere.ts
@@ -9,7 +9,7 @@ import { useTypingLocatorStore } from "@/store/typingLocatorStore";
 import { usePaletteStore } from "@/store/paletteStore";
 import { getViewWorkspaceId } from "@/store/viewWorkspaceId";
 import { getTerminalDisplayTitle } from "@/utils/terminalTitleDisplay";
-import { UI_TRANSIENT_HINT_DWELL_MS } from "@/lib/animationUtils";
+import { UI_PALETTE_EXIT_DURATION, UI_TRANSIENT_HINT_DWELL_MS } from "@/lib/animationUtils";
 import { focusPanelInput } from "@/components/Panel/panelFocusRegistry";
 import {
   findPanelIdForElement,
@@ -22,6 +22,16 @@ import {
 
 /** Best-effort focus retry budget — the draft is already safe by the time we try. */
 const FOCUS_ATTEMPT_FRAMES = 30;
+
+/**
+ * How long one locate episode suppresses repeats for the same pane. Matches the
+ * locator pill's full on-screen life (TypingLocator clears the label at dwell +
+ * exit), so an episode lasts exactly as long as the affordance naming the pane:
+ * while the user can still read where their typing is going there is nothing to
+ * re-announce, and once it is gone a keystroke still landing off-screen earns a
+ * fresh locate.
+ */
+export const LOCATE_EPISODE_MS = UI_TRANSIENT_HINT_DWELL_MS + UI_PALETTE_EXIT_DURATION;
 
 /**
  * Panel ids are opaque and may contain characters that are not selector-safe,
@@ -103,15 +113,17 @@ export function useTypeAnywhere(): void {
         // the receipt flash on the worktree card re-fires for every character
         // (pingTerminal advances pingSeq unconditionally), which is the same
         // per-keystroke flashing the card's border-accent guard already avoids
-        // (#11445). The window matches the locator pill's dwell so an episode
-        // lasts exactly as long as the affordance naming the pane: once that
-        // has faded, a keystroke still landing off-screen has earned a new one.
+        // (#11445).
         const episode = locateEpisodeRef.current;
         const now = Date.now();
+        const elapsed = episode === null ? 0 : now - episode.at;
         if (
           episode !== null &&
           episode.panelId === panelId &&
-          now - episode.at < UI_TRANSIENT_HINT_DWELL_MS
+          // A backward wall-clock step (NTP correction, manual change) must not
+          // strand the pane un-locatable until real time catches up.
+          elapsed >= 0 &&
+          elapsed < LOCATE_EPISODE_MS
         ) {
           return;
         }
@@ -185,6 +197,9 @@ export function useTypeAnywhere(): void {
       useTypingLocatorStore
         .getState()
         .showLocator(`Typing into ${getTerminalDisplayTitle(target, "compact")}`);
+      // The pill now names the rescue target, so any locate episode it replaced
+      // is over — returning to that pane deserves to be announced again.
+      locateEpisodeRef.current = null;
 
       // The pane's own focus effect drives the editor focus, but the editor is a
       // lazy chunk and its worktree may still be mounting — so poll until DOM

--- a/src/hooks/useTypeAnywhere.ts
+++ b/src/hooks/useTypeAnywhere.ts
@@ -9,6 +9,7 @@ import { useTypingLocatorStore } from "@/store/typingLocatorStore";
 import { usePaletteStore } from "@/store/paletteStore";
 import { getViewWorkspaceId } from "@/store/viewWorkspaceId";
 import { getTerminalDisplayTitle } from "@/utils/terminalTitleDisplay";
+import { UI_TRANSIENT_HINT_DWELL_MS } from "@/lib/animationUtils";
 import { focusPanelInput } from "@/components/Panel/panelFocusRegistry";
 import {
   findPanelIdForElement,
@@ -51,7 +52,8 @@ function isFocusInHybridInput(terminalId: string): boolean {
  *
  *  - **Locate.** A real terminal owns focus but its pane is scrolled out of the
  *    grid viewport. The destination is legitimate — the user just cannot see it.
- *    Scroll it back, pulse it, name it. The event is never touched.
+ *    Scroll it back, pulse it, name it — once per episode, not once per
+ *    keystroke. The event is never touched.
  *
  *  - **Rescue.** Nothing useful owns focus, so the keystroke is about to be
  *    eaten. Route it into the draft of the last agent the user typed to, focus
@@ -67,6 +69,7 @@ export function useTypeAnywhere(): void {
   // never churns; all state is read imperatively at event time anyway.
   const handlerRef = useRef<(e: KeyboardEvent) => void>(() => {});
   const focusFrameRef = useRef<number | null>(null);
+  const locateEpisodeRef = useRef<{ panelId: string; at: number } | null>(null);
 
   useEffect(() => {
     handlerRef.current = (e: KeyboardEvent) => {
@@ -89,7 +92,30 @@ export function useTypeAnywhere(): void {
         // (TerminalPane), rooted at the grid scroll container. Its rootMargin
         // pre-warms a full row, so this only fires for panes that are
         // meaningfully off-screen — not near-misses.
-        if (panel === undefined || panel.isVisible !== false) return;
+        if (panel === undefined || panel.isVisible !== false) {
+          // The pane is on screen (or gone), so whatever episode was running has
+          // ended — the next time it goes off-screen deserves a fresh locate.
+          locateEpisodeRef.current = null;
+          return;
+        }
+
+        // Locating is one action per episode, not per keystroke. Without this
+        // the receipt flash on the worktree card re-fires for every character
+        // (pingTerminal advances pingSeq unconditionally), which is the same
+        // per-keystroke flashing the card's border-accent guard already avoids
+        // (#11445). The window matches the locator pill's dwell so an episode
+        // lasts exactly as long as the affordance naming the pane: once that
+        // has faded, a keystroke still landing off-screen has earned a new one.
+        const episode = locateEpisodeRef.current;
+        const now = Date.now();
+        if (
+          episode !== null &&
+          episode.panelId === panelId &&
+          now - episode.at < UI_TRANSIENT_HINT_DWELL_MS
+        ) {
+          return;
+        }
+        locateEpisodeRef.current = { panelId, at: now };
 
         scrollPanelIntoView(panelId);
         panelStore.pingTerminal(panelId);


### PR DESCRIPTION
## Summary

Typing into an agent terminal pane that was fully in view caused the selected worktree card in the sidebar to flash its background once per keystroke. There were two independent defects behind it, exactly as the issue suspected.

Resolves #11445

## Two independent defects

### 1. `panel.isVisible` could get stuck reading `false`

This field is written only by an IntersectionObserver effect in `TerminalPane`, which captures a generation counter (`attachGeneration`) at effect setup time. The actual `attach()` call happens inside an async IIFE in a separate module, `XtermAdapter`, which awaits `getOrCreate`, and on a cold open that awaits a lazy dynamic `import()` of the Unicode11 addon. So the effect can capture the generation from before the attach finished. After that, the IntersectionObserver callback's guard compares its captured generation to the current one, and once they diverge it silently drops the write, forever, because nothing causes the effect to re-run for the rest of that mount's life.

Separately, `useUnmountVisibilityCleanup` writes `isVisible: false` on unmount, so once any lifecycle path left the store at `false`, the frozen observer could never write it back to `true`.

`useTypeAnywhere`'s locate branch treats a pane as off-screen whenever `panel.isVisible !== false` isn't true, so a stuck `false` made it treat a fully on-screen pane as off-screen. Nothing else in the system repaired the value either: `getTerminalRefreshTier` answers with a `FOCUSED` tier before it ever looks at `isVisible`, and the background reconciliation watchdog only repairs stored visibility from the `BACKGROUND` tier. So the exact pane affected by this bug, the focused one, was the one case the watchdog could never reach.

### 2. The locate branch pinged once per keystroke, not once per episode

Independent of the first defect. `pingTerminal` advances a sequence counter, `pingSeq`, unconditionally on every call. `useInputReceiptKey` emits one receipt for every advance of that counter, and the worktree card remounts a keyed overlay element for every new receipt.

The card's sibling border-accent flash already carries a guard against exactly this per-keystroke retrigger problem. The newer input-receipt flash was added later without an equivalent guard.

## The fix

- Extracted the visibility-observer logic out of `TerminalPane` and into a new hook, `useTerminalVisibilityObserver`. It now re-arms (calls `observe()` again) whenever a new counter, `attachEpoch`, changes. `XtermAdapter` bumps `attachEpoch` via a new `onAttached` callback that fires right after its existing forced `setVisible(true)` call. Re-arming with a fresh `observe()`, rather than just having the callback adopt the newer generation internally, is what makes this correct: IntersectionObserver only reports threshold crossings after its initial observation of an element, so a pane whose one and only callback delivery landed before the attach finished would otherwise never get another callback for the rest of its life. Only a brand new `observe()` call guarantees a fresh delivery.
- Updated `useUnmountVisibilityCleanup` so it now re-captures the generation it considers its own on that same `attachEpoch` signal, so a pane's own late attach is no longer misread by its own cleanup logic as some other pane's warm swap. That re-capture is deliberately kept in a separate effect from the destructive cleanup effect, because keying the cleanup effect itself directly on the epoch value would fire it in the middle of mounting, right when the generation freshly matches, and write a spurious `false`.
- Fixed a known Chromium false-negative (#9780) where a stale hide event now commits the true visibility state that geometry checks have already established, instead of just dropping the callback outright, so a visibility store stuck hidden actually gets repaired. Gated behind `checkVisibility()`, because the dock parks live-but-hidden panes in a fixed 0,0 box styled with `content-visibility: hidden`, and that box's full-size overlap with the root element would otherwise be misread as proof the pane is visible.
- Reordered the code so the generation check now runs before the geometry reads, sparing a superseded callback a reflow it was never going to use.
- The locate branch now performs one action per episode rather than one action per keystroke. An episode lasts as long as the locator pill naming the pane stays displayed. It ends when the pane's visibility reads true again, when a different pane becomes the one being located, when the rescue branch repoints the locator pill elsewhere, or if the wall clock is ever observed stepping backward.

## Preserved

The two existing safeguards still hold, each pinned by a test: the `#9780` stale-hide guard, and the `#10416` stale-mount-site generation check. `useInputReceiptKey` was already correct by design, so it's untouched.

## Testing

Ran 97 targeted tests across 6 test suites. Changed files are clean under eslint, the composite `npm run typecheck` is clean, and prettier formatting is clean. Every new regression test was mutation-checked: reverted each individual fix and confirmed the corresponding test failed.

Two known gaps worth stating honestly:

- There's no `TerminalPane`-level integration test of the `onAttached` → `attachEpoch` → re-arm wiring. The component's import surface makes a jsdom mount impractical, so the defect that actually mattered is pinned at the hook level instead.
- `LOCATE_EPISODE_MS`'s alignment with `TypingLocator`'s clear time isn't pinned by a test, because asserting that alignment would be a literal-vs-source-of-truth assertion, which this project's testing rules forbid.
