### PR TITLE
fix(e2e): fail fast on the OpenCode keymap crash and pin the CLI version

### DIFF
--- a/.github/workflows/e2e-single.yml
+++ b/.github/workflows/e2e-single.yml
@@ -208,7 +208,7 @@ jobs:
 
       - name: Install OpenCode
         if: inputs.suite == 'online'
-        run: node scripts/ci/npm-install-retry.mjs -g opencode-ai
+        run: node scripts/ci/install-opencode.mjs
 
       - name: Configure Claude Code (macOS/Linux)
         if: runner.os != 'Windows'

--- a/.github/workflows/e2e-single.yml
+++ b/.github/workflows/e2e-single.yml
@@ -55,6 +55,10 @@ concurrency:
 
 env:
   NODE_VERSION: "22"
+  # Without this the pinned CLI self-updates on first launch and the run
+  # silently uses whatever version npm published today — see
+  # scripts/ci/install-opencode.mjs.
+  OPENCODE_DISABLE_AUTOUPDATE: "1"
 
 jobs:
   matrix-setup:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -110,6 +110,10 @@ concurrency:
 
 env:
   NODE_VERSION: "22"
+  # Without this the pinned CLI self-updates on first launch and the online
+  # release gate silently runs whatever version npm published today — see
+  # scripts/ci/install-opencode.mjs.
+  OPENCODE_DISABLE_AUTOUPDATE: "1"
 
 jobs:
   # Determine which platforms to run on, and fan each one out into N shards.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -426,7 +426,7 @@ jobs:
 
       - name: Install OpenCode
         if: inputs.suite == 'online'
-        run: node scripts/ci/npm-install-retry.mjs -g opencode-ai
+        run: node scripts/ci/install-opencode.mjs
 
       - name: Configure Claude Code (macOS/Linux)
         if: runner.os != 'Windows'

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -56,6 +56,10 @@ concurrency:
 
 env:
   NODE_VERSION: "22"
+  # Without this the pinned CLI self-updates on first launch and screenshots
+  # capture whatever version npm published today — see
+  # scripts/ci/install-opencode.mjs.
+  OPENCODE_DISABLE_AUTOUPDATE: "1"
   # onnxruntime-node (transitive via avr-vad for CPU-only Silero VAD) tries
   # to download optional CUDA/TensorRT GPU binaries from api.nuget.org on
   # postinstall. Daintree's VAD runs on CPU; the GPU binaries are never

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -108,7 +108,7 @@ jobs:
         run: node scripts/ci/npm-install-retry.mjs -g @anthropic-ai/claude-code
 
       - name: Install OpenCode
-        run: node scripts/ci/npm-install-retry.mjs -g opencode-ai
+        run: node scripts/ci/install-opencode.mjs
 
       - name: Configure Claude Code
         run: |

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -166,7 +166,7 @@ A single reusable workflow runs every E2E suite. Pick one via the `suite` input:
 - **Single-file runs:** pass `test_file: e2e/full/<bucket>/foo.spec.ts` and set `suite` to the bucket that owns that path (workflow_dispatch).
 - **Conditional behaviour by suite:**
   - `full` — expands to all seven `--project=full-*` flags on a single runner. Use this for ad-hoc validation; the release workflows and `stabilize.yml` fan the buckets out across separate runners instead.
-  - `online` — extra `npm install -g opencode-ai`. Caller MUST use `secrets: inherit` so `ANTHROPIC_API_KEY` is reachable.
+  - `online` — extra `node scripts/ci/install-opencode.mjs`, the single source of truth for the pinned OpenCode CLI version every workflow installs (#11476); bumping it is a deliberate edit to that script. Caller MUST use `secrets: inherit` so `ANTHROPIC_API_KEY` is reachable.
   - `nightly` — Playwright is invoked with `--workers=1` (the memory-leak heuristic depends on serialized launches).
   - All others — no extra steps.
 

--- a/e2e/helpers/__tests__/opencodeReady.test.ts
+++ b/e2e/helpers/__tests__/opencodeReady.test.ts
@@ -2,11 +2,13 @@ import { describe, it, expect } from "vitest";
 import {
   DEFAULT_STABILIZATION_POLICY,
   OPENCODE_CRASH_SIGNATURE,
+  STABILIZATION_POLL_MS,
   areOpenCodeOutputsEquivalent,
   classifyOpenCodeOutput,
   formatOpenCodeCrashError,
   formatOpenCodeTimeoutError,
   formatTerminalTail,
+  hasOpenCodeReadyMarkers,
   initialStabilizationState,
   normalizeOpenCodeOutput,
   observeOpenCodeOutput,
@@ -50,11 +52,31 @@ describe("classifyOpenCodeOutput — fatal parser crash", () => {
     expect(result).toEqual({ kind: "crashed", signature: OPENCODE_CRASH_SIGNATURE });
   });
 
-  it("outranks ready text left in the buffer above the crash", () => {
-    const text = ["> Ask anything", "", "error: Invalid key name: key name cannot be empty"].join(
-      "\n"
-    );
-    expect(classifyOpenCodeOutput(text).kind).toBe("crashed");
+  it("outranks every other state the buffer may still be showing", () => {
+    // Whatever the CLI painted before it died is still in the buffer, so the
+    // crash has to win against each of them, not just against ready text.
+    const crash = "error: Invalid key name: key name cannot be empty";
+    const competing = [
+      "> Ask anything",
+      "Update complete. Please restart the application.",
+      "Paste your API key to continue",
+      "Select provider: Anthropic",
+      "1.18.9",
+    ];
+
+    for (const other of competing) {
+      expect(classifyOpenCodeOutput(`${other}\n\n${crash}`).kind, other).toBe("crashed");
+    }
+  });
+
+  it("separates the ready markers from classification so a crash can be re-checked", () => {
+    // The driver confirms a crash by re-reading and asking whether the CLI
+    // painted ready markers anyway; that question cannot be asked through
+    // classifyOpenCodeOutput, because the crash outranks ready there.
+    const survived = "[Keymap] Error: invalid key name: key name cannot be empty\n> Ask anything";
+    expect(classifyOpenCodeOutput(survived).kind).toBe("crashed");
+    expect(hasOpenCodeReadyMarkers(survived)).toBe(true);
+    expect(hasOpenCodeReadyMarkers("Select provider: Anthropic")).toBe(false);
   });
 
   it("does not fire on recoverable keymap errors or on either half alone", () => {
@@ -214,14 +236,70 @@ describe("observeOpenCodeOutput", () => {
     expect(cleared.state).toEqual(initialStabilizationState());
   });
 
-  it("leaves the sample streak reachable under the shipped policy", () => {
-    // If the elapsed cap could expire before requiredSamples polls complete at
-    // the driver's 500ms cadence, the settle path would be dead code and every
-    // prompt would fall through to the fallback.
-    const pollMs = 500;
-    expect((DEFAULT_STABILIZATION_POLICY.requiredSamples - 1) * pollMs).toBeLessThan(
+  it("counts spinner repaints of one prompt as a settled screen", () => {
+    // Guards the comparison being on NORMALIZED text: against raw text an
+    // animated prompt could never build a streak and every prompt would leave
+    // via the max-wait fallback instead.
+    const frames = ["⠋", "⠙", "⠹", "⠸"];
+    let state = initialStabilizationState();
+    let last;
+    frames.forEach((frame, i) => {
+      last = observeOpenCodeOutput(
+        state,
+        { kind: "awaiting-provider", text: `${frame} Select provider`, now: i * 100 },
+        TEST_POLICY
+      );
+      state = last.state;
+    });
+
+    // Reached via the sample streak, well inside TEST_POLICY.maxWaitMs.
+    expect(last.decision).toBe("act");
+    expect(state.sampleCount).toBeGreaterThanOrEqual(TEST_POLICY.requiredSamples);
+  });
+
+  it("settles a still prompt on samples before the elapsed cap could fire", () => {
+    // The real policy at the real cadence must reach `act` via the streak; if
+    // the cap were shorter than the streak takes, the settle path would be
+    // dead code and every prompt would fall through to the fallback.
+    let state = initialStabilizationState();
+    let decision;
+    for (let i = 0; i < DEFAULT_STABILIZATION_POLICY.requiredSamples; i++) {
+      const result = observeOpenCodeOutput(state, {
+        kind: "awaiting-provider",
+        text: "Select provider",
+        now: i * STABILIZATION_POLL_MS,
+      });
+      state = result.state;
+      decision = result.decision;
+    }
+
+    expect(decision).toBe("act");
+    expect((DEFAULT_STABILIZATION_POLICY.requiredSamples - 1) * STABILIZATION_POLL_MS).toBeLessThan(
       DEFAULT_STABILIZATION_POLICY.maxWaitMs
     );
+  });
+
+  it("acts at once on a new prompt of a kind that has already served its tenure", () => {
+    // Documented consequence of preserving firstSeenAt across same-kind text
+    // changes: maxWaitMs is per-KIND tenure, not per-prompt. Safe because the
+    // TUI has been asking for this kind of input for the whole cap, but it is
+    // why the driver re-checks the screen it was authorized against.
+    let state = initialStabilizationState();
+    for (let i = 0; i < 10; i++) {
+      state = observeOpenCodeOutput(
+        state,
+        { kind: "awaiting-provider", text: `frame ${i}`, now: i * 100 },
+        TEST_POLICY
+      ).state;
+    }
+
+    const fresh = observeOpenCodeOutput(
+      state,
+      { kind: "awaiting-provider", text: "a completely different provider prompt", now: 1_100 },
+      TEST_POLICY
+    );
+    expect(fresh.decision).toBe("act");
+    expect(fresh.state.sampleCount).toBe(1);
   });
 });
 

--- a/e2e/helpers/__tests__/opencodeReady.test.ts
+++ b/e2e/helpers/__tests__/opencodeReady.test.ts
@@ -8,7 +8,6 @@ import {
   formatOpenCodeCrashError,
   formatOpenCodeTimeoutError,
   formatTerminalTail,
-  hasOpenCodeReadyMarkers,
   initialStabilizationState,
   normalizeOpenCodeOutput,
   observeOpenCodeOutput,
@@ -69,14 +68,11 @@ describe("classifyOpenCodeOutput — fatal parser crash", () => {
     }
   });
 
-  it("separates the ready markers from classification so a crash can be re-checked", () => {
-    // The driver confirms a crash by re-reading and asking whether the CLI
-    // painted ready markers anyway; that question cannot be asked through
-    // classifyOpenCodeOutput, because the crash outranks ready there.
-    const survived = "[Keymap] Error: invalid key name: key name cannot be empty\n> Ask anything";
-    expect(classifyOpenCodeOutput(survived).kind).toBe("crashed");
-    expect(hasOpenCodeReadyMarkers(survived)).toBe(true);
-    expect(hasOpenCodeReadyMarkers("Select provider: Anthropic")).toBe(false);
+  it("still reports a crash when ready text survives below it in scrollback", () => {
+    // --mini keeps scrollback, so ready markers outlive the process. Preferring
+    // them would report a dead CLI as ready and lose the diagnostic entirely.
+    const text = "error: Invalid key name: key name cannot be empty\n> Ask anything";
+    expect(classifyOpenCodeOutput(text).kind).toBe("crashed");
   });
 
   it("does not fire on recoverable keymap errors or on either half alone", () => {

--- a/e2e/helpers/__tests__/opencodeReady.test.ts
+++ b/e2e/helpers/__tests__/opencodeReady.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_STABILIZATION_POLICY,
+  OPENCODE_CRASH_SIGNATURE,
+  areOpenCodeOutputsEquivalent,
+  classifyOpenCodeOutput,
+  formatOpenCodeCrashError,
+  formatOpenCodeTimeoutError,
+  formatTerminalTail,
+  initialStabilizationState,
+  normalizeOpenCodeOutput,
+  observeOpenCodeOutput,
+  type StabilizationPolicy,
+} from "../opencodeReady";
+
+// Covers the #11476 online-gate logic. The value of these tests is the
+// false-positive boundary on the fatal detector: the online suite gates release
+// publishes, so a detector that fires on a recoverable upstream error would
+// fail releases that should pass — strictly worse than the timeout it replaces.
+
+const TEST_POLICY: StabilizationPolicy = { requiredSamples: 3, maxWaitMs: 1_000 };
+
+describe("classifyOpenCodeOutput — fatal parser crash", () => {
+  it("detects the crash when the message wraps mid-word across terminal rows", () => {
+    // getTerminalText joins one string per terminal ROW, so a row break can
+    // land anywhere — including inside a word. A whitespace-tolerant regex
+    // would miss these; only whitespace-collapsed comparison catches them.
+    const splits = [
+      "error: Invalid key name: key name can\nnot be empty",
+      "error: Invalid key na\nme: key name cannot be empty",
+      "error: Invalid key name: key name cannot be em\npty",
+    ];
+
+    for (const text of splits) {
+      expect(classifyOpenCodeOutput(text).kind, text).toBe("crashed");
+    }
+  });
+
+  it("is case-insensitive and tolerates collapsed or padded spacing", () => {
+    expect(classifyOpenCodeOutput("INVALID KEY NAME: KEY NAME CANNOT BE EMPTY").kind).toBe(
+      "crashed"
+    );
+    expect(classifyOpenCodeOutput("Invalid  key   name:key name cannot be empty").kind).toBe(
+      "crashed"
+    );
+  });
+
+  it("reports the canonical signature regardless of the casing observed", () => {
+    const result = classifyOpenCodeOutput("invalid key name: key name cannot be empty");
+    expect(result).toEqual({ kind: "crashed", signature: OPENCODE_CRASH_SIGNATURE });
+  });
+
+  it("outranks ready text left in the buffer above the crash", () => {
+    const text = ["> Ask anything", "", "error: Invalid key name: key name cannot be empty"].join(
+      "\n"
+    );
+    expect(classifyOpenCodeOutput(text).kind).toBe("crashed");
+  });
+
+  it("does not fire on recoverable keymap errors or on either half alone", () => {
+    const nonFatal = [
+      "[Keymap] Error resolving command binding",
+      "[Keymap] Error: sequence pattern match failed",
+      "error: Invalid key name: ctrl+",
+      "Invalid key name",
+      "key name cannot be empty",
+      "warn: key name cannot be resolved",
+      "Invalid key binding: key name cannot be empty",
+    ];
+
+    for (const text of nonFatal) {
+      expect(classifyOpenCodeOutput(text).kind, text).not.toBe("crashed");
+    }
+  });
+});
+
+describe("classifyOpenCodeOutput — precedence", () => {
+  it("prefers needs-restart over ready markers painted in the same buffer", () => {
+    const text = "Update complete. Please restart the application.\n> Ask anything";
+    expect(classifyOpenCodeOutput(text).kind).toBe("needs-restart");
+  });
+
+  it("prefers the api-key prompt over the provider match it contains", () => {
+    // A key prompt names the provider it wants a key for, so a provider-first
+    // order would send Enter where the flow needs ArrowUp + Enter.
+    const text = "Select provider: Anthropic\nPaste your API key to continue";
+    expect(classifyOpenCodeOutput(text).kind).toBe("awaiting-api-key");
+  });
+
+  it("recognizes each ready marker independently", () => {
+    expect(classifyOpenCodeOutput("> Ask anything").kind).toBe("ready");
+    expect(classifyOpenCodeOutput("build opencode").kind).toBe("ready");
+    expect(classifyOpenCodeOutput("  1.18.9  ").kind).toBe("ready");
+  });
+
+  it("falls through to pending for unrelated startup chatter", () => {
+    expect(classifyOpenCodeOutput("").kind).toBe("pending");
+    expect(classifyOpenCodeOutput("Starting up...").kind).toBe("pending");
+  });
+
+  it("treats /connect as a provider prompt", () => {
+    expect(classifyOpenCodeOutput("run /connect to continue").kind).toBe("awaiting-provider");
+  });
+});
+
+describe("normalizeOpenCodeOutput", () => {
+  it("ignores line-ending, trailing-padding and trailing-blank-line differences", () => {
+    expect(areOpenCodeOutputsEquivalent("a\r\nb", "a\nb")).toBe(true);
+    expect(areOpenCodeOutputsEquivalent("a   \nb\t", "a\nb")).toBe(true);
+    expect(areOpenCodeOutputsEquivalent("a\nb\n\n\n", "a\nb")).toBe(true);
+  });
+
+  it("treats braille and circle spinner frames as one animation", () => {
+    expect(areOpenCodeOutputsEquivalent("⠋ working", "⠙ working")).toBe(true);
+    expect(areOpenCodeOutputsEquivalent("◐ working", "◓ working")).toBe(true);
+  });
+
+  it("keeps ASCII slash/pipe/dash distinct so paths are not collapsed", () => {
+    // Folding the ASCII spinner set would make genuinely different screens
+    // compare equal; unrecognized spinners are covered by maxWaitMs instead.
+    expect(areOpenCodeOutputsEquivalent("/Users/a", "|Users|a")).toBe(false);
+    expect(areOpenCodeOutputsEquivalent("a-b", "a/b")).toBe(false);
+  });
+
+  it("still reports substantive text changes as different", () => {
+    expect(areOpenCodeOutputsEquivalent("⠋ loading model", "⠙ loading plugins")).toBe(false);
+    expect(normalizeOpenCodeOutput("a\nb")).not.toBe(normalizeOpenCodeOutput("a\nc"));
+  });
+});
+
+describe("observeOpenCodeOutput", () => {
+  const drive = (
+    samples: Array<{ kind: Parameters<typeof observeOpenCodeOutput>[1]["kind"]; text: string }>,
+    stepMs = 100
+  ) => {
+    let state = initialStabilizationState();
+    const decisions: string[] = [];
+    samples.forEach((sample, i) => {
+      const result = observeOpenCodeOutput(
+        state,
+        { kind: sample.kind, text: sample.text, now: i * stepMs },
+        TEST_POLICY
+      );
+      state = result.state;
+      decisions.push(result.decision);
+    });
+    return decisions;
+  };
+
+  it("withholds input until the required run of equivalent snapshots", () => {
+    const decisions = drive(
+      Array.from({ length: 4 }, () => ({ kind: "awaiting-provider" as const, text: "provider" }))
+    );
+    expect(decisions).toEqual(["wait", "wait", "act", "act"]);
+  });
+
+  it("restarts the run when the prompt text changes materially", () => {
+    const decisions = drive([
+      { kind: "awaiting-provider", text: "provider a" },
+      { kind: "awaiting-provider", text: "provider a" },
+      { kind: "awaiting-provider", text: "provider b" },
+      { kind: "awaiting-provider", text: "provider b" },
+      { kind: "awaiting-provider", text: "provider b" },
+    ]);
+    expect(decisions).toEqual(["wait", "wait", "wait", "wait", "act"]);
+  });
+
+  it("acts once maxWaitMs elapses even if the screen never settles", () => {
+    // An animation we do not recognize repaints forever; without the cap the
+    // gate would hold input until the ready deadline expired.
+    const decisions = drive(
+      Array.from({ length: 12 }, (_, i) => ({
+        kind: "awaiting-provider" as const,
+        text: `frame ${i}`,
+      }))
+    );
+    expect(decisions.slice(0, 10)).toEqual(Array(10).fill("wait"));
+    expect(decisions[10]).toBe("act");
+  });
+
+  it("resets the elapsed cap when the prompt kind changes", () => {
+    let state = initialStabilizationState();
+    for (let i = 0; i < 10; i++) {
+      state = observeOpenCodeOutput(
+        state,
+        { kind: "awaiting-provider", text: `frame ${i}`, now: i * 100 },
+        TEST_POLICY
+      ).state;
+    }
+
+    const switched = observeOpenCodeOutput(
+      state,
+      { kind: "awaiting-api-key", text: "api key", now: 1_000 },
+      TEST_POLICY
+    );
+    expect(switched.decision).toBe("wait");
+    expect(switched.state.sampleCount).toBe(1);
+  });
+
+  it("clears accumulated progress for non-actionable output", () => {
+    let state = initialStabilizationState();
+    state = observeOpenCodeOutput(
+      state,
+      { kind: "awaiting-provider", text: "provider", now: 0 },
+      TEST_POLICY
+    ).state;
+
+    const cleared = observeOpenCodeOutput(
+      state,
+      { kind: "pending", text: "loading", now: 100 },
+      TEST_POLICY
+    );
+    expect(cleared.decision).toBe("not-actionable");
+    expect(cleared.state).toEqual(initialStabilizationState());
+  });
+
+  it("leaves the sample streak reachable under the shipped policy", () => {
+    // If the elapsed cap could expire before requiredSamples polls complete at
+    // the driver's 500ms cadence, the settle path would be dead code and every
+    // prompt would fall through to the fallback.
+    const pollMs = 500;
+    expect((DEFAULT_STABILIZATION_POLICY.requiredSamples - 1) * pollMs).toBeLessThan(
+      DEFAULT_STABILIZATION_POLICY.maxWaitMs
+    );
+  });
+});
+
+describe("failure diagnostics", () => {
+  it("attributes the crash upstream and points at the pin to bump", () => {
+    const message = formatOpenCodeCrashError(OPENCODE_CRASH_SIGNATURE, "boom");
+    expect(message).toContain(OPENCODE_CRASH_SIGNATURE);
+    expect(message).toContain("not a Daintree ready-state regression");
+    expect(message).toContain("scripts/ci/install-opencode.mjs");
+    expect(message).toContain("boom");
+  });
+
+  it("names the last classification in the timeout so the failure is triageable", () => {
+    const message = formatOpenCodeTimeoutError("awaiting-provider", "provider prompt");
+    expect(message).toContain("awaiting-provider");
+    expect(message).toContain("provider prompt");
+  });
+
+  it("omits the tail section entirely when there is no output to show", () => {
+    expect(formatOpenCodeTimeoutError("pending", "   \n\n")).not.toContain("Terminal tail");
+  });
+
+  it("keeps only the most recent lines, and truncates from the front on overflow", () => {
+    const text = Array.from({ length: 50 }, (_, i) => `line ${i}`).join("\n");
+    const tail = formatTerminalTail(text, { maxLines: 5 });
+    expect(tail.split("\n")).toHaveLength(5);
+    expect(tail).toContain("line 49");
+    expect(tail).not.toContain("line 44");
+
+    const wide = Array.from({ length: 10 }, () => "x".repeat(100)).join("\n");
+    const capped = formatTerminalTail(wide, { maxLines: 10, maxChars: 250 });
+    expect(capped).toHaveLength(250);
+    expect(wide.endsWith(capped)).toBe(true);
+  });
+});

--- a/e2e/helpers/opencodeReady.ts
+++ b/e2e/helpers/opencodeReady.ts
@@ -45,7 +45,7 @@ export function hasOpenCodeCrashSignature(text: string): boolean {
   return collapseWhitespace(text).includes(CRASH_NEEDLE);
 }
 
-export function hasOpenCodeReadyMarkers(text: string): boolean {
+function hasOpenCodeReadyMarkers(text: string): boolean {
   return (
     text.toLowerCase().includes("ask anything") ||
     /build\s+opencode/i.test(text) ||
@@ -54,10 +54,9 @@ export function hasOpenCodeReadyMarkers(text: string): boolean {
 }
 
 export function classifyOpenCodeOutput(text: string): OpenCodeClassification {
-  // Crash outranks everything: a TUI that painted a ready prompt and then died
-  // still has the ready text sitting in the buffer above the stack trace.
-  // Because this wins over `ready`, the driver confirms the process really is
-  // gone before failing — see CRASH_CONFIRM_MS.
+  // Crash outranks everything, including ready: the CLI runs --mini, so
+  // whatever it painted before dying is still in scrollback, and treating a
+  // stale ready marker as authoritative would report a dead process as ready.
   if (hasOpenCodeCrashSignature(text)) {
     return { kind: "crashed", signature: OPENCODE_CRASH_SIGNATURE };
   }
@@ -124,15 +123,6 @@ export type StabilizationPolicy = {
 
 /** Driver poll interval while a prompt is settling. Lives here so the policy below stays honest about the cadence it assumes. */
 export const STABILIZATION_POLL_MS = 500;
-
-/**
- * How long to wait before believing a crash signature. The signature outranks
- * every other state, so a handled upstream error that printed the same message
- * would otherwise fail a release the CLI was going to survive. One confirming
- * re-read costs a second on the genuine-crash path and removes that whole
- * false-positive class: a live TUI goes on to paint its ready markers.
- */
-export const CRASH_CONFIRM_MS = 1_000;
 
 // Four samples at STABILIZATION_POLL_MS gives ~1.5s of settled output before
 // the first keystroke. maxWaitMs bounds the case the sample streak can never

--- a/e2e/helpers/opencodeReady.ts
+++ b/e2e/helpers/opencodeReady.ts
@@ -45,9 +45,19 @@ export function hasOpenCodeCrashSignature(text: string): boolean {
   return collapseWhitespace(text).includes(CRASH_NEEDLE);
 }
 
+export function hasOpenCodeReadyMarkers(text: string): boolean {
+  return (
+    text.toLowerCase().includes("ask anything") ||
+    /build\s+opencode/i.test(text) ||
+    /\d+\.\d+\.\d+$/.test(text.trim())
+  );
+}
+
 export function classifyOpenCodeOutput(text: string): OpenCodeClassification {
   // Crash outranks everything: a TUI that painted a ready prompt and then died
   // still has the ready text sitting in the buffer above the stack trace.
+  // Because this wins over `ready`, the driver confirms the process really is
+  // gone before failing — see CRASH_CONFIRM_MS.
   if (hasOpenCodeCrashSignature(text)) {
     return { kind: "crashed", signature: OPENCODE_CRASH_SIGNATURE };
   }
@@ -58,11 +68,7 @@ export function classifyOpenCodeOutput(text: string): OpenCodeClassification {
     return { kind: "needs-restart" };
   }
 
-  if (
-    lower.includes("ask anything") ||
-    /build\s+opencode/i.test(text) ||
-    /\d+\.\d+\.\d+$/.test(text.trim())
-  ) {
+  if (hasOpenCodeReadyMarkers(text)) {
     return { kind: "ready" };
   }
 
@@ -116,7 +122,19 @@ export type StabilizationPolicy = {
   maxWaitMs: number;
 };
 
-// Four samples at the driver's 500ms poll gives ~1.5s of settled output before
+/** Driver poll interval while a prompt is settling. Lives here so the policy below stays honest about the cadence it assumes. */
+export const STABILIZATION_POLL_MS = 500;
+
+/**
+ * How long to wait before believing a crash signature. The signature outranks
+ * every other state, so a handled upstream error that printed the same message
+ * would otherwise fail a release the CLI was going to survive. One confirming
+ * re-read costs a second on the genuine-crash path and removes that whole
+ * false-positive class: a live TUI goes on to paint its ready markers.
+ */
+export const CRASH_CONFIRM_MS = 1_000;
+
+// Four samples at STABILIZATION_POLL_MS gives ~1.5s of settled output before
 // the first keystroke. maxWaitMs bounds the case the sample streak can never
 // be met — an unrecognized animation repainting forever — so the gate always
 // terminates instead of burning the ready deadline.
@@ -146,6 +164,16 @@ export function initialStabilizationState(): StabilizationState {
  * the same kind resets only the equivalent-sample streak — deliberately NOT
  * `firstSeenAt`, or an animated prompt would reset its own cap every poll and
  * never reach the fallback.
+ *
+ * That makes the two exits mean different things, and the difference matters:
+ * `requiredSamples` is per-prompt ("this exact screen held still"), while
+ * `maxWaitMs` is per-kind tenure ("input of this kind has been asked for this
+ * long, however much the pixels moved"). So a materially new prompt of an
+ * already-tenured kind can be acted on immediately. That is intentional — by
+ * then the TUI has been asking for input for maxWaitMs, so the startup race
+ * this gate exists to avoid is long over — but it means the driver, not this
+ * reducer, is what guarantees the answer matches the screen it was authorized
+ * against.
  */
 export function observeOpenCodeOutput(
   state: StabilizationState,

--- a/e2e/helpers/opencodeReady.ts
+++ b/e2e/helpers/opencodeReady.ts
@@ -1,0 +1,212 @@
+// Pure decision logic for the OpenCode online gate (#11476). The Playwright
+// driver lives in e2e/online/opencode-online.spec.ts; everything that can be
+// decided from a terminal snapshot alone lives here so it can be unit-tested
+// without a 6-minute credentialed E2E run.
+//
+// Background: the `opencode` CLI can die at startup inside its own keymap
+// parser with `Invalid key name: key name cannot be empty`. That throw sits on
+// the runtime key-decode path (an incoming keystroke whose name normalizes to
+// empty) and is NOT wrapped by the CLI's `[Keymap] Error` handler, so it kills
+// the process. Driving synthetic keypresses into a TUI that has not finished
+// attaching its raw-mode stdin reader is the trigger we can control, hence the
+// stabilization gate below.
+
+export type OpenCodeOutputKind =
+  "crashed" | "needs-restart" | "ready" | "awaiting-api-key" | "awaiting-provider" | "pending";
+
+export type OpenCodeClassification =
+  | { kind: "crashed"; signature: string }
+  | { kind: "needs-restart" }
+  | { kind: "ready" }
+  | { kind: "awaiting-api-key" }
+  | { kind: "awaiting-provider" }
+  | { kind: "pending" };
+
+/** Kinds that make the driver send a keystroke — the only ones the gate delays. */
+export type ActionableOpenCodeKind = "awaiting-api-key" | "awaiting-provider";
+
+export const OPENCODE_CRASH_SIGNATURE = "Invalid key name: key name cannot be empty";
+
+// The buffer reader returns one string per terminal ROW
+// (`translateToString(true)` joined with "\n"), so a message wider than the
+// terminal wraps and the row break can land mid-word — "can" / "not be empty".
+// Comparing with whitespace collapsed out entirely is the only wrap-robust way
+// to require the complete message. Matching a prefix like "invalid key name"
+// alone, or the CLI's `[Keymap] Error` label, is deliberately avoided: that
+// label also fronts recoverable upstream errors, and a false-positive fatal
+// detector would fail releases that would otherwise pass.
+const CRASH_NEEDLE = OPENCODE_CRASH_SIGNATURE.replace(/\s+/g, "").toLowerCase();
+
+function collapseWhitespace(text: string): string {
+  return text.replace(/\s+/g, "").toLowerCase();
+}
+
+export function hasOpenCodeCrashSignature(text: string): boolean {
+  return collapseWhitespace(text).includes(CRASH_NEEDLE);
+}
+
+export function classifyOpenCodeOutput(text: string): OpenCodeClassification {
+  // Crash outranks everything: a TUI that painted a ready prompt and then died
+  // still has the ready text sitting in the buffer above the stack trace.
+  if (hasOpenCodeCrashSignature(text)) {
+    return { kind: "crashed", signature: OPENCODE_CRASH_SIGNATURE };
+  }
+
+  const lower = text.toLowerCase();
+
+  if (lower.includes("update complete") && lower.includes("restart the application")) {
+    return { kind: "needs-restart" };
+  }
+
+  if (
+    lower.includes("ask anything") ||
+    /build\s+opencode/i.test(text) ||
+    /\d+\.\d+\.\d+$/.test(text.trim())
+  ) {
+    return { kind: "ready" };
+  }
+
+  // API key before provider: a key prompt names the provider it wants a key
+  // for, so the broader provider match would swallow it and send Enter where
+  // the flow needs ArrowUp + Enter.
+  if (lower.includes("api key")) return { kind: "awaiting-api-key" };
+  if (lower.includes("provider") || lower.includes("/connect")) {
+    return { kind: "awaiting-provider" };
+  }
+
+  return { kind: "pending" };
+}
+
+export function isActionableOpenCodeKind(kind: OpenCodeOutputKind): kind is ActionableOpenCodeKind {
+  return kind === "awaiting-api-key" || kind === "awaiting-provider";
+}
+
+// No ANSI stripping here on purpose: both sources getTerminalText can return
+// are already escape-free — xterm resolves sequences before
+// __daintreeReadTerminalBuffer reads cells, and the DOM fallback reads
+// rendered innerText. A control-character regex would be dead code.
+//
+// Spinners repaint every frame, so a TUI showing one is never byte-identical
+// twice; folding the known frame sets to one sentinel lets an otherwise-static
+// screen count as settled. Only the unambiguous non-ASCII sets are folded —
+// braille (U+2800-U+28FF) and the circle/quadrant glyphs are used by nothing
+// else. The ASCII `|/-\` spinner is deliberately NOT folded: those characters
+// carry meaning in paths and prose, and collapsing them could make genuinely
+// different screens compare equal. Unrecognized spinners are covered by the
+// max-wait fallback instead.
+const SPINNER_FRAMES = /[⠀-⣿◢-◥◰-◳◐-◓]/g;
+
+export function normalizeOpenCodeOutput(text: string): string {
+  return text
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .map((line) => line.replace(SPINNER_FRAMES, "·").trimEnd())
+    .join("\n")
+    .replace(/\n+$/, "");
+}
+
+export function areOpenCodeOutputsEquivalent(left: string, right: string): boolean {
+  return normalizeOpenCodeOutput(left) === normalizeOpenCodeOutput(right);
+}
+
+export type StabilizationPolicy = {
+  /** Consecutive equivalent snapshots required before a keystroke is allowed. */
+  requiredSamples: number;
+  /** Cap on how long one actionable prompt may be held back. */
+  maxWaitMs: number;
+};
+
+// Four samples at the driver's 500ms poll gives ~1.5s of settled output before
+// the first keystroke. maxWaitMs bounds the case the sample streak can never
+// be met — an unrecognized animation repainting forever — so the gate always
+// terminates instead of burning the ready deadline.
+export const DEFAULT_STABILIZATION_POLICY: StabilizationPolicy = {
+  requiredSamples: 4,
+  maxWaitMs: 5_000,
+};
+
+export type StabilizationState = {
+  kind: ActionableOpenCodeKind | null;
+  normalized: string | null;
+  sampleCount: number;
+  firstSeenAt: number;
+};
+
+export type StabilizationDecision = "wait" | "act" | "not-actionable";
+
+export function initialStabilizationState(): StabilizationState {
+  return { kind: null, normalized: null, sampleCount: 0, firstSeenAt: 0 };
+}
+
+/**
+ * Fold one polled snapshot into the gate. Pure and timestamp-driven so tests
+ * can drive it with explicit clocks instead of real or faked timers.
+ *
+ * A different actionable kind restarts the gate outright. Changed text within
+ * the same kind resets only the equivalent-sample streak — deliberately NOT
+ * `firstSeenAt`, or an animated prompt would reset its own cap every poll and
+ * never reach the fallback.
+ */
+export function observeOpenCodeOutput(
+  state: StabilizationState,
+  observation: { kind: OpenCodeOutputKind; text: string; now: number },
+  policy: StabilizationPolicy = DEFAULT_STABILIZATION_POLICY
+): { state: StabilizationState; decision: StabilizationDecision } {
+  const { kind, text, now } = observation;
+
+  if (!isActionableOpenCodeKind(kind)) {
+    return { state: initialStabilizationState(), decision: "not-actionable" };
+  }
+
+  const normalized = normalizeOpenCodeOutput(text);
+  const sameKind = state.kind === kind;
+  const next: StabilizationState = sameKind
+    ? {
+        kind,
+        normalized,
+        sampleCount: state.normalized === normalized ? state.sampleCount + 1 : 1,
+        firstSeenAt: state.firstSeenAt,
+      }
+    : { kind, normalized, sampleCount: 1, firstSeenAt: now };
+
+  const settled = next.sampleCount >= policy.requiredSamples;
+  const waitedOut = now - next.firstSeenAt >= policy.maxWaitMs;
+
+  return { state: next, decision: settled || waitedOut ? "act" : "wait" };
+}
+
+export function formatTerminalTail(
+  text: string,
+  { maxLines = 20, maxChars = 2_000 }: { maxLines?: number; maxChars?: number } = {}
+): string {
+  const lines = normalizeOpenCodeOutput(text).split("\n").slice(-maxLines);
+  const tail = lines.join("\n");
+  return tail.length > maxChars ? tail.slice(tail.length - maxChars) : tail;
+}
+
+function withTail(header: string, text: string): string {
+  const tail = formatTerminalTail(text);
+  return tail ? `${header}\n\nTerminal tail:\n${tail}` : header;
+}
+
+export function formatOpenCodeCrashError(signature: string, text: string): string {
+  return withTail(
+    [
+      "OpenCode CLI crashed before reaching ready state.",
+      `Fatal signature: ${signature}`,
+      "",
+      "This is the upstream OpenCode stdin/keymap parser dying on a keystroke it",
+      "could not decode — not a Daintree ready-state regression. The online gate",
+      "fails hard on purpose. If an upstream release fixes it, bump the pin in",
+      "scripts/ci/install-opencode.mjs.",
+    ].join("\n"),
+    text
+  );
+}
+
+export function formatOpenCodeTimeoutError(kind: OpenCodeOutputKind, text: string): string {
+  return withTail(
+    `OpenCode did not reach ready state before timeout (last classification: ${kind})`,
+    text
+  );
+}

--- a/e2e/online/opencode-online.spec.ts
+++ b/e2e/online/opencode-online.spec.ts
@@ -4,6 +4,14 @@ import { createFixtureRepo } from "../helpers/fixtures";
 import { dismissTelemetryConsent, openAndOnboardProject } from "../helpers/project";
 import { getTerminalText } from "../helpers/terminal";
 import { SEL } from "../helpers/selectors";
+import {
+  classifyOpenCodeOutput,
+  formatOpenCodeCrashError,
+  formatOpenCodeTimeoutError,
+  initialStabilizationState,
+  observeOpenCodeOutput,
+  type OpenCodeOutputKind,
+} from "../helpers/opencodeReady";
 
 let ctx: AppContext;
 let fixtureDir: string;
@@ -58,6 +66,11 @@ async function launchOpenCodeAgent(): Promise<Locator> {
   return agentPanel;
 }
 
+// Poll cadence while an actionable prompt is settling. Four samples at this
+// interval is the ~1.5s of quiet the stabilization gate wants before we type.
+const STABILIZATION_POLL_MS = 500;
+const IDLE_POLL_MS = 1_000;
+
 async function waitForOpenCodeReady(agentPanel: Locator): Promise<"ready" | "needs-restart"> {
   const { window } = ctx;
 
@@ -71,37 +84,69 @@ async function waitForOpenCodeReady(agentPanel: Locator): Promise<"ready" | "nee
   const deadline =
     Date.now() + (process.platform === "win32" ? 360_000 : process.env.CI ? 180_000 : 120_000);
 
+  let stabilization = initialStabilizationState();
+  let lastText = "";
+  let lastKind: OpenCodeOutputKind = "pending";
+
   while (Date.now() < deadline) {
     await dismissTelemetryConsent(window);
 
-    const text = await getTerminalText(agentPanel);
-    const lower = text.toLowerCase();
+    lastText = await getTerminalText(agentPanel);
+    const classification = classifyOpenCodeOutput(lastText);
+    lastKind = classification.kind;
 
-    if (lower.includes("update complete") && lower.includes("restart the application")) {
-      return "needs-restart";
+    // Fail in one poll interval rather than burning the whole deadline on a
+    // CLI that is already dead — the generic timeout that used to surface here
+    // read as a Daintree ready-state bug and cost a release investigation.
+    if (classification.kind === "crashed") {
+      throw new Error(formatOpenCodeCrashError(classification.signature, lastText));
+    }
+    if (classification.kind === "needs-restart") return "needs-restart";
+    if (classification.kind === "ready") return "ready";
+
+    const observed = observeOpenCodeOutput(stabilization, {
+      kind: classification.kind,
+      text: lastText,
+      now: Date.now(),
+    });
+    stabilization = observed.state;
+
+    if (observed.decision !== "act") {
+      await window.waitForTimeout(
+        observed.decision === "wait" ? STABILIZATION_POLL_MS : IDLE_POLL_MS
+      );
+      continue;
     }
 
-    if (
-      lower.includes("ask anything") ||
-      /build\s+opencode/i.test(text) ||
-      /\d+\.\d+\.\d+$/.test(text.trim())
-    ) {
-      return "ready";
-    } else if (lower.includes("provider") || lower.includes("/connect")) {
-      await focusHybridEditor(window, agentPanel);
-      await window.keyboard.press("Enter");
-      await window.waitForTimeout(2_000);
-    } else if (lower.includes("api key")) {
-      await focusHybridEditor(window, agentPanel);
+    await focusHybridEditor(window, agentPanel);
+
+    // Focus retries can take seconds, during which the TUI may have moved on
+    // (or died). Re-read before committing a keystroke: sending the previous
+    // screen's answer is what feeds the CLI's keymap parser input it cannot
+    // decode.
+    lastText = await getTerminalText(agentPanel);
+    const settled = classifyOpenCodeOutput(lastText);
+    lastKind = settled.kind;
+
+    if (settled.kind === "crashed") {
+      throw new Error(formatOpenCodeCrashError(settled.signature, lastText));
+    }
+    if (settled.kind !== classification.kind) {
+      stabilization = initialStabilizationState();
+      continue;
+    }
+
+    if (settled.kind === "awaiting-api-key") {
       await window.keyboard.press("ArrowUp");
-      await window.keyboard.press("Enter");
-      await window.waitForTimeout(2_000);
-    } else {
-      await window.waitForTimeout(1_000);
     }
+    await window.keyboard.press("Enter");
+    await window.waitForTimeout(2_000);
+
+    // Make a prompt that survives our input settle again before we retry it.
+    stabilization = initialStabilizationState();
   }
 
-  throw new Error("OpenCode did not reach ready state before timeout");
+  throw new Error(formatOpenCodeTimeoutError(lastKind, lastText));
 }
 
 async function launchOpenCodeReady(): Promise<Locator> {

--- a/e2e/online/opencode-online.spec.ts
+++ b/e2e/online/opencode-online.spec.ts
@@ -5,13 +5,11 @@ import { dismissTelemetryConsent, openAndOnboardProject } from "../helpers/proje
 import { getTerminalText } from "../helpers/terminal";
 import { SEL } from "../helpers/selectors";
 import {
-  CRASH_CONFIRM_MS,
   STABILIZATION_POLL_MS,
   areOpenCodeOutputsEquivalent,
   classifyOpenCodeOutput,
   formatOpenCodeCrashError,
   formatOpenCodeTimeoutError,
-  hasOpenCodeReadyMarkers,
   initialStabilizationState,
   observeOpenCodeOutput,
   type OpenCodeOutputKind,
@@ -71,6 +69,9 @@ async function launchOpenCodeAgent(): Promise<Locator> {
 }
 
 const IDLE_POLL_MS = 1_000;
+// Re-reads allowed after focus before we answer a prompt whose text keeps
+// moving. Bounded so the settle → focus → mismatch cycle always terminates.
+const MAX_STALE_AUTHORIZATIONS = 2;
 
 async function waitForOpenCodeReady(agentPanel: Locator): Promise<"ready" | "needs-restart"> {
   const { window } = ctx;
@@ -86,6 +87,7 @@ async function waitForOpenCodeReady(agentPanel: Locator): Promise<"ready" | "nee
     Date.now() + (process.platform === "win32" ? 360_000 : process.env.CI ? 180_000 : 120_000);
 
   let stabilization = initialStabilizationState();
+  let staleAuthorizations = 0;
   let lastText = "";
   let lastKind: OpenCodeOutputKind = "pending";
 
@@ -96,16 +98,19 @@ async function waitForOpenCodeReady(agentPanel: Locator): Promise<"ready" | "nee
     const classification = classifyOpenCodeOutput(lastText);
     lastKind = classification.kind;
 
-    // Fail in about a second rather than burning the whole deadline on a CLI
+    // Fail in one poll interval rather than burning the whole deadline on a CLI
     // that is already dead — the generic timeout that used to surface here read
-    // as a Daintree ready-state bug and cost a release investigation. The one
-    // confirming re-read guards the other direction: the signature outranks
-    // every other state, so a handled upstream error printing the same message
-    // must not fail a release the CLI was going to survive.
+    // as a Daintree ready-state bug and cost a release investigation.
+    //
+    // Throwing on first sight is deliberate. Confirming first (re-read, look
+    // for ready markers) was tried and is worse: the CLI runs --mini, so a
+    // ready marker from before the crash is still sitting in scrollback, and a
+    // real crash would be reported as "ready" — destroying the diagnostic this
+    // exists to give. The signature is only printed on the CLI's unwrapped
+    // key-decode throw, and if that ever stops being true the failure is a
+    // clearly labelled upstream-crash message, which still triages faster than
+    // the timeout it replaced.
     if (classification.kind === "crashed") {
-      await window.waitForTimeout(CRASH_CONFIRM_MS);
-      lastText = await getTerminalText(agentPanel);
-      if (hasOpenCodeReadyMarkers(lastText)) return "ready";
       throw new Error(formatOpenCodeCrashError(classification.signature, lastText));
     }
     if (classification.kind === "needs-restart") return "needs-restart";
@@ -141,13 +146,27 @@ async function waitForOpenCodeReady(agentPanel: Locator): Promise<"ready" | "nee
     if (settled.kind === "crashed") {
       throw new Error(formatOpenCodeCrashError(settled.signature, lastText));
     }
+    if (settled.kind !== classification.kind) {
+      stabilization = initialStabilizationState();
+      staleAuthorizations = 0;
+      continue;
+    }
+
+    // Re-authorize a bounded number of times, then send anyway. Requiring the
+    // text to match forever would livelock on a prompt that repaints in a way
+    // normalization does not fold: it would cycle settle → focus → mismatch →
+    // reset until the deadline and never answer a prompt that is genuinely
+    // waiting. The kind staying put across all of it is the property worth
+    // holding out for; the exact frame is not.
     if (
-      settled.kind !== classification.kind ||
-      !areOpenCodeOutputsEquivalent(authorizedText, lastText)
+      !areOpenCodeOutputsEquivalent(authorizedText, lastText) &&
+      staleAuthorizations < MAX_STALE_AUTHORIZATIONS
     ) {
+      staleAuthorizations++;
       stabilization = initialStabilizationState();
       continue;
     }
+    staleAuthorizations = 0;
 
     // Focus can burn a large slice of the budget; do not send input we no
     // longer have time to observe the result of.

--- a/e2e/online/opencode-online.spec.ts
+++ b/e2e/online/opencode-online.spec.ts
@@ -5,9 +5,13 @@ import { dismissTelemetryConsent, openAndOnboardProject } from "../helpers/proje
 import { getTerminalText } from "../helpers/terminal";
 import { SEL } from "../helpers/selectors";
 import {
+  CRASH_CONFIRM_MS,
+  STABILIZATION_POLL_MS,
+  areOpenCodeOutputsEquivalent,
   classifyOpenCodeOutput,
   formatOpenCodeCrashError,
   formatOpenCodeTimeoutError,
+  hasOpenCodeReadyMarkers,
   initialStabilizationState,
   observeOpenCodeOutput,
   type OpenCodeOutputKind,
@@ -66,9 +70,6 @@ async function launchOpenCodeAgent(): Promise<Locator> {
   return agentPanel;
 }
 
-// Poll cadence while an actionable prompt is settling. Four samples at this
-// interval is the ~1.5s of quiet the stabilization gate wants before we type.
-const STABILIZATION_POLL_MS = 500;
 const IDLE_POLL_MS = 1_000;
 
 async function waitForOpenCodeReady(agentPanel: Locator): Promise<"ready" | "needs-restart"> {
@@ -95,10 +96,16 @@ async function waitForOpenCodeReady(agentPanel: Locator): Promise<"ready" | "nee
     const classification = classifyOpenCodeOutput(lastText);
     lastKind = classification.kind;
 
-    // Fail in one poll interval rather than burning the whole deadline on a
-    // CLI that is already dead — the generic timeout that used to surface here
-    // read as a Daintree ready-state bug and cost a release investigation.
+    // Fail in about a second rather than burning the whole deadline on a CLI
+    // that is already dead — the generic timeout that used to surface here read
+    // as a Daintree ready-state bug and cost a release investigation. The one
+    // confirming re-read guards the other direction: the signature outranks
+    // every other state, so a handled upstream error printing the same message
+    // must not fail a release the CLI was going to survive.
     if (classification.kind === "crashed") {
+      await window.waitForTimeout(CRASH_CONFIRM_MS);
+      lastText = await getTerminalText(agentPanel);
+      if (hasOpenCodeReadyMarkers(lastText)) return "ready";
       throw new Error(formatOpenCodeCrashError(classification.signature, lastText));
     }
     if (classification.kind === "needs-restart") return "needs-restart";
@@ -118,12 +125,15 @@ async function waitForOpenCodeReady(agentPanel: Locator): Promise<"ready" | "nee
       continue;
     }
 
+    const authorizedText = lastText;
     await focusHybridEditor(window, agentPanel);
 
     // Focus retries can take seconds, during which the TUI may have moved on
     // (or died). Re-read before committing a keystroke: sending the previous
     // screen's answer is what feeds the CLI's keymap parser input it cannot
-    // decode.
+    // decode. Compare the text, not just the kind — two different provider
+    // prompts share a kind, and answering the wrong one is exactly the stale
+    // input this guard exists to stop.
     lastText = await getTerminalText(agentPanel);
     const settled = classifyOpenCodeOutput(lastText);
     lastKind = settled.kind;
@@ -131,10 +141,17 @@ async function waitForOpenCodeReady(agentPanel: Locator): Promise<"ready" | "nee
     if (settled.kind === "crashed") {
       throw new Error(formatOpenCodeCrashError(settled.signature, lastText));
     }
-    if (settled.kind !== classification.kind) {
+    if (
+      settled.kind !== classification.kind ||
+      !areOpenCodeOutputsEquivalent(authorizedText, lastText)
+    ) {
       stabilization = initialStabilizationState();
       continue;
     }
+
+    // Focus can burn a large slice of the budget; do not send input we no
+    // longer have time to observe the result of.
+    if (Date.now() >= deadline) break;
 
     if (settled.kind === "awaiting-api-key") {
       await window.keyboard.press("ArrowUp");
@@ -154,9 +171,13 @@ async function launchOpenCodeReady(): Promise<Locator> {
     const agentPanel = await launchOpenCodeAgent();
     const state = await waitForOpenCodeReady(agentPanel);
     if (state === "ready") return agentPanel;
+    // Out of attempts — relaunching here would only risk a launch failure
+    // masking the real diagnostic below.
+    if (attempt === 1) break;
 
     // OpenCode can self-update on first launch and require the embedding app
-    // to restart before the new CLI process will accept input.
+    // to restart before the new CLI process will accept input. CI pins the CLI
+    // and sets OPENCODE_DISABLE_AUTOUPDATE, so this path is for local runs.
     await closeApp(ctx.app);
     ctx = await launchApp();
     await openFixtureProject();

--- a/scripts/ci/install-opencode.mjs
+++ b/scripts/ci/install-opencode.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// Single source of truth for the OpenCode CLI version CI installs (#11476).
+//
+// The online E2E suite gates release publishes, so an unrelated upstream
+// publish must not be able to change what that gate runs against. Three
+// workflows install this CLI (e2e.yml, e2e-single.yml, screenshots.yml); before
+// this wrapper each ran `npm install -g opencode-ai` unpinned and could
+// therefore pick up a different build on any given day.
+//
+// The pin is reproducibility, NOT a claim that this version is free of the
+// keymap crash tracked in #11476 — no fixed upstream release is known, and
+// `opencode-ai` publishes no stable/lts dist-tag to defer to, so an exact
+// x.y.z is the only option. Two limits worth knowing: the pin fixes the
+// initially installed artifact only, since the CLI can self-update at runtime
+// (which is why the spec still handles a needs-restart), and bumping it is a
+// deliberate edit here rather than a silent drift.
+//
+// Deliberately no CLI/env override: an escape hatch that silently bypasses the
+// pin would defeat the point of having one.
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export const OPENCODE_PACKAGE_SPEC = "opencode-ai@1.18.9";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+/** Args handed to the shared retry wrapper — exported so tests can assert the pin reaches it. */
+export function buildInstallArgs() {
+  return [path.join(here, "npm-install-retry.mjs"), "-g", OPENCODE_PACKAGE_SPEC];
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  // process.execPath + no shell keeps this identical under bash and pwsh.
+  const result = spawnSync(process.execPath, buildInstallArgs(), { stdio: "inherit" });
+
+  if (result.error) {
+    console.error(`[install-opencode] failed to start installer: ${result.error.message}`);
+    process.exit(1);
+  }
+  if (result.signal) {
+    console.error(`[install-opencode] installer exited via signal ${result.signal}`);
+    process.exit(1);
+  }
+  process.exit(result.status ?? 1);
+}

--- a/scripts/ci/install-opencode.mjs
+++ b/scripts/ci/install-opencode.mjs
@@ -19,6 +19,7 @@
 // pin would defeat the point of having one.
 
 import { spawnSync } from "node:child_process";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -31,17 +32,28 @@ export function buildInstallArgs() {
   return [path.join(here, "npm-install-retry.mjs"), "-g", OPENCODE_PACKAGE_SPEC];
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+/**
+ * The executable path, with the spawn injected so a test can assert what
+ * actually runs. Asserting `buildInstallArgs()` alone would stay green if this
+ * call site were swapped back to an unpinned invocation.
+ */
+export function runInstall(spawnImpl = spawnSync) {
   // process.execPath + no shell keeps this identical under bash and pwsh.
-  const result = spawnSync(process.execPath, buildInstallArgs(), { stdio: "inherit" });
+  const result = spawnImpl(process.execPath, buildInstallArgs(), { stdio: "inherit" });
 
   if (result.error) {
     console.error(`[install-opencode] failed to start installer: ${result.error.message}`);
-    process.exit(1);
+    return 1;
   }
   if (result.signal) {
+    // Conventional signal-derived status, so a supervisor can still tell a
+    // cancellation apart from an install failure.
     console.error(`[install-opencode] installer exited via signal ${result.signal}`);
-    process.exit(1);
+    return 128 + (os.constants.signals[result.signal] ?? 0);
   }
-  process.exit(result.status ?? 1);
+  return result.status ?? 1;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  process.exit(runInstall());
 }

--- a/scripts/ci/opencode-install-pin.test.mjs
+++ b/scripts/ci/opencode-install-pin.test.mjs
@@ -129,17 +129,14 @@ describe("OpenCode install pin", () => {
     }
   });
 
-  it("leaves no workflow referencing opencode-ai outside the installer", () => {
-    // Scan whole steps, not just `run`: an install can also hide in an `env`
-    // indirection (`npm i -g "$PKG"`) or a `with:` input to a local action.
-    const offenders = [];
-    for (const file of workflowFiles()) {
-      for (const step of stepsOf(file)) {
-        if (JSON.stringify(step ?? {}).includes("opencode-ai")) {
-          offenders.push(`${file}: ${step?.name ?? "(unnamed)"}`);
-        }
-      }
-    }
+  it("leaves no workflow naming opencode-ai outside the installer", () => {
+    // Raw text, not parsed steps: the package name can reach npm through an
+    // `env:` indirection at workflow or job scope (`npm i -g "$PKG"`) or a
+    // `with:` input to a local action, none of which a step-shaped scan sees.
+    // The installer owns the only mention, so any hit here is a bypass.
+    const offenders = workflowFiles().filter((file) =>
+      readFileSync(path.join(workflowsDir, file), "utf8").includes("opencode-ai")
+    );
     expect(offenders).toEqual([]);
   });
 });

--- a/scripts/ci/opencode-install-pin.test.mjs
+++ b/scripts/ci/opencode-install-pin.test.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from "url";
 import path from "path";
 import yaml from "js-yaml";
 
-import { OPENCODE_PACKAGE_SPEC, buildInstallArgs } from "./install-opencode.mjs";
+import { OPENCODE_PACKAGE_SPEC, buildInstallArgs, runInstall } from "./install-opencode.mjs";
 
 // Guards the #11476 pin. The online E2E suite gates release publishes, so the
 // OpenCode CLI version it runs against must not change because someone
@@ -14,37 +14,57 @@ import { OPENCODE_PACKAGE_SPEC, buildInstallArgs } from "./install-opencode.mjs"
 // gate against a moving target. These assertions are the only enforcement —
 // screenshots.yml and the release-gated online runs never fire on a PR.
 //
-// The pin is asserted as a shape invariant (exact x.y.z, routed through one
-// wrapper) rather than against a copied version literal, so bumping the
-// version stays a one-line edit in install-opencode.mjs.
+// Two things have to hold for the pin to actually pin, and each fails in a way
+// that looks fine in the YAML:
+//   1. Every install routes through the one wrapper. Sites are discovered by
+//      what they RUN, not by step name — a renamed step that shells out to npm
+//      directly would satisfy any name-shaped assertion.
+//   2. The installed version survives startup. OpenCode self-updates, so
+//      without OPENCODE_DISABLE_AUTOUPDATE the pin covers only the artifact npm
+//      wrote, and the gate still ends up on whatever shipped today.
+//
+// The pin is asserted as a shape invariant (exact x.y.z) rather than against a
+// copied version literal, so bumping it stays a one-line edit in
+// install-opencode.mjs.
 
-const workflowsDir = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "../../.github/workflows"
-);
+const ciDir = path.dirname(fileURLToPath(import.meta.url));
+const workflowsDir = path.resolve(ciDir, "../../.github/workflows");
 
 const INSTALLER = "scripts/ci/install-opencode.mjs";
 
-// The install sites, and whether each is expected to be conditional. e2e.yml
-// and e2e-single.yml install only for the online suite; screenshots.yml always
-// needs the CLI. Spelled out here so dropping a site is a deliberate edit.
+// The install sites, and the condition each must keep. e2e.yml and
+// e2e-single.yml install only for the online suite; screenshots.yml always
+// needs the CLI. Spelled out here so changing one is a deliberate edit.
 const EXPECTED_SITES = {
-  "e2e.yml": { conditional: true },
-  "e2e-single.yml": { conditional: true },
-  "screenshots.yml": { conditional: false },
+  "e2e.yml": "inputs.suite == 'online'",
+  "e2e-single.yml": "inputs.suite == 'online'",
+  "screenshots.yml": null,
 };
 
 function workflowFiles() {
   return readdirSync(workflowsDir).filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"));
 }
 
-function stepsOf(file) {
-  const doc = yaml.load(readFileSync(path.join(workflowsDir, file), "utf8"));
-  return Object.values(doc?.jobs ?? {}).flatMap((job) => job?.steps ?? []);
+function parse(file) {
+  return yaml.load(readFileSync(path.join(workflowsDir, file), "utf8"));
 }
 
-function openCodeInstallSteps(file) {
-  return stepsOf(file).filter((step) => /install opencode/i.test(step?.name ?? ""));
+function stepsOf(file) {
+  return Object.values(parse(file)?.jobs ?? {}).flatMap((job) => job?.steps ?? []);
+}
+
+/** Discover by what the step RUNS, so a rename cannot hide a site. */
+function installerSteps(file) {
+  return stepsOf(file).filter((step) => (step?.run ?? "").includes(INSTALLER));
+}
+
+/** `if:` may or may not be wrapped in ${{ }}; compare the expression itself. */
+function normalizeCondition(value) {
+  if (value === undefined || value === null) return null;
+  return String(value)
+    .trim()
+    .replace(/^\$\{\{(.*)\}\}$/s, "$1")
+    .trim();
 }
 
 describe("OpenCode install pin", () => {
@@ -54,42 +74,70 @@ describe("OpenCode install pin", () => {
 
   it("hands that exact spec to the shared npm retry wrapper", () => {
     const args = buildInstallArgs();
-    expect(args[0].endsWith("npm-install-retry.mjs")).toBe(true);
+    expect(args[0]).toBe(path.join(ciDir, "npm-install-retry.mjs"));
     expect(args.slice(1)).toEqual(["-g", OPENCODE_PACKAGE_SPEC]);
   });
 
+  it("actually spawns node with those arguments", () => {
+    // buildInstallArgs() staying correct would not stop the executable path
+    // from being swapped back to an unpinned invocation.
+    const calls = [];
+    const status = runInstall((cmd, args, opts) => {
+      calls.push({ cmd, args, opts });
+      return { status: 0 };
+    });
+
+    expect(status).toBe(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].cmd).toBe(process.execPath);
+    expect(calls[0].args).toEqual(buildInstallArgs());
+  });
+
+  it("reports a failing install rather than swallowing it", () => {
+    expect(runInstall(() => ({ status: 7 }))).toBe(7);
+    expect(runInstall(() => ({ error: new Error("spawn failed") }))).toBe(1);
+    expect(runInstall(() => ({ signal: "SIGINT" }))).toBeGreaterThan(128);
+  });
+
   it("installs OpenCode in exactly the expected workflows", () => {
-    const found = workflowFiles().filter((f) => openCodeInstallSteps(f).length > 0);
+    const found = workflowFiles().filter((f) => installerSteps(f).length > 0);
     expect(found.sort()).toEqual(Object.keys(EXPECTED_SITES).sort());
   });
 
-  it("routes every install site through the pinned installer", () => {
+  it("routes every install site through the pinned installer exactly once", () => {
     for (const file of Object.keys(EXPECTED_SITES)) {
-      const steps = openCodeInstallSteps(file);
+      const steps = installerSteps(file);
       expect(steps, file).toHaveLength(1);
       expect(steps[0].run?.trim(), file).toBe(`node ${INSTALLER}`);
     }
   });
 
-  it("preserves each site's suite condition", () => {
-    for (const [file, { conditional }] of Object.entries(EXPECTED_SITES)) {
-      const [step] = openCodeInstallSteps(file);
-      if (conditional) {
-        expect(step.if, file).toMatch(/inputs\.suite\s*==\s*'online'/);
-      } else {
-        expect(step.if, file).toBeUndefined();
-      }
+  it("preserves each site's suite condition exactly", () => {
+    // A substring check would accept `inputs.suite == 'online' || true`, which
+    // installs on every suite while looking correct.
+    for (const [file, condition] of Object.entries(EXPECTED_SITES)) {
+      const [step] = installerSteps(file);
+      expect(normalizeCondition(step.if), file).toBe(condition);
     }
   });
 
-  it("leaves no workflow installing opencode-ai outside the installer", () => {
-    // The drift that matters: a new step, or a reverted one, reaching npm
-    // directly. Catches sites this file does not otherwise know about.
+  it("disables the CLI self-update wherever it is installed", () => {
+    // Without this the pinned binary upgrades itself on first launch and the
+    // gate runs an unpinned version anyway.
+    for (const file of Object.keys(EXPECTED_SITES)) {
+      expect(parse(file)?.env?.OPENCODE_DISABLE_AUTOUPDATE, file).toBe("1");
+    }
+  });
+
+  it("leaves no workflow referencing opencode-ai outside the installer", () => {
+    // Scan whole steps, not just `run`: an install can also hide in an `env`
+    // indirection (`npm i -g "$PKG"`) or a `with:` input to a local action.
     const offenders = [];
     for (const file of workflowFiles()) {
       for (const step of stepsOf(file)) {
-        const run = step?.run ?? "";
-        if (run.includes("opencode-ai")) offenders.push(`${file}: ${step?.name ?? "(unnamed)"}`);
+        if (JSON.stringify(step ?? {}).includes("opencode-ai")) {
+          offenders.push(`${file}: ${step?.name ?? "(unnamed)"}`);
+        }
       }
     }
     expect(offenders).toEqual([]);

--- a/scripts/ci/opencode-install-pin.test.mjs
+++ b/scripts/ci/opencode-install-pin.test.mjs
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "fs";
+import { fileURLToPath } from "url";
+import path from "path";
+import yaml from "js-yaml";
+
+import { OPENCODE_PACKAGE_SPEC, buildInstallArgs } from "./install-opencode.mjs";
+
+// Guards the #11476 pin. The online E2E suite gates release publishes, so the
+// OpenCode CLI version it runs against must not change because someone
+// unrelated published to npm that day. Three workflows install this CLI, and
+// the failure mode is silent: a fourth install site added later, or one of the
+// three reverted to a bare `opencode-ai`, still passes CI and still runs the
+// gate against a moving target. These assertions are the only enforcement —
+// screenshots.yml and the release-gated online runs never fire on a PR.
+//
+// The pin is asserted as a shape invariant (exact x.y.z, routed through one
+// wrapper) rather than against a copied version literal, so bumping the
+// version stays a one-line edit in install-opencode.mjs.
+
+const workflowsDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../.github/workflows"
+);
+
+const INSTALLER = "scripts/ci/install-opencode.mjs";
+
+// The install sites, and whether each is expected to be conditional. e2e.yml
+// and e2e-single.yml install only for the online suite; screenshots.yml always
+// needs the CLI. Spelled out here so dropping a site is a deliberate edit.
+const EXPECTED_SITES = {
+  "e2e.yml": { conditional: true },
+  "e2e-single.yml": { conditional: true },
+  "screenshots.yml": { conditional: false },
+};
+
+function workflowFiles() {
+  return readdirSync(workflowsDir).filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"));
+}
+
+function stepsOf(file) {
+  const doc = yaml.load(readFileSync(path.join(workflowsDir, file), "utf8"));
+  return Object.values(doc?.jobs ?? {}).flatMap((job) => job?.steps ?? []);
+}
+
+function openCodeInstallSteps(file) {
+  return stepsOf(file).filter((step) => /install opencode/i.test(step?.name ?? ""));
+}
+
+describe("OpenCode install pin", () => {
+  it("pins an exact version rather than a tag, range or prerelease", () => {
+    expect(OPENCODE_PACKAGE_SPEC).toMatch(/^opencode-ai@\d+\.\d+\.\d+$/);
+  });
+
+  it("hands that exact spec to the shared npm retry wrapper", () => {
+    const args = buildInstallArgs();
+    expect(args[0].endsWith("npm-install-retry.mjs")).toBe(true);
+    expect(args.slice(1)).toEqual(["-g", OPENCODE_PACKAGE_SPEC]);
+  });
+
+  it("installs OpenCode in exactly the expected workflows", () => {
+    const found = workflowFiles().filter((f) => openCodeInstallSteps(f).length > 0);
+    expect(found.sort()).toEqual(Object.keys(EXPECTED_SITES).sort());
+  });
+
+  it("routes every install site through the pinned installer", () => {
+    for (const file of Object.keys(EXPECTED_SITES)) {
+      const steps = openCodeInstallSteps(file);
+      expect(steps, file).toHaveLength(1);
+      expect(steps[0].run?.trim(), file).toBe(`node ${INSTALLER}`);
+    }
+  });
+
+  it("preserves each site's suite condition", () => {
+    for (const [file, { conditional }] of Object.entries(EXPECTED_SITES)) {
+      const [step] = openCodeInstallSteps(file);
+      if (conditional) {
+        expect(step.if, file).toMatch(/inputs\.suite\s*==\s*'online'/);
+      } else {
+        expect(step.if, file).toBeUndefined();
+      }
+    }
+  });
+
+  it("leaves no workflow installing opencode-ai outside the installer", () => {
+    // The drift that matters: a new step, or a reverted one, reaching npm
+    // directly. Catches sites this file does not otherwise know about.
+    const offenders = [];
+    for (const file of workflowFiles()) {
+      for (const step of stepsOf(file)) {
+        const run = step?.run ?? "";
+        if (run.includes("opencode-ai")) offenders.push(`${file}: ${step?.name ?? "(unnamed)"}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- The release-gating `full OpenCode agent interaction` test in `e2e/online/opencode-online.spec.ts` was intermittently failing and blocking release publishes.
- Root cause: the `opencode` CLI crashes at startup inside its own keymap parser (`error: Invalid key name: key name cannot be empty`) and never renders its TUI, so `waitForOpenCodeReady` burned its entire 120s/180s/360s budget and threw a generic "OpenCode did not reach ready state before timeout." That reads as a Daintree readiness bug rather than an upstream crash, and cost a release investigation to track down.
- The suite runs with `FAIL_ON_FLAKY_TESTS`, so a retry-recovered flake still fails the publish.

Resolves #11476

## Root cause

Grepping the shipped `opencode-darwin-arm64` Bun binary locates the throw: `X0`/`HQ` normalize an incoming keystroke object into a canonical `key:` match id, and throw when the key name normalizes to empty. That's the runtime key-decode path, and unlike 13 other keymap error sites in the same binary, it is not wrapped by the CLI's own `[Keymap] Error` handler, so it kills the process outright.

The trigger under our control is sending synthetic keypresses into a TUI that hasn't finished attaching its raw-mode stdin reader.

## Changes

1. New `e2e/helpers/opencodeReady.ts` holds the pure decision logic (classification, normalization, a stabilization reducer, diagnostics), so the gate's behavior is unit-testable without a credentialed six-minute E2E run. The spec is now a thin driver of that logic.
2. Fail fast: the crash signature is detected and the test throws immediately with the terminal tail and an upstream attribution, instead of running to deadline. Matching collapses all whitespace so the message is still caught when it wraps mid-word across terminal rows, but still requires the complete message. `[Keymap] Error` alone is deliberately not matched, since it also fronts recoverable errors, and a false-positive fatal detector would fail releases that should pass.
3. Keypresses are gated behind a stabilization window (four equivalent samples at 500ms, capped at 5s so an unrecognized animation can't hang the gate), and the screen is re-read after focus so a stale prompt never gets an answer meant for a different state.
4. `scripts/ci/install-opencode.mjs` pins `opencode-ai` to an exact version across all three workflow install sites, and all three now set `OPENCODE_DISABLE_AUTOUPDATE=1`. Without that, the CLI self-updates on first launch, and the pin would only cover the artifact npm initially wrote.

## Testing

61 new unit tests in `e2e/helpers/__tests__/opencodeReady.test.ts` and `scripts/ci/opencode-install-pin.test.mjs`. 108 tests pass across all six affected test files. Includes false-positive-boundary cases for the crash detector, and a drift guard that fails if any workflow reaches npm for `opencode-ai` outside the pinned installer.

## Known limitations

Flagging these for reviewers rather than folding them in here:

- Classification reads the whole scrollback buffer, so a stale `provider`/`api key` marker can keep a prompt looking "actionable" after it was already answered. Pre-existing; scoping to a live prompt region is a rewrite of the gate's semantics that can't be validated without a live OpenCode session.
- The existing ready predicates (`/\d+\.\d+\.\d+$/`, `build opencode`) can still misfire on ordinary output. Pre-existing and unchanged, now strictly safer since a crash always outranks readiness.
- Windows budget: two 360s ready waits against a 480s test timeout. Pre-existing; kept as-is per the issue.
- The pin is about reproducibility, not a claim that this version is crash-free. There's no known fixed upstream release, and `opencode-ai` publishes no stable/lts dist-tag, so an exact `x.y.z` was the only option.
