### PR TITLE
fix(switcher): rank scratch workspaces into search

### DIFF
--- a/src/ModalHostLayer.tsx
+++ b/src/ModalHostLayer.tsx
@@ -432,7 +432,7 @@ export function ModalHostLayer({
               onQueryChange={projectSwitcherPalette.setQuery}
               onSelectPrevious={projectSwitcherPalette.selectPrevious}
               onSelectNext={projectSwitcherPalette.selectNext}
-              onSelect={projectSwitcherPalette.selectProject}
+              onSelect={projectSwitcherPalette.selectRow}
               onHoverProject={projectSwitcherPalette.onHoverProject}
               onHoverProjectEnd={projectSwitcherPalette.onHoverProjectEnd}
               onClose={projectSwitcherPalette.close}

--- a/src/ModalHostLayer.tsx
+++ b/src/ModalHostLayer.tsx
@@ -469,6 +469,7 @@ export function ModalHostLayer({
                   { source: "user" }
                 );
               }}
+              rankedSearch={projectSwitcherPalette.isRankedSearch}
               scratchResults={projectSwitcherPalette.scratchResults}
               onCreateScratch={(name) => void projectSwitcherPalette.createScratch(name)}
               onSelectScratch={(scratch) => void projectSwitcherPalette.selectScratch(scratch)}

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -1614,7 +1614,7 @@ export function Toolbar({
                     onQueryChange={projectSwitcher.setQuery}
                     onSelectPrevious={projectSwitcher.selectPrevious}
                     onSelectNext={projectSwitcher.selectNext}
-                    onSelect={projectSwitcher.selectProject}
+                    onSelect={projectSwitcher.selectRow}
                     onHoverProject={projectSwitcher.onHoverProject}
                     onHoverProjectEnd={projectSwitcher.onHoverProjectEnd}
                     onClose={handlePillDropdownClose}

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -1641,6 +1641,7 @@ export function Toolbar({
                     }
                     onConfirmFreeMemory={projectSwitcher.confirmFreeMemory}
                     isFreeingMemory={projectSwitcher.isFreeingMemory}
+                    rankedSearch={projectSwitcher.isRankedSearch}
                     scratchResults={projectSwitcher.scratchResults}
                     onCreateScratch={(name) => void projectSwitcher.createScratch(name)}
                     onSelectScratch={(scratch) => void projectSwitcher.selectScratch(scratch)}

--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -206,7 +206,7 @@ export function ProjectSwitcher() {
             onQueryChange={projectSwitcher.setQuery}
             onSelectPrevious={projectSwitcher.selectPrevious}
             onSelectNext={projectSwitcher.selectNext}
-            onSelect={projectSwitcher.selectProject}
+            onSelect={projectSwitcher.selectRow}
             onClose={handleDropdownClose}
             onAddProject={projectSwitcher.addProject}
             onCloneRepo={handleCloneRepo}
@@ -288,7 +288,7 @@ export function ProjectSwitcher() {
         onQueryChange={projectSwitcher.setQuery}
         onSelectPrevious={projectSwitcher.selectPrevious}
         onSelectNext={projectSwitcher.selectNext}
-        onSelect={projectSwitcher.selectProject}
+        onSelect={projectSwitcher.selectRow}
         onClose={handleDropdownClose}
         onAddProject={projectSwitcher.addProject}
         onCloneRepo={handleCloneRepo}

--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -229,6 +229,7 @@ export function ProjectSwitcher() {
             onFreeMemoryConfirmClose={() => projectSwitcher.setFreeMemoryConfirmProject(null)}
             onConfirmFreeMemory={projectSwitcher.confirmFreeMemory}
             isFreeingMemory={projectSwitcher.isFreeingMemory}
+            rankedSearch={projectSwitcher.isRankedSearch}
             scratchResults={projectSwitcher.scratchResults}
             onCreateScratch={(name) => void projectSwitcher.createScratch(name)}
             onSelectScratch={(scratch) => void projectSwitcher.selectScratch(scratch)}
@@ -311,6 +312,7 @@ export function ProjectSwitcher() {
         onFreeMemoryConfirmClose={() => projectSwitcher.setFreeMemoryConfirmProject(null)}
         onConfirmFreeMemory={projectSwitcher.confirmFreeMemory}
         isFreeingMemory={projectSwitcher.isFreeingMemory}
+        rankedSearch={projectSwitcher.isRankedSearch}
         scratchResults={projectSwitcher.scratchResults}
         onCreateScratch={(name) => void projectSwitcher.createScratch(name)}
         onSelectScratch={(scratch) => void projectSwitcher.selectScratch(scratch)}

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -56,6 +56,9 @@ import type {
   DeleteAllScratchesSnapshot,
   ProjectSectionKey,
   ProjectSwitcherMode,
+  ProjectSwitcherProjectRow,
+  ProjectSwitcherRow,
+  ProjectSwitcherScratchRow,
   SearchableProject,
   SearchableScratch,
 } from "@/hooks/useProjectSwitcherPalette";
@@ -82,12 +85,17 @@ import {
 export interface ProjectSwitcherPaletteProps {
   isOpen: boolean;
   query: string;
-  results: SearchableProject[];
+  /**
+   * Mixed once a query is active — narrow on `kind` before reading anything a
+   * scratch row doesn't carry.
+   */
+  results: ProjectSwitcherRow[];
   selectedIndex: number;
   onQueryChange: (query: string) => void;
   onSelectPrevious: () => void;
   onSelectNext: () => void;
-  onSelect: (project: SearchableProject) => void;
+  /** Commits any row. Project-only callbacks below stay typed to projects. */
+  onSelect: (row: ProjectSwitcherRow) => void;
   onClose: () => void;
   mode?: ProjectSwitcherMode;
   onAddProject?: () => void;
@@ -159,9 +167,9 @@ export interface ProjectSwitcherPaletteProps {
 }
 
 interface ProjectListItemProps {
-  project: SearchableProject;
+  project: ProjectSwitcherProjectRow;
   isSelected: boolean;
-  onSelect: (project: SearchableProject) => void;
+  onSelect: (row: ProjectSwitcherProjectRow) => void;
   onStopProject?: (projectId: string) => void;
   onCloseProject?: (projectId: string) => void;
   onFreeMemoryProject?: (projectId: string) => void;
@@ -426,10 +434,65 @@ function ProjectListItem({
   );
 }
 
+/**
+ * A scratch as a row of the ranked search list (#11466).
+ *
+ * Deliberately NOT the button `ScratchSection` draws. That one is its own
+ * focusable stop in a nested listbox; this one belongs to the palette's roving
+ * selection, so it carries the shared `project-option-` id the scroll query and
+ * `aria-activedescendant` resolve against, and stays out of the tab order.
+ *
+ * "Scratch" rides the secondary line rather than a chip: origin has to be
+ * unambiguous, but it is not the row's headline, and a pill here would be a
+ * second emphasis signal competing with the selection stripe.
+ *
+ * Action-free on purpose. Rename, save-as-project and delete are browse-mode
+ * management — an inline rename editor would have to live inside the array the
+ * arrow keys walk, and scratch delete has no confirm, which is the last thing
+ * that should sit one keystroke away from a highlighted row.
+ */
+function ScratchListItem({
+  scratch,
+  isSelected,
+  onSelect,
+}: {
+  scratch: ProjectSwitcherScratchRow;
+  isSelected: boolean;
+  onSelect: (row: ProjectSwitcherScratchRow) => void;
+}) {
+  return (
+    <div
+      id={`project-option-${scratch.id}`}
+      role="option"
+      aria-selected={isSelected}
+      className={cn(
+        "group relative w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors border border-transparent cursor-pointer",
+        "before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-[''] before:opacity-0 before:transition-opacity aria-selected:before:opacity-100",
+        isSelected
+          ? "bg-overlay-raised border-overlay text-daintree-text"
+          : scratch.isActive
+            ? "text-daintree-text hover:bg-overlay-subtle"
+            : "text-daintree-text/70 hover:bg-overlay-subtle hover:text-daintree-text"
+      )}
+      onClick={() => onSelect(scratch)}
+    >
+      <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] bg-tint/[0.04] text-muted-foreground shrink-0">
+        <FileText className="h-4 w-4" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="truncate text-sm font-semibold leading-tight">{scratch.name}</div>
+        <div className="truncate text-[11px] leading-none text-daintree-text/50 mt-0.5">
+          {`Scratch · ${formatTimeAgo(scratch.lastOpened)}`}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 interface ProjectSection {
   key: ProjectSectionKey;
   label: string | null;
-  items: SearchableProject[];
+  items: ProjectSwitcherProjectRow[];
 }
 
 // Keyed by mode rather than a list, so the lookup below is total: a new mode in
@@ -559,10 +622,10 @@ function OtherProjectsHeader({
 }
 
 interface ProjectListContentProps {
-  results: SearchableProject[];
+  results: ProjectSwitcherRow[];
   selectedIndex: number;
   query: string;
-  onSelect: (project: SearchableProject) => void;
+  onSelect: (row: ProjectSwitcherRow) => void;
   listRef: React.RefObject<HTMLDivElement | null>;
   /** Whether this surface offers "Add Project…" — decides what the empty state can name. */
   canAddProject: boolean;
@@ -615,15 +678,21 @@ function ProjectListContent({
     if (isSearching || results.length === 0) return null;
 
     const bands: ProjectSection[] = [];
-    for (const project of results) {
+    for (const row of results) {
+      // Browse is projects only — scratches ride the pinned section below. A
+      // non-project row here would mean that changed, so drop the whole band
+      // layout rather than skipping the row: the flat branch still renders
+      // everything, where dropping one would strand the highlight on a row that
+      // isn't on screen (#11071).
+      if (row.kind !== "project") return null;
       const last = bands.at(-1);
-      if (last && last.key === project.section) {
-        last.items.push(project);
+      if (last && last.key === row.section) {
+        last.items.push(row);
       } else {
         bands.push({
-          key: project.section,
-          label: PROJECT_SECTION_LABELS[project.section],
-          items: [project],
+          key: row.section,
+          label: PROJECT_SECTION_LABELS[row.section],
+          items: [row],
         });
       }
     }
@@ -634,26 +703,31 @@ function ProjectListContent({
   // renders, so it doubles as the arrow-key domain. Never re-filter it here:
   // a second, narrower array is what stranded the highlight and let Enter
   // commit an off-screen project (#11071).
-  const selectedProjectId = results[selectedIndex]?.id;
+  const selectedRowId = results[selectedIndex]?.id;
 
-  const renderItem = (project: SearchableProject) => {
+  const renderItem = (row: ProjectSwitcherRow) => {
+    const isSelected = row.id === selectedRowId;
     return (
-      <div key={project.id} role="presentation">
-        <ProjectListItem
-          project={project}
-          isSelected={project.id === selectedProjectId}
-          onSelect={onSelect}
-          onStopProject={onStopProject}
-          onCloseProject={onCloseProject}
-          onFreeMemoryProject={onFreeMemoryProject}
-          onLocateProject={onLocateProject}
-          onMoveOrRenameProject={onMoveOrRenameProject}
-          onTogglePinProject={onTogglePinProject}
-          onCopyPath={onCopyPath}
-          onSelectNewWindow={onSelectNewWindow}
-          onHoverProject={onHoverProject}
-          onHoverProjectEnd={onHoverProjectEnd}
-        />
+      <div key={`${row.kind}-${row.id}`} role="presentation">
+        {row.kind === "scratch" ? (
+          <ScratchListItem scratch={row} isSelected={isSelected} onSelect={onSelect} />
+        ) : (
+          <ProjectListItem
+            project={row}
+            isSelected={isSelected}
+            onSelect={onSelect}
+            onStopProject={onStopProject}
+            onCloseProject={onCloseProject}
+            onFreeMemoryProject={onFreeMemoryProject}
+            onLocateProject={onLocateProject}
+            onMoveOrRenameProject={onMoveOrRenameProject}
+            onTogglePinProject={onTogglePinProject}
+            onCopyPath={onCopyPath}
+            onSelectNewWindow={onSelectNewWindow}
+            onHoverProject={onHoverProject}
+            onHoverProjectEnd={onHoverProjectEnd}
+          />
+        )}
       </div>
     );
   };
@@ -668,7 +742,10 @@ function ProjectListContent({
               data-testid="project-empty-state"
             >
               {query.trim() ? (
-                <div>{`No projects match "${query}"`}</div>
+                // "Workspaces", not "projects": scratches are ranked into this
+                // same list now, so naming only half of what was searched would
+                // read as a scratch still being findable somewhere else.
+                <div>{`No workspaces match "${query}"`}</div>
               ) : canAddProject ? (
                 // Names the button sitting directly below this list.
                 "Add a project to get started"
@@ -839,6 +916,13 @@ type ScratchEditorState =
 
 interface ScratchSectionProps {
   scratches: SearchableScratch[];
+  /**
+   * True once a query is active, where the ranked list owns the scratches. The
+   * section hides rather than unmounting: remounting would reset `collapsed`,
+   * so a section the user deliberately collapsed would spring back open the
+   * moment they cleared the box.
+   */
+  isSearching: boolean;
   onCreate?: (name?: string) => void;
   onSelect?: (scratch: SearchableScratch) => void;
   onRemove?: (scratchId: string) => void;
@@ -848,15 +932,17 @@ interface ScratchSectionProps {
 }
 
 /**
- * Collapsible "Scratch" section. Defaults to collapsed when there are no
- * scratches yet — discoverable but quiet. Once the user has scratches,
- * defaults to expanded.
+ * Collapsible "Scratch" section, rendered in browse only — searching ranks
+ * scratches into the main list instead (#11466). Defaults to collapsed when
+ * there are no scratches yet — discoverable but quiet. Once the user has
+ * scratches, defaults to expanded.
  *
  * Sort order is purely by `lastOpened` desc (the hook already does this).
  * Scratches deliberately do NOT participate in the project frecency ranking.
  */
 function ScratchSection({
   scratches,
+  isSearching,
   onCreate,
   onSelect,
   onRemove,
@@ -896,6 +982,13 @@ function ScratchSection({
     }
   }, [editor, scratches]);
 
+  // Searching hides this section, and a hidden editor is worse than a closed
+  // one: it still holds its claim on the escape stack, so Escape would cancel
+  // an edit nobody can see instead of closing the palette.
+  useEffect(() => {
+    if (isSearching) setEditor(null);
+  }, [isSearching]);
+
   const closeEditor = useCallback(() => setEditor(null), []);
 
   const handleCreateCommit = useCallback(
@@ -919,7 +1012,7 @@ function ScratchSection({
   const isCreating = editor?.kind === "create";
 
   return (
-    <div className="px-2 py-1.5">
+    <div className="px-2 py-1.5" hidden={isSearching}>
       {/*
        * The trigger stays mounted at zero scratches — only the menu content is
        * conditional. Swapping the button in and out of a ContextMenu as the last
@@ -1092,12 +1185,24 @@ function ScratchSection({
   );
 }
 
-function ProjectSwitcherFooter({ mode }: { mode?: ProjectSwitcherMode }) {
+/**
+ * Both shortcuts here are project-only, so a highlighted scratch row drops them
+ * rather than naming keys that do nothing on it: ⌘↵ falls back to a plain switch
+ * and ⌘⌫ is inert.
+ */
+function ProjectSwitcherFooter({
+  mode,
+  isScratchSelected,
+}: {
+  mode?: ProjectSwitcherMode;
+  isScratchSelected: boolean;
+}) {
   const modifiers = useModifierKeys();
 
-  const hint = modifiers.meta
-    ? { keys: "⌘↵", label: "New window" }
-    : { keys: "↵", label: "Switch" };
+  const hint =
+    modifiers.meta && !isScratchSelected
+      ? { keys: "⌘↵", label: "New window" }
+      : { keys: "↵", label: "Switch" };
 
   return (
     <div className="w-full flex items-center justify-between">
@@ -1106,7 +1211,7 @@ function ProjectSwitcherFooter({ mode }: { mode?: ProjectSwitcherMode }) {
           <kbd className={KBD_CLASS}>{hint.keys}</kbd>
           <span className="ml-1.5">{hint.label}</span>
         </span>
-        {mode !== "modal" && (
+        {mode !== "modal" && !isScratchSelected && (
           <span className="text-daintree-text/50">
             <kbd className={KBD_CLASS}>⌘⌫</kbd>
             <span className="ml-1.5">Remove</span>
@@ -1127,11 +1232,11 @@ interface ProjectPaletteInnerProps {
   inputRef: React.RefObject<HTMLInputElement | null>;
   listRef: React.RefObject<HTMLDivElement | null>;
   query: string;
-  results: SearchableProject[];
+  results: ProjectSwitcherRow[];
   selectedIndex: number;
   mode?: ProjectSwitcherMode;
   onQueryChange: (query: string) => void;
-  onSelect: (project: SearchableProject) => void;
+  onSelect: (row: ProjectSwitcherRow) => void;
   onSelectNewWindow?: (project: SearchableProject) => void;
   onClose: () => void;
   onSelectPrevious: () => void;
@@ -1223,9 +1328,12 @@ function ProjectPaletteInner({
           e.stopPropagation();
           if (results.length > 0 && selectedIndex >= 0 && selectedIndex < results.length) {
             const selected = results[selectedIndex]!;
+            // A scratch has no second window to open, so ⌘↵ falls through to
+            // the plain switch rather than swallowing the keypress.
             if (
               (e.metaKey || e.ctrlKey) &&
               onSelectNewWindow &&
+              selected.kind === "project" &&
               !selected.isActive &&
               !selected.isMissing
             ) {
@@ -1240,19 +1348,18 @@ function ProjectPaletteInner({
           e.stopPropagation();
           onClose();
           break;
-        case "Backspace":
-          if (
-            (e.metaKey || e.ctrlKey) &&
-            onCloseProject &&
-            results.length > 0 &&
-            selectedIndex >= 0 &&
-            selectedIndex < results.length
-          ) {
+        case "Backspace": {
+          // Projects only. Removing a project opens a confirm; deleting a
+          // scratch does not, so wiring this to a highlighted scratch row would
+          // put an unconfirmed destructive action one chord away.
+          const target = results[selectedIndex];
+          if ((e.metaKey || e.ctrlKey) && onCloseProject && target?.kind === "project") {
             e.preventDefault();
             e.stopPropagation();
-            onCloseProject(results[selectedIndex]!.id);
+            onCloseProject(target.id);
           }
           break;
+        }
       }
     },
     [
@@ -1269,6 +1376,7 @@ function ProjectPaletteInner({
 
   const activeResult = results[selectedIndex];
   const activeDescendant = activeResult ? `project-option-${activeResult.id}` : undefined;
+  const isSearching = query.trim().length > 0;
 
   return (
     <>
@@ -1321,9 +1429,10 @@ function ProjectPaletteInner({
         />
         {(onCreateScratch || (scratchResults && scratchResults.length > 0)) && (
           <>
-            <div className="h-[3px] bg-tint/[0.08]" />
+            <div className="h-[3px] bg-tint/[0.08]" hidden={isSearching} />
             <ScratchSection
               scratches={scratchResults ?? []}
+              isSearching={isSearching}
               onCreate={onCreateScratch}
               onSelect={onSelectScratch}
               onRemove={onRemoveScratch}
@@ -1396,7 +1505,7 @@ function ProjectPaletteInner({
       )}
 
       <AppPaletteDialog.Footer>
-        <ProjectSwitcherFooter mode={mode} />
+        <ProjectSwitcherFooter mode={mode} isScratchSelected={activeResult?.kind === "scratch"} />
       </AppPaletteDialog.Footer>
     </>
   );

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -132,6 +132,12 @@ export interface ProjectSwitcherPaletteProps {
   onConfirmFreeMemory?: () => void;
   isFreeingMemory?: boolean;
   /** Scratch (one-off agent workspace) results — rendered in their own collapsible section. */
+  /**
+   * True while `results` is the ranked list carrying the scratches, so the
+   * pinned section below can stand down. Trails the query by a commit; defaults
+   * to the live query for callers that don't track it.
+   */
+  rankedSearch?: boolean;
   scratchResults?: SearchableScratch[];
   /** Callback to create and switch to a new scratch. A blank name takes the default. */
   onCreateScratch?: (name?: string) => void;
@@ -734,7 +740,7 @@ function ProjectListContent({
 
   return (
     <>
-      <div ref={listRef} id="project-list" role="listbox" aria-label="Projects">
+      <div ref={listRef} id="project-list" role="listbox" aria-label="Workspaces">
         {results.length === 0 ? (
           <div className="p-2">
             <div
@@ -1186,9 +1192,9 @@ function ScratchSection({
 }
 
 /**
- * Both shortcuts here are project-only, so a highlighted scratch row drops them
- * rather than naming keys that do nothing on it: ⌘↵ falls back to a plain switch
- * and ⌘⌫ is inert.
+ * Every hint here is project-only, so a highlighted scratch row drops them
+ * rather than naming affordances it doesn't have: ⌘↵ falls back to a plain
+ * switch, ⌘⌫ is inert, and a search-mode scratch row carries no context menu.
  */
 function ProjectSwitcherFooter({
   mode,
@@ -1218,9 +1224,11 @@ function ProjectSwitcherFooter({
           </span>
         )}
       </div>
-      <span className="text-daintree-text/50">
-        <span>Right-click for more</span>
-      </span>
+      {!isScratchSelected && (
+        <span className="text-daintree-text/50">
+          <span>Right-click for more</span>
+        </span>
+      )}
     </div>
   );
 }
@@ -1254,6 +1262,12 @@ interface ProjectPaletteInnerProps {
   onCopyPath?: (path: string) => void;
   onHoverProject?: (projectId: string, pointerType: string) => void;
   onHoverProjectEnd?: (pointerType: string) => void;
+  /**
+   * True while `results` is the ranked list carrying the scratches, so the
+   * pinned section below can stand down. Trails the query by a commit; defaults
+   * to the live query for callers that don't track it.
+   */
+  rankedSearch?: boolean;
   scratchResults?: SearchableScratch[];
   onCreateScratch?: (name?: string) => void;
   onSelectScratch?: (scratch: SearchableScratch) => void;
@@ -1289,6 +1303,7 @@ function ProjectPaletteInner({
   onCopyPath,
   onHoverProject,
   onHoverProjectEnd,
+  rankedSearch,
   scratchResults,
   onCreateScratch,
   onSelectScratch,
@@ -1376,7 +1391,11 @@ function ProjectPaletteInner({
 
   const activeResult = results[selectedIndex];
   const activeDescendant = activeResult ? `project-option-${activeResult.id}` : undefined;
-  const isSearching = query.trim().length > 0;
+  // The RANKED list owns the scratches, and it trails the box by a commit.
+  // Hiding the pinned section on the live query instead would blank them for
+  // that frame — and for a user whose only workspaces are scratches, that frame
+  // reads as "no matches".
+  const isRankedSearch = rankedSearch ?? query.trim().length > 0;
 
   return (
     <>
@@ -1391,11 +1410,11 @@ function ProjectPaletteInner({
           value={query}
           onChange={(e) => onQueryChange(e.target.value)}
           onKeyDown={handleKeyDown}
-          placeholder="Search projects…"
+          placeholder="Search workspaces…"
           role="combobox"
           aria-expanded={true}
           aria-haspopup="listbox"
-          aria-label="Search projects"
+          aria-label="Search workspaces"
           aria-controls="project-list"
           aria-activedescendant={activeDescendant}
         />
@@ -1404,7 +1423,7 @@ function ProjectPaletteInner({
       <AppPaletteDialog.Body
         maxHeight={PALETTE_MAX_HEIGHT}
         className="p-0"
-        ariaLabel="Projects"
+        ariaLabel="Workspaces"
         activeDescendant={activeDescendant}
         onNavigationKeyDown={handleKeyDown}
       >
@@ -1429,10 +1448,10 @@ function ProjectPaletteInner({
         />
         {(onCreateScratch || (scratchResults && scratchResults.length > 0)) && (
           <>
-            <div className="h-[3px] bg-tint/[0.08]" hidden={isSearching} />
+            <div className="h-[3px] bg-tint/[0.08]" hidden={isRankedSearch} />
             <ScratchSection
               scratches={scratchResults ?? []}
-              isSearching={isSearching}
+              isSearching={isRankedSearch}
               onCreate={onCreateScratch}
               onSelect={onSelectScratch}
               onRemove={onRemoveScratch}
@@ -1554,6 +1573,7 @@ function ModalContent({
         onSelectNewWindow={innerProps.onSelectNewWindow}
         onHoverProject={innerProps.onHoverProject}
         onHoverProjectEnd={innerProps.onHoverProjectEnd}
+        rankedSearch={innerProps.rankedSearch}
         scratchResults={innerProps.scratchResults}
         onCreateScratch={innerProps.onCreateScratch}
         onSelectScratch={innerProps.onSelectScratch}
@@ -1661,6 +1681,7 @@ function DropdownContent({
           onSelectNewWindow={innerProps.onSelectNewWindow}
           onHoverProject={innerProps.onHoverProject}
           onHoverProjectEnd={innerProps.onHoverProjectEnd}
+          rankedSearch={innerProps.rankedSearch}
           scratchResults={innerProps.scratchResults}
           onCreateScratch={innerProps.onCreateScratch}
           onSelectScratch={innerProps.onSelectScratch}
@@ -1710,6 +1731,7 @@ export function ProjectSwitcherPalette({
   onFreeMemoryConfirmClose,
   onConfirmFreeMemory,
   isFreeingMemory = false,
+  rankedSearch,
   scratchResults,
   onCreateScratch,
   onSelectScratch,
@@ -1761,6 +1783,7 @@ export function ProjectSwitcherPalette({
         onOpenProjectSettings={onOpenProjectSettings}
         onDropdownCloseAutoFocus={onDropdownCloseAutoFocus}
         dropdownAlign={dropdownAlign}
+        rankedSearch={rankedSearch}
         scratchResults={scratchResults}
         onCreateScratch={onCreateScratch}
         onSelectScratch={onSelectScratch}
@@ -1797,6 +1820,7 @@ export function ProjectSwitcherPalette({
         onHoverProject={onHoverProject}
         onHoverProjectEnd={onHoverProjectEnd}
         onOpenProjectSettings={onOpenProjectSettings}
+        rankedSearch={rankedSearch}
         scratchResults={scratchResults}
         onCreateScratch={onCreateScratch}
         onSelectScratch={onSelectScratch}

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
@@ -150,12 +150,18 @@ vi.mock("@/utils/timeAgo", () => ({
   formatTimeAgo: () => "2h ago",
 }));
 
-import type { SearchableProject } from "@/hooks/useProjectSwitcherPalette";
+import type {
+  ProjectSwitcherProjectRow,
+  ProjectSwitcherRow,
+  ProjectSwitcherScratchRow,
+  SearchableProject,
+} from "@/hooks/useProjectSwitcherPalette";
 
 const { ProjectSwitcherPalette } = await import("../ProjectSwitcherPalette");
 
-function makeProject(overrides: Partial<SearchableProject> = {}): SearchableProject {
+function makeProject(overrides: Partial<SearchableProject> = {}): ProjectSwitcherProjectRow {
   return {
+    kind: "project",
     id: "proj-1",
     name: "Test Project",
     path: "/tmp/test",
@@ -417,7 +423,7 @@ describe("ProjectSwitcherPalette active descendant", () => {
   });
 
   it("Enter selects the project the active descendant points at", () => {
-    const onSelect = vi.fn<(project: SearchableProject) => void>();
+    const onSelect = vi.fn<(row: ProjectSwitcherRow) => void>();
     render(<ProjectSwitcherPalette {...mixedProps} selectedIndex={1} onSelect={onSelect} />);
 
     const input = screen.getByTestId("palette-input");
@@ -431,5 +437,78 @@ describe("ProjectSwitcherPalette active descendant", () => {
     // so this only holds if the highlighted option is really in the DOM.
     expect(activeOption).not.toBeNull();
     expect(activeOption!.textContent).toContain(selectedProject.name);
+  });
+});
+
+/**
+ * Keyboard behaviour on a highlighted scratch row (issue #11466).
+ *
+ * A scratch reached the arrow-key domain, so the two project-only chords have to
+ * stop assuming every row they land on is a project.
+ */
+describe("ProjectSwitcherPalette keyboard on a scratch row", () => {
+  const scratchRow: ProjectSwitcherScratchRow = {
+    kind: "scratch",
+    id: "s1",
+    name: "Spike notes",
+    path: "/userData/scratch/s1",
+    createdAt: 0,
+    lastOpened: 0,
+    isActive: false,
+  };
+
+  const scratchProps = {
+    isOpen: true,
+    query: "spike",
+    results: [scratchRow],
+    selectedIndex: 0,
+    onQueryChange: vi.fn(),
+    onSelectPrevious: vi.fn(),
+    onSelectNext: vi.fn(),
+    onSelect: vi.fn(),
+    onClose: vi.fn(),
+    mode: "modal" as const,
+  };
+
+  beforeEach(() => {
+    scratchProps.onSelect.mockClear();
+  });
+
+  it("commits the scratch on Enter", () => {
+    render(<ProjectSwitcherPalette {...scratchProps} />);
+    fireEvent.keyDown(screen.getByTestId("palette-input"), { key: "Enter" });
+
+    expect(scratchProps.onSelect).toHaveBeenCalledWith(scratchRow);
+  });
+
+  it("falls back to a plain switch on Meta+Enter instead of swallowing it", () => {
+    // A scratch has no second window to open, so the chord must not become a
+    // keypress that does nothing.
+    const onSelectNewWindow = vi.fn();
+    render(<ProjectSwitcherPalette {...scratchProps} onSelectNewWindow={onSelectNewWindow} />);
+    fireEvent.keyDown(screen.getByTestId("palette-input"), { key: "Enter", metaKey: true });
+
+    expect(onSelectNewWindow).not.toHaveBeenCalled();
+    expect(scratchProps.onSelect).toHaveBeenCalledWith(scratchRow);
+  });
+
+  it("leaves Meta+Backspace inert rather than removing by scratch id", () => {
+    // onCloseProject removes a PROJECT. Handing it a scratch id would delete
+    // the wrong thing, and scratch deletion has no confirm to catch it.
+    const onCloseProject = vi.fn();
+    render(<ProjectSwitcherPalette {...scratchProps} onCloseProject={onCloseProject} />);
+    fireEvent.keyDown(screen.getByTestId("palette-input"), { key: "Backspace", metaKey: true });
+
+    expect(onCloseProject).not.toHaveBeenCalled();
+  });
+
+  it("resolves the active descendant to the scratch row on screen", () => {
+    render(<ProjectSwitcherPalette {...scratchProps} />);
+    const activeDescendant = screen
+      .getByTestId("palette-input")
+      .getAttribute("aria-activedescendant");
+
+    expect(activeDescendant).toBe("project-option-s1");
+    expect(document.getElementById(activeDescendant!)).not.toBeNull();
   });
 });

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -420,7 +420,7 @@ describe("ProjectSwitcherPalette modal mode", () => {
   // selection on a row that was never in the DOM (#11071).
   it("renders every supplied result as an option in modal mode", () => {
     render(<ProjectSwitcherPalette {...modalProps} results={multiProjects} />);
-    const list = screen.getByRole("listbox", { name: "Projects" });
+    const list = screen.getByRole("listbox", { name: "Workspaces" });
     const options = within(list).getAllByRole("option");
 
     expect(options).toHaveLength(multiProjects.length);
@@ -482,7 +482,7 @@ describe("ProjectSwitcherPalette modal mode", () => {
 
   it("prints each band header in the order the results arrive", () => {
     render(<ProjectSwitcherPalette {...dropdownProps} results={multiProjects} />);
-    const list = screen.getByRole("listbox", { name: "Projects" });
+    const list = screen.getByRole("listbox", { name: "Workspaces" });
     const headers = Array.from(list.querySelectorAll("div"))
       .map((el) => el.textContent?.trim())
       .filter(
@@ -596,17 +596,24 @@ describe("ProjectSwitcherPalette scratch search rows", () => {
     onSelectScratch: vi.fn(),
   };
 
-  it("gives a scratch row the option id the active descendant resolves against", () => {
+  it("puts a scratch row in the same listbox the input drives, addressed by the same id scheme", () => {
+    const project = makeProject({ id: "p1", name: "Spike Project" });
     const scratch = makeScratchRow({ id: "s1", name: "Spike notes" });
-    render(<ProjectSwitcherPalette {...searchProps} results={[scratch]} selectedIndex={0} />);
-
-    const row = screen.getByRole("option", { name: /Spike notes/ });
-    // The palette points aria-activedescendant at this exact id, so a row that
-    // named itself anything else would leave the highlight unresolvable.
-    expect(row.getAttribute("id")).toBe(`project-option-${scratch.id}`);
-    expect(screen.getByTestId("palette-input").getAttribute("aria-activedescendant")).toBe(
-      row.getAttribute("id")
+    render(
+      <ProjectSwitcherPalette {...searchProps} results={[project, scratch]} selectedIndex={1} />
     );
+
+    // The whole fix rests on one array in one listbox: the row the input's
+    // active descendant names must resolve INSIDE the listbox it controls, or
+    // the highlight is addressing something the arrow keys don't walk (#11071).
+    const input = screen.getByTestId("palette-input");
+    const listbox = document.getElementById(input.getAttribute("aria-controls")!)!;
+    const active = document.getElementById(input.getAttribute("aria-activedescendant")!);
+
+    expect(active).not.toBeNull();
+    expect(listbox.contains(active)).toBe(true);
+    expect(active!.textContent).toContain("Spike notes");
+    expect(within(listbox).getAllByRole("option")).toHaveLength(2);
   });
 
   it("marks the highlighted row selected rather than the active workspace", () => {
@@ -632,9 +639,9 @@ describe("ProjectSwitcherPalette scratch search rows", () => {
       />
     );
 
-    const row = screen.getByRole("option", { name: /Spike notes/ });
-    expect(row.tagName).not.toBe("BUTTON");
-    expect(row.hasAttribute("tabindex")).toBe(false);
+    // The behavioural contract, not the tag: a focusable row would take a Tab
+    // stop away from the pinned section and split the arrow-key domain.
+    expect(screen.getByRole("option", { name: /Spike notes/ }).tabIndex).toBe(-1);
   });
 
   it("names the row's origin without spending the accent on it", () => {
@@ -716,9 +723,11 @@ describe("ProjectSwitcherPalette scratch search rows", () => {
   it("names both kinds in the empty state now that both were searched", () => {
     render(<ProjectSwitcherPalette {...searchProps} results={[]} />);
 
-    const copy = screen.getByTestId("project-empty-state").textContent ?? "";
-    expect(copy).toContain("spike");
-    expect(copy).not.toContain("No projects match");
+    // Positively: the umbrella term, not merely the absence of the old copy —
+    // "No bananas match spike" would satisfy a negative-only assertion.
+    expect(screen.getByTestId("project-empty-state").textContent).toBe(
+      'No workspaces match "spike"'
+    );
   });
 
   it("drops the project-only shortcut hints while a scratch is highlighted", () => {
@@ -737,5 +746,80 @@ describe("ProjectSwitcherPalette scratch search rows", () => {
     // ⌘⌫ removes a project and does nothing to a scratch, so advertising it
     // here would name a key that has no effect on the highlighted row.
     expect(screen.getByTestId("palette-footer").textContent).not.toContain("Remove");
+  });
+});
+
+/**
+ * The pinned scratch section across a search round-trip (issue #11466).
+ *
+ * Hiding rather than unmounting keeps the section's own state alive, which is
+ * the point — and also the risk, since a hidden subtree's effects and escape
+ * claims keep running.
+ */
+describe("ProjectSwitcherPalette scratch section across search", () => {
+  const scratch = {
+    id: "s1",
+    name: "Spike notes",
+    path: "/userData/scratch/s1",
+    createdAt: 0,
+    lastOpened: 0,
+    isActive: false,
+  };
+
+  const browseProps = {
+    ...dropdownProps,
+    query: "",
+    results: [],
+    scratchResults: [scratch],
+    onCreateScratch: vi.fn(),
+    onRenameScratch: vi.fn(),
+  };
+
+  it("closes an open create editor when the ranked search takes over", () => {
+    const { rerender } = render(<ProjectSwitcherPalette {...browseProps} />);
+    fireEvent.click(screen.getByTestId("scratch-create-button"));
+    expect(screen.getByTestId("scratch-create-input")).toBeTruthy();
+
+    rerender(<ProjectSwitcherPalette {...browseProps} query="spike" rankedSearch />);
+
+    // Left mounted, the editor keeps its claim on the escape stack — Escape
+    // would cancel an edit nobody can see instead of closing the palette.
+    expect(screen.queryByTestId("scratch-create-input")).toBeNull();
+  });
+
+  it("does not resurrect the editor when the query is cleared again", () => {
+    const { rerender } = render(<ProjectSwitcherPalette {...browseProps} />);
+    fireEvent.click(screen.getByTestId("scratch-create-button"));
+
+    rerender(<ProjectSwitcherPalette {...browseProps} query="spike" rankedSearch />);
+    rerender(<ProjectSwitcherPalette {...browseProps} />);
+
+    expect(screen.queryByTestId("scratch-create-input")).toBeNull();
+    expect(screen.getByTestId("scratch-create-button")).toBeTruthy();
+  });
+
+  it("keeps a collapsed section collapsed across a search round-trip", () => {
+    const { rerender } = render(<ProjectSwitcherPalette {...browseProps} />);
+    const header = screen.getByRole("button", { name: /Scratch/ });
+    fireEvent.click(header);
+    expect(header.getAttribute("aria-expanded")).toBe("false");
+
+    rerender(<ProjectSwitcherPalette {...browseProps} query="spike" rankedSearch />);
+    rerender(<ProjectSwitcherPalette {...browseProps} />);
+
+    // Unmounting instead would reseed `collapsed` from the scratch count and
+    // spring the section back open under a user who deliberately shut it.
+    expect(screen.getByRole("button", { name: /Scratch/ }).getAttribute("aria-expanded")).toBe(
+      "false"
+    );
+  });
+
+  it("keeps the section visible while the ranking is still catching up", () => {
+    // A non-empty box whose ranked results have not landed yet: the scratches
+    // are not in `results`, so hiding the section here would leave them in
+    // neither list and read as "no matches".
+    render(<ProjectSwitcherPalette {...browseProps} query="spike" rankedSearch={false} />);
+
+    expect(screen.queryByRole("listbox", { name: "Scratch workspaces" })).toBeTruthy();
   });
 });

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -123,17 +123,22 @@ vi.mock("@/utils/timeAgo", () => ({
   formatTimeAgo: (ts: number) => `${Math.round((Date.now() - ts) / 3600000)}h ago`,
 }));
 
-import type { SearchableProject } from "@/hooks/useProjectSwitcherPalette";
+import type {
+  ProjectSwitcherProjectRow,
+  ProjectSwitcherScratchRow,
+  SearchableProject,
+} from "@/hooks/useProjectSwitcherPalette";
 
 const { ProjectSwitcherPalette } = await import("../ProjectSwitcherPalette");
 
-function makeProject(overrides: Partial<SearchableProject> = {}): SearchableProject {
+function makeProject(overrides: Partial<SearchableProject> = {}): ProjectSwitcherProjectRow {
   // Deliberately dumb: `section` defaults to "other" and must be stated
   // explicitly by band tests. Deriving it here would restate the hook's
   // classification rules, so a fixture could keep rendering the intended bands
   // while the real `sectionForProject` drifted — the component tests would stay
   // green either way. Classification is owned by the hook's own suite.
   return {
+    kind: "project",
     id: "proj-1",
     name: "Test Project",
     path: "/tmp/test",
@@ -559,5 +564,178 @@ describe("ProjectSwitcherPalette modal mode", () => {
     expect(screen.getByText("Pinned Project")).toBeTruthy();
     expect(screen.getByText("Recent Project")).toBeTruthy();
     expect(screen.getByText("Old Project")).toBeTruthy();
+  });
+});
+
+/**
+ * Scratches in the ranked search list (issue #11466).
+ *
+ * The hook decides membership; what the component owes is that a scratch row
+ * joins the SAME listbox and roving-selection domain the project rows use, that
+ * the pinned browse section stops competing with it, and that nothing on screen
+ * still claims the search covered projects only.
+ */
+describe("ProjectSwitcherPalette scratch search rows", () => {
+  function makeScratchRow(
+    overrides: Partial<ProjectSwitcherScratchRow> & { id: string; name: string }
+  ): ProjectSwitcherScratchRow {
+    return {
+      kind: "scratch",
+      path: `/userData/scratch/${overrides.id}`,
+      createdAt: 0,
+      lastOpened: 0,
+      isActive: false,
+      ...overrides,
+    };
+  }
+
+  const searchProps = {
+    ...dropdownProps,
+    query: "spike",
+    onCreateScratch: vi.fn(),
+    onSelectScratch: vi.fn(),
+  };
+
+  it("gives a scratch row the option id the active descendant resolves against", () => {
+    const scratch = makeScratchRow({ id: "s1", name: "Spike notes" });
+    render(<ProjectSwitcherPalette {...searchProps} results={[scratch]} selectedIndex={0} />);
+
+    const row = screen.getByRole("option", { name: /Spike notes/ });
+    // The palette points aria-activedescendant at this exact id, so a row that
+    // named itself anything else would leave the highlight unresolvable.
+    expect(row.getAttribute("id")).toBe(`project-option-${scratch.id}`);
+    expect(screen.getByTestId("palette-input").getAttribute("aria-activedescendant")).toBe(
+      row.getAttribute("id")
+    );
+  });
+
+  it("marks the highlighted row selected rather than the active workspace", () => {
+    const rows = [
+      makeScratchRow({ id: "s1", name: "Spike one" }),
+      makeScratchRow({ id: "s2", name: "Spike two", isActive: true }),
+    ];
+    render(<ProjectSwitcherPalette {...searchProps} results={rows} selectedIndex={0} />);
+
+    expect(screen.getByRole("option", { name: /Spike one/ }).getAttribute("aria-selected")).toBe(
+      "true"
+    );
+    expect(screen.getByRole("option", { name: /Spike two/ }).getAttribute("aria-selected")).toBe(
+      "false"
+    );
+  });
+
+  it("keeps a scratch row out of the tab order so the arrow keys stay in charge", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...searchProps}
+        results={[makeScratchRow({ id: "s1", name: "Spike notes" })]}
+      />
+    );
+
+    const row = screen.getByRole("option", { name: /Spike notes/ });
+    expect(row.tagName).not.toBe("BUTTON");
+    expect(row.hasAttribute("tabindex")).toBe(false);
+  });
+
+  it("names the row's origin without spending the accent on it", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...searchProps}
+        results={[makeScratchRow({ id: "s1", name: "Spike notes" })]}
+      />
+    );
+
+    const row = screen.getByRole("option", { name: /Spike notes/ });
+    expect(row.textContent).toContain("Scratch");
+  });
+
+  it("commits a scratch row through the same select handler as a project row", () => {
+    const onSelect = vi.fn();
+    const scratch = makeScratchRow({ id: "s1", name: "Spike notes" });
+    render(<ProjectSwitcherPalette {...searchProps} results={[scratch]} onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByRole("option", { name: /Spike notes/ }));
+
+    expect(onSelect).toHaveBeenCalledWith(scratch);
+  });
+
+  it("hides the pinned scratch section while searching so rows are listed once", () => {
+    const scratch = makeScratchRow({ id: "s1", name: "Spike notes" });
+    const { rerender } = render(
+      <ProjectSwitcherPalette
+        {...dropdownProps}
+        query=""
+        results={[]}
+        scratchResults={[scratch]}
+        onCreateScratch={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole("listbox", { name: "Scratch workspaces" })).toBeTruthy();
+
+    rerender(
+      <ProjectSwitcherPalette
+        {...dropdownProps}
+        query="spike"
+        results={[scratch]}
+        scratchResults={[scratch]}
+        onCreateScratch={vi.fn()}
+      />
+    );
+
+    // Hidden, not unmounted — remounting would reset the collapse state the
+    // user set. Either way it must be gone from the accessibility tree, or the
+    // same scratch would be announced twice.
+    expect(screen.queryByRole("listbox", { name: "Scratch workspaces" })).toBeNull();
+    expect(screen.getAllByRole("option")).toHaveLength(1);
+  });
+
+  it("restores the pinned scratch section when the query is cleared", () => {
+    const scratch = makeScratchRow({ id: "s1", name: "Spike notes" });
+    const { rerender } = render(
+      <ProjectSwitcherPalette
+        {...dropdownProps}
+        query="spike"
+        results={[scratch]}
+        scratchResults={[scratch]}
+        onCreateScratch={vi.fn()}
+      />
+    );
+    rerender(
+      <ProjectSwitcherPalette
+        {...dropdownProps}
+        query=""
+        results={[]}
+        scratchResults={[scratch]}
+        onCreateScratch={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByRole("listbox", { name: "Scratch workspaces" })).toBeTruthy();
+  });
+
+  it("names both kinds in the empty state now that both were searched", () => {
+    render(<ProjectSwitcherPalette {...searchProps} results={[]} />);
+
+    const copy = screen.getByTestId("project-empty-state").textContent ?? "";
+    expect(copy).toContain("spike");
+    expect(copy).not.toContain("No projects match");
+  });
+
+  it("drops the project-only shortcut hints while a scratch is highlighted", () => {
+    const { rerender } = render(
+      <ProjectSwitcherPalette {...searchProps} results={[makeProject({ id: "p1" })]} />
+    );
+    expect(screen.getByTestId("palette-footer").textContent).toContain("Remove");
+
+    rerender(
+      <ProjectSwitcherPalette
+        {...searchProps}
+        results={[makeScratchRow({ id: "s1", name: "Spike notes" })]}
+      />
+    );
+
+    // ⌘⌫ removes a project and does nothing to a scratch, so advertising it
+    // here would name a key that has no effect on the highlighted row.
+    expect(screen.getByTestId("palette-footer").textContent).not.toContain("Remove");
   });
 });

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.sortControl.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.sortControl.test.tsx
@@ -107,7 +107,10 @@ vi.mock("@/utils/timeAgo", () => ({
   formatTimeAgo: () => "1h ago",
 }));
 
-import type { SearchableProject } from "@/hooks/useProjectSwitcherPalette";
+import type {
+  ProjectSwitcherProjectRow,
+  SearchableProject,
+} from "@/hooks/useProjectSwitcherPalette";
 import { usePreferencesStore } from "@/store/preferencesStore";
 import { DEFAULT_OTHER_PROJECTS_SORT_MODE, type OtherProjectsSortMode } from "@/lib/projectSort";
 import { primeRadix } from "@/components/ui/radix-loader";
@@ -124,8 +127,11 @@ beforeEach(() => {
   usePreferencesStore.getState().setProjectSwitcherOtherSortMode(DEFAULT_OTHER_PROJECTS_SORT_MODE);
 });
 
-function makeProject(overrides: Partial<SearchableProject> & { id: string }): SearchableProject {
+function makeProject(
+  overrides: Partial<SearchableProject> & { id: string }
+): ProjectSwitcherProjectRow {
   return {
+    kind: "project",
     name: overrides.id,
     path: `/repo/${overrides.id}`,
     emoji: "🌲",
@@ -144,7 +150,7 @@ function makeProject(overrides: Partial<SearchableProject> & { id: string }): Se
     processCount: 0,
     displayPath: `/repo/${overrides.id}`,
     ...overrides,
-  } as SearchableProject;
+  } as ProjectSwitcherProjectRow;
 }
 
 function renderPalette(otherRows: number) {

--- a/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
@@ -696,3 +696,91 @@ describe("deleteAllScratches", () => {
     expect(result.current.deleteAllScratchesConfirm).toHaveLength(seeded.length);
   });
 });
+
+/**
+ * Scratches in switcher search (issue #11466).
+ *
+ * Browse leaves them to the pinned section; a query pulls them into the one
+ * array the palette renders, indexes and walks — so a name typed in full is
+ * reachable by arrow key and committable with Enter, which it never was while
+ * they lived in their own nested listbox.
+ *
+ * The project pool is empty throughout: what these specs pin is membership,
+ * navigation and dispatch. Relative ordering against projects is the ranker's
+ * own contract, covered in `src/lib/__tests__/projectSwitcherSearch.test.ts`.
+ */
+describe("scratches in search results", () => {
+  it("keeps scratches out of the results array while browsing", async () => {
+    seedScratches(2);
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    expect(result.current.results).toEqual([]);
+    // Still listed for the pinned browse section, just not as ranked rows.
+    expect(result.current.scratchResults).toHaveLength(2);
+  });
+
+  it("ranks matching scratches into the results array once a query is active", async () => {
+    seedScratches(2);
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    act(() => result.current.setQuery("Spike 2"));
+
+    await waitFor(() => {
+      expect(result.current.results.map((row) => row.id)).toEqual(["scratch-2"]);
+    });
+    expect(result.current.results[0]!.kind).toBe("scratch");
+  });
+
+  it("drops scratches from the results array again when the query is cleared", async () => {
+    seedScratches(2);
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    act(() => result.current.setQuery("Spike"));
+    await waitFor(() => expect(result.current.results).toHaveLength(2));
+
+    act(() => result.current.setQuery(""));
+
+    await waitFor(() => expect(result.current.results).toEqual([]));
+  });
+
+  it("moves the selection across scratch rows with the arrow-key step", async () => {
+    seedScratches(2);
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    act(() => result.current.setQuery("Spike"));
+    await waitFor(() => expect(result.current.results).toHaveLength(2));
+
+    const first = result.current.results[result.current.selectedIndex]!.id;
+    act(() => result.current.selectNext());
+    const second = result.current.results[result.current.selectedIndex]!.id;
+
+    expect(second).not.toBe(first);
+    // The index must stay a valid address into the rendered array, never run
+    // past it — that is what strands a highlight off-screen (#11071).
+    expect(result.current.selectedIndex).toBeLessThan(result.current.results.length);
+  });
+
+  it("switches to the highlighted scratch on confirm rather than a project", async () => {
+    seedScratches(2);
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    // "Spike 2" is the inactive one, so a switch is genuinely dispatched.
+    act(() => result.current.setQuery("Spike 2"));
+    await waitFor(() => expect(result.current.results).toHaveLength(1));
+
+    act(() => result.current.confirmSelection());
+
+    await waitFor(() => expect(scratchState.switchScratch).toHaveBeenCalledWith("scratch-2"));
+    expect(useProjectStoreMock.getState().switchProject).not.toHaveBeenCalled();
+  });
+
+  it("matches a scratch on its name and not its generated folder path", async () => {
+    seedScratches(1);
+    const scratchPath = scratchState.scratches[0]!.path;
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    act(() => result.current.setQuery(scratchPath));
+
+    await waitFor(() => expect(result.current.results).toEqual([]));
+  });
+});

--- a/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
@@ -736,7 +736,12 @@ describe("scratches in search results", () => {
     const { result } = renderHook(() => useProjectSwitcherPalette());
 
     act(() => result.current.setQuery("Spike"));
-    await waitFor(() => expect(result.current.results).toHaveLength(2));
+    // Both scratches are present before AND after the deferred render settles,
+    // so a length check alone would not prove the ranking actually ran.
+    await waitFor(() => {
+      expect(result.current.isFiltering).toBe(false);
+      expect(result.current.results).toHaveLength(2);
+    });
 
     act(() => result.current.setQuery(""));
 
@@ -748,16 +753,54 @@ describe("scratches in search results", () => {
     const { result } = renderHook(() => useProjectSwitcherPalette());
 
     act(() => result.current.setQuery("Spike"));
-    await waitFor(() => expect(result.current.results).toHaveLength(2));
+    await waitFor(() => {
+      expect(result.current.isFiltering).toBe(false);
+      expect(result.current.results).toHaveLength(2);
+    });
 
     const first = result.current.results[result.current.selectedIndex]!.id;
     act(() => result.current.selectNext());
-    const second = result.current.results[result.current.selectedIndex]!.id;
 
-    expect(second).not.toBe(first);
-    // The index must stay a valid address into the rendered array, never run
-    // past it — that is what strands a highlight off-screen (#11071).
-    expect(result.current.selectedIndex).toBeLessThan(result.current.results.length);
+    expect(result.current.results[result.current.selectedIndex]!.id).not.toBe(first);
+  });
+
+  it("keeps ranked results in step with the scratch store under a settled query", async () => {
+    const seeded = seedScratches(2);
+    const { result, rerender } = renderHook(() => useProjectSwitcherPalette());
+
+    act(() => result.current.setQuery("Spike 2"));
+    await waitFor(() => expect(result.current.results.map((row) => row.id)).toEqual(["scratch-2"]));
+
+    // A `scratch:removed` push under an open, settled query. Without the store
+    // feeding the ranked list, the row would linger and Enter would commit a
+    // workspace that no longer exists.
+    scratchState.scratches = [seeded[0]!];
+    rerender();
+
+    await waitFor(() => expect(result.current.results).toEqual([]));
+  });
+
+  it("holds browse rows steady when only the scratches change", async () => {
+    seedScratches(2);
+    const { result, rerender } = renderHook(() => useProjectSwitcherPalette());
+
+    const before = result.current.results;
+    scratchState.scratches = [
+      ...scratchState.scratches,
+      {
+        id: "scratch-3",
+        name: "Spike 3",
+        path: "/tmp/scratches/scratch-3",
+        createdAt: 3_000,
+        lastOpened: 3_000,
+      },
+    ];
+    rerender();
+
+    // Browse ignores scratches, so its array must keep its identity — a fresh
+    // one sends the palette's scroll-into-view effect chasing the highlight
+    // while the user is reading the pinned section.
+    expect(result.current.results).toBe(before);
   });
 
   it("switches to the highlighted scratch on confirm rather than a project", async () => {

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -140,6 +140,22 @@ import {
   type OtherProjectsSortMode,
 } from "@/lib/projectSort";
 import { useProjectSwitcherPalette } from "../useProjectSwitcherPalette";
+import type { ProjectSwitcherProjectRow, ProjectSwitcherRow } from "../useProjectSwitcherPalette";
+
+/**
+ * Narrows a result row to a project, throwing if it isn't one.
+ *
+ * Search mixes scratches into `results` (#11466), so the project-only fields
+ * these specs read are no longer unconditionally present. Throwing rather than
+ * asserting keeps the failure honest: a spec that expected a project and got a
+ * scratch has found a real defect, not a typing inconvenience.
+ */
+function asProject(row: ProjectSwitcherRow | undefined): ProjectSwitcherProjectRow {
+  if (row?.kind !== "project") {
+    throw new Error(`expected a project row, got ${row?.kind ?? "nothing"}`);
+  }
+  return row;
+}
 
 function setOtherSortMode(mode: OtherProjectsSortMode): void {
   usePreferencesStore.getState().setProjectSwitcherOtherSortMode(mode);
@@ -213,8 +229,8 @@ describe("useProjectSwitcherPalette", () => {
 
     await waitFor(() => {
       expect(result.current.results).toHaveLength(1);
-      expect(result.current.results[0]?.activeAgentCount).toBe(0);
-      expect(result.current.results[0]?.waitingAgentCount).toBe(0);
+      expect(asProject(result.current.results[0]).activeAgentCount).toBe(0);
+      expect(asProject(result.current.results[0]).waitingAgentCount).toBe(0);
     });
   });
 
@@ -251,9 +267,9 @@ describe("useProjectSwitcherPalette", () => {
 
     await waitFor(() => {
       expect(result.current.results).toHaveLength(1);
-      expect(result.current.results[0]?.activeAgentCount).toBe(1);
-      expect(result.current.results[0]?.waitingAgentCount).toBe(1);
-      expect(result.current.results[0]?.processCount).toBe(3);
+      expect(asProject(result.current.results[0]).activeAgentCount).toBe(1);
+      expect(asProject(result.current.results[0]).waitingAgentCount).toBe(1);
+      expect(asProject(result.current.results[0]).processCount).toBe(3);
     });
   });
 
@@ -793,7 +809,7 @@ describe("useProjectSwitcherPalette", () => {
       });
 
       await waitFor(() => {
-        expect(result.current.results[0]?.processCount).toBe(2);
+        expect(asProject(result.current.results[0]).processCount).toBe(2);
       });
 
       await act(async () => {
@@ -1419,7 +1435,7 @@ describe("useProjectSwitcherPalette", () => {
       });
       // Nothing was absent, so nothing was written.
       expect(setStatsMock).not.toHaveBeenCalled();
-      expect(result.current.results[0]?.blockedAgentCount).toBe(2);
+      expect(asProject(result.current.results[0]).blockedAgentCount).toBe(2);
     });
 
     it("seeds a project the push store has no entry for", async () => {
@@ -1604,7 +1620,10 @@ describe("useProjectSwitcherPalette", () => {
       });
 
       const idsIn = (section: string) =>
-        result.current.results.filter((p) => p.section === section).map((p) => p.id);
+        result.current.results
+          .map(asProject)
+          .filter((p) => p.section === section)
+          .map((p) => p.id);
 
       // Blocked outranks a plain wait; a pin outranks recency; most agents
       // first; missing rows are alphabetical. None of these follow the mode.
@@ -1660,7 +1679,7 @@ describe("useProjectSwitcherPalette", () => {
       await waitFor(() => {
         expect(result.current.results[0]!.id).toBe("waiting");
       });
-      expect(result.current.results[0]!.section).toBe("attention");
+      expect(asProject(result.current.results[0]).section).toBe("attention");
 
       // The agent finishes: live state now puts this row in Other, but the
       // freeze keeps it where the user last saw it.
@@ -1670,7 +1689,7 @@ describe("useProjectSwitcherPalette", () => {
         };
         rerender();
       });
-      expect(result.current.results[0]!.section).toBe("attention");
+      expect(asProject(result.current.results[0]).section).toBe("attention");
 
       act(() => {
         setOtherSortMode("alphabetical");
@@ -1682,7 +1701,7 @@ describe("useProjectSwitcherPalette", () => {
       // Still first, still in Needs attention — the mode change reordered the
       // Other band only, and did not adopt live band membership wholesale.
       expect(result.current.results[0]!.id).toBe("waiting");
-      expect(result.current.results[0]!.section).toBe("attention");
+      expect(asProject(result.current.results[0]).section).toBe("attention");
       // The highlight reads the same frozen membership. Deciding it against
       // LIVE sections would see this row as Other and drag it into the reset.
       expect(result.current.results[result.current.selectedIndex]?.id).toBe("waiting");
@@ -1933,7 +1952,8 @@ describe("useProjectSwitcherPalette", () => {
         expect(result.current.results).toHaveLength(projects.length);
       });
 
-      const sectionOf = (id: string) => result.current.results.find((p) => p.id === id)?.section;
+      const sectionOf = (id: string) =>
+        result.current.results.map(asProject).find((p) => p.id === id)?.section;
       expect(sectionOf("active")).toBe("current");
       expect(sectionOf("waiting")).toBe("attention");
       expect(sectionOf("blocked")).toBe("attention");
@@ -1946,7 +1966,7 @@ describe("useProjectSwitcherPalette", () => {
 
       // Bands appear in priority order and each appears exactly once.
       const bands: string[] = [];
-      for (const project of result.current.results) {
+      for (const project of result.current.results.map(asProject)) {
         if (bands.at(-1) !== project.section) bands.push(project.section);
       }
       expect(bands).toEqual(["current", "attention", "pinned", "running", "other", "unavailable"]);
@@ -1986,7 +2006,8 @@ describe("useProjectSwitcherPalette", () => {
         expect(result.current.results).toHaveLength(3);
       });
 
-      const sectionOf = (id: string) => result.current.results.find((p) => p.id === id)?.section;
+      const sectionOf = (id: string) =>
+        result.current.results.map(asProject).find((p) => p.id === id)?.section;
       expect(sectionOf("reviewMe")).toBe("attention");
       expect(sectionOf("ackd")).toBe("other");
     });
@@ -2143,7 +2164,9 @@ describe("useProjectSwitcherPalette", () => {
       await waitFor(() => {
         expect(result.current.results.map((p) => p.id)).toEqual(["second", "first"]);
       });
-      expect(result.current.results.every((p) => p.section === "running")).toBe(true);
+      expect(result.current.results.map(asProject).every((p) => p.section === "running")).toBe(
+        true
+      );
     });
 
     it("regroups a cold session in place when stats arrive, then holds", async () => {
@@ -2163,7 +2186,7 @@ describe("useProjectSwitcherPalette", () => {
       });
 
       // The freeze taken at open put everything in one band.
-      expect(result.current.results.every((p) => p.section === "other")).toBe(true);
+      expect(result.current.results.map(asProject).every((p) => p.section === "other")).toBe(true);
 
       await waitFor(() => {
         expect(setStatsMock).toHaveBeenCalled();
@@ -2175,7 +2198,7 @@ describe("useProjectSwitcherPalette", () => {
       // Bands and within-band order both come from the real data, without the
       // user closing and reopening the palette.
       await waitFor(() => {
-        expect(result.current.results.map((p) => [p.id, p.section])).toEqual([
+        expect(result.current.results.map(asProject).map((p) => [p.id, p.section])).toEqual([
           ["stuck", "attention"],
           ["busy", "running"],
           ["quiet", "other"],
@@ -2193,12 +2216,12 @@ describe("useProjectSwitcherPalette", () => {
         rerender();
       });
 
-      expect(result.current.results.map((p) => [p.id, p.section])).toEqual([
+      expect(result.current.results.map(asProject).map((p) => [p.id, p.section])).toEqual([
         ["stuck", "attention"],
         ["busy", "running"],
         ["quiet", "other"],
       ]);
-      expect(result.current.results[2]!.activeAgentCount).toBe(4);
+      expect(asProject(result.current.results[2]).activeAgentCount).toBe(4);
     });
 
     it("never preselects an unavailable row while an available one exists", async () => {
@@ -2307,7 +2330,7 @@ describe("useProjectSwitcherPalette", () => {
       await waitFor(() => {
         expect(result.current.results[0]!.id).toBe("waiting");
       });
-      expect(result.current.results[0]!.section).toBe("attention");
+      expect(asProject(result.current.results[0]).section).toBe("attention");
 
       // The agent finishes while the user is reading the list, and the push
       // that carries it also fills in the row that had no entry at open. A
@@ -2322,11 +2345,11 @@ describe("useProjectSwitcherPalette", () => {
 
       // The row keeps its slot and its band, so nothing moves under the pointer.
       expect(result.current.results[0]!.id).toBe("waiting");
-      expect(result.current.results[0]!.section).toBe("attention");
+      expect(asProject(result.current.results[0]).section).toBe("attention");
       // Content underneath is live, though.
-      expect(result.current.results[0]!.waitingAgentCount).toBe(0);
-      expect(result.current.results[1]!.section).toBe("other");
-      expect(result.current.results[1]!.activeAgentCount).toBe(3);
+      expect(asProject(result.current.results[0]).waitingAgentCount).toBe(0);
+      expect(asProject(result.current.results[1]).section).toBe("other");
+      expect(asProject(result.current.results[1]).activeAgentCount).toBe(3);
     });
 
     it("regroups a project that registers while the session is still a guess", async () => {
@@ -2354,7 +2377,9 @@ describe("useProjectSwitcherPalette", () => {
         };
         rerender();
       });
-      expect(result.current.results.find((p) => p.id === "late")!.section).toBe("other");
+      expect(result.current.results.map(asProject).find((p) => p.id === "late")!.section).toBe(
+        "other"
+      );
 
       act(() => {
         projectStatsState.stats = {
@@ -2365,7 +2390,9 @@ describe("useProjectSwitcherPalette", () => {
       });
 
       await waitFor(() => {
-        expect(result.current.results.find((p) => p.id === "late")!.section).toBe("running");
+        expect(result.current.results.map(asProject).find((p) => p.id === "late")!.section).toBe(
+          "running"
+        );
       });
     });
 
@@ -2390,8 +2417,12 @@ describe("useProjectSwitcherPalette", () => {
         };
         rerender();
       });
-      expect(result.current.results.find((p) => p.id === "first")!.section).toBe("other");
-      expect(result.current.results.find((p) => p.id === "first")!.activeAgentCount).toBe(2);
+      expect(result.current.results.map(asProject).find((p) => p.id === "first")!.section).toBe(
+        "other"
+      );
+      expect(
+        result.current.results.map(asProject).find((p) => p.id === "first")!.activeAgentCount
+      ).toBe(2);
 
       // The unresolved row goes away, so nothing is a guess any more.
       act(() => {
@@ -2400,7 +2431,7 @@ describe("useProjectSwitcherPalette", () => {
       });
 
       await waitFor(() => {
-        expect(result.current.results[0]!.section).toBe("running");
+        expect(asProject(result.current.results[0]).section).toBe("running");
       });
     });
 
@@ -2421,7 +2452,9 @@ describe("useProjectSwitcherPalette", () => {
       act(() => {
         result.current.open("modal");
       });
-      expect(result.current.results.find((p) => p.id === "busy")!.section).toBe("other");
+      expect(result.current.results.map(asProject).find((p) => p.id === "busy")!.section).toBe(
+        "other"
+      );
 
       await waitFor(() => {
         expect(setStatsMock).toHaveBeenCalled();
@@ -2431,7 +2464,9 @@ describe("useProjectSwitcherPalette", () => {
       });
 
       await waitFor(() => {
-        expect(result.current.results.find((p) => p.id === "busy")!.section).toBe("running");
+        expect(result.current.results.map(asProject).find((p) => p.id === "busy")!.section).toBe(
+          "running"
+        );
       });
     });
 
@@ -2461,7 +2496,7 @@ describe("useProjectSwitcherPalette", () => {
       await waitFor(() => {
         expect(result.current.results.map((p) => p.id)).toEqual(["first", "late"]);
       });
-      expect(result.current.results[1]!.section).toBe("other");
+      expect(asProject(result.current.results[1]).section).toBe("other");
 
       // Its agents start working. A late arrival left outside the freeze would
       // jump into the running band above "first"; a frozen one stays put.
@@ -2473,8 +2508,8 @@ describe("useProjectSwitcherPalette", () => {
       });
 
       expect(result.current.results.map((p) => p.id)).toEqual(["first", "late"]);
-      expect(result.current.results[1]!.section).toBe("other");
-      expect(result.current.results[1]!.activeAgentCount).toBe(2);
+      expect(asProject(result.current.results[1]).section).toBe("other");
+      expect(asProject(result.current.results[1]).activeAgentCount).toBe(2);
     });
 
     it("re-bands on the next open", async () => {
@@ -2491,7 +2526,7 @@ describe("useProjectSwitcherPalette", () => {
         result.current.open("modal");
       });
       await waitFor(() => {
-        expect(result.current.results[0]!.section).toBe("attention");
+        expect(asProject(result.current.results[0]).section).toBe("attention");
       });
 
       act(() => {
@@ -2510,7 +2545,9 @@ describe("useProjectSwitcherPalette", () => {
       });
 
       await waitFor(() => {
-        expect(result.current.results.every((p) => p.section !== "attention")).toBe(true);
+        expect(result.current.results.map(asProject).every((p) => p.section !== "attention")).toBe(
+          true
+        );
       });
     });
 
@@ -2626,12 +2663,12 @@ describe("useProjectSwitcherPalette", () => {
       await waitFor(() => {
         expect(result.current.results).toHaveLength(3);
       });
-      expect(result.current.results[0]!.section).toBe("current");
+      expect(asProject(result.current.results[0]).section).toBe("current");
 
       // Sections must never interleave, or the component's contiguous-run
       // grouping would emit the same header twice.
       const seen: string[] = [];
-      for (const project of result.current.results) {
+      for (const project of result.current.results.map(asProject)) {
         if (seen.at(-1) !== project.section) seen.push(project.section);
       }
       expect(new Set(seen).size).toBe(seen.length);

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -2574,7 +2574,7 @@ describe("useProjectSwitcherPalette", () => {
       await waitFor(() => {
         expect(result.current.results).toHaveLength(1);
       });
-      const row = result.current.results[0]!;
+      const row = asProject(result.current.results[0]);
       expect(row.blockedAgentCount).toBe(1);
       expect(row.oldestWaitingSince).toBe(4_242);
       expect(row.section).toBe("attention");
@@ -2643,7 +2643,7 @@ describe("useProjectSwitcherPalette", () => {
         expect(modal.current.results).toHaveLength(3);
       });
       const modalOrder = modal.current.results.map((p) => p.id);
-      const modalSections = modal.current.results.map((p) => p.section);
+      const modalSections = modal.current.results.map(asProject).map((p) => p.section);
 
       const dropdown = await openIn("dropdown");
       await waitFor(() => {
@@ -2653,7 +2653,7 @@ describe("useProjectSwitcherPalette", () => {
       // Compared in order, not as sets: the two surfaces previously agreed on
       // neither scope nor grouping, and membership alone would not catch that.
       expect(dropdown.current.results.map((p) => p.id)).toEqual(modalOrder);
-      expect(dropdown.current.results.map((p) => p.section)).toEqual(modalSections);
+      expect(dropdown.current.results.map(asProject).map((p) => p.section)).toEqual(modalSections);
       expect(modalOrder).toContain("closed");
     });
 
@@ -2741,7 +2741,7 @@ describe("useProjectSwitcherPalette", () => {
         expect(result.current.results).toHaveLength(3);
       });
 
-      const current = result.current.results.find((project) => project.isActive)!;
+      const current = asProject(result.current.results.find((project) => project.isActive));
 
       act(() => {
         void result.current.selectProject(current);

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -1182,7 +1182,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         void selectScratch(row);
         return;
       }
-      selectProject(row);
+      void selectProject(row);
     },
     [selectProject, selectScratch]
   );

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -153,10 +153,6 @@ function toProjectRow(project: SearchableProject): ProjectSwitcherProjectRow {
   return { kind: "project", ...project };
 }
 
-function toScratchRow(scratch: SearchableScratch): ProjectSwitcherScratchRow {
-  return { kind: "scratch", ...scratch };
-}
-
 export interface UseProjectSwitcherPaletteReturn {
   isOpen: boolean;
   mode: ProjectSwitcherMode;
@@ -175,6 +171,14 @@ export interface UseProjectSwitcherPaletteReturn {
   results: ProjectSwitcherRow[];
   /** True while `deferredQuery` has not yet caught up to `query` — the results shown are from the previous query. */
   isFiltering: boolean;
+  /**
+   * True exactly while {@link results} is the ranked list, which is the only
+   * time it carries scratches. Trails `query` by a commit, because the ranking
+   * runs on the deferred query — so a surface that also renders scratches
+   * elsewhere must hide them on THIS, not on a non-empty query, or they would
+   * belong to neither list for a frame.
+   */
+  isRankedSearch: boolean;
   /**
    * The currently active project as a `SearchableProject`, with stats and
    * pin/missing flags enriched. Decoupled from `results` so callers (e.g. the
@@ -497,21 +501,25 @@ function compareWithinSection(
  *
  * Scratches join the ranking, and only the ranking (#11466). In browse they are
  * left to the pinned section at the bottom, where create and delete-all live and
- * spatial predictability is worth more than relevance. The one frame where the
- * live query has outrun the deferred one still carries them — unranked, after
- * the projects, exactly where browse already draws them — because dropping them
- * for that frame is what would flash the empty state at a user whose only
- * workspaces are scratches.
+ * spatial predictability is worth more than relevance.
+ *
+ * They join on `rankQuery`, not on the live one, so the frame where the live
+ * query has outrun the deferred one is still pure browse. The pinned section
+ * keys off the same signal ({@link UseProjectSwitcherPaletteReturn.isRankedSearch}),
+ * so for that frame the scratches are simply still down there — never listed
+ * twice, and never briefly absent from both places.
  */
 function buildResults(
+  browseRows: ProjectSwitcherRow[],
   browseOrdered: SearchableProject[],
   scratches: SearchableScratch[],
   rankQuery: string,
   isSearching: boolean
 ): ProjectSwitcherRow[] {
-  if (!isSearching) return browseOrdered.map(toProjectRow);
-  if (rankQuery.trim()) return rankSwitcherMatches(rankQuery, browseOrdered, scratches);
-  return [...browseOrdered.map(toProjectRow), ...scratches.map(toScratchRow)];
+  if (isSearching && rankQuery.trim()) {
+    return rankSwitcherMatches(rankQuery, browseOrdered, scratches);
+  }
+  return browseRows;
 }
 
 /**
@@ -957,9 +965,25 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   // search ranking on the way back to an empty query.
   const resultsQuery = isSearching ? deferredQuery : "";
 
+  // Held apart from `results` so browse keeps a stable array identity across
+  // scratch-store traffic. Folded into the same memo, a rename in the pinned
+  // section below would hand the component a fresh array of identical project
+  // rows, and its scroll-into-view effect would yank the list back to the
+  // highlighted project while the user was reading the section.
+  const browseRows = useMemo<ProjectSwitcherRow[]>(
+    () => browseOrdered.map(toProjectRow),
+    [browseOrdered]
+  );
+
+  // True exactly when `results` is the ranked, scratch-carrying list — which is
+  // one commit behind `isSearching`, since the ranking runs on the deferred
+  // query. The pinned scratch section hides on THIS, never on the live query:
+  // hiding a commit early would leave the scratches nowhere for that frame.
+  const isRankedSearch = isSearching && resultsQuery.trim().length > 0;
+
   const results = useMemo<ProjectSwitcherRow[]>(
-    () => buildResults(browseOrdered, scratchResults, resultsQuery, isSearching),
-    [browseOrdered, scratchResults, resultsQuery, isSearching]
+    () => buildResults(browseRows, browseOrdered, scratchResults, resultsQuery, isSearching),
+    [browseRows, browseOrdered, scratchResults, resultsQuery, isSearching]
   );
 
   // The selected ROW is the state; its index is derived. Tracking an index
@@ -1764,6 +1788,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     query,
     results,
     isFiltering,
+    isRankedSearch,
     activeProject,
     selectedIndex,
     open,

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo, useEffect, useRef, useDeferredValue } from "react";
-import { rankProjectMatches } from "@/lib/projectSwitcherSearch";
+import { rankSwitcherMatches } from "@/lib/projectSwitcherSearch";
 import { buildDisplayPaths } from "@/lib/projectDisplayPath";
 import { useProjectStore } from "@/store/projectStore";
 import { useProjectStatsStore } from "@/store/projectStatsStore";
@@ -132,17 +132,47 @@ export interface SearchableProject {
   section: ProjectSectionKey;
 }
 
+/**
+ * A row of the palette's one list, tagged with what it actually is.
+ *
+ * Flattened rather than wrapped (`{ kind, project }`) so the fields both kinds
+ * share — `id`, `name`, `isActive` — stay reachable at the sites that only care
+ * about identity: the derived index, the arrow-key step, `aria-activedescendant`
+ * and the scroll-into-view query. Only the row renderer and the commit dispatch
+ * need to narrow.
+ *
+ * Scratches are NOT synthesized into a `SearchableProject` with a flag. Sharing
+ * the shape would make every project-only path — the status line, "Pin project",
+ * "Free memory", ⌘⌫ remove — type-reachable with a scratch id behind it.
+ */
+export type ProjectSwitcherProjectRow = { kind: "project" } & SearchableProject;
+export type ProjectSwitcherScratchRow = { kind: "scratch" } & SearchableScratch;
+export type ProjectSwitcherRow = ProjectSwitcherProjectRow | ProjectSwitcherScratchRow;
+
+function toProjectRow(project: SearchableProject): ProjectSwitcherProjectRow {
+  return { kind: "project", ...project };
+}
+
+function toScratchRow(scratch: SearchableScratch): ProjectSwitcherScratchRow {
+  return { kind: "scratch", ...scratch };
+}
+
 export interface UseProjectSwitcherPaletteReturn {
   isOpen: boolean;
   mode: ProjectSwitcherMode;
   query: string;
   /**
-   * The projects the palette renders, in render order — and the only array
+   * The rows the palette renders, in render order — and the only array
    * `selectedIndex` may be read against. Every mode lists every registered
    * project: browse is section-ordered (see {@link PROJECT_SECTION_ORDER}) and
    * search is rank-ordered, but neither is scoped or capped.
+   *
+   * Browse rows are all projects; the scratches belong to the pinned section
+   * below the list. Search rows are mixed, so a scratch is reachable by name
+   * from the keyboard (#11466) — narrow on `kind` before touching anything a
+   * scratch doesn't have.
    */
-  results: SearchableProject[];
+  results: ProjectSwitcherRow[];
   /** True while `deferredQuery` has not yet caught up to `query` — the results shown are from the previous query. */
   isFiltering: boolean;
   /**
@@ -164,6 +194,12 @@ export interface UseProjectSwitcherPaletteReturn {
   selectPrevious: () => void;
   selectNext: () => void;
   selectProject: (project: SearchableProject) => void;
+  /**
+   * Commits a row of {@link results}, dispatching on its kind. The palette's
+   * primary select handler — a surface that renders `results` must use this
+   * rather than `selectProject`, which cannot accept a scratch row.
+   */
+  selectRow: (row: ProjectSwitcherRow) => void;
   /**
    * Schedule a 150ms trailing-edge hover prefetch that primes the
    * main-process hydrate cache for `projectId`. Mouse-only — touch and pen
@@ -456,18 +492,26 @@ function compareWithinSection(
  * character was typed.
  *
  * `isSearching` tracks the live query while `rankQuery` is the deferred one, so
- * the browse-to-search transition doesn't flash "No projects match" over the
+ * the browse-to-search transition doesn't flash "No workspaces match" over the
  * previous list on the first keystroke.
+ *
+ * Scratches join the ranking, and only the ranking (#11466). In browse they are
+ * left to the pinned section at the bottom, where create and delete-all live and
+ * spatial predictability is worth more than relevance. The one frame where the
+ * live query has outrun the deferred one still carries them — unranked, after
+ * the projects, exactly where browse already draws them — because dropping them
+ * for that frame is what would flash the empty state at a user whose only
+ * workspaces are scratches.
  */
 function buildResults(
   browseOrdered: SearchableProject[],
+  scratches: SearchableScratch[],
   rankQuery: string,
   isSearching: boolean
-): SearchableProject[] {
-  if (isSearching && rankQuery.trim()) {
-    return rankProjectMatches(rankQuery, browseOrdered);
-  }
-  return browseOrdered;
+): ProjectSwitcherRow[] {
+  if (!isSearching) return browseOrdered.map(toProjectRow);
+  if (rankQuery.trim()) return rankSwitcherMatches(rankQuery, browseOrdered, scratches);
+  return [...browseOrdered.map(toProjectRow), ...scratches.map(toScratchRow)];
 }
 
 /**
@@ -498,7 +542,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   // Only stale while a search is still catching up. Clearing the box restores
   // browse in the same commit, so that transition is never "filtering".
   const isFiltering = isSearching && query !== deferredQuery;
-  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+  const [selectedRowId, setSelectedRowId] = useState<string | null>(null);
   const [stopConfirmProjectId, setStopConfirmProjectId] = useState<string | null>(null);
   const [isStoppingProject, setIsStoppingProject] = useState(false);
   const [removeConfirmProject, setRemoveConfirmProject] = useState<SearchableProject | null>(null);
@@ -799,7 +843,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     // palette was open keeps its frozen slot, and a reflexive Enter landing on
     // it opens the relocation dialog rather than switching projects.
     const target = resorted.ids.find((id) => live.get(id)?.isMissing === false) ?? resorted.ids[0]!;
-    setSelectedProjectId((previousId) =>
+    setSelectedRowId((previousId) =>
       previousId !== null && frozenLayout.sections.get(previousId) === "other" ? target : previousId
     );
   }, [otherProjectsSortMode, isOpen, liveBrowseOrder, frozenLayout, isSearching]);
@@ -892,29 +936,43 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     );
   }, [liveBrowseOrder, frozenLayout]);
 
+  // Recency order, which is what the pinned browse section renders. Search takes
+  // this same list but re-ranks it against the query (#11466), so it has to be
+  // built before `results` rather than beside the other scratch callbacks below.
+  const scratchResults = useMemo<SearchableScratch[]>(() => {
+    const list: SearchableScratch[] = scratches.map((s: Scratch) => ({
+      id: s.id,
+      name: s.name,
+      path: s.path,
+      createdAt: s.createdAt,
+      lastOpened: s.lastOpened,
+      isActive: currentScratch?.id === s.id,
+    }));
+    list.sort((a, b) => b.lastOpened - a.lastOpened);
+    return list;
+  }, [scratches, currentScratch?.id]);
+
   // Clearing the box reverts to browse immediately rather than holding the
   // deferred ranking for a commit — otherwise browse would flash the stale
   // search ranking on the way back to an empty query.
   const resultsQuery = isSearching ? deferredQuery : "";
 
-  const results = useMemo<SearchableProject[]>(
-    () => buildResults(browseOrdered, resultsQuery, isSearching),
-    [browseOrdered, resultsQuery, isSearching]
+  const results = useMemo<ProjectSwitcherRow[]>(
+    () => buildResults(browseOrdered, scratchResults, resultsQuery, isSearching),
+    [browseOrdered, scratchResults, resultsQuery, isSearching]
   );
 
-  // The selected PROJECT is the state; its index is derived. Tracking an index
+  // The selected ROW is the state; its index is derived. Tracking an index
   // instead would let it outlive the row it pointed at — a list that shrinks
   // under an open palette (a project closing, a stats push) would leave the
-  // index addressing a different project than the user selected, and Enter
-  // would commit that one (#11071). Deriving means the highlight follows the
-  // project across reorders and never addresses a row that isn't rendered.
+  // index addressing a different row than the user selected, and Enter would
+  // commit that one (#11071). Deriving means the highlight follows the row
+  // across reorders and never addresses a row that isn't rendered.
   const selectedIndex = useMemo(() => {
     if (results.length === 0) return 0;
-    const index = selectedProjectId
-      ? results.findIndex((project) => project.id === selectedProjectId)
-      : -1;
+    const index = selectedRowId ? results.findIndex((row) => row.id === selectedRowId) : -1;
     return index >= 0 ? index : 0;
-  }, [results, selectedProjectId]);
+  }, [results, selectedRowId]);
 
   // Decoupled from `results` so the toolbar pill keeps the active project's
   // pin/process state even when the current search filters it out.
@@ -926,7 +984,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   // A new query re-ranks the list, so fall back to the top match.
   useEffect(() => {
     if (query) {
-      setSelectedProjectId(null);
+      setSelectedRowId(null);
     }
   }, [query]);
 
@@ -986,7 +1044,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         liveBrowseOrder.find((project) => !project.isActive && !project.isMissing) ??
         liveBrowseOrder.find((project) => !project.isActive) ??
         liveBrowseOrder[0];
-      setSelectedProjectId(initial?.id ?? null);
+      setSelectedRowId(initial?.id ?? null);
     },
     [liveBrowseOrder, captureLayout, projectStats]
   );
@@ -998,7 +1056,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
       setDropdownIsOpen(false);
     }
     setQuery("");
-    setSelectedProjectId(null);
+    setSelectedRowId(null);
     setFrozenLayout(null);
   }, [mode]);
 
@@ -1008,7 +1066,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   const step = useCallback(
     (delta: number) => {
       if (results.length === 0) return;
-      setSelectedProjectId((previousId) => {
+      setSelectedRowId((previousId) => {
         const current = previousId ? results.findIndex((project) => project.id === previousId) : -1;
         const from = current >= 0 ? current : 0;
         const next = (from + delta + results.length) % results.length;
@@ -1068,6 +1126,41 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
       }
     },
     [close, switchProject, reopenProject, openRelocation]
+  );
+
+  const selectScratch = useCallback(
+    async (scratch: SearchableScratch) => {
+      if (scratch.isActive) {
+        close();
+        return;
+      }
+      close();
+      try {
+        await switchScratchAction(scratch.id);
+      } catch (error) {
+        // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
+        notify({
+          type: "error",
+          title: "Couldn't switch scratch",
+          message: formatErrorMessage(error, "Couldn't switch to scratch workspace"),
+        });
+      }
+    },
+    [close, switchScratchAction]
+  );
+
+  // The one commit path for a row of `results`. Both branches are fire-and-
+  // forget by design — each closes the palette first and reports its own
+  // failure, so there is nothing here for a caller to await.
+  const selectRow = useCallback(
+    (row: ProjectSwitcherRow) => {
+      if (row.kind === "scratch") {
+        void selectScratch(row);
+        return;
+      }
+      selectProject(row);
+    },
+    [selectProject, selectScratch]
   );
 
   const clearPendingPrefetchTimer = useCallback(() => {
@@ -1133,8 +1226,8 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
 
   const confirmSelection = useCallback(() => {
     if (results.length === 0) return;
-    selectProject(results[selectedIndex]!);
-  }, [results, selectedIndex, selectProject]);
+    selectRow(results[selectedIndex]!);
+  }, [results, selectedIndex, selectRow]);
 
   const addProject = useCallback(async () => {
     close();
@@ -1353,19 +1446,6 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     }
   }, [freeMemoryConfirmProject, isFreeingMemory, doFreeMemory]);
 
-  const scratchResults = useMemo<SearchableScratch[]>(() => {
-    const list: SearchableScratch[] = scratches.map((s: Scratch) => ({
-      id: s.id,
-      name: s.name,
-      path: s.path,
-      createdAt: s.createdAt,
-      lastOpened: s.lastOpened,
-      isActive: currentScratch?.id === s.id,
-    }));
-    list.sort((a, b) => b.lastOpened - a.lastOpened);
-    return list;
-  }, [scratches, currentScratch?.id]);
-
   const createScratch = useCallback(
     async (name?: string) => {
       close();
@@ -1447,27 +1527,6 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
       }
     },
     [renameScratchActionStore]
-  );
-
-  const selectScratch = useCallback(
-    async (scratch: SearchableScratch) => {
-      if (scratch.isActive) {
-        close();
-        return;
-      }
-      close();
-      try {
-        await switchScratchAction(scratch.id);
-      } catch (error) {
-        // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
-        notify({
-          type: "error",
-          title: "Couldn't switch scratch",
-          message: formatErrorMessage(error, "Couldn't switch to scratch workspace"),
-        });
-      }
-    },
-    [close, switchScratchAction]
   );
 
   const removeScratchAction = useCallback(
@@ -1714,6 +1773,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     selectPrevious,
     selectNext,
     selectProject,
+    selectRow,
     onHoverProject,
     onHoverProjectEnd,
     confirmSelection,

--- a/src/lib/__tests__/projectSwitcherSearch.test.ts
+++ b/src/lib/__tests__/projectSwitcherSearch.test.ts
@@ -180,16 +180,21 @@ describe("rankSwitcherMatches", () => {
     expect(results).toHaveLength(20);
   });
 
-  it("leaves project ordering untouched when scratches are added to the pool", () => {
-    // Merging scratches must not reshuffle the projects around them, or search
-    // order would shift under a user who never asked for one.
-    const scratches = [
-      makeScratch({ id: "s1", name: "daintree-scratch" }),
-      makeScratch({ id: "s2", name: "unrelated" }),
-    ];
-    const projectOnly = rankSwitcherMatches("daintree", projects, []).map((r) => r.id);
-    const mixed = rankSwitcherMatches("daintree", projects, scratches);
-    expect(mixed.filter((r) => r.kind === "project").map((r) => r.id)).toEqual(projectOnly);
+  it("leaves project ordering untouched when a scratch ranks between two projects", () => {
+    // The scratch has to land BETWEEN the projects, or "append the scratches"
+    // would satisfy this too. Frecency also opposes input order, so a ranker
+    // that dropped the tiebreak while merging still fails.
+    const strong = makeProject({ id: "strong", name: "alpha", path: "/repos/alpha" });
+    const weak = makeProject({ id: "weak", name: "a-l-p-h-a", path: "/zzz", frecencyScore: 99 });
+    const scratch = makeScratch({ id: "mid", name: "alpha-spike" });
+
+    const mixed = rankSwitcherMatches("alpha", [weak, strong], [scratch]);
+
+    expect(mixed.map((r) => r.id)).toEqual(["strong", "mid", "weak"]);
+    // And the projects keep the order they had with no scratch in the pool.
+    expect(mixed.filter((r) => r.kind === "project").map((r) => r.id)).toEqual(
+      rankSwitcherMatches("alpha", [weak, strong], []).map((r) => r.id)
+    );
   });
 
   it("tags every row with its kind", () => {
@@ -211,12 +216,19 @@ describe("rankSwitcherMatches", () => {
   });
 
   it("puts the project first when a project and a scratch match a name equally", () => {
-    const results = rankSwitcherMatches(
-      "release",
-      [makeProject({ id: "p", name: "release", path: "/repos/release" })],
-      [makeScratch({ id: "s", name: "release" })]
+    // The path scores 0, so the two land on an EXACT numeric tie and only the
+    // kind tiebreak can order them. Give the project a matching path and it
+    // wins on score instead, leaving the tiebreak untested.
+    const project = makeProject({ id: "p", name: "release", path: "/zzz" });
+    const scratch = makeScratch({ id: "s", name: "release" });
+    expect(scoreProjectQuery("release", project.name, project.path)).toBe(
+      scoreScratchQuery("release", scratch.name)
     );
-    expect(results.map((r) => r.id)).toEqual(["p", "s"]);
+
+    expect(rankSwitcherMatches("release", [project], [scratch]).map((r) => r.id)).toEqual([
+      "p",
+      "s",
+    ]);
   });
 
   it("ranks a scratch whose name contains the query above a loosely matching project", () => {

--- a/src/lib/__tests__/projectSwitcherSearch.test.ts
+++ b/src/lib/__tests__/projectSwitcherSearch.test.ts
@@ -1,6 +1,22 @@
 import { describe, expect, it } from "vitest";
-import { scoreProjectQuery, rankProjectMatches } from "../projectSwitcherSearch";
-import type { SearchableProject } from "@/hooks/useProjectSwitcherPalette";
+import {
+  scoreProjectQuery,
+  scoreScratchQuery,
+  rankSwitcherMatches,
+} from "../projectSwitcherSearch";
+import type { SearchableProject, SearchableScratch } from "@/hooks/useProjectSwitcherPalette";
+
+function makeScratch(
+  overrides: Partial<SearchableScratch> & { id: string; name: string }
+): SearchableScratch {
+  return {
+    path: `/userData/scratch/${overrides.id}`,
+    createdAt: 0,
+    lastOpened: 0,
+    isActive: false,
+    ...overrides,
+  };
+}
 
 function makeProject(
   overrides: Partial<SearchableProject> & { id: string; name: string; path: string }
@@ -81,7 +97,33 @@ describe("scoreProjectQuery", () => {
   });
 });
 
-describe("rankProjectMatches", () => {
+describe("scoreScratchQuery", () => {
+  it("returns 0 for empty query", () => {
+    expect(scoreScratchQuery("", "scratch")).toBe(0);
+  });
+
+  it("returns 0 when query has no subsequence match", () => {
+    expect(scoreScratchQuery("xyz", "auth-notes")).toBe(0);
+  });
+
+  it("scores name identically to a project whose path contributes nothing", () => {
+    // The two scales have to be directly comparable for the mixed ranker's
+    // score-first ordering to mean anything.
+    expect(scoreScratchQuery("auth", "auth-notes")).toBe(
+      scoreProjectQuery("auth", "auth-notes", "zzz")
+    );
+  });
+
+  it("ignores the path, which for a scratch is a UUID directory", () => {
+    const scratch = makeScratch({ id: "9f8e7d6c", name: "notes" });
+    // A query lifted straight out of the scratch's own folder name must not
+    // surface it — that path is machine-generated, not something a user typed.
+    expect(scoreScratchQuery("9f8e7d6c", scratch.name)).toBe(0);
+    expect(scoreProjectQuery("9f8e7d6c", scratch.name, scratch.path)).toBeGreaterThan(0);
+  });
+});
+
+describe("rankSwitcherMatches", () => {
   const projects = [
     makeProject({ id: "1", name: "daintree-app", path: "/repos/daintree-app", lastOpened: 100 }),
     makeProject({ id: "2", name: "other-project", path: "/repos/other", lastOpened: 200 }),
@@ -89,17 +131,17 @@ describe("rankProjectMatches", () => {
   ];
 
   it("returns empty for empty query", () => {
-    expect(rankProjectMatches("", projects)).toEqual([]);
-    expect(rankProjectMatches("  ", projects)).toEqual([]);
+    expect(rankSwitcherMatches("", projects, [])).toEqual([]);
+    expect(rankSwitcherMatches("  ", projects, [])).toEqual([]);
   });
 
   it("filters out non-matching projects", () => {
-    const results = rankProjectMatches("xyz", projects);
+    const results = rankSwitcherMatches("xyz", projects, []);
     expect(results).toHaveLength(0);
   });
 
   it("ranks exact name substring matches first", () => {
-    const results = rankProjectMatches("daintree", projects);
+    const results = rankSwitcherMatches("daintree", projects, []);
     expect(results.length).toBeGreaterThanOrEqual(2);
     expect(results[0]!.name).toContain("daintree");
   });
@@ -119,13 +161,13 @@ describe("rankProjectMatches", () => {
         frecencyScore: 5.0,
       }),
     ];
-    const results = rankProjectMatches("alpha", tieProjects);
+    const results = rankSwitcherMatches("alpha", tieProjects, []);
     expect(results[0]!.id).toBe("b"); // higher frecencyScore wins
   });
 
   it("trims whitespace from query before matching", () => {
-    const results = rankProjectMatches("  daintree  ", projects);
-    const resultsClean = rankProjectMatches("daintree", projects);
+    const results = rankSwitcherMatches("  daintree  ", projects, []);
+    const resultsClean = rankSwitcherMatches("daintree", projects, []);
     expect(results).toHaveLength(resultsClean.length);
     expect(results.map((r) => r.id)).toEqual(resultsClean.map((r) => r.id));
   });
@@ -134,7 +176,69 @@ describe("rankProjectMatches", () => {
     const many = Array.from({ length: 20 }, (_, i) =>
       makeProject({ id: `p${i}`, name: `project-${i}`, path: `/repos/p${i}`, lastOpened: i })
     );
-    const results = rankProjectMatches("project", many);
+    const results = rankSwitcherMatches("project", many, []);
     expect(results).toHaveLength(20);
+  });
+
+  it("leaves project ordering untouched when scratches are added to the pool", () => {
+    // Merging scratches must not reshuffle the projects around them, or search
+    // order would shift under a user who never asked for one.
+    const scratches = [
+      makeScratch({ id: "s1", name: "daintree-scratch" }),
+      makeScratch({ id: "s2", name: "unrelated" }),
+    ];
+    const projectOnly = rankSwitcherMatches("daintree", projects, []).map((r) => r.id);
+    const mixed = rankSwitcherMatches("daintree", projects, scratches);
+    expect(mixed.filter((r) => r.kind === "project").map((r) => r.id)).toEqual(projectOnly);
+  });
+
+  it("tags every row with its kind", () => {
+    const results = rankSwitcherMatches(
+      "alpha",
+      [makeProject({ id: "p", name: "alpha-app", path: "/repos/alpha" })],
+      [makeScratch({ id: "s", name: "alpha-notes" })]
+    );
+    expect(results.map((r) => r.kind).sort()).toEqual(["project", "scratch"]);
+  });
+
+  it("filters scratches by the query rather than listing them all", () => {
+    const scratches = [
+      makeScratch({ id: "s1", name: "auth-notes" }),
+      makeScratch({ id: "s2", name: "billing-spike" }),
+    ];
+    const results = rankSwitcherMatches("auth", [], scratches);
+    expect(results.map((r) => r.id)).toEqual(["s1"]);
+  });
+
+  it("puts the project first when a project and a scratch match a name equally", () => {
+    const results = rankSwitcherMatches(
+      "release",
+      [makeProject({ id: "p", name: "release", path: "/repos/release" })],
+      [makeScratch({ id: "s", name: "release" })]
+    );
+    expect(results.map((r) => r.id)).toEqual(["p", "s"]);
+  });
+
+  it("ranks a scratch whose name contains the query above a loosely matching project", () => {
+    // The whole point of the merge: typing a scratch's name has to reach it,
+    // not a project that happened to share the letters in order.
+    const results = rankSwitcherMatches(
+      "auth",
+      [makeProject({ id: "p", name: "a-u-t-h-elper", path: "/repos/auth-adjacent" })],
+      [makeScratch({ id: "s", name: "auth-notes" })]
+    );
+    expect(results[0]!.id).toBe("s");
+  });
+
+  it("breaks scratch-vs-scratch ties on recency", () => {
+    const results = rankSwitcherMatches(
+      "notes",
+      [],
+      [
+        makeScratch({ id: "old", name: "notes", lastOpened: 100 }),
+        makeScratch({ id: "new", name: "notes", lastOpened: 900 }),
+      ]
+    );
+    expect(results.map((r) => r.id)).toEqual(["new", "old"]);
   });
 });

--- a/src/lib/projectSwitcherSearch.ts
+++ b/src/lib/projectSwitcherSearch.ts
@@ -89,8 +89,15 @@ export function scoreProjectQuery(query: string, name: string, path: string): nu
  *
  * The same {@link NAME_WEIGHT} a project's name carries, so the two scales are
  * directly comparable: an equal name match leaves the project ahead by exactly
- * its path term (which is never negative), and a scratch whose name contains the
- * query clears a project that only matched loosely.
+ * its path term, which is never negative.
+ *
+ * That a scratch containing the query outranks a loosely-matched project is a
+ * consequence of the scores, not a guarantee. Long queries let a project's
+ * per-character boundary bonuses plus a path hit overtake the substring bonus —
+ * but only where the project's own name matches nearly as exactly, which is a
+ * project that deserves the top slot anyway. Promoting substring quality into a
+ * ranking tier would have to apply to every pair, projects included, or the
+ * comparator stops being transitive.
  */
 export function scoreScratchQuery(query: string, name: string): number {
   if (!query) return 0;

--- a/src/lib/projectSwitcherSearch.ts
+++ b/src/lib/projectSwitcherSearch.ts
@@ -1,4 +1,8 @@
-import type { SearchableProject } from "@/hooks/useProjectSwitcherPalette";
+import type {
+  ProjectSwitcherRow,
+  SearchableProject,
+  SearchableScratch,
+} from "@/hooks/useProjectSwitcherPalette";
 
 const NAME_WEIGHT = 4;
 
@@ -78,24 +82,69 @@ export function scoreProjectQuery(query: string, name: string, path: string): nu
   return NAME_WEIGHT * nameScore + pathScore;
 }
 
-export function rankProjectMatches(
+/**
+ * Scratches score on NAME ONLY. Their folders are UUID directories under
+ * `userData`, so a path term would be pure noise — and matching one would let a
+ * query that looks like a path hash surface every scratch at once.
+ *
+ * The same {@link NAME_WEIGHT} a project's name carries, so the two scales are
+ * directly comparable: an equal name match leaves the project ahead by exactly
+ * its path term (which is never negative), and a scratch whose name contains the
+ * query clears a project that only matched loosely.
+ */
+export function scoreScratchQuery(query: string, name: string): number {
+  if (!query) return 0;
+
+  const nameScore = scoreField(query, name);
+  if (nameScore === 0) return 0;
+
+  return NAME_WEIGHT * nameScore;
+}
+
+/** Projects sort ahead of scratches on an exact score tie. */
+const KIND_RANK: Record<ProjectSwitcherRow["kind"], number> = { project: 0, scratch: 1 };
+
+/**
+ * Ranks projects and scratches into the one array the palette renders, indexes
+ * and walks with the arrow keys (#11071). Scratches are only ever ranked — in
+ * browse they stay in their own pinned section, which is the caller's business.
+ *
+ * The comparator is a lexicographic tuple — score, then kind, then the per-kind
+ * recency proxy — which makes it transitive and total. That matters: a rule that
+ * reordered only CROSS-kind pairs (say, promoting a name substring over a loose
+ * subsequence) while same-kind pairs stayed on raw score would admit cycles, and
+ * `Array.prototype.sort` on an intransitive comparator is implementation-defined.
+ *
+ * With an empty scratch list this reduces exactly to the old project-only
+ * ranking, so search order for a user without scratches is unchanged.
+ */
+export function rankSwitcherMatches(
   query: string,
-  projects: SearchableProject[]
-): SearchableProject[] {
+  projects: SearchableProject[],
+  scratches: SearchableScratch[]
+): ProjectSwitcherRow[] {
   const trimmed = query.trim();
   if (!trimmed) return [];
 
-  const scored = projects
-    .map((project) => ({
-      project,
-      score: scoreProjectQuery(trimmed, project.name, project.path),
-    }))
-    .filter((entry) => entry.score > 0);
+  const scored: { row: ProjectSwitcherRow; score: number }[] = [];
+
+  for (const project of projects) {
+    const score = scoreProjectQuery(trimmed, project.name, project.path);
+    if (score > 0) scored.push({ row: { kind: "project", ...project }, score });
+  }
+  for (const scratch of scratches) {
+    const score = scoreScratchQuery(trimmed, scratch.name);
+    if (score > 0) scored.push({ row: { kind: "scratch", ...scratch }, score });
+  }
 
   scored.sort((a, b) => {
     if (a.score !== b.score) return b.score - a.score;
-    return b.project.frecencyScore - a.project.frecencyScore;
+    if (a.row.kind !== b.row.kind) return KIND_RANK[a.row.kind] - KIND_RANK[b.row.kind];
+    if (a.row.kind === "project" && b.row.kind === "project") {
+      return b.row.frecencyScore - a.row.frecencyScore;
+    }
+    return b.row.lastOpened - a.row.lastOpened;
   });
 
-  return scored.map((entry) => entry.project);
+  return scored.map((entry) => entry.row);
 }


### PR DESCRIPTION
## Summary

- Scratch workspaces were completely excluded from switcher search. `scratchResults` in `useProjectSwitcherPalette.ts` had no `query` in its dependency array, and `ScratchSection` rendered outside `ProjectListContent`, so it never received the query at all.
- The practical cost: typing a scratch's exact name and pressing Enter opened whatever project weakly matched instead. There was no keystroke path to a scratch by name, only browsing.
- Once a query is active, scratches now rank into the same array the palette renders, indexes, and walks with the arrow keys. Browsing with an empty input is unchanged: the pinned, collapsible Scratch section still sits at the bottom with its create and delete-all actions.

Resolves #11466

## Technical notes

**Ranking.** Scratches score on name only. Their folders are UUID directories under `userData`, so a path term would just be noise. Name scores at the same `NAME_WEIGHT` a project's name carries. The comparator is a lexicographic tuple: score, then kind (project first), then frecency or recency. That keeps it transitive and total, and it reduces exactly to the previous project-only ordering when there are no scratches.

**One array.** The merge happens in the hook, so the rendered list, the indexed list, and the arrow-key-walked list stay the same array. `selectedIndex` is still derived from a stored id.

**Deferred-query timing.** Ranking runs on the deferred query, so the pinned section hides on a new `isRankedSearch` flag rather than a plain non-empty check. Hiding it on the raw query would leave scratches in neither list for a frame, and for a user whose only workspaces are scratches, that reads as "no matches".

**Accessibility.** Scratch search rows are non-focusable `role="option"` divs carrying the shared `project-option-` id prefix, so `aria-activedescendant` and scroll-into-view keep resolving. A scratch's origin shows on a secondary line, `Scratch · 2h ago`, with no accent color spent on it.

**Guarded affordances.** Cmd+Enter falls back to a plain switch on a scratch row. Cmd+Backspace stays inert on a scratch, since scratch delete has no confirmation dialog and a chord away from a highlighted row shouldn't be able to trigger it unconfirmed. The footer drops hints that don't apply.

**Naming.** The search box, listbox, and results region are now labeled "workspaces" instead of "projects", matching the updated empty state copy.

## Changes

- `src/lib/projectSwitcherSearch.ts`: scratch scoring, ranking comparator
- `src/hooks/useProjectSwitcherPalette.ts`: merged ranked array, `isRankedSearch` flag
- `src/components/Project/ProjectSwitcherPalette.tsx`: scratch rows in the ranked list, guarded keyboard affordances, "workspaces" labeling
- `src/components/Project/ProjectSwitcher.tsx`, `src/components/Layout/Toolbar.tsx`, `src/ModalHostLayer.tsx`: minor wiring
- Six test files covering the search lib, the palette hook, and the palette component

## Testing

- Composite `npm run typecheck`: clean
- 368 tests pass across 14 files (search lib, palette hook plus its new scratch suite, all palette component suites, accent-guard contract)
- `npm run lint:ratchet`: clean, baseline improved by 1
- Prettier and ESLint clean on all 12 changed files
- No E2E spec covers scratch workspaces or the switcher palette, so none applied
