### PR TITLE
fix: stop memory reclaim from killing the Daintree Assistant

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -533,6 +533,7 @@ export const CHANNELS = {
   HELP_REVOKE_SESSION: "help:revoke-session",
   HELP_PEEK_PENDING_HIBERNATION: "help:peek-pending-hibernation",
   HELP_TAKE_PENDING_HIBERNATION: "help:take-pending-hibernation",
+  HELP_RESTORE_PENDING_HIBERNATION: "help:restore-pending-hibernation",
   HELP_REPORT_PANEL_OPEN: "help:report-panel-open",
   HELP_GET_PINNED_ACTION_CONTEXT: "help:get-pinned-action-context",
 

--- a/electron/ipc/handlers/help.preload.ts
+++ b/electron/ipc/handlers/help.preload.ts
@@ -9,6 +9,7 @@ export const HELP_METHOD_CHANNELS = {
   revokeSession: "help:revoke-session",
   peekPendingHibernation: "help:peek-pending-hibernation",
   takePendingHibernation: "help:take-pending-hibernation",
+  restorePendingHibernation: "help:restore-pending-hibernation",
   reportPanelOpen: "help:report-panel-open",
   getPinnedActionContext: "help:get-pinned-action-context",
 } as const satisfies Record<string, keyof IpcInvokeMap>;

--- a/electron/ipc/handlers/help.ts
+++ b/electron/ipc/handlers/help.ts
@@ -181,6 +181,8 @@ async function handleTakePendingHibernation(
   agentId: string;
   agentSessionId: string;
   cwd: string;
+  // #11477: opaque handle for putting this entry back if the launch aborts.
+  claimId: string;
 } | null> {
   if (typeof projectId !== "string" || !projectId) return null;
   // Derive the calling project from the renderer's webContents binding and
@@ -197,14 +199,18 @@ async function handleTakePendingHibernation(
     return null;
   }
   const { helpSessionService } = await getHelpSessionService();
-  return helpSessionService.takePendingHibernation(projectId);
+  // The owner is the view's own id from context, never renderer-supplied — it
+  // binds the resulting claim to this view so no other can release it (#11477).
+  return helpSessionService.takePendingHibernation(projectId, ctx.webContentsId);
 }
 
 async function handleRestorePendingHibernation(
   ctx: import("../types.js").IpcContext,
-  projectId: string
+  projectId: string,
+  claimId: string
 ): Promise<boolean> {
   if (typeof projectId !== "string" || !projectId) return false;
+  if (typeof claimId !== "string" || !claimId) return false;
   // Same cross-project guard as the peek/take handlers. The entry itself never
   // crosses the bridge — main restores from its own take-side stash — so this
   // only has to establish that the caller is the view that took it.
@@ -216,7 +222,7 @@ async function handleRestorePendingHibernation(
     return false;
   }
   const { helpSessionService } = await getHelpSessionService();
-  return helpSessionService.restorePendingHibernation(projectId);
+  return helpSessionService.restorePendingHibernation(projectId, claimId, ctx.webContentsId);
 }
 
 async function handleReportPanelOpen(

--- a/electron/ipc/handlers/help.ts
+++ b/electron/ipc/handlers/help.ts
@@ -200,6 +200,25 @@ async function handleTakePendingHibernation(
   return helpSessionService.takePendingHibernation(projectId);
 }
 
+async function handleRestorePendingHibernation(
+  ctx: import("../types.js").IpcContext,
+  projectId: string
+): Promise<boolean> {
+  if (typeof projectId !== "string" || !projectId) return false;
+  // Same cross-project guard as the peek/take handlers. The entry itself never
+  // crosses the bridge — main restores from its own take-side stash — so this
+  // only has to establish that the caller is the view that took it.
+  if (!ctx.projectId || ctx.projectId !== projectId) {
+    console.warn(
+      "[help] restorePendingHibernation: projectId mismatch — refusing cross-project restore",
+      { requested: projectId, fromView: ctx.projectId, webContentsId: ctx.webContentsId }
+    );
+    return false;
+  }
+  const { helpSessionService } = await getHelpSessionService();
+  return helpSessionService.restorePendingHibernation(projectId);
+}
+
 async function handleReportPanelOpen(
   ctx: import("../types.js").IpcContext,
   projectId: string,
@@ -250,6 +269,11 @@ export const helpNamespace = defineIpcNamespace({
     takePendingHibernation: op(
       HELP_METHOD_CHANNELS.takePendingHibernation,
       handleTakePendingHibernation,
+      { withContext: true }
+    ),
+    restorePendingHibernation: op(
+      HELP_METHOD_CHANNELS.restorePendingHibernation,
+      handleRestorePendingHibernation,
       { withContext: true }
     ),
     reportPanelOpen: op(HELP_METHOD_CHANNELS.reportPanelOpen, handleReportPanelOpen, {

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -16,7 +16,10 @@ import type { ActionContext } from "../../shared/types/actions.js";
 import type { PtyClient } from "./PtyClient.js";
 import { ASSISTANT_SCRATCH_ENV_VAR, getScratchDirForSession } from "./AssistantScratchService.js";
 import { syncAssistantContent } from "./AssistantContentMirror.js";
-import type { PendingHelpHibernationStore } from "./PendingHelpHibernationStore.js";
+import type {
+  PendingHelpHibernation,
+  PendingHelpHibernationStore,
+} from "./PendingHelpHibernationStore.js";
 
 // Narrow type so the test suite (and any future caller) can satisfy this
 // dependency without instantiating a full PtyClient. `kill` is the original
@@ -285,6 +288,16 @@ export class HelpSessionService {
   // mid-kill displacement can't let a stale resume ID shadow the new session.
   // In-memory only — no in-flight capture is meaningful across an app restart.
   private readonly pendingCapturesByProject = new Map<string, string>();
+  // #11477: the entry most recently handed out by `takePendingHibernation`, per
+  // project, so a taker whose launch aborts can put it back verbatim via
+  // `restorePendingHibernation` — original `capturedAt` intact, `panelWasOpen`
+  // stripped. Holding it here rather than round-tripping it through the
+  // renderer keeps the put-back IPC to a projectId and leaves no way to write a
+  // fabricated entry into the persistent store. In-memory only and one deep per
+  // project: a take that is never answered is simply dropped, and a later take
+  // overwrites the stash so a stale put-back can't resurrect a superseded
+  // conversation.
+  private readonly lastTakenByProject = new Map<string, PendingHelpHibernation>();
   // #10815: per-project assistant-panel visibility, reported by the renderer
   // whenever its `isOpen` changes. Read at capture time to stamp
   // `panelWasOpen` onto the eviction hibernation entry so cold switch-back can
@@ -1134,12 +1147,64 @@ export class HelpSessionService {
     // already-killed agent's (now-stale) resume ID cannot overwrite the
     // placeholder the renderer just claimed. Mirrors displacePriorSessions.
     this.pendingCapturesByProject.delete(projectId);
+    // Stash the exact entry (original `capturedAt` and all) so a taker that
+    // aborts can hand it back via `restorePendingHibernation` (#11477).
+    // Overwrites any prior stash: only the most recent take is restorable, and
+    // an earlier taker's put-back must not resurrect a superseded entry.
+    const { panelWasOpen: _panelWasOpen, ...restorable } = entry;
+    this.lastTakenByProject.set(projectId, restorable);
     await this.pendingHibernationStore.clear(projectId);
     return {
       agentId: entry.agentId,
       agentSessionId: entry.agentSessionId,
       cwd: entry.cwd,
     };
+  }
+
+  /**
+   * Put back an entry a caller took via `takePendingHibernation` but did not
+   * end up using (#11477).
+   *
+   * `takePendingHibernation` is destructive by design — the atomic take is the
+   * single-winner gate that stops two windows from displacing each other's
+   * backend (#10819). But every abort downstream of a successful take dropped
+   * the entry on the floor, so a launch superseded by a StrictMode remount, the
+   * stall watchdog, or a plain provisioning failure destroyed the only resume
+   * token the user had. The watchdog case is the sharpest: it surfaces a
+   * *retryable* launch error while the token that retry needs is already gone.
+   *
+   * Refuses whenever anything newer owns the slot — that check IS the
+   * compare-and-swap, which is why no claim token is needed:
+   *
+   * - A present entry means a fresh capture landed after our take. It is newer
+   *   and describes a later conversation; overwriting it would resurrect a
+   *   superseded one.
+   * - An in-flight capture owner means a `revokeSession` is mid-`gracefulKill`
+   *   and will write the real resume id when it resolves (#9646). Restoring
+   *   under it would be clobbered anyway, or would race the placeholder.
+   *
+   * The entry itself comes from main's own take-side stash, not from the
+   * caller: the renderer only reports that it didn't use what it took. That
+   * keeps the original `capturedAt` (so a put-back can't refresh its way past
+   * the 14-day staleness cutoff), keeps `panelWasOpen` stripped — the safe
+   * default, since a put-back entry should be offered for an explicit resume
+   * but never auto-resume on switch-back (#10815) — and leaves no path for a
+   * renderer to write an agentId/cwd of its choosing into main's persistent
+   * store.
+   *
+   * Returns whether the entry was actually restored.
+   */
+  async restorePendingHibernation(projectId: string): Promise<boolean> {
+    if (!this.pendingHibernationStore) return false;
+    const stashed = this.lastTakenByProject.get(projectId);
+    if (!stashed) return false;
+    // One-shot: a take is answered by at most one restore, so a duplicate or
+    // late release can't re-resurrect an entry a subsequent take consumed.
+    this.lastTakenByProject.delete(projectId);
+    if (this.pendingHibernationStore.get(projectId)) return false;
+    if (this.pendingCapturesByProject.has(projectId)) return false;
+    await this.pendingHibernationStore.set(projectId, stashed);
+    return true;
   }
 
   private displacePriorSessions(projectId: string): void {

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -292,12 +292,22 @@ export class HelpSessionService {
   // project, so a taker whose launch aborts can put it back verbatim via
   // `restorePendingHibernation` — original `capturedAt` intact, `panelWasOpen`
   // stripped. Holding it here rather than round-tripping it through the
-  // renderer keeps the put-back IPC to a projectId and leaves no way to write a
-  // fabricated entry into the persistent store. In-memory only and one deep per
-  // project: a take that is never answered is simply dropped, and a later take
-  // overwrites the stash so a stale put-back can't resurrect a superseded
-  // conversation.
-  private readonly lastTakenByProject = new Map<string, PendingHelpHibernation>();
+  // renderer means the put-back carries no entry data at all, so there is no
+  // way to write a fabricated agentId/cwd into the persistent store.
+  //
+  // `claimId` + `ownerWebContentsId` make the put-back a compare-and-swap on
+  // the specific take rather than on the project: only the view that took this
+  // entry, quoting the id it was handed, can put it back. Without that pair a
+  // release is merely project-scoped, so a duplicate or late release could
+  // restore a stash a LATER take had already replaced, and a stash left behind
+  // by a successfully-resumed launch would stay restorable indefinitely.
+  //
+  // In-memory only, one deep per project: a take that is never answered is
+  // dropped, and a later take supersedes the stash outright.
+  private readonly lastTakenByProject = new Map<
+    string,
+    { entry: PendingHelpHibernation; claimId: string; ownerWebContentsId: number | null }
+  >();
   // #10815: per-project assistant-panel visibility, reported by the renderer
   // whenever its `isOpen` changes. Read at capture time to stamp
   // `panelWasOpen` onto the eviction hibernation entry so cold switch-back can
@@ -1133,11 +1143,20 @@ export class HelpSessionService {
    * captured on the prior eviction. The entry is one-shot — once read it's
    * dropped from the persistent store so a future cold launch without
    * intervening capture starts fresh.
+   *
+   * Returns a `claimId` alongside the entry (#11477): a launch that takes but
+   * then aborts quotes it back to `restorePendingHibernation` to put the entry
+   * back. `ownerWebContentsId` is the taking view, supplied by the IPC layer
+   * from its context — never by the renderer.
    */
-  async takePendingHibernation(projectId: string): Promise<{
+  async takePendingHibernation(
+    projectId: string,
+    ownerWebContentsId?: number
+  ): Promise<{
     agentId: string;
     agentSessionId: string;
     cwd: string;
+    claimId: string;
   } | null> {
     if (!this.pendingHibernationStore) return null;
     const entry = this.pendingHibernationStore.get(projectId);
@@ -1152,12 +1171,18 @@ export class HelpSessionService {
     // Overwrites any prior stash: only the most recent take is restorable, and
     // an earlier taker's put-back must not resurrect a superseded entry.
     const { panelWasOpen: _panelWasOpen, ...restorable } = entry;
-    this.lastTakenByProject.set(projectId, restorable);
+    const claimId = randomUUID();
+    this.lastTakenByProject.set(projectId, {
+      entry: restorable,
+      claimId,
+      ownerWebContentsId: ownerWebContentsId ?? null,
+    });
     await this.pendingHibernationStore.clear(projectId);
     return {
       agentId: entry.agentId,
       agentSessionId: entry.agentSessionId,
       cwd: entry.cwd,
+      claimId,
     };
   }
 
@@ -1173,8 +1198,9 @@ export class HelpSessionService {
    * token the user had. The watchdog case is the sharpest: it surfaces a
    * *retryable* launch error while the token that retry needs is already gone.
    *
-   * Refuses whenever anything newer owns the slot — that check IS the
-   * compare-and-swap, which is why no claim token is needed:
+   * The `claimId` from the matching take is required, so a release acts on the
+   * take that produced it rather than on the project at large. On top of that,
+   * it refuses whenever anything newer owns the slot:
    *
    * - A present entry means a fresh capture landed after our take. It is newer
    *   and describes a later conversation; overwriting it would resurrect a
@@ -1194,16 +1220,32 @@ export class HelpSessionService {
    *
    * Returns whether the entry was actually restored.
    */
-  async restorePendingHibernation(projectId: string): Promise<boolean> {
+  async restorePendingHibernation(
+    projectId: string,
+    claimId: string,
+    ownerWebContentsId?: number
+  ): Promise<boolean> {
     if (!this.pendingHibernationStore) return false;
     const stashed = this.lastTakenByProject.get(projectId);
     if (!stashed) return false;
-    // One-shot: a take is answered by at most one restore, so a duplicate or
-    // late release can't re-resurrect an entry a subsequent take consumed.
+    // Compare-and-swap on the specific take. A release quoting a superseded
+    // claim (a later take replaced the stash) or arriving from a view other
+    // than the one that took it is refused WITHOUT consuming the stash, so the
+    // rightful claimant can still put its entry back.
+    if (stashed.claimId !== claimId) return false;
+    if (
+      stashed.ownerWebContentsId !== null &&
+      ownerWebContentsId !== undefined &&
+      stashed.ownerWebContentsId !== ownerWebContentsId
+    ) {
+      return false;
+    }
+    // One-shot from here: the claim is now spent either way, so a duplicate
+    // release can't re-resurrect an entry a subsequent take consumed.
     this.lastTakenByProject.delete(projectId);
     if (this.pendingHibernationStore.get(projectId)) return false;
     if (this.pendingCapturesByProject.has(projectId)) return false;
-    await this.pendingHibernationStore.set(projectId, stashed);
+    await this.pendingHibernationStore.set(projectId, stashed.entry);
     return true;
   }
 
@@ -1325,6 +1367,10 @@ export class HelpSessionService {
     // resume mechanism for clean shutdowns; this is the safety net.
     const targets = [...this.sessionsById.values()];
     await Promise.all(targets.map((record) => this.revokeSession(record.sessionId)));
+    // Take-side stashes are launch-scoped and hold a resume id; nothing can
+    // release one across a restart, so drop them rather than carry them to
+    // shutdown. The persisted entries themselves are untouched (#11477).
+    this.lastTakenByProject.clear();
   }
 
   /**

--- a/electron/services/HibernationService.ts
+++ b/electron/services/HibernationService.ts
@@ -82,6 +82,7 @@ export class HibernationService {
   private memoryPressureInactiveMs = DEFAULT_MEMORY_PRESSURE_INACTIVE_MS;
   private ptyClient: PtyClient | null = null;
   private projectViewManagersProvider: (() => ProjectViewManager[]) | null = null;
+  private hasLiveAssistantBackend: ((projectId: string) => boolean) | null = null;
 
   /**
    * Inject the live PtyClient so hibernation reads the real terminal registry
@@ -91,6 +92,25 @@ export class HibernationService {
    */
   setPtyClient(client: PtyClient | null): void {
     this.ptyClient = client;
+  }
+
+  /**
+   * Inject the same live-assistant predicate `ProjectViewEvictionController`
+   * uses, so background hibernation can't kill a running Daintree Assistant's
+   * PTY process tree either (#11477).
+   *
+   * `hibernateUnderMemoryPressure` reaches this service from the very tier-2
+   * ladder that drives cached-view reclaim, and its own guard is
+   * `ACTIVE_AGENT_STATES` — the wrong signal, and knowingly so (#11157): an
+   * assistant that dispatched a sub-agent or a background shell reads as idle
+   * while that work runs on, which is precisely the case being lost. Binding
+   * plus PTY liveness is the correct pair.
+   *
+   * Lazy closure, not a listener — nothing to dispose. Passing `null` clears it
+   * and restores the unguarded behaviour.
+   */
+  setHasLiveAssistantBackend(predicate: ((projectId: string) => boolean) | null): void {
+    this.hasLiveAssistantBackend = predicate;
   }
 
   /**
@@ -430,6 +450,20 @@ export class HibernationService {
     reason: "scheduled" | "memory-pressure" | "user-initiated",
     ptyClient: PtyClient
   ): Promise<number> {
+    // A running Daintree Assistant outranks background hibernation (#11477).
+    // `hibernateUnderMemoryPressure` is driven by the same tier-2 ladder as
+    // cached-view reclaim, and its own filter is `ACTIVE_AGENT_STATES` — the
+    // signal #11157 established is wrong for this: an assistant that dispatched
+    // a sub-agent or background shell reads as idle while that work runs on.
+    // Killing here takes down its whole PTY process tree. Applied at this
+    // chokepoint so the scheduled sweep is covered too, and scoped to the
+    // background reasons — a user-initiated close asked for exactly this.
+    const assistantProtected =
+      reason !== "user-initiated" && this.hasLiveAssistantBackend?.(projectId) === true;
+    if (assistantProtected) {
+      logInfo("hibernate-skip-live-assistant", { project: projectName, projectId, reason });
+    }
+
     // EXPERIMENT (hibernation removal, step 4): skip the PTY-kill so backgrounded
     // projects' terminals stay fully alive; report 0 killed. Scoped to the
     // background paths only — a user-initiated close (#10831, the idle "Close
@@ -439,7 +473,8 @@ export class HibernationService {
     // scrollback before kill, so `.restore` files survive and terminals come back
     // on next project open.
     const results =
-      HibernationService.EXPERIMENT_HIBERNATION_DISABLED && reason !== "user-initiated"
+      assistantProtected ||
+      (HibernationService.EXPERIMENT_HIBERNATION_DISABLED && reason !== "user-initiated")
         ? []
         : await ptyClient.gracefulKillByProject(projectId, { preserveSession: true });
     const terminalsKilled = results.length;

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -1503,8 +1503,26 @@ describe("HelpSessionService", () => {
         agentId: "claude",
         agentSessionId: "pulled-id",
         cwd: "/help/dir",
+        // Opaque handle for putting the entry back if the launch aborts
+        // (#11477) — generated per take, so only its shape is asserted here.
+        claimId: expect.any(String),
       });
+      expect(taken!.claimId).not.toBe("");
       expect(hibernationStore.clear).toHaveBeenCalledWith("proj-A");
+    });
+
+    it("issues a distinct claim per take, so a stale release can be told apart", async () => {
+      hibernationStore.get.mockReturnValue({
+        agentId: "claude",
+        agentSessionId: "pulled-id",
+        cwd: "/help/dir",
+        capturedAt: Date.now(),
+      });
+
+      const first = await service.takePendingHibernation("proj-A");
+      const second = await service.takePendingHibernation("proj-A");
+
+      expect(first!.claimId).not.toBe(second!.claimId);
     });
 
     it("takePendingHibernation returns null and does not clear when no entry exists", async () => {
@@ -1527,11 +1545,13 @@ describe("HelpSessionService", () => {
 
       it("puts back exactly what was taken, minus panelWasOpen", async () => {
         hibernationStore.get.mockReturnValueOnce(captured);
-        await service.takePendingHibernation("proj-A");
+        const taken = await service.takePendingHibernation("proj-A");
         // The slot is empty again after the take — nothing newer has landed.
         hibernationStore.get.mockReturnValue(null);
 
-        await expect(service.restorePendingHibernation("proj-A")).resolves.toBe(true);
+        await expect(service.restorePendingHibernation("proj-A", taken!.claimId)).resolves.toBe(
+          true
+        );
 
         // capturedAt is preserved, so repeated take/restore cycles cannot
         // refresh an entry past the store's 14-day staleness cutoff. And
@@ -1547,7 +1567,7 @@ describe("HelpSessionService", () => {
 
       it("refuses when a newer capture already occupies the slot", async () => {
         hibernationStore.get.mockReturnValueOnce(captured);
-        await service.takePendingHibernation("proj-A");
+        const taken = await service.takePendingHibernation("proj-A");
         hibernationStore.set.mockClear();
         // A fresh eviction captured a later conversation while we were aborting.
         hibernationStore.get.mockReturnValue({
@@ -1557,7 +1577,9 @@ describe("HelpSessionService", () => {
           capturedAt: Date.now(),
         });
 
-        await expect(service.restorePendingHibernation("proj-A")).resolves.toBe(false);
+        await expect(service.restorePendingHibernation("proj-A", taken!.claimId)).resolves.toBe(
+          false
+        );
         expect(hibernationStore.set).not.toHaveBeenCalled();
       });
 
@@ -1569,7 +1591,7 @@ describe("HelpSessionService", () => {
 
         // A prior taker is holding a stashed entry...
         hibernationStore.get.mockReturnValueOnce(captured);
-        await service.takePendingHibernation("proj-1");
+        const taken = await service.takePendingHibernation("proj-1");
 
         // ...and a capture-revoke starts and parks on gracefulKill, claiming
         // ownership of the slot via its synchronous placeholder write (#9646).
@@ -1578,24 +1600,98 @@ describe("HelpSessionService", () => {
         hibernationStore.set.mockClear();
         hibernationStore.get.mockReturnValue(null);
 
-        await expect(service.restorePendingHibernation("proj-1")).resolves.toBe(false);
+        await expect(service.restorePendingHibernation("proj-1", taken!.claimId)).resolves.toBe(
+          false
+        );
         expect(hibernationStore.set).not.toHaveBeenCalled();
       });
 
       it("answers a take at most once, so a duplicate release cannot resurrect a consumed entry", async () => {
         hibernationStore.get.mockReturnValueOnce(captured);
-        await service.takePendingHibernation("proj-A");
+        const taken = await service.takePendingHibernation("proj-A");
         hibernationStore.get.mockReturnValue(null);
 
-        await expect(service.restorePendingHibernation("proj-A")).resolves.toBe(true);
+        await expect(service.restorePendingHibernation("proj-A", taken!.claimId)).resolves.toBe(
+          true
+        );
         hibernationStore.set.mockClear();
 
-        await expect(service.restorePendingHibernation("proj-A")).resolves.toBe(false);
+        await expect(service.restorePendingHibernation("proj-A", taken!.claimId)).resolves.toBe(
+          false
+        );
         expect(hibernationStore.set).not.toHaveBeenCalled();
       });
 
+      it("refuses a release whose claim a later take superseded, and keeps the newer claim usable", async () => {
+        // The interleaving a project-scoped put-back gets wrong: A takes, A
+        // releases, B takes the restored entry, then a late/duplicate release
+        // from A arrives. Without a per-take claim that second release restores
+        // B's stash out from under B.
+        hibernationStore.get.mockReturnValueOnce(captured);
+        const takenByA = await service.takePendingHibernation("proj-A", 11);
+        hibernationStore.get.mockReturnValue(null);
+        await expect(
+          service.restorePendingHibernation("proj-A", takenByA!.claimId, 11)
+        ).resolves.toBe(true);
+
+        hibernationStore.get.mockReturnValueOnce(captured);
+        const takenByB = await service.takePendingHibernation("proj-A", 22);
+        expect(takenByB!.claimId).not.toBe(takenByA!.claimId);
+        hibernationStore.get.mockReturnValue(null);
+        hibernationStore.set.mockClear();
+
+        // A's stale release is refused...
+        await expect(
+          service.restorePendingHibernation("proj-A", takenByA!.claimId, 11)
+        ).resolves.toBe(false);
+        expect(hibernationStore.set).not.toHaveBeenCalled();
+        // ...and, crucially, did not consume B's claim.
+        await expect(
+          service.restorePendingHibernation("proj-A", takenByB!.claimId, 22)
+        ).resolves.toBe(true);
+      });
+
+      it("refuses a release from a view other than the one that took the entry", async () => {
+        // The owner comes from the IPC context, not the renderer, so a second
+        // window cannot release a claim it does not hold even by guessing.
+        hibernationStore.get.mockReturnValueOnce(captured);
+        const taken = await service.takePendingHibernation("proj-A", 11);
+        hibernationStore.get.mockReturnValue(null);
+        hibernationStore.set.mockClear();
+
+        await expect(service.restorePendingHibernation("proj-A", taken!.claimId, 22)).resolves.toBe(
+          false
+        );
+        expect(hibernationStore.set).not.toHaveBeenCalled();
+
+        // The rightful owner can still put it back.
+        await expect(service.restorePendingHibernation("proj-A", taken!.claimId, 11)).resolves.toBe(
+          true
+        );
+      });
+
+      it("restores the empty-string resume-latest sentinel unchanged (#9639)", async () => {
+        // The sentinel routes the renderer down `buildResumeLatestCommand`; a
+        // put-back that normalized or dropped it would silently downgrade an
+        // in-flight capture's placeholder into "no resume available".
+        hibernationStore.get.mockReturnValueOnce({ ...captured, agentSessionId: "" });
+        const taken = await service.takePendingHibernation("proj-A");
+        expect(taken!.agentSessionId).toBe("");
+        hibernationStore.get.mockReturnValue(null);
+
+        await expect(service.restorePendingHibernation("proj-A", taken!.claimId)).resolves.toBe(
+          true
+        );
+        expect(hibernationStore.set).toHaveBeenCalledWith(
+          "proj-A",
+          expect.objectContaining({ agentSessionId: "" })
+        );
+      });
+
       it("is a no-op for a project that never took anything", async () => {
-        await expect(service.restorePendingHibernation("proj-untouched")).resolves.toBe(false);
+        await expect(service.restorePendingHibernation("proj-untouched", "any")).resolves.toBe(
+          false
+        );
         expect(hibernationStore.set).not.toHaveBeenCalled();
       });
     });

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -1516,6 +1516,90 @@ describe("HelpSessionService", () => {
       expect(hibernationStore.clear).not.toHaveBeenCalled();
     });
 
+    describe("restorePendingHibernation (#11477)", () => {
+      const captured = {
+        agentId: "claude",
+        agentSessionId: "pulled-id",
+        cwd: "/help/dir",
+        capturedAt: 1_700_000_000_000,
+        panelWasOpen: true,
+      };
+
+      it("puts back exactly what was taken, minus panelWasOpen", async () => {
+        hibernationStore.get.mockReturnValueOnce(captured);
+        await service.takePendingHibernation("proj-A");
+        // The slot is empty again after the take — nothing newer has landed.
+        hibernationStore.get.mockReturnValue(null);
+
+        await expect(service.restorePendingHibernation("proj-A")).resolves.toBe(true);
+
+        // capturedAt is preserved, so repeated take/restore cycles cannot
+        // refresh an entry past the store's 14-day staleness cutoff. And
+        // panelWasOpen is dropped, so a put-back entry is offered for an
+        // explicit resume but never auto-resumes on cold switch-back (#10815).
+        expect(hibernationStore.set).toHaveBeenCalledWith("proj-A", {
+          agentId: "claude",
+          agentSessionId: "pulled-id",
+          cwd: "/help/dir",
+          capturedAt: 1_700_000_000_000,
+        });
+      });
+
+      it("refuses when a newer capture already occupies the slot", async () => {
+        hibernationStore.get.mockReturnValueOnce(captured);
+        await service.takePendingHibernation("proj-A");
+        hibernationStore.set.mockClear();
+        // A fresh eviction captured a later conversation while we were aborting.
+        hibernationStore.get.mockReturnValue({
+          agentId: "claude",
+          agentSessionId: "newer-id",
+          cwd: "/help/dir",
+          capturedAt: Date.now(),
+        });
+
+        await expect(service.restorePendingHibernation("proj-A")).resolves.toBe(false);
+        expect(hibernationStore.set).not.toHaveBeenCalled();
+      });
+
+      it("refuses while a capture is mid-gracefulKill, so the put-back can't race the placeholder", async () => {
+        mockPtyGracefulKill.mockImplementation(() => new Promise(() => {}));
+        const result = await service.provisionSession(provisionInput());
+        if (!result) throw new Error("expected provision");
+        expect(service.markTerminalForToken(result.token, "term-inflight")).toBe(true);
+
+        // A prior taker is holding a stashed entry...
+        hibernationStore.get.mockReturnValueOnce(captured);
+        await service.takePendingHibernation("proj-1");
+
+        // ...and a capture-revoke starts and parks on gracefulKill, claiming
+        // ownership of the slot via its synchronous placeholder write (#9646).
+        void service.revokeSession(result.sessionId, { captureHibernation: true });
+        await Promise.resolve();
+        hibernationStore.set.mockClear();
+        hibernationStore.get.mockReturnValue(null);
+
+        await expect(service.restorePendingHibernation("proj-1")).resolves.toBe(false);
+        expect(hibernationStore.set).not.toHaveBeenCalled();
+      });
+
+      it("answers a take at most once, so a duplicate release cannot resurrect a consumed entry", async () => {
+        hibernationStore.get.mockReturnValueOnce(captured);
+        await service.takePendingHibernation("proj-A");
+        hibernationStore.get.mockReturnValue(null);
+
+        await expect(service.restorePendingHibernation("proj-A")).resolves.toBe(true);
+        hibernationStore.set.mockClear();
+
+        await expect(service.restorePendingHibernation("proj-A")).resolves.toBe(false);
+        expect(hibernationStore.set).not.toHaveBeenCalled();
+      });
+
+      it("is a no-op for a project that never took anything", async () => {
+        await expect(service.restorePendingHibernation("proj-untouched")).resolves.toBe(false);
+        expect(hibernationStore.set).not.toHaveBeenCalled();
+      });
+    });
+
     it("peekPendingHibernation reads the entry WITHOUT clearing it", async () => {
       hibernationStore.get.mockReturnValue({
         agentId: "claude",

--- a/electron/services/__tests__/HibernationService.test.ts
+++ b/electron/services/__tests__/HibernationService.test.ts
@@ -590,6 +590,85 @@ describe("HibernationService", () => {
     });
   });
 
+  describe("live assistant guard (#11477)", () => {
+    const THIRTY_ONE_MINUTES = 31 * 60 * 1000;
+
+    /** An idle project eligible for the memory-pressure sweep. */
+    function seedEligibleProject() {
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([
+        { id: "t1", projectId: "proj-1", agentState: "idle" },
+      ]);
+      (storeMock.get as Mock).mockReturnValue({ enabled: true, inactiveThresholdHours: 24 });
+      projectStoreMock.getCurrentProjectId.mockReturnValue("other-proj");
+      projectStoreMock.getAllProjects.mockReturnValue([
+        {
+          id: "proj-1",
+          name: "Old",
+          path: "/projects/proj-1",
+          lastOpened: Date.now() - THIRTY_ONE_MINUTES,
+        },
+      ]);
+    }
+
+    it("suppresses the background PTY kill for a project with a live assistant backend", async () => {
+      // The FSM guard above this can't catch it: the assistant reports "idle"
+      // while a sub-agent or background shell it dispatched runs on, which is
+      // exactly the work #11157 established gets lost. Binding + PTY liveness
+      // is the correct pair, injected the same way ProjectViewManager gets it.
+      seedEligibleProject();
+
+      const service = makeService();
+      service.setHasLiveAssistantBackend((projectId) => projectId === "proj-1");
+      await service.hibernateUnderMemoryPressure();
+
+      expect(logInfo).toHaveBeenCalledWith("hibernate-skip-live-assistant", {
+        project: "Old",
+        projectId: "proj-1",
+        reason: "memory-pressure",
+      });
+      expect(ptyManagerMock.gracefulKillByProject).not.toHaveBeenCalled();
+    });
+
+    it("does not suppress when no assistant is bound to the project", async () => {
+      seedEligibleProject();
+
+      const service = makeService();
+      service.setHasLiveAssistantBackend(() => false);
+      await service.hibernateUnderMemoryPressure();
+
+      expect(logInfo).not.toHaveBeenCalledWith("hibernate-skip-live-assistant", expect.anything());
+    });
+
+    it("leaves the user-initiated close alone — the user asked for exactly this", async () => {
+      // The guard is scoped to the background reasons. A live assistant must
+      // not make "Close Them" silently do nothing.
+      ptyManagerMock.gracefulKillByProject.mockResolvedValue([{ id: "t1", agentSessionId: null }]);
+
+      const service = makeService();
+      service.setHasLiveAssistantBackend(() => true);
+      const killed = await service.hibernateProjectOnDemand("proj-1", "Proj One", "user-initiated");
+
+      expect(killed).toBe(1);
+      expect(ptyManagerMock.gracefulKillByProject).toHaveBeenCalledWith("proj-1", {
+        preserveSession: true,
+      });
+      expect(logInfo).not.toHaveBeenCalledWith("hibernate-skip-live-assistant", expect.anything());
+    });
+
+    it("suppresses the scheduled sweep's kill too, not just memory pressure", async () => {
+      const service = makeService();
+      service.setHasLiveAssistantBackend(() => true);
+      await service.hibernateProjectOnDemand("proj-1", "Proj One", "scheduled");
+
+      expect(logInfo).toHaveBeenCalledWith("hibernate-skip-live-assistant", {
+        project: "Proj One",
+        projectId: "proj-1",
+        reason: "scheduled",
+      });
+      expect(ptyManagerMock.gracefulKillByProject).not.toHaveBeenCalled();
+    });
+  });
+
   describe("checkAndHibernate agent guard", () => {
     const TWENTY_FIVE_HOURS = 25 * 60 * 60 * 1000;
 

--- a/electron/services/__tests__/HibernationService.test.ts
+++ b/electron/services/__tests__/HibernationService.test.ts
@@ -655,6 +655,67 @@ describe("HibernationService", () => {
       expect(logInfo).not.toHaveBeenCalledWith("hibernate-skip-live-assistant", expect.anything());
     });
 
+    describe("with the hibernation-removal experiment off", () => {
+      // Every background kill is currently suppressed by
+      // EXPERIMENT_HIBERNATION_DISABLED, so with it on, "no kill happened"
+      // proves nothing about the assistant guard — deleting the guard would
+      // leave those assertions passing. Neutralize the flag so the guard is the
+      // only thing that can decide, then assert both directions. `readonly` is
+      // compile-time only, so the static is writable through a cast.
+      type ExperimentSeam = { EXPERIMENT_HIBERNATION_DISABLED: boolean };
+      let restoreFlag: () => void;
+
+      beforeEach(() => {
+        const seam = HibernationService as unknown as ExperimentSeam;
+        const original = seam.EXPERIMENT_HIBERNATION_DISABLED;
+        seam.EXPERIMENT_HIBERNATION_DISABLED = false;
+        restoreFlag = () => {
+          seam.EXPERIMENT_HIBERNATION_DISABLED = original;
+        };
+      });
+
+      afterEach(() => restoreFlag());
+
+      it("a live assistant backend is what stops the background kill", async () => {
+        ptyManagerMock.gracefulKillByProject.mockResolvedValue([
+          { id: "t1", agentSessionId: null },
+        ]);
+
+        const service = makeService();
+        service.setHasLiveAssistantBackend(() => true);
+        const killed = await service.hibernateProjectOnDemand("proj-1", "Proj One", "scheduled");
+
+        expect(killed).toBe(0);
+        expect(ptyManagerMock.gracefulKillByProject).not.toHaveBeenCalled();
+      });
+
+      it("kills as usual when no assistant is bound", async () => {
+        ptyManagerMock.gracefulKillByProject.mockResolvedValue([
+          { id: "t1", agentSessionId: null },
+        ]);
+
+        const service = makeService();
+        service.setHasLiveAssistantBackend(() => false);
+        const killed = await service.hibernateProjectOnDemand("proj-1", "Proj One", "scheduled");
+
+        expect(killed).toBe(1);
+        expect(ptyManagerMock.gracefulKillByProject).toHaveBeenCalledWith("proj-1", {
+          preserveSession: true,
+        });
+      });
+
+      it("kills as usual when no predicate is wired at all", async () => {
+        ptyManagerMock.gracefulKillByProject.mockResolvedValue([
+          { id: "t1", agentSessionId: null },
+        ]);
+
+        const service = makeService();
+        const killed = await service.hibernateProjectOnDemand("proj-1", "Proj One", "scheduled");
+
+        expect(killed).toBe(1);
+      });
+    });
+
     it("suppresses the scheduled sweep's kill too, not just memory pressure", async () => {
       const service = makeService();
       service.setHasLiveAssistantBackend(() => true);

--- a/electron/window/ProjectViewEvictionController.ts
+++ b/electron/window/ProjectViewEvictionController.ts
@@ -321,12 +321,20 @@ export function evictStaleViews(
   // rather than the active view alone is now the expected outcome, and it is
   // exactly the case where an unexplained over-cap cache would read as a leak.
   if (host.views.size > effectiveMax && candidates.length === 0 && assistantProtected.length > 0) {
+    // `overflow` counts every view over target, which mid-switch also includes
+    // the paint-gate/cold-switch bridge — excluded from `evictable` above and
+    // temporary. Report the protected share separately so a reader can tell a
+    // pinned assistant (persistent) from a bridge that resolves on its own,
+    // instead of attributing the whole overflow to the floor.
+    const gateExcluded = host.views.size - effectiveMax - assistantProtected.length;
     logInfo("projectview.eviction-skipped", {
       reason: effectiveReason,
       forced: criticalPressure,
       viewCount: host.views.size,
       effectiveMax,
       overflow: host.views.size - effectiveMax,
+      protectedOverflow: assistantProtected.length,
+      transientlyExcluded: Math.max(0, gateExcluded),
       protectedProjectIds: assistantProtected.map(([projectId]) => projectId),
     });
   }

--- a/electron/window/ProjectViewEvictionController.ts
+++ b/electron/window/ProjectViewEvictionController.ts
@@ -113,17 +113,31 @@ export function evictStaleViews(
       ? memoryPressureTarget(availableMb, policy, host.maxCachedViews)
       : { level: "none" as const, targetMax: host.maxCachedViews };
 
-  // Critical pressure (and the tier-2 forced reclaim) collapses to the active
-  // view in one pass — the pre-#11469 behaviour, kept at exactly the memory
-  // level where it used to fire.
-  const criticalPressure = forcePressure || level === "critical";
-  // Soft-band contraction is driven ONLY by the periodic sweep, so the sampler's
+  // A one-pass collapse to the active view happens ONLY on the forced tier-2
+  // reclaim. It used to also fire whenever `level === "critical"`, which let
+  // any caller self-classify from an instantaneous availability reading —
+  // including the per-window sampler, whose ungated 30s tick beat
+  // ProcessMemoryMonitor's graduated ladder to the punch by 560ms and destroyed
+  // a view the cheap tier-1 pass resolved 2.4s later without it (#11477).
+  // Critical escalation now belongs to that ladder alone: it is global (the
+  // sampler is per-window), counts consecutive pressure polls, holds a
+  // cooldown, and excludes itself while a mitigation is in flight — none of
+  // which this function can see. It reaches us through `forcePressure`.
+  const criticalPressure = forcePressure;
+  // Pressure contraction is driven ONLY by the periodic sweep, so the sampler's
   // 30s cadence is the settling interval between steps: each tick destroys one
   // renderer and the next re-reads a genuinely changed availability figure.
   // Admitting it on the switch (`"lru"`) and `"limit-change"` paths as well
   // would shed extra views at an unbounded, user-driven rate and would need a
-  // separate cooldown to stay sane.
-  const softPressure = !criticalPressure && level === "soft" && reason === "pressure";
+  // separate cooldown to stay sane — and, before #11477, let an ordinary
+  // project switch landing below `criticalMb` collapse the whole cache.
+  //
+  // Deliberately spans BOTH bands. Below `criticalMb` `targetMax` is 1, so a
+  // critical reading still converges the cache to the active view — one
+  // renderer per tick rather than all of them at once. Restricting this to the
+  // soft band would zero out per-window reclaim at exactly the memory level
+  // where it matters most, leaving only tier 2's 3-poll/10-minute escalation.
+  const gradualPressure = !criticalPressure && level !== "none" && reason === "pressure";
 
   // `effectiveMax` is the settled target this pass converges toward;
   // `evictionBudget` is how many views it may actually destroy. They are
@@ -136,24 +150,28 @@ export function evictStaleViews(
   if (criticalPressure) {
     effectiveMax = 1;
     evictionBudget = Number.POSITIVE_INFINITY;
-  } else if (softPressure) {
+  } else if (gradualPressure) {
     effectiveMax = targetMax;
     evictionBudget = 1;
   } else {
     effectiveMax = host.maxCachedViews;
     evictionBudget = Number.POSITIVE_INFINITY;
   }
-  const effectiveReason: EvictionReason = criticalPressure || softPressure ? "pressure" : reason;
+  const effectiveReason: EvictionReason = criticalPressure || gradualPressure ? "pressure" : reason;
 
   if (host.views.size <= effectiveMax) return 0;
   if (host.activeProjectId === null) return 0;
 
-  if (criticalPressure || softPressure) {
+  if (criticalPressure || gradualPressure) {
     logInfo("projectview.pressure-override", {
       availableMb,
       thresholdMb: policy?.criticalMb ?? null,
       warningThresholdMb: policy?.warningMb ?? null,
-      pressureLevel: criticalPressure ? "critical" : "soft",
+      // The sampled band, not the pass's aggressiveness — a forced tier-2
+      // reclaim can land at any band, and a sampler tick reading "critical"
+      // still sheds gradually. `forced` carries the aggressiveness.
+      pressureLevel: level,
+      forced: criticalPressure,
       configuredMax: host.maxCachedViews,
       effectiveMax,
       evictionBudget: Number.isFinite(evictionBudget) ? evictionBudget : null,
@@ -227,23 +245,33 @@ export function evictStaleViews(
   // ~400-500MB) without silently killing agent renderers mid-task, but it does
   // evict them once safe candidates run out.
   //
-  // A view with a live assistant backend is a HARD floor for routine passes
-  // (#11157). It is not merely expensive to evict, it is destructive:
-  // destroying the view fires `onViewEvicted` → `revokeByWebContentsId` →
-  // `gracefulKill`, which kills the assistant's whole PTY process tree, so
-  // every sub-agent and background shell it spawned dies with no completion
-  // record. Only the transcript's resume id survives. An ordinary grid terminal
-  // has no such coupling — its PTY lives in the pty-host and reconnects on
-  // switch-back — which is why the floor is scoped to assistant backends and
-  // not to `hasActiveAgent()` at large, whose views are safe to evict and whose
-  // projects would otherwise pin the cache for no benefit.
+  // A view with a live assistant backend is a HARD floor (#11157). It is not
+  // merely expensive to evict, it is destructive: destroying the view fires
+  // `onViewEvicted` → `revokeByWebContentsId` → `gracefulKill`, which kills the
+  // assistant's whole PTY process tree, so every sub-agent and background shell
+  // it spawned dies with no completion record. Only the transcript's resume id
+  // survives. An ordinary grid terminal has no such coupling — its PTY lives in
+  // the pty-host and reconnects on switch-back — which is why the floor is
+  // scoped to assistant backends and not to `hasActiveAgent()` at large, whose
+  // views are safe to evict and whose projects would otherwise pin the cache
+  // for no benefit.
   //
-  // The floor yields to genuine memory pressure: critical (or forced) pressure
-  // puts these views back in the pool, but LAST, so every ordinary renderer is
-  // reclaimed before an assistant's work is. Losing the assistant beats an OOM,
-  // and the hibernation capture on that path still preserves the conversation.
-  // A soft-band pass does NOT admit them — shedding one view to trim the cache
-  // must never cost a running assistant its whole PTY process tree (#11157).
+  // The floor is unconditional: no pressure level admits these views (#11477).
+  // It originally yielded to critical pressure on the theory that losing the
+  // assistant beats an OOM, but that trade does not exist. The reclaim is the
+  // renderer teardown, and `memoryFor()` below measures exactly that — the
+  // assistant's own process is a node-pty child forked inside the pty-host
+  // utility process, reachable only by `terminalId` over a MessagePort. It is
+  // never a `<webview>` guest and never appears in `app.getAppMetrics()`, so
+  // the `gracefulKill` that follows the teardown recovers nothing this pass can
+  // measure. Admitting the view bought no memory the ordinary tiers could not,
+  // and cost the user every running sub-agent.
+  //
+  // Cache growth stays bounded by construction: only the single `webContentsId`
+  // a live session pinned is protected, HelpSessionService enforces one backend
+  // per project, and another window's view of the same project remains an
+  // ordinary candidate. The ceiling is the number of assistants actually
+  // running — reported below so the over-cap cache is attributable.
   const safeToEvict: EvictionCandidate[] = [];
   const activeAgentFallback: EvictionCandidate[] = [];
   const assistantProtected: EvictionCandidate[] = [];
@@ -258,9 +286,7 @@ export function evictStaleViews(
     }
   }
 
-  const candidates = criticalPressure
-    ? [...safeToEvict, ...activeAgentFallback, ...assistantProtected]
-    : [...safeToEvict, ...activeAgentFallback];
+  const candidates = [...safeToEvict, ...activeAgentFallback];
 
   let evictedCount = 0;
   while (host.views.size > effectiveMax && candidates.length > 0 && evictedCount < evictionBudget) {
@@ -287,16 +313,17 @@ export function evictStaleViews(
   // The cache is deliberately over its cap because protecting a running
   // assistant outranks the limit. Emit it so the extra resident renderers are
   // attributable — otherwise this reads as a leak in the memory logs. Gated on
-  // an exhausted queue so a soft pass that merely spent its one-view budget
+  // an exhausted queue so a gradual pass that merely spent its one-view budget
   // (ordinary candidates still waiting) isn't misreported as assistant-blocked.
-  if (
-    !criticalPressure &&
-    host.views.size > effectiveMax &&
-    candidates.length === 0 &&
-    assistantProtected.length > 0
-  ) {
+  //
+  // Forced passes are included since #11477 made the floor unconditional: a
+  // tier-2 reclaim that converges to "active view + protected assistants"
+  // rather than the active view alone is now the expected outcome, and it is
+  // exactly the case where an unexplained over-cap cache would read as a leak.
+  if (host.views.size > effectiveMax && candidates.length === 0 && assistantProtected.length > 0) {
     logInfo("projectview.eviction-skipped", {
       reason: effectiveReason,
+      forced: criticalPressure,
       viewCount: host.views.size,
       effectiveMax,
       overflow: host.views.size - effectiveMax,
@@ -375,8 +402,16 @@ export function sampleCachedViewMemory(host: ProjectViewManager): void {
  * and paint-gate exclusions all apply.
  *
  * The gate opens at the WARNING edge, not the critical one: this is the only
- * path that performs soft-band contraction, so gating it on `criticalMb` would
+ * path that performs banded contraction, so gating it on `criticalMb` would
  * leave the graduated ladder unreachable (#11469).
+ *
+ * Never escalates to a one-pass collapse, at any band. This sampler is
+ * per-window and fires off an instantaneous availability reading with no
+ * consecutive-poll count, no cooldown, and no view of whether a cheaper
+ * mitigation is already in flight — the combination that let it destroy a
+ * live assistant's view 560ms into a tier-1 pass that resolved the pressure
+ * without it (#11477). Collapse is `ProcessMemoryMonitor`'s tier 2 alone,
+ * which owns all of that state globally and arrives via `forcePressure`.
  */
 export function maybeEvictUnderPressure(host: ProjectViewManager): void {
   if (host.views.size <= 1) return;

--- a/electron/window/ProjectViewEvictionController.ts
+++ b/electron/window/ProjectViewEvictionController.ts
@@ -321,20 +321,26 @@ export function evictStaleViews(
   // rather than the active view alone is now the expected outcome, and it is
   // exactly the case where an unexplained over-cap cache would read as a leak.
   if (host.views.size > effectiveMax && candidates.length === 0 && assistantProtected.length > 0) {
-    // `overflow` counts every view over target, which mid-switch also includes
-    // the paint-gate/cold-switch bridge — excluded from `evictable` above and
-    // temporary. Report the protected share separately so a reader can tell a
-    // pinned assistant (persistent) from a bridge that resolves on its own,
-    // instead of attributing the whole overflow to the floor.
-    const gateExcluded = host.views.size - effectiveMax - assistantProtected.length;
+    // `overflow` counts views over target; the two counts beside it say what is
+    // holding them, so a reader can tell a pinned assistant (persistent, this
+    // pass will never take it) from a paint-gate/cold-switch bridge (temporary,
+    // resolves on its own). Deliberately NOT a partition of `overflow` —
+    // counted directly rather than derived by subtraction, because with an
+    // `effectiveMax` above 1 the protected views need not all be over the cap,
+    // and subtracting would report a bigger protected share than the overflow.
+    const transientlyExcludedProjectIds = new Set(
+      [gateOutgoingProjectId, switchOutgoingProjectId].filter(
+        (id): id is string => id !== null && id !== host.activeProjectId
+      )
+    );
     logInfo("projectview.eviction-skipped", {
       reason: effectiveReason,
       forced: criticalPressure,
       viewCount: host.views.size,
       effectiveMax,
       overflow: host.views.size - effectiveMax,
-      protectedOverflow: assistantProtected.length,
-      transientlyExcluded: Math.max(0, gateExcluded),
+      protectedCount: assistantProtected.length,
+      transientlyExcludedCount: transientlyExcludedProjectIds.size,
       protectedProjectIds: assistantProtected.map(([projectId]) => projectId),
     });
   }

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -722,7 +722,13 @@ export class ProjectViewManager {
    * Legacy single-floor setter, retained as the E2E escape hatch (six specs
    * push `null` to neutralize pressure eviction so host memory can't perturb
    * their deterministic assertions). A positive value collapses the band to a
-   * cliff at `mb`, reproducing the pre-#11469 clamp-to-1 exactly.
+   * cliff at `mb`: every reading below it classifies as critical with a
+   * `targetMax` of 1.
+   *
+   * Since #11477 the cliff is a target, not a one-pass collapse. The periodic
+   * sampler converges on it one view per tick like any other band; only the
+   * forced tier-2 reclaim (`reclaimCachedViewsUnderPressure`) still clears the
+   * cache in a single pass.
    */
   setLowMemoryFreeThresholdMb(mb: number | null): void {
     if (mb == null || !Number.isFinite(mb) || mb <= 0) {

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -891,6 +891,10 @@ describe("ProjectViewManager — eviction safety", () => {
           effectiveMax: 1,
           viewCount: 2,
           overflow: 1,
+          // What is holding the overflow: a pinned assistant this pass will
+          // never take, and no transient paint-gate/cold-switch bridge.
+          protectedCount: 1,
+          transientlyExcludedCount: 0,
           protectedProjectIds: ["proj-a"],
         })
       );

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -842,11 +842,13 @@ describe("ProjectViewManager — eviction safety", () => {
       expect(wcA.close).toHaveBeenCalled();
     });
 
-    it("reclaims assistant-backed views under memory pressure, but only after ordinary ones", async () => {
-      // The floor yields to a real OOM risk: losing the assistant beats losing
-      // the app, and the revoke path still captures the conversation for
-      // resume. Ordering is the guarantee — every ordinary renderer is
-      // reclaimed first, even though the assistant's view is the LRU.
+    it("keeps an assistant-backed view through the forced tier-2 reclaim and reports the overflow (#11477)", async () => {
+      // The floor no longer yields to pressure at any level. It used to, on the
+      // theory that losing the assistant beats an OOM — but that trade never
+      // existed: the reclaim is the renderer teardown, and the assistant's PTY
+      // lives in the pty-host where no pass here can measure or free it. The
+      // forced reclaim strips every ordinary view and stops, over its cap by
+      // exactly the protected views, which it must say out loud.
       const managerWithLimit = makeManager(3);
 
       const wcA = createMockWebContents();
@@ -867,17 +869,56 @@ describe("ProjectViewManager — eviction safety", () => {
 
       managerWithLimit.reclaimCachedViewsUnderPressure();
 
-      expect(managerWithLimit.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
-      // LRU alone would have taken proj-a first; the floor pushes it last.
-      expect(evictedProjectIds()).toEqual(["proj-b", "proj-a"]);
-      expect(vi.mocked(logInfo)).toHaveBeenCalledWith(
+      // proj-a is the LRU view AND the assistant's — pure LRU would take it
+      // first, the old critical escape valve would take it last. Neither now.
+      expect(
+        managerWithLimit
+          .getAllViews()
+          .map((v) => v.projectId)
+          .sort()
+      ).toEqual(["proj-a", "proj-c"]);
+      expect(evictedProjectIds()).toEqual(["proj-b"]);
+      expect(vi.mocked(logInfo)).not.toHaveBeenCalledWith(
         "projectview.eviction",
+        expect.objectContaining({ projectId: "proj-a" })
+      );
+      // Without this the two surviving renderers read as a leak in the logs.
+      expect(vi.mocked(logInfo)).toHaveBeenCalledWith(
+        "projectview.eviction-skipped",
         expect.objectContaining({
-          projectId: "proj-a",
           reason: "pressure",
-          liveAssistantBackend: true,
+          forced: true,
+          effectiveMax: 1,
+          viewCount: 2,
+          overflow: 1,
+          protectedProjectIds: ["proj-a"],
         })
       );
+    });
+
+    it("still reclaims an assistant-backed view in another window, which kills nothing (#11477)", async () => {
+      // The floor is keyed to the exact WebContents the session pinned, so it
+      // cannot become a blanket per-project pin: a second window's view of the
+      // same project has no session bound to it, `revokeByWebContentsId` finds
+      // nothing there, and destroying it costs the assistant nothing.
+      const managerWithLimit = makeManager(3);
+
+      const wcA = createMockWebContents();
+      const viewA = { webContents: wcA, setBounds: vi.fn() };
+      managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+      await managerWithLimit.switchTo("proj-b", "/path/b");
+      await flushImmediates();
+
+      // Bind the assistant to a DIFFERENT WebContents id than this manager's
+      // proj-a view — i.e. the session lives in the other window.
+      assistantBackends.set("proj-a", { terminalId: "t-help-a", webContentsId: wcA.id + 1000 });
+      liveTerminals.add("t-help-a");
+
+      managerWithLimit.reclaimCachedViewsUnderPressure();
+
+      expect(managerWithLimit.getAllViews().map((v) => v.projectId)).toEqual(["proj-b"]);
+      expect(evictedProjectIds()).toEqual(["proj-a"]);
     });
 
     it("still evicts a crashed cached view that has a live assistant backend", async () => {
@@ -2366,6 +2407,12 @@ describe("ProjectViewManager — low-memory eviction", () => {
   let manager: ProjectViewManager;
   let win: ReturnType<typeof createMockWindow>;
 
+  // The periodic sampler is the only path that contracts the cache on a memory
+  // reading — switch/LRU/limit-change passes no longer inherit pressure
+  // (#11477), so these tests drive it explicitly.
+  const tickPressureCheck = (mgr: ProjectViewManager) =>
+    (mgr as unknown as { maybeEvictUnderPressure(): void }).maybeEvictUnderPressure();
+
   // Helper for mocking process.getSystemMemoryInfo. Chromium-extended API not in
   // the default Node typings, so spy via a cast and restore in afterEach.
   type MemInfo = { free: number; purgeable?: number; total: number };
@@ -2476,7 +2523,12 @@ describe("ProjectViewManager — low-memory eviction", () => {
     await manager.switchTo("proj-c", "/path/c");
     await flushImmediates();
 
-    // Override clamped effectiveMax to 1 — only the active proj-c remains.
+    // The switches themselves hold the user's cap of 3 — an LRU pass no longer
+    // inherits pressure (#11477). The sampler is what converges on 1.
+    expect(manager.getAllViews().length).toBe(3);
+    tickPressureCheck(manager);
+    tickPressureCheck(manager);
+
     const remaining = manager.getAllViews().map((v) => v.projectId);
     expect(remaining).toEqual(["proj-c"]);
     expect(wcA.close).toHaveBeenCalled();
@@ -2533,12 +2585,15 @@ describe("ProjectViewManager — low-memory eviction", () => {
     expect(manager.getAllViews().length).toBe(3);
 
     // Free RAM drifts below the floor while the session idles. The sampler
-    // tick's pressure check must reclaim without waiting for a switch.
+    // tick's pressure check must reclaim without waiting for a switch — one
+    // view per tick, converging on the active view (#11477).
     freeKb = 128 * 1024;
-    (manager as unknown as { maybeEvictUnderPressure(): void }).maybeEvictUnderPressure();
-
-    expect(manager.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
+    tickPressureCheck(manager);
+    expect(manager.getAllViews().map((v) => v.projectId)).toEqual(["proj-b", "proj-c"]);
     expect(wcA.close).toHaveBeenCalled();
+
+    tickPressureCheck(manager);
+    expect(manager.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
   });
 
   it("periodic pressure check is a no-op above the floor or with a null threshold", async () => {
@@ -2598,6 +2653,9 @@ describe("ProjectViewManager — low-memory eviction", () => {
     await flushImmediates();
     await manager.switchTo("proj-c", "/path/c");
     await flushImmediates();
+    // Sampler ticks converge on 1 (the switches hold the user's cap, #11477).
+    tickPressureCheck(manager);
+    tickPressureCheck(manager);
     expect(manager.getAllViews().length).toBe(1);
 
     // Pressure subsides
@@ -2625,6 +2683,7 @@ describe("ProjectViewManager — low-memory eviction", () => {
     await flushImmediates();
     await manager.switchTo("proj-c", "/path/c");
     await flushImmediates();
+    tickPressureCheck(manager);
 
     expect(vi.mocked(logInfo)).toHaveBeenCalledWith(
       "projectview.pressure-override",
@@ -2633,6 +2692,10 @@ describe("ProjectViewManager — low-memory eviction", () => {
         thresholdMb: 768,
         configuredMax: 3,
         effectiveMax: 1,
+        // The sampled band and the pass's aggressiveness are now reported
+        // separately: a sampler tick reads "critical" but never forces.
+        pressureLevel: "critical",
+        forced: false,
       })
     );
     expect(vi.mocked(logInfo)).toHaveBeenCalledWith(
@@ -2743,7 +2806,10 @@ describe("ProjectViewManager — low-memory eviction", () => {
     await manager.switchTo("proj-c", "/path/c");
     await flushImmediates();
 
-    expect(manager.getAllViews().length).toBe(1);
+    // The reading is what's under test, so drive the sampler — the switches
+    // above no longer inherit pressure themselves (#11477).
+    tickPressureCheck(manager);
+    expect(manager.getAllViews().length).toBe(2);
     expect(wcA.close).toHaveBeenCalled();
   });
 
@@ -2760,7 +2826,12 @@ describe("ProjectViewManager — low-memory eviction", () => {
     await manager.switchTo("proj-c", "/path/c");
     await flushImmediates();
 
-    // Active view (proj-c) survives even under severe pressure.
+    // Driven to its settled target one view per tick, and then some — however
+    // long pressure lasts, the active view is never a candidate.
+    tickPressureCheck(manager);
+    tickPressureCheck(manager);
+    tickPressureCheck(manager);
+
     const remaining = manager.getAllViews().map((v) => v.projectId);
     expect(remaining).toEqual(["proj-c"]);
     expect(manager.getActiveProjectId()).toBe("proj-c");
@@ -2791,7 +2862,11 @@ describe("ProjectViewManager — low-memory eviction", () => {
     await pressureManager.switchTo("proj-d", "/path/d");
     await flushImmediates();
 
-    // 4 views, override clamps to 1 → 3 evictions, callback fires for each.
+    // 4 views, override targets 1 → 3 evictions, callback fires for each. One
+    // per sampler tick since #11477, so drive it to the settled target.
+    tickPressureCheck(pressureManager);
+    tickPressureCheck(pressureManager);
+    tickPressureCheck(pressureManager);
     expect(pressureManager.getAllViews().length).toBe(1);
     expect(onViewEvicted).toHaveBeenCalledTimes(3);
   });
@@ -2945,15 +3020,32 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
     expect(manager.getAllViews().length).toBe(2);
   });
 
-  it("still collapses to the active view in one pass below the critical edge", async () => {
+  it("walks to the active view below the critical edge, but only the forced pass gets there in one (#11477)", async () => {
     setAvailableMb(2500);
     await seedThreeViews(manager);
 
+    // A critical reading targets the active view alone — but the sampler is
+    // per-window and ungated, so it walks there a view at a time rather than
+    // pre-empting ProcessMemoryMonitor's cooldown-gated ladder in one pass.
     setAvailableMb(BAND.criticalMb - 1);
     tickPressureCheck(manager);
-
+    expect(manager.getAllViews().map((v) => v.projectId)).toEqual(["proj-b", "proj-c"]);
+    tickPressureCheck(manager);
     expect(manager.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
     expect(evictedProjectIds()).toEqual(["proj-a", "proj-b"]);
+  });
+
+  it("the forced tier-2 reclaim still collapses the cache in one pass (#11477)", async () => {
+    // The escalation the sampler no longer performs has to still exist, or the
+    // graduated ladder's last rung reclaims nothing.
+    const mgr = makeManager(3);
+    mgr.setMemoryPressurePolicy(BAND);
+    setAvailableMb(2500);
+    await seedThreeViews(mgr);
+
+    // Ample memory: `forcePressure` alone drives it, not the sampled band.
+    expect(mgr.reclaimCachedViewsUnderPressure()).toBe(2);
+    expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
   });
 
   it("does not shed extra views on the switch path under soft pressure", async () => {
@@ -3044,9 +3136,10 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
     expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-b", "proj-c", "proj-d"]);
   });
 
-  it("never takes an assistant-backed view in a soft pass", async () => {
-    // Soft-band trimming must not cost a running assistant its PTY tree
-    // (#11157) — that yield is reserved for genuine OOM risk.
+  it("never takes an assistant-backed view, at any band or on the forced pass (#11477)", async () => {
+    // Trimming must not cost a running assistant its PTY tree (#11157). The
+    // floor used to yield at the critical edge on the theory that it beat an
+    // OOM; #11477 established there was no such trade, so nothing admits them.
     const mgr = makeManager(3);
     mgr.setMemoryPressurePolicy(BAND);
     setAvailableMb(2500);
@@ -3064,10 +3157,15 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
     expect(mgr.getAllViews().length).toBe(3);
     expect(evictedProjectIds()).toEqual([]);
 
-    // Critical pressure still yields the floor, ordinary renderers first.
+    // Critical band: still nothing to take but the protected views.
     setAvailableMb(BAND.criticalMb - 1);
     tickPressureCheck(mgr);
-    expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
+    expect(mgr.getAllViews().length).toBe(3);
+
+    // And the forced tier-2 reclaim — the last rung — leaves them too.
+    expect(mgr.reclaimCachedViewsUnderPressure()).toBe(0);
+    expect(mgr.getAllViews().length).toBe(3);
+    expect(evictedProjectIds()).toEqual([]);
   });
 
   it("arms the periodic sweep at the warning edge, not the critical one", async () => {
@@ -3104,7 +3202,9 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
 
   it("collapses the band to a cliff for the legacy single-floor setter", async () => {
     // The E2E escape hatch and every pre-#11469 caller pass one number; that
-    // must keep meaning "clamp to 1 below this", with no soft band.
+    // must keep meaning "target 1 below this", with no soft band. Since #11477
+    // the sampler walks to that target one view per tick rather than clearing
+    // the cache in a single pass — the target is unchanged, the rate is not.
     manager.setLowMemoryFreeThresholdMb(1500);
     setAvailableMb(2500);
     await seedThreeViews(manager);
@@ -3115,7 +3215,53 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
 
     setAvailableMb(1499);
     tickPressureCheck(manager);
+    expect(manager.getAllViews().map((v) => v.projectId)).toEqual(["proj-b", "proj-c"]);
+
+    tickPressureCheck(manager);
     expect(manager.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
+  });
+
+  it("never collapses the cache in one sampler tick, however low memory reads (#11477)", async () => {
+    // The regression this issue reports. The per-window sampler fires off an
+    // instantaneous reading with no consecutive-poll count, no cooldown, and no
+    // view of whether ProcessMemoryMonitor is already mitigating — so it beat an
+    // in-flight tier-1 pass by 560ms and destroyed views that pass made
+    // unnecessary 2.4s later. One view per tick is the settling interval: the
+    // next tick re-reads a genuinely changed availability figure.
+    manager.setMemoryPressurePolicy({ criticalMb: 500, warningMb: 2000 });
+    setAvailableMb(2500);
+    await seedThreeViews(manager);
+
+    // Far below the critical edge — the old code took everything here.
+    setAvailableMb(1);
+    tickPressureCheck(manager);
+    expect(manager.getAllViews().length).toBe(2);
+
+    // And the pressure clearing between ticks stops the walk where it stands,
+    // which is the whole point of making the sampler re-read.
+    setAvailableMb(2500);
+    tickPressureCheck(manager);
+    expect(manager.getAllViews().length).toBe(2);
+  });
+
+  it("does not let an LRU or limit-change pass inherit critical pressure (#11477)", async () => {
+    // `evictStaleViews` used to compute `criticalPressure` from live memory on
+    // EVERY path, so an ordinary project switch or a setCachedViewLimit call
+    // landing below the critical edge collapsed the whole cache as a side
+    // effect. Critical escalation belongs to the forced tier-2 caller alone.
+    manager.setMemoryPressurePolicy({ criticalMb: 500, warningMb: 2000 });
+    setAvailableMb(2500);
+    await seedThreeViews(manager);
+
+    setAvailableMb(1);
+    // A switch to a 4th project: the LRU pass runs at the user's cap of 3.
+    await manager.switchTo("proj-d", "/path/d");
+    await flushImmediates();
+    expect(manager.getAllViews().length).toBe(3);
+
+    // Re-asserting the same cap must not shed anything either.
+    manager.setCachedViewLimit(3);
+    expect(manager.getAllViews().length).toBe(3);
   });
 
   it("disables reclaim entirely when the policy is cleared", async () => {

--- a/electron/window/__tests__/ProjectViewManager.lifecycle.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.lifecycle.test.ts
@@ -624,7 +624,13 @@ describe("ProjectViewManager — lifecycle invariants", () => {
       // Free RAM collapses below the profile floor while the gate is open.
       manager.setLowMemoryFreeThresholdMb(1024);
       stubSystemMemoryInfo({ free: 100 * 1024, total: 8 * 1024 * 1024 });
-      (manager as unknown as { maybeEvictUnderPressure: () => void }).maybeEvictUnderPressure();
+      // Two ticks, because the sampler sheds one view per pass at every band
+      // since #11477 — what matters here is WHICH views it is willing to take,
+      // not how fast, so drive it to its settled target.
+      const tick = (manager as unknown as { maybeEvictUnderPressure: () => void })
+        .maybeEvictUnderPressure;
+      tick.call(manager);
+      tick.call(manager);
 
       // The bridge (C) and the incoming active view (D) survive; A and B go.
       expect(setup.onViewEvicted).toHaveBeenCalledWith(initialWc.id);
@@ -658,10 +664,14 @@ describe("ProjectViewManager — lifecycle invariants", () => {
       await coldSwitch(setup, "proj-d", "/d");
       expect(manager.getAllViews()).toHaveLength(3);
 
-      // One low-memory pass clamps to 1 without rewriting the preference.
+      // Low-memory passes converge on 1 without rewriting the preference. Two
+      // ticks: the sampler sheds one view per pass at every band (#11477).
       manager.setLowMemoryFreeThresholdMb(1024);
       stubSystemMemoryInfo({ free: 100 * 1024, total: 8 * 1024 * 1024 });
-      (manager as unknown as { maybeEvictUnderPressure: () => void }).maybeEvictUnderPressure();
+      const tick = (manager as unknown as { maybeEvictUnderPressure: () => void })
+        .maybeEvictUnderPressure;
+      tick.call(manager);
+      tick.call(manager);
       expect(manager.getAllViews().map((entry) => entry.projectId)).toEqual(["proj-d"]);
       expect(manager.getCacheConfig().maxCachedViews).toBe(5);
 

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -309,12 +309,17 @@ vi.mock("electron", () => ({
 }));
 
 import { initGlobalServices, __test__ } from "../globalServicesInit.js";
-import { getGlobalServicesInitialized, setGlobalServicesInitialized } from "../serviceRefs.js";
+import {
+  getGlobalServicesInitialized,
+  setGlobalServicesInitialized,
+  setPtyClientRef,
+} from "../serviceRefs.js";
 import type { WindowRegistry } from "../WindowRegistry.js";
 import { app, ipcMain } from "electron";
 import type { Mock } from "vitest";
 import { CHANNELS } from "../../ipc/channels.js";
 import { store } from "../../store.js";
+import { helpSessionService } from "../../services/HelpSessionService.js";
 
 describe("evictStaleSessionFiles orphan-pass safety (#11349)", () => {
   function resetSweepMocks() {
@@ -548,11 +553,39 @@ describe("initGlobalServices task ordering", () => {
     registeredTaskRuns.get("hibernation-service")!();
 
     expect(hibernationServiceMock.setHasLiveAssistantBackend).toHaveBeenCalledTimes(1);
-    const predicate = hibernationServiceMock.setHasLiveAssistantBackend.mock.calls[0][0];
+    const predicate = hibernationServiceMock.setHasLiveAssistantBackend.mock.calls[0][0] as (
+      projectId: string
+    ) => boolean;
     expect(typeof predicate).toBe("function");
-    // Lazy, like the provider above: no assistant bound in this fixture, and
-    // resolving it must not throw before the PtyClient exists.
+
+    const getAssistantBackend = helpSessionService.getAssistantBackend as unknown as Mock;
+    const hasTerminal = vi.fn<(terminalId: string) => boolean>(() => true);
+
+    // No backend bound: nothing to protect, and resolving it must not throw
+    // before the PtyClient exists (the predicate is wired lazily).
+    getAssistantBackend.mockReturnValue(null);
     expect(predicate("proj-1")).toBe(false);
+
+    // Bound but the PtyClient isn't up yet — still false. Binding alone is NOT
+    // liveness: it outlives an assistant that exited under its own steam
+    // (#11162), so a stale binding must not pin the project forever.
+    getAssistantBackend.mockReturnValue({ terminalId: "t-help", webContentsId: 5 });
+    expect(predicate("proj-1")).toBe(false);
+
+    // Both halves satisfied.
+    setPtyClientRef({ hasTerminal } as unknown as Parameters<typeof setPtyClientRef>[0]);
+    try {
+      expect(predicate("proj-1")).toBe(true);
+      expect(hasTerminal).toHaveBeenCalledWith("t-help");
+
+      // Bound, PtyClient up, but the terminal is gone — the liveness half is
+      // what decides, not the binding.
+      hasTerminal.mockReturnValue(false);
+      expect(predicate("proj-1")).toBe(false);
+    } finally {
+      setPtyClientRef(null);
+      getAssistantBackend.mockReturnValue(null);
+    }
   });
 
   it("wires a lazy ProjectViewManager provider into IdleTerminalNotificationService (#11102)", async () => {

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -146,6 +146,7 @@ vi.mock("../../setup/openFileInstall.js", () => ({
 
 const hibernationServiceMock = vi.hoisted(() => ({
   setProjectViewManagersProvider: vi.fn(),
+  setHasLiveAssistantBackend: vi.fn(),
 }));
 
 vi.mock("../../services/HibernationService.js", () => ({
@@ -270,6 +271,7 @@ vi.mock("../../services/HelpSessionService.js", () => ({
     startOrphanSweep: vi.fn(),
     validateToken: vi.fn(),
     gcStaleSessions: vi.fn(async () => {}),
+    getAssistantBackend: vi.fn(() => null),
   },
 }));
 
@@ -533,6 +535,24 @@ describe("initGlobalServices task ordering", () => {
     expect(typeof provider).toBe("function");
     // Lazy: re-reads the registry on each call rather than capturing a snapshot.
     expect(provider()).toEqual([]);
+  });
+
+  it("wires the live-assistant predicate into HibernationService (#11477)", async () => {
+    // Background hibernation reaches the same projects the cached-view reclaim
+    // does, so it needs the same binding + PTY-liveness pair — an unwired
+    // predicate leaves a fourth path that can kill a running assistant.
+    hibernationServiceMock.setHasLiveAssistantBackend.mockClear();
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    registeredTaskRuns.get("hibernation-service")!();
+
+    expect(hibernationServiceMock.setHasLiveAssistantBackend).toHaveBeenCalledTimes(1);
+    const predicate = hibernationServiceMock.setHasLiveAssistantBackend.mock.calls[0][0];
+    expect(typeof predicate).toBe("function");
+    // Lazy, like the provider above: no assistant bound in this fixture, and
+    // resolving it must not throw before the PtyClient exists.
+    expect(predicate("proj-1")).toBe(false);
   });
 
   it("wires a lazy ProjectViewManager provider into IdleTerminalNotificationService (#11102)", async () => {

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -285,6 +285,18 @@ export async function initGlobalServices(
             .map((wCtx) => wCtx.services.projectViewManager)
             .filter((pvm): pvm is ProjectViewManager => pvm !== undefined) ?? []
       );
+      // Keep background hibernation off a running Daintree Assistant (#11477).
+      // The same binding + PTY-liveness pair `ProjectViewManager` is wired with
+      // in main.ts: the binding alone survives an assistant that exited under
+      // its own steam, and `hasTerminal` is PtyClient's synchronous main-local
+      // spawn registry, so it is authoritative from the assistant's first
+      // instant. Lazy, like the provider above — the PtyClient is not resolved
+      // yet at wiring time.
+      svc.setHasLiveAssistantBackend((projectId) => {
+        const backend = helpSessionService.getAssistantBackend(projectId);
+        if (!backend) return false;
+        return getPtyClient()?.hasTerminal(backend.terminalId) === true;
+      });
     },
   });
 

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -220,6 +220,9 @@ export interface GeneratedElectronAPI {
     reportPanelOpen(
       ...args: IpcInvokeMap["help:report-panel-open"]["args"]
     ): Promise<IpcInvokeMap["help:report-panel-open"]["result"]>;
+    restorePendingHibernation(
+      ...args: IpcInvokeMap["help:restore-pending-hibernation"]["args"]
+    ): Promise<IpcInvokeMap["help:restore-pending-hibernation"]["result"]>;
     revokeSession(
       ...args: IpcInvokeMap["help:revoke-session"]["args"]
     ): Promise<IpcInvokeMap["help:revoke-session"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -657,7 +657,7 @@ export interface GeneratedIpcInvokeMap {
     result: void;
   };
   "help:restore-pending-hibernation": {
-    args: [projectId: string];
+    args: [projectId: string, claimId: string];
     result: boolean;
   };
   "help:revoke-session": {
@@ -666,7 +666,7 @@ export interface GeneratedIpcInvokeMap {
   };
   "help:take-pending-hibernation": {
     args: [projectId: string];
-    result: { agentId: string; agentSessionId: string; cwd: string } | null;
+    result: { agentId: string; agentSessionId: string; cwd: string; claimId: string } | null;
   };
   "help:unmark-terminal": {
     args: [terminalId: string];

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -656,6 +656,10 @@ export interface GeneratedIpcInvokeMap {
     args: [projectId: string, isOpen: boolean];
     result: void;
   };
+  "help:restore-pending-hibernation": {
+    args: [projectId: string];
+    result: boolean;
+  };
   "help:revoke-session": {
     args: [sessionId: string];
     result: void;

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.autoLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.autoLaunch.test.tsx
@@ -559,6 +559,7 @@ beforeEach(() => {
           provisionSession: mockProvisionSession,
           revokeSession: mockRevokeSession,
           takePendingHibernation: mockTakePendingHibernation,
+          restorePendingHibernation: vi.fn().mockResolvedValue(false),
           getPinnedActionContext: vi.fn().mockResolvedValue({}),
         },
         helpAssistant: {

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.emptyStateCustomArgs.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.emptyStateCustomArgs.test.tsx
@@ -546,6 +546,7 @@ beforeEach(() => {
           provisionSession: mockProvisionSession,
           revokeSession: mockRevokeSession,
           takePendingHibernation: mockTakePendingHibernation,
+          restorePendingHibernation: vi.fn().mockResolvedValue(false),
           getPinnedActionContext: vi.fn().mockResolvedValue({}),
         },
         helpAssistant: {

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.persistenceHibernation.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.persistenceHibernation.test.tsx
@@ -550,6 +550,7 @@ beforeEach(() => {
           provisionSession: mockProvisionSession,
           revokeSession: mockRevokeSession,
           takePendingHibernation: mockTakePendingHibernation,
+          restorePendingHibernation: vi.fn().mockResolvedValue(false),
           getPinnedActionContext: vi.fn().mockResolvedValue({}),
         },
         helpAssistant: {

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.runAnywayProvisioning.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.runAnywayProvisioning.test.tsx
@@ -545,6 +545,7 @@ beforeEach(() => {
           provisionSession: mockProvisionSession,
           revokeSession: mockRevokeSession,
           takePendingHibernation: mockTakePendingHibernation,
+          restorePendingHibernation: vi.fn().mockResolvedValue(false),
           getPinnedActionContext: vi.fn().mockResolvedValue({}),
         },
         helpAssistant: {

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
@@ -545,6 +545,7 @@ beforeEach(() => {
           provisionSession: mockProvisionSession,
           revokeSession: mockRevokeSession,
           takePendingHibernation: mockTakePendingHibernation,
+          restorePendingHibernation: vi.fn().mockResolvedValue(false),
           getPinnedActionContext: vi.fn().mockResolvedValue({}),
         },
         helpAssistant: {

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.versionGateInput.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.versionGateInput.test.tsx
@@ -546,6 +546,7 @@ beforeEach(() => {
           provisionSession: mockProvisionSession,
           revokeSession: mockRevokeSession,
           takePendingHibernation: mockTakePendingHibernation,
+          restorePendingHibernation: vi.fn().mockResolvedValue(false),
           getPinnedActionContext: vi.fn().mockResolvedValue({}),
         },
         helpAssistant: {

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -10,6 +10,7 @@ const {
   mockMarkTerminal,
   mockPeekPendingHibernation,
   mockTakePendingHibernation,
+  mockRestorePendingHibernation,
   mockReportPanelOpen,
   mockProvisionSession,
   mockRevokeSession,
@@ -41,6 +42,7 @@ const {
   mockMarkTerminal: vi.fn().mockResolvedValue(undefined),
   mockPeekPendingHibernation: vi.fn().mockResolvedValue(null),
   mockTakePendingHibernation: vi.fn().mockResolvedValue(null),
+  mockRestorePendingHibernation: vi.fn().mockResolvedValue(false),
   mockReportPanelOpen: vi.fn().mockResolvedValue(undefined),
   mockProvisionSession: vi.fn().mockResolvedValue(null),
   mockRevokeSession: vi.fn().mockResolvedValue(undefined),
@@ -433,6 +435,8 @@ function resetState() {
   mockPeekPendingHibernation.mockResolvedValue(null);
   mockTakePendingHibernation.mockReset();
   mockTakePendingHibernation.mockResolvedValue(null);
+  mockRestorePendingHibernation.mockReset();
+  mockRestorePendingHibernation.mockResolvedValue(false);
   mockReportPanelOpen.mockReset();
   mockReportPanelOpen.mockResolvedValue(undefined);
   mockProvisionSession.mockReset();
@@ -498,6 +502,7 @@ beforeEach(() => {
           markTerminal: mockMarkTerminal,
           peekPendingHibernation: mockPeekPendingHibernation,
           takePendingHibernation: mockTakePendingHibernation,
+          restorePendingHibernation: mockRestorePendingHibernation,
           reportPanelOpen: mockReportPanelOpen,
           provisionSession: mockProvisionSession,
           revokeSession: mockRevokeSession,
@@ -1114,6 +1119,47 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
       expect.anything(),
       expect.anything()
     );
+    // The token was genuinely spent, so it is NOT handed back (#11477).
+    expect(mockRestorePendingHibernation).not.toHaveBeenCalled();
+  });
+
+  it("hands the taken resume token back to main when provisioning fails (#11477)", async () => {
+    // `takePendingHibernation` clears main's side, so a launch that takes and
+    // then aborts used to destroy the user's only resume token — here via a
+    // plain provisioning failure, which the original five-site inventory of
+    // take-and-drop paths missed entirely. The put-back is what makes the
+    // resume net survive an abort.
+    helpPanelState.autoLaunchEnabled = false;
+    helpPanelState.terminalId = null;
+    helpPanelState.hibernateSessions = {};
+    helpPanelState.setHibernateSession = vi.fn(
+      (projectId: string, entry: { sessionId: string; cwd: string; agentId: string }) => {
+        helpPanelState.hibernateSessions[projectId] = entry;
+      }
+    );
+    projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockPeekPendingHibernation.mockResolvedValue({
+      agentId: "claude",
+      agentSessionId: "abc-123",
+      cwd: "/tmp/help/proj-1",
+      panelWasOpen: true,
+    });
+    mockTakePendingHibernation.mockResolvedValue({
+      agentId: "claude",
+      agentSessionId: "abc-123",
+      cwd: "/tmp/help/proj-1",
+    });
+    // Provisioning fails AFTER the take has already consumed main's entry.
+    mockProvisionSession.mockResolvedValue(null);
+
+    await act(async () => {
+      render(<HelpPanel width={380} />);
+    });
+    await flushAsyncWork();
+
+    expect(mockTakePendingHibernation).toHaveBeenCalledWith("proj-1");
+    expect(mockRestorePendingHibernation).toHaveBeenCalledWith("proj-1");
   });
 
   // #11068: the same cold-resume handoff, but the active workspace is a scratch

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -973,6 +973,47 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
     expect(helpPanelState.setAutoLaunchEnabled).not.toHaveBeenCalled();
   });
 
+  it("releases a mismatched-agent take without touching the hibernate slot it never wrote (#11477)", async () => {
+    // The resumeOnly take is hoisted above provisioning (#10819), so it lands
+    // BEFORE the agentId check. On a mismatch the launch bails without ever
+    // seeding — meaning the local hibernate slot still holds whatever was
+    // already there. The put-back must return main's copy and leave that slot
+    // alone; clearing it unconditionally would delete an entry this launch
+    // never owned.
+    helpPanelState.autoLaunchEnabled = false;
+    helpPanelState.terminalId = null;
+    const preExisting = {
+      sessionId: "graceful-close-id",
+      cwd: "/tmp/help/proj-1",
+      agentId: "codex",
+    };
+    helpPanelState.hibernateSessions = { "proj-1": preExisting };
+    projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockPeekPendingHibernation.mockResolvedValue({
+      agentId: "claude",
+      agentSessionId: "abc-123",
+      cwd: "/tmp/help/proj-1",
+      panelWasOpen: true,
+    });
+    // Main's captured entry is for a DIFFERENT agent than the one launching.
+    mockTakePendingHibernation.mockResolvedValue({
+      agentId: "gemini",
+      agentSessionId: "abc-123",
+      cwd: "/tmp/help/proj-1",
+      claimId: "claim-mismatch",
+    });
+
+    await act(async () => {
+      render(<HelpPanel width={380} />);
+    });
+    await flushAsyncWork();
+
+    expect(mockRestorePendingHibernation).toHaveBeenCalledWith("proj-1", "claim-mismatch");
+    expect(helpPanelState.clearHibernateSession).not.toHaveBeenCalledWith("proj-1");
+    expect(helpPanelState.hibernateSessions["proj-1"]).toEqual(preExisting);
+  });
+
   it("does NOT launch when a live session already exists (DevTools reload guard)", async () => {
     // A DevTools reload can mount the panel while the store still reports a live
     // terminal. The `!terminalId` gate must drop the auto-resume so a second

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -949,6 +949,7 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
       agentId: "claude",
       agentSessionId: "abc-123",
       cwd: "/tmp/help/proj-1",
+      claimId: "claim-1",
     });
 
     await act(async () => {
@@ -1033,6 +1034,7 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
       agentId: "claude",
       agentSessionId: "abc-123",
       cwd: "/tmp/help/proj-1",
+      claimId: "claim-1",
     });
 
     let view: ReturnType<typeof render> | undefined;
@@ -1098,6 +1100,7 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
       agentId: "claude",
       agentSessionId: "abc-123",
       cwd: "/tmp/help/proj-1",
+      claimId: "claim-1",
     });
 
     await act(async () => {
@@ -1149,6 +1152,7 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
       agentId: "claude",
       agentSessionId: "abc-123",
       cwd: "/tmp/help/proj-1",
+      claimId: "claim-1",
     });
     // Provisioning fails AFTER the take has already consumed main's entry.
     mockProvisionSession.mockResolvedValue(null);
@@ -1159,7 +1163,14 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
     await flushAsyncWork();
 
     expect(mockTakePendingHibernation).toHaveBeenCalledWith("proj-1");
-    expect(mockRestorePendingHibernation).toHaveBeenCalledWith("proj-1");
+    // Quoting the claim main handed out, so the put-back acts on THIS take and
+    // not on whatever the project's slot happens to hold by then.
+    expect(mockRestorePendingHibernation).toHaveBeenCalledWith("proj-1", "claim-1");
+    // The renderer's local mirror goes with it: seedFromMain wrote the taken
+    // entry into hibernateSessions, and leaving that behind while main hands
+    // the entry to another window would let two windows resume one
+    // conversation — the single-winner invariant the atomic take holds.
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
   });
 
   // #11068: the same cold-resume handoff, but the active workspace is a scratch
@@ -1200,6 +1211,7 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
       agentId: "claude",
       agentSessionId: "abc-123",
       cwd: "/scratches/scratch-1",
+      claimId: "claim-1",
     });
 
     await act(async () => {
@@ -1355,6 +1367,7 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
       agentId: "claude",
       agentSessionId: "abc-123",
       cwd: "/tmp/help/proj-1",
+      claimId: "claim-1",
     });
 
     let view: ReturnType<typeof render> | undefined;

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -1145,6 +1145,14 @@ export class HelpSessionController {
     // see this generation still holding it and silently drop the relaunch
     // (#10703) — leaving `_hasAutoLaunched` stuck and blocking all auto-launch.
     let pendingReEval: HelpSessionInputs | null = null;
+    // Project whose main-captured resume token this launch has taken but not
+    // yet used. `takePendingHibernation` is destructive on main, so every abort
+    // downstream of a successful take used to destroy the user's only resume
+    // token — across five separate early returns plus any provisioning failure
+    // or throw (#11477). One variable released from the `finally` covers them
+    // all, including early returns added later. Cleared only where the token is
+    // genuinely spent: a resumed session that survived its post-spawn checks.
+    let unreleasedHibernationProjectId: string | null = null;
     // Clear any prior failure banner up front so a retry immediately drops the
     // stale error while the new attempt is in flight.
     this._patch({ launchError: null });
@@ -1223,6 +1231,9 @@ export class HelpSessionController {
         } catch (err) {
           logError("HelpPanel: resumeOnly early hibernation take failed", err);
         }
+        // Main has already cleared its side, so from here on this launch owns
+        // the token and the `finally` is what gives it back (#11477).
+        if (earlyPending) unreleasedHibernationProjectId = launchProject.id;
         if (gen !== this._launchGen) {
           this._abandonInFlightLaunch(reservedId, session, { resetAutoLaunch });
           return;
@@ -1285,7 +1296,10 @@ export class HelpSessionController {
         // return null (the entry is consumed) and clear nothing, but running it
         // is wasteful and misleading.
         if (!options.resumeOnly) {
-          await this._hibernationManager.seedFromMain(launchProject.id, gen);
+          const seeded = await this._hibernationManager.seedFromMain(launchProject.id, gen);
+          // "released" already handed it back inside seedFromMain (it saw the
+          // stale gen first); only a live seed leaves this launch owning it.
+          if (seeded === "seeded") unreleasedHibernationProjectId = launchProject.id;
           if (gen !== this._launchGen) {
             this._abandonInFlightLaunch(reservedId, session, { resetAutoLaunch });
             return;
@@ -1311,6 +1325,10 @@ export class HelpSessionController {
               usePanelStore.getState().removePanel(resumed.panelId);
               return;
             }
+            // The token is now genuinely spent: the resumed session survived
+            // both post-spawn checks and is about to go live. Every other exit
+            // from here leaves the marker set so the `finally` gives it back.
+            unreleasedHibernationProjectId = null;
             useHelpPanelStore.getState().clearHibernateSession(launchProject.id);
             useHelpPanelStore
               .getState()
@@ -1485,6 +1503,21 @@ export class HelpSessionController {
       }
       if (ownsGen) this._surfaceLaunchError(launchAgentId, "spawn-failed");
     } finally {
+      // Hand back a resume token this launch took but never spent (#11477).
+      // Unconditional on generation: the paths that abandon a launch are
+      // dominated by stall reapers and StrictMode remounts, not by a user
+      // discarding the conversation — and the discard-intent launches
+      // (`newSession` / run-anyway) carry a `reservedId` or `seedPrompt` and so
+      // never take at all. Main refuses the put-back if a newer capture landed
+      // meanwhile, and a restored entry can only be resumed explicitly.
+      // Fire-and-forget: the launch is already unwinding and must not block on
+      // an IPC round-trip.
+      if (unreleasedHibernationProjectId) {
+        void this._hibernationManager.releaseToMain(
+          unreleasedHibernationProjectId,
+          reached ? "fresh-launch-unused" : "launch-abandoned"
+        );
+      }
       // Release the re-entrancy guard only if THIS launch() still owns it —
       // clearing it unconditionally let a stale unwind drop a newer launch's
       // guard and admit a concurrent third launch (#10693 review). A

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -1153,7 +1153,14 @@ export class HelpSessionController {
     // or throw (#11477). One variable released from the `finally` covers them
     // all, including early returns added later. Cleared only where the token is
     // genuinely spent: a resumed session that survived its post-spawn checks.
-    let unreleasedHibernation: { projectId: string; claimId: string } | null = null;
+    // `mirrored` records whether this take also reached the renderer's durable
+    // `hibernateSessions` slot, so the release only drops that mirror when it
+    // is genuinely ours — the bails below fire before it is ever written.
+    let unreleasedHibernation: {
+      projectId: string;
+      claimId: string;
+      mirrored: boolean;
+    } | null = null;
     // Clear any prior failure banner up front so a retry immediately drops the
     // stale error while the new attempt is in flight.
     this._patch({ launchError: null });
@@ -1243,6 +1250,9 @@ export class HelpSessionController {
           unreleasedHibernation = {
             projectId: launchProject.id,
             claimId: earlyPending.claimId,
+            // Not seeded yet — the two bails below return before the store
+            // write, and a release from there must not touch the slot.
+            mirrored: false,
           };
         }
         if (gen !== this._launchGen) {
@@ -1258,6 +1268,7 @@ export class HelpSessionController {
           cwd: earlyPending.cwd,
           agentId: earlyPending.agentId,
         });
+        if (unreleasedHibernation) unreleasedHibernation.mirrored = true;
       }
 
       const outcome = await provisionHelpSession(launchProject, launchAgentId, launchContext);
@@ -1311,7 +1322,12 @@ export class HelpSessionController {
           // "released" already handed it back inside seedFromMain (it saw the
           // stale gen first); only a live seed leaves this launch owning it.
           if (seeded.status === "seeded") {
-            unreleasedHibernation = { projectId: launchProject.id, claimId: seeded.claimId };
+            // "seeded" means the entry IS in the store, so the mirror is ours.
+            unreleasedHibernation = {
+              projectId: launchProject.id,
+              claimId: seeded.claimId,
+              mirrored: true,
+            };
           }
           if (gen !== this._launchGen) {
             this._abandonInFlightLaunch(reservedId, session, { resetAutoLaunch });
@@ -1529,7 +1545,8 @@ export class HelpSessionController {
         void this._hibernationManager.releaseToMain(
           unreleasedHibernation.projectId,
           unreleasedHibernation.claimId,
-          reached ? "fresh-launch-unused" : "launch-abandoned"
+          reached ? "fresh-launch-unused" : "launch-abandoned",
+          { clearMirror: unreleasedHibernation.mirrored }
         );
       }
       // Release the re-entrancy guard only if THIS launch() still owns it —

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -1145,14 +1145,15 @@ export class HelpSessionController {
     // see this generation still holding it and silently drop the relaunch
     // (#10703) — leaving `_hasAutoLaunched` stuck and blocking all auto-launch.
     let pendingReEval: HelpSessionInputs | null = null;
-    // Project whose main-captured resume token this launch has taken but not
-    // yet used. `takePendingHibernation` is destructive on main, so every abort
+    // The main-captured resume token this launch has taken but not yet used,
+    // with the claim id that authorizes putting it back.
+    // `takePendingHibernation` is destructive on main, so every abort
     // downstream of a successful take used to destroy the user's only resume
     // token — across five separate early returns plus any provisioning failure
     // or throw (#11477). One variable released from the `finally` covers them
     // all, including early returns added later. Cleared only where the token is
     // genuinely spent: a resumed session that survived its post-spawn checks.
-    let unreleasedHibernationProjectId: string | null = null;
+    let unreleasedHibernation: { projectId: string; claimId: string } | null = null;
     // Clear any prior failure banner up front so a retry immediately drops the
     // stale error while the new attempt is in flight.
     this._patch({ launchError: null });
@@ -1225,7 +1226,12 @@ export class HelpSessionController {
       // entry then drives the normal resume block; `_seedHibernateFromMain` is
       // skipped for this path since the take already happened.
       if (options.resumeOnly && !reservedId && !options.seedPrompt) {
-        let earlyPending: { agentId: string; agentSessionId: string; cwd: string } | null = null;
+        let earlyPending: {
+          agentId: string;
+          agentSessionId: string;
+          cwd: string;
+          claimId: string;
+        } | null = null;
         try {
           earlyPending = await window.electron.help.takePendingHibernation(launchProject.id);
         } catch (err) {
@@ -1233,7 +1239,12 @@ export class HelpSessionController {
         }
         // Main has already cleared its side, so from here on this launch owns
         // the token and the `finally` is what gives it back (#11477).
-        if (earlyPending) unreleasedHibernationProjectId = launchProject.id;
+        if (earlyPending) {
+          unreleasedHibernation = {
+            projectId: launchProject.id,
+            claimId: earlyPending.claimId,
+          };
+        }
         if (gen !== this._launchGen) {
           this._abandonInFlightLaunch(reservedId, session, { resetAutoLaunch });
           return;
@@ -1299,7 +1310,9 @@ export class HelpSessionController {
           const seeded = await this._hibernationManager.seedFromMain(launchProject.id, gen);
           // "released" already handed it back inside seedFromMain (it saw the
           // stale gen first); only a live seed leaves this launch owning it.
-          if (seeded === "seeded") unreleasedHibernationProjectId = launchProject.id;
+          if (seeded.status === "seeded") {
+            unreleasedHibernation = { projectId: launchProject.id, claimId: seeded.claimId };
+          }
           if (gen !== this._launchGen) {
             this._abandonInFlightLaunch(reservedId, session, { resetAutoLaunch });
             return;
@@ -1328,7 +1341,7 @@ export class HelpSessionController {
             // The token is now genuinely spent: the resumed session survived
             // both post-spawn checks and is about to go live. Every other exit
             // from here leaves the marker set so the `finally` gives it back.
-            unreleasedHibernationProjectId = null;
+            unreleasedHibernation = null;
             useHelpPanelStore.getState().clearHibernateSession(launchProject.id);
             useHelpPanelStore
               .getState()
@@ -1512,9 +1525,10 @@ export class HelpSessionController {
       // meanwhile, and a restored entry can only be resumed explicitly.
       // Fire-and-forget: the launch is already unwinding and must not block on
       // an IPC round-trip.
-      if (unreleasedHibernationProjectId) {
+      if (unreleasedHibernation) {
         void this._hibernationManager.releaseToMain(
-          unreleasedHibernationProjectId,
+          unreleasedHibernation.projectId,
+          unreleasedHibernation.claimId,
           reached ? "fresh-launch-unused" : "launch-abandoned"
         );
       }

--- a/src/controllers/HibernationManager.ts
+++ b/src/controllers/HibernationManager.ts
@@ -329,12 +329,16 @@ export class HibernationManager {
     // no return, and swallowing it in the catch would lose the token exactly
     // the way this fix exists to prevent.
     let claimId: string | null = null;
+    // Whether this take reached the store write below, so a release knows if
+    // the mirror is ours to drop.
+    let mirrored = false;
     try {
       const pending = await window.electron.help.takePendingHibernation(projectId);
       if (!pending) return { status: "empty" };
       claimId = pending.claimId;
       if (!this.host.isLaunchCurrent(gen)) {
-        await this.releaseToMain(projectId, claimId, "stale-generation");
+        // Nothing seeded yet — leave whatever the slot holds alone.
+        await this.releaseToMain(projectId, claimId, "stale-generation", { clearMirror: false });
         return { status: "released" };
       }
       // `pending.agentSessionId` can be the empty-string sentinel when main's
@@ -351,11 +355,12 @@ export class HibernationManager {
         cwd: pending.cwd,
         agentId: pending.agentId,
       });
+      mirrored = true;
       return { status: "seeded", claimId: pending.claimId };
     } catch (err) {
       logError("HelpPanel: failed to pull pending hibernation from main", err);
       if (claimId) {
-        await this.releaseToMain(projectId, claimId, "seed-threw");
+        await this.releaseToMain(projectId, claimId, "seed-threw", { clearMirror: mirrored });
         return { status: "released" };
       }
       return { status: "empty" };
@@ -371,20 +376,30 @@ export class HibernationManager {
    * (one lost resume opportunity), so it is logged and swallowed rather than
    * failing the launch that is already unwinding.
    *
-   * Drops the renderer's local mirror of the entry as part of the release. The
-   * two must move together: `seedFromMain` writes the taken entry into the
-   * durable `hibernateSessions` slot, so releasing main's copy while leaving
-   * the mirror behind would let a later launch resume from the mirror after
-   * main had already handed the entry to a different window — two windows
-   * resuming one conversation, which is exactly the single-winner invariant the
-   * atomic take exists to hold (#10820).
+   * Pass `clearMirror` when this take was written into the renderer's durable
+   * `hibernateSessions` slot. The two must then move together: releasing main's
+   * copy while leaving the mirror behind would let a later launch resume from
+   * the mirror after main had already handed the entry to a different window —
+   * two windows resuming one conversation, which is exactly the single-winner
+   * invariant the atomic take exists to hold (#10820).
+   *
+   * It is NOT unconditional, because several release paths abort before
+   * mirroring anything: the stale-generation guard below, and the early
+   * `resumeOnly` take's generation/agent-mismatch bails. Clearing there would
+   * delete whatever the slot already held — a graceful-hibernate entry from a
+   * panel close, or a newer entry — which this launch never owned.
    *
    * `reason` is carried into the log so a future incident can tell which abort
    * path fired instead of inferring it from an absence, which is what made the
    * original report take log archaeology to diagnose.
    */
-  async releaseToMain(projectId: string, claimId: string, reason: string): Promise<void> {
-    useHelpPanelStore.getState().clearHibernateSession(projectId);
+  async releaseToMain(
+    projectId: string,
+    claimId: string,
+    reason: string,
+    opts: { clearMirror: boolean }
+  ): Promise<void> {
+    if (opts.clearMirror) useHelpPanelStore.getState().clearHibernateSession(projectId);
     try {
       const restored = await window.electron.help.restorePendingHibernation(projectId, claimId);
       console.info("[HelpPanel] released pending hibernation back to main", {

--- a/src/controllers/HibernationManager.ts
+++ b/src/controllers/HibernationManager.ts
@@ -320,13 +320,22 @@ export class HibernationManager {
    * owns it (and so must consume or release it), `"released"` when it went
    * back to main, and `"empty"` when there was nothing to take.
    */
-  async seedFromMain(projectId: string, gen: number): Promise<"seeded" | "released" | "empty"> {
+  async seedFromMain(
+    projectId: string,
+    gen: number
+  ): Promise<{ status: "seeded"; claimId: string } | { status: "released" | "empty" }> {
+    // Tracked outside the try so a throw from the store write below still
+    // releases the claim main has already handed us — the take is the point of
+    // no return, and swallowing it in the catch would lose the token exactly
+    // the way this fix exists to prevent.
+    let claimId: string | null = null;
     try {
       const pending = await window.electron.help.takePendingHibernation(projectId);
-      if (!pending) return "empty";
+      if (!pending) return { status: "empty" };
+      claimId = pending.claimId;
       if (!this.host.isLaunchCurrent(gen)) {
-        await this.releaseToMain(projectId, "stale-generation");
-        return "released";
+        await this.releaseToMain(projectId, claimId, "stale-generation");
+        return { status: "released" };
       }
       // `pending.agentSessionId` can be the empty-string sentinel when main's
       // `revokeSession({ captureHibernation: true })` placeholder write raced
@@ -342,10 +351,14 @@ export class HibernationManager {
         cwd: pending.cwd,
         agentId: pending.agentId,
       });
-      return "seeded";
+      return { status: "seeded", claimId: pending.claimId };
     } catch (err) {
       logError("HelpPanel: failed to pull pending hibernation from main", err);
-      return "empty";
+      if (claimId) {
+        await this.releaseToMain(projectId, claimId, "seed-threw");
+        return { status: "released" };
+      }
+      return { status: "empty" };
     }
   }
 
@@ -358,13 +371,22 @@ export class HibernationManager {
    * (one lost resume opportunity), so it is logged and swallowed rather than
    * failing the launch that is already unwinding.
    *
+   * Drops the renderer's local mirror of the entry as part of the release. The
+   * two must move together: `seedFromMain` writes the taken entry into the
+   * durable `hibernateSessions` slot, so releasing main's copy while leaving
+   * the mirror behind would let a later launch resume from the mirror after
+   * main had already handed the entry to a different window — two windows
+   * resuming one conversation, which is exactly the single-winner invariant the
+   * atomic take exists to hold (#10820).
+   *
    * `reason` is carried into the log so a future incident can tell which abort
    * path fired instead of inferring it from an absence, which is what made the
    * original report take log archaeology to diagnose.
    */
-  async releaseToMain(projectId: string, reason: string): Promise<void> {
+  async releaseToMain(projectId: string, claimId: string, reason: string): Promise<void> {
+    useHelpPanelStore.getState().clearHibernateSession(projectId);
     try {
-      const restored = await window.electron.help.restorePendingHibernation(projectId);
+      const restored = await window.electron.help.restorePendingHibernation(projectId, claimId);
       console.info("[HelpPanel] released pending hibernation back to main", {
         projectId,
         reason,

--- a/src/controllers/HibernationManager.ts
+++ b/src/controllers/HibernationManager.ts
@@ -6,7 +6,7 @@
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { usePanelStore } from "@/store";
 import { isPtyPanel } from "@shared/types/panel";
-import { logError } from "@/utils/logger";
+import { logError, logInfo } from "@/utils/logger";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { ACTIVE_AGENT_STATES } from "@shared/types/agent";
 import { buildResumeLatestCommand } from "@shared/types/agentSettings";
@@ -402,7 +402,7 @@ export class HibernationManager {
     if (opts.clearMirror) useHelpPanelStore.getState().clearHibernateSession(projectId);
     try {
       const restored = await window.electron.help.restorePendingHibernation(projectId, claimId);
-      console.info("[HelpPanel] released pending hibernation back to main", {
+      logInfo("HelpPanel: released pending hibernation back to main", {
         projectId,
         reason,
         restored,

--- a/src/controllers/HibernationManager.ts
+++ b/src/controllers/HibernationManager.ts
@@ -303,19 +303,31 @@ export class HibernationManager {
    * after the user has explicitly started a new session somewhere along the
    * way.
    *
-   * Stale-gen guard: the caller passes the launch generation it started in.
-   * If anything bumps `_launchGen` during the IPC await (user hits "+ New
-   * session" which clears the project's hibernate slot, panel close, etc.),
-   * we DROP the pulled entry on the floor instead of writing it back. Main
-   * has already cleared the entry on its side (atomic take), so the cost is
-   * losing one resume opportunity — much cheaper than resurrecting a
-   * conversation the user just explicitly discarded.
+   * Stale-gen guard: the caller passes the launch generation it started in. If
+   * anything bumps `_launchGen` during the IPC await, this launch no longer
+   * owns the entry and must not write it into the store. It used to be dropped
+   * on the floor here — main had already cleared its side, so the resume
+   * opportunity was simply destroyed — on the theory that the bump meant the
+   * user had explicitly discarded the conversation. It usually doesn't: the
+   * gen-bump sites are dominated by the stall watchdog, the stranded-launch
+   * reaper, and StrictMode remounts, and the watchdog in particular surfaces a
+   * *retryable* error while silently destroying what the retry needs (#11477).
+   * So hand it back to main instead. `restorePendingHibernation` refuses if a
+   * newer capture has landed, and the put-back entry loses `panelWasOpen`, so
+   * it can only ever be resumed explicitly — never auto-resumed.
+   *
+   * Returns `"seeded"` when the entry is now live in the store and the caller
+   * owns it (and so must consume or release it), `"released"` when it went
+   * back to main, and `"empty"` when there was nothing to take.
    */
-  async seedFromMain(projectId: string, gen: number): Promise<void> {
+  async seedFromMain(projectId: string, gen: number): Promise<"seeded" | "released" | "empty"> {
     try {
       const pending = await window.electron.help.takePendingHibernation(projectId);
-      if (!pending) return;
-      if (!this.host.isLaunchCurrent(gen)) return;
+      if (!pending) return "empty";
+      if (!this.host.isLaunchCurrent(gen)) {
+        await this.releaseToMain(projectId, "stale-generation");
+        return "released";
+      }
       // `pending.agentSessionId` can be the empty-string sentinel when main's
       // `revokeSession({ captureHibernation: true })` placeholder write raced
       // the agent's real session-id echo (LRU eviction of the per-project
@@ -330,8 +342,36 @@ export class HibernationManager {
         cwd: pending.cwd,
         agentId: pending.agentId,
       });
+      return "seeded";
     } catch (err) {
       logError("HelpPanel: failed to pull pending hibernation from main", err);
+      return "empty";
+    }
+  }
+
+  /**
+   * Hand a taken-but-unused pending-hibernation entry back to main (#11477).
+   *
+   * Main restores from its own take-side stash, so this only reports that the
+   * caller isn't going to use what it took — nothing about the entry crosses
+   * the bridge. Best-effort: a failed put-back is exactly the old behaviour
+   * (one lost resume opportunity), so it is logged and swallowed rather than
+   * failing the launch that is already unwinding.
+   *
+   * `reason` is carried into the log so a future incident can tell which abort
+   * path fired instead of inferring it from an absence, which is what made the
+   * original report take log archaeology to diagnose.
+   */
+  async releaseToMain(projectId: string, reason: string): Promise<void> {
+    try {
+      const restored = await window.electron.help.restorePendingHibernation(projectId);
+      console.info("[HelpPanel] released pending hibernation back to main", {
+        projectId,
+        reason,
+        restored,
+      });
+    } catch (err) {
+      logError("HelpPanel: failed to release pending hibernation back to main", err);
     }
   }
 }

--- a/src/controllers/__tests__/HelpSessionController.coreLifecycle.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.coreLifecycle.test.ts
@@ -281,6 +281,7 @@ beforeEach(() => {
           provisionSession: vi.fn().mockResolvedValue(null),
           revokeSession: vi.fn().mockResolvedValue(undefined),
           takePendingHibernation: vi.fn().mockResolvedValue(null),
+          restorePendingHibernation: vi.fn().mockResolvedValue(false),
         },
         helpAssistant: {
           getSettings: vi.fn().mockResolvedValue({ idleHibernateMinutes: 30 }),

--- a/src/controllers/__tests__/HelpSessionController.launchPhaseFsm.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.launchPhaseFsm.test.ts
@@ -256,6 +256,7 @@ beforeEach(() => {
           provisionSession: vi.fn().mockResolvedValue(null),
           revokeSession: vi.fn().mockResolvedValue(undefined),
           takePendingHibernation: vi.fn().mockResolvedValue(null),
+          restorePendingHibernation: vi.fn().mockResolvedValue(false),
         },
         helpAssistant: {
           getSettings: vi.fn().mockResolvedValue({ idleHibernateMinutes: 30 }),

--- a/src/controllers/__tests__/HelpSessionController.resumeAndToolActivity.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.resumeAndToolActivity.test.ts
@@ -257,6 +257,7 @@ beforeEach(() => {
           provisionSession: vi.fn().mockResolvedValue(null),
           revokeSession: vi.fn().mockResolvedValue(undefined),
           takePendingHibernation: vi.fn().mockResolvedValue(null),
+          restorePendingHibernation: vi.fn().mockResolvedValue(false),
         },
         helpAssistant: {
           getSettings: vi.fn().mockResolvedValue({ idleHibernateMinutes: 30 }),

--- a/src/controllers/__tests__/HelpSessionController.sessionAndViewRecovery.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.sessionAndViewRecovery.test.ts
@@ -256,6 +256,7 @@ beforeEach(() => {
           provisionSession: vi.fn().mockResolvedValue(null),
           revokeSession: vi.fn().mockResolvedValue(undefined),
           takePendingHibernation: vi.fn().mockResolvedValue(null),
+          restorePendingHibernation: vi.fn().mockResolvedValue(false),
         },
         helpAssistant: {
           getSettings: vi.fn().mockResolvedValue({ idleHibernateMinutes: 30 }),

--- a/src/controllers/__tests__/HelpSessionController.versionAndLaunchErrors.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.versionAndLaunchErrors.test.ts
@@ -257,6 +257,7 @@ beforeEach(() => {
           provisionSession: vi.fn().mockResolvedValue(null),
           revokeSession: vi.fn().mockResolvedValue(undefined),
           takePendingHibernation: vi.fn().mockResolvedValue(null),
+          restorePendingHibernation: vi.fn().mockResolvedValue(false),
         },
         helpAssistant: {
           getSettings: vi.fn().mockResolvedValue({ idleHibernateMinutes: 30 }),


### PR DESCRIPTION
Resolves #11477

The in-app Assistant was being destroyed when its background project view got evicted under memory pressure, taking its whole PTY process tree with it — every sub-agent and background shell, with no completion record. Three linked problems, fixed together.

## The reclaim doesn't recover what the log claims

`evictStaleViews` measures a view's footprint through `wc.getOSProcessId()` against `app.getAppMetrics()`, whose process table is `{Browser, Tab, Utility}`. The Assistant's CLI is a node-pty child forked *inside* the pty-host utility process, addressed by `terminalId` over a MessagePort — never a `<webview>` guest, never sampled. So the incident's `memoryKb: 440880` is 100% renderer, recovered by destroying the `WebContentsView`; the `gracefulKill` that follows recovers none of it. Killing the Assistant was a straight loss, not a tradeoff — which is why the floor is now unconditional rather than yielding at the critical edge.

## Two reclaim paths raced, and the destructive one won

`evictStaleViews` derived `criticalPressure` from live memory on *every* call path, so any caller could self-classify into a one-pass collapse off a single instantaneous reading. From the incident log:

- `03:06:30.007` tier-1 mitigation starts
- `03:06:30.567` the per-window sampler evicts the Assistant's view — 560ms later, ungated
- `03:06:33.008` tier-1 reports `pressureRemains: false`

Tier 1 resolved it 2.4s later. The sampler is per-window and has no consecutive-poll count, no cooldown, and no view of whether a cheaper mitigation is already running — none of which `evictStaleViews` can see. Critical escalation now belongs to `ProcessMemoryMonitor`'s ladder alone and arrives via `forcePressure`; the sampler contracts one view per tick at every band. That also closes a case nobody had noticed: an ordinary project switch or a `setCachedViewLimit` call landing below `criticalMb` used to collapse the whole cache as a side effect.

## The resume token was taken, then dropped

`takePendingHibernation` is a destructive atomic take — that atomicity is load-bearing (#10819/#10820), it's the single-winner gate that stops two windows displacing each other. But every abort downstream of a successful take dropped the entry on the floor. The `_launchGen` bumps that trigger those aborts are dominated by stall reapers and StrictMode remounts, and `_armLaunchWatchdog` in particular surfaces a *retryable* error while destroying the token that retry needs.

A launch now holds one marker released from its `finally`, covering the five known drop sites plus provisioning failure and a throw from `_spawnResumed`. Main restores from its own take-side stash, so the put-back carries no entry data: `capturedAt` survives (a refreshed one could walk past the 14-day staleness cutoff), `panelWasOpen` stays stripped (a restored entry can be resumed explicitly but never auto-resumes), and there's no way to write a fabricated `agentId`/`cwd` into the store. A per-take `claimId` plus the taking view's id — from IPC context, never renderer-supplied — makes it a compare-and-swap on the take rather than the project.

Also hardened `HibernationService`'s background PTY kill with the same binding + liveness pair. It's dormant behind `EXPERIMENT_HIBERNATION_DISABLED`, but it's reached by the same tier-2 ladder and its only guard was `ACTIVE_AGENT_STATES` — the signal #11157 established is wrong here, since an Assistant that dispatched a sub-agent reads as idle while that work runs on.

## Tradeoffs worth knowing

- **The floor is unconditional, so a forced tier-2 reclaim can return zero** if only Assistant-backed renderers remain. Bounded by the number of live Assistants (only the exact pinned `webContentsId` is protected; another window's view of the same project stays an ordinary candidate). `projectview.eviction-skipped` now reports `protectedCount` and `transientlyExcludedCount` so an over-cap cache is attributable instead of reading as a leak.
- **Full cache convergence under critical pressure moves from one pass to one view per ~30s tick.** Shedding still starts on the same tick — only convergence is slower. Deliberate: that's what stops the destructive path pre-empting the cheap one.

## Testing

1060 targeted tests pass. Notable coverage: forced reclaim keeps the pinned view and logs the overflow; a critical sampler tick sheds at most one view; LRU/limit-change passes never inherit pressure; a stale claim can't restore a stash a newer take replaced, and being refused doesn't consume the rightful claimant's; a mismatched-agent release returns main's copy without touching the local slot it never wrote. The hibernation guard is tested with the removal experiment neutralized, so "no kill happened" proves the guard rather than the flag.