### PR TITLE
fix(project-switcher): regroup a cold-opened palette in place

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -454,6 +454,11 @@ if (!gotTheLock) {
           .catch((err) => {
             console.warn(`[main] run-history pushSnapshotTo failed for wc ${wcId}:`, err);
           });
+        // Replay the project status map for the same reason (#11452). The stats
+        // service suppresses unchanged broadcasts, so a view that loads while
+        // the fleet is static would otherwise show every project unbanded until
+        // agent state next moved. Statically imported, so no dynamic import.
+        getProjectStatsService()?.pushSnapshotTo(wc);
 
         // #10815: cold switch-back auto-resume is driven entirely by the
         // renderer's pull-on-mount `help.peekPendingHibernation` peek (which

--- a/electron/services/ProjectStatsService.ts
+++ b/electron/services/ProjectStatsService.ts
@@ -69,6 +69,34 @@ export class ProjectStatsService {
     return this.lastBroadcast;
   }
 
+  /**
+   * Replay the retained status map to a single freshly-loaded view (cold start,
+   * LRU restore, crash reload, DevTools refresh), mirroring
+   * `pushRunHistorySnapshotTo`. `computeAndBroadcast` suppresses unchanged
+   * payloads, so a view that attaches while the fleet is static — waiting,
+   * blocked and completed-unreviewed agents are exactly the states that stop
+   * transitioning — would otherwise never receive a first broadcast at all.
+   *
+   * An empty map is skipped: the initial compute is deferred off the
+   * first-interactive path, so `lastBroadcast` is `{}` for a window after boot,
+   * and "nothing computed yet" is indistinguishable on the wire from "no
+   * projects". Sending it carries no information and can only clobber a store
+   * the renderer's own bulk seed already filled.
+   *
+   * Best-effort, not durable transport: the renderer attaches its listener from
+   * a React effect, so this send can land first and be dropped. The palette's
+   * open-time bulk pull remains the guaranteed hydration path.
+   */
+  pushSnapshotTo(webContents: Electron.WebContents): void {
+    if (webContents.isDestroyed()) return;
+    if (Object.keys(this.lastBroadcast).length === 0) return;
+    try {
+      webContents.send(CHANNELS.PROJECT_STATS_UPDATED, this.lastBroadcast);
+    } catch {
+      // Silently ignore send failures during window initialization/disposal.
+    }
+  }
+
   stop(): void {
     // Always bump generation so an in-flight computeAndBroadcast — including
     // one started by a pre-start refresh() — is invalidated before any

--- a/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
+++ b/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
@@ -51,6 +51,13 @@ function makePtyClient(): FakePtyClient {
   };
 }
 
+function makeWebContents() {
+  return {
+    isDestroyed: vi.fn<() => boolean>(() => false),
+    send: vi.fn<(channel: string, payload: unknown) => void>(),
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.useFakeTimers();
@@ -552,6 +559,62 @@ describe("ProjectStatsService adversarial", () => {
     const after2 = broadcastMock.mock.calls.length;
 
     expect(after2).toBe(after1);
+    svc.stop();
+  });
+
+  it("replays the retained snapshot to a view that missed every broadcast", async () => {
+    const ptyClient = makePtyClient();
+    projectStoreMock.getAllProjects.mockReturnValue([{ id: "p1" }]);
+
+    const svc = new ProjectStatsService(ptyClient as never);
+    svc.refresh();
+    await vi.runAllTimersAsync();
+    const [liveChannel, livePayload] = broadcastMock.mock.calls[0]!;
+
+    // The fleet goes static: the next compute produces the same map and is
+    // suppressed, so a view loading now never receives a first broadcast.
+    svc.refresh();
+    await vi.runAllTimersAsync();
+    expect(broadcastMock).toHaveBeenCalledTimes(1);
+
+    const wc = makeWebContents();
+    svc.pushSnapshotTo(wc as never);
+
+    // Same channel and same payload as the live broadcast, so the replay lands
+    // on the listener the renderer already has attached.
+    expect(wc.send.mock.calls).toEqual([[liveChannel, livePayload]]);
+    svc.stop();
+  });
+
+  it("does not replay before the deferred initial compute has produced a map", () => {
+    const svc = new ProjectStatsService(makePtyClient() as never);
+    const wc = makeWebContents();
+
+    // `{}` here means "nothing computed yet", which is indistinguishable on the
+    // wire from "no projects" — sending it would only clobber a renderer that
+    // seeded itself from bulk stats.
+    svc.pushSnapshotTo(wc as never);
+
+    expect(wc.send).not.toHaveBeenCalled();
+  });
+
+  it("skips a destroyed view and swallows a send that throws", async () => {
+    const ptyClient = makePtyClient();
+    projectStoreMock.getAllProjects.mockReturnValue([{ id: "p1" }]);
+    const svc = new ProjectStatsService(ptyClient as never);
+    svc.refresh();
+    await vi.runAllTimersAsync();
+
+    const destroyed = makeWebContents();
+    destroyed.isDestroyed.mockReturnValue(true);
+    svc.pushSnapshotTo(destroyed as never);
+    expect(destroyed.send).not.toHaveBeenCalled();
+
+    const racing = makeWebContents();
+    racing.send.mockImplementation(() => {
+      throw new Error("Object has been destroyed");
+    });
+    expect(() => svc.pushSnapshotTo(racing as never)).not.toThrow();
     svc.stop();
   });
 

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -1940,6 +1940,112 @@ describe("useProjectSwitcherPalette", () => {
       expect(result.current.results[1]!.activeAgentCount).toBe(3);
     });
 
+    it("regroups a project that registers while the session is still a guess", async () => {
+      const first = base("first");
+      const late = base("late");
+      projectState.projects = [first];
+      projectState.currentProject = null;
+      projectStatsState.stats = {};
+      getBulkStatsMock.mockResolvedValue({});
+
+      const { result, rerender } = renderHook(() => useProjectSwitcherPalette());
+      act(() => {
+        result.current.open("modal");
+      });
+
+      // Registered before anything hydrated, so it joins the pending regroup
+      // rather than being locked at the band its missing stats implied.
+      act(() => {
+        projectState.projects = [first, late];
+        rerender();
+      });
+      act(() => {
+        projectStatsState.stats = {
+          first: { activeAgentCount: 0, waitingAgentCount: 0, processCount: 0 },
+        };
+        rerender();
+      });
+      expect(result.current.results.find((p) => p.id === "late")!.section).toBe("other");
+
+      act(() => {
+        projectStatsState.stats = {
+          first: { activeAgentCount: 0, waitingAgentCount: 0, processCount: 0 },
+          late: { activeAgentCount: 2, waitingAgentCount: 0, processCount: 2 },
+        };
+        rerender();
+      });
+
+      await waitFor(() => {
+        expect(result.current.results.find((p) => p.id === "late")!.section).toBe("running");
+      });
+    });
+
+    it("waits for every guessed row, and a removed one stops holding it up", async () => {
+      const first = base("first");
+      const removed = base("removed");
+      projectState.projects = [first, removed];
+      projectState.currentProject = null;
+      projectStatsState.stats = {};
+      getBulkStatsMock.mockResolvedValue({});
+
+      const { result, rerender } = renderHook(() => useProjectSwitcherPalette());
+      act(() => {
+        result.current.open("modal");
+      });
+
+      // One row resolves, the other has not: a partial answer must not move
+      // rows, or the list would regroup in installments under the pointer.
+      act(() => {
+        projectStatsState.stats = {
+          first: { activeAgentCount: 2, waitingAgentCount: 0, processCount: 2 },
+        };
+        rerender();
+      });
+      expect(result.current.results.find((p) => p.id === "first")!.section).toBe("other");
+      expect(result.current.results.find((p) => p.id === "first")!.activeAgentCount).toBe(2);
+
+      // The unresolved row goes away, so nothing is a guess any more.
+      act(() => {
+        projectState.projects = [first];
+        rerender();
+      });
+
+      await waitFor(() => {
+        expect(result.current.results[0]!.section).toBe("running");
+      });
+    });
+
+    it("treats an active-only stats map as a guess for the rows that can switch", async () => {
+      const projects = [base("active", { status: "active" }), base("busy")];
+      projectState.projects = projects;
+      projectState.currentProject = { id: "active" };
+      // The active row is keyed, but nothing is known about the switch target,
+      // so this session is still a guess despite a non-empty map.
+      projectStatsState.stats = {
+        active: { activeAgentCount: 0, waitingAgentCount: 0, processCount: 0 },
+      };
+      const bulk = emptyBulkStats(projects.map((p) => p.id));
+      bulk.busy!.activeAgentCount = 2;
+      getBulkStatsMock.mockResolvedValue(bulk);
+
+      const { result, rerender } = renderHook(() => useProjectSwitcherPalette());
+      act(() => {
+        result.current.open("modal");
+      });
+      expect(result.current.results.find((p) => p.id === "busy")!.section).toBe("other");
+
+      await waitFor(() => {
+        expect(setStatsMock).toHaveBeenCalled();
+      });
+      act(() => {
+        rerender();
+      });
+
+      await waitFor(() => {
+        expect(result.current.results.find((p) => p.id === "busy")!.section).toBe("running");
+      });
+    });
+
     it("holds a project that arrives after the freeze just as still", async () => {
       projectState.projects = [base("first")];
       projectState.currentProject = null;

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -1735,29 +1735,81 @@ describe("useProjectSwitcherPalette", () => {
       bulk.second!.latestWorkingSince = 9_000;
       getBulkStatsMock.mockResolvedValue(bulk);
 
-      const { result } = renderHook(() => useProjectSwitcherPalette());
+      const { result, rerender } = renderHook(() => useProjectSwitcherPalette());
       act(() => {
         result.current.open("modal");
       });
       await waitFor(() => {
-        expect(
-          result.current.results.every((project) => project.latestWorkingSince !== undefined)
-        ).toBe(true);
+        expect(setStatsMock).toHaveBeenCalled();
+      });
+      act(() => {
+        rerender();
       });
 
-      // The first open froze its layout before the seed landed; the seed's
-      // ordering takes effect on the next capture.
-      act(() => {
-        result.current.close();
+      // The open froze a guess before the seed landed; the seed resolves it in
+      // place. Without latestWorkingSince riding the bulk contract this would
+      // fall back to lastOpened and invert — and without the regroup it would
+      // stay inverted for the whole session, since unchanged pushes are
+      // suppressed and the freeze would hold the placeholder ordering.
+      await waitFor(() => {
+        expect(result.current.results.map((p) => p.id)).toEqual(["second", "first"]);
       });
+      expect(result.current.results.every((p) => p.section === "running")).toBe(true);
+    });
+
+    it("regroups a cold session in place when stats arrive, then holds", async () => {
+      const projects = [base("quiet"), base("busy"), base("stuck")];
+      projectState.projects = projects;
+      projectState.currentProject = null;
+      // No push has reached this view, so every row reads as zero agents.
+      projectStatsState.stats = {};
+      const bulk = emptyBulkStats(projects.map((p) => p.id));
+      bulk.busy!.activeAgentCount = 2;
+      bulk.stuck!.waitingAgentCount = 1;
+      getBulkStatsMock.mockResolvedValue(bulk);
+
+      const { result, rerender } = renderHook(() => useProjectSwitcherPalette());
       act(() => {
         result.current.open("modal");
       });
 
-      // Without latestWorkingSince riding the bulk contract, this would fall
-      // back to lastOpened and invert — potentially for the whole session,
-      // since unchanged pushes are suppressed.
-      expect(result.current.results.map((p) => p.id)).toEqual(["second", "first"]);
+      // The freeze taken at open put everything in one band.
+      expect(result.current.results.every((p) => p.section === "other")).toBe(true);
+
+      await waitFor(() => {
+        expect(setStatsMock).toHaveBeenCalled();
+      });
+      act(() => {
+        rerender();
+      });
+
+      // Bands and within-band order both come from the real data, without the
+      // user closing and reopening the palette.
+      await waitFor(() => {
+        expect(result.current.results.map((p) => [p.id, p.section])).toEqual([
+          ["stuck", "attention"],
+          ["busy", "running"],
+          ["quiet", "other"],
+        ]);
+      });
+
+      // The regroup is spent: the session is now a decision, so a later change
+      // is held exactly as it would have been on a warm open.
+      act(() => {
+        projectStatsState.stats = {
+          quiet: { activeAgentCount: 4, waitingAgentCount: 0, processCount: 4 },
+          busy: { activeAgentCount: 0, waitingAgentCount: 0, processCount: 0 },
+          stuck: { activeAgentCount: 0, waitingAgentCount: 0, processCount: 0 },
+        };
+        rerender();
+      });
+
+      expect(result.current.results.map((p) => [p.id, p.section])).toEqual([
+        ["stuck", "attention"],
+        ["busy", "running"],
+        ["quiet", "other"],
+      ]);
+      expect(result.current.results[2]!.activeAgentCount).toBe(4);
     });
 
     it("never preselects an unavailable row while an available one exists", async () => {
@@ -1868,10 +1920,13 @@ describe("useProjectSwitcherPalette", () => {
       });
       expect(result.current.results[0]!.section).toBe("attention");
 
-      // The agent finishes while the user is reading the list.
+      // The agent finishes while the user is reading the list, and the push
+      // that carries it also fills in the row that had no entry at open. A
+      // partial map is not a cold session, so this must not unlock the freeze.
       act(() => {
         projectStatsState.stats = {
           waiting: { activeAgentCount: 0, waitingAgentCount: 0, processCount: 0 },
+          idle: { activeAgentCount: 3, waitingAgentCount: 0, processCount: 3 },
         };
         rerender();
       });
@@ -1881,12 +1936,18 @@ describe("useProjectSwitcherPalette", () => {
       expect(result.current.results[0]!.section).toBe("attention");
       // Content underneath is live, though.
       expect(result.current.results[0]!.waitingAgentCount).toBe(0);
+      expect(result.current.results[1]!.section).toBe("other");
+      expect(result.current.results[1]!.activeAgentCount).toBe(3);
     });
 
     it("holds a project that arrives after the freeze just as still", async () => {
       projectState.projects = [base("first")];
       projectState.currentProject = null;
-      projectStatsState.stats = {};
+      // Keyed and idle, not absent: this session opens on real data, so the
+      // freeze is a decision from the start and no regroup is pending.
+      projectStatsState.stats = {
+        first: { activeAgentCount: 0, waitingAgentCount: 0, processCount: 0 },
+      };
       getBulkStatsMock.mockResolvedValue(emptyBulkStats(["first"]));
 
       const { result, rerender } = renderHook(() => useProjectSwitcherPalette());

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -268,11 +268,11 @@ interface FrozenLayout {
   order: string[];
   sections: Map<string, ProjectSectionKey>;
   /**
-   * Rows whose band this freeze guessed at because no stats entry had reached
-   * the view yet, or `null` once the layout reflects real data. Non-null only
-   * between a cold `open()` and the single regroup that resolves it.
+   * True while this freeze is still a guess: it was taken before any stats
+   * reached the view, so every band in it is a placeholder. Cleared by the one
+   * regroup that resolves the session.
    */
-  coldStatsProjectIds: ReadonlySet<string> | null;
+  isProvisional: boolean;
 }
 
 /**
@@ -650,18 +650,15 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   // A session that opened before any stats reached this view froze a guess, not
   // a decision: with no entry every row reads as zero agents and lands in
   // "Other", so the palette shows one ungrouped band and only re-bands on the
-  // next open (#11452). `coldStatsProjectIds` records the rows that guess
-  // covered, so the first real data for them can regroup the list in place.
+  // next open (#11452). Such a session stays provisional until real data lands,
+  // and is then regrouped once, in place.
   const [frozenLayout, setFrozenLayout] = useState<FrozenLayout | null>(null);
 
   const captureLayout = useCallback(
-    (
-      projects: SearchableProject[],
-      coldStatsProjectIds: ReadonlySet<string> | null = null
-    ): FrozenLayout => ({
+    (projects: SearchableProject[], isProvisional = false): FrozenLayout => ({
       order: projects.map((project) => project.id),
       sections: new Map(projects.map((project) => [project.id, project.section])),
-      coldStatsProjectIds,
+      isProvisional,
     }),
     []
   );
@@ -673,25 +670,30 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   useEffect(() => {
     if (!frozenLayout) return;
 
-    // A cold session's freeze is a placeholder. Once every row it guessed at
-    // has real data — or has gone away — recapture the whole layout so bands
-    // AND within-band order come from `liveBrowseOrder`'s real sort, then drop
-    // the marker. Holding out for all of them keeps the regroup a single
-    // decision rather than a trickle of rows moving under the pointer; if one
-    // never resolves the session simply behaves as it does today.
-    const { coldStatsProjectIds } = frozenLayout;
-    if (coldStatsProjectIds) {
-      const liveIds = new Set(liveBrowseOrder.map((project) => project.id));
-      const hydrated = [...coldStatsProjectIds].every(
-        (id) => !liveIds.has(id) || projectStats[id] !== undefined
+    // A provisional freeze is a placeholder. Once no row is still a guess,
+    // recapture the whole layout so bands AND within-band order come from
+    // `liveBrowseOrder`'s real sort, and stop being provisional.
+    //
+    // Judged against the rows that are live now, not a set captured at open: a
+    // project that registers while the session is still provisional would
+    // otherwise be folded in at its own guessed band and then locked there by
+    // the recapture, reproducing this very bug for that row. Reading live also
+    // means a project that goes away simply stops holding the regroup up.
+    //
+    // Waiting for all of them keeps the regroup one decision rather than a
+    // trickle of rows moving under the pointer; if a row never resolves, the
+    // session just behaves as it did before this fix.
+    if (frozenLayout.isProvisional) {
+      const stillGuessing = liveBrowseOrder.some(
+        (project) =>
+          !project.isActive && !project.isMissing && projectStats[project.id] === undefined
       );
-      if (hydrated) {
-        setFrozenLayout((previous) => {
+      if (!stillGuessing) {
+        setFrozenLayout((previous) =>
           // Identity, not truthiness: an effect left over from a previous open
-          // session must not consume this one's marker.
-          if (!previous || previous.coldStatsProjectIds !== coldStatsProjectIds) return previous;
-          return captureLayout(liveBrowseOrder);
-        });
+          // session must not recapture this one with a stale order.
+          previous === frozenLayout ? captureLayout(liveBrowseOrder) : previous
+        );
         return;
       }
     }
@@ -707,7 +709,8 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         order.push(project.id);
         sections.set(project.id, project.section);
       }
-      // Spread, so a session still waiting on its first stats stays cold.
+      // Spread, so a session still waiting on its first stats stays provisional
+      // and folds this arrival into its pending regroup.
       return { ...previous, order, sections };
     });
   }, [liveBrowseOrder, frozenLayout, projectStats, captureLayout]);
@@ -815,22 +818,20 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
       // not `browseOrdered`, which is still holding the previous session's
       // frozen shape at this point.
       //
-      // Cold means EVERY stats-sensitive row is unkeyed, not that the map is
-      // empty: a keyed all-zero entry is real data about an idle project, and
-      // one unkeyed row among settled ones is a project main hasn't reported
-      // yet — neither should unlock rows the user is already looking at.
-      // Active and unavailable rows are banded without stats, so they can't
-      // tell us anything about hydration; pinned rows can, since attention
+      // Provisional means EVERY stats-sensitive row is unkeyed, not that the
+      // map is empty: a keyed all-zero entry is real data about an idle
+      // project, and one unkeyed row among settled ones is a project main
+      // hasn't reported yet — neither should unlock rows the user is already
+      // looking at. Active and unavailable rows are banded without stats, so
+      // they say nothing about hydration; pinned rows do, since attention
       // outranks a pin.
-      const statsSensitiveIds = liveBrowseOrder
-        .filter((project) => !project.isActive && !project.isMissing)
-        .map((project) => project.id);
-      const coldStatsProjectIds =
-        statsSensitiveIds.length > 0 &&
-        statsSensitiveIds.every((id) => projectStats[id] === undefined)
-          ? new Set(statsSensitiveIds)
-          : null;
-      setFrozenLayout(captureLayout(liveBrowseOrder, coldStatsProjectIds));
+      const statsSensitive = liveBrowseOrder.filter(
+        (project) => !project.isActive && !project.isMissing
+      );
+      const isProvisional =
+        statsSensitive.length > 0 &&
+        statsSensitive.every((project) => projectStats[project.id] === undefined);
+      setFrozenLayout(captureLayout(liveBrowseOrder, isProvisional));
       // Preselect the first ENABLED row that isn't the project we're already
       // in, so open-then-Enter is a one-two return that never defaults onto an
       // Unavailable row (selecting one opens the relocation dialog — the right

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -264,6 +264,17 @@ export interface UseProjectSwitcherPaletteReturn {
   isDeletingOriginalScratch: boolean;
 }
 
+interface FrozenLayout {
+  order: string[];
+  sections: Map<string, ProjectSectionKey>;
+  /**
+   * Rows whose band this freeze guessed at because no stats entry had reached
+   * the view yet, or `null` once the layout reflects real data. Non-null only
+   * between a cold `open()` and the single regroup that resolves it.
+   */
+  coldStatsProjectIds: ReadonlySet<string> | null;
+}
+
 /**
  * Assign a project to its browse band. Actionable work first, then explicit
  * user intent, then non-actionable system activity, then habit:
@@ -636,15 +647,21 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   // Captured in `open()`/`close()` rather than during render. A ref written
   // while rendering leaks into the committed tree if React abandons that render,
   // and it never resets on a mode change that leaves the palette open.
-  const [frozenLayout, setFrozenLayout] = useState<{
-    order: string[];
-    sections: Map<string, ProjectSectionKey>;
-  } | null>(null);
+  // A session that opened before any stats reached this view froze a guess, not
+  // a decision: with no entry every row reads as zero agents and lands in
+  // "Other", so the palette shows one ungrouped band and only re-bands on the
+  // next open (#11452). `coldStatsProjectIds` records the rows that guess
+  // covered, so the first real data for them can regroup the list in place.
+  const [frozenLayout, setFrozenLayout] = useState<FrozenLayout | null>(null);
 
   const captureLayout = useCallback(
-    (projects: SearchableProject[]) => ({
+    (
+      projects: SearchableProject[],
+      coldStatsProjectIds: ReadonlySet<string> | null = null
+    ): FrozenLayout => ({
       order: projects.map((project) => project.id),
       sections: new Map(projects.map((project) => [project.id, project.section])),
+      coldStatsProjectIds,
     }),
     []
   );
@@ -655,6 +672,30 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   // the palette advertises would hold for the session's original rows only.
   useEffect(() => {
     if (!frozenLayout) return;
+
+    // A cold session's freeze is a placeholder. Once every row it guessed at
+    // has real data — or has gone away — recapture the whole layout so bands
+    // AND within-band order come from `liveBrowseOrder`'s real sort, then drop
+    // the marker. Holding out for all of them keeps the regroup a single
+    // decision rather than a trickle of rows moving under the pointer; if one
+    // never resolves the session simply behaves as it does today.
+    const { coldStatsProjectIds } = frozenLayout;
+    if (coldStatsProjectIds) {
+      const liveIds = new Set(liveBrowseOrder.map((project) => project.id));
+      const hydrated = [...coldStatsProjectIds].every(
+        (id) => !liveIds.has(id) || projectStats[id] !== undefined
+      );
+      if (hydrated) {
+        setFrozenLayout((previous) => {
+          // Identity, not truthiness: an effect left over from a previous open
+          // session must not consume this one's marker.
+          if (!previous || previous.coldStatsProjectIds !== coldStatsProjectIds) return previous;
+          return captureLayout(liveBrowseOrder);
+        });
+        return;
+      }
+    }
+
     const arrivals = liveBrowseOrder.filter((project) => !frozenLayout.sections.has(project.id));
     if (arrivals.length === 0) return;
     setFrozenLayout((previous) => {
@@ -666,9 +707,10 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         order.push(project.id);
         sections.set(project.id, project.section);
       }
-      return { order, sections };
+      // Spread, so a session still waiting on its first stats stays cold.
+      return { ...previous, order, sections };
     });
-  }, [liveBrowseOrder, frozenLayout]);
+  }, [liveBrowseOrder, frozenLayout, projectStats, captureLayout]);
 
   const browseOrdered = useMemo<SearchableProject[]>(() => {
     const frozen = frozenLayout;
@@ -772,7 +814,23 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
       // Freeze the layout for this open session. Taken from the live order,
       // not `browseOrdered`, which is still holding the previous session's
       // frozen shape at this point.
-      setFrozenLayout(captureLayout(liveBrowseOrder));
+      //
+      // Cold means EVERY stats-sensitive row is unkeyed, not that the map is
+      // empty: a keyed all-zero entry is real data about an idle project, and
+      // one unkeyed row among settled ones is a project main hasn't reported
+      // yet — neither should unlock rows the user is already looking at.
+      // Active and unavailable rows are banded without stats, so they can't
+      // tell us anything about hydration; pinned rows can, since attention
+      // outranks a pin.
+      const statsSensitiveIds = liveBrowseOrder
+        .filter((project) => !project.isActive && !project.isMissing)
+        .map((project) => project.id);
+      const coldStatsProjectIds =
+        statsSensitiveIds.length > 0 &&
+        statsSensitiveIds.every((id) => projectStats[id] === undefined)
+          ? new Set(statsSensitiveIds)
+          : null;
+      setFrozenLayout(captureLayout(liveBrowseOrder, coldStatsProjectIds));
       // Preselect the first ENABLED row that isn't the project we're already
       // in, so open-then-Enter is a one-two return that never defaults onto an
       // Unavailable row (selecting one opens the relocation dialog — the right
@@ -788,7 +846,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         liveBrowseOrder[0];
       setSelectedProjectId(initial?.id ?? null);
     },
-    [liveBrowseOrder, captureLayout]
+    [liveBrowseOrder, captureLayout, projectStats]
   );
 
   const close = useCallback(() => {


### PR DESCRIPTION
## The bug

Opening the project switcher could put every project in a single "Other projects" band, and it only sorted itself out after closing and reopening. Two things compound to cause it:

1. `ProjectStatsService.computeAndBroadcast()` suppresses a broadcast whose payload is unchanged. Waiting, blocked and completed-unreviewed agents are exactly the states that stop transitioning, so a view that loads while the fleet is static can sit on an empty stats map indefinitely — nothing ever re-sends.
2. `open()` freezes the band layout synchronously, while the bulk-stats seed that would populate it resolves later. With no stats entry every row reads as zero agents and falls to "Other", so the freeze captures a guess and `held()` then pins every row to it for the whole session.

The freeze itself is worth keeping — it's what stops a row moving under the pointer between the user deciding to click and clicking (#11450/#11071). This fixes it in place rather than removing it.

## The fix

A freeze taken before any stats arrived is a placeholder, not a decision, so the session is marked `isProvisional` and regrouped once — in place — when real data lands. Bands and within-band order both come from the real sort. After that single regroup the freeze behaves exactly as before.

Provisional means *every stats-sensitive row is unkeyed*, not *the map is empty*. A keyed all-zero entry is real data about an idle project, and one unkeyed row among settled ones is just a project main hasn't reported yet — neither should unlock rows the user is already looking at. Active and unavailable rows are banded without stats, so they're excluded from the test.

Hydration is judged against the rows that are live at that moment rather than a set captured at open. That matters: a project registering while the session is still a guess would otherwise be folded in at its own guessed band and then locked there by the regroup — the same bug, one row at a time. Reading live rows also means a project that goes away simply stops holding the regroup up.

On the main side, `ProjectStatsService.pushSnapshotTo()` replays the retained map to a freshly-loaded view from the `onViewReady` block that already does this for plugin contributions and run history. It skips an empty map: the initial compute is deferred, so `lastBroadcast` is `{}` for a window after boot, and sending that could only clobber a renderer the bulk seed had already filled. This narrows the empty-stats window; it's latency mitigation, not the correctness mechanism, since the renderer attaches its listener from a React effect and can miss the send.

## Testing

847 tests across 40 files pass locally. Both regroup behaviours are mutation-checked: disabling the hydration branch fails exactly the two regroup tests and nothing else, and reverting the late-arrival fix fails exactly that test.

The jitter guards still hold — "holds the order and the bands still while the palette is open" was strengthened so the mid-session push also fills a row that had no entry at open, proving a partial map is not a provisional session.

## Noted, not fixed (all pre-existing)

- ActionPalette's `/` route calls `openPalette("project-switcher")` directly, bypassing `open()` — so the freeze has never applied on that route at all.
- `registerInitialView` never calls `setupViewHandlers`, so the initial app view misses `onViewReady` on reload. This affects the plugin and run-history replays identically.

Resolves #11452