### PR TITLE
fix(scratch): persist and restore a scratch workspace's panel grid

### DIFF
--- a/electron/ipc/__tests__/app.state.test.ts
+++ b/electron/ipc/__tests__/app.state.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 const ipcHandlers = new Map<string, (...args: unknown[]) => unknown>();
 
@@ -18,10 +18,20 @@ vi.mock("electron", () => ({
   },
 }));
 
+// Mutable so a test can vary the legacy global app state without replacing the
+// `store.get` implementation, which `clearAllMocks` would not restore.
+const { globalAppStateRef } = vi.hoisted(() => ({
+  globalAppStateRef: {
+    current: { terminals: [], sidebarWidth: 350 } as Record<string, unknown>,
+  },
+}));
+
+const DEFAULT_GLOBAL_APP_STATE = { terminals: [], sidebarWidth: 350 };
+
 vi.mock("../../store.js", () => ({
   store: {
     get: vi.fn((key: string) => {
-      if (key === "appState") return { terminals: [], sidebarWidth: 350 };
+      if (key === "appState") return globalAppStateRef.current;
       if (key === "terminalConfig") return { resourceMonitoringEnabled: false };
       if (key === "agentSettings") return {};
       return undefined;
@@ -750,6 +760,78 @@ describe("app:boot handler", () => {
     expect(projectStore.getCurrentProject).not.toHaveBeenCalled();
   });
 
+  describe("scratch views (#11484)", () => {
+    const SCRATCH_ID = "b3d1f2a4-5c6e-4a8b-9d0f-1e2a3b4c5d6e";
+
+    afterEach(() => {
+      globalAppStateRef.current = { ...DEFAULT_GLOBAL_APP_STATE };
+    });
+
+    function scratchDeps() {
+      vi.mocked(getWindowForWebContents).mockReturnValue({
+        id: 7,
+        isDestroyed: () => false,
+      } as unknown as Electron.BrowserWindow);
+      const pvm = { getProjectIdForWebContents: vi.fn().mockReturnValue(SCRATCH_ID) };
+      return {
+        windowRegistry: {
+          getByWindowId: vi.fn().mockReturnValue({ services: { projectViewManager: pvm } }),
+        },
+        projectViewManager: pvm,
+      } as unknown as HandlerDependencies;
+    }
+
+    it("restores the persisted grid for a workspace that has no Project row", async () => {
+      const savedPanel = {
+        id: "panel-1",
+        title: "Agent",
+        location: "grid",
+        cwd: "/scratches/one",
+        kind: "terminal",
+      };
+      vi.mocked(projectStore.getProjectStateWithRecovery).mockResolvedValue({
+        state: {
+          projectId: SCRATCH_ID,
+          sidebarWidth: 350,
+          terminals: [savedPanel],
+        },
+        quarantinedPath: undefined,
+      } as unknown as Awaited<ReturnType<typeof projectStore.getProjectStateWithRecovery>>);
+
+      const result = await invokeBoot({ deps: scratchDeps(), senderId: 42 });
+
+      // No Project row exists, yet the state directory is still read and its
+      // panels returned — this is the whole fix.
+      expect(result.project).toBeNull();
+      expect(result.workspaceId).toBe(SCRATCH_ID);
+      expect(projectStore.getProjectStateWithRecovery).toHaveBeenCalledWith(SCRATCH_ID);
+      expect((result.appState as { terminals: unknown[] }).terminals).toHaveLength(1);
+      expect((result.appState as { terminals: Array<{ id: string }> }).terminals[0].id).toBe(
+        savedPanel.id
+      );
+    });
+
+    it("never inherits the legacy global terminals", async () => {
+      // The global list predates per-workspace state and belongs to whichever
+      // project was open back then. Migrating it into a scratch would hand a
+      // brand-new workspace someone else's panels.
+      globalAppStateRef.current = {
+        sidebarWidth: 350,
+        terminals: [{ id: "legacy-panel", title: "Legacy", location: "grid", cwd: "/old/project" }],
+      };
+      vi.mocked(projectStore.getProjectStateWithRecovery).mockResolvedValue({
+        state: null,
+        quarantinedPath: undefined,
+      });
+
+      const result = await invokeBoot({ deps: scratchDeps(), senderId: 42 });
+
+      expect(result.workspaceId).toBe(SCRATCH_ID);
+      expect((result.appState as { terminals: unknown[] }).terminals).toEqual([]);
+      expect(projectStore.enqueueProjectStateUpdate).not.toHaveBeenCalled();
+    });
+  });
+
   it("hydrates the URL project while a project view binding is still pending", async () => {
     const urlProject = {
       id: "proj-url",
@@ -1055,6 +1137,9 @@ describe("app:boot handler", () => {
     });
 
     expect(result.project).toBeNull();
+    // A closed project keeps its row, so it must not be mistaken for a
+    // row-less scratch and have its state served back (#11484).
+    expect(result.workspaceId).toBeNull();
     expect(projectStore.getProjectStateWithRecovery).not.toHaveBeenCalled();
     expect(projectStore.getCurrentProject).not.toHaveBeenCalled();
   });

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -49,24 +49,34 @@ import { notifyAppViewPainted } from "../../../setup/deepLinkInstall.js";
 import { resolveScopedProjectForIpcContext } from "../../projectContext.js";
 import { getValidatedOverrides } from "../keybinding.js";
 import { loadSanitizedUserAgentRegistry } from "../../../services/UserAgentRegistryService.js";
+import type { Project } from "../../../types/index.js";
 import type { HandlerDependencies, IpcContext } from "../../types.js";
+
+interface HydrationWorkspace {
+  project: Project | null;
+  /**
+   * Owner of the per-workspace state directory. Equals `project.id` for a real
+   * project, and is the scratch's own id in a scratch view, where `project` is
+   * null because scratches deliberately have no Project row (#11484).
+   */
+  workspaceId: string | null;
+}
 
 export function registerAppStateHandlers(deps?: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
-  const resolveProjectForHydration = (ctx?: IpcContext) => {
-    if (!ctx) {
-      return projectStore.getCurrentProject();
+  const resolveWorkspaceForHydration = (ctx?: IpcContext): HydrationWorkspace => {
+    if (ctx) {
+      const scoped = resolveScopedProjectForIpcContext(ctx, deps);
+      if (scoped) return { project: scoped.project, workspaceId: scoped.workspaceId };
     }
 
-    const scopedProject = resolveScopedProjectForIpcContext(ctx, deps);
-    if (scopedProject) return scopedProject.project;
-    return projectStore.getCurrentProject();
+    const project = projectStore.getCurrentProject();
+    return { project, workspaceId: project?.id ?? null };
   };
 
   const handleAppHydrate = async (ctx?: IpcContext) => {
-    const currentProject = resolveProjectForHydration(ctx);
-    const projectId = currentProject?.id;
+    const { project: currentProject, workspaceId } = resolveWorkspaceForHydration(ctx);
     const panelFilter = getCrashRecoveryService().consumePanelFilter();
 
     // Hover-prefetch fast path: when a project switcher hover (or any other
@@ -78,14 +88,14 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
     // cache is only probed when the result is actually usable.
     const cacheGuard = getCrashLoopGuard();
     const cacheInSafeMode = cacheGuard.isSafeMode();
-    const cacheEligible = Boolean(projectId) && panelFilter === null && !cacheInSafeMode;
-    const cached = cacheEligible ? consumePrefetchedHydrateResult(projectId!) : undefined;
+    const cacheEligible = Boolean(workspaceId) && panelFilter === null && !cacheInSafeMode;
+    const cached = cacheEligible ? consumePrefetchedHydrateResult(workspaceId!) : undefined;
     markPerformance(PERF_MARKS.APP_HYDRATE_PREFETCH, {
       hit: Boolean(cached),
-      projectId: projectId ?? null,
+      projectId: workspaceId ?? null,
       reason: cached
         ? "hit"
-        : !projectId
+        : !workspaceId
           ? "no-project"
           : cacheInSafeMode
             ? "safe-mode"
@@ -96,6 +106,9 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
     if (cached) {
       return {
         ...cached,
+        // The live sender's identity always wins over whatever the prefetch
+        // stamped — only ever a project today, but never assume that.
+        workspaceId,
         skippedPanelCount: 0,
         crashCount: cacheGuard.getCrashCount(),
         lastCrashAt: cacheGuard.getLastCrashTimestamp(),
@@ -156,9 +169,9 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
     let terminalSizesToUse: Record<string, { cols: number; rows: number }> | undefined;
     let draftInputsToUse: Record<string, string> | undefined;
 
-    if (projectId) {
+    if (workspaceId) {
       const { state: projectState, quarantinedPath } =
-        await projectStore.getProjectStateWithRecovery(projectId);
+        await projectStore.getProjectStateWithRecovery(workspaceId);
       projectStateQuarantinedPath = quarantinedPath;
       // Defaults match the standalone handlers' null-state returns.
       tabGroupsToUse = projectState?.tabGroups ?? [];
@@ -174,7 +187,7 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
         const validatedTerminals = filterValidTerminalEntries(
           projectState.terminals,
           TerminalSnapshotSchema,
-          `app:hydrate(project:${projectId})`
+          `app:hydrate(project:${workspaceId})`
         );
         // Filter out trashed terminals, infer missing kind, and normalize location
         terminalsToUse = validatedTerminals
@@ -201,7 +214,7 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
           focusPanelStateToUse = globalAppState.focusPanelState;
 
           // Save the migrated focus mode to per-project state
-          await projectStore.enqueueProjectStateUpdate(projectId, (existing) => ({
+          await projectStore.enqueueProjectStateUpdate(workspaceId, (existing) => ({
             ...(existing ?? projectState),
             focusMode: focusModeToUse,
             focusPanelState: focusPanelStateToUse,
@@ -211,7 +224,11 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
             `[AppHydrate] Migrated focusMode (${focusModeToUse}) to per-project state for ${currentProject?.name}`
           );
         }
-      } else if (globalAppState.terminals && globalAppState.terminals.length > 0) {
+      } else if (
+        currentProject &&
+        globalAppState.terminals &&
+        globalAppState.terminals.length > 0
+      ) {
         // Migration: use global terminals and migrate them to per-project
         terminalsToUse = filterValidTerminalEntries(
           globalAppState.terminals,
@@ -246,9 +263,9 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
             : undefined;
 
           // Include focus mode in migration
-          await projectStore.enqueueProjectStateUpdate(projectId, (existing) => ({
+          await projectStore.enqueueProjectStateUpdate(workspaceId, (existing) => ({
             ...(existing ?? {}),
-            projectId,
+            projectId: workspaceId,
             activeWorktreeId: globalAppState.activeWorktreeId,
             sidebarWidth: globalAppState.sidebarWidth ?? 350,
             terminals: migratedTerminals,
@@ -275,9 +292,9 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
             : undefined;
 
           // No terminals to migrate but still save empty state to mark migration complete
-          await projectStore.enqueueProjectStateUpdate(projectId, (existing) => ({
+          await projectStore.enqueueProjectStateUpdate(workspaceId, (existing) => ({
             ...(existing ?? {}),
-            projectId,
+            projectId: workspaceId,
             activeWorktreeId: globalAppState.activeWorktreeId,
             sidebarWidth: globalAppState.sidebarWidth ?? 350,
             terminals: existing?.terminals ?? [],
@@ -285,7 +302,7 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
             focusPanelState: normalizedFocusPanelState,
           }));
         }
-      } else {
+      } else if (currentProject) {
         // Normalize legacy focusPanelState
         const normalizedFocusPanelState = globalAppState.focusPanelState
           ? {
@@ -302,10 +319,10 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
 
         // No per-project state and no global terminals - create fresh state with focus mode migration
         await projectStore.enqueueProjectStateUpdate(
-          projectId,
+          workspaceId,
           (existing) =>
             existing ?? {
-              projectId,
+              projectId: workspaceId,
               activeWorktreeId: globalAppState.activeWorktreeId,
               sidebarWidth: globalAppState.sidebarWidth ?? 350,
               terminals: [],
@@ -314,6 +331,10 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
             }
         );
       }
+      // A scratch with no state yet falls through deliberately: the legacy
+      // global terminals and focus mode predate per-workspace state and belong
+      // to whichever project was open then, never to this scratch. Its first
+      // panel save creates the file, so there is nothing to seed here.
     } else {
       // No project - use global terminals (legacy/fallback)
       terminalsToUse = filterValidTerminalEntries(
@@ -414,7 +435,7 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
     };
 
     console.log(
-      `[AppHydrate] Project: ${currentProject?.name ?? "none"} - terminals from ${terminalsSource} (${terminalsToUse.length} valid), focusMode: ${focusModeToUse}`
+      `[AppHydrate] Project: ${currentProject?.name ?? (workspaceId ? "scratch" : "none")} - terminals from ${terminalsSource} (${terminalsToUse.length} valid), focusMode: ${focusModeToUse}`
     );
 
     const gpuStatus = getGpuFeatureStatus();
@@ -429,6 +450,7 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
       appState: appState as import("../../../../shared/types/ipc/app.js").AppState,
       terminalConfig: store.get("terminalConfig"),
       project: currentProject,
+      workspaceId,
       agentSettings: store.get("agentSettings"),
       gpuWebGLHardware,
       gpuHardwareAccelerationDisabled: isGpuDisabledByFlag(app.getPath("userData")),
@@ -685,12 +707,12 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
             sanitized.push(id);
           }
         }
-        // Persist per-project so opening another project's view can't gut this
-        // list via the quick-switcher prune pass (#9922). Fall back to the
-        // legacy global write only when there's no resolvable project.
-        const mruProject = resolveProjectForHydration(ctx);
-        if (mruProject?.id) {
-          await projectStore.enqueueProjectStateUpdate(mruProject.id, (existing) =>
+        // Persist per-workspace so opening another view can't gut this list via
+        // the quick-switcher prune pass (#9922). Fall back to the legacy global
+        // write only when there's no resolvable workspace.
+        const { workspaceId: mruWorkspaceId } = resolveWorkspaceForHydration(ctx);
+        if (mruWorkspaceId) {
+          await projectStore.enqueueProjectStateUpdate(mruWorkspaceId, (existing) =>
             existing ? { ...existing, mruList: sanitized } : null
           );
         } else {

--- a/electron/ipc/projectContext.ts
+++ b/electron/ipc/projectContext.ts
@@ -5,12 +5,29 @@ import type { HandlerDependencies, IpcContext } from "./types.js";
 
 export interface ScopedProjectResolution {
   project: Project | null;
+  /**
+   * The sender view's workspace id, whether or not it names a Project row. A
+   * scratch is a workspace with no row (#11484), so `project` is null while
+   * this still identifies the sender — anything keyed on durable per-workspace
+   * storage must use this, and anything that genuinely needs a git repository
+   * (in-repo presets, recipes) must keep using `project`.
+   */
+  workspaceId: string | null;
 }
 
-function getOpenProjectById(projectId: string): Project | null {
-  const project = projectStore.getProjectById(projectId);
-  if (project?.status === "closed") return null;
-  return project ?? null;
+/**
+ * Resolve one candidate id into a project and the workspace that owns its
+ * durable state.
+ *
+ * The two can diverge in both directions, and the distinction is load-bearing:
+ * an id with no project row at all is a scratch, whose state must still be
+ * served (#11484), whereas a *closed* project keeps its row and must not be
+ * served — hydrating it would resurrect a workspace the user closed.
+ */
+function resolveWorkspaceById(workspaceId: string): ScopedProjectResolution {
+  const project = projectStore.getProjectById(workspaceId);
+  if (project?.status === "closed") return { project: null, workspaceId: null };
+  return { project: project ?? null, workspaceId };
 }
 
 /**
@@ -48,19 +65,19 @@ export function resolveScopedProjectForIpcContext(
   if (pvm) {
     const viewProjectId = pvm.getProjectIdForWebContents(ctx.webContentsId);
     if (viewProjectId) {
-      return { project: getOpenProjectById(viewProjectId) };
+      return resolveWorkspaceById(viewProjectId);
     }
 
     const urlProjectId = getProjectIdFromSenderUrl(ctx.event.sender);
     if (urlProjectId) {
-      return { project: getOpenProjectById(urlProjectId) };
+      return resolveWorkspaceById(urlProjectId);
     }
 
-    return { project: null };
+    return { project: null, workspaceId: null };
   }
 
   if (ctx.projectId) {
-    return { project: getOpenProjectById(ctx.projectId) };
+    return resolveWorkspaceById(ctx.projectId);
   }
 
   return null;

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -738,6 +738,29 @@ export class ProjectStore {
     return adopted;
   }
 
+  /**
+   * Delete a workspace's state directory without touching the project table.
+   *
+   * Scratches persist their panel grid under the same `projects/<id>/` layout
+   * (#11484) but are removed through `ScratchStore`, which knows nothing about
+   * project rows. Without this the state directory would outlive every scratch
+   * forever. Best-effort: a failed removal is logged, never thrown, so it can
+   * never block a scratch deletion that has already tombstoned its row.
+   */
+  async removeWorkspaceStateDir(workspaceId: string): Promise<void> {
+    const stateDir = getProjectStateDir(this.projectsConfigDir, workspaceId);
+    if (!stateDir) return;
+
+    if (existsSync(stateDir)) {
+      try {
+        await fs.rm(stateDir, { recursive: true, force: true });
+      } catch (error) {
+        logError(`Failed to remove state directory for ${workspaceId}`, error);
+      }
+    }
+    this.stateManager.invalidateProjectStateCache(workspaceId);
+  }
+
   async removeProject(projectId: string): Promise<void> {
     const stateDir = getProjectStateDir(this.projectsConfigDir, projectId);
     if (!stateDir) {

--- a/electron/services/ScratchCleanupService.ts
+++ b/electron/services/ScratchCleanupService.ts
@@ -50,7 +50,7 @@
 import fs from "fs/promises";
 import path from "path";
 import PQueue from "p-queue";
-import { scratchStore as defaultScratchStore } from "./ScratchStore.js";
+import { scratchStore as defaultScratchStore, removeScratchStateDir } from "./ScratchStore.js";
 import type { ScratchRow } from "./persistence/schema.js";
 import { logError, logInfo } from "../utils/logger.js";
 import {
@@ -346,6 +346,11 @@ export async function runScratchCleanup(
         continue;
       }
     }
+
+    // The persisted panel grid lives outside the scratch directory, under the
+    // shared `projects/<id>/` state layout (#11484), so reaping the working
+    // directory alone would leak it forever.
+    await removeScratchStateDir(row.id);
 
     result.directoriesRemoved += 1;
     // The directory delete already freed the disk space, so the hard-delete DB

--- a/electron/services/ScratchStore.ts
+++ b/electron/services/ScratchStore.ts
@@ -14,6 +14,21 @@ import { logError } from "../utils/logger.js";
 
 const CURRENT_SCRATCH_KEY = "currentScratchId";
 
+/**
+ * Drop the scratch's persisted panel state, which lives under the shared
+ * `projects/<id>/` state layout (#11484). Imported lazily: `ProjectStore` is a
+ * heavyweight singleton that constructs itself at module eval, and statically
+ * importing it here would drag it into every suite that touches a scratch.
+ */
+export async function removeScratchStateDir(scratchId: string): Promise<void> {
+  try {
+    const { projectStore } = await import("./ProjectStore.js");
+    await projectStore.removeWorkspaceStateDir(scratchId);
+  } catch (error) {
+    logError(`[ScratchStore] Failed to remove scratch state directory for ${scratchId}`, error);
+  }
+}
+
 function rowToScratch(row: ScratchRow): Scratch {
   return {
     id: row.id,
@@ -202,6 +217,7 @@ export class ScratchStore {
       }
     }
 
+    await removeScratchStateDir(scratchId);
     this.hardDeleteScratch(scratchId);
   }
 

--- a/electron/services/__tests__/ScratchCleanupService.test.ts
+++ b/electron/services/__tests__/ScratchCleanupService.test.ts
@@ -31,6 +31,17 @@ vi.mock("../scratchStorePaths.js", () => ({
   getScratchDir: (root: string, id: string) => root + "/" + id,
 }));
 
+const { removeScratchStateDirMock } = vi.hoisted(() => ({
+  removeScratchStateDirMock: vi.fn(async (_scratchId: string) => {}),
+}));
+
+// The sweep only needs the state-dir hook; the default store export is never
+// used because every test injects its own `ScratchCleanupStore`.
+vi.mock("../ScratchStore.js", () => ({
+  scratchStore: {},
+  removeScratchStateDir: removeScratchStateDirMock,
+}));
+
 // Fully replace hardenedGit so the default classifier's git branch is driven by
 // a mock and no real git process is ever spawned. GIT_BLOCK_TIMEOUT_MS is a
 // plain constant the sweep only feeds to setTimeout, so a fixed stand-in is fine.
@@ -129,6 +140,7 @@ beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "scratch-cleanup-test-"));
   scratchTestRoot.current = tmpDir;
   mockedCreateHardenedGit.mockReset();
+  removeScratchStateDirMock.mockClear();
 });
 
 afterEach(async () => {
@@ -384,6 +396,42 @@ describe("runScratchCleanup — phase 1 (reap after grace)", () => {
     expect(result.directoriesRemoved).toBe(1);
     expect(store.rows).toHaveLength(0);
     await expect(fs.access(dir)).rejects.toBeDefined();
+  });
+
+  it("also drops the reaped scratch's persisted panel state (#11484)", async () => {
+    // The panel grid lives under the shared `projects/<id>/` state layout, not
+    // inside the scratch directory, so reaping the working dir alone leaks it.
+    const dir = path.join(tmpDir, "mature-with-state");
+    await fs.mkdir(dir, { recursive: true });
+    const store = makeStore([
+      row({
+        id: "mature-with-state",
+        path: dir,
+        lastOpened: NOW - 2 * SCRATCH_TTL_MS,
+        deletedAt: NOW - 2 * GRACE_MS,
+      }),
+    ]);
+
+    await runScratchCleanup(NOW, store, ALWAYS_SAFE);
+
+    expect(removeScratchStateDirMock).toHaveBeenCalledWith("mature-with-state");
+  });
+
+  it("leaves persisted state alone for a tombstone still inside the grace window", async () => {
+    const dir = path.join(tmpDir, "young-with-state");
+    await fs.mkdir(dir, { recursive: true });
+    const store = makeStore([
+      row({
+        id: "young-with-state",
+        path: dir,
+        lastOpened: NOW - 2 * SCRATCH_TTL_MS,
+        deletedAt: NOW - GRACE_MS / 2,
+      }),
+    ]);
+
+    await runScratchCleanup(NOW, store, ALWAYS_SAFE);
+
+    expect(removeScratchStateDirMock).not.toHaveBeenCalled();
   });
 
   it("does not reap a tombstone still inside the grace window", async () => {

--- a/electron/services/__tests__/ScratchStore.test.ts
+++ b/electron/services/__tests__/ScratchStore.test.ts
@@ -42,6 +42,14 @@ vi.mock("../../utils/logger.js", () => ({
   logError: vi.fn(),
 }));
 
+const { removeWorkspaceStateDirMock } = vi.hoisted(() => ({
+  removeWorkspaceStateDirMock: vi.fn(async (_workspaceId: string) => {}),
+}));
+
+vi.mock("../ProjectStore.js", () => ({
+  projectStore: { removeWorkspaceStateDir: removeWorkspaceStateDirMock },
+}));
+
 import { ScratchStore } from "../ScratchStore.js";
 
 describe("ScratchStore transaction mode", () => {
@@ -77,6 +85,59 @@ describe("ScratchStore transaction mode", () => {
     store.setCurrentScratch(scratchId);
     expect(spy).toHaveBeenCalledWith(expect.any(Function), { behavior: "immediate" });
     spy.mockRestore();
+  });
+});
+
+describe("removeScratch state cleanup (#11484)", () => {
+  let store: ScratchStore;
+  let scratchId: string;
+
+  beforeEach(() => {
+    sqlite = new Database(":memory:");
+    sqlite.exec(CREATE_TABLES_SQL);
+    db = drizzle(sqlite, { schema });
+
+    const now = Date.now();
+    scratchId = randomUUID();
+    db.insert(schema.scratches)
+      .values({
+        id: scratchId,
+        path: "/tmp/daintree-scratch-test/" + scratchId,
+        name: "Test Scratch",
+        createdAt: now - 86_400_000,
+        lastOpened: now - 3600_000,
+      })
+      .run();
+
+    store = new ScratchStore();
+    removeWorkspaceStateDirMock.mockClear();
+  });
+
+  afterEach(() => {
+    sqlite.close();
+    vi.restoreAllMocks();
+  });
+
+  it("drops the persisted panel state along with the scratch directory", async () => {
+    // The grid is persisted under `projects/<scratchId>/`, outside the scratch
+    // folder, so removing the folder alone would leave it orphaned forever.
+    vi.spyOn(fs, "rm").mockResolvedValue(undefined);
+
+    await store.removeScratch(scratchId);
+
+    expect(removeWorkspaceStateDirMock).toHaveBeenCalledWith(scratchId);
+    expect(db.select().from(schema.scratches).all()).toHaveLength(0);
+  });
+
+  it("keeps the row and the state when the directory removal fails", async () => {
+    // Bailing out before the hard delete is what lets a later sweep retry; the
+    // state directory must not be destroyed ahead of the row it belongs to.
+    vi.spyOn(fs, "rm").mockRejectedValue(new Error("EBUSY"));
+
+    await store.removeScratch(scratchId);
+
+    expect(removeWorkspaceStateDirMock).not.toHaveBeenCalled();
+    expect(db.select().from(schema.scratches).all()).toHaveLength(1);
   });
 });
 

--- a/electron/services/__tests__/projectQuarantineCleanup.test.ts
+++ b/electron/services/__tests__/projectQuarantineCleanup.test.ts
@@ -11,6 +11,7 @@ vi.mock("../../utils/logger.js", () => ({
 }));
 import path from "path";
 import os from "os";
+import { randomUUID } from "crypto";
 import {
   cleanupQuarantinedProjectFiles,
   cleanupGlobalQuarantineFiles,
@@ -117,6 +118,24 @@ describe("cleanupQuarantinedProjectFiles", () => {
 
     expect(deleted).toBe(0);
     await expect(fs.access(unknownFile)).resolves.toBeUndefined();
+  });
+
+  it("sweeps a scratch's state directory too (#11484)", async () => {
+    // Scratches persist their panel grid under the same `projects/<id>/`
+    // layout, so a corrupted scratch state file must be reaped on the same
+    // schedule rather than sitting there forever.
+    const scratchDir = await createProjectDir(randomUUID());
+    const filePath = await createCorruptedFile(
+      scratchDir,
+      "state.json.corrupted.1234567890",
+      THIRTY_ONE_DAYS_MS,
+      NOW
+    );
+
+    const deleted = await cleanupQuarantinedProjectFiles(tmpDir, NOW);
+
+    expect(deleted).toBe(1);
+    await expect(fs.access(filePath)).rejects.toThrow();
   });
 
   it("skips directories with invalid project IDs", async () => {

--- a/electron/services/__tests__/projectStorePaths.test.ts
+++ b/electron/services/__tests__/projectStorePaths.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect } from "vitest";
 import path from "path";
+import { randomUUID } from "crypto";
 import {
   stateFilePath,
   settingsFilePath,
   recipesFilePath,
+  isValidProjectId,
+  isValidWorkspaceStateId,
+  getProjectStateDir,
   UTF8_BOM,
 } from "../projectStorePaths.js";
+import { isValidScratchId } from "../scratchStorePaths.js";
 
 const BASE = path.resolve("/test/config/projects");
 
@@ -32,6 +37,64 @@ describe("projectStorePaths", () => {
       expect(stateFilePath(BASE, "invalid")).toBeNull();
       expect(settingsFilePath(BASE, "invalid")).toBeNull();
       expect(recipesFilePath(BASE, "invalid")).toBeNull();
+    });
+  });
+
+  describe("workspace state ids (#11484)", () => {
+    it("accepts a scratch id as a state-directory owner", () => {
+      const scratchId = randomUUID();
+      const dir = getProjectStateDir(BASE, scratchId);
+
+      expect(dir).toBe(path.join(BASE, scratchId));
+      expect(stateFilePath(BASE, scratchId)).toBe(path.join(BASE, scratchId, "state.json"));
+    });
+
+    it("keeps the project and scratch id spaces disjoint", () => {
+      const scratchId = randomUUID();
+      const projectId = "a".repeat(64);
+
+      expect(isValidProjectId(scratchId)).toBe(false);
+      expect(isValidScratchId(projectId)).toBe(false);
+    });
+
+    it("admits exactly the union of the two id shapes", () => {
+      const samples = [
+        ...Array.from({ length: 20 }, () => randomUUID()),
+        "a".repeat(64),
+        "0123456789abcdef".repeat(4),
+        randomUUID().toUpperCase(),
+        randomUUID().replace(/-/g, ""),
+        "a".repeat(63),
+        "a".repeat(65),
+        "",
+        "..",
+        "../escape",
+      ];
+
+      for (const sample of samples) {
+        expect(isValidWorkspaceStateId(sample)).toBe(
+          isValidProjectId(sample) || isValidScratchId(sample)
+        );
+      }
+    });
+
+    it("still rejects ids that could escape the state root", () => {
+      const escapes = ["..", "../escape", `..${path.sep}escape`, "./nested", "a/b"];
+
+      for (const escape of escapes) {
+        expect(getProjectStateDir(BASE, escape)).toBeNull();
+      }
+    });
+
+    it("gives every workspace its own directory", () => {
+      const first = randomUUID();
+      const second = randomUUID();
+      const projectId = "b".repeat(64);
+
+      const dirs = [first, second, projectId].map((id) => getProjectStateDir(BASE, id));
+
+      expect(new Set(dirs).size).toBe(3);
+      expect(dirs.every((dir) => dir !== null)).toBe(true);
     });
   });
 

--- a/electron/services/projectQuarantineCleanup.ts
+++ b/electron/services/projectQuarantineCleanup.ts
@@ -1,6 +1,6 @@
 import fs from "fs/promises";
 import path from "path";
-import { isValidProjectId } from "./projectStorePaths.js";
+import { isValidWorkspaceStateId } from "./projectStorePaths.js";
 import { resilientUnlink } from "../utils/fs.js";
 import { logInfo, logError } from "../utils/logger.js";
 
@@ -75,7 +75,7 @@ export async function cleanupQuarantinedProjectFiles(
 
   let deletedCount = 0;
   for (const entry of entries) {
-    if (!entry.isDirectory() || !isValidProjectId(entry.name)) continue;
+    if (!entry.isDirectory() || !isValidWorkspaceStateId(entry.name)) continue;
 
     const projectDir = path.join(projectsConfigDir, entry.name);
     try {

--- a/electron/services/projectStorePaths.ts
+++ b/electron/services/projectStorePaths.ts
@@ -49,8 +49,35 @@ export function isValidProjectId(projectId: string): boolean {
   return /^[0-9a-f]{64}$/.test(projectId);
 }
 
+const SCRATCH_STATE_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+/**
+ * Shape of a scratch id. Owned here rather than in `scratchStorePaths` so the
+ * state-directory gate below can accept it without importing that module (which
+ * pulls in `electron`); `isValidScratchId` delegates to this, keeping one
+ * source of truth for the shape.
+ */
+export function isValidScratchStateId(id: string): boolean {
+  return SCRATCH_STATE_ID_PATTERN.test(id);
+}
+
+/**
+ * Ids allowed to own a directory under `userData/projects/`. Scratches have no
+ * Project row but still need durable panel state (#11484), and a scratch UUID
+ * (36 chars, dashed) can never collide with a project id (64 hex, undashed), so
+ * both kinds share one state-directory namespace and all of the atomic-write /
+ * quarantine / recovery machinery built on it.
+ *
+ * Deliberately distinct from {@link isValidProjectId}, which still means "a
+ * project id" for the git-tracked `.daintree/project.json` anchor.
+ */
+export function isValidWorkspaceStateId(id: string): boolean {
+  return isValidProjectId(id) || isValidScratchStateId(id);
+}
+
 export function getProjectStateDir(projectsConfigDir: string, projectId: string): string | null {
-  if (!isValidProjectId(projectId)) {
+  if (!isValidWorkspaceStateId(projectId)) {
     return null;
   }
   const normalizedRoot = path.normalize(projectsConfigDir);

--- a/electron/services/scratchStorePaths.ts
+++ b/electron/services/scratchStorePaths.ts
@@ -1,10 +1,9 @@
 import path from "path";
 import { app } from "electron";
-
-const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+import { isValidScratchStateId } from "./projectStorePaths.js";
 
 export function isValidScratchId(scratchId: string): boolean {
-  return typeof scratchId === "string" && UUID_V4_REGEX.test(scratchId);
+  return typeof scratchId === "string" && isValidScratchStateId(scratchId);
 }
 
 /**

--- a/shared/types/ipc/app.ts
+++ b/shared/types/ipc/app.ts
@@ -164,6 +164,14 @@ export interface HydrateResult {
   appState: AppState;
   terminalConfig: TerminalConfig;
   project: import("../project.js").Project | null;
+  /**
+   * Workspace that owns the persisted panel grid in this view. Equals
+   * `project.id` for a project; in a scratch view `project` is null (scratches
+   * have no Project row) while this carries the scratch id, which is what the
+   * renderer needs to reconnect live PTYs and restore layout (#11484). Optional
+   * for backward compat with an older main process.
+   */
+  workspaceId?: string | null;
   agentSettings: import("../agentSettings.js").AgentSettings;
   gpuWebGLHardware: boolean;
   gpuHardwareAccelerationDisabled: boolean;

--- a/src/store/__tests__/projectStore.persistence.test.ts
+++ b/src/store/__tests__/projectStore.persistence.test.ts
@@ -174,7 +174,7 @@ describe("panel persistence workspace id (#11484)", () => {
         path: "/tmp/project-1",
         emoji: "folder",
         lastOpened: Date.now(),
-      } as unknown as NonNullable<ReturnType<typeof useProjectStore.getState>["currentProject"]>,
+      },
     });
 
     expect(getter()).toBe("project-1");
@@ -207,9 +207,11 @@ describe("panel persistence workspace id (#11484)", () => {
           id: "project-closed",
           name: "Closed",
           path: "/tmp/closed",
+          emoji: "folder",
+          lastOpened: Date.now(),
           status: "closed",
         },
-      ] as unknown as ReturnType<typeof useProjectStore.getState>["projects"],
+      ],
     });
 
     expect(getter()).toBeUndefined();

--- a/src/store/__tests__/projectStore.persistence.test.ts
+++ b/src/store/__tests__/projectStore.persistence.test.ts
@@ -190,6 +190,30 @@ describe("panel persistence workspace id (#11484)", () => {
 
     expect(getter()).toBeUndefined();
   });
+
+  it("refuses to persist into a closed project's state", async () => {
+    // `currentProject` is null for a closed project too. Treating that as a
+    // scratch would let a view that restored nothing overwrite the closed
+    // project's saved grid with an empty one.
+    installLocalStorage(createStorageMock());
+    viewWorkspaceIdMock.mockReturnValue("project-closed");
+
+    const getter = await loadPersistenceGetter();
+    const { useProjectStore } = await import("../projectStore");
+    useProjectStore.setState({
+      currentProject: null,
+      projects: [
+        {
+          id: "project-closed",
+          name: "Closed",
+          path: "/tmp/closed",
+          status: "closed",
+        },
+      ] as unknown as ReturnType<typeof useProjectStore.getState>["projects"],
+    });
+
+    expect(getter()).toBeUndefined();
+  });
 });
 
 describe("projectStore persistence boundary hardening", () => {

--- a/src/store/__tests__/projectStore.persistence.test.ts
+++ b/src/store/__tests__/projectStore.persistence.test.ts
@@ -69,6 +69,14 @@ vi.mock("../persistence/panelPersistence", () => ({
   panelToSnapshot: vi.fn(),
 }));
 
+const { viewWorkspaceIdMock } = vi.hoisted(() => ({
+  viewWorkspaceIdMock: vi.fn<() => string | null>(() => null),
+}));
+
+vi.mock("../viewWorkspaceId", () => ({
+  getViewWorkspaceId: viewWorkspaceIdMock,
+}));
+
 vi.mock("@/lib/notify", () => ({
   notify: vi.fn(),
 }));
@@ -125,10 +133,63 @@ function restoreLocalStorage(): void {
 beforeEach(() => {
   vi.resetModules();
   vi.clearAllMocks();
+  viewWorkspaceIdMock.mockReturnValue(null);
 });
 
 afterEach(() => {
   restoreLocalStorage();
+});
+
+describe("panel persistence workspace id (#11484)", () => {
+  async function loadPersistenceGetter() {
+    const { panelPersistence } = await import("../persistence/panelPersistence");
+    await import("../projectStore");
+    const getter = vi.mocked(panelPersistence.setProjectIdGetter).mock.calls[0]?.[0];
+    if (!getter) throw new Error("panelPersistence.setProjectIdGetter was never wired");
+    return getter;
+  }
+
+  it("falls back to the view's own workspace id when there is no project", async () => {
+    // A scratch view has no Project row, so `currentProject` is null. Before the
+    // fix the getter returned undefined and every save silently no-opped,
+    // leaving the grid to die with the view.
+    installLocalStorage(createStorageMock());
+    viewWorkspaceIdMock.mockReturnValue("b3d1f2a4-5c6e-4a8b-9d0f-1e2a3b4c5d6e");
+
+    const getter = await loadPersistenceGetter();
+
+    expect(getter()).toBe("b3d1f2a4-5c6e-4a8b-9d0f-1e2a3b4c5d6e");
+  });
+
+  it("prefers the current project over the view id", async () => {
+    installLocalStorage(createStorageMock());
+    viewWorkspaceIdMock.mockReturnValue("b3d1f2a4-5c6e-4a8b-9d0f-1e2a3b4c5d6e");
+
+    const getter = await loadPersistenceGetter();
+    const { useProjectStore } = await import("../projectStore");
+    useProjectStore.setState({
+      currentProject: {
+        id: "project-1",
+        name: "Project 1",
+        path: "/tmp/project-1",
+        emoji: "folder",
+        lastOpened: Date.now(),
+      } as unknown as NonNullable<ReturnType<typeof useProjectStore.getState>["currentProject"]>,
+    });
+
+    expect(getter()).toBe("project-1");
+  });
+
+  it("stays undefined when the view owns no workspace at all", async () => {
+    // Persistence must still no-op for a view with no identity — a null
+    // workspace is an identity, never a wildcard that writes somewhere else.
+    installLocalStorage(createStorageMock());
+    viewWorkspaceIdMock.mockReturnValue(null);
+
+    const getter = await loadPersistenceGetter();
+
+    expect(getter()).toBeUndefined();
+  });
 });
 
 describe("projectStore persistence boundary hardening", () => {

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -1161,9 +1161,22 @@ registerPersistedStore({
 // no `currentProject` — still persists its panel grid instead of silently
 // skipping every save (#11484). Same pattern as the PTY-ownership fix in
 // `panelRegistry/addPanel` and `restart`.
-panelPersistence.setProjectIdGetter(
-  () => useProjectStore.getState().currentProject?.id ?? getViewWorkspaceId() ?? undefined
-);
+//
+// The fallback is deliberately narrow. `currentProject` is also null for a
+// *closed* project, and persisting there would let a view that restored nothing
+// overwrite that project's saved grid with an empty one. Only an id that names
+// no project row at all is a scratch, which mirrors how Main resolves a sender's
+// workspace in `resolveScopedProjectForIpcContext`.
+panelPersistence.setProjectIdGetter(() => {
+  const { currentProject, projects } = useProjectStore.getState();
+  if (currentProject?.id) return currentProject.id;
+
+  const viewWorkspaceId = getViewWorkspaceId();
+  if (!viewWorkspaceId) return undefined;
+  return projects.some((candidate) => candidate.id === viewWorkspaceId)
+    ? undefined
+    : viewWorkspaceId;
+});
 
 // Keep this renderer's cached project state in sync when another renderer
 // (e.g., the welcome view where the onboarding wizard ran) adds, updates,

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -1156,8 +1156,14 @@ registerPersistedStore({
   persistedStateType: "{ projects: Project[] }",
 });
 
-// Break circular dependency by injecting project ID getter
-panelPersistence.setProjectIdGetter(() => useProjectStore.getState().currentProject?.id);
+// Break circular dependency by injecting project ID getter. Falls back to the
+// view's own workspace id so a scratch view — which has no Project row, and so
+// no `currentProject` — still persists its panel grid instead of silently
+// skipping every save (#11484). Same pattern as the PTY-ownership fix in
+// `panelRegistry/addPanel` and `restart`.
+panelPersistence.setProjectIdGetter(
+  () => useProjectStore.getState().currentProject?.id ?? getViewWorkspaceId() ?? undefined
+);
 
 // Keep this renderer's cached project state in sync when another renderer
 // (e.g., the welcome view where the onboarding wizard ran) adds, updates,

--- a/src/utils/__tests__/stateHydration.payloadFolding.test.ts
+++ b/src/utils/__tests__/stateHydration.payloadFolding.test.ts
@@ -510,6 +510,88 @@ describe("hydrateAppState", () => {
     });
   });
 
+  describe("scratch workspaces (#11484)", () => {
+    const SCRATCH_ID = "b3d1f2a4-5c6e-4a8b-9d0f-1e2a3b4c5d6e";
+
+    const scratchOptions = () => ({
+      addPanel: vi.fn().mockResolvedValue("panel-1"),
+      setActiveWorktree: vi.fn(),
+      loadRecipes: vi.fn().mockResolvedValue(undefined),
+      openDiagnosticsDock: vi.fn(),
+    });
+
+    it("reconnects live terminals and restores layout for a workspace with no project", async () => {
+      // A scratch view hydrates with `project: null` — before the fix that
+      // skipped the backend terminal query entirely, so still-running PTYs
+      // stayed orphaned in the pty-host with nothing referencing them.
+      appClientMock.hydrate.mockResolvedValue({
+        appState: { terminals: [], sidebarWidth: 350 },
+        terminalConfig,
+        project: null,
+        workspaceId: SCRATCH_ID,
+        agentSettings,
+        gpuWebGLHardware: true,
+      });
+
+      await hydrateAppState({ ...scratchOptions(), hydrateTabGroups: vi.fn() });
+
+      expect(terminalClientMock.getForProject).toHaveBeenCalledWith(SCRATCH_ID);
+      expect(projectClientMock.getTabGroups).toHaveBeenCalledWith(SCRATCH_ID);
+      expect(projectClientMock.getTerminalSizes).toHaveBeenCalledWith(SCRATCH_ID);
+      expect(projectClientMock.getDraftInputs).toHaveBeenCalledWith(SCRATCH_ID);
+    });
+
+    it("keeps repository-only work gated on a real project", async () => {
+      // Scratch folders are not git repos, so in-repo presets and recipes must
+      // not be fetched for them even though layout restore now is.
+      const options = scratchOptions();
+      appClientMock.hydrate.mockResolvedValue({
+        appState: { terminals: [], sidebarWidth: 350 },
+        terminalConfig,
+        project: null,
+        workspaceId: SCRATCH_ID,
+        agentSettings,
+        gpuWebGLHardware: true,
+      });
+
+      await hydrateAppState({ ...options, hydrateTabGroups: vi.fn() });
+
+      expect(projectClientMock.getInRepoPresets).not.toHaveBeenCalled();
+      expect(options.loadRecipes).not.toHaveBeenCalled();
+    });
+
+    it("still does nothing when the view owns no workspace at all", async () => {
+      const options = scratchOptions();
+      appClientMock.hydrate.mockResolvedValue({
+        appState: { terminals: [], sidebarWidth: 350 },
+        terminalConfig,
+        project: null,
+        workspaceId: null,
+        agentSettings,
+        gpuWebGLHardware: true,
+      });
+
+      await hydrateAppState({ ...options, hydrateTabGroups: vi.fn() });
+
+      expect(terminalClientMock.getForProject).not.toHaveBeenCalled();
+      expect(projectClientMock.getTabGroups).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the project id when an older main process omits workspaceId", async () => {
+      appClientMock.hydrate.mockResolvedValue({
+        appState: { terminals: [], sidebarWidth: 350 },
+        terminalConfig,
+        project,
+        agentSettings,
+        gpuWebGLHardware: true,
+      });
+
+      await hydrateAppState({ ...scratchOptions(), hydrateTabGroups: vi.fn() });
+
+      expect(terminalClientMock.getForProject).toHaveBeenCalledWith(project.id);
+    });
+  });
+
   describe("system temp dir folding", () => {
     const baseOptions = () => ({
       addPanel: vi.fn().mockResolvedValue("panel-1"),

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -255,6 +255,12 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
     // Discover running terminals from the backend
     // Terminals stay running across project switches - we just reconnect to them
     const currentProjectId = currentProject?.id;
+    // Owner of the persisted layout and of every live PTY in this view. In a
+    // scratch view `currentProject` is null, so keying the restore off it left
+    // the grid unrestored and the still-running PTYs orphaned in the pty-host
+    // (#11484). Layout and terminal reconnect use this; anything that genuinely
+    // needs a git repository (in-repo presets, recipes) keeps using the project.
+    const currentWorkspaceId = hydrateResult.workspaceId ?? currentProjectId;
     const projectRoot = currentProject?.path;
 
     const worktreesPromise = worktreeClient.getAll().catch((error) => {
@@ -267,11 +273,11 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
     // when the field is absent (older main process, or the safe-boot
     // {ok:false} payload). Mirrors the systemTmpDir fallback above.
     const tabGroupsPromise =
-      currentProjectId && options.hydrateTabGroups
+      currentWorkspaceId && options.hydrateTabGroups
         ? hydrateResult.tabGroups !== undefined
           ? Promise.resolve(hydrateResult.tabGroups)
           : projectClient
-              .getTabGroups(currentProjectId)
+              .getTabGroups(currentWorkspaceId)
               .then((tabGroups) => tabGroups ?? [])
               .catch((error) => {
                 logWarn("Failed to prefetch tab groups", { error });
@@ -281,11 +287,11 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
 
     type TerminalSizeMap = Record<string, { cols: number; rows: number }>;
     const emptyTerminalSizes: TerminalSizeMap = {};
-    const terminalSizesPromise: Promise<TerminalSizeMap> = currentProjectId
+    const terminalSizesPromise: Promise<TerminalSizeMap> = currentWorkspaceId
       ? hydrateResult.terminalSizes !== undefined
         ? Promise.resolve(hydrateResult.terminalSizes)
         : projectClient
-            .getTerminalSizes(currentProjectId)
+            .getTerminalSizes(currentWorkspaceId)
             .then((sizes) => sizes ?? emptyTerminalSizes)
             .catch((error) => {
               logWarn("Failed to prefetch terminal sizes", { error });
@@ -294,11 +300,11 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
       : Promise.resolve(emptyTerminalSizes);
 
     const emptyDraftInputs: Record<string, string> = {};
-    const draftInputsPromise: Promise<Record<string, string>> = currentProjectId
+    const draftInputsPromise: Promise<Record<string, string>> = currentWorkspaceId
       ? hydrateResult.draftInputs !== undefined
         ? Promise.resolve(hydrateResult.draftInputs)
         : projectClient
-            .getDraftInputs(currentProjectId)
+            .getDraftInputs(currentWorkspaceId)
             .then((drafts) => drafts ?? emptyDraftInputs)
             .catch((error) => {
               logWarn("Failed to prefetch draft inputs", { error });
@@ -335,11 +341,11 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
     // Perf span is split into startRendererSpan + manual finishGetForProject so
     // the `:end` mark fires when the awaited result is consumed below, not when
     // the in-flight promise settles in the background.
-    const finishGetForProjectSpan = currentProjectId
+    const finishGetForProjectSpan = currentWorkspaceId
       ? startRendererSpan(PERF_MARKS.HYDRATE_GET_TERMINALS)
       : null;
-    const getForProjectPromise: Promise<BackendTerminalInfo[]> = currentProjectId
-      ? terminalClient.getForProject(currentProjectId).catch((error: unknown) => {
+    const getForProjectPromise: Promise<BackendTerminalInfo[]> = currentWorkspaceId
+      ? terminalClient.getForProject(currentWorkspaceId).catch((error: unknown) => {
           logWarn("Failed to query backend terminals; continuing with saved panel restore", {
             error,
           });
@@ -349,23 +355,25 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
 
     // Restore hybrid input bar draft inputs BEFORE terminal panels are created,
     // so HybridInputBar components pick up drafts from the store at mount time.
-    if (currentProjectId) {
+    if (currentWorkspaceId) {
       try {
         const draftInputs = await draftInputsPromise;
         // Seed the close-flush baseline from the authoritative on-disk record
         // (even when empty) BEFORE restoring into the store, so a later clear of
         // a hydrated draft yields a removal tombstone instead of resurrecting on
         // next load (#11352).
-        draftInputPersistence.primeProject(currentProjectId, draftInputs);
+        draftInputPersistence.primeProject(currentWorkspaceId, draftInputs);
         if (Object.keys(draftInputs).length > 0) {
-          useTerminalInputStore.getState().restoreProjectDraftInputs(currentProjectId, draftInputs);
+          useTerminalInputStore
+            .getState()
+            .restoreProjectDraftInputs(currentWorkspaceId, draftInputs);
         }
       } catch (error) {
         logWarn("Failed to restore draft inputs", { error });
       }
     }
 
-    if (currentProjectId) {
+    if (currentWorkspaceId) {
       // Saved→restored panel id remap produced by restorePanelsPhase; consumed
       // by the tab-group hydration block below. Declared here (not in the
       // restore try) so it survives into that block even if panel restore
@@ -377,11 +385,11 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
         finishGetForProjectSpan?.();
 
         logHydrationInfo(
-          `Found ${backendTerminals.length} running terminals for project ${currentProjectId}`
+          `Found ${backendTerminals.length} running terminals for project ${currentWorkspaceId}`
         );
 
         if (isDaintreeEnvEnabled("DAINTREE_VERBOSE")) {
-          logDebug(`Project: ${currentProjectId.slice(0, 8)}`);
+          logDebug(`Project: ${currentWorkspaceId.slice(0, 8)}`);
           logDebug("Backend terminals", {
             terminals: backendTerminals.map((t) => ({
               id: t.id.slice(0, 8),
@@ -444,9 +452,9 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
         // appState.terminals is TerminalState[] (IPC wire type, more
         // lenient); the on-disk data was written by panelToSnapshot so is
         // structurally PanelSnapshot[].
-        if (currentProjectId && appState.terminals && appState.terminals.length > 0) {
+        if (currentWorkspaceId && appState.terminals && appState.terminals.length > 0) {
           panelPersistence.primeProject(
-            currentProjectId,
+            currentWorkspaceId,
             appState.terminals as unknown as PanelSnapshot[]
           );
         }
@@ -575,9 +583,9 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
             // save can emit correct removals and Main can merge concurrent
             // writes from sibling windows instead of resurrecting deleted
             // groups (#11350). Mirrors the terminal `primeProject` above.
-            if (currentProjectId) {
+            if (currentWorkspaceId) {
               panelPersistence.primeTabGroups(
-                currentProjectId,
+                currentWorkspaceId,
                 tabGroups.filter((g) => g && Array.isArray(g.panelIds) && g.panelIds.length > 1)
               );
             }


### PR DESCRIPTION
## Summary

- Scratch workspaces never wrote their panel grid to disk and never read it back, so destroying the cached `WebContentsView` (LRU eviction, memory pressure, a view crash, or an app restart) took the whole grid with it, while the underlying PTYs kept running invisibly in the pty-host, unreferenced by the rebuilt view.
- Three separate failure points had to move together here. Fixing only the renderer getter would have converted a silent skip into a thrown `Invalid project ID`.

Resolves #11484

## Changes

Five touchpoints:

1. `electron/services/projectStorePaths.ts`: `getProjectStateDir` now gates on a new `isValidWorkspaceStateId` (project id OR scratch UUID) instead of `isValidProjectId`. It's the single choke point every state/settings/recipes path funnels through, so this one change unblocks all four throw sites (`ProjectStateManager`, `ProjectSettingsManager`, `ProjectFileStore`, `ProjectStore.removeProject`). The two id shapes are provably disjoint (64 char hex with no dashes vs. UUIDv4), so a scratch can share `userData/projects/<id>/` and reuse all of `ProjectStateManager`'s atomic write, quarantine, and recovery machinery with zero collision risk. `isValidProjectId` itself is untouched, so the git-tracked `.daintree/project.json` anchor stays project-only. `scratchStorePaths.isValidScratchId` now delegates to the new predicate, so there's one source of truth for the shape.
2. `electron/ipc/projectContext.ts`: `ScopedProjectResolution` gains `workspaceId`. The new `resolveWorkspaceById` distinguishes "row exists but is closed" (refuse, since hydrating it would resurrect a workspace the user closed) from "no row at all" (a scratch, so serve it). Resolution stays fully synchronous.
3. `electron/ipc/handlers/app/state.ts`: `app:hydrate` keys its per-workspace state read/write on `workspaceId`. The legacy global-terminal and focus-mode migrations stay gated on a real `Project`, so a scratch can never inherit panels that belonged to whichever project was open in the pre-per-project-state era.
4. `shared/types/ipc/app.ts` and `src/utils/stateHydration/index.ts`: `HydrateResult` carries `workspaceId`, and the renderer's restore gate becomes workspace-scoped. This is the touchpoint the issue doesn't name, and the one that actually reconnects the orphaned PTYs: `terminalClient.getForProject()` was gated on `hydrateResult.project?.id`, so a scratch view never asked the pty-host what was still running. The backend was never the blocker. `TerminalRegistry.getForProject` does opaque string matching, and terminals are already stamped with the scratch id (#11079). Recipes and in-repo presets stay project-gated, since scratch folders aren't git repos.
5. `src/store/projectStore.ts`: the panel-persistence getter falls back to the view's own workspace id, mirroring the existing `getViewWorkspaceId()` pattern in `panelRegistry/addPanel` and `restart`. The fallback is deliberately narrow. `currentProject` is also null for a closed project, and persisting there would let a view that restored nothing overwrite that project's saved grid with an empty one. So only an id naming no project row at all counts as a scratch.

Cleanup: a scratch's state directory is now removed on both deletion paths, `ScratchStore.removeScratch` and the `ScratchCleanupService` TTL reap, via a new `ProjectStore.removeWorkspaceStateDir`. It's imported lazily so the `ProjectStore` singleton isn't dragged into every suite that touches a scratch. Without this the state dir would have leaked forever, since only the working directory under `scratches/<uuid>/` was ever reaped.

## Testing

565 tests pass across the 20 suites covering every changed module. Typecheck is clean, and the lint ratchet passes with warnings down 2.

New coverage:
- A scratch id round-trips a state dir and the id spaces stay disjoint (`projectStorePaths`).
- A scratch's corrupted state file gets quarantine-swept (`projectQuarantineCleanup`).
- Hydrate restores a grid for a workspace with no `Project` row and never inherits the legacy global terminals (`app.state`).
- A closed project resolves to a null workspace.
- The renderer reconnects live PTYs and restores layout for a project-less view, while repo-only work stays project-gated (`stateHydration.payloadFolding`).
- The persistence getter falls back to the view workspace but refuses a closed project (`projectStore.persistence`).
- Both scratch-deletion paths drop the persisted state (`ScratchStore`, `ScratchCleanupService`).

Note for reviewers: I deliberately didn't thread a workspace path for the `projectRoot` cwd fallback. Every saved snapshot and every backend terminal carries its own `cwd`, so that fallback is unreachable in practice, and pulling `ScratchStore` into the hydrate hot path would add real risk for a speculative case.
