### PR TITLE
fix(project-view): let a slow cold project switch land instead of losing it

### DIFF
--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -473,6 +473,16 @@ export class ResourceProfileService {
     } catch {
       // non-critical
     }
+    try {
+      pvm.setViewLoadTimeoutMs(config.viewLoadTimeoutMs);
+    } catch {
+      // non-critical
+    }
+    try {
+      pvm.setViewLoadHardTimeoutMs(config.viewLoadHardTimeoutMs);
+    } catch {
+      // non-critical
+    }
   }
 
   private startLagMonitor(): void {
@@ -1206,6 +1216,19 @@ export class ResourceProfileService {
       }
       try {
         pvm.setWarmPaintGateHardTimeoutMs(config.warmPaintGateHardTimeoutMs);
+      } catch {
+        // non-critical
+      }
+      // Same rationale for the cold view-load bounds: the main-process
+      // contention that selects efficiency also slows the `app://` chunks the
+      // incoming renderer is waiting on (#11459).
+      try {
+        pvm.setViewLoadTimeoutMs(config.viewLoadTimeoutMs);
+      } catch {
+        // non-critical
+      }
+      try {
+        pvm.setViewLoadHardTimeoutMs(config.viewLoadHardTimeoutMs);
       } catch {
         // non-critical
       }

--- a/electron/services/__tests__/ResourceProfileService.fanout.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.fanout.test.ts
@@ -57,6 +57,8 @@ function makeMockPvm() {
     setPaintGateHardTimeoutMs: vi.fn(),
     setWarmPaintGateTimeoutMs: vi.fn(),
     setWarmPaintGateHardTimeoutMs: vi.fn(),
+    setViewLoadTimeoutMs: vi.fn(),
+    setViewLoadHardTimeoutMs: vi.fn(),
   };
 }
 
@@ -149,6 +151,10 @@ describe("ResourceProfileService fan-out isolation", () => {
       expect(healthy.setPaintGateTimeoutMs).toHaveBeenLastCalledWith(balanced.paintGateTimeoutMs);
       expect(healthy.setWarmPaintGateHardTimeoutMs).toHaveBeenLastCalledWith(
         balanced.warmPaintGateHardTimeoutMs
+      );
+      expect(healthy.setViewLoadTimeoutMs).toHaveBeenLastCalledWith(balanced.viewLoadTimeoutMs);
+      expect(healthy.setViewLoadHardTimeoutMs).toHaveBeenLastCalledWith(
+        balanced.viewLoadHardTimeoutMs
       );
       // Downstream consumers after the PVM loop still ran.
       expect(pty.setResourceProfile).toHaveBeenLastCalledWith("balanced");
@@ -303,6 +309,8 @@ describe("ResourceProfileService fan-out isolation", () => {
       expect(pvm.setWarmPaintGateHardTimeoutMs).toHaveBeenCalledWith(
         efficiency.warmPaintGateHardTimeoutMs
       );
+      expect(pvm.setViewLoadTimeoutMs).toHaveBeenCalledWith(efficiency.viewLoadTimeoutMs);
+      expect(pvm.setViewLoadHardTimeoutMs).toHaveBeenCalledWith(efficiency.viewLoadHardTimeoutMs);
     });
   });
 });

--- a/electron/services/__tests__/ResourceProfileService.fanout.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.fanout.test.ts
@@ -312,5 +312,26 @@ describe("ResourceProfileService fan-out isolation", () => {
       expect(pvm.setViewLoadTimeoutMs).toHaveBeenCalledWith(efficiency.viewLoadTimeoutMs);
       expect(pvm.setViewLoadHardTimeoutMs).toHaveBeenCalledWith(efficiency.viewLoadHardTimeoutMs);
     });
+
+    it("a throwing soft view-load setter still lets the hard bound land", () => {
+      // The two bounds must not share a try block: a soft-setter throw that
+      // skipped the hard setter would leave the ceiling on the previous
+      // profile's value while the soft bound moved.
+      const pvm = makeMockPvm();
+      pvm.setViewLoadTimeoutMs.mockImplementation(() => {
+        throw new Error("soft bound exploded");
+      });
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service._forceProfileForTesting("efficiency");
+
+      expect(() =>
+        service.applyCurrentProfileTo(pvm as unknown as ProjectViewManager)
+      ).not.toThrow();
+
+      expect(pvm.setViewLoadHardTimeoutMs).toHaveBeenCalledWith(
+        RESOURCE_PROFILE_CONFIGS.efficiency.viewLoadHardTimeoutMs
+      );
+    });
   });
 });

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -141,6 +141,8 @@ interface MockProjectViewManager {
   setPaintGateHardTimeoutMs: Mock;
   setWarmPaintGateTimeoutMs: Mock;
   setWarmPaintGateHardTimeoutMs: Mock;
+  setViewLoadTimeoutMs: Mock;
+  setViewLoadHardTimeoutMs: Mock;
 }
 interface MockProjectStatsService {
   updatePollInterval: Mock;
@@ -166,6 +168,8 @@ function createDeps(overrides?: Partial<ResourceProfileDeps>): ResourceProfileDe
     setPaintGateHardTimeoutMs: vi.fn(),
     setWarmPaintGateTimeoutMs: vi.fn(),
     setWarmPaintGateHardTimeoutMs: vi.fn(),
+    setViewLoadTimeoutMs: vi.fn(),
+    setViewLoadHardTimeoutMs: vi.fn(),
   };
   const mockProjectStatsService: MockProjectStatsService = {
     updatePollInterval: vi.fn(),
@@ -191,6 +195,8 @@ function makeMockPvm(): MockProjectViewManager {
     setPaintGateHardTimeoutMs: vi.fn(),
     setWarmPaintGateTimeoutMs: vi.fn(),
     setWarmPaintGateHardTimeoutMs: vi.fn(),
+    setViewLoadTimeoutMs: vi.fn(),
+    setViewLoadHardTimeoutMs: vi.fn(),
   };
 }
 
@@ -721,6 +727,12 @@ describe("ResourceProfileService", () => {
       expect(latePvm.setWarmPaintGateHardTimeoutMs).toHaveBeenCalledWith(
         RESOURCE_PROFILE_CONFIGS.efficiency.warmPaintGateHardTimeoutMs
       );
+      expect(latePvm.setViewLoadTimeoutMs).toHaveBeenCalledWith(
+        RESOURCE_PROFILE_CONFIGS.efficiency.viewLoadTimeoutMs
+      );
+      expect(latePvm.setViewLoadHardTimeoutMs).toHaveBeenCalledWith(
+        RESOURCE_PROFILE_CONFIGS.efficiency.viewLoadHardTimeoutMs
+      );
       // Efficiency entry never clamps cached views — it only freezes them.
       expect(latePvm.setCachedViewLimit).not.toHaveBeenCalled();
 
@@ -779,6 +791,12 @@ describe("ResourceProfileService", () => {
     expect(pvm.setWarmPaintGateHardTimeoutMs).toHaveBeenCalledWith(
       RESOURCE_PROFILE_CONFIGS.balanced.warmPaintGateHardTimeoutMs
     );
+    expect(pvm.setViewLoadTimeoutMs).toHaveBeenCalledWith(
+      RESOURCE_PROFILE_CONFIGS.balanced.viewLoadTimeoutMs
+    );
+    expect(pvm.setViewLoadHardTimeoutMs).toHaveBeenCalledWith(
+      RESOURCE_PROFILE_CONFIGS.balanced.viewLoadHardTimeoutMs
+    );
 
     service.stop();
   });
@@ -805,6 +823,12 @@ describe("ResourceProfileService", () => {
     );
     expect(pvm.setWarmPaintGateHardTimeoutMs).toHaveBeenLastCalledWith(
       RESOURCE_PROFILE_CONFIGS.efficiency.warmPaintGateHardTimeoutMs
+    );
+    expect(pvm.setViewLoadTimeoutMs).toHaveBeenLastCalledWith(
+      RESOURCE_PROFILE_CONFIGS.efficiency.viewLoadTimeoutMs
+    );
+    expect(pvm.setViewLoadHardTimeoutMs).toHaveBeenLastCalledWith(
+      RESOURCE_PROFILE_CONFIGS.efficiency.viewLoadHardTimeoutMs
     );
 
     service.stop();
@@ -847,6 +871,12 @@ describe("ResourceProfileService", () => {
     );
     expect(pvm.setWarmPaintGateHardTimeoutMs).toHaveBeenLastCalledWith(
       RESOURCE_PROFILE_CONFIGS.balanced.warmPaintGateHardTimeoutMs
+    );
+    expect(pvm.setViewLoadTimeoutMs).toHaveBeenLastCalledWith(
+      RESOURCE_PROFILE_CONFIGS.balanced.viewLoadTimeoutMs
+    );
+    expect(pvm.setViewLoadHardTimeoutMs).toHaveBeenLastCalledWith(
+      RESOURCE_PROFILE_CONFIGS.balanced.viewLoadHardTimeoutMs
     );
 
     service.stop();

--- a/electron/utils/__tests__/resourceProfileConfig.test.ts
+++ b/electron/utils/__tests__/resourceProfileConfig.test.ts
@@ -39,6 +39,23 @@ describe("resolveResourceProfileConfig", () => {
     }
   });
 
+  it("keeps every hard timeout at or above its soft counterpart", () => {
+    // The soft bound only warns; the hard bound is what abandons the work. If
+    // a profile ever inverts them the soft phase is unreachable and the
+    // two-phase design silently collapses back to a single fatal deadline.
+    for (const profile of PROFILES) {
+      const config = RESOURCE_PROFILE_CONFIGS[profile];
+      expect(config.paintGateHardTimeoutMs).toBeGreaterThanOrEqual(config.paintGateTimeoutMs);
+      expect(config.warmPaintGateHardTimeoutMs).toBeGreaterThanOrEqual(
+        config.warmPaintGateTimeoutMs
+      );
+      expect(config.viewLoadHardTimeoutMs).toBeGreaterThanOrEqual(config.viewLoadTimeoutMs);
+      // A view-load ceiling below the paint-gate ceiling would abandon loads
+      // the gate downstream is still willing to wait for.
+      expect(config.viewLoadHardTimeoutMs).toBeGreaterThan(config.paintGateHardTimeoutMs);
+    }
+  });
+
   it("does not mutate the shared RESOURCE_PROFILE_CONFIGS table", () => {
     const balancedBefore = { ...RESOURCE_PROFILE_CONFIGS.balanced };
     resolveResourceProfileConfig("balanced", 32);

--- a/electron/utils/__tests__/resourceProfileConfig.test.ts
+++ b/electron/utils/__tests__/resourceProfileConfig.test.ts
@@ -39,21 +39,28 @@ describe("resolveResourceProfileConfig", () => {
     }
   });
 
-  it("keeps every hard timeout at or above its soft counterpart", () => {
-    // The soft bound only warns; the hard bound is what abandons the work. If
-    // a profile ever inverts them the soft phase is unreachable and the
-    // two-phase design silently collapses back to a single fatal deadline.
+  it("keeps every hard timeout strictly above its soft counterpart", () => {
+    // The soft bound only warns; the hard bound abandons the work. Equality
+    // is as broken as inversion: both fire in the same timer turn, leaving no
+    // interval in which slow-but-alive work can recover, which collapses each
+    // two-phase design back into the single fatal deadline it replaced.
     for (const profile of PROFILES) {
       const config = RESOURCE_PROFILE_CONFIGS[profile];
-      expect(config.paintGateHardTimeoutMs).toBeGreaterThanOrEqual(config.paintGateTimeoutMs);
-      expect(config.warmPaintGateHardTimeoutMs).toBeGreaterThanOrEqual(
-        config.warmPaintGateTimeoutMs
-      );
-      expect(config.viewLoadHardTimeoutMs).toBeGreaterThanOrEqual(config.viewLoadTimeoutMs);
-      // A view-load ceiling below the paint-gate ceiling would abandon loads
-      // the gate downstream is still willing to wait for.
-      expect(config.viewLoadHardTimeoutMs).toBeGreaterThan(config.paintGateHardTimeoutMs);
+      expect(config.paintGateHardTimeoutMs).toBeGreaterThan(config.paintGateTimeoutMs);
+      expect(config.warmPaintGateHardTimeoutMs).toBeGreaterThan(config.warmPaintGateTimeoutMs);
+      expect(config.viewLoadHardTimeoutMs).toBeGreaterThan(config.viewLoadTimeoutMs);
     }
+  });
+
+  it("gives efficiency more view-load headroom than balanced", () => {
+    // The profile exists because the machine is under pressure; a ceiling at
+    // or below balanced's would defeat the reason for scaling it at all.
+    expect(RESOURCE_PROFILE_CONFIGS.efficiency.viewLoadTimeoutMs).toBeGreaterThan(
+      RESOURCE_PROFILE_CONFIGS.balanced.viewLoadTimeoutMs
+    );
+    expect(RESOURCE_PROFILE_CONFIGS.efficiency.viewLoadHardTimeoutMs).toBeGreaterThan(
+      RESOURCE_PROFILE_CONFIGS.balanced.viewLoadHardTimeoutMs
+    );
   });
 
   it("does not mutate the shared RESOURCE_PROFILE_CONFIGS table", () => {

--- a/electron/window/ProjectViewEvictionController.ts
+++ b/electron/window/ProjectViewEvictionController.ts
@@ -167,9 +167,20 @@ export function evictStaleViews(
   // start) would evict the outgoing view and expose the unpainted
   // incoming frame, re-creating the exact flash this gate prevents.
   const gateOutgoingProjectId = host.pendingPaintGate?.outgoingProjectId ?? null;
+  // The gate resolves on the incoming skeleton signal (or its own hard
+  // timeout) while the outgoing view stays attached until the load finishes,
+  // so the gate alone under-covers the very case the guard above describes —
+  // by up to the full load ceiling (#11459). `pendingColdSwitch` spans the
+  // real on-screen window.
+  const switchOutgoingProjectId = host.pendingColdSwitch?.outgoingProjectId ?? null;
 
   const evictable = Array.from(host.views.entries())
-    .filter(([id]) => id !== host.activeProjectId && id !== gateOutgoingProjectId)
+    .filter(
+      ([id]) =>
+        id !== host.activeProjectId &&
+        id !== gateOutgoingProjectId &&
+        id !== switchOutgoingProjectId
+    )
     // Oldest lastUsed first — pure LRU. Sequential switchTo calls stamp
     // distinct millisecond timestamps so equal-lastUsed ties don't arise
     // in practice; Array.sort stability handles them deterministically.

--- a/electron/window/ProjectViewFactory.ts
+++ b/electron/window/ProjectViewFactory.ts
@@ -26,7 +26,17 @@ import { isDemoMode } from "../setup/runtimeFlags.js";
 import { projectStore } from "../services/ProjectStore.js";
 import type { ProjectViewManager } from "./ProjectViewManager.js";
 
-const LOAD_TIMEOUT_MS = 10_000;
+/**
+ * Two-phase load timing, captured per call. The soft bound is observability
+ * only — it logs that the load is far outside the measured distribution and
+ * keeps waiting. The hard bound is the absolute ceiling that abandons the
+ * switch. See `DEFAULT_VIEW_LOAD_*_MS` in ProjectViewManager.ts for the
+ * defaults and `RESOURCE_PROFILE_CONFIGS` for the per-profile values.
+ */
+export interface LoadViewTimings {
+  softMs: number;
+  hardMs: number;
+}
 
 export function createView(host: ProjectViewManager, projectId: string): WebContentsView {
   const ses = session.fromPartition("persist:daintree");
@@ -79,29 +89,65 @@ export function createView(host: ProjectViewManager, projectId: string): WebCont
   return view;
 }
 
-export function loadView(view: WebContentsView, projectId: string): Promise<void> {
+export function loadView(
+  view: WebContentsView,
+  projectId: string,
+  timings: LoadViewTimings
+): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     const wc = view.webContents;
     let settled = false;
+
+    const softMs = timings.softMs;
+    // Guarantee hard >= soft so the soft warning always precedes the hard
+    // rejection, regardless of how the two resource-profile setters are
+    // ordered. Mirrors the paint gate's clamp in waitForPaint().
+    const hardMs = Math.max(timings.hardMs, softMs);
 
     const cleanup = () => {
       wc.removeListener("did-finish-load", onFinish);
       wc.removeListener("did-fail-load", onFail);
       wc.removeListener("preload-error", onPreloadError);
       wc.removeListener("render-process-gone", onProcessGone);
+      wc.removeListener("dom-ready", onDomReady);
     };
 
     const settle = (fn: () => void) => {
       if (settled) return;
       settled = true;
-      clearTimeout(timeout);
+      clearTimeout(softTimeout);
+      clearTimeout(hardTimeout);
       cleanup();
       fn();
     };
 
-    const timeout = setTimeout(() => {
+    // Soft tail: log only. A cold load runs ~141ms at p50 and ~454ms at the
+    // observed max, so crossing this bound means something is genuinely
+    // wrong — but "wrong" is not "dead", and abandoning here is what lost
+    // the switch in #11459. Keep waiting for a real event or the hard bound.
+    const armedAt = performance.now();
+    const softTimeout = setTimeout(() => {
+      logWarn("projectview.load.softtimeout", {
+        projectId,
+        waitedMs: softMs,
+        hardMs,
+        // How much later than scheduled this callback actually ran. A large
+        // value means the main process was blocked (concurrent agent CLIs,
+        // git enumeration) rather than the renderer being slow — the two are
+        // indistinguishable from the elapsed time alone, and which one it is
+        // decides whether the fix is here or upstream. Clamped because the
+        // fake timers used in unit tests advance virtual time only.
+        timerLateByMs: Math.max(0, Math.round(performance.now() - armedAt - softMs)),
+      });
+    }, softMs);
+
+    // Hard ceiling: the load is presumed wedged. Deliberately never extended
+    // by progress signals — the main-process stall that delays the load
+    // delays any event that would reset it, so a wall-clock backstop is the
+    // only bound that holds.
+    const hardTimeout = setTimeout(() => {
       settle(() => reject(new Error("View load timed out")));
-    }, LOAD_TIMEOUT_MS);
+    }, hardMs);
 
     const onFinish = () => {
       void verifyProjectBootstrap(wc, projectId).then(
@@ -116,11 +162,6 @@ export function loadView(view: WebContentsView, projectId: string): Promise<void
     const onProcessGone = (_event: Electron.Event, details: Electron.RenderProcessGoneDetails) =>
       settle(() => reject(new Error(`Renderer process gone during load: ${details.reason}`)));
 
-    wc.once("did-finish-load", onFinish);
-    wc.once("did-fail-load", onFail);
-    wc.once("preload-error", onPreloadError);
-    wc.once("render-process-gone", onProcessGone);
-
     // Paint the skeleton on `dom-ready`, NOT before `loadURL`. `insertCSS`
     // and `executeJavaScript` are scoped to the live document, and the
     // navigation that `loadURL` kicks off discards anything injected into the
@@ -129,7 +170,12 @@ export function loadView(view: WebContentsView, projectId: string): Promise<void
     // is correct because each cold start creates a fresh WebContentsView.
     // Re-read the project inside the handler rather than closing over a value
     // captured now, so the freshest name/emoji/color is painted (#9162).
-    wc.once("dom-ready", () => {
+    // Named (not inline) so `cleanup` can detach it: `webContents.close()`
+    // does not remove JS listeners, so a load that fails before dom-ready
+    // would otherwise leave this bound to a view that is being torn down.
+    // Removing it on settle is safe — on the success path dom-ready always
+    // precedes did-finish-load, so it has already fired and self-removed.
+    const onDomReady = () => {
       if (wc.isDestroyed()) return;
       const project = projectStore.getProjectById(projectId);
       // instantReveal drops index.html's 400ms Doherty entry delay: a cold
@@ -139,7 +185,13 @@ export function loadView(view: WebContentsView, projectId: string): Promise<void
       // for the initial app launch (createWindow.ts), where it belongs.
       injectSkeletonCss(wc, project, { instantReveal: true });
       injectSkeletonProjectIdentity(wc, project);
-    });
+    };
+
+    wc.once("did-finish-load", onFinish);
+    wc.once("did-fail-load", onFail);
+    wc.once("preload-error", onPreloadError);
+    wc.once("render-process-gone", onProcessGone);
+    wc.once("dom-ready", onDomReady);
 
     // The document URL is intentionally static (no `?projectId=`): the id
     // travels via additionalArguments so the V8 bytecode cache stays shared

--- a/electron/window/ProjectViewHandlers.ts
+++ b/electron/window/ProjectViewHandlers.ts
@@ -164,7 +164,14 @@ export function setupViewHandlers(
 
     // If the view is still loading, loadView's one-shot handler will handle
     // the failure and trigger rollback — skip crash recovery here.
+    //
+    // `state` alone cannot detect this: performSwitch flips the entry to
+    // "active" before it awaits loadView, so a load-time crash fell through
+    // to full crash recovery (port teardown, reload, even OOM window
+    // recreation) AND then rolled back — two recovery paths for one crash.
+    // `pendingColdSwitch` marks the real in-flight load.
     if (crashEntry?.state === "loading") return;
+    if (projectId && host.pendingColdSwitch?.projectId === projectId) return;
 
     // Synchronously notify subscribers (e.g. PtyClient) so per-window
     // MessagePorts can be torn down before reload re-issues fresh ones.

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -66,6 +66,22 @@ const DEFAULT_PAINT_GATE_HARD_TIMEOUT_MS = 4_000;
 const DEFAULT_WARM_PAINT_GATE_TIMEOUT_MS = 500;
 const DEFAULT_WARM_PAINT_GATE_HARD_TIMEOUT_MS = 1_500;
 /**
+ * Soft view-load timeout (ms). At this point the cold-start load is taking far
+ * longer than the measured distribution (p90 ~177ms) and that fact is logged,
+ * but the load keeps running — crossing this bound is observable, never fatal.
+ */
+const DEFAULT_VIEW_LOAD_TIMEOUT_MS = 10_000;
+/**
+ * Hard view-load timeout (ms). Absolute ceiling at which the load is abandoned
+ * and the switch rolls back. Previously the soft bound doubled as this ceiling,
+ * so a load that was merely slow — a main process saturated by concurrent agent
+ * CLIs and git enumeration also stalls the `app://` chunks the renderer is
+ * waiting on — lost the switch outright (#11459). Progress signals deliberately
+ * do NOT extend it: the same stall that delays the load delays any event that
+ * would reset it, so only a wall-clock backstop can bound the wait.
+ */
+const DEFAULT_VIEW_LOAD_HARD_TIMEOUT_MS = 30_000;
+/**
  * Period between renderer-memory samples for cached (non-active) views. 30 s
  * matches `ProcessMemoryMonitor` and keeps the synchronous `app.getAppMetrics()`
  * call (5–50 ms per invocation) out of the budget that would risk main-thread
@@ -135,6 +151,18 @@ export interface ProjectViewManagerOptions {
    */
   warmPaintGateHardTimeoutMs?: number;
   /**
+   * Override the soft view-load timeout (default 10000 ms). Crossing this bound
+   * only logs `projectview.load.softtimeout` — the load stays alive. Lower
+   * values let tests exercise the slow-load warning path without a real stall.
+   */
+  viewLoadTimeoutMs?: number;
+  /**
+   * Override the hard view-load timeout (default 30000 ms). At this bound the
+   * load is abandoned and the switch rolls back. Lower values let tests drive
+   * the rejection deterministically without advancing 30s of fake time.
+   */
+  viewLoadHardTimeoutMs?: number;
+  /**
    * Resolve the Daintree Assistant backend bound to a project — its PTY and the
    * WebContents its help session pinned — or null when it has no session.
    * Injected from the composition root so the eviction policy can consult
@@ -190,6 +218,8 @@ export class ProjectViewManager {
   paintGateHardTimeoutMs = DEFAULT_PAINT_GATE_HARD_TIMEOUT_MS;
   warmPaintGateTimeoutMs = DEFAULT_WARM_PAINT_GATE_TIMEOUT_MS;
   warmPaintGateHardTimeoutMs = DEFAULT_WARM_PAINT_GATE_HARD_TIMEOUT_MS;
+  viewLoadTimeoutMs = DEFAULT_VIEW_LOAD_TIMEOUT_MS;
+  viewLoadHardTimeoutMs = DEFAULT_VIEW_LOAD_HARD_TIMEOUT_MS;
   // One-shot focus intent consumed by the next switchTo for this projectId.
   // Lives on the instance (not module) so multi-window does not cross-leak.
   // Cleared after delivery or discard so a later unrelated switch can't
@@ -236,6 +266,12 @@ export class ProjectViewManager {
     }
     if (opts.warmPaintGateHardTimeoutMs != null) {
       this.warmPaintGateHardTimeoutMs = Math.max(0, opts.warmPaintGateHardTimeoutMs);
+    }
+    if (opts.viewLoadTimeoutMs != null) {
+      this.viewLoadTimeoutMs = Math.max(0, opts.viewLoadTimeoutMs);
+    }
+    if (opts.viewLoadHardTimeoutMs != null) {
+      this.viewLoadHardTimeoutMs = Math.max(0, opts.viewLoadHardTimeoutMs);
     }
 
     // Single resize handler that always updates the active view's bounds.
@@ -604,6 +640,26 @@ export class ProjectViewManager {
   setWarmPaintGateHardTimeoutMs(ms: number): void {
     if (!Number.isFinite(ms) || ms < 0) return;
     this.warmPaintGateHardTimeoutMs = ms;
+  }
+
+  /**
+   * Set the soft view-load timeout (ms). Does NOT retime an in-flight load —
+   * the value is captured when `loadView` is called. Called by
+   * `ResourceProfileService` to push per-profile timing.
+   */
+  setViewLoadTimeoutMs(ms: number): void {
+    if (!Number.isFinite(ms) || ms < 0) return;
+    this.viewLoadTimeoutMs = ms;
+  }
+
+  /**
+   * Set the hard view-load timeout (ms). Does NOT retime an in-flight load —
+   * the value is captured when `loadView` is called. Called by
+   * `ResourceProfileService` to push per-profile timing.
+   */
+  setViewLoadHardTimeoutMs(ms: number): void {
+    if (!Number.isFinite(ms) || ms < 0) return;
+    this.viewLoadHardTimeoutMs = ms;
   }
 
   /**

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -511,14 +511,24 @@ export class ProjectViewManager {
   }
 
   /**
-   * Project whose view is the still-visible anti-flash bridge of an open paint
-   * gate. During a cold switch `activeProjectId` is already the incoming
-   * project, but the outgoing project's view stays on-screen until the gate
-   * settles — so it is non-evictable for the same reason as the active view.
-   * Eviction paths must skip both (mirrors the LRU guard in `evictStaleViews`).
+   * Project whose view is the still-visible anti-flash bridge of a cold switch.
+   * During a cold switch `activeProjectId` is already the incoming project, but
+   * the outgoing project's view stays on-screen until the load settles — so it
+   * is non-evictable for the same reason as the active view. Eviction paths
+   * must skip both (mirrors the LRU guard in `evictStaleViews`).
+   *
+   * Spans the whole load, not just the paint gate: the gate resolves on the
+   * incoming skeleton signal (or its own hard timeout) and nulls itself, while
+   * the outgoing view stays attached until `loadView` settles — up to the load
+   * ceiling (#11459). Falling back to `pendingColdSwitch` closes that window
+   * for every consumer (hibernation, idle auto-close, relocation, menu state),
+   * any of which would otherwise destroy the visible outgoing view and leave
+   * rollback with nothing to restore.
    */
   getOutgoingBridgeProjectId(): string | null {
-    return this.pendingPaintGate?.outgoingProjectId ?? null;
+    return (
+      this.pendingPaintGate?.outgoingProjectId ?? this.pendingColdSwitch?.outgoingProjectId ?? null
+    );
   }
 
   getActiveView(): WebContentsView | null {
@@ -839,6 +849,7 @@ export class ProjectViewManager {
     }
 
     PaintGateController.clearPaintGate(this);
+    this.pendingColdSwitch = null;
     for (const projectId of Array.from(this.views.keys())) {
       cleanupEntry(this, projectId);
     }

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -214,6 +214,24 @@ export class ProjectViewManager {
   private efficiencyFreezeTimer: NodeJS.Timeout | null = null;
   private backgroundResizeTimer: NodeJS.Timeout | null = null;
   pendingPaintGate: PaintGate | null = null;
+  /**
+   * The cold switch currently between `loadView` starting and the outgoing
+   * view being detached (or the switch rolling back).
+   *
+   * `pendingPaintGate` cannot answer "is the outgoing view still on screen?":
+   * the gate resolves on the incoming view's skeleton signal — or its own 4s
+   * hard timeout — and nulls itself, while the outgoing view stays attached
+   * and visible until `loadView` resolves. With the load ceiling raised to
+   * 30s (#11459) that divergence is wide enough to matter, so the two
+   * consumers that need the real answer read this instead:
+   *   - eviction, so a pressure pass can't destroy the visible outgoing view
+   *     and leave a blank window behind (the guard in
+   *     ProjectViewEvictionController exists for exactly this case but was
+   *     keyed off the gate);
+   *   - the persistent crash handler, so a renderer that dies mid-load takes
+   *     only `loadView`'s rollback and not crash recovery as well.
+   */
+  pendingColdSwitch: { projectId: string; outgoingProjectId: string | null } | null = null;
   paintGateTimeoutMs = DEFAULT_PAINT_GATE_TIMEOUT_MS;
   paintGateHardTimeoutMs = DEFAULT_PAINT_GATE_HARD_TIMEOUT_MS;
   warmPaintGateTimeoutMs = DEFAULT_WARM_PAINT_GATE_TIMEOUT_MS;

--- a/electron/window/ProjectViewSwitchController.ts
+++ b/electron/window/ProjectViewSwitchController.ts
@@ -323,6 +323,13 @@ export async function performSwitch(
 
   let visibleAt: number;
   let loadFinishedAt: number;
+  // Mark the window in which the outgoing view is still attached and visible
+  // while the incoming one loads. Cleared in the `finally` below, on both the
+  // success and rollback paths.
+  host.pendingColdSwitch = {
+    projectId,
+    outgoingProjectId: previousEntry?.projectId ?? null,
+  };
   try {
     // Load the renderer with projectId context. Timing is captured here as
     // primitives so a resource-profile transition mid-load can't retime an
@@ -471,6 +478,11 @@ export async function performSwitch(
     notifyError(loadError, { source: "project-switch" });
 
     throw loadError;
+  } finally {
+    // By this point the outgoing view has either been detached (success) or
+    // restored as the active view (rollback), so it no longer needs the
+    // bridge protections.
+    host.pendingColdSwitch = null;
   }
 
   // Explicit focus after swap

--- a/electron/window/ProjectViewSwitchController.ts
+++ b/electron/window/ProjectViewSwitchController.ts
@@ -324,8 +324,13 @@ export async function performSwitch(
   let visibleAt: number;
   let loadFinishedAt: number;
   try {
-    // Load the renderer with projectId context
-    await loadView(view, projectId);
+    // Load the renderer with projectId context. Timing is captured here as
+    // primitives so a resource-profile transition mid-load can't retime an
+    // in-flight load, matching the paint gate's capture-at-creation contract.
+    await loadView(view, projectId, {
+      softMs: host.viewLoadTimeoutMs,
+      hardMs: host.viewLoadHardTimeoutMs,
+    });
     loadFinishedAt = performance.now();
 
     // The incoming view is stacked behind the still-visible outgoing view,

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -20,7 +20,10 @@ interface MockWc {
   setWindowOpenHandler: ReturnType<typeof vi.fn>;
   setIgnoreMenuShortcuts: ReturnType<typeof vi.fn>;
   _handlers: Map<string, Handler[]>;
+  _persistentHandlers: Map<string, Handler[]>;
   _fireOnce: (event: string, ...args: unknown[]) => void;
+  /** Fire the persistent (`.on`) handlers setupViewHandlers registered. */
+  _fireOn: (event: string, ...args: unknown[]) => void;
 }
 
 function createMockWebContents(opts?: {
@@ -29,6 +32,7 @@ function createMockWebContents(opts?: {
 }): MockWc {
   const id = nextWebContentsId++;
   const handlers = new Map<string, Handler[]>();
+  const persistentHandlers = new Map<string, Handler[]>();
   const autoFinish = opts?.autoFinishLoad ?? true;
   const bootstrapProjectId = opts?.bootstrapProjectId ?? null;
 
@@ -46,7 +50,10 @@ function createMockWebContents(opts?: {
     close: vi.fn(),
     reload: vi.fn(),
     send: vi.fn(),
-    on: vi.fn((_event: string, _handler: Handler) => {}),
+    on: vi.fn((event: string, handler: Handler) => {
+      if (!persistentHandlers.has(event)) persistentHandlers.set(event, []);
+      persistentHandlers.get(event)!.push(handler);
+    }),
     once: vi.fn((event: string, handler: Handler) => {
       if (!handlers.has(event)) handlers.set(event, []);
       handlers.get(event)!.push(handler);
@@ -64,12 +71,16 @@ function createMockWebContents(opts?: {
     setWindowOpenHandler: vi.fn(),
     setIgnoreMenuShortcuts: vi.fn(),
     _handlers: handlers,
+    _persistentHandlers: persistentHandlers,
     _fireOnce(event: string, ...args: unknown[]) {
       const list = handlers.get(event);
       if (list && list.length > 0) {
         const h = list.shift()!;
         h(...args);
       }
+    },
+    _fireOn(event: string, ...args: unknown[]) {
+      for (const h of [...(persistentHandlers.get(event) ?? [])]) h(...args);
     },
   };
   return wc;
@@ -184,6 +195,7 @@ vi.mock("../../utils/logger.js", () => ({
 import { ProjectViewManager } from "../ProjectViewManager.js";
 import { notifyError } from "../../ipc/errorHandlers.js";
 import { logInfo, logWarn } from "../../utils/logger.js";
+import { RESOURCE_PROFILE_CONFIGS } from "../../../shared/types/resourceProfile.js";
 
 /**
  * Short stand-ins for the real 10s/30s view-load bounds so the two-phase
@@ -254,6 +266,183 @@ describe("ProjectViewManager — switch failure rollback", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it("defaults to the balanced profile's view-load bounds", () => {
+    // The manager constants are the fallback until the first resource-profile
+    // push lands, so a drift between them and the balanced profile would
+    // silently change cold-switch behaviour for the window's first switch.
+    const defaultManager = new ProjectViewManager(win as never, { dirname: "/test" });
+    expect(defaultManager.viewLoadTimeoutMs).toBe(
+      RESOURCE_PROFILE_CONFIGS.balanced.viewLoadTimeoutMs
+    );
+    expect(defaultManager.viewLoadHardTimeoutMs).toBe(
+      RESOURCE_PROFILE_CONFIGS.balanced.viewLoadHardTimeoutMs
+    );
+  });
+
+  it("leaves no load timer armed once the load settles", async () => {
+    // Both timers must be cleared on settle. Without an explicit inventory
+    // check a leaked hard timer is invisible: its callback just hits the
+    // `settled` guard, so nothing observable changes while the closure and
+    // the view it captures stay alive for the rest of the ceiling.
+    const wc = createMockWebContents({ autoFinishLoad: false });
+    wcQueue.push(wc);
+
+    const baseline = vi.getTimerCount();
+
+    const p = manager.switchTo("proj-b", "/path/b");
+    const errPromise = expectRejection(p);
+    await vi.advanceTimersByTimeAsync(0);
+    // Soft + hard are both armed while the load is in flight. (The paint-gate
+    // timers are configured to 0ms and have already fired by now.)
+    expect(vi.getTimerCount()).toBe(baseline + 2);
+
+    // Settle well before either bound. The rollback path is used deliberately:
+    // a successful switch caches the outgoing view, which starts the periodic
+    // cached-view memory sampler and would confound the count.
+    wc._fireOnce("preload-error", {}, "/test/preload.cjs", new Error("Cannot find module"));
+    await errPromise;
+
+    expect(vi.getTimerCount()).toBe(baseline);
+  });
+
+  it("records a non-negative timer lateness on the soft warning", async () => {
+    const wc = createMockWebContents({ autoFinishLoad: false });
+    wcQueue.push(wc);
+
+    const p = manager.switchTo("proj-b", "/path/b");
+    const errPromise = expectRejection(p);
+
+    await vi.advanceTimersByTimeAsync(LOAD_SOFT_MS + 1);
+
+    const [, payload] = softTimeoutWarnings()[0] as [string, Record<string, unknown>];
+    expect(payload.waitedMs).toBe(LOAD_SOFT_MS);
+    expect(payload.hardMs).toBe(LOAD_HARD_MS);
+    // The stall-vs-slow-renderer diagnostic must always be a usable number —
+    // a NaN or negative here would silently poison the telemetry it exists for.
+    expect(Number.isFinite(payload.timerLateByMs)).toBe(true);
+    expect(payload.timerLateByMs as number).toBeGreaterThanOrEqual(0);
+
+    await vi.advanceTimersByTimeAsync(LOAD_HARD_MS);
+    await errPromise;
+  });
+
+  it("applies bounds pushed through the runtime setters to the next load", async () => {
+    // The resource-profile push goes through these setters, so a no-op setter
+    // would silently strand every window on the default bounds.
+    const setterManager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
+    });
+    setterManager.setViewLoadTimeoutMs(LOAD_SOFT_MS);
+    setterManager.setViewLoadHardTimeoutMs(LOAD_HARD_MS);
+
+    const failWc = createMockWebContents({ autoFinishLoad: false });
+    wcQueue.push(failWc);
+
+    const p = setterManager.switchTo("proj-z", "/path/z");
+    const errPromise = expectRejection(p);
+
+    await vi.advanceTimersByTimeAsync(LOAD_SOFT_MS + 1);
+    expect(softTimeoutWarnings()).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(LOAD_HARD_MS);
+    const err = await errPromise;
+    expect(err.message).toBe("View load timed out");
+  });
+
+  it("ignores non-finite and negative bounds from the setters", async () => {
+    const setterManager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      viewLoadTimeoutMs: LOAD_SOFT_MS,
+      viewLoadHardTimeoutMs: LOAD_HARD_MS,
+    });
+
+    setterManager.setViewLoadTimeoutMs(Number.NaN);
+    setterManager.setViewLoadHardTimeoutMs(-1);
+    expect(setterManager.viewLoadTimeoutMs).toBe(LOAD_SOFT_MS);
+    expect(setterManager.viewLoadHardTimeoutMs).toBe(LOAD_HARD_MS);
+
+    setterManager.setViewLoadHardTimeoutMs(Number.POSITIVE_INFINITY);
+    expect(setterManager.viewLoadHardTimeoutMs).toBe(LOAD_HARD_MS);
+  });
+
+  it("keeps the in-flight load on its captured bounds when the setters move", async () => {
+    const failWc = createMockWebContents({ autoFinishLoad: false });
+    wcQueue.push(failWc);
+
+    const p = manager.switchTo("proj-b", "/path/b");
+    const errPromise = expectRejection(p);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // A resource-profile transition landing mid-load must not retime it.
+    manager.setViewLoadTimeoutMs(5_000);
+    manager.setViewLoadHardTimeoutMs(9_000);
+
+    await vi.advanceTimersByTimeAsync(LOAD_HARD_MS + 1);
+    const err = await errPromise;
+    expect(err.message).toBe("View load timed out");
+  });
+
+  it("does not run crash recovery for a renderer that dies mid-load", async () => {
+    // The persistent crash handler and loadView's one-shot handler both see
+    // render-process-gone. Only the latter should act: the former would tear
+    // down ports and reload a view the rollback is about to destroy.
+    const onViewCrashed = vi.fn();
+    const crashManager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
+      viewLoadTimeoutMs: LOAD_SOFT_MS,
+      viewLoadHardTimeoutMs: LOAD_HARD_MS,
+      onViewCrashed,
+    });
+
+    const crashWc = createMockWebContents({ autoFinishLoad: false });
+    wcQueue.push(crashWc);
+
+    const p = crashManager.switchTo("proj-b", "/path/b");
+    const errPromise = expectRejection(p);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Persistent handler first (registered before loadView's one-shot), then
+    // the one-shot that actually owns the failure.
+    crashWc._fireOn("render-process-gone", {}, { reason: "crashed", exitCode: 1 });
+    crashWc._fireOnce("render-process-gone", {}, { reason: "crashed", exitCode: 1 });
+
+    const err = await errPromise;
+    expect(err.message).toBe("Renderer process gone during load: crashed");
+    expect(onViewCrashed).not.toHaveBeenCalled();
+    expect(crashWc.reload).not.toHaveBeenCalled();
+  });
+
+  it("shields the still-visible outgoing view from eviction while the load runs", async () => {
+    // The paint gate resolves on the incoming skeleton signal, but the
+    // outgoing view stays on screen until the load finishes. A pressure pass
+    // in that gap must not destroy it — doing so leaves a blank window if the
+    // load then fails, since rollback has no live view to restore.
+    const bWc = createMockWebContents({ autoFinishLoad: true, bootstrapProjectId: "proj-b" });
+    wcQueue.push(bWc);
+    const firstSwitch = manager.switchTo("proj-b", "/path/b");
+    await vi.advanceTimersByTimeAsync(1);
+    await firstSwitch;
+
+    const slowWc = createMockWebContents({ autoFinishLoad: false, bootstrapProjectId: "proj-c" });
+    wcQueue.push(slowWc);
+    const p = manager.switchTo("proj-c", "/path/c");
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Mid-load pressure reclaim: proj-a is a genuine cached view and may go;
+    // proj-b is the visible bridge and must not.
+    manager.reclaimCachedViewsUnderPressure();
+    expect(bWc.close).not.toHaveBeenCalled();
+
+    slowWc._fireOnce("did-finish-load");
+    await vi.advanceTimersByTimeAsync(1);
+    await p;
+    expect(manager.getActiveProjectId()).toBe("proj-c");
   });
 
   it("rolls back to previous view when preload-error fires", async () => {

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -445,6 +445,88 @@ describe("ProjectViewManager — switch failure rollback", () => {
     expect(manager.getActiveProjectId()).toBe("proj-c");
   });
 
+  /**
+   * A manager whose paint gate expires strictly inside the load window, so the
+   * gap between "gate gone" and "load settled" can be observed on both sides.
+   */
+  const GATE_HARD_MS = 50;
+  function startBridgedSwitch() {
+    const bridgeManager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 3,
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: GATE_HARD_MS,
+      viewLoadTimeoutMs: LOAD_SOFT_MS,
+      viewLoadHardTimeoutMs: LOAD_HARD_MS,
+    });
+    bridgeManager.registerInitialView(
+      { webContents: createMockWebContents(), setBounds: vi.fn() } as never,
+      "bridge-a",
+      "/path/bridge-a"
+    );
+
+    const slowWc = createMockWebContents({
+      autoFinishLoad: false,
+      bootstrapProjectId: "bridge-b",
+    });
+    wcQueue.push(slowWc);
+    return {
+      bridgeManager,
+      slowWc,
+      switchPromise: bridgeManager.switchTo("bridge-b", "/path/bridge-b"),
+    };
+  }
+
+  it("keeps reporting the outgoing bridge after the paint gate clears mid-load", async () => {
+    // The gate resolves on the incoming skeleton signal — or its own hard
+    // timeout — and nulls itself, while the outgoing view stays attached and
+    // visible until the load settles. Answering from the gate alone left every
+    // consumer (hibernation, idle auto-close, relocation, menu state) blind for
+    // that whole gap, free to destroy the view rollback needs and strand the
+    // window on a project with no live entry (#11459).
+    const { bridgeManager, slowWc, switchPromise } = startBridgedSwitch();
+
+    // Gate still open: this is the case that passed before the fix too.
+    await vi.advanceTimersByTimeAsync(1);
+    expect(bridgeManager.pendingPaintGate).not.toBeNull();
+    const whileGateOpen = bridgeManager.getOutgoingBridgeProjectId();
+    expect(whileGateOpen).toBe("bridge-a");
+
+    // Gate hard-times-out and drops itself; the load is still in flight.
+    await vi.advanceTimersByTimeAsync(GATE_HARD_MS);
+    expect(bridgeManager.pendingPaintGate).toBeNull();
+    expect(bridgeManager.pendingColdSwitch?.projectId).toBe("bridge-b");
+
+    // The answer must not change across that boundary — the outgoing view is
+    // still the painted frame.
+    expect(bridgeManager.getOutgoingBridgeProjectId()).toBe(whileGateOpen);
+
+    // Only once the load settles is the bridge genuinely gone.
+    slowWc._fireOnce("did-finish-load");
+    await vi.advanceTimersByTimeAsync(1);
+    await switchPromise;
+    expect(bridgeManager.getOutgoingBridgeProjectId()).toBeNull();
+  });
+
+  it("stops reporting an outgoing bridge once the manager is disposed", async () => {
+    // dispose() clears the paint gate, so the cold switch has to go with it:
+    // otherwise a manager torn down mid-load keeps naming a project as on
+    // screen for the rest of the load ceiling, pinning it against hibernation
+    // and idle auto-close long after its window is gone.
+    const { bridgeManager, switchPromise } = startBridgedSwitch();
+    const errPromise = expectRejection(switchPromise);
+
+    await vi.advanceTimersByTimeAsync(GATE_HARD_MS + 1);
+    expect(bridgeManager.pendingPaintGate).toBeNull();
+    expect(bridgeManager.getOutgoingBridgeProjectId()).toBe("bridge-a");
+
+    bridgeManager.dispose();
+    expect(bridgeManager.getOutgoingBridgeProjectId()).toBeNull();
+
+    await vi.advanceTimersByTimeAsync(LOAD_HARD_MS);
+    await errPromise;
+  });
+
   it("rolls back to previous view when preload-error fires", async () => {
     const failWc = createMockWebContents({ autoFinishLoad: false });
     wcQueue.push(failWc);

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -183,7 +183,21 @@ vi.mock("../../utils/logger.js", () => ({
 
 import { ProjectViewManager } from "../ProjectViewManager.js";
 import { notifyError } from "../../ipc/errorHandlers.js";
-import { logInfo } from "../../utils/logger.js";
+import { logInfo, logWarn } from "../../utils/logger.js";
+
+/**
+ * Short stand-ins for the real 10s/30s view-load bounds so the two-phase
+ * behaviour can be driven without advancing 30s of fake time. The assertions
+ * below key off these, never off the production constants.
+ */
+const LOAD_SOFT_MS = 100;
+const LOAD_HARD_MS = 300;
+
+function softTimeoutWarnings() {
+  return vi
+    .mocked(logWarn)
+    .mock.calls.filter(([event]) => event === "projectview.load.softtimeout");
+}
 
 function createMockWindow() {
   return {
@@ -221,6 +235,7 @@ describe("ProjectViewManager — switch failure rollback", () => {
     wcQueue = [];
     vi.mocked(notifyError).mockClear();
     vi.mocked(logInfo).mockClear();
+    vi.mocked(logWarn).mockClear();
 
     win = createMockWindow();
     manager = new ProjectViewManager(win as never, {
@@ -228,6 +243,8 @@ describe("ProjectViewManager — switch failure rollback", () => {
       cachedProjectViews: 3,
       paintGateTimeoutMs: 0,
       paintGateHardTimeoutMs: 0,
+      viewLoadTimeoutMs: LOAD_SOFT_MS,
+      viewLoadHardTimeoutMs: LOAD_HARD_MS,
     });
 
     initialWc = createMockWebContents();
@@ -305,21 +322,110 @@ describe("ProjectViewManager — switch failure rollback", () => {
     ).toHaveLength(0);
   });
 
-  it("rolls back when load times out (10s)", async () => {
+  it("keeps the load alive past the soft timeout and only rolls back at the hard timeout", async () => {
+    const failWc = createMockWebContents({ autoFinishLoad: false });
+    wcQueue.push(failWc);
+
+    const p = manager.switchTo("proj-b", "/path/b");
+    let rejected = false;
+    const errPromise = expectRejection(p).then((err) => {
+      rejected = true;
+      return err;
+    });
+
+    // Past the soft bound: the slow load is reported, but nothing is torn
+    // down — this is the window in which #11459 used to lose the switch.
+    await vi.advanceTimersByTimeAsync(LOAD_SOFT_MS + 1);
+    expect(rejected).toBe(false);
+    expect(softTimeoutWarnings()).toHaveLength(1);
+    expect(failWc.close).not.toHaveBeenCalled();
+    expect(notifyError).not.toHaveBeenCalled();
+    expect(manager.getActiveProjectId()).toBe("proj-b");
+
+    // Past the hard bound: now the load is presumed wedged and rolled back.
+    await vi.advanceTimersByTimeAsync(LOAD_HARD_MS - LOAD_SOFT_MS);
+
+    const err = await errPromise;
+    expect(err.message).toBe("View load timed out");
+    expect(manager.getActiveProjectId()).toBe("proj-a");
+    expect(failWc.close).toHaveBeenCalled();
+    expect(notifyError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ source: "project-switch" })
+    );
+    expect(
+      vi.mocked(logInfo).mock.calls.filter(([e]) => e === "projectview.coldstart")
+    ).toHaveLength(0);
+    // The soft bound warns once, not once per elapsed interval.
+    expect(softTimeoutWarnings()).toHaveLength(1);
+  });
+
+  it("completes the switch when the load finishes between the soft and hard timeouts", async () => {
+    const slowWc = createMockWebContents({
+      autoFinishLoad: false,
+      bootstrapProjectId: "proj-b",
+    });
+    wcQueue.push(slowWc);
+
+    const p = manager.switchTo("proj-b", "/path/b");
+
+    // Cross the soft bound without finishing — previously fatal at 10s.
+    await vi.advanceTimersByTimeAsync(LOAD_SOFT_MS + 1);
+    expect(softTimeoutWarnings()).toHaveLength(1);
+
+    // The renderer catches up before the hard ceiling.
+    slowWc._fireOnce("did-finish-load");
+    await vi.advanceTimersByTimeAsync(1);
+
+    const result = await p;
+    expect(result.isNew).toBe(true);
+    expect(manager.getActiveProjectId()).toBe("proj-b");
+    expect(slowWc.close).not.toHaveBeenCalled();
+    expect(notifyError).not.toHaveBeenCalled();
+
+    // The hard timer was cleared on settle: advancing well past it must not
+    // retroactively roll back a switch that already succeeded.
+    await vi.advanceTimersByTimeAsync(LOAD_HARD_MS * 2);
+    expect(manager.getActiveProjectId()).toBe("proj-b");
+    expect(notifyError).not.toHaveBeenCalled();
+  });
+
+  it("clears both load timers when an event-driven failure settles first", async () => {
     const failWc = createMockWebContents({ autoFinishLoad: false });
     wcQueue.push(failWc);
 
     const p = manager.switchTo("proj-b", "/path/b");
     const errPromise = expectRejection(p);
 
-    await vi.advanceTimersByTimeAsync(10_001);
+    await vi.advanceTimersByTimeAsync(0);
+    failWc._fireOnce("render-process-gone", {}, { reason: "crashed", exitCode: 1 });
+    await errPromise;
 
-    const err = await errPromise;
-    expect(err.message).toBe("View load timed out");
-    expect(manager.getActiveProjectId()).toBe("proj-a");
-    expect(
-      vi.mocked(logInfo).mock.calls.filter(([e]) => e === "projectview.coldstart")
-    ).toHaveLength(0);
+    vi.mocked(notifyError).mockClear();
+
+    // Deterministic failures must not inherit the hard delay, and neither
+    // timer may fire after the promise already settled.
+    await vi.advanceTimersByTimeAsync(LOAD_HARD_MS * 2);
+    expect(softTimeoutWarnings()).toHaveLength(0);
+    expect(notifyError).not.toHaveBeenCalled();
+  });
+
+  it("detaches the dom-ready listener when the load fails before dom-ready", async () => {
+    const failWc = createMockWebContents({ autoFinishLoad: false });
+    wcQueue.push(failWc);
+
+    const p = manager.switchTo("proj-b", "/path/b");
+    const errPromise = expectRejection(p);
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(failWc._handlers.get("dom-ready") ?? []).toHaveLength(1);
+
+    failWc._fireOnce("preload-error", {}, "/test/preload.cjs", new Error("Cannot find module"));
+    await errPromise;
+
+    // `webContents.close()` does not remove JS listeners, so settle() has to
+    // detach this one itself or it stays bound to a torn-down view.
+    expect(failWc._handlers.get("dom-ready") ?? []).toHaveLength(0);
   });
 
   it("sets activeProjectId to null when no previous view exists", async () => {
@@ -327,6 +433,8 @@ describe("ProjectViewManager — switch failure rollback", () => {
       dirname: "/test",
       paintGateTimeoutMs: 0,
       paintGateHardTimeoutMs: 0,
+      viewLoadTimeoutMs: LOAD_SOFT_MS,
+      viewLoadHardTimeoutMs: LOAD_HARD_MS,
     });
 
     const failWc = createMockWebContents({ autoFinishLoad: false });
@@ -335,12 +443,36 @@ describe("ProjectViewManager — switch failure rollback", () => {
     const p = freshManager.switchTo("proj-x", "/path/x");
     const errPromise = expectRejection(p);
 
-    await vi.advanceTimersByTimeAsync(10_001);
+    await vi.advanceTimersByTimeAsync(LOAD_HARD_MS + 1);
 
     const err = await errPromise;
     expect(err.message).toBe("View load timed out");
     expect(freshManager.getActiveProjectId()).toBeNull();
     expect(notifyError).toHaveBeenCalled();
+  });
+
+  it("normalizes a hard bound below the soft bound so soft never outlives hard", async () => {
+    const invertedManager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
+      viewLoadTimeoutMs: LOAD_HARD_MS,
+      viewLoadHardTimeoutMs: LOAD_SOFT_MS,
+    });
+
+    const failWc = createMockWebContents({ autoFinishLoad: false });
+    wcQueue.push(failWc);
+
+    const p = invertedManager.switchTo("proj-y", "/path/y");
+    const errPromise = expectRejection(p);
+
+    // hard is clamped up to soft, so nothing rejects at the smaller value.
+    await vi.advanceTimersByTimeAsync(LOAD_SOFT_MS + 1);
+    expect(notifyError).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(LOAD_HARD_MS);
+    const err = await errPromise;
+    expect(err.message).toBe("View load timed out");
   });
 
   it("switchChain continues after rollback — second switch succeeds", async () => {
@@ -354,7 +486,7 @@ describe("ProjectViewManager — switch failure rollback", () => {
     const first = manager.switchTo("proj-b", "/path/b");
     const firstErr = expectRejection(first);
 
-    await vi.advanceTimersByTimeAsync(10_001);
+    await vi.advanceTimersByTimeAsync(LOAD_HARD_MS + 1);
     await firstErr;
 
     const second = manager.switchTo("proj-c", "/path/c");

--- a/shared/types/resourceProfile.ts
+++ b/shared/types/resourceProfile.ts
@@ -106,6 +106,24 @@ export interface ResourceProfileConfig {
    * signal path instead of revealing a partially repainted grid.
    */
   warmPaintGateHardTimeoutMs: number;
+  /**
+   * Cold-start view-load SOFT timeout (ms). Bounds the wait for the incoming
+   * project view's `did-finish-load`. Crossing it does NOT abandon the switch —
+   * it only logs `projectview.load.softtimeout` so slow loads are observable;
+   * the load stays alive until it finishes or the hard ceiling fires. Sized
+   * far above the measured cold-load distribution (p90 ~177ms) so the warning
+   * means "something is genuinely wrong", not "this machine is busy".
+   */
+  viewLoadTimeoutMs: number;
+  /**
+   * Cold-start view-load HARD timeout (ms). Absolute ceiling that rejects the
+   * load and rolls the switch back, assuming the renderer is wedged. Never
+   * extended by progress signals — a stalled main process delays the load and
+   * this timer alike, so only a wall-clock backstop can bound the wait. Should
+   * stay comfortably above `viewLoadTimeoutMs` so a load that is merely slow
+   * lands instead of being abandoned (#11459).
+   */
+  viewLoadHardTimeoutMs: number;
 }
 
 /**
@@ -182,6 +200,8 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, BaseResourceProfi
     paintGateHardTimeoutMs: 4_000,
     warmPaintGateTimeoutMs: 500,
     warmPaintGateHardTimeoutMs: 1_500,
+    viewLoadTimeoutMs: 10_000,
+    viewLoadHardTimeoutMs: 30_000,
   },
   balanced: {
     pollIntervalActive: 2000,
@@ -197,14 +217,16 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, BaseResourceProfi
     // Must match PORT_BATCH_THROUGHPUT_DELAY_MS — the pty-host's fallback
     // until the first set-resource-profile push lands.
     portBatchThroughputDelayMs: 16,
-    // Balanced paint-gate values (cold and warm) must match the
-    // `DEFAULT_*_PAINT_GATE_*_MS` constants in
+    // Balanced paint-gate and view-load values must match the
+    // `DEFAULT_*_PAINT_GATE_*_MS` / `DEFAULT_VIEW_LOAD_*_MS` constants in
     // `electron/window/ProjectViewManager.ts` — those constants are the
     // fallback used until the profile push lands. Keep them in lockstep.
     paintGateTimeoutMs: 1_500,
     paintGateHardTimeoutMs: 4_000,
     warmPaintGateTimeoutMs: 500,
     warmPaintGateHardTimeoutMs: 1_500,
+    viewLoadTimeoutMs: 10_000,
+    viewLoadHardTimeoutMs: 30_000,
   },
   efficiency: {
     pollIntervalActive: 4000,
@@ -238,5 +260,10 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, BaseResourceProfi
     // rationale as the cold-gate values above.
     warmPaintGateTimeoutMs: 800,
     warmPaintGateHardTimeoutMs: 2_500,
+    // The main-process contention that puts the app in efficiency is the same
+    // contention that slows the `app://` chunk serving the incoming view is
+    // waiting on, so the load bounds get the same 1.5x headroom as the gates.
+    viewLoadTimeoutMs: 15_000,
+    viewLoadHardTimeoutMs: 45_000,
   },
 };


### PR DESCRIPTION
## The problem

`loadView()` gave a cold project-switch view load one fixed 10s deadline (`LOAD_TIMEOUT_MS` in `electron/window/ProjectViewFactory.ts`). Miss it and the switch was abandoned outright — incoming view torn down, rollback to the previous project, "Couldn't switch project" toast, no retry.

Cold-load telemetry is p50 141ms / p90 177ms / max 454ms, so 10s is ~70x the median, yet a real user hit it. That points at a saturated main process (concurrent agent CLIs plus git enumeration) stalling both the `app://` chunk serving the load and the timer measuring it. A load that is merely slow shouldn't lose the switch.

## The fix

Split that one fatal deadline into the two-phase shape the paint gate next door already uses:

- **Soft bound** (10s, efficiency 15s) — logs `projectview.load.softtimeout` and keeps waiting. Observable, never fatal.
- **Hard ceiling** (30s, efficiency 45s) — abandons the load and rolls back, exactly as before.

Both are configurable on `ProjectViewManager` and pushed per profile by `ResourceProfileService`, mirroring `paintGateTimeoutMs`/`paintGateHardTimeoutMs`. The other four `loadView` rejection paths (`did-fail-load`, `preload-error`, `render-process-gone`, bootstrap verification) are deterministic failures and still reject immediately — only the timeout branch changed.

The hard ceiling is deliberately never extended by progress signals. `did-start-navigation`/`dom-ready`/`did-frame-navigate` are finite milestones, not heartbeats, and they run on the same stalled main loop as the timer — they cannot win the race they'd be there to fix. A wall-clock backstop is the only bound that holds.

The soft warning carries `timerLateByMs` (how much later than scheduled the callback actually ran). Elapsed time alone can't tell a blocked main process from a slow renderer, and that distinction decides whether the next fix belongs here or upstream.

## Fallout the longer window exposed

Holding the outgoing view for up to 30s instead of 10s widened two pre-existing gaps, both closed here via a single new `pendingColdSwitch` marker on the manager:

- **Eviction could destroy the visible outgoing view.** The guard in `ProjectViewEvictionController` is keyed off `pendingPaintGate`, but the gate resolves on the incoming view's skeleton signal (or its own 4s hard timeout) and nulls itself while the outgoing view stays on screen until the load finishes. Its own comment says it exists for "a slow cold start" — it just expired early. A pressure pass in that gap could destroy the very view rollback needs to restore, leaving a blank window.
- **A mid-load renderer crash ran two recovery paths.** `performSwitch` flips the entry to `"active"` before awaiting `loadView`, so the `state === "loading"` guard in `ProjectViewHandlers` never fired. One crash got full crash recovery (port teardown, reload, potentially OOM window recreation) *and* the rollback.

Also detaches `loadView`'s `dom-ready` listener in `cleanup()` — `webContents.close()` doesn't remove JS listeners, so a load failing before dom-ready left it bound to a torn-down view.

## Not fixed here

The paint gate's timers start before `loadView`, so a load slower than the gate's 4s hard timeout spends its entire grace period before the renderer is even load-ready — the outgoing view then detaches with no post-load paint time. Fixing that means restructuring the anti-flash bridge (latch the readiness signal, start the deadlines after the load resolves), which is too risky to bundle in here. The themed background color set in `createView` plus the skeleton injected at `dom-ready` mean the reveal shows the skeleton rather than a blank frame, so the practical impact is limited. Worth its own issue.

#11458 (teardown during load misreported as "View load timed out") is related but separately scoped and untouched.

## Testing

- Two-phase behaviour: soft bound warns and keeps waiting; a load finishing between the bounds completes the switch; nothing armed survives settle
- The three deterministic failure paths still reject immediately and clear both timers
- Runtime setters affect the next load, reject non-finite/negative input, and don't retime an in-flight load
- Eviction shield and mid-load crash guard both covered
- All three new production guards mutation-verified: breaking each fails exactly its own test and no other
- 854 tests green across `electron/window/__tests__/` and the resource-profile suites; eslint and full typecheck clean

Resolves #11459