### PR TITLE
feat(window): name the active project in each window title

### DIFF
--- a/electron/ipc/handlers/projectCrud/crud.ts
+++ b/electron/ipc/handlers/projectCrud/crud.ts
@@ -11,6 +11,7 @@ import { broadcastToRenderer, typedHandle, typedHandleWithContext } from "../../
 import { projectRelocationCoordinator } from "../../../services/ProjectRelocationCoordinator.js";
 import { resolveScopedProjectForIpcContext } from "../../projectContext.js";
 import { refreshProjectMenuState } from "../../../projectMenuState.js";
+import { notificationService } from "../../../services/NotificationService.js";
 import type { HandlerDependencies } from "../../types.js";
 import type { Project, ProjectAddOptions } from "../../../types/index.js";
 import type { ProjectCreationIdentity } from "../../../../shared/types/project.js";
@@ -143,6 +144,7 @@ export async function removeProjectWithCleanup(
   broadcastToRenderer(CHANNELS.PROJECT_REMOVED, projectId);
   // The row is gone, so a window still bound to it no longer has a project open.
   refreshProjectMenuState();
+  notificationService.refreshTitles();
 }
 
 export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () => void {
@@ -221,6 +223,12 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
     } = updates;
     const updated = projectStore.updateProject(projectId, safeUpdates);
     broadcastToRenderer(CHANNELS.PROJECT_UPDATED, updated);
+    // A rename leaves the File-menu gates alone — the project is still open —
+    // but every window showing it is now titled with a stale name. Status rides
+    // along because a row turned "closed" here stops naming a window too.
+    if (updates.name !== undefined || updates.status !== undefined) {
+      notificationService.refreshTitles();
+    }
     if (
       updated.inRepoSettings &&
       (updates.name !== undefined || updates.emoji !== undefined || "color" in updates)
@@ -331,6 +339,7 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
         // closing window's ProjectViewManager still points at this project, so
         // the row's status is what tells the menu resolver it isn't open.
         refreshProjectMenuState();
+        notificationService.refreshTitles();
 
         console.log(
           `[IPC] project:close: Killed ${terminalsKilled} process(es) ` +

--- a/electron/ipc/handlers/projectCrud/switch.ts
+++ b/electron/ipc/handlers/projectCrud/switch.ts
@@ -13,6 +13,7 @@ import { ProjectSwitchService } from "../../../services/ProjectSwitchService.js"
 import { getProjectHistory } from "../../../services/ProjectHistoryService.js";
 import { broadcastProjectSwitchUpdates } from "../../projectSwitchBroadcast.js";
 import { refreshProjectMenuState } from "../../../projectMenuState.js";
+import { notificationService } from "../../../services/NotificationService.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import { logInfo } from "../../../utils/logger.js";
 import {
@@ -79,6 +80,7 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
         // whatever state we actually landed in — including when the outgoing
         // persist rejects after a visually successful activation.
         refreshProjectMenuState();
+        notificationService.refreshTitles();
       }
       return project;
     }
@@ -101,6 +103,7 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
       return await projectSwitchService.switchProject(projectId);
     } finally {
       refreshProjectMenuState();
+      notificationService.refreshTitles();
     }
   };
   handlers.push(typedHandleWithContext(CHANNELS.PROJECT_SWITCH, handleProjectSwitch));
@@ -151,6 +154,7 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
         await persistOutgoing;
       } finally {
         refreshProjectMenuState();
+        notificationService.refreshTitles();
       }
       return project;
     }
@@ -163,6 +167,7 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
       return await projectSwitchService.reopenProject(projectId);
     } finally {
       refreshProjectMenuState();
+      notificationService.refreshTitles();
     }
   };
   handlers.push(typedHandleWithContext(CHANNELS.PROJECT_REOPEN, handleProjectReopen));

--- a/electron/ipc/handlers/scratch/index.ts
+++ b/electron/ipc/handlers/scratch/index.ts
@@ -21,6 +21,7 @@ import { scratchStore } from "../../../services/ScratchStore.js";
 import { projectStore } from "../../../services/ProjectStore.js";
 import { getProjectHistory } from "../../../services/ProjectHistoryService.js";
 import { refreshProjectMenuState } from "../../../projectMenuState.js";
+import { notificationService } from "../../../services/NotificationService.js";
 import { addProjectByPath } from "../projectCrud/crud.js";
 import { gracefulTeardownAndJournalProject } from "../../../services/pty/projectSessionJournal.js";
 import { createHardenedGit } from "../../../utils/hardenedGit.js";
@@ -137,6 +138,7 @@ export function registerScratchHandlers(deps: HandlerDependencies): () => void {
           // A scratch is not a project: the window's PVM now holds a scratch id
           // with no project row, so the File-menu project gates must drop.
           refreshProjectMenuState();
+          notificationService.refreshTitles();
 
           // Tell the PTY host the active workspace changed. PtyClient treats the ID
           // as an opaque string and the path as a working directory, so passing a

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -1,6 +1,7 @@
 import { Menu, dialog, BrowserWindow, app, webContents } from "electron";
 import { randomUUID } from "node:crypto";
 import { projectStore } from "./services/ProjectStore.js";
+import { notificationService } from "./services/NotificationService.js";
 import { openExternalUrl } from "./utils/openExternal.js";
 import { CHANNELS } from "./ipc/channels.js";
 import { broadcastProjectSwitchUpdates } from "./ipc/projectSwitchBroadcast.js";
@@ -1013,5 +1014,12 @@ export async function handleDirectoryOpen(
     } catch (dialogError) {
       console.error("Failed to surface project open error:", dialogError);
     }
+  } finally {
+    // The third switch entry point, and the one that bypasses
+    // `activateProjectView` — nothing else on this path writes the title, and
+    // the next notification tick may be far off. In `finally` for the same
+    // reason the IPC switch handler converges there: a swap that committed
+    // visually before a later step threw still moved what this window shows.
+    notificationService.refreshTitles();
   }
 }

--- a/electron/services/NotificationService.ts
+++ b/electron/services/NotificationService.ts
@@ -146,7 +146,7 @@ class NotificationService {
   initialize(registry: WindowRegistry, projectLookup?: ProjectTitleLookup): void {
     this.detachAllWindowListeners();
     this.registry = registry;
-    if (projectLookup) this.projectLookup = projectLookup;
+    this.projectLookup = projectLookup ?? null;
 
     for (const ctx of registry.all()) {
       this.attachWindowListeners(ctx);
@@ -179,6 +179,7 @@ class NotificationService {
   private applyNotifications(): void {
     if (!this.registry) return;
 
+    this.pruneDeadOwners();
     const countsByWindow = this.countsByWindow();
 
     let totalWaiting = 0;
@@ -216,19 +217,32 @@ class NotificationService {
    * An owner that no longer resolves to a window is dead or dying: a view's
    * webContents id is indexed at creation, before its renderer can send any
    * IPC, and is unindexed only on eviction (which closes it) or window
-   * teardown. Pruning here keeps the badge honest even if a "destroyed" event
-   * is missed.
+   * teardown. Pruning keeps the badge honest even if a "destroyed" event is
+   * missed.
+   *
+   * Only `applyNotifications` prunes, because dropping an owner changes the
+   * total the badge is about to be set from. A title-only pass that pruned
+   * would leave the badge stale AND make the later `removeOwner` a no-op, since
+   * its `delete` would find nothing left to remove.
    */
+  private pruneDeadOwners(): void {
+    if (!this.registry) return;
+
+    for (const ownerId of [...this.statesByOwner.keys()]) {
+      const ctx = this.registry.getByWebContentsId(ownerId);
+      if (!ctx || ctx.browserWindow.isDestroyed()) {
+        this.statesByOwner.delete(ownerId);
+      }
+    }
+  }
+
   private countsByWindow(): Map<number, number> {
     const counts = new Map<number, number>();
     if (!this.registry) return counts;
 
-    for (const [ownerId, state] of [...this.statesByOwner]) {
+    for (const [ownerId, state] of this.statesByOwner) {
       const ctx = this.registry.getByWebContentsId(ownerId);
-      if (!ctx || ctx.browserWindow.isDestroyed()) {
-        this.statesByOwner.delete(ownerId);
-        continue;
-      }
+      if (!ctx || ctx.browserWindow.isDestroyed()) continue;
       counts.set(ctx.windowId, (counts.get(ctx.windowId) ?? 0) + state.waitingCount);
     }
     return counts;

--- a/electron/services/NotificationService.ts
+++ b/electron/services/NotificationService.ts
@@ -2,6 +2,12 @@ import { app, Notification, webContents as webContentsModule } from "electron";
 import type { WindowRegistry, WindowContext } from "../window/WindowRegistry.js";
 import { sendToRenderer } from "../ipc/utils.js";
 import { getAppWebContents, getWindowForWebContents } from "../window/webContentsRegistry.js";
+import {
+  FALLBACK_WINDOW_TITLE,
+  composeWindowTitle,
+  resolveWindowProjectName,
+  type ProjectTitleLookup,
+} from "../window/windowTitle.js";
 
 export interface NotificationState {
   waitingCount: number;
@@ -41,7 +47,6 @@ export interface NativeNotificationOptions extends WatchNotificationOptions {
 }
 
 const DEBOUNCE_MS = 300;
-const DEFAULT_TITLE = "Daintree";
 
 interface TrackedWindow {
   browserWindow: import("electron").BrowserWindow;
@@ -51,6 +56,7 @@ interface TrackedWindow {
 
 class NotificationService {
   private registry: WindowRegistry | null = null;
+  private projectLookup: ProjectTitleLookup | null = null;
   private debounceTimer: NodeJS.Timeout | null = null;
   private statesByOwner = new Map<NotificationOwnerId, NotificationState>();
   private focusedWindows = new Set<number>();
@@ -131,9 +137,16 @@ class NotificationService {
     });
   }
 
-  initialize(registry: WindowRegistry): void {
+  /**
+   * `projectLookup` resolves a ProjectViewManager id to its project row so each
+   * window's title can name what it is showing. Injected rather than imported
+   * so the service stays free of the SQLite-backed project store — omit it and
+   * every window falls back to the app name.
+   */
+  initialize(registry: WindowRegistry, projectLookup?: ProjectTitleLookup): void {
     this.detachAllWindowListeners();
     this.registry = registry;
+    if (projectLookup) this.projectLookup = projectLookup;
 
     for (const ctx of registry.all()) {
       this.attachWindowListeners(ctx);
@@ -166,34 +179,13 @@ class NotificationService {
   private applyNotifications(): void {
     if (!this.registry) return;
 
-    // An owner that no longer resolves to a window is dead or dying: a view's
-    // webContents id is indexed at creation, before its renderer can send any
-    // IPC, and is unindexed only on eviction (which closes it) or window
-    // teardown. Pruning here keeps the badge honest even if a "destroyed"
-    // event is missed.
-    const countsByWindow = new Map<number, number>();
-    for (const [ownerId, state] of [...this.statesByOwner]) {
-      const ctx = this.registry.getByWebContentsId(ownerId);
-      if (!ctx || ctx.browserWindow.isDestroyed()) {
-        this.statesByOwner.delete(ownerId);
-        continue;
-      }
-      countsByWindow.set(
-        ctx.windowId,
-        (countsByWindow.get(ctx.windowId) ?? 0) + state.waitingCount
-      );
-    }
+    const countsByWindow = this.countsByWindow();
 
     let totalWaiting = 0;
     for (const ctx of this.registry.all()) {
       const waitingCount = countsByWindow.get(ctx.windowId) ?? 0;
       totalWaiting += waitingCount;
-
-      if (!ctx.browserWindow.isDestroyed()) {
-        ctx.browserWindow.setTitle(
-          waitingCount > 0 ? `(${waitingCount}) ${DEFAULT_TITLE}` : DEFAULT_TITLE
-        );
-      }
+      this.writeTitle(ctx, waitingCount);
     }
 
     if (process.platform === "darwin") {
@@ -201,11 +193,76 @@ class NotificationService {
     }
   }
 
+  /**
+   * Recompose every live window's title against the project each one is now
+   * showing, without touching the waiting counts or the Dock badge.
+   *
+   * Called after a project switch, rename, close, or removal — the moments the
+   * displayed identity changes but the notification state does not. Refreshing
+   * every window rather than a named one is deliberate: each window answers from
+   * its own ProjectViewManager, so there is no cross-window filter to get wrong
+   * (a cached, non-visible view for the same project must not retitle its host).
+   */
+  refreshTitles(): void {
+    if (!this.registry) return;
+
+    const countsByWindow = this.countsByWindow();
+    for (const ctx of this.registry.all()) {
+      this.writeTitle(ctx, countsByWindow.get(ctx.windowId) ?? 0);
+    }
+  }
+
+  /**
+   * An owner that no longer resolves to a window is dead or dying: a view's
+   * webContents id is indexed at creation, before its renderer can send any
+   * IPC, and is unindexed only on eviction (which closes it) or window
+   * teardown. Pruning here keeps the badge honest even if a "destroyed" event
+   * is missed.
+   */
+  private countsByWindow(): Map<number, number> {
+    const counts = new Map<number, number>();
+    if (!this.registry) return counts;
+
+    for (const [ownerId, state] of [...this.statesByOwner]) {
+      const ctx = this.registry.getByWebContentsId(ownerId);
+      if (!ctx || ctx.browserWindow.isDestroyed()) {
+        this.statesByOwner.delete(ownerId);
+        continue;
+      }
+      counts.set(ctx.windowId, (counts.get(ctx.windowId) ?? 0) + state.waitingCount);
+    }
+    return counts;
+  }
+
+  /**
+   * Best-effort by construction: callers invoke this from a `finally` after a
+   * switch or rename has already committed, so a throw here would replace the
+   * original result and mask the real failure.
+   */
+  private writeTitle(ctx: WindowContext, waitingCount: number): void {
+    if (ctx.browserWindow.isDestroyed()) return;
+
+    try {
+      const projectName = resolveWindowProjectName(
+        ctx.services.projectViewManager,
+        this.projectLookup
+      );
+      ctx.browserWindow.setTitle(composeWindowTitle(projectName, waitingCount));
+    } catch (err) {
+      console.warn("[NotificationService] failed to set window title:", err);
+    }
+  }
+
+  /**
+   * Only runs from `dispose()`, so it deliberately drops back to the plain app
+   * name rather than resolving project names: the store is closing on the
+   * shutdown path, and nothing reads these titles again.
+   */
   private clearNotifications(): void {
     if (this.registry) {
       for (const ctx of this.registry.all()) {
         if (!ctx.browserWindow.isDestroyed()) {
-          ctx.browserWindow.setTitle(DEFAULT_TITLE);
+          ctx.browserWindow.setTitle(FALLBACK_WINDOW_TITLE);
         }
       }
     }
@@ -355,6 +412,7 @@ class NotificationService {
     this.activeNotifications.clear();
 
     this.registry = null;
+    this.projectLookup = null;
   }
 }
 

--- a/electron/services/__tests__/NotificationService.test.ts
+++ b/electron/services/__tests__/NotificationService.test.ts
@@ -478,16 +478,23 @@ describe("NotificationService", () => {
       expect(lastTitle(win)).not.toContain("alpha-app");
     });
 
-    it("keeps the badge answerable after a title-only refresh prunes nothing", () => {
+    it("leaves a dead owner for removeOwner to clear, so the badge still settles", () => {
       const win = createWindowMock(false, [11]);
       win.activeProjectId = "alpha";
 
       notificationService.initialize(createRegistryMock([win]) as never, rows);
       notificationService.updateNotifications(11, { waitingCount: 4 });
       vi.advanceTimersByTime(301);
+      expect(electronMock.app.setBadgeCount).toHaveBeenLastCalledWith(4);
 
+      // The owner's window dies without its destroyed event being processed, so
+      // the count is now unbacked. A title-only refresh must not consume it: if
+      // it did, removeOwner's delete would find nothing and return before ever
+      // recomputing the badge, stranding it at 4.
+      win.isDestroyed.mockReturnValue(true);
       notificationService.refreshTitles();
       electronMock.app.setBadgeCount.mockClear();
+
       notificationService.removeOwner(11);
 
       expect(electronMock.app.setBadgeCount).toHaveBeenLastCalledWith(0);

--- a/electron/services/__tests__/NotificationService.test.ts
+++ b/electron/services/__tests__/NotificationService.test.ts
@@ -91,6 +91,9 @@ function createWindowMock(isFocused = false, ownerIds: number[] = []) {
     id,
     ownerIds,
     listeners,
+    /** Undefined means the window has no ProjectViewManager at all. */
+    activeProjectId: undefined as string | null | undefined,
+    bridgedProjectId: null as string | null,
     isDestroyed: vi.fn(() => false),
     isFocused: vi.fn(() => isFocused),
     isMinimized: vi.fn(() => false),
@@ -112,6 +115,29 @@ function createWindowMock(isFocused = false, ownerIds: number[] = []) {
 
 type WindowMock = ReturnType<typeof createWindowMock>;
 
+/**
+ * Reads the ids off the window mock on every call rather than closing over
+ * them, so a test can move a window to another project mid-run the way a real
+ * switch does.
+ */
+function projectViewManagerOf(w: WindowMock) {
+  return {
+    getActiveProjectId: () => w.activeProjectId ?? null,
+    getOutgoingBridgeProjectId: () => w.bridgedProjectId,
+  };
+}
+
+/** Project rows keyed by id, standing in for the SQLite-backed store. */
+function lookupOf(rows: Record<string, { name: string; status?: string }>) {
+  return (projectId: string) => rows[projectId] ?? null;
+}
+
+/** The last title a window was given — titles are rewritten on every pass. */
+function lastTitle(w: WindowMock): string {
+  const calls = w.setTitle.mock.calls;
+  return calls[calls.length - 1]?.[0] as string;
+}
+
 function createRegistryMock(windows: WindowMock[]) {
   const contexts = windows.map((w) => ({
     windowId: w.id,
@@ -119,7 +145,8 @@ function createRegistryMock(windows: WindowMock[]) {
     browserWindow: w,
     projectPath: null,
     abortController: new AbortController(),
-    services: {},
+    services:
+      w.activeProjectId === undefined ? {} : { projectViewManager: projectViewManagerOf(w) },
     cleanup: [],
   }));
 
@@ -212,6 +239,194 @@ describe("NotificationService", () => {
     notificationService.dispose();
 
     expect(() => notificationService.updateNotifications(11, { waitingCount: 1 })).not.toThrow();
+  });
+
+  describe("project-aware titles", () => {
+    const rows = lookupOf({
+      alpha: { name: "alpha-app", status: "active" },
+      beta: { name: "beta-app", status: "background" },
+      gone: { name: "archived", status: "closed" },
+    });
+
+    it("titles each window from its own project, not a shared pointer", () => {
+      const winA = createWindowMock(false, [11]);
+      const winB = createWindowMock(false, [21]);
+      winA.activeProjectId = "alpha";
+      winB.activeProjectId = "beta";
+
+      notificationService.initialize(createRegistryMock([winA, winB]) as never, rows);
+      notificationService.refreshTitles();
+
+      expect(lastTitle(winA)).toBe("alpha-app");
+      expect(lastTitle(winB)).toBe("beta-app");
+    });
+
+    it("names the same project in both windows showing it", () => {
+      const winA = createWindowMock(false, [11]);
+      const winB = createWindowMock(false, [21]);
+      winA.activeProjectId = "alpha";
+      winB.activeProjectId = "alpha";
+
+      notificationService.initialize(createRegistryMock([winA, winB]) as never, rows);
+      notificationService.refreshTitles();
+
+      expect(lastTitle(winB)).toBe(lastTitle(winA));
+    });
+
+    it("scopes the waiting count to the window that owns it", () => {
+      const winA = createWindowMock(false, [11]);
+      const winB = createWindowMock(false, [21]);
+      winA.activeProjectId = "alpha";
+      winB.activeProjectId = "beta";
+
+      notificationService.initialize(createRegistryMock([winA, winB]) as never, rows);
+      notificationService.updateNotifications(11, { waitingCount: 4 });
+      vi.advanceTimersByTime(301);
+
+      expect(lastTitle(winA)).toBe("(4) alpha-app");
+      expect(lastTitle(winB)).toBe("beta-app");
+    });
+
+    it("sums a window's cached views into one count beside its project name", () => {
+      const win = createWindowMock(false, [11, 12]);
+      win.activeProjectId = "alpha";
+
+      notificationService.initialize(createRegistryMock([win]) as never, rows);
+      notificationService.updateNotifications(11, { waitingCount: 2 });
+      notificationService.updateNotifications(12, { waitingCount: 3 });
+      vi.advanceTimersByTime(301);
+
+      expect(lastTitle(win)).toBe("(5) alpha-app");
+    });
+
+    it("keeps the waiting count when only the project identity changed", () => {
+      const win = createWindowMock(false, [11]);
+      win.activeProjectId = "alpha";
+
+      notificationService.initialize(createRegistryMock([win]) as never, rows);
+      notificationService.updateNotifications(11, { waitingCount: 2 });
+      vi.advanceTimersByTime(301);
+
+      win.activeProjectId = "beta";
+      notificationService.refreshTitles();
+
+      expect(lastTitle(win)).toBe("(2) beta-app");
+    });
+
+    it("does not disturb the badge when refreshing titles alone", () => {
+      const win = createWindowMock(false, [11]);
+      win.activeProjectId = "alpha";
+
+      notificationService.initialize(createRegistryMock([win]) as never, rows);
+      notificationService.updateNotifications(11, { waitingCount: 2 });
+      vi.advanceTimersByTime(301);
+      electronMock.app.setBadgeCount.mockClear();
+
+      notificationService.refreshTitles();
+
+      expect(electronMock.app.setBadgeCount).not.toHaveBeenCalled();
+    });
+
+    it("falls back for a closed project whose window binding lingers", () => {
+      const open = createWindowMock(false, [11]);
+      const closed = createWindowMock(false, [21]);
+      open.activeProjectId = "alpha";
+      closed.activeProjectId = "gone";
+
+      notificationService.initialize(createRegistryMock([open, closed]) as never, rows);
+      notificationService.refreshTitles();
+
+      expect(lastTitle(open)).toBe("alpha-app");
+      expect(lastTitle(closed)).toBe("Daintree");
+    });
+
+    it("falls back for a scratch id that matches no project row", () => {
+      const win = createWindowMock(false, [11]);
+      win.activeProjectId = "scratch-uuid";
+
+      notificationService.initialize(createRegistryMock([win]) as never, rows);
+      notificationService.refreshTitles();
+
+      expect(lastTitle(win)).toBe("Daintree");
+    });
+
+    it("titles the project still painted behind a cold-switch bridge", () => {
+      const win = createWindowMock(false, [11]);
+      win.activeProjectId = "alpha";
+      win.bridgedProjectId = "beta";
+
+      notificationService.initialize(createRegistryMock([win]) as never, rows);
+      notificationService.refreshTitles();
+
+      expect(lastTitle(win)).toBe("beta-app");
+    });
+
+    it("converges on the renamed project when a debounced tick lands after a refresh", () => {
+      const win = createWindowMock(false, [11]);
+      win.activeProjectId = "alpha";
+      const renamable: Record<string, { name: string; status?: string }> = {
+        alpha: { name: "alpha-app", status: "active" },
+      };
+
+      notificationService.initialize(createRegistryMock([win]) as never, lookupOf(renamable));
+      notificationService.updateNotifications(11, { waitingCount: 1 });
+
+      renamable.alpha = { name: "renamed-app", status: "active" };
+      notificationService.refreshTitles();
+      expect(lastTitle(win)).toBe("(1) renamed-app");
+
+      vi.advanceTimersByTime(301);
+      expect(lastTitle(win)).toBe("(1) renamed-app");
+    });
+
+    it("skips a destroyed window without touching its title", () => {
+      const live = createWindowMock(false, [11]);
+      const dead = createWindowMock(false, [21]);
+      live.activeProjectId = "alpha";
+      dead.activeProjectId = "beta";
+      dead.isDestroyed.mockReturnValue(true);
+
+      notificationService.initialize(createRegistryMock([live, dead]) as never, rows);
+      dead.setTitle.mockClear();
+      notificationService.refreshTitles();
+
+      expect(dead.setTitle).not.toHaveBeenCalled();
+      expect(lastTitle(live)).toBe("alpha-app");
+    });
+
+    it("keeps titling the other windows when one view manager throws", () => {
+      const broken = createWindowMock(false, [11]);
+      const healthy = createWindowMock(false, [21]);
+      broken.activeProjectId = "alpha";
+      healthy.activeProjectId = "beta";
+
+      const registry = createRegistryMock([broken, healthy]);
+      registry.all()[0].services.projectViewManager = {
+        getActiveProjectId: () => {
+          throw new Error("disposing");
+        },
+        getOutgoingBridgeProjectId: () => null,
+      };
+
+      notificationService.initialize(registry as never, rows);
+      expect(() => notificationService.refreshTitles()).not.toThrow();
+      expect(lastTitle(healthy)).toBe("beta-app");
+    });
+
+    it("titles by app name alone once the project lookup is gone", () => {
+      const win = createWindowMock(false, [11]);
+      win.activeProjectId = "alpha";
+
+      notificationService.initialize(createRegistryMock([win]) as never, rows);
+      notificationService.dispose();
+
+      const revived = createWindowMock(false, [31]);
+      revived.activeProjectId = "alpha";
+      notificationService.initialize(createRegistryMock([revived]) as never);
+      notificationService.refreshTitles();
+
+      expect(lastTitle(revived)).toBe("Daintree");
+    });
   });
 
   it("dispose detaches listeners from all tracked windows", () => {

--- a/electron/services/__tests__/NotificationService.test.ts
+++ b/electron/services/__tests__/NotificationService.test.ts
@@ -69,6 +69,7 @@ vi.mock("../../window/webContentsRegistry.js", () => registryMock);
 
 import { sendToRenderer } from "../../ipc/utils.js";
 import { notificationService } from "../NotificationService.js";
+import type { ProjectTitleLookup, ProjectTitleRow } from "../../window/windowTitle.js";
 
 const sendToRendererMock = vi.mocked(sendToRenderer);
 
@@ -128,14 +129,23 @@ function projectViewManagerOf(w: WindowMock) {
 }
 
 /** Project rows keyed by id, standing in for the SQLite-backed store. */
-function lookupOf(rows: Record<string, { name: string; status?: string }>) {
+function lookupOf(rows: Record<string, ProjectTitleRow>): ProjectTitleLookup {
   return (projectId: string) => rows[projectId] ?? null;
 }
 
-/** The last title a window was given — titles are rewritten on every pass. */
+/**
+ * The last title a window was given — titles are rewritten on every pass.
+ * Throws rather than returning undefined so a comparison between two windows
+ * can't pass because neither of them was titled at all.
+ */
 function lastTitle(w: WindowMock): string {
   const calls = w.setTitle.mock.calls;
-  return calls[calls.length - 1]?.[0] as string;
+  if (calls.length === 0) throw new Error(`window ${w.id} was never given a title`);
+  return calls[calls.length - 1][0] as string;
+}
+
+function titleCount(w: WindowMock): number {
+  return w.setTitle.mock.calls.length;
 }
 
 function createRegistryMock(windows: WindowMock[]) {
@@ -270,6 +280,7 @@ describe("NotificationService", () => {
       notificationService.initialize(createRegistryMock([winA, winB]) as never, rows);
       notificationService.refreshTitles();
 
+      expect(lastTitle(winA)).toBe("alpha-app");
       expect(lastTitle(winB)).toBe(lastTitle(winA));
     });
 
@@ -330,24 +341,29 @@ describe("NotificationService", () => {
     it("falls back for a closed project whose window binding lingers", () => {
       const open = createWindowMock(false, [11]);
       const closed = createWindowMock(false, [21]);
+      const unbound = createWindowMock(false, [31]);
       open.activeProjectId = "alpha";
       closed.activeProjectId = "gone";
+      unbound.activeProjectId = null;
 
-      notificationService.initialize(createRegistryMock([open, closed]) as never, rows);
+      notificationService.initialize(createRegistryMock([open, closed, unbound]) as never, rows);
       notificationService.refreshTitles();
 
       expect(lastTitle(open)).toBe("alpha-app");
-      expect(lastTitle(closed)).toBe("Daintree");
+      expect(lastTitle(closed)).not.toContain("archived");
+      expect(lastTitle(closed)).toBe(lastTitle(unbound));
     });
 
     it("falls back for a scratch id that matches no project row", () => {
-      const win = createWindowMock(false, [11]);
-      win.activeProjectId = "scratch-uuid";
+      const scratch = createWindowMock(false, [11]);
+      const unbound = createWindowMock(false, [21]);
+      scratch.activeProjectId = "scratch-uuid";
+      unbound.activeProjectId = null;
 
-      notificationService.initialize(createRegistryMock([win]) as never, rows);
+      notificationService.initialize(createRegistryMock([scratch, unbound]) as never, rows);
       notificationService.refreshTitles();
 
-      expect(lastTitle(win)).toBe("Daintree");
+      expect(lastTitle(scratch)).toBe(lastTitle(unbound));
     });
 
     it("titles the project still painted behind a cold-switch bridge", () => {
@@ -361,10 +377,10 @@ describe("NotificationService", () => {
       expect(lastTitle(win)).toBe("beta-app");
     });
 
-    it("converges on the renamed project when a debounced tick lands after a refresh", () => {
+    it("leaves the pending tick armed and converges it on the renamed project", () => {
       const win = createWindowMock(false, [11]);
       win.activeProjectId = "alpha";
-      const renamable: Record<string, { name: string; status?: string }> = {
+      const renamable: Record<string, ProjectTitleRow> = {
         alpha: { name: "alpha-app", status: "active" },
       };
 
@@ -375,8 +391,14 @@ describe("NotificationService", () => {
       notificationService.refreshTitles();
       expect(lastTitle(win)).toBe("(1) renamed-app");
 
+      // The refresh must not have swallowed the debounce: the tick still owes a
+      // write, and it recomputes rather than replaying the name it was queued with.
+      const beforeTick = titleCount(win);
+      renamable.alpha = { name: "renamed-again", status: "active" };
       vi.advanceTimersByTime(301);
-      expect(lastTitle(win)).toBe("(1) renamed-app");
+
+      expect(titleCount(win)).toBeGreaterThan(beforeTick);
+      expect(lastTitle(win)).toBe("(1) renamed-again");
     });
 
     it("skips a destroyed window without touching its title", () => {
@@ -413,19 +435,62 @@ describe("NotificationService", () => {
       expect(lastTitle(healthy)).toBe("beta-app");
     });
 
-    it("titles by app name alone once the project lookup is gone", () => {
+    it("drops the project lookup when reinitialized without one", () => {
+      const bound = createWindowMock(false, [11]);
+      bound.activeProjectId = "alpha";
+      notificationService.initialize(createRegistryMock([bound]) as never, rows);
+      notificationService.refreshTitles();
+      expect(lastTitle(bound)).toBe("alpha-app");
+
+      // No dispose in between: a re-init that supplies no lookup must not keep
+      // resolving names through the previous one.
+      const rebound = createWindowMock(false, [21]);
+      const unbound = createWindowMock(false, [31]);
+      rebound.activeProjectId = "alpha";
+      unbound.activeProjectId = null;
+      notificationService.initialize(createRegistryMock([rebound, unbound]) as never);
+      notificationService.refreshTitles();
+
+      expect(lastTitle(rebound)).not.toContain("alpha-app");
+      expect(lastTitle(rebound)).toBe(lastTitle(unbound));
+    });
+
+    it("names a project whose row went missing rather than blanking the window", () => {
+      const win = createWindowMock(false, [11]);
+      win.activeProjectId = "vanished";
+
+      const withMissing = lookupOf({ vanished: { name: "on-a-dead-mount", status: "missing" } });
+      notificationService.initialize(createRegistryMock([win]) as never, withMissing);
+      notificationService.refreshTitles();
+
+      expect(lastTitle(win)).toBe("on-a-dead-mount");
+    });
+
+    it("resolves a window whose view manager reports no active project", () => {
+      const win = createWindowMock(false, [11]);
+      win.activeProjectId = null;
+
+      notificationService.initialize(createRegistryMock([win]) as never, rows);
+      notificationService.updateNotifications(11, { waitingCount: 3 });
+      vi.advanceTimersByTime(301);
+
+      expect(lastTitle(win).startsWith("(3) ")).toBe(true);
+      expect(lastTitle(win)).not.toContain("alpha-app");
+    });
+
+    it("keeps the badge answerable after a title-only refresh prunes nothing", () => {
       const win = createWindowMock(false, [11]);
       win.activeProjectId = "alpha";
 
       notificationService.initialize(createRegistryMock([win]) as never, rows);
-      notificationService.dispose();
+      notificationService.updateNotifications(11, { waitingCount: 4 });
+      vi.advanceTimersByTime(301);
 
-      const revived = createWindowMock(false, [31]);
-      revived.activeProjectId = "alpha";
-      notificationService.initialize(createRegistryMock([revived]) as never);
       notificationService.refreshTitles();
+      electronMock.app.setBadgeCount.mockClear();
+      notificationService.removeOwner(11);
 
-      expect(lastTitle(revived)).toBe("Daintree");
+      expect(electronMock.app.setBadgeCount).toHaveBeenLastCalledWith(0);
     });
   });
 

--- a/electron/window/__tests__/windowTitle.test.ts
+++ b/electron/window/__tests__/windowTitle.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  composeWindowTitle,
+  resolveWindowProjectName,
+  type ProjectTitleLookup,
+  type ProjectTitleRow,
+  type TitleProjectViewManager,
+} from "../windowTitle.js";
+
+function pvm(activeId: string | null, bridgedId: string | null = null): TitleProjectViewManager {
+  return {
+    getActiveProjectId: () => activeId,
+    getOutgoingBridgeProjectId: () => bridgedId,
+  };
+}
+
+function lookupOf(rows: Record<string, ProjectTitleRow>): ProjectTitleLookup {
+  return (projectId) => rows[projectId] ?? null;
+}
+
+describe("composeWindowTitle", () => {
+  it("uses the project name alone when nothing is waiting", () => {
+    expect(composeWindowTitle("checkout-api", 0)).toBe("checkout-api");
+  });
+
+  it("prefixes the waiting count without disturbing the name", () => {
+    const name = "checkout-api";
+    expect(composeWindowTitle(name, 3)).toBe(`(3) ${composeWindowTitle(name, 0)}`);
+  });
+
+  it("treats every unusable name as the same no-project fallback", () => {
+    const fallback = composeWindowTitle(null, 0);
+
+    expect(composeWindowTitle(undefined, 0)).toBe(fallback);
+    expect(composeWindowTitle("", 0)).toBe(fallback);
+    expect(composeWindowTitle("   ", 0)).toBe(fallback);
+    expect(composeWindowTitle("\n\t", 0)).toBe(fallback);
+  });
+
+  it("counts a waiting prefix onto the fallback too", () => {
+    expect(composeWindowTitle(null, 2)).toBe(`(2) ${composeWindowTitle(null, 0)}`);
+  });
+
+  it("does not repeat the app name after a project name", () => {
+    const fallback = composeWindowTitle(null, 0);
+    expect(composeWindowTitle("checkout-api", 0)).not.toContain(fallback);
+  });
+
+  it("strips surrounding whitespace rather than passing it into the title", () => {
+    expect(composeWindowTitle("  checkout-api  ", 0)).toBe(composeWindowTitle("checkout-api", 0));
+  });
+
+  it("replaces embedded control characters so the title stays one line", () => {
+    const title = composeWindowTitle("check\nout\tapi", 0);
+
+    expect([...title].some((ch) => ch.charCodeAt(0) < 0x20)).toBe(false);
+    expect(title).toContain("check");
+    expect(title).toContain("api");
+  });
+
+  it("shortens a runaway name and marks the elision", () => {
+    const long = "x".repeat(400);
+    const title = composeWindowTitle(long, 0);
+
+    expect(title.length).toBeLessThan(long.length);
+    expect(title.endsWith("…")).toBe(true);
+  });
+
+  it("keeps the count readable when the name is truncated", () => {
+    const long = "x".repeat(400);
+    expect(composeWindowTitle(long, 7).startsWith("(7) ")).toBe(true);
+  });
+
+  it("leaves a name at the length ceiling untouched", () => {
+    const atCeiling = "y".repeat(100);
+    expect(composeWindowTitle(atCeiling, 0)).toBe(atCeiling);
+  });
+});
+
+describe("resolveWindowProjectName", () => {
+  const rows = lookupOf({
+    "proj-open": { name: "checkout-api", status: "active" },
+    "proj-background": { name: "billing", status: "background" },
+    "proj-closed": { name: "archived", status: "closed" },
+    "proj-missing-status": { name: "no-status" },
+  });
+
+  it("names the project the window has active", () => {
+    expect(resolveWindowProjectName(pvm("proj-open"), rows)).toBe("checkout-api");
+  });
+
+  it("prefers the still-painted bridge over the incoming project mid-switch", () => {
+    expect(resolveWindowProjectName(pvm("proj-open", "proj-background"), rows)).toBe("billing");
+  });
+
+  it("falls through to the active project when the bridge names a closed row", () => {
+    expect(resolveWindowProjectName(pvm("proj-open", "proj-closed"), rows)).toBe("checkout-api");
+  });
+
+  it("keeps a project visible in an unfocused window, which reads as background", () => {
+    expect(resolveWindowProjectName(pvm("proj-background"), rows)).toBe("billing");
+  });
+
+  it("accepts a row with no status rather than treating it as closed", () => {
+    expect(resolveWindowProjectName(pvm("proj-missing-status"), rows)).toBe("no-status");
+  });
+
+  it("reports no project once the row is closed but the binding lingers", () => {
+    expect(resolveWindowProjectName(pvm("proj-closed"), rows)).toBeNull();
+  });
+
+  it("reports no project for an id with no row, as a scratch workspace has", () => {
+    expect(resolveWindowProjectName(pvm("scratch-uuid"), rows)).toBeNull();
+  });
+
+  it("reports no project for an unbound window", () => {
+    expect(resolveWindowProjectName(pvm(null), rows)).toBeNull();
+  });
+
+  it("reports no project when the window has no view manager", () => {
+    expect(resolveWindowProjectName(undefined, rows)).toBeNull();
+  });
+
+  it("reports no project when no lookup was injected", () => {
+    expect(resolveWindowProjectName(pvm("proj-open"), null)).toBeNull();
+  });
+});

--- a/electron/window/__tests__/windowTitle.test.ts
+++ b/electron/window/__tests__/windowTitle.test.ts
@@ -18,6 +18,12 @@ function lookupOf(rows: Record<string, ProjectTitleRow>): ProjectTitleLookup {
   return (projectId) => rows[projectId] ?? null;
 }
 
+/** The C0 range plus DEL — what an NSWindow title must not carry. */
+function isStrippedControl(ch: string): boolean {
+  const code = ch.charCodeAt(0);
+  return code < 0x20 || code === 0x7f;
+}
+
 describe("composeWindowTitle", () => {
   it("uses the project name alone when nothing is waiting", () => {
     expect(composeWindowTitle("checkout-api", 0)).toBe("checkout-api");
@@ -53,17 +59,27 @@ describe("composeWindowTitle", () => {
   it("replaces embedded control characters so the title stays one line", () => {
     const title = composeWindowTitle("check\nout\tapi", 0);
 
-    expect([...title].some((ch) => ch.charCodeAt(0) < 0x20)).toBe(false);
+    expect([...title].some((ch) => isStrippedControl(ch))).toBe(false);
     expect(title).toContain("check");
     expect(title).toContain("api");
   });
 
-  it("shortens a runaway name and marks the elision", () => {
+  it("strips DEL as well as the low control range", () => {
+    const title = composeWindowTitle("del\u007Fimited", 0);
+
+    expect([...title].some((ch) => isStrippedControl(ch))).toBe(false);
+    expect(title).toContain("del");
+    expect(title).toContain("imited");
+  });
+
+  it("shortens a runaway name and marks where it was cut", () => {
     const long = "x".repeat(400);
     const title = composeWindowTitle(long, 0);
+    const points = [...title];
 
-    expect(title.length).toBeLessThan(long.length);
-    expect(title.endsWith("…")).toBe(true);
+    expect(points.length).toBeLessThan(long.length);
+    expect(title.startsWith("xx")).toBe(true);
+    expect(points[points.length - 1]).not.toBe("x");
   });
 
   it("keeps the count readable when the name is truncated", () => {
@@ -75,6 +91,32 @@ describe("composeWindowTitle", () => {
     const atCeiling = "y".repeat(100);
     expect(composeWindowTitle(atCeiling, 0)).toBe(atCeiling);
   });
+
+  it("shortens a name one past the ceiling to the ceiling", () => {
+    const atCeiling = "y".repeat(100);
+    const overBy1 = "y".repeat(101);
+    const title = composeWindowTitle(overBy1, 0);
+
+    expect(title).not.toBe(overBy1);
+    expect([...title]).toHaveLength([...atCeiling].length);
+  });
+
+  it("counts astral characters as one, so truncation never splits a surrogate pair", () => {
+    const emojiName = "🌲".repeat(120);
+    const title = composeWindowTitle(emojiName, 0);
+    const points = [...title];
+
+    expect(points).toHaveLength(100);
+    expect(points.slice(0, 99).every((ch) => ch === "🌲")).toBe(true);
+    // A split pair would surface as an unpaired surrogate rather than the tree.
+    expect(title).not.toContain("�");
+    expect([...title].some((ch) => ch.charCodeAt(0) >= 0xd800 && ch.length === 1)).toBe(false);
+  });
+
+  it("keeps an astral name at the ceiling whole", () => {
+    const atCeiling = "🌲".repeat(100);
+    expect(composeWindowTitle(atCeiling, 0)).toBe(atCeiling);
+  });
 });
 
 describe("resolveWindowProjectName", () => {
@@ -83,6 +125,7 @@ describe("resolveWindowProjectName", () => {
     "proj-background": { name: "billing", status: "background" },
     "proj-closed": { name: "archived", status: "closed" },
     "proj-missing-status": { name: "no-status" },
+    "proj-missing": { name: "on-a-dead-mount", status: "missing" },
   });
 
   it("names the project the window has active", () => {
@@ -103,6 +146,10 @@ describe("resolveWindowProjectName", () => {
 
   it("accepts a row with no status rather than treating it as closed", () => {
     expect(resolveWindowProjectName(pvm("proj-missing-status"), rows)).toBe("no-status");
+  });
+
+  it("still names a project whose folder went missing — it is open, just unreachable", () => {
+    expect(resolveWindowProjectName(pvm("proj-missing"), rows)).toBe("on-a-dead-mount");
   });
 
   it("reports no project once the row is closed but the binding lingers", () => {

--- a/electron/window/perWindowInit.ts
+++ b/electron/window/perWindowInit.ts
@@ -17,6 +17,7 @@ import { CHANNELS } from "../ipc/channels.js";
 import { createApplicationMenu } from "../menu.js";
 import { ProjectSwitchService } from "../services/ProjectSwitchService.js";
 import { notificationService } from "../services/NotificationService.js";
+import { projectStore } from "../services/ProjectStore.js";
 import { logInfo } from "../utils/logger.js";
 import { SCROLLBACK_BACKGROUND } from "../../shared/config/scrollback.js";
 import { isDemoMode } from "../setup/environment.js";
@@ -110,7 +111,9 @@ export async function initPerWindowServices(
   finalizeDeferredRegistration();
 
   if (windowRegistry) {
-    notificationService.initialize(windowRegistry);
+    notificationService.initialize(windowRegistry, (projectId) =>
+      projectStore.getProjectById(projectId)
+    );
     ctx.cleanup.add(toDisposable(() => notificationService.detachWindowListeners(win.id)));
   }
   console.log("[MAIN] NotificationService initialized");

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -9,6 +9,7 @@ import { getWorkspaceClient } from "../services/WorkspaceClient.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { createApplicationMenu, handleDirectoryOpen } from "../menu.js";
 import { refreshProjectMenuState } from "../projectMenuState.js";
+import { notificationService } from "../services/NotificationService.js";
 import { getMainProcessWatchdogClient } from "../services/MainProcessWatchdogClient.js";
 import { projectStore } from "../services/ProjectStore.js";
 import { scratchStore } from "../services/ScratchStore.js";
@@ -630,6 +631,7 @@ export async function setupWindowServices(
     // The menu was built before this binding existed, so its project gates
     // resolved against a PVM with no active project. Converge them now (#11136).
     refreshProjectMenuState();
+    notificationService.refreshTitles();
   }
 
   // Load worktrees — prefer initialProjectPath, else restoreProject for

--- a/electron/window/windowTitle.ts
+++ b/electron/window/windowTitle.ts
@@ -1,0 +1,89 @@
+import type { Project } from "../../shared/types/project.js";
+
+/** Shown when no project is on screen: the picker, a scratch, an unbound window. */
+export const FALLBACK_WINDOW_TITLE = "Daintree";
+
+/**
+ * Mission Control and the Dock menu elide long titles anyway, and a runaway
+ * name would push the waiting-count prefix out of view. Matches the 100-char
+ * ceiling the project-identity creation paths already apply.
+ */
+const MAX_TITLE_LENGTH = 100;
+
+/** Control characters render as glyphs in an NSWindow title rather than breaking the line. */
+// eslint-disable-next-line no-control-regex -- stripping control characters is the point
+const CONTROL_CHARS = /[\u0000-\u001F\u007F]/g;
+
+/** The slice of a project row title resolution needs. */
+export type ProjectTitleRow = Pick<Project, "name" | "status">;
+
+export type ProjectTitleLookup = (projectId: string) => ProjectTitleRow | null;
+
+/** The `ProjectViewManager` surface title resolution reads — narrow so the resolver stays testable. */
+export interface TitleProjectViewManager {
+  getActiveProjectId(): string | null;
+  getOutgoingBridgeProjectId(): string | null;
+}
+
+/**
+ * The name of the project a window is currently displaying, or null when none is.
+ *
+ * Mirrors `resolveProjectIdForApplicationMenu` (projectMenuState.ts), which
+ * answers the same question for the process-global menu bar. Never consults
+ * `projectStore.getCurrentProjectId()`: that global pointer names whichever
+ * window switched most recently, so with two windows open it routinely answers
+ * for the wrong one (#11101) — the exact confusion this title is meant to end.
+ *
+ * A raw ProjectViewManager id is not proof a project is open. Scratch
+ * workspaces share the PVM and surface an id with no project row, and closing a
+ * project marks its row "closed" while leaving the window's binding pointed at
+ * it. Only "closed" is rejected: project status is process-global, so a project
+ * visible in a non-focused window is legitimately "background".
+ */
+export function resolveWindowProjectName(
+  pvm: TitleProjectViewManager | undefined,
+  lookup: ProjectTitleLookup | null
+): string | null {
+  if (!pvm || !lookup) return null;
+
+  // A cold switch flips `activeProjectId` to the incoming project while the
+  // outgoing view stays on screen as the anti-flash bridge. Answer with what is
+  // actually painted, or the window renames itself before the user sees why.
+  const bridged = openProjectName(pvm.getOutgoingBridgeProjectId(), lookup);
+  return bridged ?? openProjectName(pvm.getActiveProjectId(), lookup);
+}
+
+function openProjectName(projectId: string | null, lookup: ProjectTitleLookup): string | null {
+  if (!projectId) return null;
+  const project = lookup(projectId);
+  if (!project || project.status === "closed") return null;
+  return project.name ?? null;
+}
+
+/**
+ * The native title for one window: `(N) projectName`, falling back to the app
+ * name when no project is on screen.
+ *
+ * The app name is deliberately not appended after a project name — the Dock
+ * already groups every window under one icon, so repeating it costs the space
+ * that distinguishes the windows.
+ */
+export function composeWindowTitle(
+  projectName: string | null | undefined,
+  waitingCount: number
+): string {
+  const base = normalizeProjectName(projectName) ?? FALLBACK_WINDOW_TITLE;
+  return waitingCount > 0 ? `(${waitingCount}) ${base}` : base;
+}
+
+/** Null when nothing displayable survives, so the caller falls back to the app name. */
+function normalizeProjectName(name: string | null | undefined): string | null {
+  if (typeof name !== "string") return null;
+
+  const cleaned = name.replace(CONTROL_CHARS, " ").trim();
+  if (!cleaned) return null;
+
+  const points = [...cleaned];
+  if (points.length <= MAX_TITLE_LENGTH) return cleaned;
+  return `${points.slice(0, MAX_TITLE_LENGTH - 1).join("")}…`;
+}


### PR DESCRIPTION
## Summary

- Every window's native title now names the project it's showing: `projectName` when idle, `(N) projectName` when N agents are waiting, so the macOS Dock right click menu, Mission Control, and the window switcher can finally tell windows apart.
- Falls back to `Daintree` / `(N) Daintree` when no project is on screen (picker, scratch, unbound window). The app name isn't appended after a project name on purpose: the Dock already groups every window under one icon, so repeating it just costs the characters that distinguish the windows.

Resolves #11456

## Changes

- New `electron/window/windowTitle.ts`: a pure composer plus a per-window resolver. The resolver mirrors the already-shipped `resolveProjectIdForApplicationMenu` in `projectMenuState.ts`, preferring `getOutgoingBridgeProjectId()` (the view still painted behind a cold-switch paint gate) over `getActiveProjectId()`, validating the id against a project row, and rejecting only `status === "closed"`. A project visible in an unfocused window is legitimately background.
- `NotificationService` stays the sole `setTitle()` writer, so the waiting-count prefix can never be clobbered. It gets a new public `refreshTitles()` method and an injected project lookup function, injected rather than imported so the service stays free of the SQLite-backed store.
- Identity is read per-window from that window's own `ProjectViewManager`, never `projectStore.getCurrentProjectId()`. That global pointer only names whichever window switched most recently, which is the recurring multi-window bug this feature exists to fix (#11101, #6016, #5541).
- `refreshTitles()` refreshes every window rather than a single named one, deliberately. Each window answers from its own `ProjectViewManager`, so there's no cross-window filter that can be got wrong: a cached, non-visible view for a renamed project must not retitle its host.
- Wired at every point the displayed project changes: project switch and reopen, scratch switch, project close and remove, rename, initial view binding, and `handleDirectoryOpen` (File → Open, Recent Projects, Dock drop, CLI open). That last path bypasses `activateProjectView` entirely, so it needed its own convergence in a `finally`.

Scope notes worth flagging:

- Scratch workspaces still show the app name. There's no per-window scratch accessor today (`ScratchStore.getCurrentScratchId()` is the same global-pointer shape that's disallowed here), so naming them means solving that separately.
- No initial `title:` on the `BrowserWindow` constructor. That would need `readLastActiveProjectIdentitySync`, which opens its own throwaway SQLite connection, and the window stays hidden until `dom-ready` anyway, so it would add startup cost to fix a flash nobody can see.
- During a cold switch away from a scratch workspace or an unbound welcome view, the title names the incoming project for the duration of the paint gate. That matches the existing behavior of the File menu gates; separating it would require exposing a "non-project bridge exists" signal through the paint-gate API.

## Testing

New `windowTitle.test.ts` covers title composition, fallback equivalence, control-character and DEL stripping, the 100/101 code-point truncation boundary including astral characters, and every resolver branch. `NotificationService.test.ts` gains a `project-aware titles` block covering two windows on different projects (fails if the global pointer is ever reintroduced), the same project open in two windows, per-window waiting-count scoping, cached-view count summing, closed/scratch/missing project rows, the paint bridge case, and confirmation that an explicit refresh neither swallows nor is swallowed by the existing 300ms debounce. 627 tests across 27 related files pass; `npm run typecheck` is clean.