### PR TITLE
fix(terminal): keep the remembered focus target when a click activates an unfocused pane

### DIFF
--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -878,16 +878,17 @@ function TerminalPaneComponent({
     // A physical click that reaches xterm is an explicit "I want the terminal"
     // gesture — record it so subsequent Cmd-Opt-Arrow navigation stays on
     // xterm across panes. Classify the click first: a suppressed activation
-    // click never reaches xterm, and overwriting the preference there is what
-    // used to destroy the pane's remembered hybrid-input target (#11465).
+    // click is swallowed before xterm sees it, and recording there is what
+    // used to destroy the remembered hybrid-input target (#11465).
     if (shouldRecordXtermFocusPreference({ isAtSynthesized, shouldSuppress })) {
       setPreferredTerminalFocusTarget("xterm");
     }
 
     if (!shouldSuppress) {
-      // Already-focused panes: let the click through so xterm selection,
-      // cursor positioning, and mouse reporting work natively. The xterm
-      // focus listener (TerminalInstanceService) records the focus event.
+      // Pass-through cases — already-focused panes, dock panes, link cells,
+      // shift+click. Let the click reach xterm so selection, cursor
+      // positioning, and mouse reporting work natively. The xterm focus
+      // listener (TerminalInstanceService) records the focus event.
       return;
     }
 

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -85,6 +85,7 @@ import {
   getTerminalFocusTarget,
   isLikelyAtSynthesizedPointer,
   resolvePaneFocusAction,
+  shouldRecordXtermFocusPreference,
   shouldShowHybridInputBar,
   shouldSuppressUnfocusedClick,
 } from "./terminalFocus";
@@ -867,20 +868,21 @@ function TerminalPaneComponent({
       e.timeStamp
     );
 
-    // A physical click on xterm is an explicit "I want the terminal" gesture —
-    // record it so subsequent Cmd-Opt-Arrow navigation stays on xterm across
-    // panes. Skip for AT routing so a screen reader reaching terminal output
-    // doesn't silently clobber the user's hybrid-input focus preference.
-    if (!isAtSynthesized) {
-      setPreferredTerminalFocusTarget("xterm");
-    }
-
     const shouldSuppress = shouldSuppressUnfocusedClick({
       location,
       isFocused,
       isCursorPointer: xtermElement.classList.contains("xterm-cursor-pointer"),
       isShiftKey: e.shiftKey,
     });
+
+    // A physical click that reaches xterm is an explicit "I want the terminal"
+    // gesture — record it so subsequent Cmd-Opt-Arrow navigation stays on
+    // xterm across panes. Classify the click first: a suppressed activation
+    // click never reaches xterm, and overwriting the preference there is what
+    // used to destroy the pane's remembered hybrid-input target (#11465).
+    if (shouldRecordXtermFocusPreference({ isAtSynthesized, shouldSuppress })) {
+      setPreferredTerminalFocusTarget("xterm");
+    }
 
     if (!shouldSuppress) {
       // Already-focused panes: let the click through so xterm selection,
@@ -910,8 +912,12 @@ function TerminalPaneComponent({
       // Element was detached (e.g. LRU view eviction). Safe to ignore.
     }
 
+    // Activate the pane only. The `isFocused` effect below owns the resolved
+    // handoff via getTerminalFocusTarget / resolvePaneFocusAction, so forcing
+    // xterm focus here would both duplicate that resolver and defeat it —
+    // landing DOM focus on xterm fires `focusin`, which unconditionally
+    // records "xterm" and overwrites the target we just preserved.
     setFocused(id);
-    requestAnimationFrame(() => terminalInstanceService.focus(id));
   };
 
   const handleXtermPointerNoop = () => {};

--- a/src/components/Terminal/__tests__/focusClickSuppression.test.ts
+++ b/src/components/Terminal/__tests__/focusClickSuppression.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { isLikelyAtSynthesizedPointer, shouldSuppressUnfocusedClick } from "../terminalFocus";
+import {
+  isLikelyAtSynthesizedPointer,
+  shouldRecordXtermFocusPreference,
+  shouldSuppressUnfocusedClick,
+} from "../terminalFocus";
 
 describe("shouldSuppressUnfocusedClick", () => {
   it("suppresses click on unfocused xterm grid panel", () => {
@@ -83,5 +87,38 @@ describe("AT-synthesized vs physical suppression on unfocused panes", () => {
     });
     const atSynthesized = isLikelyAtSynthesizedPointer(null, 1000);
     expect(suppress && atSynthesized).toBe(true);
+  });
+});
+
+describe("recording the xterm focus preference on pointerdown", () => {
+  // Only a click that actually reaches xterm is an explicit "I want the
+  // terminal" gesture. Inputs are derived through the production classifiers
+  // rather than passed as bare booleans, so these cases exercise the real
+  // composition the pane handler performs.
+  const classify = (options: { location: string; isFocused: boolean; lastMoveAt: number | null }) =>
+    shouldRecordXtermFocusPreference({
+      isAtSynthesized: isLikelyAtSynthesizedPointer(options.lastMoveAt, 1000),
+      shouldSuppress: shouldSuppressUnfocusedClick({
+        location: options.location,
+        isFocused: options.isFocused,
+        isCursorPointer: false,
+        isShiftKey: false,
+      }),
+    });
+
+  it("records for a physical click on an already-focused pane — the click reaches xterm", () => {
+    expect(classify({ location: "grid", isFocused: true, lastMoveAt: 990 })).toBe(true);
+  });
+
+  it("preserves the remembered target when the same physical click activates an unfocused pane", () => {
+    // Identical gesture to the case above; only the pane's focus state differs,
+    // which makes the click suppressed and therefore never seen by xterm.
+    expect(classify({ location: "grid", isFocused: false, lastMoveAt: 990 })).toBe(false);
+  });
+
+  it("preserves the remembered target for AT cursor routing that does reach xterm", () => {
+    // Pass-through click (already focused), but with no preceding pointermove:
+    // a screen reader reading terminal output must not switch the user's mode.
+    expect(classify({ location: "grid", isFocused: true, lastMoveAt: null })).toBe(false);
   });
 });

--- a/src/components/Terminal/terminalFocus.ts
+++ b/src/components/Terminal/terminalFocus.ts
@@ -120,3 +120,26 @@ export function isLikelyAtSynthesizedPointer(
   if (lastMoveAt === null) return true;
   return now - lastMoveAt > thresholdMs;
 }
+
+/**
+ * Whether a pointerdown on xterm should record `"xterm"` as the session focus
+ * preference. Only clicks that actually reach xterm count as the explicit
+ * "I want the terminal" gesture.
+ *
+ * Both exclusions matter for different reasons. AT cursor routing reaches
+ * xterm but isn't a deliberate mode switch, so a screen reader reading
+ * terminal output must not clobber a hybrid-input preference. A suppressed
+ * click never reaches xterm at all: it's the activation click on an unfocused
+ * grid pane, which should restore that pane's remembered target the same way
+ * `Cmd+<n>` does rather than overwrite it (#11465).
+ *
+ * Callers must pair this with *not* forcing xterm focus on the suppressed
+ * path — DOM focus on xterm fires `focusin`, which records `"xterm"`
+ * unconditionally and would undo the preservation.
+ */
+export function shouldRecordXtermFocusPreference(options: {
+  isAtSynthesized: boolean;
+  shouldSuppress: boolean;
+}): boolean {
+  return !options.isAtSynthesized && !options.shouldSuppress;
+}

--- a/src/components/Terminal/terminalFocus.ts
+++ b/src/components/Terminal/terminalFocus.ts
@@ -122,16 +122,17 @@ export function isLikelyAtSynthesizedPointer(
 }
 
 /**
- * Whether a pointerdown on xterm should record `"xterm"` as the session focus
- * preference. Only clicks that actually reach xterm count as the explicit
- * "I want the terminal" gesture.
+ * Whether a pointerdown on xterm should record `"xterm"` as the session-wide
+ * focus preference. Only a deliberate click that lands in xterm counts as the
+ * explicit "I want the terminal" gesture.
  *
- * Both exclusions matter for different reasons. AT cursor routing reaches
- * xterm but isn't a deliberate mode switch, so a screen reader reading
- * terminal output must not clobber a hybrid-input preference. A suppressed
- * click never reaches xterm at all: it's the activation click on an unfocused
- * grid pane, which should restore that pane's remembered target the same way
- * `Cmd+<n>` does rather than overwrite it (#11465).
+ * The two exclusions are independent. AT cursor routing does reach xterm, but
+ * it isn't a mode switch — a screen reader reading terminal output must not
+ * clobber a hybrid-input preference. `shouldSuppress` marks the activation
+ * click on an unfocused grid pane, which should restore the remembered target
+ * the same way `Cmd+<n>` does rather than overwrite it (#11465); a physical
+ * one is swallowed before xterm sees it, and an AT-routed one is already
+ * excluded by the rule above.
  *
  * Callers must pair this with *not* forcing xterm focus on the suppressed
  * path — DOM focus on xterm fires `focusin`, which records `"xterm"`


### PR DESCRIPTION
Clicking the terminal body of an unfocused grid pane used to overwrite the session-wide `preferredTerminalFocusTarget`. So a pane that had remembered Ask Codex (the hybrid input bar) as its preferred focus target lost that preference on the very click that activated the pane. `Cmd+<n>` already handled this correctly; now the activating click matches it.

Two changes were required, neither sufficient on its own.

## 1. Gate the preference write on click classification

In `TerminalPane.tsx`, `handleXtermPointerDownCapture` now classifies the click via `shouldSuppressUnfocusedClick` before recording the preference. That's gated behind a new pure predicate in `terminalFocus.ts`, `shouldRecordXtermFocusPreference({ isAtSynthesized, shouldSuppress })`. Only a deliberate click that actually lands in xterm counts as the explicit "I want the terminal" gesture.

## 2. Stop force-focusing xterm on suppressed clicks

The suppressed branch no longer calls `requestAnimationFrame(() => terminalInstanceService.focus(id))`. This isn't just cleanup: `TerminalListenerInstaller` installs a bubbling `focusin` listener on every terminal host that calls `notifyXtermFocused()`, which calls `setPreferredTerminalFocusTarget("xterm")` with no gating. Landing DOM focus on xterm would immediately re-clobber the preference the gate just preserved.

The existing `isFocused` effect already performs the resolved handoff through `getTerminalFocusTarget` and `resolvePaneFocusAction`, the same mechanism `Cmd+<n>` relies on. As a bonus, the suppressed path now fires one focus RAF instead of two.

## Resulting behavior

The first click on an unfocused pane activates it and restores the remembered focus target. A subsequent click on the already-focused pane's terminal body still explicitly switches to xterm.

## Not regressed

- Shift+click and DECSET 1002/1003 passthrough (#8531) and accessibility-tree cursor routing both live in code paths this diff doesn't touch.
- The hybrid input's deferred focus-claim abort (#8487) still sees a synchronous `"xterm"` write on every pass-through click.
- WebGL focus pinning rides `terminalInstanceService.setFocused()` in the effect, not the removed `focus()` call.

## Tests

Three cases in `focusClickSuppression.test.ts` feed the real classifiers into the new predicate, forming a minimal MC/DC set over its two conjuncts. The unfocused-activation case fails against the pre-fix gate, so it's a genuine regression test.

One known gap worth a follow-up: nothing covers removal of the forced focus call itself. Restoring that line would recreate the bug with the unit tests still green.

An E2E test was considered and deliberately deferred. The preference is session-wide, and a separately-tracked, ungated `focusin` leak rewrites it the moment focus lands on any plain terminal's xterm. Such a spec would have to route focus between two agent panes, coupling a release-gating test to a mechanism that's itself slated to change. It belongs with that fix instead.

## Out of scope (deferred to separate issues)

- The ungated `focusin` to `notifyXtermFocused` write in `TerminalListenerInstaller`.
- The case where `focusedId` never clears when the app region loses focus.

## Local verification

687 tests across 27 files pass, covering the two terminal-focus suites plus every suite that consumes `terminalFocus.ts` (HelpPanel, DockedTabGroup/DockedTerminalItem, HybridInputBar, `terminalFocusSlice`). eslint shows 0 errors and prettier is clean on the three changed files, with no new lint-ratchet warnings.

Resolves #11465
