### PR TITLE
feat(project-switcher): add a sort control to the Other projects band

### DIFF
--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -29,9 +29,19 @@ import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ArrowDownAZ, Clock, Flame } from "@/components/icons";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { formatTimeAgo } from "@/utils/timeAgo";
 import { getProjectRowStatus, type ProjectRowTone } from "@/lib/projectRowStatus";
@@ -49,7 +59,12 @@ import type {
   SearchableProject,
   SearchableScratch,
 } from "@/hooks/useProjectSwitcherPalette";
-import { PROJECT_SECTION_LABELS } from "@/hooks/useProjectSwitcherPalette";
+import {
+  PROJECT_SECTION_LABELS,
+  OTHER_PROJECTS_SORT_CONTROL_MIN_ROWS,
+} from "@/hooks/useProjectSwitcherPalette";
+import { usePreferencesStore } from "@/store/preferencesStore";
+import { isOtherProjectsSortMode, type OtherProjectsSortMode } from "@/lib/projectSort";
 import { useUIStore } from "@/store/uiStore";
 import {
   useProjectSettingsStore,
@@ -413,6 +428,110 @@ interface ProjectSection {
   items: SearchableProject[];
 }
 
+const OTHER_PROJECTS_SORT_OPTIONS: readonly {
+  value: OtherProjectsSortMode;
+  label: string;
+  Icon: typeof Flame;
+}[] = [
+  { value: "hottest", label: "Hottest", Icon: Flame },
+  { value: "recent", label: "Recent", Icon: Clock },
+  { value: "alphabetical", label: "A to Z", Icon: ArrowDownAZ },
+];
+
+/**
+ * The Other band's header, which doubles as its sort control (#11455). Every
+ * row in the band prints a timestamp, so an unlabelled frecency order reads as
+ * broken — the control's first job is naming the order, changing it second.
+ *
+ * Two structural constraints shape the markup:
+ *
+ * - The `id` stays on a leaf element holding ONLY the label text. It is the
+ *   `aria-labelledby` target for the surrounding `role="group"`, and that name
+ *   is computed from the element's whole subtree — nesting the mode inside it
+ *   would name the band "Other projects Hottest".
+ * - The trigger is `tabIndex={-1}`. Section headers live inside the
+ *   `role="listbox"`, where a focusable child is invalid and unreachable
+ *   anyway (arrow keys move `aria-activedescendant` across rows, never here).
+ *   Right-click reaches the same options, matching every other secondary
+ *   action in this palette.
+ */
+function OtherProjectsHeader({
+  headerId,
+  label,
+  itemCount,
+}: {
+  headerId: string;
+  label: string;
+  itemCount: number;
+}) {
+  const sortMode = usePreferencesStore((state) => state.projectSwitcherOtherSortMode);
+  const setSortMode = usePreferencesStore((state) => state.setProjectSwitcherOtherSortMode);
+
+  const active =
+    OTHER_PROJECTS_SORT_OPTIONS.find((option) => option.value === sortMode) ??
+    OTHER_PROJECTS_SORT_OPTIONS[0];
+  const ActiveIcon = active.Icon;
+
+  const handleValueChange = (value: string) => {
+    if (isOtherProjectsSortMode(value)) setSortMode(value);
+  };
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div
+          role="presentation"
+          className="flex items-center justify-between px-3 py-1 text-[10px] font-medium text-daintree-text/40 select-none"
+        >
+          <div id={headerId} className="tracking-wider uppercase">
+            {label}
+          </div>
+          {itemCount >= OTHER_PROJECTS_SORT_CONTROL_MIN_ROWS && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  data-testid="other-projects-sort-trigger"
+                  aria-label={`Sort other projects, currently ${active.label}`}
+                  className="flex shrink-0 items-center gap-1 text-daintree-text/40 hover:text-daintree-text/60 transition-colors"
+                >
+                  <ActiveIcon className="w-3 h-3" aria-hidden="true" />
+                  {active.label}
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuRadioGroup value={sortMode} onValueChange={handleValueChange}>
+                  {OTHER_PROJECTS_SORT_OPTIONS.map(({ value, label: optionLabel, Icon }) => (
+                    <DropdownMenuRadioItem key={value} value={value}>
+                      <Icon className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
+                      {optionLabel}
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
+      </ContextMenuTrigger>
+      {/*
+       * Right-click keeps the options reachable below the row threshold, where
+       * the visible trigger hides itself — the preference still applies there.
+       */}
+      <ContextMenuContent>
+        <ContextMenuRadioGroup value={sortMode} onValueChange={handleValueChange}>
+          {OTHER_PROJECTS_SORT_OPTIONS.map(({ value, label: optionLabel, Icon }) => (
+            <ContextMenuRadioItem key={value} value={value}>
+              <Icon className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
+              {optionLabel}
+            </ContextMenuRadioItem>
+          ))}
+        </ContextMenuRadioGroup>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}
+
 interface ProjectListContentProps {
   results: SearchableProject[];
   selectedIndex: number;
@@ -554,14 +673,21 @@ function ProjectListContent({
                     isActiveSection && "bg-overlay-subtle"
                   )}
                 >
-                  {section.label && (
-                    <div
-                      id={headerId}
-                      className="px-3 py-1 text-[10px] font-medium tracking-wider uppercase text-daintree-text/40 select-none"
-                    >
-                      {section.label}
-                    </div>
-                  )}
+                  {section.label &&
+                    (section.key === "other" ? (
+                      <OtherProjectsHeader
+                        headerId={headerId}
+                        label={section.label}
+                        itemCount={section.items.length}
+                      />
+                    ) : (
+                      <div
+                        id={headerId}
+                        className="px-3 py-1 text-[10px] font-medium tracking-wider uppercase text-daintree-text/40 select-none"
+                      >
+                        {section.label}
+                      </div>
+                    ))}
                   {section.items.map(renderItem)}
                 </div>
               </div>

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -459,10 +459,12 @@ function OtherProjectsHeader({
   headerId,
   label,
   itemCount,
+  onReturnFocus,
 }: {
   headerId: string;
   label: string;
   itemCount: number;
+  onReturnFocus?: () => void;
 }) {
   const sortMode = usePreferencesStore((state) => state.projectSwitcherOtherSortMode);
   const setSortMode = usePreferencesStore((state) => state.setProjectSwitcherOtherSortMode);
@@ -500,7 +502,21 @@ function OtherProjectsHeader({
                   {active.label}
                 </button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
+              <DropdownMenuContent
+                align="end"
+                onCloseAutoFocus={(event) => {
+                  // Radix would restore focus to the trigger, which then eats
+                  // ArrowDown and Enter to reopen itself — leaving the palette
+                  // unable to walk or commit a row until focus moved by hand.
+                  // The search box owns those keys, so send focus back there.
+                  //
+                  // Deferred a frame: focusing inside Radix's own focus-restore
+                  // window loses the race with its teardown (same reason
+                  // `ContentPanel`'s rename input defers).
+                  event.preventDefault();
+                  requestAnimationFrame(() => onReturnFocus?.());
+                }}
+              >
                 <DropdownMenuRadioGroup value={sortMode} onValueChange={handleValueChange}>
                   {OTHER_PROJECTS_SORT_OPTIONS.map(({ value, label: optionLabel, Icon }) => (
                     <DropdownMenuRadioItem key={value} value={value}>
@@ -550,6 +566,8 @@ interface ProjectListContentProps {
   onSelectNewWindow?: (project: SearchableProject) => void;
   onHoverProject?: (projectId: string, pointerType: string) => void;
   onHoverProjectEnd?: (pointerType: string) => void;
+  /** Hands focus back to the search box after the sort menu closes. */
+  onReturnFocus?: () => void;
 }
 
 function ProjectListContent({
@@ -569,6 +587,7 @@ function ProjectListContent({
   onSelectNewWindow,
   onHoverProject,
   onHoverProjectEnd,
+  onReturnFocus,
 }: ProjectListContentProps) {
   const isSearching = query.trim().length > 0;
 
@@ -679,6 +698,7 @@ function ProjectListContent({
                         headerId={headerId}
                         label={section.label}
                         itemCount={section.items.length}
+                        onReturnFocus={onReturnFocus}
                       />
                     ) : (
                       <div
@@ -1287,6 +1307,7 @@ function ProjectPaletteInner({
           onSelectNewWindow={onSelectNewWindow}
           onHoverProject={onHoverProject}
           onHoverProjectEnd={onHoverProjectEnd}
+          onReturnFocus={() => inputRef.current?.focus()}
         />
         {(onCreateScratch || (scratchResults && scratchResults.length > 0)) && (
           <>

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -64,7 +64,11 @@ import {
   OTHER_PROJECTS_SORT_CONTROL_MIN_ROWS,
 } from "@/hooks/useProjectSwitcherPalette";
 import { usePreferencesStore } from "@/store/preferencesStore";
-import { isOtherProjectsSortMode, type OtherProjectsSortMode } from "@/lib/projectSort";
+import {
+  isOtherProjectsSortMode,
+  OTHER_PROJECTS_SORT_MODES,
+  type OtherProjectsSortMode,
+} from "@/lib/projectSort";
 import { useUIStore } from "@/store/uiStore";
 import {
   useProjectSettingsStore,
@@ -428,15 +432,17 @@ interface ProjectSection {
   items: SearchableProject[];
 }
 
-const OTHER_PROJECTS_SORT_OPTIONS: readonly {
-  value: OtherProjectsSortMode;
-  label: string;
-  Icon: typeof Flame;
-}[] = [
-  { value: "hottest", label: "Hottest", Icon: Flame },
-  { value: "recent", label: "Recent", Icon: Clock },
-  { value: "alphabetical", label: "A to Z", Icon: ArrowDownAZ },
-];
+// Keyed by mode rather than a list, so the lookup below is total: a new mode in
+// the union is a compile error here until it gets a label and an icon. The menu
+// takes its order from `OTHER_PROJECTS_SORT_MODES`.
+const OTHER_PROJECTS_SORT_OPTIONS: Record<
+  OtherProjectsSortMode,
+  { label: string; Icon: typeof Flame }
+> = {
+  hottest: { label: "Hottest", Icon: Flame },
+  recent: { label: "Recent", Icon: Clock },
+  alphabetical: { label: "A to Z", Icon: ArrowDownAZ },
+};
 
 /**
  * The Other band's header, which doubles as its sort control (#11455). Every
@@ -469,9 +475,7 @@ function OtherProjectsHeader({
   const sortMode = usePreferencesStore((state) => state.projectSwitcherOtherSortMode);
   const setSortMode = usePreferencesStore((state) => state.setProjectSwitcherOtherSortMode);
 
-  const active =
-    OTHER_PROJECTS_SORT_OPTIONS.find((option) => option.value === sortMode) ??
-    OTHER_PROJECTS_SORT_OPTIONS[0];
+  const active = OTHER_PROJECTS_SORT_OPTIONS[sortMode];
   const ActiveIcon = active.Icon;
 
   const handleValueChange = (value: string) => {
@@ -518,12 +522,15 @@ function OtherProjectsHeader({
                 }}
               >
                 <DropdownMenuRadioGroup value={sortMode} onValueChange={handleValueChange}>
-                  {OTHER_PROJECTS_SORT_OPTIONS.map(({ value, label: optionLabel, Icon }) => (
-                    <DropdownMenuRadioItem key={value} value={value}>
-                      <Icon className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
-                      {optionLabel}
-                    </DropdownMenuRadioItem>
-                  ))}
+                  {OTHER_PROJECTS_SORT_MODES.map((value) => {
+                    const { label: optionLabel, Icon } = OTHER_PROJECTS_SORT_OPTIONS[value];
+                    return (
+                      <DropdownMenuRadioItem key={value} value={value}>
+                        <Icon className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
+                        {optionLabel}
+                      </DropdownMenuRadioItem>
+                    );
+                  })}
                 </DropdownMenuRadioGroup>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -536,12 +543,15 @@ function OtherProjectsHeader({
        */}
       <ContextMenuContent>
         <ContextMenuRadioGroup value={sortMode} onValueChange={handleValueChange}>
-          {OTHER_PROJECTS_SORT_OPTIONS.map(({ value, label: optionLabel, Icon }) => (
-            <ContextMenuRadioItem key={value} value={value}>
-              <Icon className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
-              {optionLabel}
-            </ContextMenuRadioItem>
-          ))}
+          {OTHER_PROJECTS_SORT_MODES.map((value) => {
+            const { label: optionLabel, Icon } = OTHER_PROJECTS_SORT_OPTIONS[value];
+            return (
+              <ContextMenuRadioItem key={value} value={value}>
+                <Icon className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
+                {optionLabel}
+              </ContextMenuRadioItem>
+            );
+          })}
         </ContextMenuRadioGroup>
       </ContextMenuContent>
     </ContextMenu>

--- a/src/components/Project/WelcomeScreen.tsx
+++ b/src/components/Project/WelcomeScreen.tsx
@@ -368,8 +368,8 @@ function TopProjects({
 }) {
   return (
     <div className="w-full">
-      {/* "Your projects", not "Recent projects": the list is ranked by decayed
-          use, and each row already shows its own true "opened X ago". */}
+      {/* "Your projects", not "Recent projects": the order follows the switcher's
+          Other-band sort mode, so no fixed order-word belongs in the heading. */}
       <h3 className="text-xs font-medium text-daintree-text/50 uppercase tracking-wider mb-3">
         Your projects
       </h3>

--- a/src/components/Project/WelcomeScreen.tsx
+++ b/src/components/Project/WelcomeScreen.tsx
@@ -18,6 +18,8 @@ import { BrandMark, DaintreeIcon } from "@/components/icons";
 import { useProjectStore } from "@/store/projectStore";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
+import { usePreferencesStore } from "@/store/preferencesStore";
+import { compareProjectsByMode } from "@/lib/projectSort";
 import { cn } from "@/lib/utils";
 import { actionService } from "@/services/ActionService";
 import { keybindingService } from "@/services/KeybindingService";
@@ -56,18 +58,34 @@ export function WelcomeScreen({ gettingStarted }: WelcomeScreenProps) {
   const projects = useProjectStore((state) => state.projects);
   const switchProject = useProjectStore((state) => state.switchProject);
 
+  const otherProjectsSortMode = usePreferencesStore((state) => state.projectSwitcherOtherSortMode);
+
   // Effective (read-time decayed) scores against one shared now — comparing
   // raw persisted scores compares snapshots frozen on different dates, which
-  // let months-dormant projects hold the top slots. Same transform as the
-  // project switcher, so the two surfaces can never disagree on order.
+  // let months-dormant projects hold the top slots. Same transform AND the same
+  // comparator as the project switcher's Other band, reading the same
+  // preference, so the two surfaces can never disagree on order (#11455).
+  //
+  // Sorted before the cap, never after: slicing first would rank five projects
+  // the frecency order happened to surface, not the five this mode ranks top.
   const topProjects = useMemo(() => {
     const now = Date.now();
-    const effective = (p: (typeof projects)[number]) =>
-      decayFrecencyScore(p.frecencyScore ?? FRECENCY_COLD_START, p.lastAccessedAt ?? 0, now);
     return [...projects]
-      .sort((a, b) => effective(b) - effective(a) || (b.lastOpened ?? 0) - (a.lastOpened ?? 0))
-      .slice(0, 5);
-  }, [projects]);
+      .map((project) => ({
+        project,
+        id: project.id,
+        name: project.name,
+        lastOpened: project.lastOpened ?? 0,
+        frecencyScore: decayFrecencyScore(
+          project.frecencyScore ?? FRECENCY_COLD_START,
+          project.lastAccessedAt ?? 0,
+          now
+        ),
+      }))
+      .sort((a, b) => compareProjectsByMode(a, b, otherProjectsSortMode))
+      .slice(0, 5)
+      .map((entry) => entry.project);
+  }, [projects, otherProjectsSortMode]);
 
   const hasProjects = topProjects.length > 0;
   const { checklist } = gettingStarted;

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
@@ -137,6 +137,8 @@ vi.mock("@/components/ui/context-menu", () => ({
   ContextMenuContent: () => null,
   ContextMenuItem: () => null,
   ContextMenuSeparator: () => null,
+  ContextMenuRadioGroup: () => null,
+  ContextMenuRadioItem: () => null,
 }));
 
 const modifierKeysState = { meta: false, alt: false };

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -506,21 +506,27 @@ describe("ProjectSwitcherPalette modal mode", () => {
       ];
     }
 
-    it("advertises the order once the band is long enough to need it", () => {
-      render(<ProjectSwitcherPalette {...dropdownProps} results={withOtherRows(4)} />);
-      expect(screen.getByTestId("other-projects-sort-trigger")).toBeTruthy();
+    it.each([
+      [0, false],
+      [3, false],
+      [4, true],
+      [6, true],
+    ])("with %i Other rows, shows the control: %s", (rows, shown) => {
+      render(<ProjectSwitcherPalette {...dropdownProps} results={withOtherRows(rows)} />);
+      expect(screen.queryByTestId("other-projects-sort-trigger") !== null).toBe(shown);
     });
 
-    it("stays quiet on a band short enough to read at a glance", () => {
-      render(<ProjectSwitcherPalette {...dropdownProps} results={withOtherRows(3)} />);
-      expect(screen.queryByTestId("other-projects-sort-trigger")).toBeNull();
-    });
-
-    it("puts the control only on the Other band", () => {
+    it("puts the control on the Other band and nowhere else", () => {
       render(<ProjectSwitcherPalette {...dropdownProps} results={withOtherRows(4)} />);
       // Pinned and Running are load-bearing orders this preference must not
-      // claim to govern, so neither header may grow a control.
-      expect(screen.getAllByTestId("other-projects-sort-trigger")).toHaveLength(1);
+      // claim to govern, so neither header may grow a control. Scoped by group
+      // rather than counted globally, which would pass if it had moved bands.
+      const other = screen.getByRole("group", { name: "Other projects" });
+      expect(within(other).getByTestId("other-projects-sort-trigger")).toBeTruthy();
+      for (const band of ["Pinned", "Running"]) {
+        const group = screen.getByRole("group", { name: band });
+        expect(within(group).queryByTestId("other-projects-sort-trigger")).toBeNull();
+      }
     });
 
     it("keeps the band's accessible name free of the mode it is showing", () => {

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -111,6 +111,8 @@ vi.mock("@/components/ui/context-menu", () => ({
   ContextMenuContent: () => null,
   ContextMenuItem: () => null,
   ContextMenuSeparator: () => null,
+  ContextMenuRadioGroup: () => null,
+  ContextMenuRadioItem: () => null,
 }));
 
 vi.mock("@/hooks/useModifierKeys", () => ({
@@ -487,6 +489,54 @@ describe("ProjectSwitcherPalette modal mode", () => {
     expect(headers[0]).toBe("Pinned");
     expect(headers).toContain("Running");
     expect(headers).toContain("Other projects");
+  });
+
+  describe("Other band sort control — issue #11455", () => {
+    function withOtherRows(count: number) {
+      return [
+        ...multiProjects.filter((project) => project.section !== "other"),
+        ...Array.from({ length: count }, (_, i) =>
+          makeProject({
+            id: `other-${i}`,
+            name: `Other ${i}`,
+            section: "other",
+            lastOpened: now - (i + 1) * 3600000,
+          })
+        ),
+      ];
+    }
+
+    it("advertises the order once the band is long enough to need it", () => {
+      render(<ProjectSwitcherPalette {...dropdownProps} results={withOtherRows(4)} />);
+      expect(screen.getByTestId("other-projects-sort-trigger")).toBeTruthy();
+    });
+
+    it("stays quiet on a band short enough to read at a glance", () => {
+      render(<ProjectSwitcherPalette {...dropdownProps} results={withOtherRows(3)} />);
+      expect(screen.queryByTestId("other-projects-sort-trigger")).toBeNull();
+    });
+
+    it("puts the control only on the Other band", () => {
+      render(<ProjectSwitcherPalette {...dropdownProps} results={withOtherRows(4)} />);
+      // Pinned and Running are load-bearing orders this preference must not
+      // claim to govern, so neither header may grow a control.
+      expect(screen.getAllByTestId("other-projects-sort-trigger")).toHaveLength(1);
+    });
+
+    it("keeps the band's accessible name free of the mode it is showing", () => {
+      // The header id is the group's aria-labelledby target, and that name is
+      // computed from the element's whole subtree — nesting the mode inside it
+      // would name the band "Other projects Hottest" to a screen reader.
+      render(<ProjectSwitcherPalette {...dropdownProps} results={withOtherRows(4)} />);
+      expect(screen.getByRole("group", { name: "Other projects" })).toBeTruthy();
+    });
+
+    it("keeps the trigger out of the Tab order", () => {
+      // Section headers live inside the listbox, where a focusable child is
+      // invalid; arrow keys move aria-activedescendant across rows only.
+      render(<ProjectSwitcherPalette {...dropdownProps} results={withOtherRows(4)} />);
+      expect(screen.getByTestId("other-projects-sort-trigger").getAttribute("tabindex")).toBe("-1");
+    });
   });
 
   it("shows Remove hint in dropdown mode footer", () => {

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.scratchNaming.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.scratchNaming.test.tsx
@@ -139,6 +139,11 @@ vi.mock("@/components/ui/context-menu", () => ({
     </button>
   ),
   ContextMenuSeparator: () => null,
+  // Null rather than the button seam above: the Other band's sort options are
+  // not this suite's subject, and rendering them would add buttons to a DOM
+  // these specs query by role.
+  ContextMenuRadioGroup: () => null,
+  ContextMenuRadioItem: () => null,
 }));
 
 vi.mock("@/hooks/useModifierKeys", () => ({

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.sortControl.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.sortControl.test.tsx
@@ -1,0 +1,259 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The Other band's sort control (#11455).
+ *
+ * Uses the REAL dropdown and context-menu primitives: the whole feature is that
+ * a header control opens a menu whose choice reaches the preference store, and
+ * a stub that renders items as plain buttons would pass even if the trigger
+ * were never wired to the menu.
+ */
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+
+const originalScrollIntoView = Element.prototype.scrollIntoView;
+beforeAll(() => {
+  Object.defineProperty(Element.prototype, "scrollIntoView", {
+    value: vi.fn(),
+    configurable: true,
+  });
+});
+afterAll(() => {
+  Object.defineProperty(Element.prototype, "scrollIntoView", {
+    value: originalScrollIntoView,
+    configurable: true,
+  });
+});
+
+vi.mock("react-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
+  return { ...actual, createPortal: (children: React.ReactNode) => children };
+});
+
+vi.mock("@/lib/colorUtils", () => ({
+  getProjectGradient: () => "linear-gradient(red, blue)",
+}));
+
+vi.mock("@/hooks/useKeybinding", () => ({
+  useKeybindingDisplay: () => "⌘P",
+  useEffectiveCombo: () => undefined,
+}));
+
+vi.mock("@/hooks", () => ({
+  useOverlayState: () => {},
+  useOverlayClaim: () => {},
+}));
+
+vi.mock("@/store/paletteStore", () => ({
+  usePaletteStore: { getState: () => ({ activePaletteId: null }) },
+}));
+
+vi.mock("@/store/uiStore", () => ({
+  useUIStore: () => 0,
+}));
+
+vi.mock("@/components/ui/AppPaletteDialog", () => {
+  const Header = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  const Input = ({
+    inputRef,
+    ...props
+  }: React.InputHTMLAttributes<HTMLInputElement> & {
+    inputRef?: React.Ref<HTMLInputElement>;
+  }) => <input ref={inputRef} data-testid="palette-input" {...props} />;
+  const Body = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  const Footer = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+
+  const Dialog = ({
+    isOpen,
+    children,
+    ariaLabel,
+  }: {
+    isOpen: boolean;
+    children: React.ReactNode;
+    ariaLabel: string;
+  }) =>
+    isOpen ? (
+      <div role="dialog" aria-modal="true" aria-label={ariaLabel}>
+        {children}
+      </div>
+    ) : null;
+  Dialog.Header = Header;
+  Dialog.Input = Input;
+  Dialog.Body = Body;
+  Dialog.Footer = Footer;
+
+  return { AppPaletteDialog: Dialog, KBD_CLASS: "kbd" };
+});
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/ConfirmDialog", () => ({
+  ConfirmDialog: () => null,
+}));
+
+vi.mock("@/hooks/useModifierKeys", () => ({
+  useModifierKeys: () => ({ meta: false, alt: false }),
+}));
+
+vi.mock("@/utils/timeAgo", () => ({
+  formatTimeAgo: () => "1h ago",
+}));
+
+import type { SearchableProject } from "@/hooks/useProjectSwitcherPalette";
+import { usePreferencesStore } from "@/store/preferencesStore";
+import { DEFAULT_OTHER_PROJECTS_SORT_MODE, type OtherProjectsSortMode } from "@/lib/projectSort";
+import { primeRadix } from "@/components/ui/radix-loader";
+
+const { ProjectSwitcherPalette } = await import("../ProjectSwitcherPalette");
+
+beforeAll(async () => {
+  // The menu primitives resolve through the lazy Radix loader; without priming
+  // the trigger renders as an inert passthrough and never opens.
+  await primeRadix();
+});
+
+beforeEach(() => {
+  usePreferencesStore.getState().setProjectSwitcherOtherSortMode(DEFAULT_OTHER_PROJECTS_SORT_MODE);
+});
+
+function makeProject(overrides: Partial<SearchableProject> & { id: string }): SearchableProject {
+  return {
+    name: overrides.id,
+    path: `/repo/${overrides.id}`,
+    emoji: "🌲",
+    lastOpened: 1_000,
+    status: "closed",
+    frecencyScore: 1,
+    section: "other",
+    isActive: false,
+    isBackground: false,
+    isMissing: false,
+    isPinned: false,
+    activeAgentCount: 0,
+    waitingAgentCount: 0,
+    blockedAgentCount: 0,
+    unacknowledgedCompletedAgentCount: 0,
+    processCount: 0,
+    displayPath: `/repo/${overrides.id}`,
+    ...overrides,
+  } as SearchableProject;
+}
+
+function renderPalette(otherRows: number) {
+  const results = Array.from({ length: otherRows }, (_, i) =>
+    makeProject({ id: `other-${i}`, lastOpened: 1_000 - i })
+  );
+  return render(
+    <ProjectSwitcherPalette
+      isOpen
+      mode="modal"
+      query=""
+      results={results}
+      selectedIndex={0}
+      onQueryChange={vi.fn()}
+      onSelectPrevious={vi.fn()}
+      onSelectNext={vi.fn()}
+      onSelect={vi.fn()}
+      onClose={vi.fn()}
+    />
+  );
+}
+
+function trigger(): HTMLElement {
+  return screen.getByTestId("other-projects-sort-trigger");
+}
+
+/**
+ * The header ROW carries the context-menu trigger; the labelling leaf inside it
+ * carries the id. Right-clicking the surrounding group would not reach Radix,
+ * since events bubble up from the trigger rather than down to it.
+ */
+function headerRow(): HTMLElement {
+  const label = document.getElementById("project-section-other");
+  if (!label?.parentElement) throw new Error("Other projects header not found");
+  return label.parentElement;
+}
+
+/** Radix opens a dropdown on primary-button pointerdown, not on click. */
+function openSortMenu(): void {
+  fireEvent.pointerDown(trigger(), { button: 0, ctrlKey: false, pointerType: "mouse" });
+}
+
+function sortMode(): OtherProjectsSortMode {
+  return usePreferencesStore.getState().projectSwitcherOtherSortMode;
+}
+
+describe("Other projects sort control (#11455)", () => {
+  it("names the order the band is currently in", () => {
+    renderPalette(4);
+    // The control's first job is naming the order — every row shows a
+    // timestamp, so an unlabelled frecency sort reads as broken.
+    expect(trigger().textContent).toContain("Hottest");
+    expect(trigger().getAttribute("aria-label")).toContain("Hottest");
+  });
+
+  it("offers every mode as a radio item reflecting the current choice", () => {
+    renderPalette(4);
+    openSortMenu();
+
+    const items = screen.getAllByRole("menuitemradio");
+    expect(items.map((el) => el.textContent?.trim())).toEqual(["Hottest", "Recent", "A to Z"]);
+    // Exactly one checked, and it is the mode the trigger advertises.
+    const checked = items.filter((el) => el.getAttribute("aria-checked") === "true");
+    expect(checked).toHaveLength(1);
+    expect(checked[0]!.textContent).toContain("Hottest");
+  });
+
+  it("writes the chosen mode to the preference and relabels the trigger", () => {
+    renderPalette(4);
+    openSortMenu();
+
+    fireEvent.click(screen.getByRole("menuitemradio", { name: /Recent/ }));
+
+    expect(sortMode()).toBe("recent");
+    expect(trigger().textContent).toContain("Recent");
+    expect(trigger().getAttribute("aria-label")).toContain("Recent");
+  });
+
+  it("keeps the choice reachable by right-click below the visible threshold", () => {
+    // Three rows hide the control, but the preference still governs the band,
+    // so the options must not become unreachable with it.
+    renderPalette(3);
+    expect(screen.queryByTestId("other-projects-sort-trigger")).toBeNull();
+
+    fireEvent.contextMenu(headerRow());
+    fireEvent.click(screen.getByRole("menuitemradio", { name: /A to Z/ }));
+
+    expect(sortMode()).toBe("alphabetical");
+  });
+
+  it("hands focus back to the search box instead of the trigger", async () => {
+    // Radix restores focus to the trigger by default, which then swallows
+    // ArrowDown and Enter to reopen itself — leaving the palette unable to
+    // walk or commit a row.
+    renderPalette(4);
+    openSortMenu();
+    fireEvent.click(screen.getByRole("menuitemradio", { name: /Recent/ }));
+
+    // The refocus is deferred a frame to clear Radix's own restore window.
+    await waitFor(() => {
+      expect(document.activeElement).toBe(screen.getByTestId("palette-input"));
+    });
+    expect(document.activeElement).not.toBe(trigger());
+  });
+
+  it("does not lend its label to the band's accessible name", () => {
+    renderPalette(4);
+    const group = screen.getByRole("group", { name: "Other projects" });
+    // The control lives inside the header row but outside the labelling leaf.
+    expect(within(group).getByTestId("other-projects-sort-trigger")).toBeTruthy();
+  });
+});

--- a/src/components/Project/__tests__/WelcomeScreen.test.tsx
+++ b/src/components/Project/__tests__/WelcomeScreen.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { render, screen, fireEvent, act } from "@testing-library/react";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 const { dispatchMock } = vi.hoisted(() => ({
   dispatchMock: vi.fn(() => Promise.resolve()),
@@ -205,6 +205,8 @@ Object.defineProperty(window, "electron", {
 import { WelcomeScreen, isAgentWelcomeCardEligible } from "../WelcomeScreen";
 import type { GettingStartedChecklistState } from "@/hooks/app/useGettingStartedChecklist";
 import type { ChecklistState } from "@shared/types/ipc/maps";
+import { usePreferencesStore } from "@/store/preferencesStore";
+import { DEFAULT_OTHER_PROJECTS_SORT_MODE, type OtherProjectsSortMode } from "@/lib/projectSort";
 
 const allIncomplete: ChecklistState = {
   dismissed: false,
@@ -361,6 +363,79 @@ describe("WelcomeScreen", () => {
 
     const projectNames = screen.getAllByText(/Project (Stale|Fresh)/).map((el) => el.textContent);
     expect(projectNames).toEqual(["Project Fresh", "Project Stale"]);
+  });
+
+  // The switcher's Other band and this list carry a standing promise never to
+  // disagree on order, so this list follows the same preference (#11455).
+  describe("follows the project switcher's Other band sort mode — issue #11455", () => {
+    // Alpha is hottest, Beta is oldest and alphabetically last, Gamma sits in
+    // the middle on score — every mode has to pick a different winner.
+    const conflicting = [
+      { name: "Project Alpha", lastOpened: 3000, frecencyScore: 10.0 },
+      { name: "Project Beta", lastOpened: 9000, frecencyScore: 2.0 },
+      { name: "Project Gamma", lastOpened: 2000, frecencyScore: 5.0 },
+    ];
+
+    function renderWithMode(mode: OtherProjectsSortMode): (string | null)[] {
+      usePreferencesStore.getState().setProjectSwitcherOtherSortMode(mode);
+      storeState = {
+        ...storeState,
+        projects: conflicting.map((p, i) => ({
+          id: `c${i}`,
+          path: `/c${i}`,
+          emoji: "🌲",
+          ...p,
+        })),
+      };
+      render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
+      return screen.getAllByText(/Project (Alpha|Beta|Gamma)/).map((el) => el.textContent);
+    }
+
+    afterEach(() => {
+      usePreferencesStore
+        .getState()
+        .setProjectSwitcherOtherSortMode(DEFAULT_OTHER_PROJECTS_SORT_MODE);
+    });
+
+    it("ranks by decayed score in hottest", () => {
+      expect(renderWithMode("hottest")).toEqual(["Project Alpha", "Project Gamma", "Project Beta"]);
+    });
+
+    it("ranks by last opened in recent", () => {
+      expect(renderWithMode("recent")).toEqual(["Project Beta", "Project Alpha", "Project Gamma"]);
+    });
+
+    it("ranks by name in alphabetical", () => {
+      expect(renderWithMode("alphabetical")).toEqual([
+        "Project Alpha",
+        "Project Beta",
+        "Project Gamma",
+      ]);
+    });
+
+    it("applies the cap after sorting, not before", () => {
+      // Slicing first would cap the frecency order and then re-rank those five,
+      // so the list would show whichever projects frecency happened to surface
+      // rather than the five this mode actually ranks top.
+      usePreferencesStore.getState().setProjectSwitcherOtherSortMode("recent");
+      storeState = {
+        ...storeState,
+        projects: Array.from({ length: 8 }, (_, i) => ({
+          id: `p${i}`,
+          name: `Project ${i}`,
+          path: `/path/${i}`,
+          emoji: "🌲",
+          // Recency runs opposite to score: the highest-scoring projects are
+          // the least recent, so a cap-then-sort would show 7..3 instead.
+          lastOpened: (8 - i) * 1000,
+          frecencyScore: i,
+        })),
+      };
+      render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
+
+      const names = screen.getAllByText(/Project \d/).map((el) => el.textContent);
+      expect(names).toEqual(["Project 0", "Project 1", "Project 2", "Project 3", "Project 4"]);
+    });
   });
 
   it("does not render the project list section when no projects exist", () => {

--- a/src/components/Project/__tests__/WelcomeScreen.test.tsx
+++ b/src/components/Project/__tests__/WelcomeScreen.test.tsx
@@ -418,6 +418,9 @@ describe("WelcomeScreen", () => {
       // so the list would show whichever projects frecency happened to surface
       // rather than the five this mode actually ranks top.
       usePreferencesStore.getState().setProjectSwitcherOtherSortMode("recent");
+      // The five most recent are 7,6,5,4,3 — all sitting PAST the cap in array
+      // order, and the array is in ascending recency so a cap-then-sort would
+      // return 0..4, the five LEAST recent. Only sorting first can find them.
       storeState = {
         ...storeState,
         projects: Array.from({ length: 8 }, (_, i) => ({
@@ -425,16 +428,16 @@ describe("WelcomeScreen", () => {
           name: `Project ${i}`,
           path: `/path/${i}`,
           emoji: "🌲",
-          // Recency runs opposite to score: the highest-scoring projects are
-          // the least recent, so a cap-then-sort would show 7..3 instead.
-          lastOpened: (8 - i) * 1000,
-          frecencyScore: i,
+          lastOpened: (i + 1) * 1000,
+          // Score runs opposite to recency, so a stray frecency comparison
+          // would also produce a different set.
+          frecencyScore: 8 - i,
         })),
       };
       render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
 
       const names = screen.getAllByText(/Project \d/).map((el) => el.textContent);
-      expect(names).toEqual(["Project 0", "Project 1", "Project 2", "Project 3", "Project 4"]);
+      expect(names).toEqual(["Project 7", "Project 6", "Project 5", "Project 4", "Project 3"]);
     });
   });
 

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -9,8 +9,11 @@ export * from "./brands";
 // Each was chosen to fit the metaphor.
 export {
   Activity, // project pulse / live activity heartbeat
+  ArrowDownAZ, // alphabetical sort order (A to Z)
   BellDot, // watch alert / notify on completion
+  Clock, // recency sort order (most recently opened first)
   FileText, // view selected file path in the read-only file viewer
+  Flame, // frecency sort order ("hottest" — decayed access score)
   FolderGit2, // git worktree (single)
   FolderOpen, // reveal in file manager (Finder / Explorer / file manager)
   FolderOutput, // worktree living outside the project directory (external)

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -134,7 +134,11 @@ vi.mock("@/hooks/useCopyWithFeedback", () => ({
 
 import { usePaletteStore } from "@/store/paletteStore";
 import { usePreferencesStore } from "@/store/preferencesStore";
-import { DEFAULT_OTHER_PROJECTS_SORT_MODE, type OtherProjectsSortMode } from "@/lib/projectSort";
+import {
+  DEFAULT_OTHER_PROJECTS_SORT_MODE,
+  OTHER_PROJECTS_SORT_MODES,
+  type OtherProjectsSortMode,
+} from "@/lib/projectSort";
 import { useProjectSwitcherPalette } from "../useProjectSwitcherPalette";
 
 function setOtherSortMode(mode: OtherProjectsSortMode): void {
@@ -1544,53 +1548,138 @@ describe("useProjectSwitcherPalette", () => {
       setOtherSortMode(DEFAULT_OTHER_PROJECTS_SORT_MODE);
     });
 
-    it("orders the Other band by the selected mode", async () => {
-      const hottest = await openWith("hottest", conflicting());
-      expect(hottest.result.current.results.map((p) => p.id)).toEqual(["zulu", "alpha", "mike"]);
+    const EXPECTED_ORDER: Record<OtherProjectsSortMode, string[]> = {
+      hottest: ["zulu", "alpha", "mike"],
+      recent: ["mike", "zulu", "alpha"],
+      alphabetical: ["alpha", "mike", "zulu"],
+    };
 
-      const recent = await openWith("recent", conflicting());
-      expect(recent.result.current.results.map((p) => p.id)).toEqual(["mike", "zulu", "alpha"]);
-
-      const alphabetical = await openWith("alphabetical", conflicting());
-      expect(alphabetical.result.current.results.map((p) => p.id)).toEqual([
-        "alpha",
-        "mike",
-        "zulu",
-      ]);
+    it.each(OTHER_PROJECTS_SORT_MODES)("orders the Other band for %s", async (mode) => {
+      const view = await openWith(mode, conflicting());
+      expect(view.result.current.results.map((p) => p.id)).toEqual(EXPECTED_ORDER[mode]);
+      view.unmount();
     });
 
-    it("leaves the pinned band alphabetical whatever the Other mode is", async () => {
-      // The load-bearing orders belong to their bands, not to this preference:
-      // asking for A-Z in the residual band is not asking for it everywhere,
-      // and asking for Recent must not un-sort a user-curated pinned set.
+    // The load-bearing orders belong to their bands, not to this preference:
+    // asking for A-Z in the residual band is not asking for it everywhere, and
+    // asking for Recent must not un-sort a user-curated pinned set.
+    it.each(OTHER_PROJECTS_SORT_MODES)("leaves every other band untouched in %s", async (mode) => {
       const projects = [
+        // Attention: severity then oldest first — the reverse of every mode here.
+        base("zBlocked", { lastOpened: 9_000, frecencyScore: 50.0 }),
+        base("aWaiting", { lastOpened: 100, frecencyScore: 1.0 }),
+        // Pinned: alphabetical.
         base("zPinned", { pinned: true, lastOpened: 9_000, frecencyScore: 50.0 }),
         base("aPinned", { pinned: true, lastOpened: 100, frecencyScore: 1.0 }),
+        // Running: most work first.
+        base("aOneAgent", { lastOpened: 9_000, frecencyScore: 50.0 }),
+        base("zThreeAgents", { lastOpened: 100, frecencyScore: 1.0 }),
+        // Unavailable: alphabetical.
+        base("zGone", { status: "missing", lastOpened: 9_000, frecencyScore: 50.0 }),
+        base("aGone", { status: "missing", lastOpened: 100, frecencyScore: 1.0 }),
+        ...conflicting(),
       ];
-      const view = await openWith("recent", projects);
-      expect(view.result.current.results.map((p) => p.id)).toEqual(["aPinned", "zPinned"]);
-    });
-
-    it("leaves the running band ordered by agent count whatever the Other mode is", async () => {
-      const projects = [base("oneAgent"), base("threeAgents")];
-      setOtherSortMode("alphabetical");
+      setOtherSortMode(mode);
       projectState.projects = projects;
       projectState.currentProject = null;
       projectStatsState.stats = {
-        oneAgent: { activeAgentCount: 1, waitingAgentCount: 0, processCount: 0 },
-        threeAgents: { activeAgentCount: 3, waitingAgentCount: 0, processCount: 0 },
+        zBlocked: {
+          activeAgentCount: 0,
+          waitingAgentCount: 1,
+          blockedAgentCount: 1,
+          processCount: 0,
+        },
+        aWaiting: { activeAgentCount: 0, waitingAgentCount: 1, processCount: 0 },
+        aOneAgent: { activeAgentCount: 1, waitingAgentCount: 0, processCount: 0 },
+        zThreeAgents: { activeAgentCount: 3, waitingAgentCount: 0, processCount: 0 },
       };
       getBulkStatsMock.mockResolvedValue(emptyBulkStats(projects.map((p) => p.id)));
 
-      const { result } = renderHook(() => useProjectSwitcherPalette());
+      const { result, unmount } = renderHook(() => useProjectSwitcherPalette());
       act(() => {
         result.current.open("modal");
       });
       await waitFor(() => {
-        expect(result.current.results).toHaveLength(2);
+        expect(result.current.results).toHaveLength(projects.length);
       });
-      // Alphabetically "oneAgent" precedes "threeAgents"; most-work-first wins.
-      expect(result.current.results.map((p) => p.id)).toEqual(["threeAgents", "oneAgent"]);
+
+      const idsIn = (section: string) =>
+        result.current.results.filter((p) => p.section === section).map((p) => p.id);
+
+      // Blocked outranks a plain wait; a pin outranks recency; most agents
+      // first; missing rows are alphabetical. None of these follow the mode.
+      expect(idsIn("attention")).toEqual(["zBlocked", "aWaiting"]);
+      expect(idsIn("pinned")).toEqual(["aPinned", "zPinned"]);
+      expect(idsIn("running")).toEqual(["zThreeAgents", "aOneAgent"]);
+      expect(idsIn("unavailable")).toEqual(["aGone", "zGone"]);
+      // Only the residual band tracks the preference.
+      expect(idsIn("other")).toEqual(EXPECTED_ORDER[mode]);
+      unmount();
+    });
+
+    it("re-sorts on the next open when the mode changed while closed", async () => {
+      const view = await openWith("hottest", conflicting());
+      act(() => {
+        view.result.current.close();
+      });
+
+      act(() => {
+        setOtherSortMode("alphabetical");
+      });
+      act(() => {
+        view.result.current.open("modal");
+      });
+
+      await waitFor(() => {
+        expect(view.result.current.results.map((p) => p.id)).toEqual(["alpha", "mike", "zulu"]);
+      });
+      view.unmount();
+    });
+
+    it("re-sorts the Other band without disturbing a frozen band", async () => {
+      // The freeze holds a row in the band it had at open, so an agent
+      // finishing mid-read can't move it. Changing an unrelated band's sort
+      // order must not become a back door that releases that hold.
+      const projects = [base("waiting"), ...conflicting()];
+      setOtherSortMode("hottest");
+      projectState.projects = projects;
+      projectState.currentProject = null;
+      projectStatsState.stats = {
+        waiting: { activeAgentCount: 0, waitingAgentCount: 1, processCount: 0 },
+      };
+      getBulkStatsMock.mockResolvedValue(emptyBulkStats(projects.map((p) => p.id)));
+
+      const { result, rerender, unmount } = renderHook(() => useProjectSwitcherPalette());
+      act(() => {
+        result.current.open("modal");
+      });
+      await waitFor(() => {
+        expect(result.current.results[0]!.id).toBe("waiting");
+      });
+      expect(result.current.results[0]!.section).toBe("attention");
+
+      // The agent finishes: live state now puts this row in Other, but the
+      // freeze keeps it where the user last saw it.
+      act(() => {
+        projectStatsState.stats = {
+          waiting: { activeAgentCount: 0, waitingAgentCount: 0, processCount: 0 },
+        };
+        rerender();
+      });
+      expect(result.current.results[0]!.section).toBe("attention");
+
+      act(() => {
+        setOtherSortMode("alphabetical");
+      });
+
+      await waitFor(() => {
+        expect(result.current.results.slice(1).map((p) => p.id)).toEqual(["alpha", "mike", "zulu"]);
+      });
+      // Still first, still in Needs attention — the mode change reordered the
+      // Other band only, and did not adopt live band membership wholesale.
+      expect(result.current.results[0]!.id).toBe("waiting");
+      expect(result.current.results[0]!.section).toBe("attention");
+      unmount();
     });
 
     it("re-sorts an already-open palette when the mode changes", async () => {

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -133,7 +133,13 @@ vi.mock("@/hooks/useCopyWithFeedback", () => ({
 }));
 
 import { usePaletteStore } from "@/store/paletteStore";
+import { usePreferencesStore } from "@/store/preferencesStore";
+import { DEFAULT_OTHER_PROJECTS_SORT_MODE, type OtherProjectsSortMode } from "@/lib/projectSort";
 import { useProjectSwitcherPalette } from "../useProjectSwitcherPalette";
+
+function setOtherSortMode(mode: OtherProjectsSortMode): void {
+  usePreferencesStore.getState().setProjectSwitcherOtherSortMode(mode);
+}
 
 const emptyBulkStats = (projectIds: string[]) => {
   const result: Record<
@@ -1498,6 +1504,138 @@ describe("useProjectSwitcherPalette", () => {
   // Classification is tested here, against raw projects plus pushed stats,
   // rather than through the component — a component fixture that restates the
   // banding rules would go on passing while this logic drifted.
+  describe("Other band sort mode — issue #11455", () => {
+    const base = (id: string, extra: Record<string, unknown> = {}) => ({
+      id,
+      name: id,
+      path: `/repo/${id}`,
+      emoji: "🌲",
+      lastOpened: 100,
+      frecencyScore: 3.0,
+      status: "closed" as const,
+      ...extra,
+    });
+
+    // Every signal disagrees, so each mode must produce a different order.
+    const conflicting = () => [
+      base("zulu", { lastOpened: 300, frecencyScore: 9.0 }),
+      base("alpha", { lastOpened: 100, frecencyScore: 3.0 }),
+      base("mike", { lastOpened: 500, frecencyScore: 1.0 }),
+    ];
+
+    async function openWith(mode: OtherProjectsSortMode, projects: ReturnType<typeof base>[]) {
+      setOtherSortMode(mode);
+      projectState.projects = projects;
+      projectState.currentProject = null;
+      projectStatsState.stats = {};
+      getBulkStatsMock.mockResolvedValue(emptyBulkStats(projects.map((p) => p.id)));
+
+      const view = renderHook(() => useProjectSwitcherPalette());
+      act(() => {
+        view.result.current.open("modal");
+      });
+      await waitFor(() => {
+        expect(view.result.current.results).toHaveLength(projects.length);
+      });
+      return view;
+    }
+
+    afterEach(() => {
+      setOtherSortMode(DEFAULT_OTHER_PROJECTS_SORT_MODE);
+    });
+
+    it("orders the Other band by the selected mode", async () => {
+      const hottest = await openWith("hottest", conflicting());
+      expect(hottest.result.current.results.map((p) => p.id)).toEqual(["zulu", "alpha", "mike"]);
+
+      const recent = await openWith("recent", conflicting());
+      expect(recent.result.current.results.map((p) => p.id)).toEqual(["mike", "zulu", "alpha"]);
+
+      const alphabetical = await openWith("alphabetical", conflicting());
+      expect(alphabetical.result.current.results.map((p) => p.id)).toEqual([
+        "alpha",
+        "mike",
+        "zulu",
+      ]);
+    });
+
+    it("leaves the pinned band alphabetical whatever the Other mode is", async () => {
+      // The load-bearing orders belong to their bands, not to this preference:
+      // asking for A-Z in the residual band is not asking for it everywhere,
+      // and asking for Recent must not un-sort a user-curated pinned set.
+      const projects = [
+        base("zPinned", { pinned: true, lastOpened: 9_000, frecencyScore: 50.0 }),
+        base("aPinned", { pinned: true, lastOpened: 100, frecencyScore: 1.0 }),
+      ];
+      const view = await openWith("recent", projects);
+      expect(view.result.current.results.map((p) => p.id)).toEqual(["aPinned", "zPinned"]);
+    });
+
+    it("leaves the running band ordered by agent count whatever the Other mode is", async () => {
+      const projects = [base("oneAgent"), base("threeAgents")];
+      setOtherSortMode("alphabetical");
+      projectState.projects = projects;
+      projectState.currentProject = null;
+      projectStatsState.stats = {
+        oneAgent: { activeAgentCount: 1, waitingAgentCount: 0, processCount: 0 },
+        threeAgents: { activeAgentCount: 3, waitingAgentCount: 0, processCount: 0 },
+      };
+      getBulkStatsMock.mockResolvedValue(emptyBulkStats(projects.map((p) => p.id)));
+
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+      act(() => {
+        result.current.open("modal");
+      });
+      await waitFor(() => {
+        expect(result.current.results).toHaveLength(2);
+      });
+      // Alphabetically "oneAgent" precedes "threeAgents"; most-work-first wins.
+      expect(result.current.results.map((p) => p.id)).toEqual(["threeAgents", "oneAgent"]);
+    });
+
+    it("re-sorts an already-open palette when the mode changes", async () => {
+      // Without an explicit recapture the frozen layout keeps serving the order
+      // captured at open(), so the menu would appear to do nothing.
+      const view = await openWith("hottest", conflicting());
+      expect(view.result.current.results.map((p) => p.id)).toEqual(["zulu", "alpha", "mike"]);
+
+      act(() => {
+        setOtherSortMode("alphabetical");
+      });
+
+      await waitFor(() => {
+        expect(view.result.current.results.map((p) => p.id)).toEqual(["alpha", "mike", "zulu"]);
+      });
+    });
+
+    it("keeps the highlight on the same project across a mode change", async () => {
+      const view = await openWith("hottest", conflicting());
+      // Walk the highlight down to the last row, where the reorder is
+      // guaranteed to move it to a different index.
+      act(() => {
+        view.result.current.selectNext();
+        view.result.current.selectNext();
+      });
+      const selectedBefore = view.result.current.results[view.result.current.selectedIndex]?.id;
+      const indexBefore = view.result.current.selectedIndex;
+      expect(selectedBefore).toBe("mike");
+
+      act(() => {
+        setOtherSortMode("alphabetical");
+      });
+
+      await waitFor(() => {
+        expect(view.result.current.results.map((p) => p.id)).toEqual(["alpha", "mike", "zulu"]);
+      });
+      // The index moved but the selection is the project, not the slot — the
+      // highlight must not be left addressing whatever row inherited index 2.
+      expect(view.result.current.selectedIndex).not.toBe(indexBefore);
+      expect(view.result.current.results[view.result.current.selectedIndex]?.id).toBe(
+        selectedBefore
+      );
+    });
+  });
+
   describe("section classification", () => {
     const base = (id: string, extra: Record<string, unknown> = {}) => ({
       id,

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -705,13 +705,48 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     // A change while closed needs no recapture: the next `open()` captures the
     // new order anyway, and recapturing here would queue it against a stale list.
     if (!isOpen) return;
-    setFrozenLayout((previous) =>
-      // Provisionality is a property of the DATA, not of the order, so it
-      // survives the recapture — otherwise changing the mode during a cold
-      // open would cancel the pending one-time regroup (#11452).
-      previous ? captureLayout(liveBrowseOrder, previous.isProvisional) : previous
-    );
-  }, [otherProjectsSortMode, isOpen, liveBrowseOrder, captureLayout]);
+    setFrozenLayout((previous) => {
+      if (!previous) return previous;
+      // Re-sort the Other rows IN THEIR EXISTING SLOTS rather than recapturing
+      // the whole layout from `liveBrowseOrder`. A blanket recapture would also
+      // adopt live BAND membership, so a project whose agent finished while the
+      // palette was open would jump out of Needs attention the moment the user
+      // touched an unrelated sort control. The user changed one band's order;
+      // nothing else may move.
+      const slots: number[] = [];
+      const ids: string[] = [];
+      previous.order.forEach((id, index) => {
+        if (previous.sections.get(id) === "other") {
+          slots.push(index);
+          ids.push(id);
+        }
+      });
+      if (ids.length < 2) return previous;
+
+      const live = new Map(liveBrowseOrder.map((project) => [project.id, project]));
+      const resorted = [...ids].sort((a, b) => {
+        const projectA = live.get(a);
+        const projectB = live.get(b);
+        // A row whose project has gone away is dropped downstream anyway; order
+        // it last so this stays a total order rather than an inconsistent one.
+        if (!projectA || !projectB) {
+          if (projectA) return -1;
+          if (projectB) return 1;
+          return a.localeCompare(b);
+        }
+        return compareProjectsByMode(projectA, projectB, otherProjectsSortMode);
+      });
+
+      const order = [...previous.order];
+      slots.forEach((slot, index) => {
+        order[slot] = resorted[index]!;
+      });
+      // Sections and provisionality are untouched: provisionality describes the
+      // DATA, so a mode change during a cold open must not cancel the pending
+      // one-time regroup (#11452).
+      return { ...previous, order };
+    });
+  }, [otherProjectsSortMode, isOpen, liveBrowseOrder]);
 
   // Fold projects that appeared after the freeze into it, at the position the
   // renderer already gives them (end of their live band). Without this they are

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -6,6 +6,8 @@ import { useProjectStatsStore } from "@/store/projectStatsStore";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { useScratchStore } from "@/store/scratchStore";
 import { usePaletteStore } from "@/store/paletteStore";
+import { usePreferencesStore } from "@/store/preferencesStore";
+import { compareProjectsByMode, type OtherProjectsSortMode } from "@/lib/projectSort";
 import { useProjectRelocationStore } from "@/store/projectRelocationStore";
 import { notify } from "@/lib/notify";
 import { closeAndAnnounce } from "@/lib/accessibility";
@@ -78,6 +80,14 @@ export const PROJECT_SECTION_LABELS: Record<ProjectSectionKey, string | null> = 
   other: "Other projects",
   unavailable: "Unavailable",
 };
+
+/**
+ * Rows the Other band needs before its sort control is worth advertising
+ * (#11455). Below this the order is self-evident from the rows themselves, so
+ * the control would be chrome naming something nobody asked about. The
+ * preference still applies — only the visible affordance is gated.
+ */
+export const OTHER_PROJECTS_SORT_CONTROL_MIN_ROWS = 4;
 
 export interface SearchableProject {
   id: string;
@@ -323,9 +333,19 @@ function attentionClass(project: SearchableProject): number {
  * - Pinned/Unavailable: alphabetical. Pinning is user-curated — reordering a
  *   curated set by a hidden score reads as rows moving on their own.
  * - Running: most work first, then freshest working transition.
- * - Other (and the single-row current): effective frecency.
+ * - Other: whichever order the user picked (#11455); effective frecency by
+ *   default, which is what this band has always done.
+ * - Current: effective frecency, though it is a single row either way.
+ *
+ * Only Other reads the preference. The other bands' orders are decisions in
+ * their own right — a user asking for A-Z in the residual band is not asking
+ * for their blocked agents to be alphabetised.
  */
-function compareWithinSection(a: SearchableProject, b: SearchableProject): number {
+function compareWithinSection(
+  a: SearchableProject,
+  b: SearchableProject,
+  otherProjectsSortMode: OtherProjectsSortMode
+): number {
   const section = a.section;
   if (section === "attention") {
     const aClass = attentionClass(a);
@@ -363,6 +383,10 @@ function compareWithinSection(a: SearchableProject, b: SearchableProject): numbe
     const aWorking = a.latestWorkingSince ?? 0;
     const bWorking = b.latestWorkingSince ?? 0;
     if (aWorking !== bWorking) return bWorking - aWorking;
+  } else if (section === "other") {
+    // `frecencyScore` is already read-time decayed here (see `searchableProjects`),
+    // so it is safe to hand straight to the shared comparator.
+    return compareProjectsByMode(a, b, otherProjectsSortMode);
   } else if (a.frecencyScore !== b.frecencyScore) {
     return b.frecencyScore - a.frecencyScore;
   }
@@ -623,14 +647,16 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     return { activeAgentCount, waitingAgentCount, waitingProjectCount };
   }, [searchableProjects]);
 
+  const otherProjectsSortMode = usePreferencesStore((state) => state.projectSwitcherOtherSortMode);
+
   const liveBrowseOrder = useMemo<SearchableProject[]>(() => {
     return [...searchableProjects].sort((a, b) => {
       if (a.section !== b.section) {
         return PROJECT_SECTION_ORDER.indexOf(a.section) - PROJECT_SECTION_ORDER.indexOf(b.section);
       }
-      return compareWithinSection(a, b);
+      return compareWithinSection(a, b, otherProjectsSortMode);
     });
-  }, [searchableProjects]);
+  }, [searchableProjects, otherProjectsSortMode]);
 
   // Layout is frozen for the lifetime of an open palette; content stays live.
   //
@@ -662,6 +688,30 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     }),
     []
   );
+
+  // Changing the sort order is the one input that must beat the freeze. The
+  // freeze exists so rows don't move on their own; a mode the user just picked
+  // is the opposite of that, and holding it until the next open would read as
+  // the menu doing nothing.
+  //
+  // Guarded on the mode having actually changed, via a ref rather than the
+  // effect's own dependencies: `liveBrowseOrder` is a dependency because the
+  // recapture must read the freshly re-sorted order, and without the guard
+  // every stats push would recapture and destroy the freeze outright.
+  const previousOtherProjectsSortMode = useRef(otherProjectsSortMode);
+  useEffect(() => {
+    if (previousOtherProjectsSortMode.current === otherProjectsSortMode) return;
+    previousOtherProjectsSortMode.current = otherProjectsSortMode;
+    // A change while closed needs no recapture: the next `open()` captures the
+    // new order anyway, and recapturing here would queue it against a stale list.
+    if (!isOpen) return;
+    setFrozenLayout((previous) =>
+      // Provisionality is a property of the DATA, not of the order, so it
+      // survives the recapture — otherwise changing the mode during a cold
+      // open would cancel the pending one-time regroup (#11452).
+      previous ? captureLayout(liveBrowseOrder, previous.isProvisional) : previous
+    );
+  }, [otherProjectsSortMode, isOpen, liveBrowseOrder, captureLayout]);
 
   // Fold projects that appeared after the freeze into it, at the position the
   // renderer already gives them (end of their live band). Without this they are

--- a/src/lib/__tests__/projectSort.test.ts
+++ b/src/lib/__tests__/projectSort.test.ts
@@ -51,6 +51,35 @@ describe("compareProjectsByMode", () => {
     expect(order(mixed, "alphabetical")).toEqual(["apple", "Banana"]);
   });
 
+  it("does not consult the score in recent when timestamps tie", () => {
+    // Score is the loudest signal in hottest and must be silent here, or
+    // "Recent" quietly becomes "Hottest with extra steps" on any tie.
+    const tied: SortableProject[] = [
+      { id: "hi", name: "Zulu", lastOpened: 500, frecencyScore: 99 },
+      { id: "lo", name: "Alpha", lastOpened: 500, frecencyScore: 1 },
+    ];
+    expect(order(tied, "recent")).toEqual(["Alpha", "Zulu"]);
+  });
+
+  it("reaches the name tie-break before the id in hottest and recent", () => {
+    // Ids are opaque and ordered against the names here, so skipping the name
+    // comparison would surface them in the wrong order.
+    const tied: SortableProject[] = [
+      { id: "id-aaa", name: "Zulu", lastOpened: 500, frecencyScore: 5 },
+      { id: "id-zzz", name: "Alpha", lastOpened: 500, frecencyScore: 5 },
+    ];
+    expect(order(tied, "hottest")).toEqual(["Alpha", "Zulu"]);
+    expect(order(tied, "recent")).toEqual(["Alpha", "Zulu"]);
+  });
+
+  it("does not let score or recency leak into alphabetical", () => {
+    const mixed: SortableProject[] = [
+      { id: "a", name: "Alpha", lastOpened: 1, frecencyScore: 0 },
+      { id: "z", name: "Zulu", lastOpened: 999, frecencyScore: 99 },
+    ];
+    expect(order(mixed, "alphabetical")).toEqual(["Alpha", "Zulu"]);
+  });
+
   it("falls back to last opened when scores tie in hottest", () => {
     const tied: SortableProject[] = [
       { id: "older", name: "Older", lastOpened: 100, frecencyScore: 5 },

--- a/src/lib/__tests__/projectSort.test.ts
+++ b/src/lib/__tests__/projectSort.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import {
+  compareProjectsByMode,
+  isOtherProjectsSortMode,
+  OTHER_PROJECTS_SORT_MODES,
+  type OtherProjectsSortMode,
+  type SortableProject,
+} from "../projectSort";
+
+/**
+ * One fixture where every signal disagrees, so each mode has to pick a
+ * different winner. A fixture where score, recency and name happen to agree
+ * would pass under any comparator and prove nothing.
+ */
+const CONFLICTING: SortableProject[] = [
+  { id: "p-zulu", name: "Zulu", lastOpened: 300, frecencyScore: 9 },
+  { id: "p-alpha", name: "Alpha", lastOpened: 100, frecencyScore: 3 },
+  { id: "p-mike", name: "Mike", lastOpened: 500, frecencyScore: 1 },
+];
+
+function order(projects: SortableProject[], mode: OtherProjectsSortMode): string[] {
+  return [...projects].sort((a, b) => compareProjectsByMode(a, b, mode)).map((p) => p.name);
+}
+
+describe("compareProjectsByMode", () => {
+  it("ranks by decayed score in hottest, ignoring which row was opened last", () => {
+    // Mike is the most recently opened and still ranks last: score leads.
+    expect(order(CONFLICTING, "hottest")).toEqual(["Zulu", "Alpha", "Mike"]);
+  });
+
+  it("ranks by last opened in recent, ignoring the score entirely", () => {
+    expect(order(CONFLICTING, "recent")).toEqual(["Mike", "Zulu", "Alpha"]);
+  });
+
+  it("ranks by name in alphabetical, ignoring both score and recency", () => {
+    expect(order(CONFLICTING, "alphabetical")).toEqual(["Alpha", "Mike", "Zulu"]);
+  });
+
+  it("gives each mode a distinct order for the same input", () => {
+    const orders = OTHER_PROJECTS_SORT_MODES.map((mode) => order(CONFLICTING, mode).join("|"));
+    expect(new Set(orders).size).toBe(OTHER_PROJECTS_SORT_MODES.length);
+  });
+
+  it("compares names case-insensitively rather than by code point", () => {
+    // A byte-wise compare puts every uppercase letter before every lowercase
+    // one, which would file "apple" after "Banana".
+    const mixed: SortableProject[] = [
+      { id: "b", name: "Banana", lastOpened: 0, frecencyScore: 0 },
+      { id: "a", name: "apple", lastOpened: 0, frecencyScore: 0 },
+    ];
+    expect(order(mixed, "alphabetical")).toEqual(["apple", "Banana"]);
+  });
+
+  it("falls back to last opened when scores tie in hottest", () => {
+    const tied: SortableProject[] = [
+      { id: "older", name: "Older", lastOpened: 100, frecencyScore: 5 },
+      { id: "newer", name: "Newer", lastOpened: 900, frecencyScore: 5 },
+    ];
+    expect(order(tied, "hottest")).toEqual(["Newer", "Older"]);
+  });
+
+  it.each(OTHER_PROJECTS_SORT_MODES)("breaks a total tie deterministically in %s", (mode) => {
+    // Same name, same score, same timestamp: without the id tie-break the
+    // relative order would be whatever the sort implementation happened to do,
+    // and rows could swap between renders for no visible reason.
+    const twins: SortableProject[] = [
+      { id: "id-b", name: "Same", lastOpened: 7, frecencyScore: 2 },
+      { id: "id-a", name: "Same", lastOpened: 7, frecencyScore: 2 },
+    ];
+    const first = [...twins].sort((a, b) => compareProjectsByMode(a, b, mode));
+    const second = [...twins].reverse().sort((a, b) => compareProjectsByMode(a, b, mode));
+    expect(first.map((p) => p.id)).toEqual(["id-a", "id-b"]);
+    expect(second.map((p) => p.id)).toEqual(first.map((p) => p.id));
+  });
+
+  it.each(OTHER_PROJECTS_SORT_MODES)("is antisymmetric in %s", (mode) => {
+    // Normalised to -1/0/1 rather than via `Math.sign`, whose negated zero is
+    // `-0` — a distinction `toBe` (Object.is) would report as a failure.
+    const sign = (n: number) => (n > 0 ? 1 : n < 0 ? -1 : 0);
+    for (const a of CONFLICTING) {
+      for (const b of CONFLICTING) {
+        expect(sign(compareProjectsByMode(a, b, mode))).toBe(
+          sign(-compareProjectsByMode(b, a, mode))
+        );
+      }
+    }
+  });
+});
+
+describe("isOtherProjectsSortMode", () => {
+  it.each(OTHER_PROJECTS_SORT_MODES)("accepts %s", (mode) => {
+    expect(isOtherProjectsSortMode(mode)).toBe(true);
+  });
+
+  it("rejects values a hand-edited or stale persisted blob could hold", () => {
+    for (const value of ["", "Hottest", "frecency", null, undefined, 0, {}, ["hottest"]]) {
+      expect(isOtherProjectsSortMode(value)).toBe(false);
+    }
+  });
+});

--- a/src/lib/projectSort.ts
+++ b/src/lib/projectSort.ts
@@ -1,0 +1,65 @@
+/**
+ * Sort order for the project switcher's "Other projects" band, and for the
+ * welcome screen's recent-projects list — the two surfaces that render the same
+ * frecency-ranked residual set and carry a standing promise never to disagree
+ * on order (#11455).
+ *
+ * Scoped to that band alone. Needs attention (severity, then oldest first),
+ * Pinned (alphabetical), and Running (most work first) each encode a decision
+ * this preference must not override.
+ */
+export const OTHER_PROJECTS_SORT_MODES = ["hottest", "recent", "alphabetical"] as const;
+
+export type OtherProjectsSortMode = (typeof OTHER_PROJECTS_SORT_MODES)[number];
+
+export const DEFAULT_OTHER_PROJECTS_SORT_MODE: OtherProjectsSortMode = "hottest";
+
+export function isOtherProjectsSortMode(value: unknown): value is OtherProjectsSortMode {
+  return (
+    typeof value === "string" && (OTHER_PROJECTS_SORT_MODES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * The fields any sortable project must expose. Callers normalise into this
+ * shape so the comparator can't be handed a raw persisted score by mistake:
+ * `frecencyScore` here is the READ-TIME DECAYED value, never the stored one.
+ * Comparing stored scores compares snapshots frozen on different dates, which
+ * is how a months-dormant project once held a top slot.
+ */
+export interface SortableProject {
+  id: string;
+  name: string;
+  lastOpened: number;
+  frecencyScore: number;
+}
+
+/**
+ * Order within the Other band for `mode`.
+ *
+ * Every mode ends on `id` so the order is a total one: two projects sharing a
+ * name (or a score and a timestamp) must not swap places between renders, or
+ * rows move under the pointer for no reason the user can see.
+ */
+export function compareProjectsByMode(
+  a: SortableProject,
+  b: SortableProject,
+  mode: OtherProjectsSortMode
+): number {
+  if (mode === "alphabetical") {
+    const byName = a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+    if (byName !== 0) return byName;
+    return a.id.localeCompare(b.id);
+  }
+
+  // Hottest keeps frecency as the primary key; Recent drops it entirely and
+  // ranks on the timestamp the rows already show. Both then fall through to
+  // the same tie-breaks, so switching modes never changes how ties resolve.
+  if (mode === "hottest" && a.frecencyScore !== b.frecencyScore) {
+    return b.frecencyScore - a.frecencyScore;
+  }
+  if (a.lastOpened !== b.lastOpened) return b.lastOpened - a.lastOpened;
+  const byName = a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+  if (byName !== 0) return byName;
+  return a.id.localeCompare(b.id);
+}

--- a/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
@@ -120,6 +120,43 @@ describe("preferencesStore cross-view write merge (#11351)", () => {
     expect(written.state.reduceAnimations).toBe(true); // sibling's change survived
   });
 
+  // The generic scalar tests above pass even if this specific field is dropped
+  // from the merge, which would silently make the sort mode the one preference
+  // a stale sibling view can clobber (#11455).
+  it("keeps a sibling's sort mode when this view changes an unrelated scalar", async () => {
+    const backing = installLocalStorage({});
+    const { usePreferencesStore: store } = await import("../preferencesStore");
+
+    store.getState().setDockDensity("normal");
+
+    const disk = readBlob(backing);
+    disk.state.projectSwitcherOtherSortMode = "recent";
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    store.getState().setDockDensity("compact");
+
+    const written = readBlob(backing);
+    expect(written.state.projectSwitcherOtherSortMode).toBe("recent");
+    expect(written.state.dockDensity).toBe("compact");
+  });
+
+  it("keeps this view's sort mode when a sibling changes an unrelated scalar", async () => {
+    const backing = installLocalStorage({});
+    const { usePreferencesStore: store } = await import("../preferencesStore");
+
+    store.getState().setDockDensity("normal");
+
+    const disk = readBlob(backing);
+    disk.state.reduceAnimations = true;
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    store.getState().setProjectSwitcherOtherSortMode("alphabetical");
+
+    const written = readBlob(backing);
+    expect(written.state.projectSwitcherOtherSortMode).toBe("alphabetical");
+    expect(written.state.reduceAnimations).toBe(true);
+  });
+
   it("does not resurrect a recipe entry this view cleared, and keeps a sibling's", async () => {
     const backing = installLocalStorage({});
     const { usePreferencesStore: store } = await import("../preferencesStore");

--- a/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
@@ -9,7 +9,6 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
  */
 describe("preferencesStore cross-view write merge (#11351)", () => {
   const STORAGE_KEY = "daintree-preferences";
-  const VERSION = 13;
   const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
 
   type PersistedBlob = {
@@ -77,10 +76,13 @@ describe("preferencesStore cross-view write merge (#11351)", () => {
     const backing = installLocalStorage({});
     const { usePreferencesStore: store } = await import("../preferencesStore");
 
+    // Read from the store rather than pinning a literal: the merge SKIPS
+    // reconciliation when the on-disk version differs, so a stale fixture
+    // silently stops testing the merge instead of failing loudly.
     backing.set(
       STORAGE_KEY,
       JSON.stringify({
-        version: VERSION,
+        version: store.persist.getOptions().version,
         state: {
           lastSelectedWorktreeRecipeIdByProject: { "proj-b": "recipe-b" },
           showProjectPulse: false,

--- a/src/store/__tests__/preferencesStore.test.ts
+++ b/src/store/__tests__/preferencesStore.test.ts
@@ -782,4 +782,57 @@ describe("preferencesStore migration", () => {
       expect(store.getState().fileBrowserAlwaysHiddenPatterns).toEqual(["ok"]);
     });
   });
+
+  describe("projectSwitcherOtherSortMode (v14 migration)", () => {
+    it("defaults to the band's existing frecency order on a fresh install", async () => {
+      // The default has to reproduce today's behavior exactly, or shipping the
+      // control silently reorders every user's Other band on upgrade.
+      const store = await loadStore();
+      expect(store.getState().projectSwitcherOtherSortMode).toBe("hottest");
+    });
+
+    it("round-trips a non-default choice through storage", async () => {
+      const store = await loadStore();
+      store.getState().setProjectSwitcherOtherSortMode("alphabetical");
+
+      const persisted = JSON.parse(storage[STORAGE_KEY]!) as {
+        state: Record<string, unknown>;
+      };
+      expect(persisted.state.projectSwitcherOtherSortMode).toBe("alphabetical");
+    });
+
+    it("survives a reload rather than resetting to the default", async () => {
+      const first = await loadStore();
+      first.getState().setProjectSwitcherOtherSortMode("recent");
+
+      vi.resetModules();
+      _resetPersistedStoreRegistryForTests();
+      const reloaded = await loadStore();
+      expect(reloaded.getState().projectSwitcherOtherSortMode).toBe("recent");
+    });
+
+    it("defaults a pre-v14 blob that predates the field", async () => {
+      setStoredState({ dockDensity: "compact" }, 13);
+      const store = await loadStore();
+
+      expect(store.getState().projectSwitcherOtherSortMode).toBe("hottest");
+      // The migration must not trample the state it is migrating past.
+      expect(store.getState().dockDensity).toBe("compact");
+    });
+
+    it("preserves an explicit choice across the v14 migration", async () => {
+      setStoredState({ projectSwitcherOtherSortMode: "recent" }, 13);
+      const store = await loadStore();
+      expect(store.getState().projectSwitcherOtherSortMode).toBe("recent");
+    });
+
+    it("normalises a value outside the closed set", async () => {
+      // Hand-edited or written by a newer build: an unknown mode would leave
+      // the radio group with no checked item and fall through every branch of
+      // the comparator.
+      setStoredState({ projectSwitcherOtherSortMode: "newest" }, 14);
+      const store = await loadStore();
+      expect(store.getState().projectSwitcherOtherSortMode).toBe("hottest");
+    });
+  });
 });

--- a/src/store/__tests__/preferencesStore.test.ts
+++ b/src/store/__tests__/preferencesStore.test.ts
@@ -811,6 +811,26 @@ describe("preferencesStore migration", () => {
       expect(reloaded.getState().projectSwitcherOtherSortMode).toBe("recent");
     });
 
+    it("supplies the field in the migration itself, not only in the sanitizer", async () => {
+      // Hydration sanitizes too, so a blob-in/state-out test passes even with
+      // the migration branch deleted. Drive `migrate` directly to pin it.
+      const store = await loadStore();
+      const options = store.persist.getOptions();
+      const migrated = options.migrate?.({ dockDensity: "compact" }, 13) as Record<string, unknown>;
+
+      expect(migrated.projectSwitcherOtherSortMode).toBe("hottest");
+      expect(migrated.dockDensity).toBe("compact");
+    });
+
+    it("leaves an explicit choice alone when migrating", async () => {
+      const store = await loadStore();
+      const migrated = store.persist
+        .getOptions()
+        .migrate?.({ projectSwitcherOtherSortMode: "recent" }, 13) as Record<string, unknown>;
+
+      expect(migrated.projectSwitcherOtherSortMode).toBe("recent");
+    });
+
     it("defaults a pre-v14 blob that predates the field", async () => {
       setStoredState({ dockDensity: "compact" }, 13);
       const store = await loadStore();

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -8,6 +8,11 @@ import {
   type PersistWriteMergeContext,
 } from "./persistence/persistWriteMerge";
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
+import {
+  DEFAULT_OTHER_PROJECTS_SORT_MODE,
+  isOtherProjectsSortMode,
+  type OtherProjectsSortMode,
+} from "@/lib/projectSort";
 
 export type DockDensity = "compact" | "normal" | "comfortable";
 
@@ -121,6 +126,13 @@ interface PreferencesState {
    * 0 disables auto-cleanup.
    */
   deletedWorktreeCleanupSeconds: DeletedWorktreeCleanupSeconds;
+  /**
+   * Sort order for the project switcher's "Other projects" band and the welcome
+   * screen's recent list (#11455). Global rather than per-project: it names how
+   * the user reads their whole project set, not anything about one project.
+   */
+  projectSwitcherOtherSortMode: OtherProjectsSortMode;
+  setProjectSwitcherOtherSortMode: (mode: OtherProjectsSortMode) => void;
   setDeletedWorktreeCleanupSeconds: (value: DeletedWorktreeCleanupSeconds) => void;
   /**
    * Basename globs always hidden in the file browser, across every panel. See
@@ -179,6 +191,9 @@ function sanitizePersistedPreferences(
   if (!isDeletedWorktreeCleanupSeconds(sanitized.deletedWorktreeCleanupSeconds)) {
     sanitized.deletedWorktreeCleanupSeconds = DELETED_WORKTREE_CLEANUP_DEFAULT;
   }
+  if (!isOtherProjectsSortMode(sanitized.projectSwitcherOtherSortMode)) {
+    sanitized.projectSwitcherOtherSortMode = DEFAULT_OTHER_PROJECTS_SORT_MODE;
+  }
   // Absent (new field) → defaults; a hand-edited array is filtered to valid
   // basename patterns; a legitimately empty list is preserved.
   sanitized.fileBrowserAlwaysHiddenPatterns = sanitizeAlwaysHiddenPatterns(
@@ -216,6 +231,7 @@ type PreferencesPersistedState = Pick<
   | "diffFontSize"
   | "markdownWrapLines"
   | "deletedWorktreeCleanupSeconds"
+  | "projectSwitcherOtherSortMode"
   | "lastSelectedWorktreeRecipeIdByProject"
   | "skipPushConfirmByWorktreePath"
   | "fileBrowserAlwaysHiddenPatterns"
@@ -238,6 +254,7 @@ const PREFERENCES_PERSISTED_DEFAULTS: PreferencesPersistedState = {
   diffFontSize: "m",
   markdownWrapLines: true,
   deletedWorktreeCleanupSeconds: DELETED_WORKTREE_CLEANUP_DEFAULT,
+  projectSwitcherOtherSortMode: DEFAULT_OTHER_PROJECTS_SORT_MODE,
   lastSelectedWorktreeRecipeIdByProject: {},
   skipPushConfirmByWorktreePath: {},
   fileBrowserAlwaysHiddenPatterns: [...DEFAULT_FILE_BROWSER_ALWAYS_HIDDEN],
@@ -302,6 +319,9 @@ function toPreferencesPersisted(
     )
       ? raw.deletedWorktreeCleanupSeconds
       : d.deletedWorktreeCleanupSeconds,
+    projectSwitcherOtherSortMode: isOtherProjectsSortMode(raw.projectSwitcherOtherSortMode)
+      ? raw.projectSwitcherOtherSortMode
+      : d.projectSwitcherOtherSortMode,
     lastSelectedWorktreeRecipeIdByProject: normalizeRecipeMap(
       raw.lastSelectedWorktreeRecipeIdByProject
     ),
@@ -401,6 +421,11 @@ function mergePreferencesPersistedWrite({
         inc.deletedWorktreeCleanupSeconds,
         disk.deletedWorktreeCleanupSeconds
       ),
+      projectSwitcherOtherSortMode: pickFieldByWriterDelta(
+        base.projectSwitcherOtherSortMode,
+        inc.projectSwitcherOtherSortMode,
+        disk.projectSwitcherOtherSortMode
+      ),
       lastSelectedWorktreeRecipeIdByProject: mergeRecordByWriterDelta(
         base.lastSelectedWorktreeRecipeIdByProject,
         inc.lastSelectedWorktreeRecipeIdByProject,
@@ -482,6 +507,8 @@ export const usePreferencesStore = create<PreferencesState>()(
         }),
       deletedWorktreeCleanupSeconds: DELETED_WORKTREE_CLEANUP_DEFAULT,
       setDeletedWorktreeCleanupSeconds: (value) => set({ deletedWorktreeCleanupSeconds: value }),
+      projectSwitcherOtherSortMode: DEFAULT_OTHER_PROJECTS_SORT_MODE,
+      setProjectSwitcherOtherSortMode: (mode) => set({ projectSwitcherOtherSortMode: mode }),
       fileBrowserAlwaysHiddenPatterns: [...DEFAULT_FILE_BROWSER_ALWAYS_HIDDEN],
       setFileBrowserAlwaysHiddenPatterns: (patterns) =>
         set({ fileBrowserAlwaysHiddenPatterns: sanitizeAlwaysHiddenPatterns(patterns) }),
@@ -493,7 +520,7 @@ export const usePreferencesStore = create<PreferencesState>()(
       storage: createSafeJSONStorage<PreferencesPersistedState>({
         mergeOnWrite: mergePreferencesPersistedWrite,
       }),
-      version: 13,
+      version: 14,
       // Explicit persisted subset — matches the pre-existing default (setters are
       // dropped by JSON serialization); named so the write merge (#11351) has a
       // typed persisted shape to reconcile.
@@ -514,6 +541,7 @@ export const usePreferencesStore = create<PreferencesState>()(
         diffFontSize: state.diffFontSize,
         markdownWrapLines: state.markdownWrapLines,
         deletedWorktreeCleanupSeconds: state.deletedWorktreeCleanupSeconds,
+        projectSwitcherOtherSortMode: state.projectSwitcherOtherSortMode,
         lastSelectedWorktreeRecipeIdByProject: state.lastSelectedWorktreeRecipeIdByProject,
         skipPushConfirmByWorktreePath: state.skipPushConfirmByWorktreePath,
         fileBrowserAlwaysHiddenPatterns: state.fileBrowserAlwaysHiddenPatterns,
@@ -625,6 +653,11 @@ export const usePreferencesStore = create<PreferencesState>()(
             persisted.deletedWorktreeCleanupSeconds = DELETED_WORKTREE_CLEANUP_DEFAULT;
           }
         }
+        if (version < 14 && isRecord(persisted)) {
+          if (!isOtherProjectsSortMode(persisted.projectSwitcherOtherSortMode)) {
+            persisted.projectSwitcherOtherSortMode = DEFAULT_OTHER_PROJECTS_SORT_MODE;
+          }
+        }
         return persisted as PreferencesState;
       },
     }
@@ -635,5 +668,5 @@ registerPersistedStore({
   storeId: "preferencesStore",
   store: usePreferencesStore,
   persistedStateType:
-    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; showAgentTaskTitles: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; diffViewType: DiffViewType; diffWrapLines: boolean; diffIgnoreWhitespace: boolean; diffShowFileList: boolean; diffFullFile: boolean; diffFontSize: DiffFontSize; markdownWrapLines: boolean; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>; skipPushConfirmByWorktreePath: Record<string, boolean>; deletedWorktreeCleanupSeconds: DeletedWorktreeCleanupSeconds; fileBrowserAlwaysHiddenPatterns: string[] }",
+    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; showAgentTaskTitles: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; diffViewType: DiffViewType; diffWrapLines: boolean; diffIgnoreWhitespace: boolean; diffShowFileList: boolean; diffFullFile: boolean; diffFontSize: DiffFontSize; markdownWrapLines: boolean; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>; skipPushConfirmByWorktreePath: Record<string, boolean>; deletedWorktreeCleanupSeconds: DeletedWorktreeCleanupSeconds; projectSwitcherOtherSortMode: OtherProjectsSortMode; fileBrowserAlwaysHiddenPatterns: string[] }",
 });


### PR DESCRIPTION
Resolves #11455

The `OTHER PROJECTS` band sorts by decayed frecency, but every row under it prints a timestamp, so the order reads as broken. The band can't be labelled with its order either — any fixed label would be a lie the timestamps immediately expose. So the header now carries a small muted control on the right that names the current order, in the same optical column the Scratch header uses for its count. Changing it is the bonus.

Three modes: **Hottest** (decayed frecency — the default, and exactly what the band does today), **Recent** (last opened), **A to Z**. The choice persists across sessions and applies to both the modal and the sidebar/toolbar dropdown, plus the welcome screen's recent-projects list, which carries a standing promise never to disagree with the switcher on order.

Scope is strictly the Other band. Needs attention (severity, then oldest first), Pinned (alphabetical), and Running (most work first) are load-bearing and untouched — there's a test asserting each of those subsequences is identical across all three modes.

## Notes on the three traps

**The frozen layout.** Row order and band membership are frozen for the lifetime of an open palette so an agent finishing mid-read can't move rows under the pointer. A mode change has to beat that freeze or the menu looks dead. The first pass recaptured the whole layout, which was wrong in a way worth calling out: recapturing also adopts live *band* membership, so a project whose agent had finished while you were reading would jump out of Needs attention the moment you touched an unrelated sort control. It now re-sorts only the rows frozen into Other, in their existing slots, leaving every other band's membership and order alone.

**Escape and outside-click.** These turned out to need no new wiring. `AppPaletteDialog`'s Escape backstop already bails when a Radix layer was open (`radixLayerWasOpenWhenEscapePressed`), and the dropdown surface already calls `preventDefault` on `onInteractOutside` for targets inside `[role="menu"]`. A plain Radix `DropdownMenu` slots in behind both.

**The listbox.** Section headers live inside `role="listbox"`, where a focusable child isn't valid and isn't reachable anyway (arrow keys move `aria-activedescendant` across rows). So the trigger is `tabIndex={-1}` and right-click on the header reaches the same options — the tier every other secondary action in this palette already ships at. Two consequences worth knowing: the mode label is a *sibling* of the element carrying the header id, not a descendant, so the band's accessible name stays exactly "Other projects" rather than "Other projects Hottest"; and after picking a mode, focus goes back to the search box instead of the trigger, because Radix restores focus to the trigger by default and the trigger then eats ArrowDown and Enter to reopen itself.

Selection survives a re-sort on its own — the highlight tracks the project id, not an index — but there's now a test pinning that rather than assuming it.

## Persistence

The mode lives in `preferencesStore` (the global persisted store, bumped to v14) rather than `AppConfig` + a new IPC namespace. It already has the baseline-aware write merge from #11351, so a stale project view can't clobber a sibling's choice. Live cross-view reactivity isn't a property any preference in that store has today; that's its own issue if it's wanted.

## Not done

The control is pointer-only, so there's no Tab or Shift+F10 route to the sort options — consistent with the rest of this palette, but it is a real gap rather than a solved problem. Fixing it properly means moving the control out of the listbox or giving it a command-palette action.

Below four rows the control hides itself; the preference still applies, and right-click still reaches it.

## Testing

535 targeted tests pass locally, covering the comparator's invariants, the band-order matrix across all three modes, the freeze recapture, real Radix menu interaction (open → select → store write → relabel → focus handoff), the cross-view merge of the new field, and the v14 migration branch itself.