### PR TITLE
fix(session-restore): stop restored panes sharing one agent conversation

### DIFF
--- a/electron/lifecycle/__tests__/shutdown.test.ts
+++ b/electron/lifecycle/__tests__/shutdown.test.ts
@@ -90,8 +90,26 @@ vi.mock("../../services/McpServerService.js", () => ({
   mcpServerService: mcpServerMock,
 }));
 
-vi.mock("../../ipc/utils.js", () => ({
+// The shutdown chain reaches this module through a dynamic import, so the export
+// is exposed behind a getter that can be armed to throw. Arming it makes the
+// chain's `const { drainRateLimitQueues } = await import(...)` statement itself
+// fail, which a plain throwing mock function cannot — that would only prove the
+// CALL is guarded. It is a stand-in, not a true module-resolution failure: the
+// throw happens when the binding is read rather than when the loader rejects, so
+// a refactor that split the import and the destructure across the `try` boundary
+// could still pass. Armed after `setup()` so only the chain's import sees it.
+const ipcUtilsMock = vi.hoisted(() => ({
+  failLoad: false,
   drainRateLimitQueues: vi.fn(),
+}));
+
+vi.mock("../../ipc/utils.js", () => ({
+  get drainRateLimitQueues() {
+    if (ipcUtilsMock.failLoad) {
+      throw new Error("app.asar replaced under the running process");
+    }
+    return ipcUtilsMock.drainRateLimitQueues;
+  },
 }));
 
 const signalShutdownMock = vi.hoisted(() => ({
@@ -1118,6 +1136,70 @@ describe("registerShutdownHandler", () => {
       expect(record.branch).toBe("feature/x");
     });
 
+    it("still captures and journals when the rate-limit drain import fails", async () => {
+      // The motivating failure: an installer replaced app.asar under the running
+      // process, so the chain's `await import(...)` no longer yields the module. It
+      // sits ahead of the graceful kill, and unguarded its rejection took every
+      // session capture and journal record with it.
+      projectStoreMock.getAllProjects.mockReturnValue([{ id: "proj-1" }] as never);
+      const ptyClient = makePtyClient({
+        getAllTerminalsAsync: vi.fn(async () => [agentTerminal]),
+        gracefulKillByProject: vi.fn(async () => [{ id: "t1", agentSessionId: "sess-1" }]),
+      });
+      const { beforeQuitCb } = await setup({ getPtyClient: () => ptyClient });
+
+      try {
+        ipcUtilsMock.failLoad = true;
+        await beforeQuitCb(makeEvent());
+        await vi.waitFor(() => expect(appMock.exit).toHaveBeenCalled());
+
+        expect(ipcUtilsMock.drainRateLimitQueues).not.toHaveBeenCalled();
+        expect(projectStoreMock.enqueueProjectStateUpdate).toHaveBeenCalled();
+        expect(persistAgentSessionMock).toHaveBeenCalledTimes(1);
+        expect(
+          (persistAgentSessionMock.mock.calls[0][0] as Record<string, unknown>).sessionId
+        ).toBe("sess-1");
+        // A best-effort drain must not downgrade the exit to dirty either.
+        expect(appMock.exit).toHaveBeenCalledWith(0);
+      } finally {
+        ipcUtilsMock.failLoad = false;
+      }
+    });
+
+    it("still captures and journals when the rate-limit drain itself throws", async () => {
+      // The other half of the guard: the module loads, the drain blows up.
+      const { drainRateLimitQueues } = await import("../../ipc/utils.js");
+      vi.mocked(drainRateLimitQueues).mockImplementationOnce(() => {
+        throw new Error("rate-limit queue wedged");
+      });
+      projectStoreMock.getAllProjects.mockReturnValue([{ id: "proj-1" }] as never);
+      const gracefulKillByProject = vi.fn(async () => [{ id: "t1", agentSessionId: "sess-1" }]);
+      const ptyClient = makePtyClient({
+        getAllTerminalsAsync: vi.fn(async () => [agentTerminal]),
+        gracefulKillByProject,
+      });
+      const workspaceClient = {
+        dispose: vi.fn(),
+        getMonitorAsync: vi.fn(async () => ({ branch: "feature/x" })),
+      };
+      const { beforeQuitCb } = await setup({
+        getPtyClient: () => ptyClient,
+        getWorkspaceClient: () => workspaceClient as never,
+      });
+
+      await beforeQuitCb(makeEvent());
+      await vi.waitFor(() => expect(appMock.exit).toHaveBeenCalled());
+
+      expect(gracefulKillByProject).toHaveBeenCalledWith("proj-1");
+      expect(projectStoreMock.enqueueProjectStateUpdate).toHaveBeenCalled();
+      expect(persistAgentSessionMock).toHaveBeenCalledTimes(1);
+      expect((persistAgentSessionMock.mock.calls[0][0] as Record<string, unknown>).sessionId).toBe(
+        "sess-1"
+      );
+      // A best-effort drain must not downgrade the exit to dirty either.
+      expect(appMock.exit).toHaveBeenCalledWith(0);
+    });
+
     it("does not journal non-agent terminals or null-session captures", async () => {
       projectStoreMock.getAllProjects.mockReturnValue([{ id: "proj-1" }] as never);
       const ptyClient = makePtyClient({
@@ -1172,6 +1254,57 @@ describe("registerShutdownHandler", () => {
       );
       expect(persistedIds).toContain("sess-1");
       expect(persistedIds).toContain("sess-2");
+    });
+
+    it("keeps one project's captures when another project's kill rejects", async () => {
+      // The per-project timeout already isolates a slow project; a rejected IPC
+      // has to be isolated for the same reason. Unhandled, it escapes to the
+      // outer catch and takes the state write and the journal with it — for every
+      // project, including the ones that captured fine.
+      projectStoreMock.getAllProjects.mockReturnValue([
+        { id: "proj-1" },
+        { id: "proj-2" },
+      ] as never);
+      const ptyClient = makePtyClient({
+        getAllTerminalsAsync: vi.fn(async () => [{ ...agentTerminal, id: "t2" }]),
+        gracefulKillByProject: vi.fn(async (pid: string) => {
+          if (pid === "proj-1") throw new Error("pty-host gone");
+          return [{ id: "t2", agentSessionId: "sess-2" }];
+        }),
+      });
+      const { beforeQuitCb } = await setup({ getPtyClient: () => ptyClient });
+
+      await beforeQuitCb(makeEvent());
+      await vi.waitFor(() => expect(appMock.exit).toHaveBeenCalled());
+
+      expect(projectStoreMock.enqueueProjectStateUpdate).toHaveBeenCalledWith(
+        "proj-2",
+        expect.any(Function)
+      );
+      expect(persistAgentSessionMock).toHaveBeenCalledTimes(1);
+      expect((persistAgentSessionMock.mock.calls[0][0] as Record<string, unknown>).sessionId).toBe(
+        "sess-2"
+      );
+    });
+
+    it("still journals when persisting a project's captures rejects", async () => {
+      // The journal is the other half of the resume story and recoverable on its
+      // own (session history reads it), so a failed state write must not skip it.
+      projectStoreMock.getAllProjects.mockReturnValue([{ id: "proj-1" }] as never);
+      projectStoreMock.enqueueProjectStateUpdate.mockRejectedValueOnce(new Error("disk full"));
+      const ptyClient = makePtyClient({
+        getAllTerminalsAsync: vi.fn(async () => [agentTerminal]),
+        gracefulKillByProject: vi.fn(async () => [{ id: "t1", agentSessionId: "sess-1" }]),
+      });
+      const { beforeQuitCb } = await setup({ getPtyClient: () => ptyClient });
+
+      await beforeQuitCb(makeEvent());
+      await vi.waitFor(() => expect(appMock.exit).toHaveBeenCalled());
+
+      expect(persistAgentSessionMock).toHaveBeenCalledTimes(1);
+      expect((persistAgentSessionMock.mock.calls[0][0] as Record<string, unknown>).sessionId).toBe(
+        "sess-1"
+      );
     });
 
     it("still journals (branch undefined) when the branch lookup rejects", async () => {

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -194,8 +194,20 @@ async function runShutdownChain(deps: ShutdownDeps): Promise<ShutdownOutcome> {
   }
 
   console.log("[MAIN] Starting graceful shutdown...");
-  const { drainRateLimitQueues } = await import("../ipc/utils.js");
-  drainRateLimitQueues();
+  // Guarded like every other dynamic import in this chain, and for a sharper
+  // reason: this one runs BEFORE the graceful kill, so a rejection here rejects
+  // runShutdownChain outright and costs every agent's session capture and journal
+  // record — for the sake of a best-effort queue drain. A dynamic import can fail
+  // even for a module that resolved at boot: an installer replacing app.asar under
+  // a running process leaves anything not already in the module cache unreadable.
+  // The coordinator maps the rejection to a dirty exit, so the process still ends;
+  // what it cannot recover is the capture that never ran.
+  try {
+    const { drainRateLimitQueues } = await import("../ipc/utils.js");
+    drainRateLimitQueues();
+  } catch (err) {
+    console.warn("[MAIN] Rate-limit queue drain at quit failed:", err);
+  }
 
   const ptyClient = deps.getPtyClient();
   const workspaceClient = deps.getWorkspaceClient();
@@ -230,6 +242,10 @@ async function runShutdownChain(deps: ShutdownDeps): Promise<ShutdownOutcome> {
       // project must not discard the captured sessions of projects that did
       // finish in time — both the projectStore write and the resume journal
       // below depend on those partial results. Wall-clock stays ~4s (parallel).
+      // A rejected kill is isolated the same way and for the same reason: one
+      // project's IPC failing must cost only that project's captures, not every
+      // project's (an unhandled rejection here would escape to the outer catch
+      // and skip the state write and the journal wholesale).
       const allResults = await Promise.all(
         projectIds.map((pid) => {
           let timer: ReturnType<typeof setTimeout> | undefined;
@@ -238,9 +254,14 @@ async function runShutdownChain(deps: ShutdownDeps): Promise<ShutdownOutcome> {
             new Promise<Array<{ id: string; agentSessionId: string | null }>>((resolve) => {
               timer = setTimeout(() => resolve([]), 4000);
             }),
-          ]).finally(() => {
-            if (timer) clearTimeout(timer);
-          });
+          ])
+            .catch((error) => {
+              console.warn(`[MAIN] Graceful kill failed for project ${pid}:`, error);
+              return [] as Array<{ id: string; agentSessionId: string | null }>;
+            })
+            .finally(() => {
+              if (timer) clearTimeout(timer);
+            });
         })
       );
 
@@ -249,16 +270,26 @@ async function runShutdownChain(deps: ShutdownDeps): Promise<ShutdownOutcome> {
         const captured = results.filter((r) => r.agentSessionId);
         if (captured.length === 0) continue;
 
-        await projectStore.enqueueProjectStateUpdate(projectIds[i], (state) => {
-          if (!state?.terminals) return null;
-          for (const result of captured) {
-            const snapshot = state.terminals.find((t: { id: string }) => t.id === result.id);
-            if (snapshot) {
-              snapshot.agentSessionId = result.agentSessionId ?? undefined;
+        try {
+          await projectStore.enqueueProjectStateUpdate(projectIds[i], (state) => {
+            if (!state?.terminals) return null;
+            for (const result of captured) {
+              const snapshot = state.terminals.find((t: { id: string }) => t.id === result.id);
+              if (snapshot) {
+                snapshot.agentSessionId = result.agentSessionId ?? undefined;
+              }
             }
-          }
-          return state;
-        });
+            return state;
+          });
+        } catch (error) {
+          // Per-project so one failed write can't skip the remaining projects —
+          // or the journal below, which is the other half of the resume story and
+          // is recoverable on its own (session history reads it).
+          console.warn(
+            `[MAIN] Persisting captured sessions failed for project ${projectIds[i]}:`,
+            error
+          );
+        }
       }
 
       // Journal a resume record per captured agent session, matching the

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -29,7 +29,10 @@ vi.mock("../reconnectManager", () => ({
 
 vi.mock("../statePatcher", () => ({
   inferKind: (s: TerminalState) => s.kind ?? "terminal",
-  resolveAgentId: (id: string | undefined) => id,
+  // Mirrors the real two-arg resolver (primary, then fallback, both by
+  // truthiness) — dropping the fallback here would quietly make every
+  // live-record-first identity lookup resolve to nothing.
+  resolveAgentId: (id: string | undefined, fallback?: string) => id || fallback || undefined,
   inferAgentIdFromTitle: (
     _title: string | undefined,
     kind: string | undefined,
@@ -65,7 +68,7 @@ vi.mock("../statePatcher", () => ({
     reconnectTimedOut?: boolean,
     _clipboardDirectory?: string,
     _projectPresetsByAgent?: unknown,
-    options?: { allowResumeLatest?: boolean }
+    options?: { allowResumeLatest?: boolean; allowSessionIdResume?: boolean }
   ) => ({
     cwd: s.cwd ?? "/cwd",
     kind,
@@ -75,9 +78,10 @@ vi.mock("../statePatcher", () => ({
     // requested id so the store generates a fresh one (#10440).
     requestedId: reconnectTimedOut ? undefined : s.id,
     launchAgentId: s.launchAgentId,
-    // Not a real AddTerminalArgs field — surfaced on the mock's output so the
-    // resume-latest election (#11461) is assertable through addPanel's args.
+    // Not real AddTerminalArgs fields — surfaced on the mock's output so the
+    // resume election (#11461) is assertable through addPanel's args.
     allowResumeLatest: options?.allowResumeLatest ?? true,
+    allowSessionIdResume: options?.allowSessionIdResume ?? true,
   }),
   // Mirrors the real resolver's title recovery (same agent order) so the
   // election's identity resolution can't silently diverge from production.
@@ -1202,6 +1206,19 @@ describe("restorePanelsPhase — one resume-latest per agent+cwd (issue #11461)"
     return byId;
   }
 
+  /** id → the allowSessionIdResume the respawn builder was handed. */
+  function sessionAllowanceById(ctx: MockedContext): Map<string, boolean> {
+    const byId = new Map<string, boolean>();
+    for (const [args] of ctx.addPanel.mock.calls as [
+      { requestedId?: string; allowSessionIdResume?: boolean },
+    ][]) {
+      if (args.requestedId !== undefined && args.allowSessionIdResume !== undefined) {
+        byId.set(args.requestedId, args.allowSessionIdResume);
+      }
+    }
+    return byId;
+  }
+
   const codexPanel = (id: string, overrides: Partial<TerminalState> = {}): TerminalState =>
     panel(id, { kind: "agent", launchAgentId: "codex", ...overrides });
 
@@ -1312,25 +1329,41 @@ describe("restorePanelsPhase — one resume-latest per agent+cwd (issue #11461)"
     expect(allowanceById(ctx).get("dotted")).toBe(false);
   });
 
-  it("does not let a pane with its own session id consume the slot", async () => {
+  it("suppresses the fallback where a sibling resumes an exact session id", async () => {
     const ctx = makeContext();
 
     await restorePanelsPhase(
       [
-        codexPanel("exact", { agentSessionId: "abc", lastActiveAt: 900 }),
-        codexPanel("idless", { lastActiveAt: 1 }),
+        codexPanel("exact", { agentSessionId: "abc", lastActiveAt: 1 }),
+        codexPanel("idless", { lastActiveAt: 900 }),
       ],
       ctx
     );
 
-    // The exact-id pane resumes precisely and never contends, so the id-less one
-    // still gets the fallback despite being far less recent.
+    // "Resume the latest session here" cannot be steered away from the session
+    // `exact` is replaying into, and being the more recently focused pane does
+    // not change which of the two reaches the directory first.
+    expect(allowanceById(ctx).get("idless")).toBe(false);
+  });
+
+  it("keeps an exact-id pane's claim inside its own directory", async () => {
+    const ctx = makeContext();
+
+    await restorePanelsPhase(
+      [
+        codexPanel("exact", { cwd: "/proj/one", agentSessionId: "abc" }),
+        codexPanel("idless", { cwd: "/proj/two" }),
+      ],
+      ctx
+    );
+
+    // Different scope, different pool of sessions — nothing to collide with.
     expect(allowanceById(ctx).get("idless")).toBe(true);
   });
 
-  it("does not spend the slot on a pane whose PTY survived", async () => {
-    // A live backend reconnects instead of respawning, so it can never reach the
-    // fallback — letting it win would strand the pane that actually respawns.
+  it("suppresses the fallback where a sibling's PTY survived", async () => {
+    // The survivor reconnects to a session that is open and being written right
+    // now, which is exactly what resume-latest would resolve to.
     const ctx = makeContext({
       backendTerminalMap: new Map([["survivor", backend("survivor", { kind: "agent" })]]),
     });
@@ -1340,7 +1373,40 @@ describe("restorePanelsPhase — one resume-latest per agent+cwd (issue #11461)"
       ctx
     );
 
-    expect(allowanceById(ctx).get("respawner")).toBe(true);
+    expect(allowanceById(ctx).get("respawner")).toBe(false);
+  });
+
+  it("suppresses every candidate in a claimed scope, not just the losers", async () => {
+    const ctx = makeContext();
+
+    await restorePanelsPhase(
+      [
+        codexPanel("exact", { agentSessionId: "abc" }),
+        codexPanel("a", { lastActiveAt: 100 }),
+        codexPanel("b", { lastActiveAt: 300 }),
+      ],
+      ctx
+    );
+
+    // Asserted as a complete map: a claim must not degrade into "one winner
+    // survives", which is the collision this suppression exists to prevent. The
+    // claimant's own allowance is moot — it resumes by id and never reaches the
+    // fallback — so it stays untouched.
+    expect(Object.fromEntries(allowanceById(ctx))).toEqual({ exact: true, a: false, b: false });
+  });
+
+  it("does not let one agent's claim suppress another agent's fallback", async () => {
+    const ctx = makeContext();
+
+    await restorePanelsPhase(
+      [
+        codexPanel("cx-exact", { agentSessionId: "abc" }),
+        panel("cl", { kind: "agent", launchAgentId: "claude" }),
+      ],
+      ctx
+    );
+
+    expect(allowanceById(ctx).get("cl")).toBe(true);
   });
 
   it("elects for a non-Codex capable agent too", async () => {
@@ -1359,9 +1425,10 @@ describe("restorePanelsPhase — one resume-latest per agent+cwd (issue #11461)"
     expect(Object.fromEntries(allowanceById(ctx))).toEqual({ "g-old": false, "g-new": true });
   });
 
-  it("does not spend the slot on a pane a prefetched probe says is still alive", async () => {
-    // The probe short-circuits reconnect to "found", so this pane never respawns
-    // and must not consume the scope's only slot.
+  it("suppresses the fallback where a prefetched probe says a sibling is alive", async () => {
+    // The probe reports a live PTY, so that pane keeps its open session in the
+    // directory. (Only the election is asserted here — the describe-level
+    // reconnect mock answers "not_found" for every pane regardless.)
     const ctx = makeContext({
       prefetchedReconnectResults: {
         alive: { id: "alive", exists: true, hasPty: true },
@@ -1373,7 +1440,179 @@ describe("restorePanelsPhase — one resume-latest per agent+cwd (issue #11461)"
       ctx
     );
 
+    expect(allowanceById(ctx).get("cold")).toBe(false);
+  });
+
+  it("does not let a backend record with no live PTY claim the scope", async () => {
+    // A dead agent backend is dropped outright by the restore branch (it would be
+    // a phantom idle panel), so it holds no session — suppressing its cold sibling
+    // would cost a resume to protect a conversation that isn't there.
+    const ctx = makeContext({
+      backendTerminalMap: new Map([
+        ["dead", backend("dead", { kind: "agent", launchAgentId: "codex", hasPty: false })],
+      ]),
+    });
+
+    await restorePanelsPhase(
+      [codexPanel("dead", { lastActiveAt: 900 }), codexPanel("cold", { lastActiveAt: 1 })],
+      ctx
+    );
+
     expect(allowanceById(ctx).get("cold")).toBe(true);
+  });
+
+  it("does not treat a probe reporting no live PTY as a claim", async () => {
+    // `exists` without `hasPty` is a known-but-dead terminal: it respawns like any
+    // other cold pane, so it neither claims the scope nor escapes the vote.
+    const ctx = makeContext({
+      prefetchedReconnectResults: {
+        dead: { id: "dead", exists: true, hasPty: false },
+      },
+    });
+
+    await restorePanelsPhase(
+      [codexPanel("dead", { lastActiveAt: 900 }), codexPanel("cold", { lastActiveAt: 1 })],
+      ctx
+    );
+
+    expect(Object.fromEntries(allowanceById(ctx))).toEqual({ dead: true, cold: false });
+  });
+
+  it("scopes a live sibling by its own cwd when the snapshot never recorded one", async () => {
+    // A legacy snapshot with no cwd would key on projectRoot, missing the
+    // directory its live PTY is actually running in.
+    const ctx = makeContext({
+      backendTerminalMap: new Map([
+        ["alive", backend("alive", { kind: "agent", launchAgentId: "codex", cwd: "/proj/sub" })],
+      ]),
+    });
+
+    await restorePanelsPhase(
+      [
+        codexPanel("alive", { cwd: undefined }),
+        codexPanel("cold", { cwd: "/proj/sub" }),
+        codexPanel("elsewhere", { cwd: "/proj/other" }),
+      ],
+      ctx
+    );
+
+    expect(allowanceById(ctx).get("cold")).toBe(false);
+    expect(allowanceById(ctx).get("elsewhere")).toBe(true);
+  });
+
+  it("identifies a live sibling's agent from its backend record", async () => {
+    // Same gap on the other axis: a snapshot written before `launchAgentId`
+    // existed can only be recognized as an agent through the live record.
+    const ctx = makeContext({
+      backendTerminalMap: new Map([
+        ["alive", backend("alive", { kind: "agent", launchAgentId: "codex" })],
+      ]),
+    });
+
+    await restorePanelsPhase(
+      [
+        panel("alive", { kind: "terminal", title: "Terminal", launchAgentId: undefined }),
+        codexPanel("cold"),
+      ],
+      ctx
+    );
+
+    expect(allowanceById(ctx).get("cold")).toBe(false);
+  });
+
+  it("elects one owner when two panes carry the same session id", async () => {
+    // The state the original collision leaves behind: both panes reopened one
+    // conversation, so the next quit captured that one id into both snapshots.
+    // Replaying both would put two writers on one transcript.
+    const ctx = makeContext();
+
+    await restorePanelsPhase(
+      [
+        codexPanel("older", { agentSessionId: "dupe", lastActiveAt: 1 }),
+        codexPanel("newer", { agentSessionId: "dupe", lastActiveAt: 9 }),
+      ],
+      ctx
+    );
+
+    expect(Object.fromEntries(sessionAllowanceById(ctx))).toEqual({ older: false, newer: true });
+    // The loser must not fall through to resume-latest either — in this directory
+    // that resolves to the very session the owner is replaying.
+    expect(allowanceById(ctx).get("older")).toBe(false);
+  });
+
+  it("elects one owner for an agent that has no resume-latest fallback", async () => {
+    // Goose resumes by session id but ships no resume-latest args, so it never
+    // reaches the capability probe's side of the pre-pass. Duplicate ids still
+    // have to be deduped — moving that probe ahead of the exact-id branch would
+    // silently exempt every such agent.
+    const goosePanel = (id: string, lastActiveAt: number): TerminalState =>
+      panel(id, { kind: "agent", launchAgentId: "goose", agentSessionId: "dupe", lastActiveAt });
+    const ctx = makeContext();
+
+    await restorePanelsPhase([goosePanel("older", 1), goosePanel("newer", 9)], ctx);
+
+    expect(Object.fromEntries(sessionAllowanceById(ctx))).toEqual({ older: false, newer: true });
+  });
+
+  it("gives a live PTY outright ownership of the session id it is attached to", async () => {
+    // Ranking is meaningless against a pane that is writing to the transcript
+    // right now, and the cold holder loses even though it is the only snapshot
+    // contending for that id.
+    const ctx = makeContext({
+      backendTerminalMap: new Map([
+        [
+          "alive",
+          backend("alive", { kind: "agent", launchAgentId: "codex", agentSessionId: "dupe" }),
+        ],
+      ]),
+    });
+
+    await restorePanelsPhase(
+      [
+        codexPanel("alive", { agentSessionId: "dupe", lastActiveAt: 1 }),
+        codexPanel("cold", { agentSessionId: "dupe", lastActiveAt: 900 }),
+      ],
+      ctx
+    );
+
+    expect(sessionAllowanceById(ctx).get("cold")).toBe(false);
+    expect(allowanceById(ctx).get("cold")).toBe(false);
+  });
+
+  it("claims a reconnecting pane's scope under the agent its live record names", async () => {
+    // Reconnect resolves identity live-first, so a stale snapshot agent id would
+    // claim a scope this pane is not in and leave the one it IS in open.
+    const ctx = makeContext({
+      backendTerminalMap: new Map([
+        ["alive", backend("alive", { kind: "agent", launchAgentId: "claude" })],
+      ]),
+    });
+
+    await restorePanelsPhase(
+      [
+        codexPanel("alive"),
+        panel("cold-claude", { kind: "agent", launchAgentId: "claude" }),
+        codexPanel("cold-codex"),
+      ],
+      ctx
+    );
+
+    expect(allowanceById(ctx).get("cold-claude")).toBe(false);
+    expect(allowanceById(ctx).get("cold-codex")).toBe(true);
+  });
+
+  it("leaves distinct session ids alone", async () => {
+    const ctx = makeContext();
+
+    await restorePanelsPhase(
+      [
+        codexPanel("a", { agentSessionId: "sess-a" }),
+        codexPanel("b", { agentSessionId: "sess-b" }),
+      ],
+      ctx
+    );
+
+    expect(Object.fromEntries(sessionAllowanceById(ctx))).toEqual({ a: true, b: true });
   });
 
   it("does not let a smoke-test pane consume a real pane's slot", async () => {

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -824,6 +824,110 @@ describe("buildArgsForRespawn", () => {
       expect(suppressed.sessionLostOnRestore).toBe(allowed.sessionLostOnRestore);
     });
 
+    it("withholds an exact session id a sibling owns (#11461)", () => {
+      // Two panes can persist ONE session id — that is what the collision this
+      // guards against leaves behind — so the loser must not replay it.
+      buildResumeCommandMock.mockReturnValue("claude --resume dupe");
+      buildResumeLatestCommandMock.mockReturnValue("claude --continue");
+      const result = buildArgsForRespawn(
+        {
+          id: "t1",
+          kind: "terminal" as const,
+          agentId: "claude",
+          cwd: "/p",
+          location: "grid",
+          agentSessionId: "dupe",
+        },
+        "terminal",
+        "/p",
+        { agents: { claude: {} } },
+        false,
+        "/tmp",
+        undefined,
+        { allowSessionIdResume: false, allowResumeLatest: false }
+      );
+      expect(result.command).toBe("claude --generated");
+      expect(result.sessionLostOnRestore).toBe(true);
+    });
+
+    it("does not inherit a persisted --resume command when the id is withheld (#11461)", () => {
+      // With nothing to rebuild from, `saved.command` still holds the resume
+      // command an earlier restore built. Re-running it would put this pane back
+      // in the owner's conversation, which is the collision being prevented.
+      buildResumeCommandMock.mockReturnValue("claude --resume dupe");
+      // No resume-latest fallback for this agent: the withheld id alone has to
+      // drive the clean rebuild.
+      buildResumeLatestCommandMock.mockReturnValue(undefined);
+      const result = buildArgsForRespawn(
+        {
+          id: "t1",
+          kind: "terminal" as const,
+          agentId: "claude",
+          cwd: "/p",
+          location: "grid",
+          agentSessionId: "dupe",
+          command: "claude --resume dupe",
+        },
+        "terminal",
+        "/p",
+        undefined,
+        false,
+        "/tmp",
+        undefined,
+        { allowSessionIdResume: false, allowResumeLatest: false }
+      );
+      expect(result.command).toBe("claude");
+      expect(result.sessionLostOnRestore).toBe(true);
+    });
+
+    it("does not fall back to resume-latest when the session id is withheld (#11461)", () => {
+      // The two allowances always travel together from the election, but the gate
+      // holds on its own: reaching the fallback here would land in the very
+      // conversation the owner is replaying.
+      buildResumeCommandMock.mockReturnValue("claude --resume dupe");
+      buildResumeLatestCommandMock.mockReturnValue("claude --continue");
+      const result = buildArgsForRespawn(
+        {
+          id: "t1",
+          kind: "terminal" as const,
+          agentId: "claude",
+          cwd: "/p",
+          location: "grid",
+          agentSessionId: "dupe",
+        },
+        "terminal",
+        "/p",
+        { agents: { claude: {} } },
+        false,
+        "/tmp",
+        undefined,
+        { allowSessionIdResume: false }
+      );
+      expect(result.command).toBe("claude --generated");
+      expect(result.sessionLostOnRestore).toBe(true);
+    });
+
+    it("resumes its own session id by default when no allowance is passed (#11461)", () => {
+      buildResumeCommandMock.mockReturnValue("claude --resume sess-1");
+      const result = buildArgsForRespawn(
+        {
+          id: "t1",
+          kind: "terminal" as const,
+          agentId: "claude",
+          cwd: "/p",
+          location: "grid",
+          agentSessionId: "sess-1",
+        },
+        "terminal",
+        "/p",
+        { agents: { claude: {} } },
+        false,
+        "/tmp"
+      );
+      expect(result.command).toBe("claude --resume sess-1");
+      expect(result.sessionLostOnRestore).toBeUndefined();
+    });
+
     it("uses resume-latest by default when no allowance is passed (#11461)", () => {
       buildResumeLatestCommandMock.mockReturnValue("claude --continue");
       const result = buildArgsForRespawn(

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -55,86 +55,214 @@ function resumeLatestScopeCwd(cwd: string): string {
 }
 
 /**
- * Ids of panes that must NOT use their agent's resume-latest fallback because a
- * sibling pane in the same (agent, cwd) scope already owns that scope's single
- * slot (#11461). Highest valid `lastActiveAt` wins and ties keep the earlier
- * saved entry, so the outcome is deterministic and independent of restore order.
+ * Compound key for the resume election. NUL-joined: neither an agent id, a path
+ * nor a session id can contain it, so a key can never be forged by an unusual
+ * path or a future custom agent id.
+ */
+function resumeKey(agentId: string, part: string): string {
+  return `${agentId}\u0000${part}`;
+}
+
+/** Key for one (agent, directory) resume-latest scope. */
+function resumeScopeKey(agentId: string, cwd: string): string {
+  return resumeKey(agentId, resumeLatestScopeCwd(cwd));
+}
+
+/**
+ * Which panes must be denied which resume on restore, so no two restored panes
+ * end up writing into one agent conversation (#11461).
+ */
+interface ResumeSuppression {
+  /** Panes denied their agent's resume-latest fallback. */
+  resumeLatest: Set<string>;
+  /** Panes denied the exact `agentSessionId` they carry, because a sibling owns it. */
+  sessionId: Set<string>;
+}
+
+/**
+ * Decide, before any restore task dispatches, which panes may resume what.
  *
- * Only panes that could actually reach the fallback are candidates: an id-less
- * agent pane, of an agent that declares resume-latest args, whose PTY did not
- * survive. A pane with a live backend record — or a prefetched probe that already
- * says its PTY exists — reconnects instead of respawning, so letting one win a
- * slot would strand its genuinely-respawning siblings on fresh launches.
+ * Two collisions are possible and they need different answers.
  *
- * Scopes with a single candidate are omitted entirely, so the common one-pane
- * case keeps its existing behavior by construction.
+ * **The fallback resolves by recency, not identity.** `claude --continue` and
+ * `codex resume --last` reopen whichever session in the directory was touched
+ * last, and nothing about the command says which one that is. So a pane may use
+ * it only when nothing else in its (agent, cwd) scope is already attached to a
+ * session there. Two kinds of pane claim a scope: one carrying its own
+ * `agentSessionId`, which replays into that exact transcript, and one whose PTY
+ * survived, which reconnects to a conversation running right now. `lastActiveAt`
+ * cannot rank around a claim — whether the fallback reaches the directory before
+ * or after the claimant depends on launch order, not on which pane the user last
+ * focused — so every candidate in a claimed scope is suppressed. Among candidates
+ * in an UNCLAIMED scope the highest valid `lastActiveAt` takes the scope's single
+ * slot, ties keeping the earlier saved entry, so the outcome is deterministic and
+ * independent of restore order. A lone candidate in an unclaimed scope is never
+ * recorded, so the common single-pane case keeps its behavior by construction.
+ *
+ * **Two panes can carry the SAME `agentSessionId`.** That is exactly what the bug
+ * this guards against produces: two panes reopen one conversation, and the next
+ * quit captures that one session id into both snapshots. Replaying both would put
+ * two writers on one transcript, so one owner is elected per (agent, session id)
+ * by the same ranking, and the losers resume nothing at all. A live PTY attached
+ * to that session owns it outright rather than by ranking — it is writing now —
+ * so every cold holder of its id loses, alone or not.
+ *
+ * A suppressed pane launches fresh with `sessionLostOnRestore`, which raises the
+ * existing banner and leaves the conversation reachable from session history.
+ * That is the trade throughout: one pane missing a resume beats two panes writing
+ * into one conversation.
  *
  * Liveness is only as good as what is known synchronously. When the bulk probe
  * timed out there is no prefetched result, and a per-panel reconnect can still
- * find a live PTY after the election has run — that pane then holds a slot it
- * never uses and its cold sibling launches fresh. Deliberately accepted: the
+ * find a live PTY after the election has run — that scope is then judged unclaimed
+ * and its winner resumes latest into the live session. Deliberately accepted: the
  * election has to complete before any task dispatches (a claim taken after an
- * await races, the hazard #11052 fixed for restart), and the cost is one pane
- * missing a resume rather than two panes sharing a conversation.
+ * await races, the hazard #11052 fixed for restart), and treating unknown liveness
+ * as a claim would cost every multi-pane scope its resume on a transient probe
+ * failure. A failed prefetch degrades to the behavior that shipped with the
+ * election rather than to something worse.
  */
-function electSuppressedResumeLatestIds(
+function electResumeSuppression(
   panels: readonly (TerminalState | undefined)[],
   context: {
     projectRoot: string;
     backendTerminalMap: Map<string, BackendTerminalInfo>;
     prefetchedReconnectResults?: Record<string, TerminalReconnectResult>;
   }
-): Set<string> {
+): ResumeSuppression {
   const winnerByScope = new Map<string, { id: string; lastActiveAt: number }>();
   const candidateIdsByScope = new Map<string, string[]>();
+  const claimedScopes = new Set<string>();
+  const ownerBySession = new Map<string, { id: string; lastActiveAt: number }>();
+  const holderIdsBySession = new Map<string, string[]>();
+  const liveOwnedSessions = new Set<string>();
+
+  // A corrupt or missing stamp ranks lowest rather than winning anything, and a
+  // tie keeps the entry seen first — the saved array's order, not restore order.
+  const recordBest = (
+    best: Map<string, { id: string; lastActiveAt: number }>,
+    key: string,
+    saved: TerminalState
+  ): void => {
+    const stamp = saved.lastActiveAt ?? 0;
+    const lastActiveAt = Number.isFinite(stamp) && stamp > 0 ? stamp : 0;
+    const current = best.get(key);
+    if (current === undefined || lastActiveAt > current.lastActiveAt) {
+      best.set(key, { id: saved.id, lastActiveAt });
+    }
+  };
+  const pushId = (into: Map<string, string[]>, key: string, id: string): void => {
+    const existing = into.get(key);
+    if (existing === undefined) {
+      into.set(key, [id]);
+    } else {
+      existing.push(id);
+    }
+  };
 
   for (const saved of panels) {
     if (saved === undefined) continue;
     if (isSmokeTestTerminalId(saved.id)) continue;
-    // An exact per-pane session id resumes precisely and never consumes a slot.
-    if (saved.agentSessionId) continue;
-    if (context.backendTerminalMap.has(saved.id)) continue;
-    // A prefetched probe reporting a live PTY takes the reconnect path in
-    // `reconnectWithTimeout`, so this pane never respawns either.
+
+    // A pane with a backend record reconnects rather than respawns; the prefetched
+    // probe stands in for the same thing when it reports a live PTY. Either way
+    // the live record — not the snapshot — describes what is actually running, and
+    // can supply an identity a legacy snapshot lacks.
+    const backendTerminal = context.backendTerminalMap.get(saved.id);
     const prefetched = context.prefetchedReconnectResults?.[saved.id];
-    if (prefetched?.exists && prefetched.hasPty) continue;
-    const kind = inferKind(saved);
+    const livePrefetch =
+      backendTerminal === undefined && prefetched?.exists === true && prefetched.hasPty === true
+        ? prefetched
+        : undefined;
+    const record = backendTerminal ?? livePrefetch;
+    const reconnects = record !== undefined;
+    // Holds an open conversation only with a live PTY. A `hasPty === false`
+    // backend record is either dropped outright by the restore branch below (a
+    // dead agent would be a phantom idle panel) or recreated with no session —
+    // neither is something the fallback can collide with.
+    const holdsLiveSession = reconnects && record.hasPty !== false;
+
+    const kind = record?.kind ?? inferKind(saved);
     if (kind === "assistant" || !panelKindHasPty(kind)) continue;
-    const agentId = resolveRespawnAgentId(saved, kind);
+    const savedAgentId = resolveRespawnAgentId(saved, inferKind(saved));
+
+    if (reconnects) {
+      if (!holdsLiveSession) continue;
+      // Identity live-first, mirroring `buildArgsForBackendTerminal` — a stale
+      // snapshot agent id would otherwise claim a scope this pane is not in, and
+      // leave the one it IS in open to a colliding fallback. `saved.cwd` still
+      // leads for the directory, because it is already rebased across a worktree
+      // move (#11388) while the live record reports the pre-move path, and it is
+      // the key every candidate uses; the live cwd fills in for a snapshot that
+      // never recorded one.
+      const liveAgentId = resolveAgentId(record.launchAgentId, savedAgentId);
+      if (liveAgentId === undefined) continue;
+      claimedScopes.add(
+        resumeScopeKey(liveAgentId, saved.cwd || record.cwd || context.projectRoot)
+      );
+      // A live PTY owns its session outright: it is attached NOW, so a cold pane
+      // holding the same id has nothing to rank against and must not replay it.
+      const liveSessionId = record.agentSessionId ?? saved.agentSessionId;
+      if (liveSessionId) {
+        liveOwnedSessions.add(resumeKey(liveAgentId, liveSessionId));
+      }
+      continue;
+    }
+
+    // Respawning: identity is whatever the respawn itself will resolve.
+    const agentId = savedAgentId;
     if (agentId === undefined) continue;
+    const scope = resumeScopeKey(agentId, saved.cwd || context.projectRoot);
+
+    if (saved.agentSessionId) {
+      // Respawning with an exact id: claims the scope, and contends for sole
+      // ownership of the session id itself.
+      claimedScopes.add(scope);
+      const sessionKey = resumeKey(agentId, saved.agentSessionId);
+      pushId(holderIdsBySession, sessionKey, saved.id);
+      recordBest(ownerBySession, sessionKey, saved);
+      continue;
+    }
+
     // Probe capability through the very builder the respawn branch calls, so
     // eligibility can't drift from behavior (covers custom/plugin agents too).
     if (buildResumeLatestCommand(agentId) === undefined) continue;
 
-    // NUL-joined: neither an agent id nor a path can contain it, so the key can
-    // never be forged by an unusual path or a future custom agent id.
-    const scope = `${agentId}\u0000${resumeLatestScopeCwd(saved.cwd || context.projectRoot)}`;
-    const existingIds = candidateIdsByScope.get(scope);
-    if (existingIds === undefined) {
-      candidateIdsByScope.set(scope, [saved.id]);
-    } else {
-      existingIds.push(saved.id);
-    }
-
-    // A corrupt or missing stamp ranks lowest rather than winning the slot.
-    const savedLastActiveAt = saved.lastActiveAt ?? 0;
-    const lastActiveAt =
-      Number.isFinite(savedLastActiveAt) && savedLastActiveAt > 0 ? savedLastActiveAt : 0;
-    const currentWinner = winnerByScope.get(scope);
-    if (currentWinner === undefined || lastActiveAt > currentWinner.lastActiveAt) {
-      winnerByScope.set(scope, { id: saved.id, lastActiveAt });
-    }
+    pushId(candidateIdsByScope, scope, saved.id);
+    recordBest(winnerByScope, scope, saved);
   }
 
-  const suppressed = new Set<string>();
+  const resumeLatest = new Set<string>();
+  const sessionId = new Set<string>();
   for (const [scope, ids] of candidateIdsByScope) {
+    if (claimedScopes.has(scope)) {
+      for (const id of ids) {
+        resumeLatest.add(id);
+      }
+      continue;
+    }
     if (ids.length < 2) continue;
     const winnerId = winnerByScope.get(scope)?.id;
     for (const id of ids) {
-      if (id !== winnerId) suppressed.add(id);
+      if (id !== winnerId) resumeLatest.add(id);
     }
   }
-  return suppressed;
+  for (const [sessionKey, ids] of holderIdsBySession) {
+    // A live PTY already owns the session, so every cold holder loses — including
+    // a lone one, which has no rival among the snapshots but a very real one on
+    // the other end of that transcript.
+    const liveOwned = liveOwnedSessions.has(sessionKey);
+    if (!liveOwned && ids.length < 2) continue;
+    const ownerId = liveOwned ? undefined : ownerBySession.get(sessionKey)?.id;
+    for (const id of ids) {
+      if (id === ownerId) continue;
+      // Denied the id it carries — and the fallback with it, since resume-latest
+      // in that directory resolves to the very session the owner is replaying.
+      sessionId.add(id);
+      resumeLatest.add(id);
+    }
+  }
+  return { resumeLatest, sessionId };
 }
 
 /**
@@ -361,16 +489,18 @@ export async function restorePanelsPhase(
       }
     }
 
-    // Elect at most one pane per (agent, cwd) to use the agent's resume-latest
-    // fallback. That fallback resolves to the most recent session in scope
-    // (`codex resume --last`, `claude --continue`), so N id-less panes sharing a
-    // directory would every one of them reopen the SAME conversation (#11461).
-    // Computed synchronously over static saved fields before any task executes:
-    // same-tier tasks run concurrently via Promise.allSettled, so a check-and-claim
-    // inside the closures would race (the hazard already fixed once for restart,
-    // #11052). Only the losers are recorded, so a lone candidate — the common
-    // single-pane case — is never suppressed.
-    const resumeLatestSuppressedIds = electSuppressedResumeLatestIds(panels, {
+    // Decide which panes may resume what, before any restore task runs. At most
+    // one pane per (agent, cwd) may use the agent's resume-latest fallback, none
+    // may where a sibling already holds a session in that directory, and only one
+    // pane may replay a given session id. That fallback resolves to the most
+    // recent session in scope (`codex resume --last`, `claude --continue`), so
+    // panes sharing a directory would otherwise all reopen the SAME conversation
+    // (#11461). Computed synchronously over static saved fields: same-tier tasks
+    // run concurrently via Promise.allSettled, so a check-and-claim inside the
+    // closures would race (the hazard already fixed once for restart, #11052).
+    // Only suppressions are recorded, so a lone candidate in an unclaimed scope —
+    // the common single-pane case — is never touched.
+    const resumeSuppression = electResumeSuppression(panels, {
       projectRoot: projectRoot || "",
       backendTerminalMap,
       prefetchedReconnectResults,
@@ -577,7 +707,8 @@ export async function restorePanelsPhase(
                   projectPresetsByAgent,
                   {
                     resolvedAgentBaseCommand,
-                    allowResumeLatest: !resumeLatestSuppressedIds.has(saved.id),
+                    allowResumeLatest: !resumeSuppression.resumeLatest.has(saved.id),
+                    allowSessionIdResume: !resumeSuppression.sessionId.has(saved.id),
                   }
                 );
 

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -483,10 +483,17 @@ export interface BuildArgsForRespawnOptions {
   resolvedAgentBaseCommand?: string;
   /**
    * False when a sibling pane already owns this agent+cwd's single resume-latest
-   * slot (#11461). Only suppresses the resume-latest fallback — an exact
-   * per-pane session id still resumes normally.
+   * slot, or when something else in that directory already holds a session the
+   * fallback would resolve to (#11461).
    */
   allowResumeLatest?: boolean;
+  /**
+   * False when a sibling pane owns the exact `agentSessionId` this snapshot
+   * carries (#11461). Two panes can persist one session id — that is what the
+   * collision this guards against leaves behind — and replaying both would put
+   * two writers on one transcript, so the loser resumes nothing.
+   */
+  allowSessionIdResume?: boolean;
 }
 
 export function buildArgsForRespawn(
@@ -501,6 +508,13 @@ export function buildArgsForRespawn(
 ): AddTerminalArgs {
   const resolvedAgentBaseCommand = options?.resolvedAgentBaseCommand;
   const allowResumeLatest = options?.allowResumeLatest ?? true;
+  const allowSessionIdResume = options?.allowSessionIdResume ?? true;
+  // True once a resume this snapshot could have replayed was withheld on purpose.
+  // `command` still holds `saved.command`, which is itself a resume command
+  // whenever an earlier restore built one, so the suppressed paths below have to
+  // rebuild it rather than inherit it — that would reinstate the very collision
+  // the suppression exists to prevent.
+  const resumeWithheld = Boolean(saved.agentSessionId) && !allowSessionIdResume;
   const effectiveAgentId = resolveRespawnAgentId(saved, kind);
 
   const isAgentPanel = Boolean(effectiveAgentId);
@@ -580,7 +594,7 @@ export function buildArgsForRespawn(
         shareClipboardDirectory,
       });
 
-    if (saved.agentSessionId) {
+    if (saved.agentSessionId && allowSessionIdResume) {
       const resumeCmd = resolvedAgentBaseCommand
         ? buildResumeCommand(agentId, saved.agentSessionId, resumeFlags, baseCommand)
         : buildResumeCommand(agentId, saved.agentSessionId, resumeFlags);
@@ -600,14 +614,19 @@ export function buildArgsForRespawn(
         sessionLostOnRestore = true;
       }
     } else {
-      // No session ID was captured (graceful-shutdown pattern match missed or
-      // timed out). Try the agent's resume-latest fallback before falling
-      // through to a fresh launch so the user keeps their prior conversation.
-      // Suppressed when a sibling pane owns this agent+cwd's single slot:
+      // Either no session id was captured (graceful-shutdown pattern match missed
+      // or timed out) or a sibling owns the one this snapshot carries. Try the
+      // agent's resume-latest fallback before falling through to a fresh launch so
+      // the user keeps their prior conversation. Suppressed when a sibling pane
+      // owns this agent+cwd's single slot, or holds a session in that directory:
       // resume-latest resolves to the most recent session in scope, so several
       // panes running it would all land in the SAME conversation (#11461).
+      // `resumeWithheld` gates it too, so the two allowances can't be set
+      // inconsistently by a caller: a pane denied the session id it carries must
+      // not reach that same conversation through the back door, since the owner
+      // replaying it is exactly what resume-latest would resolve to.
       let resumeLatestCmd: string | undefined;
-      if (allowResumeLatest) {
+      if (allowResumeLatest && !resumeWithheld) {
         resumeLatestCmd = resolvedAgentBaseCommand
           ? buildResumeLatestCommand(agentId, resumeFlags, baseCommand)
           : buildResumeLatestCommand(agentId, resumeFlags);
@@ -626,14 +645,18 @@ export function buildArgsForRespawn(
           globalUseAltScreen,
         });
         sessionLostOnRestore = true;
-      } else if (!allowResumeLatest && buildResumeLatestCommand(agentId) !== undefined) {
+      } else if (
+        resumeWithheld ||
+        (!allowResumeLatest && buildResumeLatestCommand(agentId) !== undefined)
+      ) {
         // Nothing above rebuilt the command, so `command` still holds
-        // `saved.command` — which is itself a persisted resume-latest command
-        // whenever an earlier restore used one. Inheriting it would reinstate the
-        // very collision this suppression exists to prevent, so launch clean.
-        // The bare capability probe (config-only, so flag-independent and in
-        // agreement with the restore election's) keeps suppression from touching
-        // an agent that has no resume-latest fallback to suppress.
+        // `saved.command` — which is itself a persisted resume command whenever an
+        // earlier restore built one. Inheriting it would reinstate the very
+        // collision this suppression exists to prevent, so launch clean. The bare
+        // capability probe (config-only, so flag-independent and in agreement with
+        // the restore election's) keeps resume-latest suppression from touching an
+        // agent that has no such fallback; a withheld session id needs no probe,
+        // since the id in hand is proof the snapshot can carry a resume command.
         command = buildLaunchCommandFromFlags(baseCommand, agentId, injectedFromEmpty, {
           clipboardDirectory,
           shareClipboardDirectory,


### PR DESCRIPTION
This closes the gaps left by #11464, where restored agent panes reopen each other's conversation. I found them checking whether that merge had broken Claude Code resuming on my own machine. It hadn't (the ids were lost by the old binary's quit, before the fix was live) but the state on disk had two Claude panes in one directory, one on `--resume <id>` and one on `--continue`, which is a collision the merged fix does not cover.

Three defects.

**The resume-latest fallback can land in a session a sibling already holds.** `claude --continue` and `codex resume --last` resolve by recency, not identity, so nothing about the command says which conversation it opens. #11464 only deduplicated panes that had no session id, and skipped panes that hold one: a pane resuming an exact `agentSessionId` replays into that transcript at restore time, and a pane whose PTY survived is mid-conversation. Both are exactly what a concurrent `--continue` in the same directory resolves to. Any pane holding a session now claims its (agent, cwd) scope, and every fallback candidate in a claimed scope is suppressed.

**Two panes can persist the same `agentSessionId`.** This is what the original collision leaves behind: both panes reopen one conversation, the next quit captures that single id into both snapshots, and the next launch replays it twice. Two writers on one transcript, no fallback involved. One owner is now elected per (agent, session id) on the same ranking as the scope election, and a live PTY owns its session outright rather than by ranking, since it is attached now. Losers resume nothing.

**Three unguarded failure points in `electron/lifecycle/shutdown.ts` could discard every captured session.** All of them sit ahead of the graceful kill that does the capturing:

* `await import("../ipc/utils.js")` for `drainRateLimitQueues` was unguarded, so a rejection rejected the whole chain. Worth guarding for its own sake: a dynamic import can fail for a module that resolved at boot if an installer replaces `app.asar` under a running process, which is how I hit it.
* One project's `gracefulKillByProject` rejecting failed the whole `Promise.all`, discarding every other project's captures. The per-project timeout already isolated slowness; rejection needed the same treatment.
* A rejected `enqueueProjectStateUpdate` exited the try before any journal record was written.

Suppressed panes launch fresh with `sessionLostOnRestore`, which raises the existing "session no longer reachable" banner and leaves the conversation reachable from session history. That is the trade throughout: one pane missing a resume beats two panes writing into one conversation.

## Deliberate limitation

When the bulk reconnect probe times out, unknown liveness is still treated as cold. The probe times out for every pane at once, so treating unknown as a claim would cost every multi-pane scope its resume on a transient failure. Probe timeouts also correlate with cold boots, where live siblings are least likely. Pre-existing, documented in the function, and unchanged here.

## Testing

`npm run check` clean (typecheck, codegen guards, lint ratchet at baseline, format). 2353 tests pass across the affected suites.

Every new test was mutation checked: revert the implementation line, confirm the test fails. That turned up a test fidelity bug too, where the `resolveAgentId` mock in `panelRestorePhase.test.ts` silently dropped its fallback argument, which would have made every live-record identity lookup resolve to nothing.

No E2E covers this path (restore with real agent CLIs lives in `e2e/online/`). Real-world verification is a quit and restart with the build running, then Terminal Info on a restored pane.
