### PR TITLE
fix(restore): stop restored agent panes resuming one another's session

### DIFF
--- a/electron/ipc/handlers/__tests__/project.switch.test.ts
+++ b/electron/ipc/handlers/__tests__/project.switch.test.ts
@@ -894,7 +894,7 @@ describe("project:switch outgoing agentSessionId field merge (#11461)", () => {
   async function runSwitchWithTerminals(
     existingTerminals: Record<string, unknown>[],
     outgoingState: Record<string, unknown>
-  ): Promise<Record<string, unknown>> {
+  ): Promise<{ id: string; agentSessionId?: string }[]> {
     const mockView = {
       webContents: { id: 100, isDestroyed: () => false, send: vi.fn() },
     };
@@ -930,7 +930,10 @@ describe("project:switch outgoing agentSessionId field merge (#11461)", () => {
     }
     const handler = handleMap.get(CHANNELS.PROJECT_SWITCH);
     await handler!({ sender: { id: 99 } }, "proj-new", outgoingState);
-    return projectStoreMock.saveProjectState.mock.calls[0]?.[1] as Record<string, unknown>;
+    const state = projectStoreMock.saveProjectState.mock.calls[0]?.[1] as {
+      terminals?: { id: string; agentSessionId?: string }[];
+    };
+    return state.terminals ?? [];
   }
 
   const pane = (extra: Record<string, unknown> = {}) => ({
@@ -943,21 +946,17 @@ describe("project:switch outgoing agentSessionId field merge (#11461)", () => {
     ...extra,
   });
 
-  const sessionIdOf = (saved: Record<string, unknown>): string | undefined =>
-    (saved.terminals as { id: string; agentSessionId?: string }[]).find((t) => t.id === "t1")
-      ?.agentSessionId;
-
   it("keeps a shutdown-captured session id the outgoing snapshot omits", async () => {
-    const saved = await runSwitchWithTerminals([pane({ agentSessionId: "captured" })], {
+    const terminals = await runSwitchWithTerminals([pane({ agentSessionId: "captured" })], {
       terminals: [pane({ agentState: "exited" })],
       terminalDelta: { changedIds: ["t1"], removedIds: [] },
     });
 
-    expect(sessionIdOf(saved)).toBe("captured");
+    expect(terminals.find((t) => t.id === "t1")?.agentSessionId).toBe("captured");
   });
 
   it("clears it when the outgoing delta claims the change", async () => {
-    const saved = await runSwitchWithTerminals([pane({ agentSessionId: "consumed" })], {
+    const terminals = await runSwitchWithTerminals([pane({ agentSessionId: "consumed" })], {
       terminals: [pane()],
       terminalDelta: {
         changedIds: ["t1"],
@@ -966,7 +965,7 @@ describe("project:switch outgoing agentSessionId field merge (#11461)", () => {
       },
     });
 
-    expect(sessionIdOf(saved)).toBeUndefined();
+    expect(terminals.find((t) => t.id === "t1")?.agentSessionId).toBeUndefined();
   });
 });
 

--- a/electron/ipc/handlers/__tests__/project.switch.test.ts
+++ b/electron/ipc/handlers/__tests__/project.switch.test.ts
@@ -885,6 +885,91 @@ describe("project:switch outgoing draftInputs merge (#11352)", () => {
   });
 });
 
+describe("project:switch outgoing agentSessionId field merge (#11461)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetProjectForWebContents.mockReturnValue("proj-old");
+  });
+
+  async function runSwitchWithTerminals(
+    existingTerminals: Record<string, unknown>[],
+    outgoingState: Record<string, unknown>
+  ): Promise<Record<string, unknown>> {
+    const mockView = {
+      webContents: { id: 100, isDestroyed: () => false, send: vi.fn() },
+    };
+    const pvm = {
+      switchTo: vi.fn().mockResolvedValue({ view: mockView, isNew: false }),
+      getProjectIdForWebContents: vi.fn(),
+    };
+    mockGetWindowForWebContents.mockReturnValue(null);
+    projectStoreMock.getCurrentProjectId.mockReturnValue("proj-old");
+    projectStoreMock.getProjectById.mockReturnValue({
+      id: "proj-new",
+      name: "New Project",
+      path: "/projects/new",
+    });
+    projectStoreMock.setCurrentProject.mockResolvedValue(undefined);
+    projectStoreMock.getProjectState.mockResolvedValue({
+      projectId: "proj-old",
+      sidebarWidth: 350,
+      terminals: existingTerminals,
+      tabGroups: [],
+    });
+    projectStoreMock.saveProjectState.mockResolvedValue(undefined);
+
+    const deps = {
+      mainWindow: { id: 1 } as unknown,
+      projectViewManager: pvm,
+    } as unknown as HandlerDependencies;
+    registerProjectCrudHandlers(deps);
+
+    const handleMap = new Map<string, (...args: unknown[]) => unknown>();
+    for (const call of (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls) {
+      handleMap.set(call[0] as string, call[1] as (...args: unknown[]) => unknown);
+    }
+    const handler = handleMap.get(CHANNELS.PROJECT_SWITCH);
+    await handler!({ sender: { id: 99 } }, "proj-new", outgoingState);
+    return projectStoreMock.saveProjectState.mock.calls[0]?.[1] as Record<string, unknown>;
+  }
+
+  const pane = (extra: Record<string, unknown> = {}) => ({
+    id: "t1",
+    title: "Codex",
+    kind: "terminal",
+    cwd: "/proj",
+    location: "grid",
+    launchAgentId: "codex",
+    ...extra,
+  });
+
+  const sessionIdOf = (saved: Record<string, unknown>): string | undefined =>
+    (saved.terminals as { id: string; agentSessionId?: string }[]).find((t) => t.id === "t1")
+      ?.agentSessionId;
+
+  it("keeps a shutdown-captured session id the outgoing snapshot omits", async () => {
+    const saved = await runSwitchWithTerminals([pane({ agentSessionId: "captured" })], {
+      terminals: [pane({ agentState: "exited" })],
+      terminalDelta: { changedIds: ["t1"], removedIds: [] },
+    });
+
+    expect(sessionIdOf(saved)).toBe("captured");
+  });
+
+  it("clears it when the outgoing delta claims the change", async () => {
+    const saved = await runSwitchWithTerminals([pane({ agentSessionId: "consumed" })], {
+      terminals: [pane()],
+      terminalDelta: {
+        changedIds: ["t1"],
+        removedIds: [],
+        fieldEdits: [{ id: "t1", fields: ["agentSessionId"] }],
+      },
+    });
+
+    expect(sessionIdOf(saved)).toBeUndefined();
+  });
+});
+
 describe("project:switch worktree-load-status (#8400)", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/electron/ipc/handlers/__tests__/terminalLayout.test.ts
+++ b/electron/ipc/handlers/__tests__/terminalLayout.test.ts
@@ -16,6 +16,7 @@ const setTerminals = terminalLayoutNamespace.ops.setTerminals.handler as (payloa
   terminals: TerminalSnapshot[];
   changedIds?: string[];
   removedIds?: string[];
+  clearedFields?: unknown;
 }) => Promise<void>;
 
 const setTabGroups = terminalLayoutNamespace.ops.setTabGroups.handler as (payload: {
@@ -125,6 +126,96 @@ describe("setTerminals merge (#11350)", () => {
     const saved = onDisk(baseState([term("1"), term("2"), term("3")]));
     await setTerminals({ projectId: "p1", terminals: [term("1")] });
     expect(ids(saved()?.terminals)).toEqual(["1"]);
+  });
+});
+
+describe("setTerminals session-id preservation (#11461)", () => {
+  const withSession = (id: string, agentSessionId?: string): TerminalSnapshot =>
+    ({ ...term(id), launchAgentId: "codex", ...(agentSessionId && { agentSessionId }) }) as
+      TerminalSnapshot;
+
+  const sessionIdOf = (state: ProjectState | null, id: string): string | undefined =>
+    state?.terminals?.find((t) => t.id === id)?.agentSessionId;
+
+  it("keeps a shutdown-captured session id when the writer omits it", async () => {
+    const saved = onDisk(baseState([withSession("1", "captured")]));
+
+    await setTerminals({
+      projectId: "p1",
+      terminals: [withSession("1")],
+      changedIds: ["1"],
+      removedIds: [],
+    });
+
+    expect(sessionIdOf(saved(), "1")).toBe("captured");
+  });
+
+  it("clears the stored session id when the writer tombstones it", async () => {
+    const saved = onDisk(baseState([withSession("1", "stale")]));
+
+    await setTerminals({
+      projectId: "p1",
+      terminals: [withSession("1")],
+      changedIds: ["1"],
+      removedIds: [],
+      clearedFields: [{ id: "1", fields: ["agentSessionId"] }],
+    });
+
+    expect(sessionIdOf(saved(), "1")).toBeUndefined();
+  });
+
+  it("ignores field names outside the allowlist", async () => {
+    const saved = onDisk(baseState([withSession("1", "captured")]));
+
+    await setTerminals({
+      projectId: "p1",
+      terminals: [{ ...withSession("1"), title: "renamed" } as TerminalSnapshot],
+      changedIds: ["1"],
+      removedIds: [],
+      clearedFields: [{ id: "1", fields: ["title", "cwd"] }],
+    });
+
+    const entry = saved()?.terminals?.find((t) => t.id === "1");
+    expect(entry?.agentSessionId).toBe("captured");
+    expect(entry?.title).toBe("renamed");
+    expect(entry?.cwd).toBe("/tmp");
+  });
+
+  it("survives malformed clear metadata without dropping the stored id", async () => {
+    const saved = onDisk(baseState([withSession("1", "captured")]));
+
+    await setTerminals({
+      projectId: "p1",
+      terminals: [withSession("1")],
+      changedIds: ["1"],
+      removedIds: [],
+      clearedFields: [null, "nope", { id: 7, fields: ["agentSessionId"] }, { id: "1" }],
+    });
+
+    expect(sessionIdOf(saved(), "1")).toBe("captured");
+  });
+
+  it("does not let one entry's tombstone clear another's session id", async () => {
+    const saved = onDisk(baseState([withSession("1", "keep-a"), withSession("2", "keep-b")]));
+
+    await setTerminals({
+      projectId: "p1",
+      terminals: [withSession("1"), withSession("2")],
+      changedIds: ["1", "2"],
+      removedIds: [],
+      clearedFields: [{ id: "1", fields: ["agentSessionId"] }],
+    });
+
+    expect(sessionIdOf(saved(), "1")).toBeUndefined();
+    expect(sessionIdOf(saved(), "2")).toBe("keep-b");
+  });
+
+  it("full-replace still drops an omitted session id (legacy contract unchanged)", async () => {
+    const saved = onDisk(baseState([withSession("1", "captured")]));
+
+    await setTerminals({ projectId: "p1", terminals: [withSession("1")] });
+
+    expect(sessionIdOf(saved(), "1")).toBeUndefined();
   });
 });
 

--- a/electron/ipc/handlers/__tests__/terminalLayout.test.ts
+++ b/electron/ipc/handlers/__tests__/terminalLayout.test.ts
@@ -9,14 +9,14 @@ const projectStoreMock = vi.hoisted(() => ({
 
 vi.mock("../../../services/ProjectStore.js", () => ({ projectStore: projectStoreMock }));
 
-import { terminalLayoutNamespace } from "../terminalLayout.js";
+import { terminalLayoutNamespace, sanitizeFieldEdits } from "../terminalLayout.js";
 
 const setTerminals = terminalLayoutNamespace.ops.setTerminals.handler as (payload: {
   projectId: string;
   terminals: TerminalSnapshot[];
   changedIds?: string[];
   removedIds?: string[];
-  clearedFields?: unknown;
+  fieldEdits?: unknown;
 }) => Promise<void>;
 
 const setTabGroups = terminalLayoutNamespace.ops.setTabGroups.handler as (payload: {
@@ -150,7 +150,7 @@ describe("setTerminals session-id preservation (#11461)", () => {
     expect(sessionIdOf(saved(), "1")).toBe("captured");
   });
 
-  it("clears the stored session id when the writer tombstones it", async () => {
+  it("clears the stored session id when the writer claims the change", async () => {
     const saved = onDisk(baseState([withSession("1", "stale")]));
 
     await setTerminals({
@@ -158,10 +158,27 @@ describe("setTerminals session-id preservation (#11461)", () => {
       terminals: [withSession("1")],
       changedIds: ["1"],
       removedIds: [],
-      clearedFields: [{ id: "1", fields: ["agentSessionId"] }],
+      fieldEdits: [{ id: "1", fields: ["agentSessionId"] }],
     });
 
     expect(sessionIdOf(saved(), "1")).toBeUndefined();
+  });
+
+  it("does not let a stale sibling window resurrect a consumed session id", async () => {
+    // Window A already consumed and cleared the session, so disk has none.
+    // Window B is stale, still carries the old id, and saves for an unrelated
+    // reason without claiming the field.
+    const saved = onDisk(baseState([{ ...withSession("1"), agentState: "idle" } as TerminalSnapshot]));
+
+    await setTerminals({
+      projectId: "p1",
+      terminals: [{ ...withSession("1", "consumed"), agentState: "exited" } as TerminalSnapshot],
+      changedIds: ["1"],
+      removedIds: [],
+    });
+
+    expect(sessionIdOf(saved(), "1")).toBeUndefined();
+    expect(saved()?.terminals?.find((t) => t.id === "1")?.agentState).toBe("exited");
   });
 
   it("ignores field names outside the allowlist", async () => {
@@ -172,7 +189,7 @@ describe("setTerminals session-id preservation (#11461)", () => {
       terminals: [{ ...withSession("1"), title: "renamed" } as TerminalSnapshot],
       changedIds: ["1"],
       removedIds: [],
-      clearedFields: [{ id: "1", fields: ["title", "cwd"] }],
+      fieldEdits: [{ id: "1", fields: ["title", "cwd"] }],
     });
 
     const entry = saved()?.terminals?.find((t) => t.id === "1");
@@ -181,7 +198,7 @@ describe("setTerminals session-id preservation (#11461)", () => {
     expect(entry?.cwd).toBe("/tmp");
   });
 
-  it("survives malformed clear metadata without dropping the stored id", async () => {
+  it("survives malformed claim metadata without dropping the stored id", async () => {
     const saved = onDisk(baseState([withSession("1", "captured")]));
 
     await setTerminals({
@@ -189,7 +206,7 @@ describe("setTerminals session-id preservation (#11461)", () => {
       terminals: [withSession("1")],
       changedIds: ["1"],
       removedIds: [],
-      clearedFields: [null, "nope", { id: 7, fields: ["agentSessionId"] }, { id: "1" }],
+      fieldEdits: [null, "nope", { id: 7, fields: ["agentSessionId"] }, { id: "1" }],
     });
 
     expect(sessionIdOf(saved(), "1")).toBe("captured");
@@ -203,7 +220,7 @@ describe("setTerminals session-id preservation (#11461)", () => {
       terminals: [withSession("1"), withSession("2")],
       changedIds: ["1", "2"],
       removedIds: [],
-      clearedFields: [{ id: "1", fields: ["agentSessionId"] }],
+      fieldEdits: [{ id: "1", fields: ["agentSessionId"] }],
     });
 
     expect(sessionIdOf(saved(), "1")).toBeUndefined();
@@ -216,6 +233,44 @@ describe("setTerminals session-id preservation (#11461)", () => {
     await setTerminals({ projectId: "p1", terminals: [withSession("1")] });
 
     expect(sessionIdOf(saved(), "1")).toBeUndefined();
+  });
+});
+
+describe("sanitizeFieldEdits (#11461 trust boundary)", () => {
+  // Asserted directly: the merge independently ignores unknown fields, so a
+  // handler-level test alone would still pass with the sanitizer bypassed.
+  it("keeps only allowlisted field names", () => {
+    expect(sanitizeFieldEdits([{ id: "1", fields: ["agentSessionId", "title", "cwd"] }])).toEqual([
+      { id: "1", fields: ["agentSessionId"] },
+    ]);
+  });
+
+  it("returns undefined when nothing survives", () => {
+    expect(sanitizeFieldEdits([{ id: "1", fields: ["title"] }])).toBeUndefined();
+    expect(sanitizeFieldEdits([])).toBeUndefined();
+    expect(sanitizeFieldEdits("nope")).toBeUndefined();
+    expect(sanitizeFieldEdits(undefined)).toBeUndefined();
+  });
+
+  it("drops entries with an unusable id or fields list", () => {
+    expect(
+      sanitizeFieldEdits([
+        null,
+        "nope",
+        { id: 7, fields: ["agentSessionId"] },
+        { id: "", fields: ["agentSessionId"] },
+        { id: "ok", fields: "agentSessionId" },
+        { id: "ok", fields: ["agentSessionId"] },
+      ])
+    ).toEqual([{ id: "ok", fields: ["agentSessionId"] }]);
+  });
+
+  it("does not treat a prototype-chain key as a usable id", () => {
+    const sanitized = sanitizeFieldEdits([{ id: "__proto__", fields: ["agentSessionId"] }]) ?? [];
+    // Accepted as a plain string id; what matters is that indexing it later can't
+    // reach Object.prototype — the merge keys claims in a Map.
+    expect(sanitized.map((e) => e.id)).toEqual(["__proto__"]);
+    expect(({} as Record<string, unknown>)["agentSessionId"]).toBeUndefined();
   });
 });
 

--- a/electron/ipc/handlers/__tests__/terminalLayout.test.ts
+++ b/electron/ipc/handlers/__tests__/terminalLayout.test.ts
@@ -130,9 +130,16 @@ describe("setTerminals merge (#11350)", () => {
 });
 
 describe("setTerminals session-id preservation (#11461)", () => {
-  const withSession = (id: string, agentSessionId?: string): TerminalSnapshot =>
-    ({ ...term(id), launchAgentId: "codex", ...(agentSessionId && { agentSessionId }) }) as
-      TerminalSnapshot;
+  const withSession = (
+    id: string,
+    agentSessionId?: string,
+    extra: Partial<TerminalSnapshot> = {}
+  ): TerminalSnapshot => ({
+    ...term(id),
+    launchAgentId: "codex",
+    ...(agentSessionId && { agentSessionId }),
+    ...extra,
+  });
 
   const sessionIdOf = (state: ProjectState | null, id: string): string | undefined =>
     state?.terminals?.find((t) => t.id === id)?.agentSessionId;
@@ -168,11 +175,11 @@ describe("setTerminals session-id preservation (#11461)", () => {
     // Window A already consumed and cleared the session, so disk has none.
     // Window B is stale, still carries the old id, and saves for an unrelated
     // reason without claiming the field.
-    const saved = onDisk(baseState([{ ...withSession("1"), agentState: "idle" } as TerminalSnapshot]));
+    const saved = onDisk(baseState([withSession("1", undefined, { agentState: "idle" })]));
 
     await setTerminals({
       projectId: "p1",
-      terminals: [{ ...withSession("1", "consumed"), agentState: "exited" } as TerminalSnapshot],
+      terminals: [withSession("1", "consumed", { agentState: "exited" })],
       changedIds: ["1"],
       removedIds: [],
     });
@@ -186,7 +193,7 @@ describe("setTerminals session-id preservation (#11461)", () => {
 
     await setTerminals({
       projectId: "p1",
-      terminals: [{ ...withSession("1"), title: "renamed" } as TerminalSnapshot],
+      terminals: [withSession("1", undefined, { title: "renamed" })],
       changedIds: ["1"],
       removedIds: [],
       fieldEdits: [{ id: "1", fields: ["title", "cwd"] }],
@@ -265,12 +272,11 @@ describe("sanitizeFieldEdits (#11461 trust boundary)", () => {
     ).toEqual([{ id: "ok", fields: ["agentSessionId"] }]);
   });
 
-  it("does not treat a prototype-chain key as a usable id", () => {
+  it("carries a prototype-chain id through as plain data", () => {
+    // Kept as an ordinary string id; the merge keys claims in a Map, so it can
+    // never reach Object.prototype downstream.
     const sanitized = sanitizeFieldEdits([{ id: "__proto__", fields: ["agentSessionId"] }]) ?? [];
-    // Accepted as a plain string id; what matters is that indexing it later can't
-    // reach Object.prototype — the merge keys claims in a Map.
     expect(sanitized.map((e) => e.id)).toEqual(["__proto__"]);
-    expect(({} as Record<string, unknown>)["agentSessionId"]).toBeUndefined();
   });
 });
 

--- a/electron/ipc/handlers/projectCrud/switch.ts
+++ b/electron/ipc/handlers/projectCrud/switch.ts
@@ -20,8 +20,8 @@ import {
   sanitizeTerminals,
   sanitizeTerminalSizes,
   sanitizeDraftInputs,
-  sanitizeClearedFields,
-  TERMINAL_PRESERVE_ON_OMISSION,
+  sanitizeFieldEdits,
+  TERMINAL_FIELD_LEVEL_MERGE,
 } from "../terminalLayout.js";
 import { sanitizeTabGroups } from "../../../schemas/index.js";
 import { mergeIdArray, mergeRecord } from "../../../../shared/utils/layoutMerge.js";
@@ -325,8 +325,8 @@ async function persistOutgoingProjectState(
                 // Same out-of-band-field policy as the setTerminals handler: a
                 // stale outgoing snapshot must not erase a session id Main
                 // captured on shutdown (#11461).
-                preserveOnOmission: TERMINAL_PRESERVE_ON_OMISSION,
-                clearedFields: sanitizeClearedFields(terminalDelta.clearedFields),
+                fieldLevelMerge: TERMINAL_FIELD_LEVEL_MERGE,
+                fieldEdits: sanitizeFieldEdits(terminalDelta.fieldEdits),
               }
             )
           : validTerminals;

--- a/electron/ipc/handlers/projectCrud/switch.ts
+++ b/electron/ipc/handlers/projectCrud/switch.ts
@@ -20,6 +20,8 @@ import {
   sanitizeTerminals,
   sanitizeTerminalSizes,
   sanitizeDraftInputs,
+  sanitizeClearedFields,
+  TERMINAL_PRESERVE_ON_OMISSION,
 } from "../terminalLayout.js";
 import { sanitizeTabGroups } from "../../../schemas/index.js";
 import { mergeIdArray, mergeRecord } from "../../../../shared/utils/layoutMerge.js";
@@ -318,7 +320,14 @@ async function persistOutgoingProjectState(
               existing?.terminals ?? [],
               validTerminals,
               terminalDelta.changedIds,
-              terminalDelta.removedIds
+              terminalDelta.removedIds,
+              {
+                // Same out-of-band-field policy as the setTerminals handler: a
+                // stale outgoing snapshot must not erase a session id Main
+                // captured on shutdown (#11461).
+                preserveOnOmission: TERMINAL_PRESERVE_ON_OMISSION,
+                clearedFields: sanitizeClearedFields(terminalDelta.clearedFields),
+              }
             )
           : validTerminals;
     const mergedTabGroups =

--- a/electron/ipc/handlers/terminalLayout.preload.ts
+++ b/electron/ipc/handlers/terminalLayout.preload.ts
@@ -1,4 +1,5 @@
 import type { IpcInvokeMap } from "../../types/index.js";
+import type { IdArrayFieldClear } from "../../../shared/utils/layoutMerge.js";
 
 // Opt out of `scripts/codegen/ipc-renderer.mjs` — `terminalLayout`'s renderer
 // API uses positional arguments (e.g. `setTerminals(projectId, terminals)`)
@@ -29,11 +30,13 @@ export interface TerminalLayoutPreloadBindings {
   // `changedIds`/`removedIds` describe what this renderer changed relative to
   // its last-persisted baseline so Main can merge concurrent writes from
   // sibling windows of the same project (#11350). Omit both for a full replace.
+  // `clearedFields` tombstones fields Main may author out-of-band (#11461).
   setTerminals(
     projectId: string,
     terminals: TerminalSnapshot[],
     changedIds?: string[],
-    removedIds?: string[]
+    removedIds?: string[],
+    clearedFields?: IdArrayFieldClear[]
   ): Promise<void>;
   getTerminalSizes(projectId: string): Promise<Record<string, { cols: number; rows: number }>>;
   setTerminalSizes(
@@ -74,12 +77,13 @@ export function buildTerminalLayoutPreloadBindings(invoke: Invoker): TerminalLay
       invoke(TERMINAL_LAYOUT_METHOD_CHANNELS.getTerminals, projectId) as Promise<
         TerminalSnapshot[]
       >,
-    setTerminals: (projectId, terminals, changedIds, removedIds) =>
+    setTerminals: (projectId, terminals, changedIds, removedIds, clearedFields) =>
       invoke(TERMINAL_LAYOUT_METHOD_CHANNELS.setTerminals, {
         projectId,
         terminals,
         changedIds,
         removedIds,
+        clearedFields,
       }) as Promise<void>,
     getTerminalSizes: (projectId) =>
       invoke(TERMINAL_LAYOUT_METHOD_CHANNELS.getTerminalSizes, projectId) as Promise<

--- a/electron/ipc/handlers/terminalLayout.preload.ts
+++ b/electron/ipc/handlers/terminalLayout.preload.ts
@@ -30,7 +30,8 @@ export interface TerminalLayoutPreloadBindings {
   // `changedIds`/`removedIds` describe what this renderer changed relative to
   // its last-persisted baseline so Main can merge concurrent writes from
   // sibling windows of the same project (#11350). Omit both for a full replace.
-  // `fieldEdits` tombstones fields Main may author out-of-band (#11461).
+  // `fieldEdits` names which Main-authorable fields this renderer changed; the
+  // rest keep their on-disk value (#11461).
   setTerminals(
     projectId: string,
     terminals: TerminalSnapshot[],

--- a/electron/ipc/handlers/terminalLayout.preload.ts
+++ b/electron/ipc/handlers/terminalLayout.preload.ts
@@ -1,5 +1,5 @@
 import type { IpcInvokeMap } from "../../types/index.js";
-import type { IdArrayFieldClear } from "../../../shared/utils/layoutMerge.js";
+import type { IdArrayFieldEdit } from "../../../shared/utils/layoutMerge.js";
 
 // Opt out of `scripts/codegen/ipc-renderer.mjs` — `terminalLayout`'s renderer
 // API uses positional arguments (e.g. `setTerminals(projectId, terminals)`)
@@ -30,13 +30,13 @@ export interface TerminalLayoutPreloadBindings {
   // `changedIds`/`removedIds` describe what this renderer changed relative to
   // its last-persisted baseline so Main can merge concurrent writes from
   // sibling windows of the same project (#11350). Omit both for a full replace.
-  // `clearedFields` tombstones fields Main may author out-of-band (#11461).
+  // `fieldEdits` tombstones fields Main may author out-of-band (#11461).
   setTerminals(
     projectId: string,
     terminals: TerminalSnapshot[],
     changedIds?: string[],
     removedIds?: string[],
-    clearedFields?: IdArrayFieldClear[]
+    fieldEdits?: IdArrayFieldEdit[]
   ): Promise<void>;
   getTerminalSizes(projectId: string): Promise<Record<string, { cols: number; rows: number }>>;
   setTerminalSizes(
@@ -77,13 +77,13 @@ export function buildTerminalLayoutPreloadBindings(invoke: Invoker): TerminalLay
       invoke(TERMINAL_LAYOUT_METHOD_CHANNELS.getTerminals, projectId) as Promise<
         TerminalSnapshot[]
       >,
-    setTerminals: (projectId, terminals, changedIds, removedIds, clearedFields) =>
+    setTerminals: (projectId, terminals, changedIds, removedIds, fieldEdits) =>
       invoke(TERMINAL_LAYOUT_METHOD_CHANNELS.setTerminals, {
         projectId,
         terminals,
         changedIds,
         removedIds,
-        clearedFields,
+        fieldEdits,
       }) as Promise<void>,
     getTerminalSizes: (projectId) =>
       invoke(TERMINAL_LAYOUT_METHOD_CHANNELS.getTerminalSizes, projectId) as Promise<

--- a/electron/ipc/handlers/terminalLayout.ts
+++ b/electron/ipc/handlers/terminalLayout.ts
@@ -7,7 +7,11 @@ import {
 import type { HandlerDependencies } from "../types.js";
 import type { TerminalSnapshot, TabGroup } from "../../types/index.js";
 import { defineIpcNamespace, op } from "../define.js";
-import { mergeIdArray, mergeRecord } from "../../../shared/utils/layoutMerge.js";
+import {
+  mergeIdArray,
+  mergeRecord,
+  type IdArrayFieldClear,
+} from "../../../shared/utils/layoutMerge.js";
 import { TERMINAL_LAYOUT_METHOD_CHANNELS } from "./terminalLayout.preload.js";
 
 /**
@@ -32,6 +36,42 @@ function sanitizeIdList(value: unknown): string[] | undefined {
  */
 export function sanitizeTerminals(terminals: unknown[], context: string): TerminalSnapshot[] {
   return filterValidTerminalEntries(terminals, TerminalSnapshotSchema, context);
+}
+
+/**
+ * Fields on a terminal snapshot that Main itself can author, so a renderer delta
+ * has to tombstone them explicitly rather than clearing them by omission
+ * (#11461). Kept to the minimum: only the graceful-shutdown session capture.
+ */
+export const TERMINAL_PRESERVE_ON_OMISSION = [
+  "agentSessionId",
+] as const satisfies readonly (keyof TerminalSnapshot)[];
+
+const TERMINAL_CLEARABLE_FIELD_SET: ReadonlySet<string> = new Set(TERMINAL_PRESERVE_ON_OMISSION);
+
+/**
+ * Coerce untrusted `clearedFields` metadata into the tombstone list the merge
+ * accepts. Entries without a usable id are dropped and field names outside the
+ * allowlist are ignored, so a malformed payload can never delete anything the
+ * renderer isn't entitled to clear. Returns `undefined` when nothing survives so
+ * the merge keeps its cheap path.
+ */
+export function sanitizeClearedFields(value: unknown): IdArrayFieldClear[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const sanitized: IdArrayFieldClear[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") continue;
+    const { id, fields } = entry as { id?: unknown; fields?: unknown };
+    if (typeof id !== "string" || !id || !Array.isArray(fields)) continue;
+    const allowed = fields.filter(
+      (field): field is string => typeof field === "string" && TERMINAL_CLEARABLE_FIELD_SET.has(field)
+    );
+    if (allowed.length === 0) continue;
+    sanitized.push({ id, fields: allowed });
+  }
+  return sanitized.length > 0 ? sanitized : undefined;
 }
 
 /**
@@ -103,6 +143,7 @@ export const terminalLayoutNamespace = defineIpcNamespace({
         terminals: TerminalSnapshot[];
         changedIds?: string[];
         removedIds?: string[];
+        clearedFields?: IdArrayFieldClear[];
       }): Promise<void> => {
         if (!payload || typeof payload !== "object") {
           throw new Error("Invalid payload");
@@ -121,6 +162,7 @@ export const terminalLayoutNamespace = defineIpcNamespace({
         // Absent metadata = legacy full-replace write.
         const changedIds = sanitizeIdList(payload.changedIds);
         const removedIds = sanitizeIdList(payload.removedIds);
+        const clearedFields = sanitizeClearedFields(payload.clearedFields);
 
         await projectStore.enqueueProjectStateUpdate(projectId, (existingState) => ({
           projectId,
@@ -133,7 +175,11 @@ export const terminalLayoutNamespace = defineIpcNamespace({
                   existingState?.terminals ?? [],
                   validTerminals,
                   changedIds,
-                  removedIds ?? []
+                  removedIds ?? [],
+                  {
+                    preserveOnOmission: TERMINAL_PRESERVE_ON_OMISSION,
+                    clearedFields,
+                  }
                 ),
           tabGroups: existingState?.tabGroups ?? [],
           terminalLayout: existingState?.terminalLayout,

--- a/electron/ipc/handlers/terminalLayout.ts
+++ b/electron/ipc/handlers/terminalLayout.ts
@@ -10,7 +10,7 @@ import { defineIpcNamespace, op } from "../define.js";
 import {
   mergeIdArray,
   mergeRecord,
-  type IdArrayFieldClear,
+  type IdArrayFieldEdit,
 } from "../../../shared/utils/layoutMerge.js";
 import { TERMINAL_LAYOUT_METHOD_CHANNELS } from "./terminalLayout.preload.js";
 
@@ -39,34 +39,34 @@ export function sanitizeTerminals(terminals: unknown[], context: string): Termin
 }
 
 /**
- * Fields on a terminal snapshot that Main itself can author, so a renderer delta
- * has to tombstone them explicitly rather than clearing them by omission
- * (#11461). Kept to the minimum: only the graceful-shutdown session capture.
+ * Fields on a terminal snapshot that Main itself can author, so a renderer only
+ * moves them when it says it changed them (#11461). Kept to the minimum: just the
+ * graceful-shutdown session capture.
  */
-export const TERMINAL_PRESERVE_ON_OMISSION = [
+export const TERMINAL_FIELD_LEVEL_MERGE = [
   "agentSessionId",
 ] as const satisfies readonly (keyof TerminalSnapshot)[];
 
-const TERMINAL_CLEARABLE_FIELD_SET: ReadonlySet<string> = new Set(TERMINAL_PRESERVE_ON_OMISSION);
+const TERMINAL_TRACKED_FIELD_SET: ReadonlySet<string> = new Set(TERMINAL_FIELD_LEVEL_MERGE);
 
 /**
- * Coerce untrusted `clearedFields` metadata into the tombstone list the merge
+ * Coerce untrusted `fieldEdits` metadata into the authority claims the merge
  * accepts. Entries without a usable id are dropped and field names outside the
- * allowlist are ignored, so a malformed payload can never delete anything the
- * renderer isn't entitled to clear. Returns `undefined` when nothing survives so
- * the merge keeps its cheap path.
+ * allowlist are ignored, so a malformed payload can neither clear nor overwrite
+ * anything the renderer isn't entitled to touch. Returns `undefined` when nothing
+ * survives so the merge keeps its cheap path.
  */
-export function sanitizeClearedFields(value: unknown): IdArrayFieldClear[] | undefined {
+export function sanitizeFieldEdits(value: unknown): IdArrayFieldEdit[] | undefined {
   if (!Array.isArray(value)) {
     return undefined;
   }
-  const sanitized: IdArrayFieldClear[] = [];
+  const sanitized: IdArrayFieldEdit[] = [];
   for (const entry of value) {
     if (!entry || typeof entry !== "object") continue;
     const { id, fields } = entry as { id?: unknown; fields?: unknown };
     if (typeof id !== "string" || !id || !Array.isArray(fields)) continue;
     const allowed = fields.filter(
-      (field): field is string => typeof field === "string" && TERMINAL_CLEARABLE_FIELD_SET.has(field)
+      (field): field is string => typeof field === "string" && TERMINAL_TRACKED_FIELD_SET.has(field)
     );
     if (allowed.length === 0) continue;
     sanitized.push({ id, fields: allowed });
@@ -143,7 +143,7 @@ export const terminalLayoutNamespace = defineIpcNamespace({
         terminals: TerminalSnapshot[];
         changedIds?: string[];
         removedIds?: string[];
-        clearedFields?: IdArrayFieldClear[];
+        fieldEdits?: IdArrayFieldEdit[];
       }): Promise<void> => {
         if (!payload || typeof payload !== "object") {
           throw new Error("Invalid payload");
@@ -162,7 +162,7 @@ export const terminalLayoutNamespace = defineIpcNamespace({
         // Absent metadata = legacy full-replace write.
         const changedIds = sanitizeIdList(payload.changedIds);
         const removedIds = sanitizeIdList(payload.removedIds);
-        const clearedFields = sanitizeClearedFields(payload.clearedFields);
+        const fieldEdits = sanitizeFieldEdits(payload.fieldEdits);
 
         await projectStore.enqueueProjectStateUpdate(projectId, (existingState) => ({
           projectId,
@@ -177,8 +177,8 @@ export const terminalLayoutNamespace = defineIpcNamespace({
                   changedIds,
                   removedIds ?? [],
                   {
-                    preserveOnOmission: TERMINAL_PRESERVE_ON_OMISSION,
-                    clearedFields,
+                    fieldLevelMerge: TERMINAL_FIELD_LEVEL_MERGE,
+                    fieldEdits,
                   }
                 ),
           tabGroups: existingState?.tabGroups ?? [],

--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -144,8 +144,10 @@ export interface AddPanelOptionsBase {
   fallbackChainIndex?: number;
   /**
    * PTY-only, transient. True when session restore fell through to a fresh
-   * agent launch because no resume command (neither exact-session nor
-   * resume-latest) was available — the prior conversation is unreachable.
+   * agent launch because no resume command was usable — either none was
+   * available (neither exact-session nor resume-latest), or resume-latest was
+   * suppressed because a sibling pane owns this agent+cwd's single slot
+   * (#11461) — so the prior conversation is unreachable for this pane.
    * Drives the "Session no longer reachable" restart banner. Never persisted;
    * cleared on the next restart. See `serializePtyPanel` (intentionally omitted).
    */

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1,4 +1,5 @@
 import type { PushProgressEvent } from "./gitPush.js";
+import type { IdArrayFieldClear } from "../../utils/layoutMerge.js";
 import type { GitStatus, StagingStatus } from "../git.js";
 import type { AgentId } from "../agent.js";
 import type { TabGroup } from "../panel.js";
@@ -652,12 +653,15 @@ export interface ElectronAPI extends GeneratedElectronAPI {
      * `changedIds`/`removedIds` describe what this renderer changed relative to
      * its last-persisted baseline so Main can merge concurrent writes from
      * sibling windows of the same project (#11350). Omit both for a full replace.
+     * `clearedFields` tombstones fields Main may have authored out-of-band, so
+     * absence alone never erases them (#11461).
      */
     setTerminals(
       projectId: string,
       terminals: TerminalSnapshot[],
       changedIds?: string[],
-      removedIds?: string[]
+      removedIds?: string[],
+      clearedFields?: IdArrayFieldClear[]
     ): Promise<void>;
     /**
      * Get terminal dimensions for a project.

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -653,8 +653,9 @@ export interface ElectronAPI extends GeneratedElectronAPI {
      * `changedIds`/`removedIds` describe what this renderer changed relative to
      * its last-persisted baseline so Main can merge concurrent writes from
      * sibling windows of the same project (#11350). Omit both for a full replace.
-     * `fieldEdits` tombstones fields Main may have authored out-of-band, so
-     * absence alone never erases them (#11461).
+     * `fieldEdits` names, per entry, which fields Main may also author that this
+     * renderer actually changed — those move, the rest keep their on-disk value
+     * (#11461).
      */
     setTerminals(
       projectId: string,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1,5 +1,5 @@
 import type { PushProgressEvent } from "./gitPush.js";
-import type { IdArrayFieldClear } from "../../utils/layoutMerge.js";
+import type { IdArrayFieldEdit } from "../../utils/layoutMerge.js";
 import type { GitStatus, StagingStatus } from "../git.js";
 import type { AgentId } from "../agent.js";
 import type { TabGroup } from "../panel.js";
@@ -653,7 +653,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
      * `changedIds`/`removedIds` describe what this renderer changed relative to
      * its last-persisted baseline so Main can merge concurrent writes from
      * sibling windows of the same project (#11350). Omit both for a full replace.
-     * `clearedFields` tombstones fields Main may have authored out-of-band, so
+     * `fieldEdits` tombstones fields Main may have authored out-of-band, so
      * absence alone never erases them (#11461).
      */
     setTerminals(
@@ -661,7 +661,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
       terminals: TerminalSnapshot[],
       changedIds?: string[],
       removedIds?: string[],
-      clearedFields?: IdArrayFieldClear[]
+      fieldEdits?: IdArrayFieldEdit[]
     ): Promise<void>;
     /**
      * Get terminal dimensions for a project.

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1302,6 +1302,7 @@ export interface GeneratedIpcInvokeMap {
         terminals: import("../project.js").PanelSnapshot[];
         changedIds?: string[] | undefined;
         removedIds?: string[] | undefined;
+        clearedFields?: import("../../utils/layoutMerge.js").IdArrayFieldClear[] | undefined;
       },
     ];
     result: void;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1302,7 +1302,7 @@ export interface GeneratedIpcInvokeMap {
         terminals: import("../project.js").PanelSnapshot[];
         changedIds?: string[] | undefined;
         removedIds?: string[] | undefined;
-        clearedFields?: import("../../utils/layoutMerge.js").IdArrayFieldClear[] | undefined;
+        fieldEdits?: import("../../utils/layoutMerge.js").IdArrayFieldEdit[] | undefined;
       },
     ];
     result: void;

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -514,7 +514,9 @@ export interface PtyPanelData extends BasePanelData {
   fallbackChainIndex?: number;
   /**
    * Live-only restore signal. True on first mount when the saved agent session
-   * could not be resumed and a fresh session was launched instead. Drives the
+   * could not be safely resumed — unreachable, or resume-latest suppressed
+   * because a sibling pane owns the slot (#11461) — and a fresh session was
+   * launched instead. Drives the
    * "Session no longer reachable" restart banner. Cleared on restart; never
    * serialized — see `serializePtyPanel`.
    */

--- a/shared/utils/__tests__/layoutMerge.test.ts
+++ b/shared/utils/__tests__/layoutMerge.test.ts
@@ -212,6 +212,164 @@ describe("mergeIdArray", () => {
   });
 });
 
+describe("out-of-band field preservation (#11461)", () => {
+  interface Snap {
+    id: string;
+    agentSessionId?: string;
+    agentState?: string;
+    detectedProcessId?: string;
+  }
+
+  // Mirrors the real producer: undefined-valued keys are dropped, so an absent
+  // field and an explicitly-undefined one are the same wire shape.
+  const snapEq = (a: Snap, b: Snap) => deepEqualIgnoringUndefined(a, b);
+  const preserveSession = { preserveOnOmission: ["agentSessionId"] } as const;
+
+  it("keeps a session id only Main knows when an ambient change flags the entry", () => {
+    // The #11461 scenario: shutdown captured the id straight to disk, the
+    // renderer never had it, and a PTY exit flips agentState on the next save.
+    const existing: Snap[] = [{ id: "1", agentSessionId: "captured", agentState: "idle" }];
+    const incoming: Snap[] = [{ id: "1", agentState: "exited" }];
+
+    const merged = mergeIdArray(existing, incoming, ["1"], [], preserveSession);
+
+    expect(merged[0]!.agentSessionId).toBe("captured");
+    // The ambient field the writer *did* change still wins.
+    expect(merged[0]!.agentState).toBe("exited");
+  });
+
+  it("deletes the field when the writer tombstones it", () => {
+    const existing: Snap[] = [{ id: "1", agentSessionId: "stale" }];
+    const incoming: Snap[] = [{ id: "1" }];
+
+    const merged = mergeIdArray(existing, incoming, ["1"], [], {
+      ...preserveSession,
+      clearedFields: [{ id: "1", fields: ["agentSessionId"] }],
+    });
+
+    expect(merged[0]!.agentSessionId).toBeUndefined();
+  });
+
+  it("lets a defined incoming value win over a contradictory tombstone", () => {
+    // Our producer can't emit both, so this only guards malformed IPC input:
+    // a persistence merge must never destroy a live value it was handed.
+    const existing: Snap[] = [{ id: "1", agentSessionId: "old" }];
+    const incoming: Snap[] = [{ id: "1", agentSessionId: "new" }];
+
+    const merged = mergeIdArray(existing, incoming, ["1"], [], {
+      ...preserveSession,
+      clearedFields: [{ id: "1", fields: ["agentSessionId"] }],
+    });
+
+    expect(merged[0]!.agentSessionId).toBe("new");
+  });
+
+  it("does not preserve a field outside the allowlist", () => {
+    const existing: Snap[] = [{ id: "1", agentSessionId: "keep", agentState: "idle" }];
+    const incoming: Snap[] = [{ id: "1" }];
+
+    const merged = mergeIdArray(existing, incoming, ["1"], [], preserveSession);
+
+    expect(merged[0]!.agentSessionId).toBe("keep");
+    expect(merged[0]!.agentState).toBeUndefined();
+  });
+
+  it("unions duplicate tombstone entries for the same id", () => {
+    const existing: Snap[] = [{ id: "1", agentSessionId: "a", detectedProcessId: "b" }];
+    const incoming: Snap[] = [{ id: "1" }];
+
+    const merged = mergeIdArray(existing, incoming, ["1"], [], {
+      preserveOnOmission: ["agentSessionId", "detectedProcessId"],
+      clearedFields: [
+        { id: "1", fields: ["agentSessionId"] },
+        { id: "1", fields: ["detectedProcessId"] },
+      ],
+    });
+
+    expect(merged[0]!.agentSessionId).toBeUndefined();
+    expect(merged[0]!.detectedProcessId).toBeUndefined();
+  });
+
+  it("returns the incoming entry unchanged when nothing needs carrying", () => {
+    const existing: Snap[] = [{ id: "1" }];
+    const incoming: Snap[] = [{ id: "1", agentSessionId: "x" }];
+
+    const merged = mergeIdArray(existing, incoming, ["1"], [], preserveSession);
+
+    expect(merged[0]).toBe(incoming[0]);
+  });
+
+  it("ignores a tombstone for an entry the writer never changed", () => {
+    const existing: Snap[] = [{ id: "1", agentSessionId: "sibling" }];
+    const incoming: Snap[] = [{ id: "1" }];
+
+    const merged = mergeIdArray(existing, incoming, [], [], {
+      ...preserveSession,
+      clearedFields: [{ id: "1", fields: ["agentSessionId"] }],
+    });
+
+    expect(merged[0]!.agentSessionId).toBe("sibling");
+  });
+
+  it("emits no tombstone when the baseline never carried the field", () => {
+    // Renderer baseline is primed from disk at hydration, so a value only Main
+    // ever wrote is absent from both sides — which must read as "unknown".
+    const base: Snap[] = [{ id: "1", agentState: "idle" }];
+    const current: Snap[] = [{ id: "1", agentState: "exited" }];
+
+    const delta = computeIdArrayDelta(base, current, snapEq, ["agentSessionId"]);
+
+    expect(delta.changedIds).toEqual(["1"]);
+    expect(delta.clearedFields).toBeUndefined();
+  });
+
+  it("emits a tombstone when a tracked field goes from a value to absent", () => {
+    const base: Snap[] = [{ id: "1", agentSessionId: "consumed" }];
+    const current: Snap[] = [{ id: "1" }];
+
+    const delta = computeIdArrayDelta(base, current, snapEq, ["agentSessionId"]);
+
+    expect(delta.clearedFields).toEqual([{ id: "1", fields: ["agentSessionId"] }]);
+  });
+
+  it("flags a tombstoned id as changed even when equals ignores the field", () => {
+    // A tombstone is only honoured for an entry the writer is allowed to touch,
+    // so the two lists have to stay consistent under a partial equality fn.
+    const base: Snap[] = [{ id: "1", agentSessionId: "consumed", agentState: "idle" }];
+    const current: Snap[] = [{ id: "1", agentState: "idle" }];
+    const stateOnlyEq = (a: Snap, b: Snap) => a.agentState === b.agentState;
+
+    const delta = computeIdArrayDelta(base, current, stateOnlyEq, ["agentSessionId"]);
+
+    expect(delta.changedIds).toEqual(["1"]);
+    expect(delta.clearedFields).toHaveLength(1);
+  });
+
+  it("round-trips: a deliberate clear survives the merge, an unknown value does not clear", () => {
+    const disk: Snap[] = [
+      { id: "consumed", agentSessionId: "old-a" },
+      { id: "captured", agentSessionId: "from-shutdown" },
+    ];
+    // Baseline = what this renderer last acknowledged. It knew "consumed"'s id
+    // and then dropped it; it never knew "captured"'s.
+    const base: Snap[] = [{ id: "consumed", agentSessionId: "old-a" }, { id: "captured" }];
+    const current: Snap[] = [
+      { id: "consumed" },
+      { id: "captured", agentState: "exited" },
+    ];
+
+    const delta = computeIdArrayDelta(base, current, snapEq, ["agentSessionId"]);
+    const merged = mergeIdArray(disk, current, delta.changedIds, delta.removedIds, {
+      ...preserveSession,
+      clearedFields: delta.clearedFields,
+    });
+
+    const byId = new Map(merged.map((entry) => [entry.id, entry]));
+    expect(byId.get("consumed")!.agentSessionId).toBeUndefined();
+    expect(byId.get("captured")!.agentSessionId).toBe("from-shutdown");
+  });
+});
+
 describe("computeRecordDelta (draft inputs, #11352)", () => {
   it("reports an added key as changed", () => {
     const delta = computeRecordDelta({ a: "x" }, { a: "x", b: "y" });

--- a/shared/utils/__tests__/layoutMerge.test.ts
+++ b/shared/utils/__tests__/layoutMerge.test.ts
@@ -357,9 +357,10 @@ describe("field-level merge for out-of-band fields (#11461)", () => {
     expect(delta.fieldEdits).toEqual([{ id: "1", fields: ["agentSessionId"] }]);
   });
 
-  it("claims every tracked field on an entry it just added", () => {
-    // No baseline entry means the writer created this panel, so it owns its
-    // fields outright — nothing on disk could be newer.
+  it("claims nothing for an entry with no baseline", () => {
+    // A missing baseline usually means the writer just created the panel, but it
+    // can also mean an earlier save failed or the view was cached across a switch
+    // — in which case disk may hold something newer. Silence, not authority.
     const delta = computeIdArrayDelta(
       [],
       [{ id: "new", agentSessionId: "fresh" }] as Snap[],
@@ -367,7 +368,37 @@ describe("field-level merge for out-of-band fields (#11461)", () => {
       ["agentSessionId"]
     );
 
-    expect(delta.fieldEdits).toEqual([{ id: "new", fields: ["agentSessionId"] }]);
+    expect(delta.fieldEdits).toBeUndefined();
+  });
+
+  it("still persists a genuinely new entry's tracked value", () => {
+    // Nothing on disk to defer to, so the unclaimed value stands and creating a
+    // panel with a session id (the resume-a-session flow) still records it.
+    const merged = mergeIdArray(
+      [],
+      [{ id: "new", agentSessionId: "fresh" }] as Snap[],
+      ["new"],
+      [],
+      sessionMerge
+    );
+
+    expect(merged[0]!.agentSessionId).toBe("fresh");
+  });
+
+  it("defers to disk for an unbaselined entry that already exists on disk", () => {
+    // A stale writer whose baseline lost the entry must not out-rank a value
+    // another window wrote in the meantime — here a deliberate clear.
+    const existing: Snap[] = [{ id: "1", agentState: "idle" }];
+    const current: Snap[] = [{ id: "1", agentSessionId: "stale", agentState: "exited" }];
+
+    const delta = computeIdArrayDelta([], current, snapEq, ["agentSessionId"]);
+    const merged = mergeIdArray(existing, current, delta.changedIds, delta.removedIds, {
+      ...sessionMerge,
+      fieldEdits: delta.fieldEdits,
+    });
+
+    expect(merged[0]!.agentSessionId).toBeUndefined();
+    expect(merged[0]!.agentState).toBe("exited");
   });
 
   it("flags a claimed id as changed even when equals ignores the field", () => {

--- a/shared/utils/__tests__/layoutMerge.test.ts
+++ b/shared/utils/__tests__/layoutMerge.test.ts
@@ -361,12 +361,9 @@ describe("field-level merge for out-of-band fields (#11461)", () => {
     // A missing baseline usually means the writer just created the panel, but it
     // can also mean an earlier save failed or the view was cached across a switch
     // — in which case disk may hold something newer. Silence, not authority.
-    const delta = computeIdArrayDelta(
-      [],
-      [{ id: "new", agentSessionId: "fresh" }] as Snap[],
-      snapEq,
-      ["agentSessionId"]
-    );
+    const added: Snap[] = [{ id: "new", agentSessionId: "fresh" }];
+
+    const delta = computeIdArrayDelta([], added, snapEq, ["agentSessionId"]);
 
     expect(delta.fieldEdits).toBeUndefined();
   });
@@ -374,13 +371,9 @@ describe("field-level merge for out-of-band fields (#11461)", () => {
   it("still persists a genuinely new entry's tracked value", () => {
     // Nothing on disk to defer to, so the unclaimed value stands and creating a
     // panel with a session id (the resume-a-session flow) still records it.
-    const merged = mergeIdArray(
-      [],
-      [{ id: "new", agentSessionId: "fresh" }] as Snap[],
-      ["new"],
-      [],
-      sessionMerge
-    );
+    const added: Snap[] = [{ id: "new", agentSessionId: "fresh" }];
+
+    const merged = mergeIdArray([], added, ["new"], [], sessionMerge);
 
     expect(merged[0]!.agentSessionId).toBe("fresh");
   });

--- a/shared/utils/__tests__/layoutMerge.test.ts
+++ b/shared/utils/__tests__/layoutMerge.test.ts
@@ -212,7 +212,7 @@ describe("mergeIdArray", () => {
   });
 });
 
-describe("out-of-band field preservation (#11461)", () => {
+describe("field-level merge for out-of-band fields (#11461)", () => {
   interface Snap {
     id: string;
     agentSessionId?: string;
@@ -223,7 +223,8 @@ describe("out-of-band field preservation (#11461)", () => {
   // Mirrors the real producer: undefined-valued keys are dropped, so an absent
   // field and an explicitly-undefined one are the same wire shape.
   const snapEq = (a: Snap, b: Snap) => deepEqualIgnoringUndefined(a, b);
-  const preserveSession = { preserveOnOmission: ["agentSessionId"] } as const;
+  const sessionMerge = { fieldLevelMerge: ["agentSessionId"] } as const;
+  const claim = (id: string) => [{ id, fields: ["agentSessionId"] }];
 
   it("keeps a session id only Main knows when an ambient change flags the entry", () => {
     // The #11461 scenario: shutdown captured the id straight to disk, the
@@ -231,56 +232,68 @@ describe("out-of-band field preservation (#11461)", () => {
     const existing: Snap[] = [{ id: "1", agentSessionId: "captured", agentState: "idle" }];
     const incoming: Snap[] = [{ id: "1", agentState: "exited" }];
 
-    const merged = mergeIdArray(existing, incoming, ["1"], [], preserveSession);
+    const merged = mergeIdArray(existing, incoming, ["1"], [], sessionMerge);
 
     expect(merged[0]!.agentSessionId).toBe("captured");
     // The ambient field the writer *did* change still wins.
     expect(merged[0]!.agentState).toBe("exited");
   });
 
-  it("deletes the field when the writer tombstones it", () => {
+  it("clears the field when the writer claims it and sends nothing", () => {
     const existing: Snap[] = [{ id: "1", agentSessionId: "stale" }];
     const incoming: Snap[] = [{ id: "1" }];
 
     const merged = mergeIdArray(existing, incoming, ["1"], [], {
-      ...preserveSession,
-      clearedFields: [{ id: "1", fields: ["agentSessionId"] }],
+      ...sessionMerge,
+      fieldEdits: claim("1"),
     });
 
     expect(merged[0]!.agentSessionId).toBeUndefined();
   });
 
-  it("lets a defined incoming value win over a contradictory tombstone", () => {
-    // Our producer can't emit both, so this only guards malformed IPC input:
-    // a persistence merge must never destroy a live value it was handed.
+  it("rejects an unclaimed value, so a stale writer cannot resurrect a consumed id", () => {
+    // Window A consumed the session and cleared it; disk has no id. Window B is
+    // stale, still carries the old id, and saves for an unrelated reason. Without
+    // per-field authority B's carried value would reinstate a dead session — and
+    // permanently, since neither window can then claim a change to clear it.
+    const existing: Snap[] = [{ id: "1", agentState: "idle" }];
+    const incoming: Snap[] = [{ id: "1", agentSessionId: "consumed", agentState: "exited" }];
+
+    const merged = mergeIdArray(existing, incoming, ["1"], [], sessionMerge);
+
+    expect(merged[0]!.agentSessionId).toBeUndefined();
+    expect(merged[0]!.agentState).toBe("exited");
+  });
+
+  it("applies a claimed value over a differing on-disk one", () => {
     const existing: Snap[] = [{ id: "1", agentSessionId: "old" }];
     const incoming: Snap[] = [{ id: "1", agentSessionId: "new" }];
 
     const merged = mergeIdArray(existing, incoming, ["1"], [], {
-      ...preserveSession,
-      clearedFields: [{ id: "1", fields: ["agentSessionId"] }],
+      ...sessionMerge,
+      fieldEdits: claim("1"),
     });
 
     expect(merged[0]!.agentSessionId).toBe("new");
   });
 
-  it("does not preserve a field outside the allowlist", () => {
+  it("leaves fields outside the allowlist on entry-level last-writer-wins", () => {
     const existing: Snap[] = [{ id: "1", agentSessionId: "keep", agentState: "idle" }];
     const incoming: Snap[] = [{ id: "1" }];
 
-    const merged = mergeIdArray(existing, incoming, ["1"], [], preserveSession);
+    const merged = mergeIdArray(existing, incoming, ["1"], [], sessionMerge);
 
     expect(merged[0]!.agentSessionId).toBe("keep");
     expect(merged[0]!.agentState).toBeUndefined();
   });
 
-  it("unions duplicate tombstone entries for the same id", () => {
+  it("unions duplicate claim entries for the same id", () => {
     const existing: Snap[] = [{ id: "1", agentSessionId: "a", detectedProcessId: "b" }];
     const incoming: Snap[] = [{ id: "1" }];
 
     const merged = mergeIdArray(existing, incoming, ["1"], [], {
-      preserveOnOmission: ["agentSessionId", "detectedProcessId"],
-      clearedFields: [
+      fieldLevelMerge: ["agentSessionId", "detectedProcessId"],
+      fieldEdits: [
         { id: "1", fields: ["agentSessionId"] },
         { id: "1", fields: ["detectedProcessId"] },
       ],
@@ -290,51 +303,76 @@ describe("out-of-band field preservation (#11461)", () => {
     expect(merged[0]!.detectedProcessId).toBeUndefined();
   });
 
-  it("returns the incoming entry unchanged when nothing needs carrying", () => {
-    const existing: Snap[] = [{ id: "1" }];
-    const incoming: Snap[] = [{ id: "1", agentSessionId: "x" }];
-
-    const merged = mergeIdArray(existing, incoming, ["1"], [], preserveSession);
-
-    expect(merged[0]).toBe(incoming[0]);
-  });
-
-  it("ignores a tombstone for an entry the writer never changed", () => {
+  it("ignores a claim for an entry the writer never changed", () => {
     const existing: Snap[] = [{ id: "1", agentSessionId: "sibling" }];
     const incoming: Snap[] = [{ id: "1" }];
 
     const merged = mergeIdArray(existing, incoming, [], [], {
-      ...preserveSession,
-      clearedFields: [{ id: "1", fields: ["agentSessionId"] }],
+      ...sessionMerge,
+      fieldEdits: claim("1"),
     });
 
     expect(merged[0]!.agentSessionId).toBe("sibling");
   });
 
-  it("emits no tombstone when the baseline never carried the field", () => {
+  it("claims nothing when a tracked field matches the baseline on both sides", () => {
     // Renderer baseline is primed from disk at hydration, so a value only Main
-    // ever wrote is absent from both sides — which must read as "unknown".
+    // ever wrote matches on both sides — which must read as "no opinion".
     const base: Snap[] = [{ id: "1", agentState: "idle" }];
     const current: Snap[] = [{ id: "1", agentState: "exited" }];
 
     const delta = computeIdArrayDelta(base, current, snapEq, ["agentSessionId"]);
 
     expect(delta.changedIds).toEqual(["1"]);
-    expect(delta.clearedFields).toBeUndefined();
+    expect(delta.fieldEdits).toBeUndefined();
   });
 
-  it("emits a tombstone when a tracked field goes from a value to absent", () => {
+  it("claims an unchanged-but-held value nowhere, even when the entry changed", () => {
+    // The producer half of the stale-writer guard: B still holds the id it was
+    // hydrated with, so it must not claim authority over it.
+    const base: Snap[] = [{ id: "1", agentSessionId: "held", agentState: "idle" }];
+    const current: Snap[] = [{ id: "1", agentSessionId: "held", agentState: "exited" }];
+
+    const delta = computeIdArrayDelta(base, current, snapEq, ["agentSessionId"]);
+
+    expect(delta.changedIds).toEqual(["1"]);
+    expect(delta.fieldEdits).toBeUndefined();
+  });
+
+  it("claims a tracked field going from a value to absent", () => {
     const base: Snap[] = [{ id: "1", agentSessionId: "consumed" }];
     const current: Snap[] = [{ id: "1" }];
 
     const delta = computeIdArrayDelta(base, current, snapEq, ["agentSessionId"]);
 
-    expect(delta.clearedFields).toEqual([{ id: "1", fields: ["agentSessionId"] }]);
+    expect(delta.fieldEdits).toEqual([{ id: "1", fields: ["agentSessionId"] }]);
   });
 
-  it("flags a tombstoned id as changed even when equals ignores the field", () => {
-    // A tombstone is only honoured for an entry the writer is allowed to touch,
-    // so the two lists have to stay consistent under a partial equality fn.
+  it("claims a tracked field going from absent to a value", () => {
+    const base: Snap[] = [{ id: "1" }];
+    const current: Snap[] = [{ id: "1", agentSessionId: "resumed" }];
+
+    const delta = computeIdArrayDelta(base, current, snapEq, ["agentSessionId"]);
+
+    expect(delta.fieldEdits).toEqual([{ id: "1", fields: ["agentSessionId"] }]);
+  });
+
+  it("claims every tracked field on an entry it just added", () => {
+    // No baseline entry means the writer created this panel, so it owns its
+    // fields outright — nothing on disk could be newer.
+    const delta = computeIdArrayDelta(
+      [],
+      [{ id: "new", agentSessionId: "fresh" }] as Snap[],
+      snapEq,
+      ["agentSessionId"]
+    );
+
+    expect(delta.fieldEdits).toEqual([{ id: "new", fields: ["agentSessionId"] }]);
+  });
+
+  it("flags a claimed id as changed even when equals ignores the field", () => {
+    // A claim is only honoured for an entry the writer is allowed to touch, so
+    // the two lists have to stay consistent under a partial equality fn.
     const base: Snap[] = [{ id: "1", agentSessionId: "consumed", agentState: "idle" }];
     const current: Snap[] = [{ id: "1", agentState: "idle" }];
     const stateOnlyEq = (a: Snap, b: Snap) => a.agentState === b.agentState;
@@ -342,10 +380,10 @@ describe("out-of-band field preservation (#11461)", () => {
     const delta = computeIdArrayDelta(base, current, stateOnlyEq, ["agentSessionId"]);
 
     expect(delta.changedIds).toEqual(["1"]);
-    expect(delta.clearedFields).toHaveLength(1);
+    expect(delta.fieldEdits).toHaveLength(1);
   });
 
-  it("round-trips: a deliberate clear survives the merge, an unknown value does not clear", () => {
+  it("round-trips: a deliberate clear applies, a value the writer never held does not", () => {
     const disk: Snap[] = [
       { id: "consumed", agentSessionId: "old-a" },
       { id: "captured", agentSessionId: "from-shutdown" },
@@ -353,15 +391,12 @@ describe("out-of-band field preservation (#11461)", () => {
     // Baseline = what this renderer last acknowledged. It knew "consumed"'s id
     // and then dropped it; it never knew "captured"'s.
     const base: Snap[] = [{ id: "consumed", agentSessionId: "old-a" }, { id: "captured" }];
-    const current: Snap[] = [
-      { id: "consumed" },
-      { id: "captured", agentState: "exited" },
-    ];
+    const current: Snap[] = [{ id: "consumed" }, { id: "captured", agentState: "exited" }];
 
     const delta = computeIdArrayDelta(base, current, snapEq, ["agentSessionId"]);
     const merged = mergeIdArray(disk, current, delta.changedIds, delta.removedIds, {
-      ...preserveSession,
-      clearedFields: delta.clearedFields,
+      ...sessionMerge,
+      fieldEdits: delta.fieldEdits,
     });
 
     const byId = new Map(merged.map((entry) => [entry.id, entry]));

--- a/shared/utils/layoutMerge.ts
+++ b/shared/utils/layoutMerge.ts
@@ -36,13 +36,34 @@
  * window moved that same panel, the ambient-driven save can overwrite the move.
  * The old code overwrote every panel's layout on every save, so this is strictly
  * better; fully fixing it needs a field-level merge and is tracked separately.
+ *
+ * `preserveOnOmission` (#11461) is the narrow, opt-in slice of that field-level
+ * merge: a field Main itself can author out-of-band (an agent's captured
+ * `agentSessionId`) must not be destroyed just because the writer's entry
+ * happened to be flagged changed by an unrelated ambient field. For those fields
+ * only, absence from a changed entry means "the writer doesn't know", and a
+ * deliberate clear has to be stated explicitly via `clearedFields`.
  */
+
+/**
+ * Fields the writer deliberately cleared on one entry since its baseline. Only
+ * meaningful for `preserveOnOmission` fields, where plain absence is ambiguous.
+ */
+export interface IdArrayFieldClear {
+  id: string;
+  fields: string[];
+}
 
 export interface IdArrayDelta {
   /** Ids the writer added or whose content changed relative to its baseline. */
   changedIds: string[];
   /** Ids present in the writer's baseline but absent from its current array. */
   removedIds: string[];
+  /**
+   * Per-entry tombstones for tracked fields that went from a value in the
+   * writer's baseline to absent in its current array. Omitted when empty.
+   */
+  clearedFields?: IdArrayFieldClear[];
 }
 
 function hasStringId(entry: unknown): entry is { id: string } {
@@ -102,11 +123,20 @@ export function deepEqualIgnoringUndefined(left: unknown, right: unknown): boole
  * Compute the delta between a renderer's last-acknowledged baseline and its
  * current array. `equals` decides whether an entry's content changed (identity
  * is by `id`; content equality is caller-defined, e.g. a deep comparison).
+ *
+ * `trackedClearFields` names the `preserveOnOmission` fields this writer is
+ * authoritative about clearing. A field with a value in the baseline and none in
+ * the current entry becomes an explicit `clearedFields` tombstone, which is the
+ * only way Main can tell a deliberate clear from "not sent" (#11461). Inferring
+ * this from the baseline — rather than tracking clear intent in the store — works
+ * because the baseline is primed from the on-disk snapshot at hydration, so a
+ * value only Main ever knew is absent from both sides and yields no tombstone.
  */
 export function computeIdArrayDelta<T extends { id: string }>(
   base: readonly T[],
   current: readonly T[],
-  equals: (a: T, b: T) => boolean
+  equals: (a: T, b: T) => boolean,
+  trackedClearFields?: readonly (keyof T & string)[]
 ): IdArrayDelta {
   const baseById = new Map<string, T>();
   for (const entry of base) {
@@ -114,12 +144,28 @@ export function computeIdArrayDelta<T extends { id: string }>(
   }
 
   const changedIds: string[] = [];
+  const changedSeen = new Set<string>();
+  const clearedFields: IdArrayFieldClear[] = [];
   const currentIds = new Set<string>();
   for (const entry of current) {
     if (!hasStringId(entry)) continue;
     currentIds.add(entry.id);
     const prev = baseById.get(entry.id);
     if (prev === undefined || !equals(prev, entry)) {
+      changedSeen.add(entry.id);
+      changedIds.push(entry.id);
+    }
+    if (prev === undefined || trackedClearFields === undefined) continue;
+    const cleared = trackedClearFields.filter(
+      (field) => prev[field] !== undefined && entry[field] === undefined
+    );
+    if (cleared.length === 0) continue;
+    clearedFields.push({ id: entry.id, fields: [...cleared] });
+    // A tombstone is only honoured for an entry the writer is allowed to touch,
+    // so keep the two lists consistent even if a caller-supplied `equals`
+    // ignores the tracked field.
+    if (!changedSeen.has(entry.id)) {
+      changedSeen.add(entry.id);
       changedIds.push(entry.id);
     }
   }
@@ -131,7 +177,60 @@ export function computeIdArrayDelta<T extends { id: string }>(
     }
   }
 
-  return { changedIds, removedIds };
+  // Omitted when empty so the common delta keeps its historical shape.
+  return clearedFields.length > 0
+    ? { changedIds, removedIds, clearedFields }
+    : { changedIds, removedIds };
+}
+
+export interface IdArrayMergeOptions<T> {
+  /**
+   * Fields where absence from a changed entry means "the writer doesn't know"
+   * rather than "cleared", so the on-disk value is carried forward.
+   */
+  preserveOnOmission: readonly (keyof T & string)[];
+  /** Explicit tombstones that override the preserve rule for a single entry. */
+  clearedFields?: readonly IdArrayFieldClear[];
+}
+
+function buildClearedIndex(
+  clearedFields: readonly IdArrayFieldClear[] | undefined
+): Map<string, Set<string>> {
+  const byId = new Map<string, Set<string>>();
+  if (clearedFields === undefined) return byId;
+  for (const entry of clearedFields) {
+    if (!hasStringId(entry) || !Array.isArray(entry.fields)) continue;
+    // Union duplicate entries for the same id rather than letting the last win.
+    const fields = byId.get(entry.id) ?? new Set<string>();
+    for (const field of entry.fields) {
+      if (typeof field === "string" && field.length > 0) fields.add(field);
+    }
+    byId.set(entry.id, fields);
+  }
+  return byId;
+}
+
+/**
+ * Carry forward on-disk values for `preserveOnOmission` fields the incoming
+ * entry omits and did not tombstone. Returns `incoming` untouched when nothing
+ * needs carrying, so the common path allocates nothing.
+ */
+function preserveOmittedFields<T extends { id: string }>(
+  incoming: T,
+  onDisk: T | undefined,
+  preserveOnOmission: readonly (keyof T & string)[],
+  cleared: ReadonlySet<string> | undefined
+): T {
+  if (onDisk === undefined) return incoming;
+  let patched: T | undefined;
+  for (const field of preserveOnOmission) {
+    if (incoming[field] !== undefined) continue;
+    if (cleared?.has(field)) continue;
+    if (onDisk[field] === undefined) continue;
+    patched = patched ?? { ...incoming };
+    patched[field] = onDisk[field];
+  }
+  return patched ?? incoming;
 }
 
 /**
@@ -149,12 +248,18 @@ export function computeIdArrayDelta<T extends { id: string }>(
  *     did not touch it, so the writer has no authority to resurrect it).
  * Existing entries the writer never knew (not in `incoming`, not in
  * `removedIds`) are appended, preserving sibling additions.
+ *
+ * `options.preserveOnOmission` narrows the "incoming value wins" rule for the
+ * named fields only: an omitted value carries the on-disk one forward unless the
+ * writer tombstoned it in `options.clearedFields` (#11461). A defined incoming
+ * value always wins, so malformed metadata can never delete live data.
  */
 export function mergeIdArray<T extends { id: string }>(
   existing: readonly T[],
   incoming: readonly T[],
   changedIds: readonly string[],
-  removedIds: readonly string[]
+  removedIds: readonly string[],
+  options?: IdArrayMergeOptions<T>
 ): T[] {
   const existingById = new Map<string, T>();
   for (const entry of existing) {
@@ -165,6 +270,7 @@ export function mergeIdArray<T extends { id: string }>(
   const changed = new Set(changedIds);
   const removed = new Set(removedIds);
   const incomingIds = new Set<string>();
+  const clearedById = buildClearedIndex(options?.clearedFields);
 
   const result: T[] = [];
   for (const entry of incoming) {
@@ -174,7 +280,16 @@ export function mergeIdArray<T extends { id: string }>(
       continue;
     }
     if (changed.has(entry.id)) {
-      result.push(entry);
+      result.push(
+        options === undefined
+          ? entry
+          : preserveOmittedFields(
+              entry,
+              existingById.get(entry.id),
+              options.preserveOnOmission,
+              clearedById.get(entry.id)
+            )
+      );
       continue;
     }
     const onDisk = existingById.get(entry.id);

--- a/shared/utils/layoutMerge.ts
+++ b/shared/utils/layoutMerge.ts
@@ -189,7 +189,9 @@ export function computeIdArrayDelta<T extends { id: string }>(
   }
 
   // Omitted when empty so the common delta keeps its historical shape.
-  return fieldEdits.length > 0 ? { changedIds, removedIds, fieldEdits } : { changedIds, removedIds };
+  return fieldEdits.length > 0
+    ? { changedIds, removedIds, fieldEdits }
+    : { changedIds, removedIds };
 }
 
 export interface IdArrayMergeOptions<T> {

--- a/shared/utils/layoutMerge.ts
+++ b/shared/utils/layoutMerge.ts
@@ -37,19 +37,26 @@
  * The old code overwrote every panel's layout on every save, so this is strictly
  * better; fully fixing it needs a field-level merge and is tracked separately.
  *
- * `preserveOnOmission` (#11461) is the narrow, opt-in slice of that field-level
- * merge: a field Main itself can author out-of-band (an agent's captured
- * `agentSessionId`) must not be destroyed just because the writer's entry
- * happened to be flagged changed by an unrelated ambient field. For those fields
- * only, absence from a changed entry means "the writer doesn't know", and a
- * deliberate clear has to be stated explicitly via `clearedFields`.
+ * `fieldLevelMerge` (#11461) is the narrow, opt-in slice of that field-level
+ * merge, for fields Main itself can author out-of-band (an agent's captured
+ * `agentSessionId`). Such a field must not move just because the containing entry
+ * was flagged changed by an unrelated ambient field. For those fields only,
+ * authority is per-field: the incoming value applies when the writer listed the
+ * field in `fieldEdits` (it genuinely changed it since its own baseline), and
+ * otherwise the on-disk value stands — whether the writer omitted the field or
+ * is carrying a stale copy of it.
+ *
+ * Both halves matter. Preserving on omission stops a post-exit save from erasing
+ * a session id the renderer never held; rejecting an unauthored value stops a
+ * stale sibling window from resurrecting one that was deliberately consumed.
  */
 
 /**
- * Fields the writer deliberately cleared on one entry since its baseline. Only
- * meaningful for `preserveOnOmission` fields, where plain absence is ambiguous.
+ * The `fieldLevelMerge` fields a writer actually changed on one entry since its
+ * baseline — set, changed, or cleared. Absence from this list is what tells Main
+ * the writer has no opinion, so plain presence/absence of the value can't.
  */
-export interface IdArrayFieldClear {
+export interface IdArrayFieldEdit {
   id: string;
   fields: string[];
 }
@@ -60,10 +67,10 @@ export interface IdArrayDelta {
   /** Ids present in the writer's baseline but absent from its current array. */
   removedIds: string[];
   /**
-   * Per-entry tombstones for tracked fields that went from a value in the
-   * writer's baseline to absent in its current array. Omitted when empty.
+   * Per-entry field-level authority claims for tracked fields. Omitted when
+   * empty, so the common delta keeps its historical shape.
    */
-  clearedFields?: IdArrayFieldClear[];
+  fieldEdits?: IdArrayFieldEdit[];
 }
 
 function hasStringId(entry: unknown): entry is { id: string } {
@@ -124,19 +131,20 @@ export function deepEqualIgnoringUndefined(left: unknown, right: unknown): boole
  * current array. `equals` decides whether an entry's content changed (identity
  * is by `id`; content equality is caller-defined, e.g. a deep comparison).
  *
- * `trackedClearFields` names the `preserveOnOmission` fields this writer is
- * authoritative about clearing. A field with a value in the baseline and none in
- * the current entry becomes an explicit `clearedFields` tombstone, which is the
- * only way Main can tell a deliberate clear from "not sent" (#11461). Inferring
- * this from the baseline — rather than tracking clear intent in the store — works
- * because the baseline is primed from the on-disk snapshot at hydration, so a
- * value only Main ever knew is absent from both sides and yields no tombstone.
+ * `trackedFields` names the `fieldLevelMerge` fields this writer can speak for. A
+ * tracked field whose value differs from the writer's baseline — set, changed, or
+ * cleared — is reported in `fieldEdits`; one that matches its baseline is not, and
+ * Main then leaves the on-disk value alone (#11461). Deriving authority from the
+ * baseline rather than tracking intent in the store works because the baseline is
+ * primed from the on-disk snapshot at hydration: a value only Main ever knew
+ * matches on both sides and is never claimed. An entry with no baseline at all is
+ * this writer's own addition, so it speaks for every tracked field on it.
  */
 export function computeIdArrayDelta<T extends { id: string }>(
   base: readonly T[],
   current: readonly T[],
   equals: (a: T, b: T) => boolean,
-  trackedClearFields?: readonly (keyof T & string)[]
+  trackedFields?: readonly (keyof T & string)[]
 ): IdArrayDelta {
   const baseById = new Map<string, T>();
   for (const entry of base) {
@@ -145,7 +153,7 @@ export function computeIdArrayDelta<T extends { id: string }>(
 
   const changedIds: string[] = [];
   const changedSeen = new Set<string>();
-  const clearedFields: IdArrayFieldClear[] = [];
+  const fieldEdits: IdArrayFieldEdit[] = [];
   const currentIds = new Set<string>();
   for (const entry of current) {
     if (!hasStringId(entry)) continue;
@@ -155,15 +163,16 @@ export function computeIdArrayDelta<T extends { id: string }>(
       changedSeen.add(entry.id);
       changedIds.push(entry.id);
     }
-    if (prev === undefined || trackedClearFields === undefined) continue;
-    const cleared = trackedClearFields.filter(
-      (field) => prev[field] !== undefined && entry[field] === undefined
-    );
-    if (cleared.length === 0) continue;
-    clearedFields.push({ id: entry.id, fields: [...cleared] });
-    // A tombstone is only honoured for an entry the writer is allowed to touch,
-    // so keep the two lists consistent even if a caller-supplied `equals`
-    // ignores the tracked field.
+    if (trackedFields === undefined) continue;
+    const edited =
+      prev === undefined
+        ? trackedFields.filter((field) => entry[field] !== undefined)
+        : trackedFields.filter((field) => prev[field] !== entry[field]);
+    if (edited.length === 0) continue;
+    fieldEdits.push({ id: entry.id, fields: [...edited] });
+    // A claim is only honoured for an entry the writer is allowed to touch, so
+    // keep the two lists consistent even if a caller-supplied `equals` ignores
+    // the tracked field.
     if (!changedSeen.has(entry.id)) {
       changedSeen.add(entry.id);
       changedIds.push(entry.id);
@@ -178,27 +187,26 @@ export function computeIdArrayDelta<T extends { id: string }>(
   }
 
   // Omitted when empty so the common delta keeps its historical shape.
-  return clearedFields.length > 0
-    ? { changedIds, removedIds, clearedFields }
-    : { changedIds, removedIds };
+  return fieldEdits.length > 0 ? { changedIds, removedIds, fieldEdits } : { changedIds, removedIds };
 }
 
 export interface IdArrayMergeOptions<T> {
   /**
-   * Fields where absence from a changed entry means "the writer doesn't know"
-   * rather than "cleared", so the on-disk value is carried forward.
+   * Fields merged per-field instead of with the containing entry, because Main
+   * can author them out-of-band. The incoming value applies only when the writer
+   * claimed the field in `fieldEdits`.
    */
-  preserveOnOmission: readonly (keyof T & string)[];
-  /** Explicit tombstones that override the preserve rule for a single entry. */
-  clearedFields?: readonly IdArrayFieldClear[];
+  fieldLevelMerge: readonly (keyof T & string)[];
+  /** Per-entry authority claims for those fields, as sent by the writer. */
+  fieldEdits?: readonly IdArrayFieldEdit[];
 }
 
-function buildClearedIndex(
-  clearedFields: readonly IdArrayFieldClear[] | undefined
+function buildFieldEditIndex(
+  fieldEdits: readonly IdArrayFieldEdit[] | undefined
 ): Map<string, Set<string>> {
   const byId = new Map<string, Set<string>>();
-  if (clearedFields === undefined) return byId;
-  for (const entry of clearedFields) {
+  if (fieldEdits === undefined) return byId;
+  for (const entry of fieldEdits) {
     if (!hasStringId(entry) || !Array.isArray(entry.fields)) continue;
     // Union duplicate entries for the same id rather than letting the last win.
     const fields = byId.get(entry.id) ?? new Set<string>();
@@ -211,22 +219,24 @@ function buildClearedIndex(
 }
 
 /**
- * Carry forward on-disk values for `preserveOnOmission` fields the incoming
- * entry omits and did not tombstone. Returns `incoming` untouched when nothing
- * needs carrying, so the common path allocates nothing.
+ * Resolve `fieldLevelMerge` fields against the on-disk entry: a field the writer
+ * claimed keeps its incoming value, and every other one reverts to what is on
+ * disk. That rejects both an omission (which would erase a value the writer never
+ * held) and a stale carried-over value (which would resurrect one another writer
+ * deliberately cleared). Returns `incoming` untouched when the two already agree,
+ * so the common path allocates nothing.
  */
-function preserveOmittedFields<T extends { id: string }>(
+function applyFieldAuthority<T extends { id: string }>(
   incoming: T,
   onDisk: T | undefined,
-  preserveOnOmission: readonly (keyof T & string)[],
-  cleared: ReadonlySet<string> | undefined
+  fieldLevelMerge: readonly (keyof T & string)[],
+  claimed: ReadonlySet<string> | undefined
 ): T {
   if (onDisk === undefined) return incoming;
   let patched: T | undefined;
-  for (const field of preserveOnOmission) {
-    if (incoming[field] !== undefined) continue;
-    if (cleared?.has(field)) continue;
-    if (onDisk[field] === undefined) continue;
+  for (const field of fieldLevelMerge) {
+    if (claimed?.has(field)) continue;
+    if (onDisk[field] === incoming[field]) continue;
     patched = patched ?? { ...incoming };
     patched[field] = onDisk[field];
   }
@@ -249,10 +259,9 @@ function preserveOmittedFields<T extends { id: string }>(
  * Existing entries the writer never knew (not in `incoming`, not in
  * `removedIds`) are appended, preserving sibling additions.
  *
- * `options.preserveOnOmission` narrows the "incoming value wins" rule for the
- * named fields only: an omitted value carries the on-disk one forward unless the
- * writer tombstoned it in `options.clearedFields` (#11461). A defined incoming
- * value always wins, so malformed metadata can never delete live data.
+ * `options.fieldLevelMerge` narrows the "incoming value wins" rule for the named
+ * fields only: they move only where the writer claimed them in
+ * `options.fieldEdits`, and otherwise keep their on-disk value (#11461).
  */
 export function mergeIdArray<T extends { id: string }>(
   existing: readonly T[],
@@ -270,7 +279,7 @@ export function mergeIdArray<T extends { id: string }>(
   const changed = new Set(changedIds);
   const removed = new Set(removedIds);
   const incomingIds = new Set<string>();
-  const clearedById = buildClearedIndex(options?.clearedFields);
+  const claimedById = buildFieldEditIndex(options?.fieldEdits);
 
   const result: T[] = [];
   for (const entry of incoming) {
@@ -283,11 +292,11 @@ export function mergeIdArray<T extends { id: string }>(
       result.push(
         options === undefined
           ? entry
-          : preserveOmittedFields(
+          : applyFieldAuthority(
               entry,
               existingById.get(entry.id),
-              options.preserveOnOmission,
-              clearedById.get(entry.id)
+              options.fieldLevelMerge,
+              claimedById.get(entry.id)
             )
       );
       continue;

--- a/shared/utils/layoutMerge.ts
+++ b/shared/utils/layoutMerge.ts
@@ -137,8 +137,13 @@ export function deepEqualIgnoringUndefined(left: unknown, right: unknown): boole
  * Main then leaves the on-disk value alone (#11461). Deriving authority from the
  * baseline rather than tracking intent in the store works because the baseline is
  * primed from the on-disk snapshot at hydration: a value only Main ever knew
- * matches on both sides and is never claimed. An entry with no baseline at all is
- * this writer's own addition, so it speaks for every tracked field on it.
+ * matches on both sides and is never claimed.
+ *
+ * An entry with no baseline entry at all claims nothing. Usually that means the
+ * writer just created the panel, and its values still apply because there is no
+ * on-disk row to defer to. But a baseline can also be missing because an earlier
+ * save failed or the view was cached across a project switch, and then the
+ * on-disk row may hold something newer — so silence, not authority, is correct.
  */
 export function computeIdArrayDelta<T extends { id: string }>(
   base: readonly T[],
@@ -163,11 +168,8 @@ export function computeIdArrayDelta<T extends { id: string }>(
       changedSeen.add(entry.id);
       changedIds.push(entry.id);
     }
-    if (trackedFields === undefined) continue;
-    const edited =
-      prev === undefined
-        ? trackedFields.filter((field) => entry[field] !== undefined)
-        : trackedFields.filter((field) => prev[field] !== entry[field]);
+    if (trackedFields === undefined || prev === undefined) continue;
+    const edited = trackedFields.filter((field) => prev[field] !== entry[field]);
     if (edited.length === 0) continue;
     fieldEdits.push({ id: entry.id, fields: [...edited] });
     // A claim is only honoured for an entry the writer is allowed to touch, so
@@ -225,6 +227,11 @@ function buildFieldEditIndex(
  * held) and a stale carried-over value (which would resurrect one another writer
  * deliberately cleared). Returns `incoming` untouched when the two already agree,
  * so the common path allocates nothing.
+ *
+ * With no on-disk entry there is nothing to defer to, so the incoming values
+ * stand. A writer whose entry was deleted on disk therefore still recreates it
+ * with its own tracked values — the entry-level last-writer-wins rule #11350
+ * already applies to a changed entry, and this does not narrow it.
  */
 function applyFieldAuthority<T extends { id: string }>(
   incoming: T,

--- a/src/clients/__tests__/projectClient.test.ts
+++ b/src/clients/__tests__/projectClient.test.ts
@@ -418,3 +418,45 @@ describe("projectClient.setDraftInputs delta forwarding (#11352)", () => {
     );
   });
 });
+
+describe("projectClient.setTerminals fieldEdits forwarding (#11461)", () => {
+  let setTerminalsMock: ReturnType<typeof vi.fn>;
+  let client: typeof import("../projectClient").projectClient;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    setTerminalsMock = vi.fn().mockResolvedValue(undefined);
+    typedGlobal.window = {
+      electron: {
+        project: {
+          onSwitch: vi.fn(() => () => {}),
+          setTerminals: setTerminalsMock,
+        },
+      },
+    };
+    client = (await import("../projectClient")).projectClient;
+  });
+
+  afterEach(() => {
+    delete typedGlobal.window;
+  });
+
+  it("forwards field-level authority claims to the IPC layer", async () => {
+    // Without this hop the renderer computes claims that never reach Main, so an
+    // explicit session-id clear would silently stop applying.
+    const snapshots = [{ id: "t1", title: "T", cwd: "/p", location: "grid" as const }];
+    const fieldEdits = [{ id: "t1", fields: ["agentSessionId"] }];
+
+    await client.setTerminals("proj-1", snapshots, ["t1"], [], fieldEdits);
+
+    expect(setTerminalsMock).toHaveBeenCalledWith("proj-1", snapshots, ["t1"], [], fieldEdits);
+  });
+
+  it("passes undefined through when there is nothing to claim", async () => {
+    const snapshots = [{ id: "t1", title: "T", cwd: "/p", location: "grid" as const }];
+
+    await client.setTerminals("proj-1", snapshots, ["t1"], []);
+
+    expect(setTerminalsMock).toHaveBeenCalledWith("proj-1", snapshots, ["t1"], [], undefined);
+  });
+});

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -16,7 +16,7 @@ import type { NotificationSettings } from "@shared/types/ipc/api";
 import type { RelocationPreview, RelocationRequest } from "@shared/types/projectRelocation";
 import type { AgentPreset } from "@shared/config/agentRegistry";
 import type { ProjectSwitchOutgoingState } from "@shared/types/ipc/project";
-import type { IdArrayFieldClear } from "@shared/utils/layoutMerge";
+import type { IdArrayFieldEdit } from "@shared/utils/layoutMerge";
 import type {
   GitInitOptions,
   GitInitResult,
@@ -353,14 +353,14 @@ export const projectClient = {
     terminals: TerminalSnapshot[],
     changedIds?: string[],
     removedIds?: string[],
-    clearedFields?: IdArrayFieldClear[]
+    fieldEdits?: IdArrayFieldEdit[]
   ): Promise<void> => {
     return window.electron.project.setTerminals(
       projectId,
       terminals,
       changedIds,
       removedIds,
-      clearedFields
+      fieldEdits
     );
   },
 

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -16,6 +16,7 @@ import type { NotificationSettings } from "@shared/types/ipc/api";
 import type { RelocationPreview, RelocationRequest } from "@shared/types/projectRelocation";
 import type { AgentPreset } from "@shared/config/agentRegistry";
 import type { ProjectSwitchOutgoingState } from "@shared/types/ipc/project";
+import type { IdArrayFieldClear } from "@shared/utils/layoutMerge";
 import type {
   GitInitOptions,
   GitInitResult,
@@ -351,9 +352,16 @@ export const projectClient = {
     projectId: string,
     terminals: TerminalSnapshot[],
     changedIds?: string[],
-    removedIds?: string[]
+    removedIds?: string[],
+    clearedFields?: IdArrayFieldClear[]
   ): Promise<void> => {
-    return window.electron.project.setTerminals(projectId, terminals, changedIds, removedIds);
+    return window.electron.project.setTerminals(
+      projectId,
+      terminals,
+      changedIds,
+      removedIds,
+      clearedFields
+    );
   },
 
   getTerminalSizes: (

--- a/src/store/persistence/__tests__/panelPersistence.test.ts
+++ b/src/store/persistence/__tests__/panelPersistence.test.ts
@@ -443,9 +443,9 @@ describe("PanelPersistence", () => {
       persistence.save([createMockTerminal({ id: "a", title: "renamed" })], projectId);
       await vi.advanceTimersByTimeAsync(100);
 
-      const [, , changedIds, , clearedFields] = client.setTerminals.mock.calls[0]!;
+      const [, , changedIds, , fieldEdits] = client.setTerminals.mock.calls[0]!;
       expect(changedIds).toEqual(["a"]);
-      expect(clearedFields).toBeUndefined();
+      expect(fieldEdits).toBeUndefined();
     });
 
     it("sends a session-id tombstone when the renderer drops a known id (#11461)", async () => {
@@ -458,8 +458,8 @@ describe("PanelPersistence", () => {
       persistence.save([createMockTerminal({ id: "a" })], projectId);
       await vi.advanceTimersByTimeAsync(100);
 
-      const [, , , , clearedFields] = client.setTerminals.mock.calls[0]!;
-      expect(clearedFields).toEqual([{ id: "a", fields: ["agentSessionId"] }]);
+      const [, , , , fieldEdits] = client.setTerminals.mock.calls[0]!;
+      expect(fieldEdits).toEqual([{ id: "a", fields: ["agentSessionId"] }]);
     });
 
     it("carries the same tombstone through the project-switch delta (#11461)", async () => {
@@ -473,7 +473,7 @@ describe("PanelPersistence", () => {
         panelToSnapshot(createMockTerminal({ id: "a" })),
       ]);
 
-      expect(delta.clearedFields).toEqual([{ id: "a", fields: ["agentSessionId"] }]);
+      expect(delta.fieldEdits).toEqual([{ id: "a", fields: ["agentSessionId"] }]);
     });
 
     it("marks every panel changed when there is no primed baseline", async () => {

--- a/src/store/persistence/__tests__/panelPersistence.test.ts
+++ b/src/store/persistence/__tests__/panelPersistence.test.ts
@@ -145,7 +145,8 @@ describe("PanelPersistence", () => {
           expect.objectContaining({ id: "dock-1" }),
         ]),
         expect.any(Array),
-        expect.any(Array)
+        expect.any(Array),
+        undefined
       );
 
       const savedTerminals = client.setTerminals.mock.calls[0]![1] as TerminalSnapshot[];
@@ -268,7 +269,8 @@ describe("PanelPersistence", () => {
           },
         ],
         expect.any(Array),
-        expect.any(Array)
+        expect.any(Array),
+        undefined
       );
     });
 
@@ -346,7 +348,8 @@ describe("PanelPersistence", () => {
           }),
         ],
         expect.any(Array),
-        expect.any(Array)
+        expect.any(Array),
+        undefined
       );
     });
 
@@ -378,7 +381,8 @@ describe("PanelPersistence", () => {
         "from-option",
         expect.any(Array),
         expect.any(Array),
-        expect.any(Array)
+        expect.any(Array),
+        undefined
       );
     });
 
@@ -413,7 +417,8 @@ describe("PanelPersistence", () => {
         projectId,
         expect.arrayContaining([expect.objectContaining({ title: "Two" })]),
         expect.any(Array),
-        expect.any(Array)
+        expect.any(Array),
+        undefined
       );
     });
   });
@@ -424,6 +429,52 @@ describe("PanelPersistence", () => {
     // comparison would then mark an untouched panel changed on the first save.
     const hydratedBaseline = (...terminals: TerminalInstance[]): TerminalSnapshot[] =>
       terminals.map((t) => JSON.parse(JSON.stringify(panelToSnapshot(t))) as TerminalSnapshot);
+
+    it("sends no session-id tombstone when the baseline never carried one (#11461)", async () => {
+      // The shutdown-capture case: Main wrote the id straight to disk after this
+      // renderer primed, so the renderer omits a value it never held. That must
+      // read as "unknown" — no tombstone — or Main would erase the capture.
+      const client = createMockProjectClient();
+      const persistence = new PanelPersistence(client, { debounceMs: 100 });
+
+      const a = createMockTerminal({ id: "a" });
+      persistence.primeProject(projectId, hydratedBaseline(a));
+
+      persistence.save([createMockTerminal({ id: "a", title: "renamed" })], projectId);
+      await vi.advanceTimersByTimeAsync(100);
+
+      const [, , changedIds, , clearedFields] = client.setTerminals.mock.calls[0]!;
+      expect(changedIds).toEqual(["a"]);
+      expect(clearedFields).toBeUndefined();
+    });
+
+    it("sends a session-id tombstone when the renderer drops a known id (#11461)", async () => {
+      const client = createMockProjectClient();
+      const persistence = new PanelPersistence(client, { debounceMs: 100 });
+
+      const withSession = createMockTerminal({ id: "a", agentSessionId: "sess-1" });
+      persistence.primeProject(projectId, hydratedBaseline(withSession));
+
+      persistence.save([createMockTerminal({ id: "a" })], projectId);
+      await vi.advanceTimersByTimeAsync(100);
+
+      const [, , , , clearedFields] = client.setTerminals.mock.calls[0]!;
+      expect(clearedFields).toEqual([{ id: "a", fields: ["agentSessionId"] }]);
+    });
+
+    it("carries the same tombstone through the project-switch delta (#11461)", async () => {
+      const client = createMockProjectClient();
+      const persistence = new PanelPersistence(client, { debounceMs: 100 });
+
+      const withSession = createMockTerminal({ id: "a", agentSessionId: "sess-1" });
+      persistence.primeProject(projectId, hydratedBaseline(withSession));
+
+      const delta = persistence.computeTerminalDelta(projectId, [
+        panelToSnapshot(createMockTerminal({ id: "a" })),
+      ]);
+
+      expect(delta.clearedFields).toEqual([{ id: "a", fields: ["agentSessionId"] }]);
+    });
 
     it("marks every panel changed when there is no primed baseline", async () => {
       const client = createMockProjectClient();
@@ -606,7 +657,8 @@ describe("PanelPersistence", () => {
           }),
         ],
         expect.any(Array),
-        expect.any(Array)
+        expect.any(Array),
+        undefined
       );
     });
   });
@@ -1145,7 +1197,8 @@ describe("PanelPersistence", () => {
           }),
         ],
         expect.any(Array),
-        expect.any(Array)
+        expect.any(Array),
+        undefined
       );
 
       const saved = client.setTerminals.mock.calls[0]![1][0] as Record<string, unknown>;

--- a/src/store/persistence/panelPersistence.ts
+++ b/src/store/persistence/panelPersistence.ts
@@ -42,6 +42,15 @@ const BASE_PANEL_FIELDS = [
 ] as const satisfies readonly (keyof PanelSnapshot)[];
 const BASE_PANEL_FIELD_SET: ReadonlySet<string> = new Set(BASE_PANEL_FIELDS);
 
+// Fields Main can author out-of-band, so the delta must state a clear explicitly
+// instead of letting mere absence delete them (#11461). `agentSessionId` is
+// captured by the graceful-shutdown path straight into project state and is never
+// pushed back into the live store, so an ordinary post-exit save omits a value it
+// never had — which must not erase what Main just wrote.
+const TERMINAL_CLEAR_TRACKED_FIELDS = [
+  "agentSessionId",
+] as const satisfies readonly (keyof PanelSnapshot)[];
+
 export function panelToSnapshot(
   t: TerminalInstance,
   previousSnapshot?: PanelSnapshot
@@ -233,13 +242,20 @@ export class PanelPersistence {
           // Describe what changed relative to this renderer's last-acknowledged
           // baseline so Main merges concurrent writes from sibling windows of
           // the same project instead of clobbering them (#11350).
-          const { changedIds, removedIds } = computeIdArrayDelta(
+          const { changedIds, removedIds, clearedFields } = computeIdArrayDelta(
             baseline ?? [],
             transformed,
-            deepEqualIgnoringUndefined
+            deepEqualIgnoringUndefined,
+            TERMINAL_CLEAR_TRACKED_FIELDS
           );
           try {
-            await this.client.setTerminals(projectId, transformed, changedIds, removedIds);
+            await this.client.setTerminals(
+              projectId,
+              transformed,
+              changedIds,
+              removedIds,
+              clearedFields
+            );
             if (collectPerf) {
               const now = typeof performance !== "undefined" ? performance.now() : Date.now();
               markRendererPerformance("persistence_terminals_save", {
@@ -436,7 +452,8 @@ export class PanelPersistence {
     return computeIdArrayDelta(
       this.persistedTerminalsByProject.get(projectId) ?? [],
       snapshots,
-      deepEqualIgnoringUndefined
+      deepEqualIgnoringUndefined,
+      TERMINAL_CLEAR_TRACKED_FIELDS
     );
   }
 

--- a/src/store/persistence/panelPersistence.ts
+++ b/src/store/persistence/panelPersistence.ts
@@ -42,12 +42,14 @@ const BASE_PANEL_FIELDS = [
 ] as const satisfies readonly (keyof PanelSnapshot)[];
 const BASE_PANEL_FIELD_SET: ReadonlySet<string> = new Set(BASE_PANEL_FIELDS);
 
-// Fields Main can author out-of-band, so the delta must state a clear explicitly
-// instead of letting mere absence delete them (#11461). `agentSessionId` is
-// captured by the graceful-shutdown path straight into project state and is never
-// pushed back into the live store, so an ordinary post-exit save omits a value it
-// never had — which must not erase what Main just wrote.
-const TERMINAL_CLEAR_TRACKED_FIELDS = [
+// Fields Main can author out-of-band, so the delta states which of them this
+// renderer actually changed rather than letting the serialized value speak for
+// itself (#11461). `agentSessionId` is captured by the graceful-shutdown path
+// straight into project state and never pushed back into the live store: an
+// ordinary post-exit save omits a value it never had (which must not erase what
+// Main just wrote), and a stale sibling window carries one it no longer owns
+// (which must not resurrect a session another window consumed).
+const TERMINAL_TRACKED_FIELDS = [
   "agentSessionId",
 ] as const satisfies readonly (keyof PanelSnapshot)[];
 
@@ -242,11 +244,11 @@ export class PanelPersistence {
           // Describe what changed relative to this renderer's last-acknowledged
           // baseline so Main merges concurrent writes from sibling windows of
           // the same project instead of clobbering them (#11350).
-          const { changedIds, removedIds, clearedFields } = computeIdArrayDelta(
+          const { changedIds, removedIds, fieldEdits } = computeIdArrayDelta(
             baseline ?? [],
             transformed,
             deepEqualIgnoringUndefined,
-            TERMINAL_CLEAR_TRACKED_FIELDS
+            TERMINAL_TRACKED_FIELDS
           );
           try {
             await this.client.setTerminals(
@@ -254,7 +256,7 @@ export class PanelPersistence {
               transformed,
               changedIds,
               removedIds,
-              clearedFields
+              fieldEdits
             );
             if (collectPerf) {
               const now = typeof performance !== "undefined" ? performance.now() : Date.now();
@@ -453,7 +455,7 @@ export class PanelPersistence {
       this.persistedTerminalsByProject.get(projectId) ?? [],
       snapshots,
       deepEqualIgnoringUndefined,
-      TERMINAL_CLEAR_TRACKED_FIELDS
+      TERMINAL_TRACKED_FIELDS
     );
   }
 

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -1336,10 +1336,7 @@ describe("restorePanelsPhase — one resume-latest per agent+cwd (issue #11461)"
     });
 
     await restorePanelsPhase(
-      [
-        codexPanel("survivor", { lastActiveAt: 900 }),
-        codexPanel("respawner", { lastActiveAt: 1 }),
-      ],
+      [codexPanel("survivor", { lastActiveAt: 900 }), codexPanel("respawner", { lastActiveAt: 1 })],
       ctx
     );
 
@@ -1367,7 +1364,7 @@ describe("restorePanelsPhase — one resume-latest per agent+cwd (issue #11461)"
     // and must not consume the scope's only slot.
     const ctx = makeContext({
       prefetchedReconnectResults: {
-        alive: { id: "alive", exists: true, hasPty: true } as never,
+        alive: { id: "alive", exists: true, hasPty: true },
       },
     });
 
@@ -1383,10 +1380,7 @@ describe("restorePanelsPhase — one resume-latest per agent+cwd (issue #11461)"
     const ctx = makeContext();
 
     await restorePanelsPhase(
-      [
-        codexPanel("smoke-1", { lastActiveAt: 900 }),
-        codexPanel("real", { lastActiveAt: 1 }),
-      ],
+      [codexPanel("smoke-1", { lastActiveAt: 900 }), codexPanel("real", { lastActiveAt: 1 })],
       ctx
     );
 

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -79,8 +79,16 @@ vi.mock("../statePatcher", () => ({
     // resume-latest election (#11461) is assertable through addPanel's args.
     allowResumeLatest: options?.allowResumeLatest ?? true,
   }),
-  resolveRespawnAgentId: (s: TerminalState, kind: string | undefined) =>
-    s.launchAgentId ?? (kind === "agent" ? "claude" : undefined),
+  // Mirrors the real resolver's title recovery (same agent order) so the
+  // election's identity resolution can't silently diverge from production.
+  resolveRespawnAgentId: (s: TerminalState, kind: string | undefined) => {
+    if (s.launchAgentId) return s.launchAgentId;
+    if (kind !== "agent") return undefined;
+    const title = (s.title ?? "").toLowerCase();
+    return ["claude", "antigravity", "gemini", "codex", "opencode"].find((id) =>
+      title.includes(id)
+    );
+  },
   buildArgsForNonPtyRecreation: (s: TerminalState, kind: string) => ({
     cwd: s.cwd ?? "/cwd",
     kind,
@@ -110,19 +118,10 @@ vi.mock("@shared/utils/smokeTestTerminals", () => ({
   isSmokeTestTerminalId: (id: string) => id.startsWith("smoke-"),
 }));
 
-// Only codex/claude declare resume-latest args here, so the election's capability
-// probe is deterministic and an agent without the fallback can be exercised.
-const { buildResumeLatestCommandMock } = vi.hoisted(() => ({
-  buildResumeLatestCommandMock: vi.fn((agentId: string) =>
-    agentId === "codex" || agentId === "claude" ? `${agentId} --resume-latest` : undefined
-  ),
-}));
-
-vi.mock("@shared/types/agentSettings", async () => {
-  const actual =
-    await vi.importActual<typeof import("@shared/types/agentSettings")>("@shared/types/agentSettings");
-  return { ...actual, buildResumeLatestCommand: buildResumeLatestCommandMock };
-});
+// `buildResumeLatestCommand` is deliberately NOT mocked: the election's capability
+// probe should be measured against the real agent configs, so an agent that gains
+// or loses `resumeLatestArgs` is caught here rather than passing against a
+// hand-maintained list.
 
 // Override stagger constants so tests don't have to wait 100ms × N
 // Spy on getRestoreBatchParams so tests can both pin fast/deterministic batches
@@ -1222,8 +1221,9 @@ describe("restorePanelsPhase — one resume-latest per agent+cwd (issue #11461)"
       ctx
     );
 
-    const allowed = [...allowanceById(ctx)].filter(([, allow]) => allow).map(([id]) => id);
-    expect(allowed).toEqual(["b"]);
+    // Asserted as a complete map, not just the allowed subset: a regression that
+    // dropped the losing panes entirely would still leave one `true`.
+    expect(Object.fromEntries(allowanceById(ctx))).toEqual({ a: false, b: true, c: false });
   });
 
   it("gives the slot to the most recently active pane", async () => {
@@ -1344,6 +1344,70 @@ describe("restorePanelsPhase — one resume-latest per agent+cwd (issue #11461)"
     );
 
     expect(allowanceById(ctx).get("respawner")).toBe(true);
+  });
+
+  it("elects for a non-Codex capable agent too", async () => {
+    // Guards against the blast radius narrowing to whatever the tests name: this
+    // resolves capability from the real gemini config, not a mock list.
+    const ctx = makeContext();
+
+    await restorePanelsPhase(
+      [
+        panel("g-old", { kind: "agent", launchAgentId: "gemini", lastActiveAt: 1 }),
+        panel("g-new", { kind: "agent", launchAgentId: "gemini", lastActiveAt: 2 }),
+      ],
+      ctx
+    );
+
+    expect(Object.fromEntries(allowanceById(ctx))).toEqual({ "g-old": false, "g-new": true });
+  });
+
+  it("does not spend the slot on a pane a prefetched probe says is still alive", async () => {
+    // The probe short-circuits reconnect to "found", so this pane never respawns
+    // and must not consume the scope's only slot.
+    const ctx = makeContext({
+      prefetchedReconnectResults: {
+        alive: { id: "alive", exists: true, hasPty: true } as never,
+      },
+    });
+
+    await restorePanelsPhase(
+      [codexPanel("alive", { lastActiveAt: 900 }), codexPanel("cold", { lastActiveAt: 1 })],
+      ctx
+    );
+
+    expect(allowanceById(ctx).get("cold")).toBe(true);
+  });
+
+  it("does not let a smoke-test pane consume a real pane's slot", async () => {
+    const ctx = makeContext();
+
+    await restorePanelsPhase(
+      [
+        codexPanel("smoke-1", { lastActiveAt: 900 }),
+        codexPanel("real", { lastActiveAt: 1 }),
+      ],
+      ctx
+    );
+
+    expect(allowanceById(ctx).get("real")).toBe(true);
+  });
+
+  it("contends on projectRoot when panes carry no cwd", async () => {
+    const ctx = makeContext();
+
+    await restorePanelsPhase(
+      [
+        codexPanel("no-cwd-a", { cwd: undefined, lastActiveAt: 1 }),
+        codexPanel("no-cwd-b", { cwd: undefined, lastActiveAt: 2 }),
+      ],
+      ctx
+    );
+
+    expect(Object.fromEntries(allowanceById(ctx))).toEqual({
+      "no-cwd-a": false,
+      "no-cwd-b": true,
+    });
   });
 
   it("does not suppress panes of an agent that has no resume-latest fallback", async () => {

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -62,7 +62,10 @@ vi.mock("../statePatcher", () => ({
     kind: string,
     _projectRoot?: string,
     _agentSettings?: unknown,
-    reconnectTimedOut?: boolean
+    reconnectTimedOut?: boolean,
+    _clipboardDirectory?: string,
+    _projectPresetsByAgent?: unknown,
+    options?: { allowResumeLatest?: boolean }
   ) => ({
     cwd: s.cwd ?? "/cwd",
     kind,
@@ -72,7 +75,12 @@ vi.mock("../statePatcher", () => ({
     // requested id so the store generates a fresh one (#10440).
     requestedId: reconnectTimedOut ? undefined : s.id,
     launchAgentId: s.launchAgentId,
+    // Not a real AddTerminalArgs field — surfaced on the mock's output so the
+    // resume-latest election (#11461) is assertable through addPanel's args.
+    allowResumeLatest: options?.allowResumeLatest ?? true,
   }),
+  resolveRespawnAgentId: (s: TerminalState, kind: string | undefined) =>
+    s.launchAgentId ?? (kind === "agent" ? "claude" : undefined),
   buildArgsForNonPtyRecreation: (s: TerminalState, kind: string) => ({
     cwd: s.cwd ?? "/cwd",
     kind,
@@ -101,6 +109,20 @@ vi.mock("@shared/config/panelKindRegistry", () => ({
 vi.mock("@shared/utils/smokeTestTerminals", () => ({
   isSmokeTestTerminalId: (id: string) => id.startsWith("smoke-"),
 }));
+
+// Only codex/claude declare resume-latest args here, so the election's capability
+// probe is deterministic and an agent without the fallback can be exercised.
+const { buildResumeLatestCommandMock } = vi.hoisted(() => ({
+  buildResumeLatestCommandMock: vi.fn((agentId: string) =>
+    agentId === "codex" || agentId === "claude" ? `${agentId} --resume-latest` : undefined
+  ),
+}));
+
+vi.mock("@shared/types/agentSettings", async () => {
+  const actual =
+    await vi.importActual<typeof import("@shared/types/agentSettings")>("@shared/types/agentSettings");
+  return { ...actual, buildResumeLatestCommand: buildResumeLatestCommandMock };
+});
 
 // Override stagger constants so tests don't have to wait 100ms × N
 // Spy on getRestoreBatchParams so tests can both pin fast/deterministic batches
@@ -1164,5 +1186,188 @@ describe("restorePanelsPhase — panels surviving a worktree move (issue #11388)
     await restorePanelsPhase([panel("t1", { worktreeId: "/old/feature" })], ctx);
 
     expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({ worktreeId: "wA" });
+  });
+});
+
+describe("restorePanelsPhase — one resume-latest per agent+cwd (issue #11461)", () => {
+  /** id → the allowResumeLatest the respawn builder was handed. */
+  function allowanceById(ctx: MockedContext): Map<string, boolean> {
+    const byId = new Map<string, boolean>();
+    for (const [args] of ctx.addPanel.mock.calls as [
+      { requestedId?: string; allowResumeLatest?: boolean },
+    ][]) {
+      if (args.requestedId !== undefined && args.allowResumeLatest !== undefined) {
+        byId.set(args.requestedId, args.allowResumeLatest);
+      }
+    }
+    return byId;
+  }
+
+  const codexPanel = (id: string, overrides: Partial<TerminalState> = {}): TerminalState =>
+    panel(id, { kind: "agent", launchAgentId: "codex", ...overrides });
+
+  beforeEach(() => {
+    reconnectWithTimeoutMock.mockResolvedValue({ status: "not_found" });
+  });
+
+  it("allows exactly one of several id-less panes sharing a directory", async () => {
+    const ctx = makeContext();
+
+    await restorePanelsPhase(
+      [
+        codexPanel("a", { lastActiveAt: 100 }),
+        codexPanel("b", { lastActiveAt: 300 }),
+        codexPanel("c", { lastActiveAt: 200 }),
+      ],
+      ctx
+    );
+
+    const allowed = [...allowanceById(ctx)].filter(([, allow]) => allow).map(([id]) => id);
+    expect(allowed).toEqual(["b"]);
+  });
+
+  it("gives the slot to the most recently active pane", async () => {
+    const ctx = makeContext();
+
+    await restorePanelsPhase(
+      [codexPanel("older", { lastActiveAt: 5 }), codexPanel("newer", { lastActiveAt: 9 })],
+      ctx
+    );
+
+    expect(allowanceById(ctx).get("newer")).toBe(true);
+    expect(allowanceById(ctx).get("older")).toBe(false);
+  });
+
+  it("breaks a tie in favour of the earlier saved entry", async () => {
+    const ctx = makeContext();
+
+    await restorePanelsPhase(
+      [codexPanel("first", { lastActiveAt: 7 }), codexPanel("second", { lastActiveAt: 7 })],
+      ctx
+    );
+
+    expect(allowanceById(ctx).get("first")).toBe(true);
+    expect(allowanceById(ctx).get("second")).toBe(false);
+  });
+
+  it("treats a corrupt lastActiveAt as least-recent rather than winning", async () => {
+    const ctx = makeContext();
+
+    await restorePanelsPhase(
+      [
+        codexPanel("corrupt", { lastActiveAt: Number.NaN }),
+        codexPanel("valid", { lastActiveAt: 1 }),
+      ],
+      ctx
+    );
+
+    expect(allowanceById(ctx).get("valid")).toBe(true);
+    expect(allowanceById(ctx).get("corrupt")).toBe(false);
+  });
+
+  it("leaves a lone id-less pane untouched", async () => {
+    const ctx = makeContext();
+
+    await restorePanelsPhase([codexPanel("solo")], ctx);
+
+    expect(allowanceById(ctx).get("solo")).toBe(true);
+  });
+
+  it("scopes the slot per agent — different agents don't contend", async () => {
+    const ctx = makeContext();
+
+    await restorePanelsPhase(
+      [codexPanel("cx"), panel("cl", { kind: "agent", launchAgentId: "claude" })],
+      ctx
+    );
+
+    expect(allowanceById(ctx).get("cx")).toBe(true);
+    expect(allowanceById(ctx).get("cl")).toBe(true);
+  });
+
+  it("scopes the slot per directory — different cwds don't contend", async () => {
+    const ctx = makeContext();
+
+    await restorePanelsPhase(
+      [codexPanel("here", { cwd: "/proj/one" }), codexPanel("there", { cwd: "/proj/two" })],
+      ctx
+    );
+
+    expect(allowanceById(ctx).get("here")).toBe(true);
+    expect(allowanceById(ctx).get("there")).toBe(true);
+  });
+
+  it("groups equivalent spellings of one directory into the same scope", async () => {
+    const ctx = makeContext();
+
+    await restorePanelsPhase(
+      [
+        codexPanel("plain", { cwd: "/proj/work", lastActiveAt: 2 }),
+        codexPanel("dotted", { cwd: "/proj/work/./", lastActiveAt: 1 }),
+      ],
+      ctx
+    );
+
+    expect(allowanceById(ctx).get("plain")).toBe(true);
+    expect(allowanceById(ctx).get("dotted")).toBe(false);
+  });
+
+  it("does not let a pane with its own session id consume the slot", async () => {
+    const ctx = makeContext();
+
+    await restorePanelsPhase(
+      [
+        codexPanel("exact", { agentSessionId: "abc", lastActiveAt: 900 }),
+        codexPanel("idless", { lastActiveAt: 1 }),
+      ],
+      ctx
+    );
+
+    // The exact-id pane resumes precisely and never contends, so the id-less one
+    // still gets the fallback despite being far less recent.
+    expect(allowanceById(ctx).get("idless")).toBe(true);
+  });
+
+  it("does not spend the slot on a pane whose PTY survived", async () => {
+    // A live backend reconnects instead of respawning, so it can never reach the
+    // fallback — letting it win would strand the pane that actually respawns.
+    const ctx = makeContext({
+      backendTerminalMap: new Map([["survivor", backend("survivor", { kind: "agent" })]]),
+    });
+
+    await restorePanelsPhase(
+      [
+        codexPanel("survivor", { lastActiveAt: 900 }),
+        codexPanel("respawner", { lastActiveAt: 1 }),
+      ],
+      ctx
+    );
+
+    expect(allowanceById(ctx).get("respawner")).toBe(true);
+  });
+
+  it("does not suppress panes of an agent that has no resume-latest fallback", async () => {
+    const ctx = makeContext();
+
+    await restorePanelsPhase(
+      [
+        panel("g1", { kind: "agent", launchAgentId: "goose" }),
+        panel("g2", { kind: "agent", launchAgentId: "goose" }),
+      ],
+      ctx
+    );
+
+    // They fall through to a fresh launch individually; no slot to contend for.
+    expect(allowanceById(ctx).get("g1")).toBe(true);
+    expect(allowanceById(ctx).get("g2")).toBe(true);
+  });
+
+  it("does not make plain terminals contend for a slot", async () => {
+    const ctx = makeContext();
+
+    await restorePanelsPhase([panel("t1"), panel("t2")], ctx);
+
+    expect(allowanceById(ctx).get("t1")).toBe(true);
+    expect(allowanceById(ctx).get("t2")).toBe(true);
   });
 });

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -719,7 +719,7 @@ describe("buildArgsForRespawn", () => {
         { allowResumeLatest: false }
       );
       expect(buildResumeLatestCommandMock).not.toHaveBeenCalled();
-      expect(result.command).not.toBe("claude --continue");
+      expect(result.command).toBe("claude --generated");
       expect(result.sessionLostOnRestore).toBe(true);
     });
 
@@ -745,7 +745,7 @@ describe("buildArgsForRespawn", () => {
         undefined,
         { allowResumeLatest: false }
       );
-      expect(result.command).not.toContain("--continue");
+      expect(result.command).toBe("claude");
       expect(result.sessionLostOnRestore).toBe(true);
     });
 
@@ -792,8 +792,36 @@ describe("buildArgsForRespawn", () => {
         undefined,
         { allowResumeLatest: false }
       );
-      expect(result.command).toContain("--flagged");
+      expect(result.command).toBe("claude --flagged");
       expect(result.sessionLostOnRestore).toBe(true);
+    });
+
+    it("leaves an agent with no resume-latest fallback untouched when suppressed (#11461)", () => {
+      // Suppression may only affect an agent that has a fallback to suppress, so
+      // the option can't quietly rewrite an unrelated agent's saved command.
+      buildResumeLatestCommandMock.mockReturnValue(undefined);
+      const saved = {
+        id: "t1",
+        kind: "terminal" as const,
+        agentId: "claude",
+        cwd: "/p",
+        location: "grid",
+        command: "claude --custom-mode",
+      };
+      const allowed = buildArgsForRespawn(saved, "terminal", "/p", undefined, false, "/tmp");
+      const suppressed = buildArgsForRespawn(
+        saved,
+        "terminal",
+        "/p",
+        undefined,
+        false,
+        "/tmp",
+        undefined,
+        { allowResumeLatest: false }
+      );
+
+      expect(suppressed.command).toBe(allowed.command);
+      expect(suppressed.sessionLostOnRestore).toBe(allowed.sessionLostOnRestore);
     });
 
     it("uses resume-latest by default when no allowance is passed (#11461)", () => {

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -706,6 +706,110 @@ describe("buildArgsForRespawn", () => {
       expect(result.sessionLostOnRestore).toBeUndefined();
     });
 
+    it("is set when resume-latest is suppressed for a sibling-owned slot (#11461)", () => {
+      buildResumeLatestCommandMock.mockReturnValue("claude --continue");
+      const result = buildArgsForRespawn(
+        { id: "t1", kind: "terminal" as const, agentId: "claude", cwd: "/p", location: "grid" },
+        "terminal",
+        "/p",
+        { agents: { claude: {} } },
+        false,
+        "/tmp",
+        undefined,
+        { allowResumeLatest: false }
+      );
+      expect(buildResumeLatestCommandMock).not.toHaveBeenCalled();
+      expect(result.command).not.toBe("claude --continue");
+      expect(result.sessionLostOnRestore).toBe(true);
+    });
+
+    it("does not inherit a persisted resume-latest command when suppressed (#11461)", () => {
+      // A prior restore persists its resume command, so `saved.command` can itself
+      // be `--continue`. With no settings and no flags to rebuild from, the
+      // suppressed pane must still not re-run it.
+      buildResumeLatestCommandMock.mockReturnValue("claude --continue");
+      const result = buildArgsForRespawn(
+        {
+          id: "t1",
+          kind: "terminal" as const,
+          agentId: "claude",
+          cwd: "/p",
+          location: "grid",
+          command: "claude --continue",
+        },
+        "terminal",
+        "/p",
+        undefined,
+        false,
+        "/tmp",
+        undefined,
+        { allowResumeLatest: false }
+      );
+      expect(result.command).not.toContain("--continue");
+      expect(result.sessionLostOnRestore).toBe(true);
+    });
+
+    it("still resumes an exact session id when resume-latest is suppressed (#11461)", () => {
+      // The gate must touch only the no-session-id branch.
+      buildResumeCommandMock.mockReturnValue("claude --resume sess-1");
+      const result = buildArgsForRespawn(
+        {
+          id: "t1",
+          kind: "terminal" as const,
+          agentId: "claude",
+          cwd: "/p",
+          location: "grid",
+          agentSessionId: "sess-1",
+        },
+        "terminal",
+        "/p",
+        { agents: { claude: {} } },
+        false,
+        "/tmp",
+        undefined,
+        { allowResumeLatest: false }
+      );
+      expect(result.command).toBe("claude --resume sess-1");
+      expect(result.sessionLostOnRestore).toBeUndefined();
+    });
+
+    it("prefers persisted flags over a bare rebuild when suppressed (#11461)", () => {
+      buildResumeLatestCommandMock.mockReturnValue("claude --continue");
+      const result = buildArgsForRespawn(
+        {
+          id: "t1",
+          kind: "terminal" as const,
+          agentId: "claude",
+          cwd: "/p",
+          location: "grid",
+          agentLaunchFlags: ["--flagged"],
+        },
+        "terminal",
+        "/p",
+        { agents: { claude: {} } },
+        false,
+        "/tmp",
+        undefined,
+        { allowResumeLatest: false }
+      );
+      expect(result.command).toContain("--flagged");
+      expect(result.sessionLostOnRestore).toBe(true);
+    });
+
+    it("uses resume-latest by default when no allowance is passed (#11461)", () => {
+      buildResumeLatestCommandMock.mockReturnValue("claude --continue");
+      const result = buildArgsForRespawn(
+        { id: "t1", kind: "terminal" as const, agentId: "claude", cwd: "/p", location: "grid" },
+        "terminal",
+        "/p",
+        { agents: { claude: {} } },
+        false,
+        "/tmp"
+      );
+      expect(result.command).toBe("claude --continue");
+      expect(result.sessionLostOnRestore).toBeUndefined();
+    });
+
     it("is not set for non-agent panels", () => {
       const result = buildArgsForRespawn(
         { id: "t1", kind: "terminal" as const, cwd: "/p", location: "grid" },
@@ -837,7 +941,7 @@ describe("buildArgsForRespawn", () => {
       false,
       "/tmp/clip",
       undefined,
-      "'/tmp/daintree-fake-bin/claude'"
+      { resolvedAgentBaseCommand: "'/tmp/daintree-fake-bin/claude'" }
     );
 
     expect(result.command).toBe("'/tmp/daintree-fake-bin/claude' --generated");
@@ -915,7 +1019,7 @@ describe("buildArgsForRespawn", () => {
       false,
       undefined,
       undefined,
-      "'/tmp/daintree-fake-bin/claude'"
+      { resolvedAgentBaseCommand: "'/tmp/daintree-fake-bin/claude'" }
     );
 
     expect(result.command).toBe("'/tmp/daintree-fake-bin/claude' --continue");

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -74,6 +74,14 @@ function resumeLatestScopeCwd(cwd: string): string {
  *
  * Scopes with a single candidate are omitted entirely, so the common one-pane
  * case keeps its existing behavior by construction.
+ *
+ * Liveness is only as good as what is known synchronously. When the bulk probe
+ * timed out there is no prefetched result, and a per-panel reconnect can still
+ * find a live PTY after the election has run — that pane then holds a slot it
+ * never uses and its cold sibling launches fresh. Deliberately accepted: the
+ * election has to complete before any task dispatches (a claim taken after an
+ * await races, the hazard #11052 fixed for restart), and the cost is one pane
+ * missing a resume rather than two panes sharing a conversation.
  */
 function electSuppressedResumeLatestIds(
   panels: readonly (TerminalState | undefined)[],

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -43,12 +43,6 @@ type AddPanelFn = HydrationOptions["addPanel"];
 type RestoreTerminalOrderFn = NonNullable<HydrationOptions["restoreTerminalOrder"]>;
 
 /**
- * Rebase a restore arg's `cwd` from a moved worktree's old root to its new one.
- * No-op when the panel's worktree didn't move or the arg carries no cwd. Used on
- * the surviving-PTY paths, whose cwd comes from the live backend record (the old
- * path) rather than the already-rebased `saved.cwd` (#11388).
- */
-/**
  * Scope key component for the resume-latest election: the directory a pane will
  * launch in, normalized lexically so two spellings of one directory share a slot.
  * Deliberately not realpath'd — the election must stay synchronous and the path
@@ -143,6 +137,12 @@ function electSuppressedResumeLatestIds(
   return suppressed;
 }
 
+/**
+ * Rebase a restore arg's `cwd` from a moved worktree's old root to its new one.
+ * No-op when the panel's worktree didn't move or the arg carries no cwd. Used on
+ * the surviving-PTY paths, whose cwd comes from the live backend record (the old
+ * path) rather than the already-rebased `saved.cwd` (#11388).
+ */
 function rebaseMovedArgsCwd(
   args: { cwd?: string },
   move: { oldRoot: string; newRoot: string } | undefined

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -67,8 +67,9 @@ function resumeLatestScopeCwd(cwd: string): string {
  * saved entry, so the outcome is deterministic and independent of restore order.
  *
  * Only panes that could actually reach the fallback are candidates: an id-less
- * agent pane, of an agent that declares resume-latest args, with no surviving
- * backend PTY — a live PTY reconnects instead of respawning, so letting one win a
+ * agent pane, of an agent that declares resume-latest args, whose PTY did not
+ * survive. A pane with a live backend record — or a prefetched probe that already
+ * says its PTY exists — reconnects instead of respawning, so letting one win a
  * slot would strand its genuinely-respawning siblings on fresh launches.
  *
  * Scopes with a single candidate are omitted entirely, so the common one-pane
@@ -76,7 +77,11 @@ function resumeLatestScopeCwd(cwd: string): string {
  */
 function electSuppressedResumeLatestIds(
   panels: readonly (TerminalState | undefined)[],
-  context: { projectRoot: string; backendTerminalMap: Map<string, BackendTerminalInfo> }
+  context: {
+    projectRoot: string;
+    backendTerminalMap: Map<string, BackendTerminalInfo>;
+    prefetchedReconnectResults?: Record<string, TerminalReconnectResult>;
+  }
 ): Set<string> {
   const winnerByScope = new Map<string, { id: string; lastActiveAt: number }>();
   const candidateIdsByScope = new Map<string, string[]>();
@@ -87,6 +92,10 @@ function electSuppressedResumeLatestIds(
     // An exact per-pane session id resumes precisely and never consumes a slot.
     if (saved.agentSessionId) continue;
     if (context.backendTerminalMap.has(saved.id)) continue;
+    // A prefetched probe reporting a live PTY takes the reconnect path in
+    // `reconnectWithTimeout`, so this pane never respawns either.
+    const prefetched = context.prefetchedReconnectResults?.[saved.id];
+    if (prefetched?.exists && prefetched.hasPty) continue;
     const kind = inferKind(saved);
     if (kind === "assistant" || !panelKindHasPty(kind)) continue;
     const agentId = resolveRespawnAgentId(saved, kind);
@@ -356,6 +365,7 @@ export async function restorePanelsPhase(
     const resumeLatestSuppressedIds = electSuppressedResumeLatestIds(panels, {
       projectRoot: projectRoot || "",
       backendTerminalMap,
+      prefetchedReconnectResults,
     });
 
     const panelTasks: PanelRestoreTaskEntry[] = [];

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -28,7 +28,10 @@ import {
   buildArgsForNonPtyRecreation,
   buildArgsForOrphanedTerminal,
   inferWorktreeIdFromCwd,
+  resolveRespawnAgentId,
 } from "./statePatcher";
+import { buildResumeLatestCommand } from "@shared/types/agentSettings";
+import { normalize as normalizePath } from "@shared/utils/path";
 import type { HydrationOptions } from "./";
 import { getAgentConfig } from "@/config/agents";
 import {
@@ -45,6 +48,84 @@ type RestoreTerminalOrderFn = NonNullable<HydrationOptions["restoreTerminalOrder
  * the surviving-PTY paths, whose cwd comes from the live backend record (the old
  * path) rather than the already-rebased `saved.cwd` (#11388).
  */
+/**
+ * Scope key component for the resume-latest election: the directory a pane will
+ * launch in, normalized lexically so two spellings of one directory share a slot.
+ * Deliberately not realpath'd — the election must stay synchronous and the path
+ * may no longer exist, so symlink aliases remain separate scopes.
+ */
+function resumeLatestScopeCwd(cwd: string): string {
+  const normalized = normalizePath(cwd).normalize("NFC");
+  // Windows paths are case-insensitive; fold so `C:/Repo` and `c:/repo` collide.
+  return /^([A-Za-z]:\/|\/\/)/.test(normalized) ? normalized.toLowerCase() : normalized;
+}
+
+/**
+ * Ids of panes that must NOT use their agent's resume-latest fallback because a
+ * sibling pane in the same (agent, cwd) scope already owns that scope's single
+ * slot (#11461). Highest valid `lastActiveAt` wins and ties keep the earlier
+ * saved entry, so the outcome is deterministic and independent of restore order.
+ *
+ * Only panes that could actually reach the fallback are candidates: an id-less
+ * agent pane, of an agent that declares resume-latest args, with no surviving
+ * backend PTY — a live PTY reconnects instead of respawning, so letting one win a
+ * slot would strand its genuinely-respawning siblings on fresh launches.
+ *
+ * Scopes with a single candidate are omitted entirely, so the common one-pane
+ * case keeps its existing behavior by construction.
+ */
+function electSuppressedResumeLatestIds(
+  panels: readonly (TerminalState | undefined)[],
+  context: { projectRoot: string; backendTerminalMap: Map<string, BackendTerminalInfo> }
+): Set<string> {
+  const winnerByScope = new Map<string, { id: string; lastActiveAt: number }>();
+  const candidateIdsByScope = new Map<string, string[]>();
+
+  for (const saved of panels) {
+    if (saved === undefined) continue;
+    if (isSmokeTestTerminalId(saved.id)) continue;
+    // An exact per-pane session id resumes precisely and never consumes a slot.
+    if (saved.agentSessionId) continue;
+    if (context.backendTerminalMap.has(saved.id)) continue;
+    const kind = inferKind(saved);
+    if (kind === "assistant" || !panelKindHasPty(kind)) continue;
+    const agentId = resolveRespawnAgentId(saved, kind);
+    if (agentId === undefined) continue;
+    // Probe capability through the very builder the respawn branch calls, so
+    // eligibility can't drift from behavior (covers custom/plugin agents too).
+    if (buildResumeLatestCommand(agentId) === undefined) continue;
+
+    // NUL-joined: neither an agent id nor a path can contain it, so the key can
+    // never be forged by an unusual path or a future custom agent id.
+    const scope = `${agentId}\u0000${resumeLatestScopeCwd(saved.cwd || context.projectRoot)}`;
+    const existingIds = candidateIdsByScope.get(scope);
+    if (existingIds === undefined) {
+      candidateIdsByScope.set(scope, [saved.id]);
+    } else {
+      existingIds.push(saved.id);
+    }
+
+    const lastActiveAt =
+      Number.isFinite(saved.lastActiveAt) && (saved.lastActiveAt ?? 0) > 0
+        ? (saved.lastActiveAt as number)
+        : 0;
+    const currentWinner = winnerByScope.get(scope);
+    if (currentWinner === undefined || lastActiveAt > currentWinner.lastActiveAt) {
+      winnerByScope.set(scope, { id: saved.id, lastActiveAt });
+    }
+  }
+
+  const suppressed = new Set<string>();
+  for (const [scope, ids] of candidateIdsByScope) {
+    if (ids.length < 2) continue;
+    const winnerId = winnerByScope.get(scope)?.id;
+    for (const id of ids) {
+      if (id !== winnerId) suppressed.add(id);
+    }
+  }
+  return suppressed;
+}
+
 function rebaseMovedArgsCwd(
   args: { cwd?: string },
   move: { oldRoot: string; newRoot: string } | undefined
@@ -263,6 +344,20 @@ export async function restorePanelsPhase(
       }
     }
 
+    // Elect at most one pane per (agent, cwd) to use the agent's resume-latest
+    // fallback. That fallback resolves to the most recent session in scope
+    // (`codex resume --last`, `claude --continue`), so N id-less panes sharing a
+    // directory would every one of them reopen the SAME conversation (#11461).
+    // Computed synchronously over static saved fields before any task executes:
+    // same-tier tasks run concurrently via Promise.allSettled, so a check-and-claim
+    // inside the closures would race (the hazard already fixed once for restart,
+    // #11052). Only the losers are recorded, so a lone candidate — the common
+    // single-pane case — is never suppressed.
+    const resumeLatestSuppressedIds = electSuppressedResumeLatestIds(panels, {
+      projectRoot: projectRoot || "",
+      backendTerminalMap,
+    });
+
     const panelTasks: PanelRestoreTaskEntry[] = [];
     const restoredIdsByIndex = new Map<number, string>();
 
@@ -462,7 +557,10 @@ export async function restorePanelsPhase(
                   reconnectTimedOut,
                   clipboardDirectory,
                   projectPresetsByAgent,
-                  resolvedAgentBaseCommand
+                  {
+                    resolvedAgentBaseCommand,
+                    allowResumeLatest: !resumeLatestSuppressedIds.has(saved.id),
+                  }
                 );
 
                 // Assign to the active worktree when the saved terminal has no

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -122,10 +122,10 @@ function electSuppressedResumeLatestIds(
       existingIds.push(saved.id);
     }
 
+    // A corrupt or missing stamp ranks lowest rather than winning the slot.
+    const savedLastActiveAt = saved.lastActiveAt ?? 0;
     const lastActiveAt =
-      Number.isFinite(saved.lastActiveAt) && (saved.lastActiveAt ?? 0) > 0
-        ? (saved.lastActiveAt as number)
-        : 0;
+      Number.isFinite(savedLastActiveAt) && savedLastActiveAt > 0 ? savedLastActiveAt : 0;
     const currentWinner = winnerByScope.get(scope);
     if (currentWinner === undefined || lastActiveAt > currentWinner.lastActiveAt) {
       winnerByScope.set(scope, { id: saved.id, lastActiveAt });

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -626,11 +626,14 @@ export function buildArgsForRespawn(
           globalUseAltScreen,
         });
         sessionLostOnRestore = true;
-      } else if (!allowResumeLatest) {
+      } else if (!allowResumeLatest && buildResumeLatestCommand(agentId) !== undefined) {
         // Nothing above rebuilt the command, so `command` still holds
         // `saved.command` — which is itself a persisted resume-latest command
         // whenever an earlier restore used one. Inheriting it would reinstate the
         // very collision this suppression exists to prevent, so launch clean.
+        // The bare capability probe (config-only, so flag-independent and in
+        // agreement with the restore election's) keeps suppression from touching
+        // an agent that has no resume-latest fallback to suppress.
         command = buildLaunchCommandFromFlags(baseCommand, agentId, injectedFromEmpty, {
           clipboardDirectory,
           shareClipboardDirectory,

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -457,6 +457,38 @@ export function buildArgsForReconnectedFallback(
   };
 }
 
+/**
+ * Resolve the agent identity a respawn will actually launch under: the legacy
+ * on-disk `agentId`/`type` migration plus the title-based recovery for snapshots
+ * written under the old `kind: "agent"` marker. Shared with restore's
+ * resume-latest election (#11461) so slot eligibility can never disagree with the
+ * command the respawn goes on to build. Pure — safe to call in a pre-pass.
+ */
+export function resolveRespawnAgentId(
+  saved: SavedTerminalData,
+  kind: PanelKind | undefined
+): string | undefined {
+  const savedLaunchAgentId =
+    saved.launchAgentId ?? (saved.type === "claude" ? "claude" : saved.agentId);
+  return inferAgentIdFromTitle(
+    saved.title,
+    kind,
+    resolveAgentId(savedLaunchAgentId),
+    saved.id,
+    "Respawn"
+  );
+}
+
+export interface BuildArgsForRespawnOptions {
+  resolvedAgentBaseCommand?: string;
+  /**
+   * False when a sibling pane already owns this agent+cwd's single resume-latest
+   * slot (#11461). Only suppresses the resume-latest fallback — an exact
+   * per-pane session id still resumes normally.
+   */
+  allowResumeLatest?: boolean;
+}
+
 export function buildArgsForRespawn(
   saved: SavedTerminalData,
   kind: PanelKind,
@@ -465,19 +497,11 @@ export function buildArgsForRespawn(
   reconnectTimedOut: boolean,
   clipboardDirectory: string | undefined,
   projectPresetsByAgent?: Record<string, AgentPreset[]>,
-  resolvedAgentBaseCommand?: string
+  options?: BuildArgsForRespawnOptions
 ): AddTerminalArgs {
-  // Migrate legacy on-disk agentId/type to launchAgentId at the read boundary.
-  const savedLaunchAgentId =
-    saved.launchAgentId ?? (saved.type === "claude" ? "claude" : saved.agentId);
-  let effectiveAgentId = resolveAgentId(savedLaunchAgentId);
-  effectiveAgentId = inferAgentIdFromTitle(
-    saved.title,
-    kind,
-    effectiveAgentId,
-    saved.id,
-    "Respawn"
-  );
+  const resolvedAgentBaseCommand = options?.resolvedAgentBaseCommand;
+  const allowResumeLatest = options?.allowResumeLatest ?? true;
+  const effectiveAgentId = resolveRespawnAgentId(saved, kind);
 
   const isAgentPanel = Boolean(effectiveAgentId);
   const agentId = effectiveAgentId;
@@ -579,9 +603,15 @@ export function buildArgsForRespawn(
       // No session ID was captured (graceful-shutdown pattern match missed or
       // timed out). Try the agent's resume-latest fallback before falling
       // through to a fresh launch so the user keeps their prior conversation.
-      const resumeLatestCmd = resolvedAgentBaseCommand
-        ? buildResumeLatestCommand(agentId, resumeFlags, baseCommand)
-        : buildResumeLatestCommand(agentId, resumeFlags);
+      // Suppressed when a sibling pane owns this agent+cwd's single slot:
+      // resume-latest resolves to the most recent session in scope, so several
+      // panes running it would all land in the SAME conversation (#11461).
+      let resumeLatestCmd: string | undefined;
+      if (allowResumeLatest) {
+        resumeLatestCmd = resolvedAgentBaseCommand
+          ? buildResumeLatestCommand(agentId, resumeFlags, baseCommand)
+          : buildResumeLatestCommand(agentId, resumeFlags);
+      }
       if (resumeLatestCmd) {
         command = resumeLatestCmd;
       } else if (hasPersistedFlags) {
@@ -594,6 +624,16 @@ export function buildArgsForRespawn(
           presetArgs: preset?.args?.join(" "),
           globalSkipPermissions,
           globalUseAltScreen,
+        });
+        sessionLostOnRestore = true;
+      } else if (!allowResumeLatest) {
+        // Nothing above rebuilt the command, so `command` still holds
+        // `saved.command` — which is itself a persisted resume-latest command
+        // whenever an earlier restore used one. Inheriting it would reinstate the
+        // very collision this suppression exists to prevent, so launch clean.
+        command = buildLaunchCommandFromFlags(baseCommand, agentId, injectedFromEmpty, {
+          clipboardDirectory,
+          shareClipboardDirectory,
         });
         sessionLostOnRestore = true;
       }


### PR DESCRIPTION
## Summary

Two independent defects behind #11461 ("Restored Codex panes all resume the same conversation"), both fixed.

- A captured `agentSessionId` was getting erased on the very next renderer save, because the merge function replaced a changed panel entry wholesale instead of merging it field by field.
- Multiple id-less panes of the same agent sharing a working directory each issued the identical resume-latest command on restore, so they silently reopened the same conversation with no warning banner.

Resolves #11461

## Changes

**1. Session id was being erased.** `electron/lifecycle/shutdown.ts` captures each agent's `agentSessionId` at quit and writes it into project state, but never pushes it back into the renderer's store. `mergeIdArray` (`shared/utils/layoutMerge.ts`) replaced a changed entry wholesale, and a PTY exit alone flips `agentState`/`lastStateChange`, marking the panel changed, so the renderer's next ordinary save replaced the entry and dropped the id it never held in the first place. Both writers already share one serialized queue, so this was never a race, just a merge that was too coarse.

The fix makes authority per-field for the fields Main can also author. `computeIdArrayDelta` now reports, per entry, which tracked fields the writer actually changed relative to its own baseline (`fieldEdits`), and `mergeIdArray` takes only those fields, leaving everything else at its on-disk value. That separates the three states the old shape conflated (changed, cleared, unknown) without a `null` union or a patch log, and it works both ways: a post-exit save no longer erases a captured id, and a stale sibling window can't resurrect an id another window deliberately cleared. Applied at both terminal merge sites (the `setTerminals` handler and the project-switch outgoing persist), with the wire metadata sanitized at the IPC boundary against an allowlist.

**2. Every id-less pane ran the same resume-latest command.** `buildArgsForRespawn`'s no-session-id branch called `buildResumeLatestCommand` per pane with no cross-pane coordination, so N panes of one agent sharing a directory each ran "resume the most recent session here" and all reopened the same conversation, silently, since `sessionLostOnRestore` wasn't set on that branch. Not Codex specific: six agents ship a resume-latest fallback (codex, claude, gemini, grok, opencode, antigravity).

`restorePanelsPhase` now elects at most one pane per (agent, normalized cwd) to use the fallback, in a synchronous pre-pass over saved panels before any restore task dispatches, the same shape as the existing `maxLastActiveAtByWorktree` pass, and deliberately not a check-and-claim inside the task closures, since same-tier tasks run concurrently under `Promise.allSettled` (the race #11052 already fixed for the restart path). Highest `lastActiveAt` wins; ties keep the earlier saved entry. Panes that already have their own session id don't contend, and a scope with a single candidate is skipped entirely, so the common one-pane case is untouched by construction. Losing panes launch fresh with `sessionLostOnRestore` set, which drives the existing "session no longer reachable" banner. No new UI.

**Two limits accepted deliberately, both documented in code:**

- A writer recreating a pane that was deleted on disk still carries its own tracked values, because entry-level last-writer-wins for a changed entry predates this fix and is unchanged by it.
- When the bulk reconnect probe times out there's no prefetched result, so a per-panel reconnect can find a live PTY after the election already ran. That pane then holds a slot it never uses, and its cold sibling launches fresh anyway. The election has to complete before dispatch, so the cost is one pane missing a resume rather than two sharing a conversation.

**Out of scope** (per the issue author): the `sessionIdPattern` regex bug where `codex resume -- <name>` captures `--`; adding `terminalId` to `AgentSessionRecord` (a journal backstop that reopens a known cross-process write race); the full-quit renderer flush gap.

## Testing

477 tests pass across the 8 affected suites. Typecheck clean, ESLint ratchet at baseline (+0), format clean.

New coverage includes both cases the issue asked for (a delta omitting `agentSessionId` must not delete it, while an explicit clear must still clear it; N id-less panes in one cwd must produce at most one resume-latest command), plus the stale-sibling regression, the project-switch merge site, `fieldEdits` transport through the client, and the IPC sanitizer directly.
