### PR TITLE
fix(assistant): stop background panel updates stealing focus from other panes

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -43,7 +43,7 @@ import {
   useWorktreeSelectionStore,
   useTerminalInputStore,
 } from "@/store";
-import { useMacroFocusStore } from "@/store/macroFocusStore";
+import { isAssistantFocused, useMacroFocusStore } from "@/store/macroFocusStore";
 // Leaf import, not the `@/store` barrel: the barrel is mocked wholesale (with a
 // hand-listed hook set) across the HelpPanel/controller suites, so pulling a new
 // hook through it would crash every one of them on an undefined destructure.
@@ -135,6 +135,22 @@ export function HelpPanel({
   // it on close so keyboard users return to where they were rather than
   // body. Mirrors the pattern in AppDialog/AppPaletteDialog.
   const previousFocusRef = useRef<HTMLElement | null>(null);
+  // Invalidates any deferred reveal-focus frame whose authorizing effect run has
+  // already been torn down. Mirrors HybridInputBar's `focusGenerationRef`
+  // (#8487) — a frame that was already dequeued can't be stopped by
+  // `cancelAnimationFrame`, so it has to check that it still owns the grab.
+  const revealFocusGenerationRef = useRef(0);
+  // The last (isOpen, isVisible, focusRequest) tuple whose focus grab actually
+  // completed. Tracking *completion* rather than the previous effect setup is
+  // what makes the grab survive StrictMode: the first setup schedules a frame,
+  // the immediate cleanup cancels it, and the replayed setup must still see an
+  // outstanding request. A "previous setup" ref would mark it consumed and the
+  // panel would open unfocused (#11472).
+  const lastCompletedFocusTriggerRef = useRef<{
+    isOpen: boolean;
+    isVisible: boolean;
+    focusRequest: number;
+  } | null>(null);
   // Idempotent teardown for an in-flight resize drag. Stored in a ref so an
   // unmount (or window blur) mid-drag can run it and never leak the document
   // listeners or the body userSelect/cursor overrides. Mirrors TwoPaneSplitDivider.
@@ -215,6 +231,17 @@ export function HelpPanel({
 
   const terminal = usePanelStore((s) => (terminalId ? s.panelsById[terminalId] : undefined));
   const terminalPty = terminal && isPtyPanel(terminal) ? terminal : undefined;
+  // Narrow structural triggers for the reveal-focus effect below. A live
+  // assistant replaces its whole panel object constantly — `updateAgentState`,
+  // `updateLastObservedTitle` on every distinct OSC title, and the RAF-coalesced
+  // activity buffer all swap the identity — so depending on `terminal` itself
+  // made every one of those a focus trigger (#11472). These two primitives move
+  // only when the terminal genuinely appears or changes spawn phase, which is
+  // the only structural churn worth retrying a focus grab for. Same shape as
+  // useContentGridContext.tsx (#8593): subscribe to primitives, read the map
+  // non-reactively at execution time.
+  const terminalExists = terminal !== undefined;
+  const terminalSpawnStatus = terminalPty?.spawnStatus;
   // Mirrors useGettingStartedChecklist.ts:45-55 — must stay in sync. Gates the
   // intro banner so it never reappears once the user has launched any assistant
   // (`everDetectedAgent` is persisted via panelStore so this survives restarts).
@@ -652,47 +679,100 @@ export function HelpPanel({
   // focusRequest re-triggers this effect so repeated Cmd+L presses can
   // re-focus a blurred panel without closing it.
   useEffect(() => {
+    const focusTrigger = { isOpen, isVisible, focusRequest };
+    const lastCompleted = lastCompletedFocusTriggerRef.current;
+    // Only opening, revealing and an explicit focusRequest authorize taking
+    // focus away from wherever the user is actually typing. Everything else
+    // that re-runs this effect is structural (the terminal appeared, finished
+    // spawning, was replaced, or the input bar came and went) and may only
+    // re-target focus the assistant already owns.
+    const hasNewFocusTrigger =
+      lastCompleted === null ||
+      lastCompleted.isOpen !== isOpen ||
+      lastCompleted.isVisible !== isVisible ||
+      lastCompleted.focusRequest !== focusRequest;
+
     if (isOpen && isVisible) {
       const active = document.activeElement;
       if (active instanceof HTMLElement && !panelRef.current?.contains(active)) {
         previousFocusRef.current = active;
       }
+
+      const generation = ++revealFocusGenerationRef.current;
+      let hybridCompletionRaf: number | null = null;
+
       const raf = requestAnimationFrame(() => {
+        if (revealFocusGenerationRef.current !== generation) return;
+
         const state = useHelpPanelStore.getState();
-        if (!state.isOpen) return;
+        // The panel can close, or rebind to a different session, between this
+        // effect and the frame that runs it. A frame already dequeued when
+        // cleanup ran can't be cancelled, so re-read both.
+        if (!state.isOpen || state.terminalId !== terminalId) return;
+
+        // Ownership is re-checked here, on the final deferred frame, rather
+        // than in the effect body — focus can move during the frame boundary,
+        // and a decision made one frame ago is exactly the stale authorization
+        // that let a background agent-state update yank the caret out of
+        // another pane's editor (#11472).
+        if (!hasNewFocusTrigger && !isAssistantFocused()) return;
+
+        const completeFocusTrigger = () => {
+          if (hasNewFocusTrigger) lastCompletedFocusTriggerRef.current = focusTrigger;
+        };
 
         const current = document.activeElement;
         if (
           (current?.closest?.(".xterm-helper-textarea") || current?.closest?.(".cm-editor")) &&
           panelRef.current?.contains(current)
         ) {
+          completeFocusTrigger();
           return;
         }
 
+        // Read the panel non-reactively at execution time. The effect no longer
+        // subscribes to the panel object, so this is both the freshest value
+        // and the only one that reflects a terminal removed or failed between
+        // the effect and this frame.
+        const currentTerminal = terminalId
+          ? usePanelStore.getState().panelsById[terminalId]
+          : undefined;
+        const currentTerminalPty =
+          currentTerminal && isPtyPanel(currentTerminal) ? currentTerminal : undefined;
+
         // When an agent terminal is running, target the HybridInputBar editor
-        // first (when available), then the xterm input as fallback. The bar
-        // ref is null during the lazy Suspense window — in that case fall back
-        // to xterm so cold-load opens still focus something.
+        // first (when available), then the xterm input as fallback.
         //
         // `focusWithCursorAtEnd()` schedules `view.focus()` inside its own
-        // requestAnimationFrame (HybridInputBar.tsx:538), so we cannot
-        // synchronously check `document.activeElement` after calling it. We
-        // trust the bar's internal rAF to take focus when its ref is present
-        // — no xterm fallback in that branch, otherwise CodeMirror would
-        // steal focus from xterm one frame later and produce a focus flicker.
+        // requestAnimationFrame, so we cannot synchronously check
+        // `document.activeElement` after calling it. We trust the bar's
+        // internal rAF when it reports it scheduled the grab — no xterm
+        // fallback in that branch, otherwise CodeMirror would steal focus from
+        // xterm one frame later and produce a focus flicker. A `false` return
+        // means no editor was mounted (the lazy Suspense window) and nothing
+        // was scheduled, so falling through to xterm is safe and still focuses
+        // something on a cold open.
         if (
           terminalId &&
-          terminal &&
-          terminalPty?.spawnStatus !== "missing-cli" &&
-          terminalPty?.spawnStatus !== "failed"
+          currentTerminal &&
+          currentTerminalPty?.spawnStatus !== "missing-cli" &&
+          currentTerminalPty?.spawnStatus !== "failed"
         ) {
-          if (showHybridInputBar && inputBarRef.current) {
-            inputBarRef.current.focusWithCursorAtEnd();
+          if (showHybridInputBar && inputBarRef.current?.focusWithCursorAtEnd()) {
+            // The editor takes focus in the bar's own frame. Hold the request
+            // open until then so a cleanup landing in between (which cancels
+            // that inner frame) leaves it outstanding for the next run to
+            // reissue rather than silently dropping it.
+            hybridCompletionRaf = requestAnimationFrame(() => {
+              if (revealFocusGenerationRef.current !== generation) return;
+              completeFocusTrigger();
+            });
             return;
           }
           terminalInstanceService.focus(terminalId);
           const after = document.activeElement;
           if (after?.closest?.(".xterm-helper-textarea") && panelRef.current?.contains(after)) {
+            completeFocusTrigger();
             return;
           }
         }
@@ -709,16 +789,39 @@ export function HelpPanel({
         } else {
           panelRef.current?.focus();
         }
+        completeFocusTrigger();
       });
-      return () => cancelAnimationFrame(raf);
+
+      return () => {
+        cancelAnimationFrame(raf);
+        if (hybridCompletionRaf !== null) cancelAnimationFrame(hybridCompletionRaf);
+        // Invalidate any frame this run already handed out, including the one
+        // nested inside HybridInputBar — `cancelAnimationFrame` can't reach
+        // that one, and without this it lands after the panel closed (#11472).
+        revealFocusGenerationRef.current += 1;
+        inputBarRef.current?.cancelPendingFocus();
+      };
     }
+
+    // Record the closed/hidden tuple so the next open or reveal reads as a new
+    // request rather than one already satisfied.
+    lastCompletedFocusTriggerRef.current = focusTrigger;
+
     const el = previousFocusRef.current;
     previousFocusRef.current = null;
     if (el && document.contains(el) && !panelRef.current?.contains(el)) {
       el.focus();
     }
     return undefined;
-  }, [isOpen, isVisible, focusRequest, terminalId, terminal, showHybridInputBar]);
+  }, [
+    isOpen,
+    isVisible,
+    focusRequest,
+    terminalId,
+    terminalExists,
+    terminalSpawnStatus,
+    showHybridInputBar,
+  ]);
 
   // Pin the WebGL context to the assistant terminal while it owns focus (#10672).
   // The reveal effect above only calls `focus()` (xterm DOM focus); it never

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -14,7 +14,10 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { XtermAdapter } from "@/components/Terminal/XtermAdapter";
 import { MissingCliGate } from "@/components/Terminal/MissingCliGate";
-import { shouldShowHybridInputBar } from "@/components/Terminal/terminalFocus";
+import {
+  getTerminalFocusTarget,
+  shouldShowHybridInputBar,
+} from "@/components/Terminal/terminalFocus";
 import type { HybridInputBarHandle } from "@/components/Terminal/HybridInputBar";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { terminalClient } from "@/clients";
@@ -693,13 +696,24 @@ export function HelpPanel({
       lastCompleted.focusRequest !== focusRequest;
 
     if (isOpen && isVisible) {
+      // Only remember a restore target when this run is actually authorized to
+      // move focus. A structural re-run that the ownership gate goes on to
+      // reject must not overwrite it with whatever unrelated pane the user
+      // happens to be typing in.
       const active = document.activeElement;
-      if (active instanceof HTMLElement && !panelRef.current?.contains(active)) {
+      if (
+        hasNewFocusTrigger &&
+        active instanceof HTMLElement &&
+        !panelRef.current?.contains(active)
+      ) {
         previousFocusRef.current = active;
       }
 
       const generation = ++revealFocusGenerationRef.current;
       let hybridCompletionRaf: number | null = null;
+      // The exact bar we handed a focus request to, so cleanup revokes that one
+      // rather than whatever `inputBarRef` happens to point at by then.
+      let pendingFocusBar: HybridInputBarHandle | null = null;
 
       const raf = requestAnimationFrame(() => {
         if (revealFocusGenerationRef.current !== generation) return;
@@ -740,8 +754,22 @@ export function HelpPanel({
         const currentTerminalPty =
           currentTerminal && isPtyPanel(currentTerminal) ? currentTerminal : undefined;
 
-        // When an agent terminal is running, target the HybridInputBar editor
-        // first (when available), then the xterm input as fallback.
+        // Ownership is settled by this point, so now — and only now — the
+        // remembered preference gets to pick which surface receives focus.
+        // Resolving it here rather than letting HybridInputBar's own
+        // `preferredTerminalFocusTarget` check veto the grab matters: that
+        // check aborts silently, which would leave an authorized open request
+        // marked complete with focus still in another pane.
+        const bar = inputBarRef.current;
+        const focusTarget = getTerminalFocusTarget({
+          preferredTarget: usePanelStore.getState().preferredTerminalFocusTarget,
+          hasHybridInputSurface: showHybridInputBar && bar !== null,
+          isInputDisabled: currentTerminalPty?.isInputLocked === true,
+          hybridInputEnabled: useTerminalInputStore.getState().hybridInputEnabled,
+        });
+
+        // When an agent terminal is running, focus the surface the preference
+        // resolved to, falling back to xterm when the editor can't take it.
         //
         // `focusWithCursorAtEnd()` schedules `view.focus()` inside its own
         // requestAnimationFrame, so we cannot synchronously check
@@ -758,16 +786,29 @@ export function HelpPanel({
           currentTerminalPty?.spawnStatus !== "missing-cli" &&
           currentTerminalPty?.spawnStatus !== "failed"
         ) {
-          if (showHybridInputBar && inputBarRef.current?.focusWithCursorAtEnd()) {
-            // The editor takes focus in the bar's own frame. Hold the request
-            // open until then so a cleanup landing in between (which cancels
-            // that inner frame) leaves it outstanding for the next run to
-            // reissue rather than silently dropping it.
+          if (focusTarget === "hybridInput" && bar) {
+            // The bar defers the real `view.focus()` to a frame of its own,
+            // which is the LAST frame in this grab — so the last ownership
+            // check has to run inside it. We can't edit that shared component,
+            // but a frame queued here, before the bar schedules its own, is
+            // dequeued ahead of it: it gets to re-read ownership and revoke the
+            // grab via `cancelPendingFocus()` when the user has moved on in the
+            // gap. Without it a structural retry that was legitimate one frame
+            // ago still lands in the other pane's editor (#11472).
             hybridCompletionRaf = requestAnimationFrame(() => {
               if (revealFocusGenerationRef.current !== generation) return;
+              if (!hasNewFocusTrigger && !isAssistantFocused()) {
+                bar.cancelPendingFocus();
+                return;
+              }
               completeFocusTrigger();
             });
-            return;
+            pendingFocusBar = bar;
+            if (bar.focusWithCursorAtEnd()) return;
+            // No editor was mounted, so nothing is pending to guard.
+            cancelAnimationFrame(hybridCompletionRaf);
+            hybridCompletionRaf = null;
+            pendingFocusBar = null;
           }
           terminalInstanceService.focus(terminalId);
           const after = document.activeElement;
@@ -799,7 +840,7 @@ export function HelpPanel({
         // nested inside HybridInputBar — `cancelAnimationFrame` can't reach
         // that one, and without this it lands after the panel closed (#11472).
         revealFocusGenerationRef.current += 1;
-        inputBarRef.current?.cancelPendingFocus();
+        pendingFocusBar?.cancelPendingFocus();
       };
     }
 
@@ -809,7 +850,22 @@ export function HelpPanel({
 
     const el = previousFocusRef.current;
     previousFocusRef.current = null;
-    if (el && document.contains(el) && !panelRef.current?.contains(el)) {
+    // Hand focus back only if the assistant still had it. Closing a panel the
+    // user already left must not drag them out of wherever they went — that is
+    // the same steal this effect exists to prevent, just on the way out.
+    // `body`/null covers the panel tearing down its focused descendant, which
+    // is the normal close path.
+    const activeOnClose = document.activeElement;
+    const assistantStillOwnedFocus =
+      activeOnClose === null ||
+      activeOnClose === document.body ||
+      panelRef.current?.contains(activeOnClose) === true;
+    if (
+      el &&
+      assistantStillOwnedFocus &&
+      document.contains(el) &&
+      !panelRef.current?.contains(el)
+    ) {
       el.focus();
     }
     return undefined;

--- a/src/components/HelpPanel/__tests__/HelpPanel.agentExit.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.agentExit.test.tsx
@@ -100,9 +100,12 @@ vi.mock("@/components/Terminal/XtermAdapter", () => ({
 }));
 vi.mock("@/components/Terminal/HybridInputBar", () => ({ HybridInputBar: () => null }));
 vi.mock("@/components/Terminal/MissingCliGate", () => ({ MissingCliGate: () => null }));
-vi.mock("@/components/Terminal/terminalFocus", () => ({
-  shouldShowHybridInputBar: () => false,
-}));
+vi.mock("@/components/Terminal/terminalFocus", async (importOriginal) => {
+  // Keep the real `getTerminalFocusTarget` — the reveal effect resolves the
+  // remembered target through it, and a hand-stubbed copy would drift.
+  const actual = await importOriginal<typeof import("@/components/Terminal/terminalFocus")>();
+  return { ...actual, shouldShowHybridInputBar: () => false };
+});
 vi.mock("./HelpIntroBanner", () => ({ HelpIntroBanner: () => null }));
 vi.mock("./HelpPanelBanners", () => ({ HelpPanelBanners: () => null }));
 vi.mock("./HelpPanelVersionGate", () => ({ HelpPanelVersionGate: () => null }));

--- a/src/components/HelpPanel/__tests__/HelpPanel.agentExit.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.agentExit.test.tsx
@@ -202,7 +202,12 @@ vi.mock("@/store/macroFocusStore", () => {
     const next = typeof partial === "function" ? partial(state) : partial;
     Object.assign(state, next);
   };
-  return { useMacroFocusStore: store };
+  return {
+    useMacroFocusStore: store,
+    // Mirrors the real contract (macroFocusStore.ts:94) closely enough for these
+    // suites: the assistant owns focus when its macro region is selected.
+    isAssistantFocused: () => state.focusedRegion === "assistant",
+  };
 });
 
 vi.mock("@/components/ui/ConfirmDialog", () => ({ ConfirmDialog: () => null }));

--- a/src/components/HelpPanel/__tests__/HelpPanel.agentSwitch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.agentSwitch.test.tsx
@@ -185,7 +185,7 @@ vi.mock("@/store", () => {
 });
 
 vi.mock("@/store/macroFocusStore", () => {
-  const state = { focusedRegion: null, setRegionRef: vi.fn() };
+  const state = { focusedRegion: null as string | null, setRegionRef: vi.fn() };
   const store = (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state);
   store.getState = () => state;
   store.setState = (
@@ -194,7 +194,12 @@ vi.mock("@/store/macroFocusStore", () => {
     const next = typeof partial === "function" ? partial(state) : partial;
     Object.assign(state, next);
   };
-  return { useMacroFocusStore: store };
+  return {
+    useMacroFocusStore: store,
+    // Mirrors the real contract (macroFocusStore.ts:94) closely enough for these
+    // suites: the assistant owns focus when its macro region is selected.
+    isAssistantFocused: () => state.focusedRegion === "assistant",
+  };
 });
 
 vi.mock("@/components/ui/ConfirmDialog", () => ({

--- a/src/components/HelpPanel/__tests__/HelpPanel.agentSwitch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.agentSwitch.test.tsx
@@ -96,9 +96,12 @@ vi.mock("@/components/Terminal/XtermAdapter", () => ({
 }));
 vi.mock("@/components/Terminal/HybridInputBar", () => ({ HybridInputBar: () => null }));
 vi.mock("@/components/Terminal/MissingCliGate", () => ({ MissingCliGate: () => null }));
-vi.mock("@/components/Terminal/terminalFocus", () => ({
-  shouldShowHybridInputBar: () => false,
-}));
+vi.mock("@/components/Terminal/terminalFocus", async (importOriginal) => {
+  // Keep the real `getTerminalFocusTarget` — the reveal effect resolves the
+  // remembered target through it, and a hand-stubbed copy would drift.
+  const actual = await importOriginal<typeof import("@/components/Terminal/terminalFocus")>();
+  return { ...actual, shouldShowHybridInputBar: () => false };
+});
 vi.mock("./HelpIntroBanner", () => ({ HelpIntroBanner: () => null }));
 vi.mock("./HelpPanelHeader", () => ({ HelpPanelHeader: () => null }));
 vi.mock("./HelpPanelBanners", () => ({ HelpPanelBanners: () => null }));

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.autoLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.autoLaunch.test.tsx
@@ -347,7 +347,7 @@ vi.mock("@/store/scratchStore", () => {
 });
 
 vi.mock("@/store/macroFocusStore", () => {
-  const state = { focusedRegion: null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
+  const state = { focusedRegion: null as string | null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
   const store = (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state);
   store.getState = () => state;
   store.setState = (
@@ -356,7 +356,12 @@ vi.mock("@/store/macroFocusStore", () => {
     const next = typeof partial === "function" ? partial(state) : partial;
     Object.assign(state, next);
   };
-  return { useMacroFocusStore: store };
+  return {
+    useMacroFocusStore: store,
+    // Mirrors the real contract (macroFocusStore.ts:94) closely enough for these
+    // suites: the assistant owns focus when its macro region is selected.
+    isAssistantFocused: () => state.focusedRegion === "assistant",
+  };
 });
 
 vi.mock("@/lib/sidebarToggle", () => ({

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.autoLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.autoLaunch.test.tsx
@@ -347,7 +347,11 @@ vi.mock("@/store/scratchStore", () => {
 });
 
 vi.mock("@/store/macroFocusStore", () => {
-  const state = { focusedRegion: null as string | null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
+  const state = {
+    focusedRegion: null as string | null,
+    setRegionRef: vi.fn(),
+    setVisibility: vi.fn(),
+  };
   const store = (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state);
   store.getState = () => state;
   store.setState = (

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.emptyStateCustomArgs.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.emptyStateCustomArgs.test.tsx
@@ -334,7 +334,11 @@ vi.mock("@/store", () => {
 });
 
 vi.mock("@/store/macroFocusStore", () => {
-  const state = { focusedRegion: null as string | null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
+  const state = {
+    focusedRegion: null as string | null,
+    setRegionRef: vi.fn(),
+    setVisibility: vi.fn(),
+  };
   const store = (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state);
   store.getState = () => state;
   store.setState = (

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.emptyStateCustomArgs.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.emptyStateCustomArgs.test.tsx
@@ -334,7 +334,7 @@ vi.mock("@/store", () => {
 });
 
 vi.mock("@/store/macroFocusStore", () => {
-  const state = { focusedRegion: null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
+  const state = { focusedRegion: null as string | null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
   const store = (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state);
   store.getState = () => state;
   store.setState = (
@@ -343,7 +343,12 @@ vi.mock("@/store/macroFocusStore", () => {
     const next = typeof partial === "function" ? partial(state) : partial;
     Object.assign(state, next);
   };
-  return { useMacroFocusStore: store };
+  return {
+    useMacroFocusStore: store,
+    // Mirrors the real contract (macroFocusStore.ts:94) closely enough for these
+    // suites: the assistant owns focus when its macro region is selected.
+    isAssistantFocused: () => state.focusedRegion === "assistant",
+  };
 });
 
 vi.mock("@/lib/sidebarToggle", () => ({

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.persistenceHibernation.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.persistenceHibernation.test.tsx
@@ -334,7 +334,11 @@ vi.mock("@/store", () => {
 });
 
 vi.mock("@/store/macroFocusStore", () => {
-  const state = { focusedRegion: null as string | null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
+  const state = {
+    focusedRegion: null as string | null,
+    setRegionRef: vi.fn(),
+    setVisibility: vi.fn(),
+  };
   const store = (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state);
   store.getState = () => state;
   store.setState = (

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.persistenceHibernation.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.persistenceHibernation.test.tsx
@@ -334,7 +334,7 @@ vi.mock("@/store", () => {
 });
 
 vi.mock("@/store/macroFocusStore", () => {
-  const state = { focusedRegion: null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
+  const state = { focusedRegion: null as string | null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
   const store = (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state);
   store.getState = () => state;
   store.setState = (
@@ -343,7 +343,12 @@ vi.mock("@/store/macroFocusStore", () => {
     const next = typeof partial === "function" ? partial(state) : partial;
     Object.assign(state, next);
   };
-  return { useMacroFocusStore: store };
+  return {
+    useMacroFocusStore: store,
+    // Mirrors the real contract (macroFocusStore.ts:94) closely enough for these
+    // suites: the assistant owns focus when its macro region is selected.
+    isAssistantFocused: () => state.focusedRegion === "assistant",
+  };
 });
 
 vi.mock("@/lib/sidebarToggle", () => ({

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.runAnywayProvisioning.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.runAnywayProvisioning.test.tsx
@@ -334,7 +334,11 @@ vi.mock("@/store", () => {
 });
 
 vi.mock("@/store/macroFocusStore", () => {
-  const state = { focusedRegion: null as string | null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
+  const state = {
+    focusedRegion: null as string | null,
+    setRegionRef: vi.fn(),
+    setVisibility: vi.fn(),
+  };
   const store = (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state);
   store.getState = () => state;
   store.setState = (

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.runAnywayProvisioning.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.runAnywayProvisioning.test.tsx
@@ -334,7 +334,7 @@ vi.mock("@/store", () => {
 });
 
 vi.mock("@/store/macroFocusStore", () => {
-  const state = { focusedRegion: null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
+  const state = { focusedRegion: null as string | null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
   const store = (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state);
   store.getState = () => state;
   store.setState = (
@@ -343,7 +343,12 @@ vi.mock("@/store/macroFocusStore", () => {
     const next = typeof partial === "function" ? partial(state) : partial;
     Object.assign(state, next);
   };
-  return { useMacroFocusStore: store };
+  return {
+    useMacroFocusStore: store,
+    // Mirrors the real contract (macroFocusStore.ts:94) closely enough for these
+    // suites: the assistant owns focus when its macro region is selected.
+    isAssistantFocused: () => state.focusedRegion === "assistant",
+  };
 });
 
 vi.mock("@/lib/sidebarToggle", () => ({

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
@@ -334,7 +334,11 @@ vi.mock("@/store", () => {
 });
 
 vi.mock("@/store/macroFocusStore", () => {
-  const state = { focusedRegion: null as string | null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
+  const state = {
+    focusedRegion: null as string | null,
+    setRegionRef: vi.fn(),
+    setVisibility: vi.fn(),
+  };
   const store = (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state);
   store.getState = () => state;
   store.setState = (

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
@@ -334,7 +334,7 @@ vi.mock("@/store", () => {
 });
 
 vi.mock("@/store/macroFocusStore", () => {
-  const state = { focusedRegion: null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
+  const state = { focusedRegion: null as string | null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
   const store = (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state);
   store.getState = () => state;
   store.setState = (
@@ -343,7 +343,12 @@ vi.mock("@/store/macroFocusStore", () => {
     const next = typeof partial === "function" ? partial(state) : partial;
     Object.assign(state, next);
   };
-  return { useMacroFocusStore: store };
+  return {
+    useMacroFocusStore: store,
+    // Mirrors the real contract (macroFocusStore.ts:94) closely enough for these
+    // suites: the assistant owns focus when its macro region is selected.
+    isAssistantFocused: () => state.focusedRegion === "assistant",
+  };
 });
 
 vi.mock("@/lib/sidebarToggle", () => ({

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.versionGateInput.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.versionGateInput.test.tsx
@@ -334,7 +334,11 @@ vi.mock("@/store", () => {
 });
 
 vi.mock("@/store/macroFocusStore", () => {
-  const state = { focusedRegion: null as string | null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
+  const state = {
+    focusedRegion: null as string | null,
+    setRegionRef: vi.fn(),
+    setVisibility: vi.fn(),
+  };
   const store = (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state);
   store.getState = () => state;
   store.setState = (

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.versionGateInput.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.versionGateInput.test.tsx
@@ -334,7 +334,7 @@ vi.mock("@/store", () => {
 });
 
 vi.mock("@/store/macroFocusStore", () => {
-  const state = { focusedRegion: null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
+  const state = { focusedRegion: null as string | null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
   const store = (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state);
   store.getState = () => state;
   store.setState = (
@@ -343,7 +343,12 @@ vi.mock("@/store/macroFocusStore", () => {
     const next = typeof partial === "function" ? partial(state) : partial;
     Object.assign(state, next);
   };
-  return { useMacroFocusStore: store };
+  return {
+    useMacroFocusStore: store,
+    // Mirrors the real contract (macroFocusStore.ts:94) closely enough for these
+    // suites: the assistant owns focus when its macro region is selected.
+    isAssistantFocused: () => state.focusedRegion === "assistant",
+  };
 });
 
 vi.mock("@/lib/sidebarToggle", () => ({

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -306,7 +306,7 @@ vi.mock("@/store/scratchStore", () => {
 });
 
 vi.mock("@/store/macroFocusStore", () => {
-  const state = { focusedRegion: null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
+  const state = { focusedRegion: null as string | null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
   const store = (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state);
   store.getState = () => state;
   store.setState = (
@@ -315,7 +315,12 @@ vi.mock("@/store/macroFocusStore", () => {
     const next = typeof partial === "function" ? partial(state) : partial;
     Object.assign(state, next);
   };
-  return { useMacroFocusStore: store };
+  return {
+    useMacroFocusStore: store,
+    // Mirrors the real contract (macroFocusStore.ts:94) closely enough for these
+    // suites: the assistant owns focus when its macro region is selected.
+    isAssistantFocused: () => state.focusedRegion === "assistant",
+  };
 });
 
 vi.mock("@/lib/sidebarToggle", () => ({

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -306,7 +306,11 @@ vi.mock("@/store/scratchStore", () => {
 });
 
 vi.mock("@/store/macroFocusStore", () => {
-  const state = { focusedRegion: null as string | null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
+  const state = {
+    focusedRegion: null as string | null,
+    setRegionRef: vi.fn(),
+    setVisibility: vi.fn(),
+  };
   const store = (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state);
   store.getState = () => state;
   store.setState = (

--- a/src/components/HelpPanel/__tests__/HelpPanel.revealBackstop.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.revealBackstop.test.tsx
@@ -101,9 +101,12 @@ vi.mock("@/components/Terminal/XtermAdapter", () => ({
 }));
 vi.mock("@/components/Terminal/HybridInputBar", () => ({ HybridInputBar: () => null }));
 vi.mock("@/components/Terminal/MissingCliGate", () => ({ MissingCliGate: () => null }));
-vi.mock("@/components/Terminal/terminalFocus", () => ({
-  shouldShowHybridInputBar: () => false,
-}));
+vi.mock("@/components/Terminal/terminalFocus", async (importOriginal) => {
+  // Keep the real `getTerminalFocusTarget` — the reveal effect resolves the
+  // remembered target through it, and a hand-stubbed copy would drift.
+  const actual = await importOriginal<typeof import("@/components/Terminal/terminalFocus")>();
+  return { ...actual, shouldShowHybridInputBar: () => false };
+});
 vi.mock("./HelpIntroBanner", () => ({ HelpIntroBanner: () => null }));
 vi.mock("./HelpPanelHeader", () => ({ HelpPanelHeader: () => null }));
 vi.mock("./HelpPanelBanners", () => ({ HelpPanelBanners: () => null }));

--- a/src/components/HelpPanel/__tests__/HelpPanel.revealBackstop.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.revealBackstop.test.tsx
@@ -195,7 +195,7 @@ vi.mock("@/store", () => {
 });
 
 vi.mock("@/store/macroFocusStore", () => {
-  const state = { focusedRegion: null, setRegionRef: vi.fn() };
+  const state = { focusedRegion: null as string | null, setRegionRef: vi.fn() };
   const store = (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state);
   store.getState = () => state;
   store.setState = (
@@ -204,7 +204,12 @@ vi.mock("@/store/macroFocusStore", () => {
     const next = typeof partial === "function" ? partial(state) : partial;
     Object.assign(state, next);
   };
-  return { useMacroFocusStore: store };
+  return {
+    useMacroFocusStore: store,
+    // Mirrors the real contract (macroFocusStore.ts:94) closely enough for these
+    // suites: the assistant owns focus when its macro region is selected.
+    isAssistantFocused: () => state.focusedRegion === "assistant",
+  };
 });
 
 vi.mock("@/components/ui/ConfirmDialog", () => ({ ConfirmDialog: () => null }));

--- a/src/components/HelpPanel/__tests__/HelpPanel.revealFocusOwnership.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.revealFocusOwnership.test.tsx
@@ -46,7 +46,11 @@ const { focusMock, helpPanelState, panelStoreState, hybridHandle } = vi.hoisted(
   },
   panelStoreState: {
     panelIds: [] as string[],
-    panelsById: {} as Record<string, { agentState?: string; cwd?: string; spawnStatus?: string }>,
+    panelsById: {} as Record<
+      string,
+      { agentState?: string; cwd?: string; spawnStatus?: string; isInputLocked?: boolean }
+    >,
+    preferredTerminalFocusTarget: "hybridInput" as "hybridInput" | "xterm",
     removePanel: vi.fn(),
     addPanel: vi.fn().mockResolvedValue(""),
   },
@@ -81,7 +85,13 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
   DropdownMenuContent: ({ children }: { children?: unknown }) => (
     <div data-testid="overflow-menu">{children as never}</div>
   ),
-  DropdownMenuItem: ({ children, onSelect }: { children?: unknown; onSelect?: (e: Event) => void }) => (
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+  }: {
+    children?: unknown;
+    onSelect?: (e: Event) => void;
+  }) => (
     <button type="button" onClick={() => onSelect?.(new Event("select"))}>
       {children as never}
     </button>
@@ -143,9 +153,12 @@ vi.mock("@/components/Terminal/HybridInputBar", () => ({
 }));
 
 vi.mock("@/components/Terminal/MissingCliGate", () => ({ MissingCliGate: () => null }));
-vi.mock("@/components/Terminal/terminalFocus", () => ({
-  shouldShowHybridInputBar: () => hybridBarVisible,
-}));
+vi.mock("@/components/Terminal/terminalFocus", async (importOriginal) => {
+  // Keep the real `getTerminalFocusTarget` so target resolution is exercised
+  // for real; only the visibility predicate is driven per test.
+  const actual = await importOriginal<typeof import("@/components/Terminal/terminalFocus")>();
+  return { ...actual, shouldShowHybridInputBar: () => hybridBarVisible };
+});
 vi.mock("./HelpIntroBanner", () => ({ HelpIntroBanner: () => null }));
 vi.mock("./HelpPanelHeader", () => ({ HelpPanelHeader: () => null }));
 vi.mock("./HelpPanelBanners", () => ({ HelpPanelBanners: () => null }));
@@ -349,6 +362,7 @@ beforeEach(() => {
   helpPanelState.preferredAgentId = null;
   helpPanelState.conversationTouched = false;
   helpPanelState.focusRequest = 0;
+  panelStoreState.preferredTerminalFocusTarget = "hybridInput";
   setPanel("t-1");
 
   foreignEditor = document.createElement("textarea");
@@ -425,12 +439,18 @@ describe("HelpPanel — reveal focus ownership (#11472)", () => {
     });
 
     // #11465's lesson: gating only the HybridInputBar path leaves the raw xterm
-    // fallback as a silent bypass. Same scenario, hybrid bar hidden.
+    // fallback as a silent bypass. Same structural trigger, hybrid bar hidden,
+    // so the xterm writer is the one under test.
     it("gates the raw xterm fallback too, not just the HybridInputBar path", () => {
       hybridBarVisible = false;
-      const { rerender } = renderSettledWithForeignFocus();
+      setPanel("t-1", "spawning");
+      const { rerender } = render(<HelpPanel width={380} />);
+      act(() => flushFrame());
+      act(() => flushFrame());
+      focusForeignEditor();
+      clearFocusSpies();
 
-      churnPanelIdentity("t-1");
+      setPanel("t-1", "ready");
       rerender(<HelpPanel width={380} />);
       act(() => flushFrame());
       act(() => flushFrame());
@@ -440,20 +460,55 @@ describe("HelpPanel — reveal focus ownership (#11472)", () => {
     });
 
     it("blocks a structural retry when focus leaves between the effect and its frame", () => {
+      setPanel("t-1", "spawning");
       const { rerender } = render(<HelpPanel width={380} />);
       act(() => flushFrame());
       act(() => flushFrame());
+      act(() => {
+        document.getElementById("daintree-assistant-panel")?.focus();
+      });
       clearFocusSpies();
 
-      // Assistant still owns focus when the structural change is committed...
-      setPanel("t-1", "ready", "working");
+      // The assistant still owns focus when the structural change commits...
+      setPanel("t-1", "ready");
       rerender(<HelpPanel width={380} />);
-      // ...but the user clicks into the other pane before the frame runs.
+      // ...but the user clicks into the other pane before the frame runs, so
+      // the recheck inside the frame — not the effect body — has to catch it.
       focusForeignEditor();
       act(() => flushFrame());
       act(() => flushFrame());
 
       expect(anyFocusWriterCalled()).toBe(false);
+      expect(document.activeElement).toBe(foreignEditor);
+    });
+
+    // The bar defers the real focus to a frame of its own, so ownership can
+    // still change AFTER HelpPanel's frame has already asked for focus. That
+    // last frame is the one the issue calls the "final deferred frame".
+    it("revokes the bar's pending focus when ownership is lost in the final frame", () => {
+      setPanel("t-1", "spawning");
+      const { rerender } = render(<HelpPanel width={380} />);
+      act(() => flushFrame());
+      act(() => flushFrame());
+      act(() => {
+        document.getElementById("daintree-assistant-panel")?.focus();
+      });
+      clearFocusSpies();
+
+      setPanel("t-1", "ready");
+      rerender(<HelpPanel width={380} />);
+      // Frame 1: HelpPanel asks the bar for focus; the bar queues its own frame.
+      act(() => flushFrame());
+      expect(hybridHandle.focusWithCursorAtEnd).toHaveBeenCalled();
+      expect(hybridHandle.scheduled).toBe(1);
+
+      // The user clicks into the other pane in the gap.
+      focusForeignEditor();
+
+      // Frame 2: the guard runs ahead of the bar's callback and revokes it.
+      act(() => flushFrame());
+
+      expect(hybridHandle.cancelPendingFocus).toHaveBeenCalled();
       expect(document.activeElement).toBe(foreignEditor);
     });
   });
@@ -530,26 +585,144 @@ describe("HelpPanel — reveal focus ownership (#11472)", () => {
       expect(document.activeElement).toBe(foreignEditor);
     });
 
+    // Mounting already-open is what puts the open branch through StrictMode's
+    // setup/cleanup/setup replay. The first setup's frame is cancelled and its
+    // pending bar focus revoked, so only tracking the last *completed* trigger
+    // (rather than the last setup) lets the replay reissue the grab.
     it("still lands focus under StrictMode's mount/cleanup/mount replay", () => {
-      helpPanelState.isOpen = false;
-      const { rerender } = render(
-        <StrictMode>
-          <HelpPanel width={380} />
-        </StrictMode>
-      );
-      focusForeignEditor();
-      clearFocusSpies();
+      foreignEditor.focus();
+      expect(document.activeElement).toBe(foreignEditor);
 
-      helpPanelState.isOpen = true;
-      rerender(
+      render(
         <StrictMode>
           <HelpPanel width={380} />
         </StrictMode>
       );
       act(() => flushFrame());
+      act(() => flushFrame());
 
-      // The replayed setup must reissue the grab the first cleanup cancelled.
       expect(hybridHandle.focusWithCursorAtEnd).toHaveBeenCalled();
+      expect(document.activeElement).toBe(
+        document.querySelector("[data-testid=assistant-cm-input]")
+      );
+    });
+
+    it("actually lands focus in the assistant input, not just dispatches the request", () => {
+      helpPanelState.isOpen = false;
+      const { rerender } = render(<HelpPanel width={380} />);
+      focusForeignEditor();
+      clearFocusSpies();
+
+      helpPanelState.isOpen = true;
+      rerender(<HelpPanel width={380} />);
+      // Frame 1 asks the bar; frame 2 is where the bar actually focuses.
+      act(() => flushFrame());
+      expect(document.activeElement).toBe(foreignEditor);
+      act(() => flushFrame());
+
+      expect(document.activeElement).toBe(
+        document.querySelector("[data-testid=assistant-cm-input]")
+      );
+    });
+  });
+
+  describe("the remembered target picks the surface, and never authorizes", () => {
+    it("focuses xterm instead of the input bar when the preference is xterm", () => {
+      panelStoreState.preferredTerminalFocusTarget = "xterm";
+      helpPanelState.isOpen = false;
+      const { rerender } = render(<HelpPanel width={380} />);
+      focusForeignEditor();
+      clearFocusSpies();
+
+      helpPanelState.isOpen = true;
+      rerender(<HelpPanel width={380} />);
+      act(() => flushFrame());
+      act(() => flushFrame());
+
+      // The bar's own preference check would have aborted silently, leaving an
+      // authorized open request with focus still in the other pane.
+      expect(hybridHandle.focusWithCursorAtEnd).not.toHaveBeenCalled();
+      expect(focusMock).toHaveBeenCalledWith("t-1");
+    });
+
+    it("routes to xterm when the assistant input is locked", () => {
+      helpPanelState.isOpen = false;
+      const { rerender } = render(<HelpPanel width={380} />);
+      focusForeignEditor();
+      clearFocusSpies();
+
+      panelStoreState.panelsById = {
+        "t-1": { agentState: "idle", cwd: "/repo", spawnStatus: "ready", isInputLocked: true },
+      };
+      helpPanelState.isOpen = true;
+      rerender(<HelpPanel width={380} />);
+      act(() => flushFrame());
+      act(() => flushFrame());
+
+      expect(hybridHandle.focusWithCursorAtEnd).not.toHaveBeenCalled();
+      expect(focusMock).toHaveBeenCalledWith("t-1");
+    });
+
+    // The preference must not become a back door around the ownership gate.
+    it("does not let the xterm preference authorize a background structural retry", () => {
+      panelStoreState.preferredTerminalFocusTarget = "xterm";
+      setPanel("t-1", "spawning");
+      const { rerender } = render(<HelpPanel width={380} />);
+      act(() => flushFrame());
+      act(() => flushFrame());
+      focusForeignEditor();
+      clearFocusSpies();
+
+      setPanel("t-1", "ready");
+      rerender(<HelpPanel width={380} />);
+      act(() => flushFrame());
+      act(() => flushFrame());
+
+      expect(anyFocusWriterCalled()).toBe(false);
+      expect(document.activeElement).toBe(foreignEditor);
+    });
+  });
+
+  describe("restoring focus on close", () => {
+    it("returns focus to the opener when the assistant still owns it", () => {
+      const opener = document.createElement("button");
+      document.body.appendChild(opener);
+      opener.focus();
+
+      helpPanelState.isOpen = false;
+      const { rerender } = render(<HelpPanel width={380} />);
+      helpPanelState.isOpen = true;
+      rerender(<HelpPanel width={380} />);
+      act(() => flushFrame());
+      act(() => flushFrame());
+
+      helpPanelState.isOpen = false;
+      rerender(<HelpPanel width={380} />);
+
+      expect(document.activeElement).toBe(opener);
+      opener.remove();
+    });
+
+    it("leaves focus alone when the user has already moved to another pane", () => {
+      const opener = document.createElement("button");
+      document.body.appendChild(opener);
+      opener.focus();
+
+      helpPanelState.isOpen = false;
+      const { rerender } = render(<HelpPanel width={380} />);
+      helpPanelState.isOpen = true;
+      rerender(<HelpPanel width={380} />);
+      act(() => flushFrame());
+      act(() => flushFrame());
+
+      // The user leaves the assistant for another pane, then closes it from a
+      // global shortcut. Restoring the opener here would be the same steal.
+      focusForeignEditor();
+      helpPanelState.isOpen = false;
+      rerender(<HelpPanel width={380} />);
+
+      expect(document.activeElement).toBe(foreignEditor);
+      opener.remove();
     });
   });
 

--- a/src/components/HelpPanel/__tests__/HelpPanel.revealFocusOwnership.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.revealFocusOwnership.test.tsx
@@ -346,6 +346,11 @@ beforeEach(() => {
   hybridHandle.cancelPendingFocus.mockImplementation(() => {
     hybridHandle.generation += 1;
   });
+  // The real service focuses xterm synchronously. Doing it here too means the
+  // xterm route is proved by where focus actually landed, not just by a spy.
+  focusMock.mockImplementation(() => {
+    document.querySelector<HTMLTextAreaElement>("[data-testid=xterm-textarea]")?.focus();
+  });
 
   globalThis.requestAnimationFrame = ((cb: FrameRequestCallback): number => {
     const id = ++rafIdCounter;
@@ -504,12 +509,18 @@ describe("HelpPanel — reveal focus ownership (#11472)", () => {
 
       // The user clicks into the other pane in the gap.
       focusForeignEditor();
+      hybridHandle.cancelPendingFocus.mockClear();
 
       // Frame 2: the guard runs ahead of the bar's callback and revokes it.
       act(() => flushFrame());
 
+      // Asserted on where focus ended up, not just on the spy — the bar's
+      // callback runs in this same flush, so the caret moving would show here.
       expect(hybridHandle.cancelPendingFocus).toHaveBeenCalled();
       expect(document.activeElement).toBe(foreignEditor);
+      expect(document.activeElement).not.toBe(
+        document.querySelector("[data-testid=assistant-cm-input]")
+      );
     });
   });
 

--- a/src/components/HelpPanel/__tests__/HelpPanel.revealFocusOwnership.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.revealFocusOwnership.test.tsx
@@ -1,0 +1,633 @@
+// @vitest-environment jsdom
+import { render, act } from "@testing-library/react";
+import { StrictMode, useImperativeHandle } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Regression guard for #11472: a background update to the assistant's own panel
+// object must never move keyboard focus out of whatever the user is actually
+// typing in. A live assistant replaces `panelsById[terminalId]` constantly
+// (`updateAgentState`, `updateLastObservedTitle` on every distinct OSC title,
+// and the RAF-coalesced activity buffer), and the reveal effect used to list
+// that whole object as a dependency — so every one of those writes re-ran it and
+// re-grabbed focus, yanking the caret out of Ask Codex in another pane.
+//
+// The contract this file pins:
+//   1. Only open / reveal / focusRequest authorize taking focus from elsewhere.
+//   2. Structural churn (terminal appears, finishes spawning, is replaced) may
+//      only re-target focus the assistant ALREADY owns.
+//   3. Ownership is re-checked on the final deferred frame, not in the effect.
+//   4. Both focus writers — HybridInputBar and the raw xterm fallback — share
+//      the identical gate (#11465: gating only one path is inert).
+//   5. Cleanup cancels HybridInputBar's nested frame so it can't land late.
+
+const { focusMock, helpPanelState, panelStoreState, hybridHandle } = vi.hoisted(() => ({
+  focusMock: vi.fn(),
+  helpPanelState: {
+    isOpen: true,
+    width: 380,
+    terminalId: "t-1" as string | null,
+    agentId: "claude" as string | null,
+    preferredAgentId: null as string | null,
+    sessionId: null as string | null,
+    introDismissed: true,
+    conversationTouched: false,
+    hibernateSessions: {} as Record<string, unknown>,
+    focusRequest: 0,
+    figures: [] as unknown[],
+    markConversationStarted: vi.fn(),
+    setWidth: vi.fn(),
+    setOpen: vi.fn(),
+    clearTerminal: vi.fn(),
+    setPreferredAgent: vi.fn(),
+    setTerminal: vi.fn(),
+    dismissIntro: vi.fn(),
+    setHibernateSession: vi.fn(),
+    clearHibernateSession: vi.fn(),
+  },
+  panelStoreState: {
+    panelIds: [] as string[],
+    panelsById: {} as Record<string, { agentState?: string; cwd?: string; spawnStatus?: string }>,
+    removePanel: vi.fn(),
+    addPanel: vi.fn().mockResolvedValue(""),
+  },
+  // Stands in for HybridInputBar's imperative handle. `focusWithCursorAtEnd`
+  // schedules the real focus inside its own rAF behind a generation token, and
+  // `cancelPendingFocus` invalidates it — the exact shape HelpPanel must drive.
+  hybridHandle: {
+    generation: 0,
+    scheduled: 0,
+    editor: null as HTMLElement | null,
+    focusWithCursorAtEnd: vi.fn(),
+    cancelPendingFocus: vi.fn(),
+  },
+}));
+
+const snapshot = {
+  showResumeBanner: false,
+  tierMismatch: null,
+  isApprovingTier: false,
+  assistantVersionTooOld: null,
+};
+
+// Controls `shouldShowHybridInputBar` per test without re-mocking the module.
+let hybridBarVisible = true;
+// Controls whether the mocked bar publishes an imperative handle — `null` models
+// the lazy Suspense window where the ref hasn't attached yet.
+let hybridHandleAttached = true;
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children?: unknown }) => <div>{children as never}</div>,
+  DropdownMenuTrigger: ({ children }: { children?: unknown }) => <>{children as never}</>,
+  DropdownMenuContent: ({ children }: { children?: unknown }) => (
+    <div data-testid="overflow-menu">{children as never}</div>
+  ),
+  DropdownMenuItem: ({ children, onSelect }: { children?: unknown; onSelect?: (e: Event) => void }) => (
+    <button type="button" onClick={() => onSelect?.(new Event("select"))}>
+      {children as never}
+    </button>
+  ),
+  DropdownMenuSeparator: () => <hr />,
+}));
+
+vi.mock("@/controllers/HelpSessionController", () => ({
+  HelpSessionController: class {
+    start = vi.fn();
+    stop = vi.fn();
+    subscribe = (_cb: () => void) => () => {};
+    getSnapshot = () => snapshot;
+    syncInputs = vi.fn();
+    handleTerminalPanelMissing = vi.fn();
+    handleAgentExited = vi.fn();
+    handleViewRevealed = vi.fn();
+    selectAgent = vi.fn();
+    newSession = vi.fn();
+    runAnyway = vi.fn();
+    dismissResumeBanner = vi.fn();
+    dismissTierMismatch = vi.fn();
+    approveTierOnce = vi.fn();
+    alwaysAllowTier = vi.fn();
+  },
+}));
+
+vi.mock("@/lib/utils", () => ({ cn: (...args: unknown[]) => args.filter(Boolean).join(" ") }));
+vi.mock("@/components/icons/DaintreeIcon", () => ({ DaintreeIcon: () => null }));
+
+// The assistant's xterm lives inside the aside, so its helper textarea is a real
+// descendant of `panelRef` — that containment is what makes `isAssistantFocused()`
+// true after the xterm fallback fires.
+vi.mock("@/components/Terminal/XtermAdapter", () => ({
+  XtermAdapter: () => (
+    <div data-testid="xterm-adapter">
+      <textarea className="xterm-helper-textarea" data-testid="xterm-textarea" />
+    </div>
+  ),
+}));
+
+vi.mock("@/components/Terminal/HybridInputBar", () => ({
+  HybridInputBar: ({ ref }: { ref?: React.Ref<unknown> }) => {
+    useImperativeHandle(ref, () => (hybridHandleAttached ? hybridHandle : null), []);
+    return (
+      <div className="cm-editor" data-testid="assistant-cm-editor">
+        {/* The element the deferred grab really focuses. Publishing it to the
+            handle keeps `isAssistantFocused()` honest: a landed grab leaves
+            `document.activeElement` genuinely inside the assistant root. */}
+        <textarea
+          data-testid="assistant-cm-input"
+          ref={(el) => {
+            hybridHandle.editor = el;
+          }}
+        />
+      </div>
+    );
+  },
+}));
+
+vi.mock("@/components/Terminal/MissingCliGate", () => ({ MissingCliGate: () => null }));
+vi.mock("@/components/Terminal/terminalFocus", () => ({
+  shouldShowHybridInputBar: () => hybridBarVisible,
+}));
+vi.mock("./HelpIntroBanner", () => ({ HelpIntroBanner: () => null }));
+vi.mock("./HelpPanelHeader", () => ({ HelpPanelHeader: () => null }));
+vi.mock("./HelpPanelBanners", () => ({ HelpPanelBanners: () => null }));
+vi.mock("./HelpPanelVersionGate", () => ({ HelpPanelVersionGate: () => null }));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    focus: (...args: unknown[]) => focusMock(...args),
+    setFocused: vi.fn(),
+    notifyUserInput: vi.fn(),
+    repaintForReveal: vi.fn(),
+  },
+}));
+
+vi.mock("@/clients", () => ({ terminalClient: { submit: vi.fn(), sendKey: vi.fn() } }));
+vi.mock("@shared/config/agentIds", () => ({
+  BUILT_IN_AGENT_IDS: ["claude", "codex", "claude-code"] as const,
+  ASSISTANT_ONLY_AGENT_IDS: [] as const,
+  LAUNCHABLE_AGENT_IDS: ["claude", "codex", "claude-code"] as const,
+  isBuiltInAgentId: (v: unknown): v is string =>
+    typeof v === "string" && ["claude", "codex", "claude-code"].includes(v),
+  isAssistantOnlyAgentId: () => false,
+}));
+vi.mock("../../../shared/utils/agentAvailability", () => ({ isAgentInstalled: () => true }));
+vi.mock("@/lib/accessibility", () => ({ TABBABLE_SELECTOR: "button" }));
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn(), getContext: () => ({}) },
+}));
+vi.mock("@/lib/sidebarToggle", () => ({ suppressSidebarResizes: vi.fn() }));
+vi.mock("@/hooks/useEscapeStack", () => ({ useEscapeStack: vi.fn() }));
+vi.mock("@/types", () => ({ TerminalRefreshTier: { BACKGROUND: 0, ACTIVE: 1 } }));
+
+vi.mock("@/config/agents", () => ({
+  getAgentConfig: (id: string) =>
+    ({
+      claude: { name: "Claude", icon: () => null },
+      codex: { name: "Codex", icon: () => null },
+      "claude-code": { name: "Claude Code", icon: () => null },
+    })[id],
+  getAssistantSupportedAgentIds: () => ["claude", "codex", "claude-code"],
+}));
+
+vi.mock("@/store/helpPanelStore", () => {
+  const store = (selector?: (s: typeof helpPanelState) => unknown) =>
+    selector ? selector(helpPanelState) : helpPanelState;
+  store.getState = () => helpPanelState;
+  return { useHelpPanelStore: store, HELP_PANEL_MIN_WIDTH: 320, HELP_PANEL_MAX_WIDTH: 800 };
+});
+
+vi.mock("@/store", () => {
+  const panelStore = (selector?: (s: typeof panelStoreState) => unknown) =>
+    selector ? selector(panelStoreState) : panelStoreState;
+  panelStore.getState = () => panelStoreState;
+
+  const cliState = {
+    availability: { claude: "ready", codex: "ready", "claude-code": "ready" } as Record<
+      string,
+      string
+    >,
+    isInitialized: true,
+    hasRealData: true,
+    details: {} as Record<string, unknown>,
+  };
+  const cliStore = (selector?: (s: typeof cliState) => unknown) =>
+    selector ? selector(cliState) : cliState;
+  cliStore.getState = () => cliState;
+
+  const projectState = { currentProject: { id: "proj-1", path: "/repo" } };
+  const projectStore = (selector?: (s: typeof projectState) => unknown) =>
+    selector ? selector(projectState) : projectState;
+  projectStore.getState = () => projectState;
+
+  const worktreeState = { activeWorktreeId: null as string | null };
+  const worktreeStore = (selector?: (s: typeof worktreeState) => unknown) =>
+    selector ? selector(worktreeState) : worktreeState;
+  worktreeStore.getState = () => worktreeState;
+
+  const terminalInputState = { hybridInputEnabled: true };
+  const terminalInputStore = (selector?: (s: typeof terminalInputState) => unknown) =>
+    selector ? selector(terminalInputState) : terminalInputState;
+  terminalInputStore.getState = () => terminalInputState;
+
+  return {
+    usePanelStore: panelStore,
+    useCliAvailabilityStore: cliStore,
+    useProjectStore: projectStore,
+    useWorktreeSelectionStore: worktreeStore,
+    useTerminalInputStore: terminalInputStore,
+    getTerminalRefreshTier: () => 0,
+  };
+});
+
+// Faithful macro-focus mock: `setRegionRef` really records the assistant root so
+// `isAssistantFocused()` resolves containment against the live DOM exactly as
+// macroFocusStore.ts:94 does. The whole fix turns on that answer, so a stubbed
+// constant here would make every assertion below meaningless.
+vi.mock("@/store/macroFocusStore", () => {
+  let assistantRoot: HTMLElement | null = null;
+  const state = {
+    focusedRegion: null as string | null,
+    setRegionRef: vi.fn((region: string, el: HTMLElement | null) => {
+      if (region === "assistant") assistantRoot = el;
+    }),
+  };
+  const store = (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state);
+  store.getState = () => state;
+  store.setState = (partial: Partial<typeof state>) => Object.assign(state, partial);
+  return {
+    useMacroFocusStore: store,
+    isAssistantFocused: () =>
+      state.focusedRegion === "assistant" ||
+      Boolean(assistantRoot && assistantRoot.contains(document.activeElement)),
+  };
+});
+
+vi.mock("@/components/ui/ConfirmDialog", () => ({ ConfirmDialog: () => null }));
+vi.mock("../FigureRail", () => ({ FigureRail: () => null }));
+
+import { HelpPanel } from "../HelpPanel";
+
+// rAF mock so every deferred focus frame is driven explicitly. A flush runs only
+// the callbacks already queued, so HybridInputBar's nested frame needs a second
+// flush — which is exactly the window the cleanup gap lived in.
+const rafQueue = new Map<number, FrameRequestCallback>();
+let rafIdCounter = 0;
+function flushFrame(): void {
+  const pending = [...rafQueue.entries()];
+  rafQueue.clear();
+  for (const [, cb] of pending) cb(0);
+}
+
+// A focusable element standing in for Ask Codex's CodeMirror in another pane.
+let foreignEditor: HTMLTextAreaElement;
+
+function focusForeignEditor(): void {
+  act(() => {
+    foreignEditor.focus();
+  });
+}
+
+function setPanel(id: string, spawnStatus = "ready", agentState = "idle"): void {
+  panelStoreState.panelIds = [id];
+  panelStoreState.panelsById = { [id]: { agentState, cwd: "/repo", spawnStatus } };
+}
+
+/** Replace the panel object's identity without changing anything load-bearing —
+ *  what `updateLastObservedTitle` / the activity buffer do on every tick. */
+function churnPanelIdentity(id: string): void {
+  const prev = panelStoreState.panelsById[id];
+  panelStoreState.panelsById = { [id]: { ...prev } };
+}
+
+function clearFocusSpies(): void {
+  focusMock.mockClear();
+  hybridHandle.focusWithCursorAtEnd.mockClear();
+  hybridHandle.cancelPendingFocus.mockClear();
+  hybridHandle.scheduled = 0;
+}
+
+/** True when either focus writer fired — the paired-path assertion (#11465). */
+function anyFocusWriterCalled(): boolean {
+  return focusMock.mock.calls.length > 0 || hybridHandle.focusWithCursorAtEnd.mock.calls.length > 0;
+}
+
+beforeEach(() => {
+  rafQueue.clear();
+  rafIdCounter = 0;
+  hybridBarVisible = true;
+  hybridHandleAttached = true;
+  clearFocusSpies();
+
+  hybridHandle.generation = 0;
+  hybridHandle.editor = null;
+  // Model HybridInputBar.tsx:626-652: capture the generation, defer the real
+  // focus to a frame, and bail if the generation moved on in the meantime.
+  hybridHandle.focusWithCursorAtEnd.mockImplementation(() => {
+    const gen = hybridHandle.generation;
+    hybridHandle.scheduled += 1;
+    requestAnimationFrame(() => {
+      if (hybridHandle.generation !== gen) return;
+      hybridHandle.editor?.focus();
+    });
+    return true;
+  });
+  hybridHandle.cancelPendingFocus.mockImplementation(() => {
+    hybridHandle.generation += 1;
+  });
+
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback): number => {
+    const id = ++rafIdCounter;
+    rafQueue.set(id, cb);
+    return id;
+  }) as typeof globalThis.requestAnimationFrame;
+  globalThis.cancelAnimationFrame = ((id: number): void => {
+    rafQueue.delete(id);
+  }) as typeof globalThis.cancelAnimationFrame;
+
+  helpPanelState.isOpen = true;
+  helpPanelState.terminalId = "t-1";
+  helpPanelState.agentId = "claude";
+  helpPanelState.preferredAgentId = null;
+  helpPanelState.conversationTouched = false;
+  helpPanelState.focusRequest = 0;
+  setPanel("t-1");
+
+  foreignEditor = document.createElement("textarea");
+  foreignEditor.className = "cm-editor";
+  document.body.appendChild(foreignEditor);
+
+  Object.defineProperty(globalThis, "window", {
+    value: {
+      electron: {
+        help: { getPinnedActionContext: vi.fn().mockResolvedValue({}) },
+        app: { onViewRevealed: () => () => {} },
+      },
+    },
+    writable: true,
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  foreignEditor.remove();
+});
+
+/** Render, settle the authorized open grab, then hand focus to the other pane. */
+function renderSettledWithForeignFocus() {
+  const view = render(<HelpPanel width={380} />);
+  act(() => flushFrame());
+  act(() => flushFrame());
+  focusForeignEditor();
+  clearFocusSpies();
+  return view;
+}
+
+describe("HelpPanel — reveal focus ownership (#11472)", () => {
+  describe("background churn must not steal focus", () => {
+    it("ignores a panel-identity replacement while another pane owns focus", () => {
+      const { rerender } = renderSettledWithForeignFocus();
+
+      churnPanelIdentity("t-1");
+      rerender(<HelpPanel width={380} />);
+      act(() => flushFrame());
+      act(() => flushFrame());
+
+      expect(anyFocusWriterCalled()).toBe(false);
+      expect(document.activeElement).toBe(foreignEditor);
+    });
+
+    it("ignores an agent-state transition while another pane owns focus", () => {
+      const { rerender } = renderSettledWithForeignFocus();
+
+      // The Codex completionPatterns case from the issue: working -> completed
+      // -> working repeatedly inside a single turn.
+      for (const next of ["completed", "working", "completed"]) {
+        setPanel("t-1", "ready", next);
+        rerender(<HelpPanel width={380} />);
+        act(() => flushFrame());
+        act(() => flushFrame());
+      }
+
+      expect(anyFocusWriterCalled()).toBe(false);
+      expect(document.activeElement).toBe(foreignEditor);
+    });
+
+    it("does not re-grab focus when the terminal is replaced in the background", () => {
+      const { rerender } = renderSettledWithForeignFocus();
+
+      helpPanelState.terminalId = "t-2";
+      setPanel("t-2");
+      rerender(<HelpPanel width={380} />);
+      act(() => flushFrame());
+      act(() => flushFrame());
+
+      expect(anyFocusWriterCalled()).toBe(false);
+      expect(document.activeElement).toBe(foreignEditor);
+    });
+
+    // #11465's lesson: gating only the HybridInputBar path leaves the raw xterm
+    // fallback as a silent bypass. Same scenario, hybrid bar hidden.
+    it("gates the raw xterm fallback too, not just the HybridInputBar path", () => {
+      hybridBarVisible = false;
+      const { rerender } = renderSettledWithForeignFocus();
+
+      churnPanelIdentity("t-1");
+      rerender(<HelpPanel width={380} />);
+      act(() => flushFrame());
+      act(() => flushFrame());
+
+      expect(focusMock).not.toHaveBeenCalled();
+      expect(document.activeElement).toBe(foreignEditor);
+    });
+
+    it("blocks a structural retry when focus leaves between the effect and its frame", () => {
+      const { rerender } = render(<HelpPanel width={380} />);
+      act(() => flushFrame());
+      act(() => flushFrame());
+      clearFocusSpies();
+
+      // Assistant still owns focus when the structural change is committed...
+      setPanel("t-1", "ready", "working");
+      rerender(<HelpPanel width={380} />);
+      // ...but the user clicks into the other pane before the frame runs.
+      focusForeignEditor();
+      act(() => flushFrame());
+      act(() => flushFrame());
+
+      expect(anyFocusWriterCalled()).toBe(false);
+      expect(document.activeElement).toBe(foreignEditor);
+    });
+  });
+
+  describe("legitimate focus requests still land", () => {
+    it("focuses the assistant on open even when another pane owns focus", () => {
+      helpPanelState.isOpen = false;
+      const { rerender } = render(<HelpPanel width={380} />);
+      focusForeignEditor();
+      clearFocusSpies();
+
+      helpPanelState.isOpen = true;
+      rerender(<HelpPanel width={380} />);
+      act(() => flushFrame());
+
+      expect(hybridHandle.focusWithCursorAtEnd).toHaveBeenCalled();
+    });
+
+    it("focuses the assistant on reveal even when another pane owns focus", () => {
+      const { rerender } = render(<HelpPanel width={0} isVisible={false} />);
+      focusForeignEditor();
+      clearFocusSpies();
+
+      rerender(<HelpPanel width={380} isVisible />);
+      act(() => flushFrame());
+
+      expect(hybridHandle.focusWithCursorAtEnd).toHaveBeenCalled();
+    });
+
+    it("re-focuses a blurred but open panel on a focusRequest bump (Cmd+L)", () => {
+      const { rerender } = renderSettledWithForeignFocus();
+
+      helpPanelState.focusRequest += 1;
+      rerender(<HelpPanel width={380} />);
+      act(() => flushFrame());
+
+      expect(hybridHandle.focusWithCursorAtEnd).toHaveBeenCalled();
+    });
+
+    it("retries the grab on spawning -> ready while the assistant owns focus", () => {
+      // Cold open against a still-spawning terminal parks focus on the panel
+      // root rather than the editor. Becoming ready is a structural retry, and
+      // the assistant still owning focus is what authorizes it.
+      setPanel("t-1", "spawning");
+      const { rerender } = render(<HelpPanel width={380} />);
+      act(() => flushFrame());
+      act(() => flushFrame());
+      act(() => {
+        document.getElementById("daintree-assistant-panel")?.focus();
+      });
+      clearFocusSpies();
+
+      setPanel("t-1", "ready");
+      rerender(<HelpPanel width={380} />);
+      act(() => flushFrame());
+
+      expect(hybridHandle.focusWithCursorAtEnd).toHaveBeenCalled();
+    });
+
+    it("does not retry on spawning -> ready when another pane owns focus", () => {
+      setPanel("t-1", "spawning");
+      const { rerender } = render(<HelpPanel width={380} />);
+      act(() => flushFrame());
+      act(() => flushFrame());
+      focusForeignEditor();
+      clearFocusSpies();
+
+      setPanel("t-1", "ready");
+      rerender(<HelpPanel width={380} />);
+      act(() => flushFrame());
+      act(() => flushFrame());
+
+      expect(anyFocusWriterCalled()).toBe(false);
+      expect(document.activeElement).toBe(foreignEditor);
+    });
+
+    it("still lands focus under StrictMode's mount/cleanup/mount replay", () => {
+      helpPanelState.isOpen = false;
+      const { rerender } = render(
+        <StrictMode>
+          <HelpPanel width={380} />
+        </StrictMode>
+      );
+      focusForeignEditor();
+      clearFocusSpies();
+
+      helpPanelState.isOpen = true;
+      rerender(
+        <StrictMode>
+          <HelpPanel width={380} />
+        </StrictMode>
+      );
+      act(() => flushFrame());
+
+      // The replayed setup must reissue the grab the first cleanup cancelled.
+      expect(hybridHandle.focusWithCursorAtEnd).toHaveBeenCalled();
+    });
+  });
+
+  describe("live panel reads and deferred-frame cancellation", () => {
+    it("does not target a terminal removed between the effect and its frame", () => {
+      helpPanelState.isOpen = false;
+      const { rerender } = render(<HelpPanel width={380} />);
+      clearFocusSpies();
+
+      helpPanelState.isOpen = true;
+      rerender(<HelpPanel width={380} />);
+      // The panel disappears before the deferred frame runs — only a live read
+      // at frame time can see this.
+      panelStoreState.panelIds = [];
+      panelStoreState.panelsById = {};
+      act(() => flushFrame());
+
+      expect(anyFocusWriterCalled()).toBe(false);
+    });
+
+    it.each(["failed", "missing-cli"])(
+      "does not target a terminal that turned %s before its frame",
+      (status) => {
+        helpPanelState.isOpen = false;
+        const { rerender } = render(<HelpPanel width={380} />);
+        clearFocusSpies();
+
+        helpPanelState.isOpen = true;
+        rerender(<HelpPanel width={380} />);
+        setPanel("t-1", status);
+        act(() => flushFrame());
+
+        expect(anyFocusWriterCalled()).toBe(false);
+      }
+    );
+
+    it("cancels HybridInputBar's nested frame when the panel closes mid-grab", () => {
+      helpPanelState.isOpen = false;
+      const { rerender } = render(<HelpPanel width={380} />);
+      clearFocusSpies();
+
+      helpPanelState.isOpen = true;
+      rerender(<HelpPanel width={380} />);
+      // First frame: HelpPanel's own rAF runs and asks the bar for focus, which
+      // defers the real `view.focus()` to a frame of its own.
+      act(() => flushFrame());
+      expect(hybridHandle.scheduled).toBe(1);
+
+      const editor = document.createElement("textarea");
+      document.body.appendChild(editor);
+      hybridHandle.editor = editor;
+
+      // The panel closes in that gap. Without cancelPendingFocus() the bar's
+      // queued frame would still fire and focus a closed panel's editor.
+      helpPanelState.isOpen = false;
+      rerender(<HelpPanel width={380} />);
+      act(() => flushFrame());
+
+      expect(hybridHandle.cancelPendingFocus).toHaveBeenCalled();
+      expect(document.activeElement).not.toBe(editor);
+      editor.remove();
+    });
+
+    it("falls back to xterm when the bar is mounted but its editor is not ready", () => {
+      // `focusWithCursorAtEnd()` returning false means no view was mounted and
+      // nothing was scheduled, so the xterm fallback is safe rather than a
+      // second competing grab.
+      hybridHandle.focusWithCursorAtEnd.mockImplementation(() => false);
+      helpPanelState.isOpen = false;
+      const { rerender } = render(<HelpPanel width={380} />);
+      clearFocusSpies();
+
+      helpPanelState.isOpen = true;
+      rerender(<HelpPanel width={380} />);
+      act(() => flushFrame());
+
+      expect(hybridHandle.focusWithCursorAtEnd).toHaveBeenCalled();
+      expect(focusMock).toHaveBeenCalledWith("t-1");
+    });
+  });
+});

--- a/src/components/HelpPanel/__tests__/HelpPanel.webglPin.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.webglPin.test.tsx
@@ -205,7 +205,12 @@ vi.mock("@/store/macroFocusStore", () => {
     const next = typeof partial === "function" ? partial(state) : partial;
     Object.assign(state, next);
   };
-  return { useMacroFocusStore: store };
+  return {
+    useMacroFocusStore: store,
+    // Mirrors the real contract (macroFocusStore.ts:94) closely enough for these
+    // suites: the assistant owns focus when its macro region is selected.
+    isAssistantFocused: () => state.focusedRegion === "assistant",
+  };
 });
 
 vi.mock("@/components/ui/ConfirmDialog", () => ({ ConfirmDialog: () => null }));

--- a/src/components/HelpPanel/__tests__/HelpPanel.webglPin.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.webglPin.test.tsx
@@ -102,9 +102,12 @@ vi.mock("@/components/Terminal/XtermAdapter", () => ({
 }));
 vi.mock("@/components/Terminal/HybridInputBar", () => ({ HybridInputBar: () => null }));
 vi.mock("@/components/Terminal/MissingCliGate", () => ({ MissingCliGate: () => null }));
-vi.mock("@/components/Terminal/terminalFocus", () => ({
-  shouldShowHybridInputBar: () => false,
-}));
+vi.mock("@/components/Terminal/terminalFocus", async (importOriginal) => {
+  // Keep the real `getTerminalFocusTarget` — the reveal effect resolves the
+  // remembered target through it, and a hand-stubbed copy would drift.
+  const actual = await importOriginal<typeof import("@/components/Terminal/terminalFocus")>();
+  return { ...actual, shouldShowHybridInputBar: () => false };
+});
 vi.mock("./HelpIntroBanner", () => ({ HelpIntroBanner: () => null }));
 vi.mock("./HelpPanelHeader", () => ({ HelpPanelHeader: () => null }));
 vi.mock("./HelpPanelBanners", () => ({ HelpPanelBanners: () => null }));


### PR DESCRIPTION
## Summary

- While an agent is running and the Daintree Assistant panel is open, background updates to the assistant panel's own state were stealing keyboard focus from wherever the user was actually typing, most visibly out of Ask Codex's CodeMirror editor in another pane.
- The reveal-focus effect in `HelpPanel.tsx` bound the entire panel object as a dependency, and a live assistant replaces `panelsById[terminalId]` constantly (`updateAgentState`, `updateLastObservedTitle` on every distinct OSC title, and the RAF-coalesced activity buffer in `panelStatusBuffer.ts`), so any of that churn made the effect eligible to re-run and re-grab focus with no ownership check outside its own panel.
- This rewrites the effect to depend on narrow structural primitives instead of the panel object, gates both focus writers behind an explicit ownership check, and closes a final-frame race where the actual `view.focus()` call landed after ownership had already moved elsewhere.

Resolves #11472

## Root cause

`HelpPanel.tsx:216` bound the whole panel object and the reveal-focus effect listed it as a dependency. A live assistant replaces `panelsById[terminalId]` constantly, so each of those writes made the effect eligible to re-run and re-grab focus. The effect's only ownership check was scoped to `panelRef`, so focus sitting in another pane's `.cm-editor` failed the `contains` check and fell straight through to the focus writers. Both `focusWithCursorAtEnd()` and the raw `terminalInstanceService.focus()` were called with no gating at all.

## Changes

All in `HelpPanel.tsx`:

1. The effect no longer treats the whole terminal object as focus intent. It depends on narrow structural primitives (`terminalExists`, `terminalSpawnStatus`) and reads the panel map non-reactively at frame time, the same pattern `useContentGridContext.tsx` uses from #8593. Agent-state, title, and activity churn no longer re-run it at all.
2. Only `open`, `reveal`, and `focusRequest` authorize taking focus from elsewhere. This is tracked via the last *completed* trigger tuple rather than the last effect setup, so React StrictMode's cancelled first pass still reissues the grab on the second one.
3. Ownership is re-checked on the genuinely final deferred frame. `focusWithCursorAtEnd()` defers the real `view.focus()` to its own frame, and nothing was cancelling that when the user simply clicked elsewhere. `HelpPanel` now queues its own guard frame before asking the input bar for focus, and because `requestAnimationFrame` callbacks run in registration order, that guard runs ahead of the bar's callback and revokes the grab via `cancelPendingFocus()` if ownership was lost in the gap.
4. `preferredTerminalFocusTarget` now only picks between xterm and hybrid input after ownership is settled. It never authorizes a grab by itself, resolved through a new `getTerminalFocusTarget` helper, which also fixes a bug where an authorized open would silently do nothing when the remembered target was xterm, because the input bar's own internal check aborted without focusing anything.
5. Cleanup revokes the nested focus request against the exact handle it was issued to.
6. Closing the panel no longer restores focus to the opener if the user has since moved to another pane. Same steal, just on the way out.

## Testing

Added `HelpPanel.revealFocusOwnership.test.tsx` (23 tests) to pin the contract: churn while another pane owns focus touches neither focus writer, open/reveal/Cmd+L still land focus correctly, structural retries require pre-existing ownership, the final frame revokes a lost grab, and cleanup cancels the nested frame. The tests are mutation-checked: reverting to the old behavior fails 6 of them, and removing the final-frame guard fails its own dedicated test.

The 11 existing `HelpPanel` suites needed their `macroFocusStore` mock updated to export `isAssistantFocused`. The 5 suites that mock `terminalFocus` now spread the real module so `getTerminalFocusTarget` isn't a drifting hand-written stub.

Locally: 1,613 tests across the HelpPanel, Layout, Terminal-focus, focusStore, and VoiceRecordingService suites pass. Composite typecheck, ESLint (no new warnings, the ratchet is per-rule), and Prettier are all clean.

## Notes

Per the issue thread, no assistant-specific logic was added to `HybridInputBar`. It's shared by every pane and is only called here, never modified. The `IdentityWatcher` angle from #10911 is out of scope, as already noted in that issue's thread.

This is the third fix in this family after #8487 and #11465. The intent this time was the structural fix, not another narrow point patch.
