### PR TITLE
feat(slash-commands): share /goal across Claude Code and Codex

### DIFF
--- a/shared/types/__tests__/slashCommands.test.ts
+++ b/shared/types/__tests__/slashCommands.test.ts
@@ -80,11 +80,13 @@ describe("getBuiltinSlashCommands", () => {
   });
 
   it("applies per-agent description overrides for /goal", () => {
+    const entry = BUILTIN_SLASH_COMMANDS.find((e) => e.id === "goal");
     const claudeGoal = getBuiltinSlashCommands("claude").find((c) => c.label === "/goal");
     const codexGoal = getBuiltinSlashCommands("codex").find((c) => c.label === "/goal");
 
-    expect(claudeGoal?.description).toBeTruthy();
-    expect(codexGoal?.description).toBeTruthy();
+    expect(entry?.descriptions?.codex).toBeTruthy();
+    expect(claudeGoal?.description).toBe(entry?.description);
+    expect(codexGoal?.description).toBe(entry?.descriptions?.codex);
     expect(claudeGoal?.description).not.toBe(codexGoal?.description);
   });
 

--- a/shared/types/__tests__/slashCommands.test.ts
+++ b/shared/types/__tests__/slashCommands.test.ts
@@ -20,8 +20,8 @@ describe("BUILTIN_SLASH_COMMANDS registry", () => {
 });
 
 describe("getBuiltinSlashCommands", () => {
-  it("returns 33 commands for claude", () => {
-    expect(getBuiltinSlashCommands("claude")).toHaveLength(33);
+  it("returns 34 commands for claude", () => {
+    expect(getBuiltinSlashCommands("claude")).toHaveLength(34);
   });
 
   it("returns 27 commands for gemini", () => {
@@ -79,10 +79,25 @@ describe("getBuiltinSlashCommands", () => {
     expect(geminiClear?.description).toBe("Clear the terminal display");
   });
 
+  it("applies per-agent description overrides for /goal", () => {
+    const claudeGoal = getBuiltinSlashCommands("claude").find((c) => c.label === "/goal");
+    const codexGoal = getBuiltinSlashCommands("codex").find((c) => c.label === "/goal");
+
+    expect(claudeGoal?.description).toBeTruthy();
+    expect(codexGoal?.description).toBeTruthy();
+    expect(claudeGoal?.description).not.toBe(codexGoal?.description);
+  });
+
   it("/compact appears for claude and codex but not gemini", () => {
     expect(getBuiltinSlashCommands("claude").some((c) => c.label === "/compact")).toBe(true);
     expect(getBuiltinSlashCommands("codex").some((c) => c.label === "/compact")).toBe(true);
     expect(getBuiltinSlashCommands("gemini").some((c) => c.label === "/compact")).toBe(false);
+  });
+
+  it("/goal appears for claude and codex but not gemini", () => {
+    expect(getBuiltinSlashCommands("claude").some((c) => c.label === "/goal")).toBe(true);
+    expect(getBuiltinSlashCommands("codex").some((c) => c.label === "/goal")).toBe(true);
+    expect(getBuiltinSlashCommands("gemini").some((c) => c.label === "/goal")).toBe(false);
   });
 
   it("/compress appears for gemini only", () => {

--- a/shared/types/slashCommands.ts
+++ b/shared/types/slashCommands.ts
@@ -175,6 +175,13 @@ const BUILTIN_SLASH_COMMANDS: readonly BuiltinSlashCommandEntry[] = [
     description: "Summarize history to save tokens",
     supportedAgents: ["claude", "codex"],
   },
+  {
+    id: "goal",
+    label: "/goal",
+    description: "Set a goal that must be met before stopping",
+    descriptions: { codex: "Manage the session goal (edit, pause, resume, clear)" },
+    supportedAgents: ["claude", "codex"],
+  },
 
   // Claude-only
   {
@@ -369,12 +376,6 @@ const BUILTIN_SLASH_COMMANDS: readonly BuiltinSlashCommandEntry[] = [
     id: "plan",
     label: "/plan",
     description: "Draft a plan before acting",
-    supportedAgents: ["codex"],
-  },
-  {
-    id: "goal",
-    label: "/goal",
-    description: "Set the session goal",
     supportedAgents: ["codex"],
   },
   {


### PR DESCRIPTION
## Summary

- `/goal` was listed as Codex only in `shared/types/slashCommands.ts`, with the stale description `Set the session goal`. Claude Code 2.1.220 now ships `/goal` too, and Codex's own `/goal` has grown a subcommand family since that entry was written.
- Moves `/goal` out of the Codex only discovery batch into the shared `claude + codex` group (alphabetically after `/compact`), with `supportedAgents: ["claude", "codex"]`.
- Base description is now "Set a goal that must be met before stopping"; a Codex specific override adds "Manage the session goal (edit, pause, resume, clear)".

Resolves #11490

## Changes

- `shared/types/slashCommands.ts`: relocated the `/goal` entry, updated the base description and added the Codex override.
- `shared/types/__tests__/slashCommands.test.ts`: Claude count moves 33 to 34 (Codex stays at 35, it's just changing groups; Gemini stays at 27). Added a `/goal` membership test and a per agent description override test that derives its expectations from `BUILTIN_SLASH_COMMANDS` instead of copying literal strings.

Wording came from the installed binaries, not the web. Claude Code 2.1.220 registers `/goal` as "Set a goal Claude checks before stopping" with argument hint `[<condition> | clear]`. Codex 0.146.0 exposes `/goal edit`, `/goal pause`, `/goal clear`, and `/goal resume` once paused. A web search turned up a plausible looking but unverifiable `/goal view` subcommand that doesn't exist in the binary, so it's left out.

The block comment referencing the installed Codex v0.144.1 batch is untouched on purpose. It records the provenance of that Codex only discovery batch, and bumping it would falsely imply the whole block got re-audited when only this one entry moved.

## Testing

- 140 tests across 7 files pass: `slashCommands.test.ts`, `slashCommandsClient.test.ts`, `slashCommandMatch.test.ts`, `slashAutocompleteItems.test.ts`, `SlashCommandService.test.ts`, `CompletionDiscoveryEngine.test.ts`, `hybridInputParsing.test.ts`.
- `prettier --check` and `eslint` clean on both changed files.
- No e2e coverage exists for slash commands.
