### PR TITLE
fix(project-view): cancel a pending view load on teardown instead of reporting a phantom timeout

### DIFF
--- a/electron/window/ProjectViewFactory.ts
+++ b/electron/window/ProjectViewFactory.ts
@@ -100,11 +100,11 @@ export function createView(host: ProjectViewManager, projectId: string): WebCont
 type LoadPhase = "navigation" | "bootstrap";
 
 /**
- * True when a `loadView` rejection is the view being torn down mid-load rather
- * than a genuine load failure. Teardown (window close, app quit, dispose) is a
- * normal event, so callers must skip rollback and user-facing error reporting
- * — mirroring the repo-wide convention that abort-shaped errors never reach
- * `notifyError` (see `handleRetry` in ipc/errorHandlers.ts).
+ * True when a `loadView` rejection was settled by the `destroyed` listener
+ * rather than by a load event. Purely diagnostic: it feeds the `cancelled`
+ * field of the `projectview.coldstart.abandoned` log. Rollback and user-facing
+ * error reporting are keyed on host liveness ALONE, never on this predicate
+ * (see ProjectViewSwitchController's catch).
  *
  * Keyed on the code alone: `loadView` is the only producer of `CANCELLED` here,
  * and every other rejection path — including anything thrown by the bootstrap

--- a/electron/window/ProjectViewFactory.ts
+++ b/electron/window/ProjectViewFactory.ts
@@ -10,6 +10,7 @@ import path from "path";
 import { registerProtocolsForSession, getDistPath } from "../setup/protocols.js";
 import { getDevServerUrl } from "../../shared/config/devServer.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+import { AppError, isAppError } from "../utils/errorTypes.js";
 import { logWarn } from "../utils/logger.js";
 import {
   injectSkeletonCss,
@@ -89,14 +90,50 @@ export function createView(host: ProjectViewManager, projectId: string): WebCont
   return view;
 }
 
+/**
+ * Which stage of the cold start a `loadView` rejection happened in. Carried in
+ * the error's `context` so a production report can tell "the page never
+ * navigated" apart from "the page loaded but the renderer never answered the
+ * bootstrap eval" — one hard budget spans both, so the bare message could not
+ * distinguish them (#11458).
+ */
+type LoadPhase = "navigation" | "bootstrap";
+
+/**
+ * True when a `loadView` rejection is the view being torn down mid-load rather
+ * than a genuine load failure. Teardown (window close, app quit, dispose) is a
+ * normal event, so callers must skip rollback and user-facing error reporting
+ * — mirroring the repo-wide convention that abort-shaped errors never reach
+ * `notifyError` (see `handleRetry` in ipc/errorHandlers.ts).
+ *
+ * Keyed on the code alone: `loadView` is the only producer of `CANCELLED` here,
+ * and every other rejection path — including anything thrown by the bootstrap
+ * eval — is wrapped as `INTERNAL` with the original attached as `cause`.
+ */
+export function isViewLoadCancelled(error: unknown): boolean {
+  return isAppError(error) && error.code === "CANCELLED";
+}
+
 export function loadView(
   view: WebContentsView,
   projectId: string,
   timings: LoadViewTimings
 ): Promise<void> {
   return new Promise<void>((resolve, reject) => {
+    // Captured once: `view.webContents` reads back undefined once the view is
+    // destroyed (electron#50249), and every path below — including the
+    // teardown listener — must keep working past that point.
     const wc = view.webContents;
     let settled = false;
+    let phase: LoadPhase = "navigation";
+
+    const failure = (message: string, cause?: Error) =>
+      new AppError({
+        code: "INTERNAL",
+        message,
+        context: { phase, projectId },
+        cause,
+      });
 
     const softMs = timings.softMs;
     // Guarantee hard >= soft so the soft warning always precedes the hard
@@ -110,6 +147,7 @@ export function loadView(
       wc.removeListener("preload-error", onPreloadError);
       wc.removeListener("render-process-gone", onProcessGone);
       wc.removeListener("dom-ready", onDomReady);
+      wc.removeListener("destroyed", onDestroyed);
     };
 
     const settle = (fn: () => void) => {
@@ -146,21 +184,65 @@ export function loadView(
     // delays any event that would reset it, so a wall-clock backstop is the
     // only bound that holds.
     const hardTimeout = setTimeout(() => {
-      settle(() => reject(new Error("View load timed out")));
+      settle(() =>
+        reject(
+          failure(
+            phase === "bootstrap"
+              ? "View load timed out: project bootstrap never reported"
+              : "View load timed out: page never finished loading"
+          )
+        )
+      );
     }, hardMs);
 
     const onFinish = () => {
+      // Flipped synchronously, before the eval's first await, so a timeout
+      // landing during the round trip is attributed to the bootstrap phase
+      // rather than to navigation. The hard budget deliberately stays
+      // end-to-end — restarting it here would double the worst-case cold start.
+      phase = "bootstrap";
       void verifyProjectBootstrap(wc, projectId).then(
         () => settle(() => resolve()),
-        (error) => settle(() => reject(error))
+        // Always re-wrapped, never passed through: `CANCELLED` must be
+        // reachable only from `onDestroyed`, which is the invariant
+        // `isViewLoadCancelled` keys on.
+        (error: unknown) =>
+          settle(() =>
+            reject(
+              failure(
+                formatErrorMessage(error, "Project view bootstrap verification failed"),
+                error instanceof Error ? error : undefined
+              )
+            )
+          )
       );
     };
     const onFail = (_event: Electron.Event, errorCode: number, errorDescription: string) =>
-      settle(() => reject(new Error(`View load failed: ${errorDescription} (${errorCode})`)));
+      settle(() => reject(failure(`View load failed: ${errorDescription} (${errorCode})`)));
     const onPreloadError = (_event: Electron.Event, _preloadPath: string, error: Error) =>
-      settle(() => reject(error ?? new Error("Preload script failed")));
+      settle(() =>
+        reject(failure(formatErrorMessage(error, "Preload script failed"), error ?? undefined))
+      );
     const onProcessGone = (_event: Electron.Event, details: Electron.RenderProcessGoneDetails) =>
-      settle(() => reject(new Error(`Renderer process gone during load: ${details.reason}`)));
+      settle(() => reject(failure(`Renderer process gone during load: ${details.reason}`)));
+    // Fifth race participant (#11458). Teardown closes the webContents without
+    // firing any of the four load events above, so before this the promise sat
+    // until the full hard timeout and then reported a timeout that never
+    // happened — surfacing a spurious error toast long after an ordinary window
+    // close, and the wait got longer once #11459 widened the hard bound.
+    // `destroyed` is the right granularity: a merely *deactivated*
+    // (cached) view stays alive and must not cancel its own pending load, while
+    // every real teardown path routes through `cleanupEntry` → `wc.close()`.
+    const onDestroyed = () =>
+      settle(() =>
+        reject(
+          new AppError({
+            code: "CANCELLED",
+            message: "Project view load cancelled — view was destroyed",
+            context: { phase, projectId },
+          })
+        )
+      );
 
     // Paint the skeleton on `dom-ready`, NOT before `loadURL`. `insertCSS`
     // and `executeJavaScript` are scoped to the live document, and the
@@ -192,6 +274,7 @@ export function loadView(
     wc.once("preload-error", onPreloadError);
     wc.once("render-process-gone", onProcessGone);
     wc.once("dom-ready", onDomReady);
+    wc.once("destroyed", onDestroyed);
 
     // The document URL is intentionally static (no `?projectId=`): the id
     // travels via additionalArguments so the V8 bytecode cache stays shared

--- a/electron/window/ProjectViewFactory.ts
+++ b/electron/window/ProjectViewFactory.ts
@@ -155,7 +155,17 @@ export function loadView(
       settled = true;
       clearTimeout(softTimeout);
       clearTimeout(hardTimeout);
-      cleanup();
+      try {
+        cleanup();
+      } catch {
+        // Electron can throw from removeListener once the WebContents is torn
+        // down (same hazard webContentsRegistry guards). The teardown path is
+        // the one that always cleans up against a destroyed webContents, and
+        // `settled` is already latched here — letting a throw escape would
+        // skip the settle callback below and strand the promise pending
+        // FOREVER, which is strictly worse than the hard-bound stall being
+        // fixed.
+      }
       fn();
     };
 

--- a/electron/window/ProjectViewSwitchController.ts
+++ b/electron/window/ProjectViewSwitchController.ts
@@ -16,7 +16,12 @@ import { notifyError } from "../ipc/errorHandlers.js";
 import { logInfo, logWarn } from "../utils/logger.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { unfreezeWebContents } from "../utils/webContentsLifecycle.js";
-import { createView, loadView, updateViewBounds } from "./ProjectViewFactory.js";
+import {
+  createView,
+  isViewLoadCancelled,
+  loadView,
+  updateViewBounds,
+} from "./ProjectViewFactory.js";
 import {
   activateView,
   deactivateEntry,
@@ -425,6 +430,25 @@ export async function performSwitch(
     // unrelated switch can't pick it up.
     consumePendingFocusIntent(host, projectId);
     cleanupEntry(host, projectId);
+
+    // The load was cancelled by the manager/window going away — window close,
+    // app quit, dispose() landing on a queued switch (#11458). Everything
+    // above is local cleanup that runs either way; everything below restores
+    // the previous view as the visible active one, which teardown has already
+    // torn down — `dispose()` nulled `activeProjectId`, so rolling it back
+    // resurrects what teardown just cleared. Reporting it is wrong too: this
+    // spurious 10s-late error toast is the bug.
+    //
+    // Gated on the manager actually being torn down, not on the cancellation
+    // alone: if the view died while the manager lives, the outgoing view is
+    // still attached and visible, so `activeProjectId` must follow it back or
+    // pointer and view disagree — that case keeps the normal rollback below
+    // and still gains the prompt settle. Rethrown either way; a destroyed view
+    // is never a successful switch result.
+    if (isViewLoadCancelled(loadError) && (host.disposed || host.win.isDestroyed())) {
+      logInfo("projectview.coldstart.cancelled", { projectId });
+      throw loadError;
+    }
 
     host.activeProjectId = previousProjectId;
     if (previousEntry && !previousEntry.view.webContents.isDestroyed()) {

--- a/electron/window/ProjectViewSwitchController.ts
+++ b/electron/window/ProjectViewSwitchController.ts
@@ -431,22 +431,33 @@ export async function performSwitch(
     consumePendingFocusIntent(host, projectId);
     cleanupEntry(host, projectId);
 
-    // The load was cancelled by the manager/window going away — window close,
-    // app quit, dispose() landing on a queued switch (#11458). Everything
-    // above is local cleanup that runs either way; everything below restores
-    // the previous view as the visible active one, which teardown has already
-    // torn down — `dispose()` nulled `activeProjectId`, so rolling it back
-    // resurrects what teardown just cleared. Reporting it is wrong too: this
-    // spurious 10s-late error toast is the bug.
+    // The manager/window is going away — window close, app quit, dispose()
+    // landing on a queued switch (#11458). Everything above is local cleanup
+    // that runs either way; everything below restores the previous view as the
+    // visible active one, which teardown has already destroyed: `dispose()`
+    // nulled `activeProjectId`, so rolling it back resurrects what teardown
+    // just cleared. Reporting is wrong too — this spurious error toast
+    // arriving after an ordinary window close is the bug.
     //
-    // Gated on the manager actually being torn down, not on the cancellation
-    // alone: if the view died while the manager lives, the outgoing view is
-    // still attached and visible, so `activeProjectId` must follow it back or
-    // pointer and view disagree — that case keeps the normal rollback below
-    // and still gains the prompt settle. Rethrown either way; a destroyed view
-    // is never a successful switch result.
-    if (isViewLoadCancelled(loadError) && (host.disposed || host.win.isDestroyed())) {
-      logInfo("projectview.coldstart.cancelled", { projectId });
+    // Keyed on host liveness ALONE, deliberately not on the rejection being a
+    // cancellation. `wc.close()` aborts the in-flight navigation, so a
+    // teardown often surfaces as did-fail-load/ERR_ABORTED settling the load
+    // first (the "dominant normal case" loadView's own comment describes) —
+    // which removes the destroyed listener and rejects as INTERNAL. Gating on
+    // the error class would let that far-from-rare ordering fall through to a
+    // full rollback against dead state. Why the load failed and whether the
+    // host survives are independent questions; only the latter belongs here.
+    //
+    // A view dying under a still-live manager is the opposite case: the
+    // outgoing view remains attached and visible, so `activeProjectId` must
+    // follow it back or pointer and view disagree. That keeps the rollback
+    // below, and still gains the prompt settle. Rethrown either way — a
+    // half-loaded view is never a successful switch result.
+    if (host.disposed || host.win.isDestroyed()) {
+      logInfo("projectview.coldstart.abandoned", {
+        projectId,
+        cancelled: isViewLoadCancelled(loadError),
+      });
       throw loadError;
     }
 

--- a/electron/window/__tests__/ProjectViewManager.lifecycle.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.lifecycle.test.ts
@@ -49,8 +49,13 @@ function createMockWebContents(options?: MockWebContentsOptions) {
     loadURL: vi.fn(() => Promise.resolve()),
     focus: vi.fn(),
     invalidate: vi.fn(),
+    // Electron 42 tears the native object down synchronously inside close()
+    // and emits `destroyed` in the same call — the signal a pending loadView
+    // races against, so it has to be modelled here rather than only latched.
     close: vi.fn(() => {
+      if (destroyed) return;
       destroyed = true;
+      wc._fire("destroyed");
     }),
     reload: vi.fn(),
     send: vi.fn(),
@@ -734,6 +739,34 @@ describe("ProjectViewManager — lifecycle invariants", () => {
       await expect(queued).rejects.toThrow("disposed");
       expect(manager.getAllViews()).toEqual([]);
       expect(manager.getActiveProjectId()).toBeNull();
+    });
+
+    it("dispose during a pending cold load cancels it and strands nothing", async () => {
+      const setup = createManager();
+      const { manager, win } = setup;
+
+      // autoFinishLoad: false — the load never completes on its own, so the
+      // switch is still awaiting loadView when teardown lands. Before #11458
+      // nothing settled that promise: it sat for the full 10s timeout and then
+      // reported a timeout that never happened.
+      const bWc = createMockWebContents({ autoFinishLoad: false });
+      wcQueue.push(bWc);
+      const inFlight = manager.switchTo("proj-b", "/b");
+      await flushMicrotasks();
+
+      manager.dispose();
+
+      const err = await inFlight.then(
+        () => new Error("expected the in-flight switch to reject"),
+        (e: unknown) => e
+      );
+      expect((err as { code?: string }).code).toBe("CANCELLED");
+      // The cancellation branch skips rollback, so this is where a stranded
+      // entry or a resurrected pointer would show up.
+      expect(manager.getAllViews()).toEqual([]);
+      expect(manager.getAllWebContentsIds()).toEqual([]);
+      expect(manager.getActiveProjectId()).toBeNull();
+      assertLifecycleInvariants(manager as never, win as never);
     });
 
     it("destroyView survives a view whose webContents getter is already gone (Electron #50249)", async () => {

--- a/electron/window/__tests__/ProjectViewManager.lifecycle.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.lifecycle.test.ts
@@ -751,7 +751,7 @@ describe("ProjectViewManager — lifecycle invariants", () => {
 
       // autoFinishLoad: false — the load never completes on its own, so the
       // switch is still awaiting loadView when teardown lands. Before #11458
-      // nothing settled that promise: it sat for the full 10s timeout and then
+      // nothing settled that promise: it sat for the full hard timeout and then
       // reported a timeout that never happened.
       const bWc = createMockWebContents({ autoFinishLoad: false });
       wcQueue.push(bWc);

--- a/electron/window/__tests__/ProjectViewManager.lifecycle.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.lifecycle.test.ts
@@ -53,8 +53,6 @@ function createMockWebContents(options?: MockWebContentsOptions) {
     // and emits `destroyed` in the same call — the signal a pending loadView
     // races against, so it has to be modelled here rather than only latched.
     close: vi.fn(() => {
-      if (destroyed) return;
-      destroyed = true;
       wc._fire("destroyed");
     }),
     reload: vi.fn(),
@@ -96,6 +94,12 @@ function createMockWebContents(options?: MockWebContentsOptions) {
     // handleDidFinishLoad (→ onViewReady, the production port-broker hook)
     // via wc.on, so firing only once-handlers would silently skip it.
     _fire(event: string, ...args: unknown[]) {
+      // Latched before dispatch and only ever delivered once, matching close()
+      // above, so a directly-fired destruction behaves like a real one.
+      if (event === "destroyed") {
+        if (destroyed) return;
+        destroyed = true;
+      }
       const onceList = onceHandlers.get(event);
       const onceHandler = onceList?.shift();
       onceHandler?.(...args);

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -36,9 +36,14 @@ function createMockWebContents(opts?: {
   const autoFinish = opts?.autoFinishLoad ?? true;
   const bootstrapProjectId = opts?.bootstrapProjectId ?? null;
 
+  // Electron 42: `close()` tears the native object down synchronously and
+  // fires `destroyed` inside the call. Modelled here so teardown-during-load
+  // is drivable the same way the real webContents drives it (#11458).
+  let destroyed = false;
+
   const wc: MockWc = {
     id,
-    isDestroyed: vi.fn(() => false),
+    isDestroyed: vi.fn(() => destroyed),
     executeJavaScript: vi.fn((code?: string) =>
       String(code ?? "").includes("__DAINTREE_INITIAL_PROJECT__")
         ? Promise.resolve(bootstrapProjectId)
@@ -47,7 +52,9 @@ function createMockWebContents(opts?: {
     loadURL: vi.fn(() => Promise.resolve()),
     focus: vi.fn(),
     invalidate: vi.fn(),
-    close: vi.fn(),
+    close: vi.fn(() => {
+      wc._fireOnce("destroyed");
+    }),
     reload: vi.fn(),
     send: vi.fn(),
     on: vi.fn((event: string, handler: Handler) => {
@@ -73,6 +80,12 @@ function createMockWebContents(opts?: {
     _handlers: handlers,
     _persistentHandlers: persistentHandlers,
     _fireOnce(event: string, ...args: unknown[]) {
+      // Destruction is latched before the handlers run so anything they call
+      // back into sees the same post-close state the real webContents exposes.
+      if (event === "destroyed") {
+        if (destroyed) return;
+        destroyed = true;
+      }
       const list = handlers.get(event);
       if (list && list.length > 0) {
         const h = list.shift()!;
@@ -236,6 +249,16 @@ async function expectRejection(promise: Promise<unknown>): Promise<Error> {
   }
 }
 
+/** The `code` discriminant a load rejection carries, or undefined for an untyped error. */
+function errorCode(err: Error): string | undefined {
+  return (err as { code?: string }).code;
+}
+
+/** The diagnostic `context` bag a load rejection carries (phase, projectId). */
+function errorContext(err: Error): Record<string, unknown> | undefined {
+  return (err as { context?: Record<string, unknown> }).context;
+}
+
 describe("ProjectViewManager — switch failure rollback", () => {
   let manager: ProjectViewManager;
   let win: ReturnType<typeof createMockWindow>;
@@ -350,7 +373,7 @@ describe("ProjectViewManager — switch failure rollback", () => {
 
     await vi.advanceTimersByTimeAsync(LOAD_HARD_MS);
     const err = await errPromise;
-    expect(err.message).toBe("View load timed out");
+    expect(err.message).toContain("View load timed out");
   });
 
   it("ignores non-finite and negative bounds from the setters", async () => {
@@ -383,7 +406,7 @@ describe("ProjectViewManager — switch failure rollback", () => {
 
     await vi.advanceTimersByTimeAsync(LOAD_HARD_MS + 1);
     const err = await errPromise;
-    expect(err.message).toBe("View load timed out");
+    expect(err.message).toContain("View load timed out");
   });
 
   it("does not run crash recovery for a renderer that dies mid-load", async () => {
@@ -617,7 +640,11 @@ describe("ProjectViewManager — switch failure rollback", () => {
     await vi.advanceTimersByTimeAsync(LOAD_HARD_MS - LOAD_SOFT_MS);
 
     const err = await errPromise;
-    expect(err.message).toBe("View load timed out");
+    // Timing out before did-finish-load is the navigation phase — the message
+    // and context must say so, so a production report can be told apart from a
+    // renderer that loaded but never answered the bootstrap eval (#11458).
+    expect(err.message).toContain("page never finished loading");
+    expect(errorContext(err)).toMatchObject({ phase: "navigation", projectId: "proj-b" });
     expect(manager.getActiveProjectId()).toBe("proj-a");
     expect(failWc.close).toHaveBeenCalled();
     expect(notifyError).toHaveBeenCalledWith(
@@ -699,6 +726,26 @@ describe("ProjectViewManager — switch failure rollback", () => {
     expect(failWc._handlers.get("dom-ready") ?? []).toHaveLength(0);
   });
 
+  it("attributes a timeout after did-finish-load to the bootstrap phase", async () => {
+    // Renderer navigates fine but never answers the bootstrap eval — the same
+    // hard budget expires, but in a different phase than the case above.
+    const stalledWc = createMockWebContents({ autoFinishLoad: false });
+    stalledWc.executeJavaScript.mockImplementation(() => new Promise(() => {}));
+    wcQueue.push(stalledWc);
+
+    const p = manager.switchTo("proj-b", "/path/b");
+    const errPromise = expectRejection(p);
+
+    await vi.advanceTimersByTimeAsync(0);
+    stalledWc._fireOnce("did-finish-load");
+    await vi.advanceTimersByTimeAsync(LOAD_HARD_MS + 1);
+
+    const err = await errPromise;
+    expect(err.message).toContain("project bootstrap never reported");
+    expect(errorContext(err)).toMatchObject({ phase: "bootstrap", projectId: "proj-b" });
+    expect(manager.getActiveProjectId()).toBe("proj-a");
+  });
+
   it("sets activeProjectId to null when no previous view exists", async () => {
     const freshManager = new ProjectViewManager(win as never, {
       dirname: "/test",
@@ -717,7 +764,7 @@ describe("ProjectViewManager — switch failure rollback", () => {
     await vi.advanceTimersByTimeAsync(LOAD_HARD_MS + 1);
 
     const err = await errPromise;
-    expect(err.message).toBe("View load timed out");
+    expect(err.message).toContain("page never finished loading");
     expect(freshManager.getActiveProjectId()).toBeNull();
     expect(notifyError).toHaveBeenCalled();
   });
@@ -743,7 +790,7 @@ describe("ProjectViewManager — switch failure rollback", () => {
 
     await vi.advanceTimersByTimeAsync(LOAD_HARD_MS);
     const err = await errPromise;
-    expect(err.message).toBe("View load timed out");
+    expect(err.message).toContain("View load timed out");
   });
 
   it("switchChain continues after rollback — second switch succeeds", async () => {
@@ -858,5 +905,68 @@ describe("ProjectViewManager — switch failure rollback", () => {
       expect.any(Error),
       expect.objectContaining({ source: "project-switch" })
     );
+  });
+
+  it("cancels a pending cold load when the manager is disposed mid-load", async () => {
+    const pendingWc = createMockWebContents({ autoFinishLoad: false });
+    wcQueue.push(pendingWc);
+
+    const p = manager.switchTo("proj-b", "/path/b");
+    const errPromise = expectRejection(p);
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Window close / app quit: dispose() closes every view, which fires
+    // `destroyed` — the teardown signal none of the four load events deliver.
+    manager.dispose();
+
+    // Settles on microtasks alone. No timer is advanced here, so if the load
+    // promise still hung on the hard deadline this would never resolve — which
+    // is exactly the stall that produced the phantom timeout (#11458).
+    const err = await errPromise;
+    expect(errorCode(err)).toBe("CANCELLED");
+    expect(errorContext(err)).toMatchObject({ projectId: "proj-b" });
+    // An ordinary teardown is not a user-facing failure.
+    expect(notifyError).not.toHaveBeenCalled();
+    // Rollback skipped: dispose() already cleared the pointer and tore down
+    // proj-a's view, so restoring it would resurrect state teardown cleared.
+    expect(manager.getActiveProjectId()).toBeNull();
+  });
+
+  it("settles promptly but still rolls back when the view dies and the manager lives", async () => {
+    const doomedWc = createMockWebContents({ autoFinishLoad: false });
+    wcQueue.push(doomedWc);
+
+    const p = manager.switchTo("proj-b", "/path/b");
+    const errPromise = expectRejection(p);
+
+    await vi.advanceTimersByTimeAsync(0);
+    doomedWc._fireOnce("destroyed");
+
+    const err = await errPromise;
+    expect(errorCode(err)).toBe("CANCELLED");
+    // The outgoing view is still attached and visible, so the pointer has to
+    // follow it back rather than linger on the destroyed project.
+    expect(manager.getActiveProjectId()).toBe("proj-a");
+    expect(notifyError).toHaveBeenCalled();
+  });
+
+  it("ignores a destroyed event that lands after the load already settled", async () => {
+    const wc = createMockWebContents({ autoFinishLoad: false, bootstrapProjectId: "proj-b" });
+    wcQueue.push(wc);
+
+    const p = manager.switchTo("proj-b", "/path/b");
+    await vi.advanceTimersByTimeAsync(0);
+    wc._fireOnce("did-finish-load");
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(p).resolves.toMatchObject({ isNew: true });
+
+    // Deregistered on every settle path, so the eventual close during normal
+    // eviction cannot retroactively cancel a switch that already succeeded.
+    expect(wc._handlers.get("destroyed") ?? []).toHaveLength(0);
+    wc._fireOnce("destroyed");
+    await expect(p).resolves.toMatchObject({ isNew: true });
+    expect(notifyError).not.toHaveBeenCalled();
   });
 });

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -640,10 +640,11 @@ describe("ProjectViewManager — switch failure rollback", () => {
     await vi.advanceTimersByTimeAsync(LOAD_HARD_MS - LOAD_SOFT_MS);
 
     const err = await errPromise;
-    // Timing out before did-finish-load is the navigation phase — the message
-    // and context must say so, so a production report can be told apart from a
-    // renderer that loaded but never answered the bootstrap eval (#11458).
-    expect(err.message).toContain("page never finished loading");
+    // Timing out before did-finish-load is the navigation phase. The phase is
+    // what makes a production timeout report actionable — it tells "the page
+    // never navigated" apart from "the renderer loaded but never answered the
+    // bootstrap eval", which one shared 10s budget otherwise conflates (#11458).
+    expect(errorCode(err)).toBe("INTERNAL");
     expect(errorContext(err)).toMatchObject({ phase: "navigation", projectId: "proj-b" });
     expect(manager.getActiveProjectId()).toBe("proj-a");
     expect(failWc.close).toHaveBeenCalled();
@@ -741,7 +742,7 @@ describe("ProjectViewManager — switch failure rollback", () => {
     await vi.advanceTimersByTimeAsync(LOAD_HARD_MS + 1);
 
     const err = await errPromise;
-    expect(err.message).toContain("project bootstrap never reported");
+    expect(errorCode(err)).toBe("INTERNAL");
     expect(errorContext(err)).toMatchObject({ phase: "bootstrap", projectId: "proj-b" });
     expect(manager.getActiveProjectId()).toBe("proj-a");
   });
@@ -764,7 +765,7 @@ describe("ProjectViewManager — switch failure rollback", () => {
     await vi.advanceTimersByTimeAsync(LOAD_HARD_MS + 1);
 
     const err = await errPromise;
-    expect(err.message).toContain("page never finished loading");
+    expect(errorContext(err)).toMatchObject({ phase: "navigation" });
     expect(freshManager.getActiveProjectId()).toBeNull();
     expect(notifyError).toHaveBeenCalled();
   });
@@ -933,6 +934,95 @@ describe("ProjectViewManager — switch failure rollback", () => {
     expect(manager.getActiveProjectId()).toBeNull();
   });
 
+  it("skips rollback during teardown even when the load failed before it", async () => {
+    const failWc = createMockWebContents({ autoFinishLoad: false });
+    wcQueue.push(failWc);
+
+    const p = manager.switchTo("proj-b", "/path/b");
+    const errPromise = expectRejection(p);
+
+    await vi.advanceTimersByTimeAsync(0);
+    // Closing the webContents aborts the in-flight navigation, so teardown
+    // routinely surfaces as ERR_ABORTED settling the load FIRST — which
+    // deregisters the destroyed listener, so the rejection is an ordinary load
+    // failure, not a cancellation. Gating the teardown branch on the error
+    // class would let this ordering roll back against dead state and report.
+    failWc._fireOnce("did-fail-load", {}, -3, "ERR_ABORTED");
+    manager.dispose();
+
+    const err = await errPromise;
+    // The rejection keeps its truthful classification...
+    expect(errorCode(err)).toBe("INTERNAL");
+    // ...but the host is gone, so nothing is restored and nobody is told.
+    expect(notifyError).not.toHaveBeenCalled();
+    expect(manager.getActiveProjectId()).toBeNull();
+  });
+
+  it("cancels during the bootstrap phase and reports that phase", async () => {
+    const pendingWc = createMockWebContents({ autoFinishLoad: false });
+    // Navigation completes; the bootstrap eval never answers, so teardown
+    // lands while the promise is parked mid-verify.
+    pendingWc.executeJavaScript.mockImplementation(() => new Promise(() => {}));
+    wcQueue.push(pendingWc);
+
+    const p = manager.switchTo("proj-b", "/path/b");
+    const errPromise = expectRejection(p);
+
+    await vi.advanceTimersByTimeAsync(0);
+    pendingWc._fireOnce("did-finish-load");
+    await vi.advanceTimersByTimeAsync(0);
+    manager.dispose();
+
+    const err = await errPromise;
+    expect(errorCode(err)).toBe("CANCELLED");
+    // Cancellation records which stage it interrupted, not just that it happened.
+    expect(errorContext(err)).toMatchObject({ phase: "bootstrap", projectId: "proj-b" });
+    expect(notifyError).not.toHaveBeenCalled();
+  });
+
+  it("wraps a preload failure with the load phase while preserving the original", async () => {
+    const failWc = createMockWebContents({ autoFinishLoad: false });
+    wcQueue.push(failWc);
+    const original = new Error("Cannot find module");
+
+    const p = manager.switchTo("proj-b", "/path/b");
+    const errPromise = expectRejection(p);
+
+    await vi.advanceTimersByTimeAsync(0);
+    failWc._fireOnce("preload-error", {}, "/test/preload.cjs", original);
+
+    const err = await errPromise;
+    // Rewrapped for the phase context, with the original kept as the cause —
+    // the message alone would look identical if it were passed through.
+    expect(errorCode(err)).toBe("INTERNAL");
+    expect(errorContext(err)).toMatchObject({ phase: "navigation" });
+    expect((err as { cause?: unknown }).cause).toBe(original);
+    expect(err.message).toBe(original.message);
+  });
+
+  it("still settles when listener cleanup throws on the destroyed webContents", async () => {
+    const pendingWc = createMockWebContents({ autoFinishLoad: false });
+    wcQueue.push(pendingWc);
+
+    const p = manager.switchTo("proj-b", "/path/b");
+    const errPromise = expectRejection(p);
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Electron throws from removeListener on a torn-down webContents — the
+    // hazard webContentsRegistry already guards. Teardown is the one settle
+    // path that always cleans up against a destroyed webContents, so a throw
+    // escaping there would strand the promise pending forever, with `settled`
+    // latched so nothing could ever settle it again.
+    pendingWc.removeListener.mockImplementation(() => {
+      throw new Error("Object has been destroyed");
+    });
+    manager.dispose();
+
+    const err = await errPromise;
+    expect(errorCode(err)).toBe("CANCELLED");
+  });
+
   it("settles promptly but still rolls back when the view dies and the manager lives", async () => {
     const doomedWc = createMockWebContents({ autoFinishLoad: false });
     wcQueue.push(doomedWc);
@@ -963,10 +1053,10 @@ describe("ProjectViewManager — switch failure rollback", () => {
     await expect(p).resolves.toMatchObject({ isNew: true });
 
     // Deregistered on every settle path, so the eventual close during normal
-    // eviction cannot retroactively cancel a switch that already succeeded.
+    // eviction has no cancellation handler left to run against a switch that
+    // already succeeded.
     expect(wc._handlers.get("destroyed") ?? []).toHaveLength(0);
     wc._fireOnce("destroyed");
-    await expect(p).resolves.toMatchObject({ isNew: true });
     expect(notifyError).not.toHaveBeenCalled();
   });
 });

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -643,7 +643,7 @@ describe("ProjectViewManager — switch failure rollback", () => {
     // Timing out before did-finish-load is the navigation phase. The phase is
     // what makes a production timeout report actionable — it tells "the page
     // never navigated" apart from "the renderer loaded but never answered the
-    // bootstrap eval", which one shared 10s budget otherwise conflates (#11458).
+    // bootstrap eval", which one shared hard budget otherwise conflates (#11458).
     expect(errorCode(err)).toBe("INTERNAL");
     expect(errorContext(err)).toMatchObject({ phase: "navigation", projectId: "proj-b" });
     expect(manager.getActiveProjectId()).toBe("proj-a");


### PR DESCRIPTION
## Summary

- Tearing down a project view while its cold-start load was still pending (window close, app quit, a queued switch landing on an already-disposed host) left `loadView` racing four `once` listeners with no participant for teardown, so the promise sat pending for the full 10 second `LOAD_TIMEOUT_MS` and then rejected with a timeout that never actually happened.
- `performSwitch` then ran a full rollback against already-destroyed state and called `notifyError`, so an ordinary window close surfaced a spurious error toast about ten seconds later.
- The same 10 second budget also covered `verifyProjectBootstrap`'s post-load `executeJavaScript` round trip, and the rejection carried no marker for which phase ran out, so a real production `View load timed out` report gave no way to tell "page never loaded" from "renderer never answered the bootstrap eval" from "view was destroyed mid-load."

Resolves #11458

## Changes

- `electron/window/ProjectViewFactory.ts`: `loadView` gets a `wc.once("destroyed", ...)` listener as a fifth race participant, settled through the existing `settle()`/`cleanup()` machinery and rejecting with `AppError({ code: "CANCELLED" })`. `destroyed` is the right event to key on: a merely deactivated (cached) view stays alive and must not cancel its own load, while every real teardown routes through `cleanupEntry` into `wc.close()`. Every load rejection now also carries `context: { phase: "navigation" | "bootstrap", projectId }`, with the phase flipped synchronously before the bootstrap eval runs. The 10 second budget stays a single shared window rather than restarting after navigation, since that would double the worst-case cold start. `settle()` also now tolerates a throwing `cleanup()`: Electron can throw from `removeListener` on a torn-down webContents, and teardown is the one settle path that always cleans up against a destroyed webContents, so a throw there would previously have latched `settled` and stranded the promise pending forever, strictly worse than the original 10 second stall.
- `electron/window/ProjectViewSwitchController.ts`: the failure handler in `performSwitch` now skips its rollback block and `notifyError` call when `host.disposed || host.win.isDestroyed()`, gating on host liveness alone rather than on the rejection being a cancellation. Closing the webContents aborts the in-flight navigation, so teardown often settles the load as `did-fail-load`/`ERR_ABORTED` first, before the `destroyed` listener even gets a turn. Gating on error class would have let that common ordering fall through to a rollback against dead state. A view dying under a still-live manager keeps the normal rollback, since the outgoing view is still visible and `activeProjectId` has to follow it back.
- `electron/window/__tests__/ProjectViewManager.switchFailure.test.ts` and `ProjectViewManager.lifecycle.test.ts`: both suites' local mocks now model Electron's synchronous `close()` to `destroyed`, plus new coverage for dispose-during-cold-load, the `did-fail-load`-then-dispose ordering, cancellation during the bootstrap phase, a throwing `removeListener`, preload rewrapping with the original error preserved as `cause`, and post-settle `destroyed` events being ignored.

## Testing

345 tests green across 18 targeted suites (all `ProjectViewManager.*`, the window-level suites, and `projectCrud`). Prettier and eslint clean on all four changed files.

## Follow-up

Not fixed here, a pre-existing bug both review passes surfaced:

> `performSwitch` sets `entry.state = "active"` before `loadView()` begins, so the cold-load guard in `ProjectViewHandlers.ts` (`if (crashEntry?.state === "loading") return;`) can never match. A renderer crash mid-cold-load is therefore handled twice: crash recovery notifies and schedules a reload while the switch separately reports a failure, and on `reason: "oom"` it schedules a whole-window recreate that the successful rollback makes wrong. It predates this branch and lives in crash recovery rather than the teardown race, so it wants its own change and tests.
