### PR TITLE
fix(file-panel): re-read the file when it changes on disk

### DIFF
--- a/src/components/FileViewer/FileImagePreview.tsx
+++ b/src/components/FileViewer/FileImagePreview.tsx
@@ -14,6 +14,14 @@ interface FileImagePreviewProps {
    * raw SVG must never reach this component.
    */
   sanitizedSvg?: string | null;
+  /**
+   * Opaque token appended to the raster `daintree-file://` URL. The protocol URL
+   * is otherwise a pure function of path and root, so a rewritten image on disk
+   * is never refetched — `Cache-Control: no-store` only governs a request that
+   * actually happens. Changing this changes the URL, which is what asks for one.
+   * Ignored for inlined SVG, which is re-read and re-sanitized upstream.
+   */
+  cacheBust?: string;
   onError?: () => void;
   /** Height cap for the preview surface — dialogs and panes want different ones. */
   maxHeightClassName?: string;
@@ -96,6 +104,7 @@ export function FileImagePreview({
   rootPath,
   alt,
   sanitizedSvg,
+  cacheBust,
   onError,
   maxHeightClassName = "max-h-[70vh]",
 }: FileImagePreviewProps) {
@@ -113,9 +122,15 @@ export function FileImagePreview({
       ) : (
         <img
           // Keyed by path so switching files remounts rather than showing the
-          // previous image until the new one decodes.
+          // previous image until the new one decodes. Deliberately not keyed by
+          // cacheBust: a rewritten image swaps its bytes in place, and the old
+          // frame stays painted until the new one decodes.
           key={filePath}
-          src={buildDaintreeFileUrl(filePath, rootPath)}
+          src={
+            cacheBust === undefined
+              ? buildDaintreeFileUrl(filePath, rootPath)
+              : `${buildDaintreeFileUrl(filePath, rootPath)}&v=${encodeURIComponent(cacheBust)}`
+          }
           alt={alt}
           className={`max-w-full ${maxHeightClassName} object-contain rounded`}
           draggable={false}

--- a/src/components/FileViewer/__tests__/FileImagePreview.test.tsx
+++ b/src/components/FileViewer/__tests__/FileImagePreview.test.tsx
@@ -11,6 +11,7 @@ import { describe, it, expect } from "vitest";
 import { render, cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
 import { FileImagePreview } from "../FileImagePreview";
+import { buildDaintreeFileUrl } from "../filePreviewKinds";
 
 afterEach(cleanup);
 
@@ -94,29 +95,40 @@ describe("FileImagePreview cache busting", () => {
     );
   }
 
-  function parseSrc(container: HTMLElement): URL {
+  function rawSrc(container: HTMLElement): string {
     const src = container.querySelector("img")?.getAttribute("src");
     if (!src) throw new Error("img not rendered");
-    return new URL(src);
+    return src;
+  }
+
+  function parseSrc(container: HTMLElement): URL {
+    return new URL(rawSrc(container));
+  }
+
+  /** The one parameter the token adds, whatever it happens to be named. */
+  function addedParam(busted: URL, canonical: URL): [string, string] {
+    const extra = [...busted.searchParams].filter(([key]) => !canonical.searchParams.has(key));
+    expect(extra).toHaveLength(1);
+    return extra[0];
   }
 
   it("leaves the URL untouched when no token is supplied", () => {
-    // Callers with nothing to invalidate against must not get a phantom param.
+    // Whole-URL equality, so a phantom `&…=undefined` fails no matter its name.
     const { container } = renderRaster();
 
-    expect(parseSrc(container).searchParams.has("v")).toBe(false);
+    expect(rawSrc(container)).toBe(buildDaintreeFileUrl("/repo/assets/logo.png", "/repo"));
   });
 
   it("carries an opaque token through without disturbing path or root", () => {
-    const token = "7 &v=x/?#";
+    // Reserved characters throughout: unencoded, this would inject extra
+    // parameters and corrupt the path/root the protocol resolves against.
+    const token = "7 &root=/etc/?#";
     const canonical = parseSrc(renderRaster().container);
     cleanup();
 
     const busted = parseSrc(renderRaster(token).container);
 
-    // Round-trips intact — an unencoded token would inject extra params and
-    // corrupt the path/root the protocol handler resolves against.
-    expect(busted.searchParams.get("v")).toBe(token);
+    expect(addedParam(busted, canonical)[1]).toBe(token);
     expect(busted.searchParams.get("path")).toBe(canonical.searchParams.get("path"));
     expect(busted.searchParams.get("root")).toBe(canonical.searchParams.get("root"));
   });
@@ -126,7 +138,7 @@ describe("FileImagePreview cache busting", () => {
     // point is to change the URL while the element survives.
     const { container, rerender } = renderRaster("1");
     const img = container.querySelector("img");
-    const before = parseSrc(container).searchParams.get("v");
+    const before = rawSrc(container);
 
     rerender(
       <FileImagePreview
@@ -138,7 +150,7 @@ describe("FileImagePreview cache busting", () => {
       />
     );
 
-    expect(parseSrc(container).searchParams.get("v")).not.toBe(before);
+    expect(rawSrc(container)).not.toBe(before);
     expect(container.querySelector("img")).toBe(img);
   });
 

--- a/src/components/FileViewer/__tests__/FileImagePreview.test.tsx
+++ b/src/components/FileViewer/__tests__/FileImagePreview.test.tsx
@@ -105,11 +105,11 @@ describe("FileImagePreview cache busting", () => {
     return new URL(rawSrc(container));
   }
 
-  /** The one parameter the token adds, whatever it happens to be named. */
-  function addedParam(busted: URL, canonical: URL): [string, string] {
+  /** The value of the one parameter the token adds, whatever it is named. */
+  function addedParamValue(busted: URL, canonical: URL): string | undefined {
     const extra = [...busted.searchParams].filter(([key]) => !canonical.searchParams.has(key));
     expect(extra).toHaveLength(1);
-    return extra[0];
+    return extra[0]?.[1];
   }
 
   it("leaves the URL untouched when no token is supplied", () => {
@@ -128,7 +128,7 @@ describe("FileImagePreview cache busting", () => {
 
     const busted = parseSrc(renderRaster(token).container);
 
-    expect(addedParam(busted, canonical)[1]).toBe(token);
+    expect(addedParamValue(busted, canonical)).toBe(token);
     expect(busted.searchParams.get("path")).toBe(canonical.searchParams.get("path"));
     expect(busted.searchParams.get("root")).toBe(canonical.searchParams.get("root"));
   });

--- a/src/components/FileViewer/__tests__/FileImagePreview.test.tsx
+++ b/src/components/FileViewer/__tests__/FileImagePreview.test.tsx
@@ -75,3 +75,86 @@ describe("FileImagePreview SVG inlining", () => {
     expect(img?.getAttribute("src")).toContain("daintree-file://");
   });
 });
+
+/**
+ * The protocol URL is a pure function of path and root, so a rewritten image is
+ * never refetched without a changing token (#11451). `Cache-Control: no-store`
+ * on the response only governs a request that actually happens.
+ */
+describe("FileImagePreview cache busting", () => {
+  function renderRaster(cacheBust?: string) {
+    return render(
+      <FileImagePreview
+        filePath="/repo/assets/logo.png"
+        rootPath="/repo"
+        alt="logo.png"
+        sanitizedSvg={null}
+        cacheBust={cacheBust}
+      />
+    );
+  }
+
+  function parseSrc(container: HTMLElement): URL {
+    const src = container.querySelector("img")?.getAttribute("src");
+    if (!src) throw new Error("img not rendered");
+    return new URL(src);
+  }
+
+  it("leaves the URL untouched when no token is supplied", () => {
+    // Callers with nothing to invalidate against must not get a phantom param.
+    const { container } = renderRaster();
+
+    expect(parseSrc(container).searchParams.has("v")).toBe(false);
+  });
+
+  it("carries an opaque token through without disturbing path or root", () => {
+    const token = "7 &v=x/?#";
+    const canonical = parseSrc(renderRaster().container);
+    cleanup();
+
+    const busted = parseSrc(renderRaster(token).container);
+
+    // Round-trips intact — an unencoded token would inject extra params and
+    // corrupt the path/root the protocol handler resolves against.
+    expect(busted.searchParams.get("v")).toBe(token);
+    expect(busted.searchParams.get("path")).toBe(canonical.searchParams.get("path"));
+    expect(busted.searchParams.get("root")).toBe(canonical.searchParams.get("root"));
+  });
+
+  it("swaps the src in place when the token changes, without remounting", () => {
+    // Remounting would drop the painted frame and flash empty mid-refresh; the
+    // point is to change the URL while the element survives.
+    const { container, rerender } = renderRaster("1");
+    const img = container.querySelector("img");
+    const before = parseSrc(container).searchParams.get("v");
+
+    rerender(
+      <FileImagePreview
+        filePath="/repo/assets/logo.png"
+        rootPath="/repo"
+        alt="logo.png"
+        sanitizedSvg={null}
+        cacheBust="2"
+      />
+    );
+
+    expect(parseSrc(container).searchParams.get("v")).not.toBe(before);
+    expect(container.querySelector("img")).toBe(img);
+  });
+
+  it("ignores the token when SVG markup is inlined", () => {
+    // Inlined SVG has no URL to bust — it is re-read and re-sanitized upstream.
+    const { container } = render(
+      <FileImagePreview
+        filePath="/repo/assets/icon.svg"
+        rootPath="/repo"
+        alt="icon.svg"
+        sanitizedSvg={`<svg xmlns="${SVG_NS}"><rect /></svg>`}
+        cacheBust="9"
+      />
+    );
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector("svg rect")).not.toBeNull();
+  });
+});

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -466,14 +466,16 @@ export function FilePane({
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const markdownViewerRef = useRef<MarkdownViewerHandle>(null);
   const codeViewerRef = useRef<CodeViewerHandle>(null);
-  // Whether something readable for the *current* file is already on screen.
-  // A silent refresh may only swallow a failure when there is good content to
-  // preserve — otherwise the pane would sit on a skeleton forever, waiting for
-  // a load that already failed. Reset per identity, since content from the
-  // previous file is not something worth keeping.
-  const hasGoodViewRef = useRef(false);
+  // The state the last good view of the *current* file settled into, or null if
+  // there has not been one. A silent refresh may only swallow a failure when
+  // there is good content to preserve, and swallowing has to restore this
+  // rather than merely return: the silent read may have superseded an explicit
+  // one that already switched the pane to its skeleton, and nothing else is
+  // left to settle it. Reset per identity — the previous file's content is not
+  // something worth keeping.
+  const lastGoodStateRef = useRef<LoadState | null>(null);
   useEffect(() => {
-    hasGoodViewRef.current = false;
+    lastGoodStateRef.current = null;
   }, [filePath, effectiveRootPath]);
 
   useEffect(() => {
@@ -594,13 +596,15 @@ export function FilePane({
               setLoadState("svg");
               setErrorCode(null);
               setErrorMessage(null);
-              hasGoodViewRef.current = true;
-            } else if (!silent || !hasGoodViewRef.current) {
+              lastGoodStateRef.current = "svg";
+            } else if (silent && lastGoodStateRef.current !== null) {
+              // A background pass catching a half-written file mid-save reads
+              // as a sanitizer rejection, so keep the last good drawing rather
+              // than replacing it — the same bargain the text path's transient
+              // -failure guard below makes.
+              setLoadState(lastGoodStateRef.current);
+            } else {
               // The file read fine; its contents just aren't safe to inline.
-              // A background pass catching a half-written file mid-save would
-              // read as sanitizer rejection, so keep the last good drawing
-              // rather than replacing it — the same bargain the text path's
-              // transient-failure guard below makes.
               setErrorCode("INVALID_PATH");
               setErrorMessage(sanitized.error);
               setLoadState("error");
@@ -618,7 +622,7 @@ export function FilePane({
           setLoadState("loaded");
           setErrorCode(null);
           setErrorMessage(null);
-          hasGoodViewRef.current = true;
+          lastGoodStateRef.current = "loaded";
         })
         .catch((error: unknown) => {
           if (requestRef.current !== requestId) return;
@@ -626,12 +630,16 @@ export function FilePane({
           // Silent background refreshes keep showing the last good content on
           // transient failures, but a permanently-gone file (deleted, perms
           // revoked) must surface rather than display stale text forever.
-          // Only worth swallowing when there is good content to keep: a silent
-          // pass that supersedes the very first read would otherwise strand the
-          // pane on its skeleton with nothing left to settle it.
+          // Only worth swallowing when there is good content to keep — and it
+          // has to be restored rather than merely left alone: this read may
+          // have superseded an explicit one that already showed the skeleton,
+          // in which case nothing else would ever settle it.
           const permanent =
             code === "NOT_FOUND" || code === "PERMISSION" || code === "OUTSIDE_ROOT";
-          if (silent && !permanent && hasGoodViewRef.current) return;
+          if (silent && !permanent && lastGoodStateRef.current !== null) {
+            setLoadState(lastGoodStateRef.current);
+            return;
+          }
           setErrorCode(code);
           setErrorMessage(null);
           setLoadState("error");

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -696,8 +696,7 @@ export function FilePane({
   // Video, audio and PDF are deliberately absent: their reload key only moves on
   // an explicit load, so a silent pass here would be inert for them anyway, and
   // widening it would reset playback or a reader's page on an unrelated write.
-  const reloadsSilently =
-    loadState === "loaded" || loadState === "image" || loadState === "svg";
+  const reloadsSilently = loadState === "loaded" || loadState === "image" || loadState === "svg";
 
   // Still worth re-reading on focus regain: a write that landed while no watcher
   // covered the file (opened outside every known worktree) has no tick at all.

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -466,6 +466,15 @@ export function FilePane({
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const markdownViewerRef = useRef<MarkdownViewerHandle>(null);
   const codeViewerRef = useRef<CodeViewerHandle>(null);
+  // Whether something readable for the *current* file is already on screen.
+  // A silent refresh may only swallow a failure when there is good content to
+  // preserve — otherwise the pane would sit on a skeleton forever, waiting for
+  // a load that already failed. Reset per identity, since content from the
+  // previous file is not something worth keeping.
+  const hasGoodViewRef = useRef(false);
+  useEffect(() => {
+    hasGoodViewRef.current = false;
+  }, [filePath, effectiveRootPath]);
 
   useEffect(() => {
     return () => {
@@ -585,8 +594,13 @@ export function FilePane({
               setLoadState("svg");
               setErrorCode(null);
               setErrorMessage(null);
-            } else {
+              hasGoodViewRef.current = true;
+            } else if (!silent || !hasGoodViewRef.current) {
               // The file read fine; its contents just aren't safe to inline.
+              // A background pass catching a half-written file mid-save would
+              // read as sanitizer rejection, so keep the last good drawing
+              // rather than replacing it — the same bargain the text path's
+              // transient-failure guard below makes.
               setErrorCode("INVALID_PATH");
               setErrorMessage(sanitized.error);
               setLoadState("error");
@@ -604,6 +618,7 @@ export function FilePane({
           setLoadState("loaded");
           setErrorCode(null);
           setErrorMessage(null);
+          hasGoodViewRef.current = true;
         })
         .catch((error: unknown) => {
           if (requestRef.current !== requestId) return;
@@ -611,9 +626,12 @@ export function FilePane({
           // Silent background refreshes keep showing the last good content on
           // transient failures, but a permanently-gone file (deleted, perms
           // revoked) must surface rather than display stale text forever.
+          // Only worth swallowing when there is good content to keep: a silent
+          // pass that supersedes the very first read would otherwise strand the
+          // pane on its skeleton with nothing left to settle it.
           const permanent =
             code === "NOT_FOUND" || code === "PERMISSION" || code === "OUTSIDE_ROOT";
-          if (silent && !permanent) return;
+          if (silent && !permanent && hasGoodViewRef.current) return;
           setErrorCode(code);
           setErrorMessage(null);
           setLoadState("error");
@@ -669,7 +687,8 @@ export function FilePane({
   // load, and firing here as well would read the same file twice.
   const lastChangeSignalRef = useRef({
     filePath,
-    worktreePath: diffWorktreePath,
+    readRoot: effectiveRootPath,
+    watchRoot: diffWorktreePath,
     tick: changeTick,
     viewMode,
   });
@@ -677,7 +696,8 @@ export function FilePane({
     const previous = lastChangeSignalRef.current;
     lastChangeSignalRef.current = {
       filePath,
-      worktreePath: diffWorktreePath,
+      readRoot: effectiveRootPath,
+      watchRoot: diffWorktreePath,
       tick: changeTick,
       viewMode,
     };
@@ -686,10 +706,17 @@ export function FilePane({
     // tick on either side of that transition would only duplicate the work.
     if (viewMode === "diff" || previous.viewMode === "diff") return;
     if (!filePath || !diffWorktreePath || changeTick === undefined) return;
-    if (previous.filePath !== filePath || previous.worktreePath !== diffWorktreePath) return;
-    if (previous.tick === changeTick) return;
+    // What the pane reads, versus what it watches. Only a change to the former
+    // implies an explicit load already happened — `loadFile` is keyed on those
+    // two alone, so acquiring a watcher moves `watchRoot` while leaving the read
+    // identity untouched, and nothing else would re-read.
+    if (previous.filePath !== filePath || previous.readRoot !== effectiveRootPath) return;
+    // A newly resolved worktree counts as a signal in its own right: whatever
+    // happened to the file before anything was watching it is exactly what the
+    // pane cannot otherwise know about.
+    if (previous.watchRoot === diffWorktreePath && previous.tick === changeTick) return;
     loadFile(true);
-  }, [filePath, diffWorktreePath, changeTick, viewMode, loadFile]);
+  }, [filePath, effectiveRootPath, diffWorktreePath, changeTick, viewMode, loadFile]);
 
   // Which surfaces a background re-read may replace. Images and inlined SVG join
   // "loaded" because both are cheap to re-request and show nothing but the file.

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -296,6 +296,34 @@ export function FilePane({
     [filePath, diffWorktreePath]
   );
 
+  // The containing worktree's "something moved on disk" signal, resolved off the
+  // same containment path as the diff subject rather than `panel.worktreeId`.
+  // Two ticks, because neither is sufficient alone: `worktreeChanges.lastUpdated`
+  // misses writes into gitignored folders (git status never moves), and the raw
+  // filesystem tick misses nothing but says nothing about git. Whichever moved
+  // most recently wins, matching FileBrowserPane (#11330). Scalar for the same
+  // reason as `localChangeStatus` — an object would re-render on every poll.
+  // `undefined` when the file is in no known worktree: no watcher covers it, so
+  // there is simply no live signal to give.
+  const changeTick = useWorktreeStore(
+    useCallback(
+      (state): number | undefined => {
+        if (!diffWorktreePath) return undefined;
+        for (const worktree of state.worktrees.values()) {
+          if (normalize(worktree.path) !== normalize(diffWorktreePath)) continue;
+          return (
+            Math.max(
+              worktree.worktreeChanges?.lastUpdated ?? 0,
+              state.workingTreeChangedAtById.get(worktree.id) ?? 0
+            ) || undefined
+          );
+        }
+        return undefined;
+      },
+      [diffWorktreePath]
+    )
+  );
+
   // Scalar status, never the change entry: `changes` is rebuilt wholesale every
   // poll tick, so returning the object would re-render the pane on each tick —
   // the same Object.is bail-out `selectDiffFreshnessKey` relies on (#8635).
@@ -415,9 +443,12 @@ export function FilePane({
   const [pathCopied, setPathCopied] = useState(false);
   // Sandboxed-iframe preview URL for HTML files (#11191), minted by files:read.
   const [htmlPreviewUrl, setHtmlPreviewUrl] = useState<string | null>(null);
-  // Bumped on every successful (re)load so the (cross-origin) preview frame
-  // re-navigates — a rewritten report re-renders on refresh/focus. Bumping on
-  // every load, not just entry-file changes, keeps relative assets fresh too.
+  // Reload generation for every surface whose content lives behind a URL rather
+  // than in React state: the sandboxed HTML preview frame, the media players,
+  // and the raster <img>. Their URLs are pure functions of path and root, so
+  // without a changing token a rewritten file is never re-requested. Bumped on
+  // every successful load, not just entry-file changes, so relative assets stay
+  // fresh too. Never a `loadFile` dependency — that would re-trigger the load.
   const [reloadNonce, setReloadNonce] = useState(0);
   // Which surface a toolbar Refresh press is currently spinning for (or null).
   // The mode is captured at click so a mode switch mid-refresh doesn't settle
@@ -463,6 +494,11 @@ export function FilePane({
       if (isImageFilePath(filePath) && !isSvgFilePath(filePath)) {
         setContent(null);
         setSanitizedSvg(null);
+        // Unconditionally, unlike the media branches below: a still image has no
+        // playback or reader position to protect, so a silent background pass
+        // should show the new bytes rather than preserve the old ones. Without
+        // this the <img> URL never changes and even toolbar Refresh is inert.
+        setReloadNonce((nonce) => nonce + 1);
         setLoadState("image");
         setErrorCode(null);
         setErrorMessage(null);
@@ -624,22 +660,61 @@ export function FilePane({
     wasDiffModeRef.current = viewMode === "diff";
   }, [viewMode, loadFile]);
 
-  // Agents rewrite files while the user reads them: silently re-read when the
-  // pane regains focus or the app window returns to the foreground.
+  // Agents rewrite files while the user watches, and the pane stays focused the
+  // whole time — so focus regain alone can't be the only live signal. Re-read
+  // silently whenever the containing worktree reports a change.
+  //
+  // Identity travels with the tick so only a genuine disk write triggers this: a
+  // path or root switch changes the tick too, but already has its own explicit
+  // load, and firing here as well would read the same file twice.
+  const lastChangeSignalRef = useRef({
+    filePath,
+    worktreePath: diffWorktreePath,
+    tick: changeTick,
+    viewMode,
+  });
+  useEffect(() => {
+    const previous = lastChangeSignalRef.current;
+    lastChangeSignalRef.current = {
+      filePath,
+      worktreePath: diffWorktreePath,
+      tick: changeTick,
+      viewMode,
+    };
+    // Diff owns its own freshness — useDiffContent subscribes to the same store
+    // and raises a stale banner — and leaving Diff already re-reads source, so a
+    // tick on either side of that transition would only duplicate the work.
+    if (viewMode === "diff" || previous.viewMode === "diff") return;
+    if (!filePath || !diffWorktreePath || changeTick === undefined) return;
+    if (previous.filePath !== filePath || previous.worktreePath !== diffWorktreePath) return;
+    if (previous.tick === changeTick) return;
+    loadFile(true);
+  }, [filePath, diffWorktreePath, changeTick, viewMode, loadFile]);
+
+  // Which surfaces a background re-read may replace. Images and inlined SVG join
+  // "loaded" because both are cheap to re-request and show nothing but the file.
+  // Video, audio and PDF are deliberately absent: their reload key only moves on
+  // an explicit load, so a silent pass here would be inert for them anyway, and
+  // widening it would reset playback or a reader's page on an unrelated write.
+  const reloadsSilently =
+    loadState === "loaded" || loadState === "image" || loadState === "svg";
+
+  // Still worth re-reading on focus regain: a write that landed while no watcher
+  // covered the file (opened outside every known worktree) has no tick at all.
   const wasFocusedRef = useRef(isFocused);
   useEffect(() => {
-    if (isFocused && !wasFocusedRef.current && loadState === "loaded") {
+    if (isFocused && !wasFocusedRef.current && reloadsSilently) {
       loadFile(true);
     }
     wasFocusedRef.current = isFocused;
-  }, [isFocused, loadState, loadFile]);
+  }, [isFocused, reloadsSilently, loadFile]);
 
   useEffect(() => {
-    if (loadState !== "loaded") return;
+    if (!reloadsSilently) return;
     const handleWindowFocus = () => loadFile(true);
     window.addEventListener("focus", handleWindowFocus);
     return () => window.removeEventListener("focus", handleWindowFocus);
-  }, [loadState, loadFile]);
+  }, [reloadsSilently, loadFile]);
 
   // Route Cmd+F to the source view's find bar while this pane is focused
   // (no-op in rendered markdown, matching the dialog).
@@ -966,6 +1041,7 @@ export function FilePane({
             rootPath={effectiveRootPath}
             alt={fileName ?? filePath}
             sanitizedSvg={loadState === "svg" ? sanitizedSvg : null}
+            cacheBust={String(reloadNonce)}
             onError={() => {
               setErrorCode("NOT_FOUND");
               setLoadState("error");

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -474,8 +474,13 @@ export function FilePane({
   // left to settle it. Reset per identity — the previous file's content is not
   // something worth keeping.
   const lastGoodStateRef = useRef<LoadState | null>(null);
+  // The text currently on screen for the *current* identity, so a silent re-read
+  // can tell an actual rewrite from a tick that changed nothing. Reset per
+  // identity alongside the state above.
+  const lastContentRef = useRef<string | null>(null);
   useEffect(() => {
     lastGoodStateRef.current = null;
+    lastContentRef.current = null;
   }, [filePath, effectiveRootPath]);
 
   useEffect(() => {
@@ -612,13 +617,20 @@ export function FilePane({
             return;
           }
           setSanitizedSvg(null);
+          const bytesChanged = lastContentRef.current !== fileContent;
+          lastContentRef.current = fileContent;
           setContent((previous) => (previous === fileContent ? previous : fileContent));
           setHtmlPreviewUrl(previewUrl ?? null);
-          // Re-navigate the preview frame on every successful load so a rewritten
-          // report — or an unchanged entry file whose relative asset changed —
-          // always reflects the latest bytes. reloadNonce isn't a loadFile dep,
-          // so this can't re-trigger the load.
-          setReloadNonce((nonce) => nonce + 1);
+          // Re-navigate the preview frame so a rewritten report — or an unchanged
+          // entry file whose relative asset changed — reflects the latest bytes.
+          // The nonce is the sandboxed frame's only src input, so a silent pass
+          // only bumps it when the bytes actually moved: otherwise every worktree
+          // tick, most of them writes to unrelated files, would throw away the
+          // rendered page's scroll and in-page JS state. Explicit loads (open,
+          // toolbar Refresh) stay unconditional, keeping a manual path for an
+          // asset-only change. reloadNonce isn't a loadFile dep, so neither can
+          // re-trigger the load.
+          if (!silent || bytesChanged) setReloadNonce((nonce) => nonce + 1);
           setLoadState("loaded");
           setErrorCode(null);
           setErrorMessage(null);
@@ -733,22 +745,30 @@ export function FilePane({
   // widening it would reset playback or a reader's page on an unrelated write.
   const reloadsSilently = loadState === "loaded" || loadState === "image" || loadState === "svg";
 
+  // Focus regain also retries a failure. A background re-read that raced a
+  // half-written file lands on an error the ticks can no longer clear — the one
+  // that reported the last write of a burst is the one that failed — so without
+  // this the pane sits on "File not found" for a file that exists until someone
+  // presses Refresh. A file that is genuinely gone just re-errors immediately
+  // through the permanent-code branch.
+  const refetchesOnFocus = reloadsSilently || loadState === "error";
+
   // Still worth re-reading on focus regain: a write that landed while no watcher
   // covered the file (opened outside every known worktree) has no tick at all.
   const wasFocusedRef = useRef(isFocused);
   useEffect(() => {
-    if (isFocused && !wasFocusedRef.current && reloadsSilently) {
+    if (isFocused && !wasFocusedRef.current && refetchesOnFocus) {
       loadFile(true);
     }
     wasFocusedRef.current = isFocused;
-  }, [isFocused, reloadsSilently, loadFile]);
+  }, [isFocused, refetchesOnFocus, loadFile]);
 
   useEffect(() => {
-    if (!reloadsSilently) return;
+    if (!refetchesOnFocus) return;
     const handleWindowFocus = () => loadFile(true);
     window.addEventListener("focus", handleWindowFocus);
     return () => window.removeEventListener("focus", handleWindowFocus);
-  }, [reloadsSilently, loadFile]);
+  }, [refetchesOnFocus, loadFile]);
 
   // Route Cmd+F to the source view's find bar while this pane is focused
   // (no-op in rendered markdown, matching the dialog).

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -1644,11 +1644,7 @@ describe("FilePane live disk refresh (#11451)", () => {
   const OUTER_ID = "wt-outer";
   const INNER_ID = "wt-inner";
 
-  function seedWorktree(
-    id: string,
-    path: string,
-    ticks: { git?: number; fs?: number } = {}
-  ): void {
+  function seedWorktree(id: string, path: string, ticks: { git?: number; fs?: number } = {}): void {
     const seeded: WorktreeLike = {
       id,
       path,

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -2,6 +2,7 @@
 import type { ReactNode } from "react";
 import { render, act, screen, waitFor, fireEvent } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GitStatus } from "@shared/types/git";
 
 // FilePane forwards a fixed prop list to ContentPanel; #10991 was a dropped
 // `showRestoreControl`, which hid the inline "Move to grid" button on a docked
@@ -64,15 +65,18 @@ vi.mock("@/store/preferencesStore", () => ({
 // change tick (#11451) reads `id` off the snapshot to index the side map, so a
 // seeded worktree missing one silently resolves no tick at all.
 interface WorktreeLike {
-  id?: string;
+  id: string;
   path: string;
   worktreeChanges?: {
-    changes: Array<{ path: string; status: string }>;
+    changes: Array<{ path: string; status: GitStatus }>;
     lastUpdated?: number;
   } | null;
 }
 const worktreeState = vi.hoisted(() => ({
-  worktrees: new Map<string, unknown>(),
+  // Typed rather than `unknown`: the mocked hook hands the state to the pane's
+  // selectors as `unknown`, so nothing else would catch a seed whose shape has
+  // drifted from the real snapshot — and vitest never typechecks.
+  worktrees: new Map<string, WorktreeLike>(),
   // The raw filesystem-write tick, keyed by worktree id and stored beside the
   // snapshots rather than on them (#11330). Absent here, the pane's change-tick
   // selector would throw on `.get`.
@@ -114,7 +118,11 @@ vi.mock("@/components/Markdown/MarkdownViewer", () => ({
   },
 }));
 vi.mock("@/components/FileViewer/CodeViewer", () => ({
-  CodeViewer: () => <div data-testid="code-viewer-mock" />,
+  // Surfaces `content` so a re-read's result is observable — the only way to
+  // tell a stale settle apart from a fresh one (#11451).
+  CodeViewer: (props: { content?: string }) => (
+    <div data-testid="code-viewer-mock" data-content={props.content ?? ""} />
+  ),
 }));
 // Typed rather than bare vi.fn() so reading .mock.calls needs no `as` cast
 // (which would regress the no-unsafe-type-assertion ratchet).
@@ -948,6 +956,7 @@ describe("FilePane diff mode (#11274)", () => {
 
   function seedWorktree(changes: Array<{ path: string; status: string }> | null) {
     const worktree: WorktreeLike = {
+      id: WORKTREE_ID,
       path: WORKTREE_PATH,
       worktreeChanges: changes === null ? null : { changes },
     };
@@ -1212,7 +1221,11 @@ describe("FilePane diff mode (#11274)", () => {
 
     it("finds the change when the panel is bound to a different worktree", async () => {
       seedWorktree([{ path: "/repo/src/index.ts", status: "modified" }]);
-      worktreeState.worktrees.set("wt-other", { path: "/other", worktreeChanges: { changes: [] } });
+      worktreeState.worktrees.set("wt-other", {
+        id: "wt-other",
+        path: "/other",
+        worktreeChanges: { changes: [] },
+      });
       await renderPane({ filePath: "/repo/src/index.ts", worktreeId: "wt-other" });
       expect(toggleLabels()).toContain("Diff");
     });
@@ -1227,10 +1240,12 @@ describe("FilePane diff mode (#11274)", () => {
     // worktree rather than its parent — which may not list it as changed.
     it("prefers the deepest containing worktree", async () => {
       worktreeState.worktrees.set("wt-outer", {
+        id: "wt-outer",
         path: "/repo",
         worktreeChanges: { changes: [] },
       });
       worktreeState.worktrees.set("wt-inner", {
+        id: "wt-inner",
         path: "/repo/nested",
         worktreeChanges: { changes: [{ path: "src/index.ts", status: "added" }] },
       });
@@ -1387,10 +1402,12 @@ describe("FilePane diff mode (#11274)", () => {
       // Panel is stamped with the outer worktree; the file lives in the nested
       // one, so the relative paths in the diff are relative to the nested root.
       worktreeState.worktrees.set(WORKTREE_ID, {
+        id: WORKTREE_ID,
         path: WORKTREE_PATH,
         worktreeChanges: { changes: [] },
       });
       worktreeState.worktrees.set("wt-inner", {
+        id: "wt-inner",
         path: "/repo/nested",
         worktreeChanges: { changes: [{ path: "src/index.ts", status: "modified" }] },
       });
@@ -1592,6 +1609,7 @@ describe("FilePane toolbar refresh spin (#11323)", () => {
     // A modified file so Diff mode is available; the diff never resolves
     // (content stays undefined), the exact shape that stranded the old predicate.
     worktreeState.worktrees.set("wt-1", {
+      id: "wt-1",
       path: "/repo",
       worktreeChanges: { changes: [{ path: "/repo/src/index.ts", status: "modified" }] },
     });
@@ -1705,6 +1723,21 @@ describe("FilePane live disk refresh (#11451)", () => {
     return container.querySelector('[role="status"][aria-label="Loading file"]');
   }
 
+  function viewerContent(container: HTMLElement): string | null {
+    return (
+      container.querySelector('[data-testid="code-viewer-mock"]')?.getAttribute("data-content") ??
+      null
+    );
+  }
+
+  function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((res) => {
+      resolve = res;
+    });
+    return { promise, resolve };
+  }
+
   it("re-reads the file when the containing worktree's git-status tick moves", async () => {
     seedWorktree(OUTER_ID, "/repo", { git: 100 });
     readMock.mockResolvedValue({ content: "v1" });
@@ -1759,12 +1792,72 @@ describe("FilePane live disk refresh (#11451)", () => {
     seedWorktree(OUTER_ID, "/repo", { git: 100 });
     readMock.mockResolvedValue({ content: "v1" });
     const { rerender } = await renderPane({ filePath: "/elsewhere/notes.txt" });
-    const initialReads = readMock.mock.calls.length;
+    // The pane does read it once — the baseline is a real read, so the
+    // assertion below can't pass merely because nothing ever happened.
+    expect(readMock).toHaveBeenCalled();
+    readMock.mockClear();
 
     seedWorktree(OUTER_ID, "/repo", { git: 200, fs: 300 });
     await commitTick(rerender);
 
-    expect(readMock.mock.calls.length).toBe(initialReads);
+    expect(readMock).not.toHaveBeenCalled();
+  });
+
+  it("re-reads once, not twice, when a tick lands together with leaving Diff", async () => {
+    // The tick effect and the leave-Diff effect both fire on that commit; the
+    // tick side defers so the file is read once rather than twice.
+    worktreeState.worktrees.set(OUTER_ID, {
+      id: OUTER_ID,
+      path: "/repo",
+      worktreeChanges: {
+        changes: [{ path: "/repo/src/index.ts", status: "modified" }],
+        lastUpdated: 100,
+      },
+    });
+    useDiffContentMock.mockReturnValue({ content: "diff", stale: false, retry: vi.fn() });
+    readMock.mockResolvedValue({ content: "v1" });
+    const { rerender } = await renderPane({ fileViewMode: "diff" });
+    readMock.mockClear();
+
+    // Tick and mode change land in the same commit.
+    worktreeState.worktrees.set(OUTER_ID, {
+      id: OUTER_ID,
+      path: "/repo",
+      worktreeChanges: {
+        changes: [{ path: "/repo/src/index.ts", status: "modified" }],
+        lastUpdated: 200,
+      },
+    });
+    panelsById["file-1"] = {
+      id: "file-1",
+      kind: "file",
+      filePath: "/repo/src/index.ts",
+      worktreeId: OUTER_ID,
+      fileViewMode: "source",
+    };
+    await commitTick(rerender);
+
+    expect(readMock.mock.calls.length).toBe(1);
+  });
+
+  it("re-reads when a nearer worktree takes over watching an already-open file", async () => {
+    // Both ticks are 100 throughout, so only the change of *which* worktree is
+    // watched can trigger this. Nothing was watching /repo/packages/app before,
+    // making whatever happened there invisible — and because the pane still
+    // reads against /repo, its read identity never moves and no explicit load
+    // covers the handover.
+    seedWorktree(OUTER_ID, "/repo", { git: 100 });
+    readMock.mockResolvedValue({ content: "v1" });
+    const { rerender } = await renderPane({
+      filePath: "/repo/packages/app/src/index.ts",
+      worktreeId: OUTER_ID,
+    });
+    readMock.mockClear();
+
+    seedWorktree(INNER_ID, "/repo/packages/app", { git: 100 });
+    await commitTick(rerender);
+
+    expect(readMock).toHaveBeenCalled();
   });
 
   it("keeps the current viewer on screen while a tick's re-read is in flight", async () => {
@@ -1856,10 +1949,85 @@ describe("FilePane live disk refresh (#11451)", () => {
     expect(container.querySelector("svg rect")).toBeNull();
   });
 
+  it("keeps the last good SVG when a background re-read catches it half-written", async () => {
+    // A tick can land mid-save, and truncated markup reads as a sanitizer
+    // rejection. Replacing a good drawing with an error over that would be the
+    // same mistake the text path's transient-failure guard already avoids.
+    seedWorktree(OUTER_ID, "/repo", { git: 100 });
+    readMock.mockResolvedValue({
+      content: '<svg xmlns="http://www.w3.org/2000/svg"><rect /></svg>',
+    });
+    const { container, rerender } = await renderPane({ filePath: "/repo/assets/icon.svg" });
+    await waitFor(() => expect(container.querySelector("svg rect")).not.toBeNull());
+
+    readMock.mockResolvedValue({ content: "<svg" });
+    seedWorktree(OUTER_ID, "/repo", { git: 200 });
+    await commitTick(rerender);
+
+    expect(container.querySelector("svg rect")).not.toBeNull();
+  });
+
+  it("surfaces unusable SVG markup on the first read rather than hanging", async () => {
+    // Nothing good is on screen yet, so there is nothing to preserve — the
+    // failure has to settle the pane instead of leaving it mid-load.
+    readMock.mockResolvedValue({ content: "<svg" });
+    const { container } = await renderPane({ filePath: "/repo/assets/icon.svg" });
+
+    // Settled into the error surface — not still sitting on the skeleton.
+    await waitFor(() => expect(screen.getByText("Retry")).toBeTruthy());
+    expect(loadingSkeleton(container)).toBeNull();
+  });
+
+  it("re-reads an SVG when the app window regains the foreground", async () => {
+    // A separate listener from the pane-focus one, and the only automatic
+    // signal a file outside every worktree ever gets — no tick can reach it.
+    readMock.mockResolvedValue({
+      content: '<svg xmlns="http://www.w3.org/2000/svg"><rect /></svg>',
+    });
+    const { container } = await renderPane({ filePath: "/elsewhere/icon.svg" });
+    await waitFor(() => expect(container.querySelector("svg rect")).not.toBeNull());
+
+    readMock.mockResolvedValue({
+      content: '<svg xmlns="http://www.w3.org/2000/svg"><circle /></svg>',
+    });
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    await waitFor(() => expect(container.querySelector("svg circle")).not.toBeNull());
+  });
+
+  it("keeps the newest bytes when two overlapping re-reads settle out of order", async () => {
+    // Ticks can now start a read while another is still in flight, so the
+    // latest-request-wins guard is reachable for the first time: a slow earlier
+    // read must not overwrite a newer one that already landed.
+    seedWorktree(OUTER_ID, "/repo", { git: 100 });
+    readMock.mockResolvedValue({ content: "v1" });
+    const { container, rerender } = await renderPane({});
+
+    const first = deferred<{ content: string }>();
+    const second = deferred<{ content: string }>();
+    readMock.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+
+    seedWorktree(OUTER_ID, "/repo", { git: 200 });
+    await commitTick(rerender);
+    seedWorktree(OUTER_ID, "/repo", { git: 300 });
+    await commitTick(rerender);
+
+    // Newer read lands first, then the stale one tries to overwrite it.
+    await act(async () => {
+      second.resolve({ content: "newest" });
+    });
+    await act(async () => {
+      first.resolve({ content: "stale" });
+    });
+
+    expect(viewerContent(container)).toBe("newest");
+  });
+
   it("leaves the hidden source alone while Diff owns the surface", async () => {
     // useDiffContent subscribes to the same store and raises its own stale
     // banner; re-reading source nobody can see would just duplicate the work.
-    seedWorktree(OUTER_ID, "/repo", { git: 100 });
     worktreeState.worktrees.set(OUTER_ID, {
       id: OUTER_ID,
       path: "/repo",
@@ -1888,8 +2056,14 @@ describe("FilePane live disk refresh (#11451)", () => {
 
   describe("media keeps playing across a tick", () => {
     // Same fetch-to-blob boundary the video/audio suites above stub: Chromium's
-    // custom-scheme media loader can't do follow-up range requests.
-    const mediaFetchMock = vi.fn();
+    // custom-scheme media loader can't do follow-up range requests. Typed so
+    // reading .mock.calls needs no cast (which would regress the lint ratchet).
+    const mediaFetchMock =
+      vi.fn<
+        (
+          input: string | URL | Request
+        ) => Promise<Pick<Response, "ok" | "status" | "headers" | "blob">>
+      >();
     const realCreateObjectURL = URL.createObjectURL;
     const realRevokeObjectURL = URL.revokeObjectURL;
     beforeEach(() => {
@@ -1924,6 +2098,37 @@ describe("FilePane live disk refresh (#11451)", () => {
 
       expect(container.querySelector("video")).toBe(playerBefore);
       expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore);
+    });
+
+    it("keeps the same <audio> element rather than refetching", async () => {
+      // Its own nonce condition, separate from video's — a regression in one
+      // leaves the other's test green while restarting the track being played.
+      seedWorktree(OUTER_ID, "/repo", { git: 100 });
+      const { container, rerender } = await renderPane({ filePath: "/repo/media/track.mp3" });
+      await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+      const playerBefore = container.querySelector("audio");
+      const fetchesBefore = mediaFetchMock.mock.calls.length;
+
+      seedWorktree(OUTER_ID, "/repo", { git: 200, fs: 300 });
+      await commitTick(rerender);
+
+      expect(container.querySelector("audio")).toBe(playerBefore);
+      expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore);
+    });
+
+    it("keeps the same PDF frame and URL rather than re-navigating", async () => {
+      // Reloading the frame would throw away the reader's page and zoom.
+      seedWorktree(OUTER_ID, "/repo", { git: 100 });
+      const { container, rerender } = await renderPane({ filePath: "/repo/docs/spec.pdf" });
+      await waitFor(() => expect(container.querySelector("iframe")).not.toBeNull());
+      const frameBefore = container.querySelector("iframe");
+      const srcBefore = frameBefore?.getAttribute("src");
+
+      seedWorktree(OUTER_ID, "/repo", { git: 200, fs: 300 });
+      await commitTick(rerender);
+
+      expect(container.querySelector("iframe")).toBe(frameBefore);
+      expect(container.querySelector("iframe")?.getAttribute("src")).toBe(srcBefore);
     });
   });
 });

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -954,7 +954,7 @@ describe("FilePane diff mode (#11274)", () => {
   const WORKTREE_ID = "wt-1";
   const WORKTREE_PATH = "/repo";
 
-  function seedWorktree(changes: Array<{ path: string; status: string }> | null) {
+  function seedWorktree(changes: Array<{ path: string; status: GitStatus }> | null) {
     const worktree: WorktreeLike = {
       id: WORKTREE_ID,
       path: WORKTREE_PATH,
@@ -1965,6 +1965,36 @@ describe("FilePane live disk refresh (#11451)", () => {
     await commitTick(rerender);
 
     expect(container.querySelector("svg rect")).not.toBeNull();
+  });
+
+  it("settles the pane when a failing tick read supersedes an explicit refresh", async () => {
+    // Refresh shows the skeleton, then a tick's silent read supersedes it and
+    // fails transiently. Swallowing that failure outright would leave nothing
+    // to settle the pane: the explicit read is already stale, so the skeleton
+    // and the toolbar spin would stay up forever.
+    seedWorktree(OUTER_ID, "/repo", { git: 100 });
+    readMock.mockResolvedValue({ content: "v1" });
+    const { container, rerender } = await renderPane({});
+
+    const explicit = deferred<{ content: string }>();
+    readMock.mockReturnValueOnce(explicit.promise);
+    await act(async () => {
+      Array.from(container.querySelectorAll("button"))
+        .find((b) => b.getAttribute("aria-label") === "Refresh")
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(loadingSkeleton(container)).not.toBeNull();
+
+    // The tick's read supersedes the explicit one, then fails transiently.
+    readMock.mockRejectedValueOnce(new Error("EBUSY"));
+    seedWorktree(OUTER_ID, "/repo", { git: 200 });
+    await commitTick(rerender);
+    await act(async () => {
+      explicit.resolve({ content: "v1" });
+    });
+
+    expect(loadingSkeleton(container)).toBeNull();
+    expect(viewerContent(container)).toBe("v1");
   });
 
   it("surfaces unusable SVG markup on the first read rather than hanging", async () => {

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -1930,6 +1930,28 @@ describe("FilePane live disk refresh (#11451)", () => {
     expect(imageSrc(container)).not.toBe(before);
   });
 
+  it("retries an image that failed a background refetch when the pane regains focus", async () => {
+    // A refetch racing a half-written PNG fires <img> onError, and the tick that
+    // reported the last write of a burst is the one that lost the race — nothing
+    // else follows it, so without a focus retry the pane sits on "File not
+    // found" for a file that is right there.
+    seedWorktree(OUTER_ID, "/repo", { git: 100 });
+    const { container, rerender } = await renderPane({
+      filePath: "/repo/assets/logo.png",
+      isFocused: false,
+    });
+
+    const img = container.querySelector("img");
+    if (!img) throw new Error("image preview not rendered");
+    fireEvent.error(img);
+    expect(screen.getByText(FILE_READ_ERROR_MESSAGES.NOT_FOUND)).toBeTruthy();
+
+    await commitTick(rerender, true);
+
+    expect(screen.queryByText(FILE_READ_ERROR_MESSAGES.NOT_FOUND)).toBeNull();
+    expect(container.querySelector("img")).not.toBeNull();
+  });
+
   it("re-reads and re-sanitizes an SVG on a worktree tick", async () => {
     seedWorktree(OUTER_ID, "/repo", { git: 100 });
     readMock.mockResolvedValue({
@@ -2082,6 +2104,73 @@ describe("FilePane live disk refresh (#11451)", () => {
     await commitTick(rerender);
 
     expect(readMock.mock.calls.length).toBe(initialReads);
+  });
+
+  describe("rendered HTML across a tick", () => {
+    const PREVIEW_URL = "daintree-html://tok/report.html";
+
+    function htmlNonce(container: HTMLElement): string {
+      const nonce = container
+        .querySelector('[data-testid="html-viewer-mock"]')
+        ?.getAttribute("data-reload-nonce");
+      if (nonce === null || nonce === undefined) throw new Error("html viewer not rendered");
+      return nonce;
+    }
+
+    async function renderRendered() {
+      seedWorktree(OUTER_ID, "/repo", { git: 100 });
+      readMock.mockResolvedValue({ content: "<h1>v1</h1>", htmlPreviewUrl: PREVIEW_URL });
+      const view = await renderPane({
+        filePath: "/repo/dist/report.html",
+        fileViewMode: "rendered",
+      });
+      await waitFor(() => expect(htmlNonce(view.container)).toBeTruthy());
+      return view;
+    }
+
+    it("holds the frame steady when a tick returns identical bytes", async () => {
+      // The nonce is the sandboxed frame's only src input, so bumping it on a
+      // no-op tick re-navigates the page — losing scroll and every bit of
+      // in-page JS state — each time an agent writes an unrelated file.
+      const { container, rerender } = await renderRendered();
+      const before = htmlNonce(container);
+      const readsBefore = readMock.mock.calls.length;
+
+      seedWorktree(OUTER_ID, "/repo", { git: 200 });
+      await commitTick(rerender);
+      await act(async () => {});
+
+      // The re-read really happened; it just had nothing to show for it.
+      expect(readMock.mock.calls.length).toBe(readsBefore + 1);
+      expect(htmlNonce(container)).toBe(before);
+    });
+
+    it("re-navigates the frame when a tick brings new bytes", async () => {
+      const { container, rerender } = await renderRendered();
+      const before = htmlNonce(container);
+
+      readMock.mockResolvedValue({ content: "<h1>v2</h1>", htmlPreviewUrl: PREVIEW_URL });
+      seedWorktree(OUTER_ID, "/repo", { git: 200 });
+      await commitTick(rerender);
+
+      await waitFor(() => expect(htmlNonce(container)).not.toBe(before));
+    });
+
+    it("re-navigates the frame on toolbar Refresh even when the bytes are identical", async () => {
+      // An entry file can be unchanged while a relative asset it pulls in is
+      // not, so the explicit path stays unconditional — it is the only way to
+      // ask for those bytes again.
+      const { container } = await renderRendered();
+      const before = htmlNonce(container);
+
+      await act(async () => {
+        Array.from(container.querySelectorAll("button"))
+          .find((b) => b.getAttribute("aria-label") === "Refresh")
+          ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      await waitFor(() => expect(htmlNonce(container)).not.toBe(before));
+    });
   });
 
   describe("media keeps playing across a tick", () => {

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -60,11 +60,24 @@ vi.mock("@/store/preferencesStore", () => ({
 }));
 // Mutable so a test can seed a worktree whose change list makes the file
 // locally changed — the Diff option's only trigger (#11274).
+// Field names mirror WorktreeSnapshot / WorktreeViewState exactly: the live
+// change tick (#11451) reads `id` off the snapshot to index the side map, so a
+// seeded worktree missing one silently resolves no tick at all.
 interface WorktreeLike {
+  id?: string;
   path: string;
-  worktreeChanges?: { changes: Array<{ path: string; status: string }> } | null;
+  worktreeChanges?: {
+    changes: Array<{ path: string; status: string }>;
+    lastUpdated?: number;
+  } | null;
 }
-const worktreeState = vi.hoisted(() => ({ worktrees: new Map<string, unknown>() }));
+const worktreeState = vi.hoisted(() => ({
+  worktrees: new Map<string, unknown>(),
+  // The raw filesystem-write tick, keyed by worktree id and stored beside the
+  // snapshots rather than on them (#11330). Absent here, the pane's change-tick
+  // selector would throw on `.get`.
+  workingTreeChangedAtById: new Map<string, number>(),
+}));
 vi.mock("@/hooks/useWorktreeStore", () => ({
   useWorktreeStore: (selector: (state: unknown) => unknown) => selector(worktreeState),
 }));
@@ -154,6 +167,7 @@ beforeEach(() => {
   useDiffContentMock.mockReset();
   useDiffContentMock.mockReturnValue({ content: undefined, stale: false, retry: vi.fn() });
   worktreeState.worktrees.clear();
+  worktreeState.workingTreeChangedAtById.clear();
   // Reset per test so a prior test's read call can't satisfy a later
   // toHaveBeenCalledWith assertion (cross-test contamination).
   readMock.mockReset();
@@ -1619,5 +1633,301 @@ describe("FilePane toolbar refresh spin (#11323)", () => {
       refreshIcon(container).dispatchEvent(new Event("animationiteration", { bubbles: true }));
     });
     expect(refreshIcon(container).classList.contains("animate-spin")).toBe(false);
+  });
+});
+
+// #11451: the pane had no live signal at all. Text only re-read on focus
+// regain — never while the pane stayed focused, which is exactly when an agent
+// is rewriting the file — and images, whose URL is a pure function of path and
+// root, never re-read even on an explicit Refresh.
+describe("FilePane live disk refresh (#11451)", () => {
+  const OUTER_ID = "wt-outer";
+  const INNER_ID = "wt-inner";
+
+  function seedWorktree(
+    id: string,
+    path: string,
+    ticks: { git?: number; fs?: number } = {}
+  ): void {
+    const seeded: WorktreeLike = {
+      id,
+      path,
+      worktreeChanges: ticks.git === undefined ? null : { changes: [], lastUpdated: ticks.git },
+    };
+    worktreeState.worktrees.set(id, seeded);
+    if (ticks.fs !== undefined) worktreeState.workingTreeChangedAtById.set(id, ticks.fs);
+  }
+
+  function paneElement(isFocused = false) {
+    return (
+      <TooltipProvider>
+        <FilePane
+          id="file-1"
+          title="index.ts"
+          isFocused={isFocused}
+          location="grid"
+          onFocus={() => {}}
+          onClose={() => {}}
+        />
+      </TooltipProvider>
+    );
+  }
+
+  async function renderPane(options: {
+    filePath?: string;
+    worktreeId?: string;
+    fileViewMode?: string;
+    isFocused?: boolean;
+  }) {
+    panelsById["file-1"] = {
+      id: "file-1",
+      kind: "file",
+      filePath: options.filePath ?? "/repo/src/index.ts",
+      worktreeId: options.worktreeId ?? OUTER_ID,
+      fileViewMode: options.fileViewMode,
+    };
+    const view = render(paneElement(options.isFocused));
+    // Can't wait on readMock — image and media paths short-circuit before it.
+    await act(async () => {});
+    return view;
+  }
+
+  /** The mocked store is a plain object, so a tick only lands on re-render. */
+  async function commitTick(rerender: (ui: ReactNode) => void, isFocused = false) {
+    await act(async () => {
+      rerender(paneElement(isFocused));
+    });
+  }
+
+  function imageSrc(container: HTMLElement): string {
+    const src = container.querySelector("img")?.getAttribute("src");
+    if (!src) throw new Error("image preview not rendered");
+    return src;
+  }
+
+  function loadingSkeleton(container: HTMLElement): Element | null {
+    return container.querySelector('[role="status"][aria-label="Loading file"]');
+  }
+
+  it("re-reads the file when the containing worktree's git-status tick moves", async () => {
+    seedWorktree(OUTER_ID, "/repo", { git: 100 });
+    readMock.mockResolvedValue({ content: "v1" });
+    const { rerender } = await renderPane({});
+    const initialReads = readMock.mock.calls.length;
+
+    seedWorktree(OUTER_ID, "/repo", { git: 200 });
+    await commitTick(rerender);
+
+    expect(readMock.mock.calls.length).toBe(initialReads + 1);
+  });
+
+  it("re-reads the file when only the raw filesystem-write tick moves", async () => {
+    // A write into a gitignored folder never moves git status, so the git tick
+    // alone would leave the pane stale — the reason both signals are combined.
+    seedWorktree(OUTER_ID, "/repo", { fs: 100 });
+    readMock.mockResolvedValue({ content: "v1" });
+    const { rerender } = await renderPane({});
+    const initialReads = readMock.mock.calls.length;
+
+    seedWorktree(OUTER_ID, "/repo", { fs: 200 });
+    await commitTick(rerender);
+
+    expect(readMock.mock.calls.length).toBe(initialReads + 1);
+  });
+
+  it("takes its tick from the deepest worktree containing the file, not the panel's", async () => {
+    // `file.openPanel` stamps the *active* worktree id even when the file lives
+    // in another one, so trusting `panel.worktreeId` would watch the wrong tree.
+    seedWorktree(OUTER_ID, "/repo", { git: 100 });
+    seedWorktree(INNER_ID, "/repo/packages/app", { git: 100 });
+    readMock.mockResolvedValue({ content: "v1" });
+    const { rerender } = await renderPane({
+      filePath: "/repo/packages/app/src/index.ts",
+      worktreeId: OUTER_ID,
+    });
+    const initialReads = readMock.mock.calls.length;
+
+    // The panel's own worktree moving is not this file's business.
+    seedWorktree(OUTER_ID, "/repo", { git: 200 });
+    await commitTick(rerender);
+    expect(readMock.mock.calls.length).toBe(initialReads);
+
+    seedWorktree(INNER_ID, "/repo/packages/app", { git: 200 });
+    await commitTick(rerender);
+    expect(readMock.mock.calls.length).toBe(initialReads + 1);
+  });
+
+  it("stays quiet for a file outside every known worktree", async () => {
+    // No watcher covers it, so there is no tick to resolve — it must degrade to
+    // no live signal rather than reading on every unrelated worktree update.
+    seedWorktree(OUTER_ID, "/repo", { git: 100 });
+    readMock.mockResolvedValue({ content: "v1" });
+    const { rerender } = await renderPane({ filePath: "/elsewhere/notes.txt" });
+    const initialReads = readMock.mock.calls.length;
+
+    seedWorktree(OUTER_ID, "/repo", { git: 200, fs: 300 });
+    await commitTick(rerender);
+
+    expect(readMock.mock.calls.length).toBe(initialReads);
+  });
+
+  it("keeps the current viewer on screen while a tick's re-read is in flight", async () => {
+    // The whole point of a background re-read: no skeleton swap, so the reader
+    // keeps their content and scroll position while the new bytes land.
+    seedWorktree(OUTER_ID, "/repo", { git: 100 });
+    readMock.mockResolvedValue({ content: "v1" });
+    const { container, rerender } = await renderPane({});
+    const viewerBefore = container.querySelector('[data-testid="code-viewer-mock"]');
+    expect(viewerBefore).not.toBeNull();
+
+    let resolveRead!: (value: { content: string }) => void;
+    readMock.mockReturnValueOnce(
+      new Promise<{ content: string }>((resolve) => {
+        resolveRead = resolve;
+      })
+    );
+    seedWorktree(OUTER_ID, "/repo", { git: 200 });
+    await commitTick(rerender);
+
+    expect(loadingSkeleton(container)).toBeNull();
+    // Same node, not merely an equivalent one — a remount would reset scroll.
+    expect(container.querySelector('[data-testid="code-viewer-mock"]')).toBe(viewerBefore);
+
+    await act(async () => {
+      resolveRead({ content: "v2" });
+    });
+  });
+
+  it("re-requests a raster image on a worktree tick", async () => {
+    seedWorktree(OUTER_ID, "/repo", { git: 100 });
+    const { container, rerender } = await renderPane({ filePath: "/repo/assets/logo.png" });
+    const before = imageSrc(container);
+
+    seedWorktree(OUTER_ID, "/repo", { git: 200 });
+    await commitTick(rerender);
+
+    // The URL must actually change: identical `src` lets Chromium skip the
+    // fetch entirely, which is why `Cache-Control: no-store` alone never helped.
+    expect(imageSrc(container)).not.toBe(before);
+    expect(readMock).not.toHaveBeenCalled();
+  });
+
+  it("re-requests a raster image on toolbar Refresh", async () => {
+    // The headline symptom: the icon spun and the image never reloaded.
+    seedWorktree(OUTER_ID, "/repo", { git: 100 });
+    const { container } = await renderPane({ filePath: "/repo/assets/logo.png" });
+    const before = imageSrc(container);
+
+    await act(async () => {
+      Array.from(container.querySelectorAll("button"))
+        .find((b) => b.getAttribute("aria-label") === "Refresh")
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(imageSrc(container)).not.toBe(before);
+  });
+
+  it("re-requests a raster image when the pane regains focus", async () => {
+    // Both focus effects gated on "loaded", which no image ever reaches.
+    seedWorktree(OUTER_ID, "/repo", { git: 100 });
+    const { container, rerender } = await renderPane({
+      filePath: "/repo/assets/logo.png",
+      isFocused: false,
+    });
+    const before = imageSrc(container);
+
+    await commitTick(rerender, true);
+
+    expect(imageSrc(container)).not.toBe(before);
+  });
+
+  it("re-reads and re-sanitizes an SVG on a worktree tick", async () => {
+    seedWorktree(OUTER_ID, "/repo", { git: 100 });
+    readMock.mockResolvedValue({
+      content: '<svg xmlns="http://www.w3.org/2000/svg"><rect /></svg>',
+    });
+    const { container, rerender } = await renderPane({ filePath: "/repo/assets/icon.svg" });
+    await waitFor(() => expect(container.querySelector("svg rect")).not.toBeNull());
+
+    readMock.mockResolvedValue({
+      content: '<svg xmlns="http://www.w3.org/2000/svg"><circle /></svg>',
+    });
+    seedWorktree(OUTER_ID, "/repo", { git: 200 });
+    await commitTick(rerender);
+
+    // Inlined markup, so freshness rides React state rather than a URL.
+    await waitFor(() => expect(container.querySelector("svg circle")).not.toBeNull());
+    expect(container.querySelector("svg rect")).toBeNull();
+  });
+
+  it("leaves the hidden source alone while Diff owns the surface", async () => {
+    // useDiffContent subscribes to the same store and raises its own stale
+    // banner; re-reading source nobody can see would just duplicate the work.
+    seedWorktree(OUTER_ID, "/repo", { git: 100 });
+    worktreeState.worktrees.set(OUTER_ID, {
+      id: OUTER_ID,
+      path: "/repo",
+      worktreeChanges: {
+        changes: [{ path: "/repo/src/index.ts", status: "modified" }],
+        lastUpdated: 100,
+      },
+    } satisfies WorktreeLike);
+    useDiffContentMock.mockReturnValue({ content: "diff", stale: false, retry: vi.fn() });
+    readMock.mockResolvedValue({ content: "v1" });
+    const { rerender } = await renderPane({ fileViewMode: "diff" });
+    const initialReads = readMock.mock.calls.length;
+
+    worktreeState.worktrees.set(OUTER_ID, {
+      id: OUTER_ID,
+      path: "/repo",
+      worktreeChanges: {
+        changes: [{ path: "/repo/src/index.ts", status: "modified" }],
+        lastUpdated: 200,
+      },
+    } satisfies WorktreeLike);
+    await commitTick(rerender);
+
+    expect(readMock.mock.calls.length).toBe(initialReads);
+  });
+
+  describe("media keeps playing across a tick", () => {
+    // Same fetch-to-blob boundary the video/audio suites above stub: Chromium's
+    // custom-scheme media loader can't do follow-up range requests.
+    const mediaFetchMock = vi.fn();
+    const realCreateObjectURL = URL.createObjectURL;
+    const realRevokeObjectURL = URL.revokeObjectURL;
+    beforeEach(() => {
+      mediaFetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        blob: () => Promise.resolve(new Blob(["x"])),
+      });
+      vi.stubGlobal("fetch", mediaFetchMock);
+      URL.createObjectURL = vi.fn(() => "blob:app://daintree/media-preview");
+      URL.revokeObjectURL = vi.fn();
+    });
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      mediaFetchMock.mockReset();
+      URL.createObjectURL = realCreateObjectURL;
+      URL.revokeObjectURL = realRevokeObjectURL;
+    });
+
+    it("keeps the same <video> element rather than refetching", async () => {
+      // A worktree-wide tick fires on any write; remounting here would restart
+      // playback every time an agent touched an unrelated file.
+      seedWorktree(OUTER_ID, "/repo", { git: 100 });
+      const { container, rerender } = await renderPane({ filePath: "/repo/media/demo.mp4" });
+      await waitFor(() => expect(container.querySelector("video")).not.toBeNull());
+      const playerBefore = container.querySelector("video");
+      const fetchesBefore = mediaFetchMock.mock.calls.length;
+
+      seedWorktree(OUTER_ID, "/repo", { git: 200, fs: 300 });
+      await commitTick(rerender);
+
+      expect(container.querySelector("video")).toBe(playerBefore);
+      expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- The standalone file panel never re-read a file after it changed on disk, so agents rewriting an open file left it showing stale content, and for raster images the Refresh button did nothing at all.
- Subscribes the panel to the containing worktree's git-status and filesystem-write ticks, the same signal `FileBrowserPane` already uses, and threads a cache-busting token through to the image element so Refresh (and the new automatic tick) actually reload.
- Widens focus-based re-reads to cover image and SVG, and keeps background re-reads from blanking the view or losing scroll position.

## What was wrong

The standalone file panel (`FilePane`) never re-read a file after it changed on disk, while the file browser panel already did. Agents rewrite files while they're open on screen, so the panel just sat there showing stale content.

Raster images were the worst case. The toolbar Refresh button would spin and nothing would reload, because the `daintree-file://` URL is a pure function of path and root, and the image branch of the load path returned before anything could force a refetch. This isn't an HTTP cache problem: the protocol already sends `Cache-Control: no-store`. The `<img>` was simply never asked to reload.

Text, markdown and HTML only re-read on focus regain, never while the panel stayed focused, which is exactly when someone is watching an agent work. SVG, image, video and PDF were excluded from even that, because both focus effects gated on a `loaded` state.

## What changed

- Subscribes the pane to the containing worktree's git-status tick and raw filesystem-write tick, combined into one signal the way `FileBrowserPane` already does. The second half matters because writes into gitignored folders never move git status (#11330). The watched worktree is resolved by deepest path containment, never `panel.worktreeId`: `file.openPanel` resolves an explicit `rootPath` but still stamps the active worktree id, so the panel can name a worktree the file isn't in.
- Threads a cache-busting token to the image element via a new optional `cacheBust` prop on `FileImagePreview`, mirroring what `ZoomableImage` already does. The raster branch now bumps the reload nonce on every load, silent or not. Previously it never bumped at all, which is why Refresh did nothing.
- Widens the pane-focus and window-focus re-read gates to cover image and SVG. Video, audio and PDF stay out of automatic reloads on purpose, matching `FileBrowserViewer`: a worktree-wide tick fires on any write, and remounting would reset playback or a reader's page every time an agent touched an unrelated file.
- Background re-reads keep the current content on screen rather than blanking to a skeleton and dropping scroll position.

## Also fixed in review

All three of these live in the new code paths added here.

- A silent read that supersedes an explicit one now restores the last good view instead of returning early. Returning wasn't enough: the explicit read is already stale by then, so the skeleton and the toolbar spin would stay up with nothing left to settle them.
- A background re-read that catches a half-written SVG keeps the last good drawing instead of replacing it with a sanitizer error, the same bargain the text path already makes for transient failures.
- Acquiring or changing the watched worktree now counts as a signal in its own right. `loadFile` is keyed on the read root, which doesn't move when only the watched root does, so nothing else would have noticed the handover.

## Known limitation

A raster `<img>` that fails to decode during a background refetch, say a truncated PNG caught mid-write, still flips the pane to an error state. The `<img>` error event carries no response status, so there's no way to tell a genuine deletion from undecodable-but-valid bytes, and suppressing every silent failure would hide real deletions. Doing it properly needs staged decode-then-commit.

The same exposure already ships in `FileBrowserViewer`. It self-heals on the next tick, so I'm leaving it as a follow-up rather than restructuring a shared component here.

## Testing

- 17 new tests across `FilePane.test.tsx` and `FileImagePreview.test.tsx`. 615 unit tests pass across every affected test directory, plus the focus-ring and accent contract guards.
- Mutation-checked in both directions: reverting the nonce bump, the tick effect and the widened focus gate fails 7 tests; making the tick reload non-silent or widening the gate to media fails the 2 guard tests; dropping the last-good-view restore fails its regression test alone.
- `npm run typecheck` is clean. Prettier and eslint are clean on the four changed files.
- No local E2E: `e2e/full/panels/core-file-panel.spec.ts` covers layout, scroll and mode-toggle only and doesn't exercise on-disk change, and PR CI doesn't run E2E.

Resolves #11451
