### PR TITLE
fix(file-browser): keep a promoted workspace-rooted browser on its own folder

### DIFF
--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -281,6 +281,12 @@ export interface FileBrowserPanelOptions extends AddPanelOptionsBase {
   browserTreeSnapshot?: FileBrowserTreeSnapshot;
   /** Tree column width in px to restore; absent or 288 = the default width */
   browserSidebarWidth?: number;
+  /**
+   * Restores a workspace-rooted panel whose `worktreeId` is grid placement
+   * only (#11489). On a fresh open it is the absence of `worktreeId` that
+   * decides this, so openers never pass it.
+   */
+  browserWorkspaceRooted?: boolean;
 }
 
 /**

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -748,11 +748,13 @@ export interface FileBrowserTreeSnapshot {
  * root comes from `worktreeId`, like `DiffPanelData.filePath`), so moving or
  * renaming the folder can't strand the panel on a dead path.
  *
- * An absent `worktreeId` roots the tree at the *view's own workspace* — the
- * project or scratch folder it was created for (#11482). Deliberately no
- * absolute root is stored for that case either: main derives it from the same
- * sender binding it authorizes against, so resolving it fresh on both sides is
- * what keeps them from ever disagreeing.
+ * A panel opened without a worktree is rooted at the *view's own workspace* —
+ * the project or scratch folder it was created for (#11482) — and records that
+ * as `browserWorkspaceRooted`, because grid promotion later stamps a
+ * placement `worktreeId` onto it (#11290) and absence alone would stop
+ * answering (#11489). Deliberately no absolute root is stored for that case
+ * either: main derives it from the same sender binding it authorizes against,
+ * so resolving it fresh on both sides is what keeps them from ever disagreeing.
  *
  * Every field persists: the issue's contract is that a pinned panel keeps its
  * expansion, selection and layout, and `promoteDialogPanelToGrid` reuses the
@@ -803,6 +805,18 @@ export interface FileBrowserPanelData extends BasePanelData {
    * it, so re-opening restores the last-dragged width (#11331).
    */
   browserSidebarWidth?: number;
+  /**
+   * Whether the tree is rooted at the view's workspace folder — a scratch or
+   * worktree-less project root (#11482) — rather than at `worktreeId`.
+   *
+   * Decided once at creation from the absence of a requested worktree, and
+   * never changed by a placement gesture. Promotion into the grid adopts the
+   * active worktree so the panel lands in a rendered index bucket (#11290);
+   * for a workspace-rooted panel that id is placement metadata only, and
+   * re-deriving the browse root from it silently re-roots the tree to a folder
+   * the user never asked for (#11489). Only `true` is persisted.
+   */
+  browserWorkspaceRooted?: boolean;
 }
 
 export type PanelInstance =

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -236,6 +236,12 @@ export interface PanelSnapshot {
   browserTreeSnapshot?: FileBrowserTreeSnapshot;
   /** File browser tree column width in px (only a non-default, in-range value persisted) */
   browserSidebarWidth?: number;
+  /**
+   * Whether a file browser panel browses the view's workspace root rather than
+   * its `worktreeId`, which for such a panel is grid placement only (#11489).
+   * Only `true` is persisted.
+   */
+  browserWorkspaceRooted?: boolean;
   /** Legacy pre-file-panel field: absolute path shown in a markdown panel */
   markdownFilePath?: string;
   /** Legacy pre-file-panel field: markdown panel view mode */

--- a/src/config/panelKindSerialisers.ts
+++ b/src/config/panelKindSerialisers.ts
@@ -275,6 +275,10 @@ const BUILT_IN_DESERIALIZERS = {
     // hand-edited snapshot falls back to the default rather than becoming a
     // broken inline `style.width` (#11331).
     browserSidebarWidth: normalizeFileBrowserSidebarWidth(saved.browserSidebarWidth),
+    // Literal `true` only: anything else leaves the field absent so the create
+    // path re-derives rooting from `worktreeId` instead of trusting a corrupted
+    // value to redirect the browse root (#11489).
+    browserWorkspaceRooted: saved.browserWorkspaceRooted === true ? true : undefined,
   }),
   diff: (saved) => ({
     filePath: saved.filePath,

--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -286,6 +286,10 @@ const FILE_BROWSER_FIELD_CLASSIFICATION = {
   // eviction.
   browserTreeSnapshot: true,
   browserSidebarWidth: true,
+  // Which folder the panel browses. Derivable from an absent `worktreeId` only
+  // at creation — a promoted panel carries an adopted placement id by save time
+  // (#11489) — so it has to ride the record like any other user intent.
+  browserWorkspaceRooted: true,
   // BasePanelData carrier-bookkeeping timestamps — written by the base
   // serialization layer in panelToSnapshot, not per-kind serializers.
   createdAt: false,
@@ -477,6 +481,7 @@ const fileBrowserFixture: FileBrowserPanelData = {
   // A non-default width (the serializer omits 288), so the coverage spread emits
   // the key instead of dropping it as a default.
   browserSidebarWidth: 360,
+  browserWorkspaceRooted: true,
 };
 
 const savedFileBrowser: SavedTerminalData = {
@@ -489,6 +494,7 @@ const savedFileBrowser: SavedTerminalData = {
   browserSidebarCollapsed: true,
   browserTreeSnapshot: browserTreeSnapshotFixture,
   browserSidebarWidth: 360,
+  browserWorkspaceRooted: true,
 };
 
 const diffFixture: DiffPanelData = {

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -148,12 +148,27 @@ export function FileBrowserPane({
     )
   );
 
+  const workspaceRooted = usePanelStore(
+    useCallback(
+      (state) => {
+        const panel = state.panelsById[id];
+        return panel?.kind === "file-browser" ? panel.browserWorkspaceRooted === true : false;
+      },
+      [id]
+    )
+  );
+  // The worktree this panel *browses*, which is not the one it is placed under:
+  // promotion into the grid stamps the active worktree onto a workspace-rooted
+  // panel so it lands in a rendered index bucket (#11290), and following that
+  // id here would re-root the tree to a folder the user never opened (#11489).
+  const sourceWorktreeId = workspaceRooted ? undefined : worktreeId;
+
   // Resolved fresh from the worktree store rather than persisted, so a rename
   // or move is reflected without restarting the panel.
   const worktreePath = useWorktreeStore(
     useCallback(
-      (state) => (worktreeId ? (state.worktrees.get(worktreeId)?.path ?? "") : ""),
-      [worktreeId]
+      (state) => (sourceWorktreeId ? (state.worktrees.get(sourceWorktreeId)?.path ?? "") : ""),
+      [sourceWorktreeId]
     )
   );
   // The fallback root for a panel with no worktree: this view's own project or
@@ -169,11 +184,13 @@ export function FileBrowserPane({
     // Presence, not truthiness: a persisted `worktreeId: ""` names a worktree
     // that cannot resolve, and treating it as absent would quietly browse the
     // workspace root instead of refusing it.
-    if (worktreeId !== undefined) {
-      return worktreePath ? { kind: "worktree", worktreeId, basePath: worktreePath } : null;
+    if (sourceWorktreeId !== undefined) {
+      return worktreePath
+        ? { kind: "worktree", worktreeId: sourceWorktreeId, basePath: worktreePath }
+        : null;
     }
     return workspaceRootPath ? { kind: "workspace", basePath: workspaceRootPath } : null;
-  }, [worktreeId, worktreePath, workspaceRootPath]);
+  }, [sourceWorktreeId, worktreePath, workspaceRootPath]);
 
   // Everything path-shaped in the pane joins against this: the tree's rows are
   // relative to it in both modes.
@@ -186,8 +203,10 @@ export function FileBrowserPane({
   const gitChangeTick = useWorktreeStore(
     useCallback(
       (state) =>
-        worktreeId ? state.worktrees.get(worktreeId)?.worktreeChanges?.lastUpdated : undefined,
-      [worktreeId]
+        sourceWorktreeId
+          ? state.worktrees.get(sourceWorktreeId)?.worktreeChanges?.lastUpdated
+          : undefined,
+      [sourceWorktreeId]
     )
   );
   // The raw filesystem-write tick, independent of git status. Combining the two
@@ -196,8 +215,9 @@ export function FileBrowserPane({
   // snapshots) never advances (#11330).
   const fsChangeTick = useWorktreeStore(
     useCallback(
-      (state) => (worktreeId ? state.workingTreeChangedAtById.get(worktreeId) : undefined),
-      [worktreeId]
+      (state) =>
+        sourceWorktreeId ? state.workingTreeChangedAtById.get(sourceWorktreeId) : undefined,
+      [sourceWorktreeId]
     )
   );
   // A single monotonic signal for "re-read the tree/file": whichever moved most
@@ -449,14 +469,14 @@ export function FileBrowserPane({
 
   const handleCopyFolderContext = useCallback(
     (path: string) => {
-      if (!worktreeId) return;
+      if (!sourceWorktreeId) return;
       // Literal path, not a pattern: scoping keeps the worktree's ignore rules
       // in play, so the folder yields what a whole-worktree copy would have.
-      void copyContextWithFeedback(worktreeId, "context-menu", {
+      void copyContextWithFeedback(sourceWorktreeId, "context-menu", {
         scopePaths: [path],
       });
     },
-    [worktreeId]
+    [sourceWorktreeId]
   );
 
   const copyToClipboard = useCallback((text: string, errorTitle: string) => {

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -56,6 +56,7 @@ interface MockPanel {
   browserRootPath?: string;
   browserSidebarCollapsed?: boolean;
   browserSidebarWidth?: number;
+  browserWorkspaceRooted?: boolean;
 }
 
 const mockPanel: MockPanel = { id: "fb-1", kind: "file-browser" };
@@ -234,6 +235,7 @@ beforeEach(() => {
   mockPanel.browserRootPath = undefined;
   mockPanel.browserShowIgnored = undefined;
   mockPanel.browserSidebarWidth = undefined;
+  mockPanel.browserWorkspaceRooted = undefined;
   for (const name of ["matchMedia"] as const) {
     if (typeof window[name] !== "function") {
       Object.defineProperty(window, name, {
@@ -1086,5 +1088,50 @@ describe("workspace-rooted browser", () => {
     renderPane({ worktreeId: "wt-missing" });
 
     expect(screen.getByText("Open a folder to browse its files")).toBeTruthy();
+  });
+});
+
+/**
+ * Promotion into the grid stamps the active worktree onto a workspace-rooted
+ * panel so it lands in a rendered index bucket (#11290). That id is placement
+ * only — a resolvable one, so nothing fails loudly; the panel just quietly
+ * showed the wrong folder until #11489.
+ */
+describe("promoted workspace-rooted browser (#11489)", () => {
+  it("keeps browsing the workspace after promotion stamps a placement worktree", async () => {
+    workspaceRootPathMock.mockReturnValue("/scratches/one");
+    mockPanel.browserWorkspaceRooted = true;
+    renderPane({ worktreeId: "wt-1" });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Copy full path" }));
+    });
+
+    // wt-1 resolves to "/repo", which is what this joined against before the fix.
+    expect(writeTextMock).toHaveBeenCalledWith(`/scratches/one/${FOLDER_ROW.path}`);
+  });
+
+  it("hides Copy context for a promoted workspace-rooted browser", () => {
+    workspaceRootPathMock.mockReturnValue("/scratches/one");
+    mockPanel.browserWorkspaceRooted = true;
+    renderPane({ worktreeId: "wt-1" });
+
+    expect(screen.queryByRole("button", { name: "Copy context" })).toBeNull();
+  });
+
+  it("still refuses to render when the workspace root is unknown", () => {
+    // The placement worktree resolves, but it is not this panel's folder — so
+    // an unresolved workspace is the unbound case, not a reason to use it.
+    mockPanel.browserWorkspaceRooted = true;
+    renderPane({ worktreeId: "wt-1" });
+
+    expect(screen.getByText("Open a folder to browse its files")).toBeTruthy();
+  });
+
+  it("leaves an unmarked worktree panel on its worktree", () => {
+    workspaceRootPathMock.mockReturnValue("/scratches/one");
+    renderPane({ worktreeId: "wt-1" });
+
+    expect(screen.getByRole("button", { name: "Copy context" })).toBeTruthy();
   });
 });

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -9,43 +9,49 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // FileBrowserViewer so the toggle and the shared toolbar `Root` actually render
 // — that's what makes the aria-controls and header-alignment invariants real.
 
-const { setFileBrowserViewMock, readMock, treeState, defaultRows } = vi.hoisted(() => {
-  const defaultRows = [
-    {
-      path: "src",
-      name: "src",
-      isDirectory: true,
-      depth: 0,
-      isExpanded: true,
-      isLoading: false,
-    },
-    // A file row so a selection can resolve a real viewer path.
-    {
-      path: "src/app.ts",
-      name: "app.ts",
-      isDirectory: false,
-      depth: 1,
-      isExpanded: false,
-      isLoading: false,
-    },
-  ];
-  return {
-    setFileBrowserViewMock: vi.fn(),
-    readMock: vi.fn(),
-    defaultRows,
-    // Mutable so individual tests can drive error/loading/capture states.
-    treeState: {
-      rows: defaultRows as typeof defaultRows,
-      isInitialLoading: false,
-      rootError: null as string | null,
-      hasHiddenDotfiles: false,
-      ensureLoaded: vi.fn(),
-      refresh: vi.fn(),
-      isRefreshing: false,
-      captureSnapshot: (() => null) as () => unknown,
-    },
-  };
-});
+const { setFileBrowserViewMock, readMock, treeState, defaultRows, treeArgs, worktreeTicks } =
+  vi.hoisted(() => {
+    const defaultRows = [
+      {
+        path: "src",
+        name: "src",
+        isDirectory: true,
+        depth: 0,
+        isExpanded: true,
+        isLoading: false,
+      },
+      // A file row so a selection can resolve a real viewer path.
+      {
+        path: "src/app.ts",
+        name: "app.ts",
+        isDirectory: false,
+        depth: 1,
+        isExpanded: false,
+        isLoading: false,
+      },
+    ];
+    return {
+      setFileBrowserViewMock: vi.fn(),
+      readMock: vi.fn(),
+      defaultRows,
+      // Mutable so individual tests can drive error/loading/capture states.
+      treeState: {
+        rows: defaultRows as typeof defaultRows,
+        isInitialLoading: false,
+        rootError: null as string | null,
+        hasHiddenDotfiles: false,
+        ensureLoaded: vi.fn(),
+        refresh: vi.fn(),
+        isRefreshing: false,
+        captureSnapshot: (() => null) as () => unknown,
+      },
+      // What the pane last handed the tree hook, so a test can assert the derived
+      // change tick rather than only what renders.
+      treeArgs: { changeTick: undefined as number | undefined },
+      // Ticks the worktree store reports for wt-1; both default to "never moved".
+      worktreeTicks: { git: undefined as number | undefined, fs: undefined as number | undefined },
+    };
+  });
 
 interface MockPanel {
   id: string;
@@ -72,10 +78,21 @@ vi.mock("@/store/panelStore", () => ({
 vi.mock("@/hooks/useWorktreeStore", () => ({
   useWorktreeStore: (selector: (state: unknown) => unknown) =>
     selector({
-      worktrees: new Map([["wt-1", { path: "/repo", worktreeChanges: undefined }]]),
+      worktrees: new Map([
+        [
+          "wt-1",
+          {
+            path: "/repo",
+            worktreeChanges:
+              worktreeTicks.git === undefined ? undefined : { lastUpdated: worktreeTicks.git },
+          },
+        ],
+      ]),
       // The pane reads the raw filesystem-write side map for its change tick
       // (#11330); an absent map would crash the `.get(worktreeId)` selector.
-      workingTreeChangedAtById: new Map<string, number>(),
+      workingTreeChangedAtById: new Map<string, number>(
+        worktreeTicks.fs === undefined ? [] : [["wt-1", worktreeTicks.fs]]
+      ),
     }),
 }));
 
@@ -83,7 +100,10 @@ vi.mock("@/hooks/useWorktreeStore", () => ({
 // state bag so the tree column renders its header (and the FileTreeView stub
 // below) without touching filesClient, and tests can drive error states.
 vi.mock("../useFileBrowserTree", () => ({
-  useFileBrowserTree: () => ({ ...treeState }),
+  useFileBrowserTree: (args: { changeTick?: number }) => {
+    treeArgs.changeTick = args.changeTick;
+    return { ...treeState };
+  },
 }));
 
 // The pane flushes panel persistence when the view hides; the real module
@@ -236,6 +256,9 @@ beforeEach(() => {
   mockPanel.browserShowIgnored = undefined;
   mockPanel.browserSidebarWidth = undefined;
   mockPanel.browserWorkspaceRooted = undefined;
+  treeArgs.changeTick = undefined;
+  worktreeTicks.git = undefined;
+  worktreeTicks.fs = undefined;
   for (const name of ["matchMedia"] as const) {
     if (typeof window[name] !== "function") {
       Object.defineProperty(window, name, {
@@ -1133,5 +1156,27 @@ describe("promoted workspace-rooted browser (#11489)", () => {
     renderPane({ worktreeId: "wt-1" });
 
     expect(screen.getByRole("button", { name: "Copy context" })).toBeTruthy();
+  });
+
+  it("follows its own worktree's change ticks when it is not workspace-rooted", () => {
+    worktreeTicks.git = 120;
+    worktreeTicks.fs = 450;
+    renderPane({ worktreeId: "wt-1" });
+
+    // Whichever moved most recently, per the pane's Math.max of the two sources.
+    expect(treeArgs.changeTick).toBe(450);
+  });
+
+  it("ignores the placement worktree's change ticks once workspace-rooted", () => {
+    // Both tick maps are keyed by worktree, so a workspace source has no tick at
+    // all — following the placement worktree's would refresh the tree on writes
+    // in a folder this panel isn't showing.
+    worktreeTicks.git = 120;
+    worktreeTicks.fs = 450;
+    workspaceRootPathMock.mockReturnValue("/scratches/one");
+    mockPanel.browserWorkspaceRooted = true;
+    renderPane({ worktreeId: "wt-1" });
+
+    expect(treeArgs.changeTick).toBeUndefined();
   });
 });

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -1158,13 +1158,22 @@ describe("promoted workspace-rooted browser (#11489)", () => {
     expect(screen.getByRole("button", { name: "Copy context" })).toBeTruthy();
   });
 
-  it("follows its own worktree's change ticks when it is not workspace-rooted", () => {
-    worktreeTicks.git = 120;
-    worktreeTicks.fs = 450;
+  it("follows its own worktree's git tick when it is not workspace-rooted", () => {
+    // Asserted per source rather than together: with both set, the larger one
+    // alone satisfies the Math.max and a disconnected sibling selector reads
+    // green.
+    worktreeTicks.git = 450;
+    worktreeTicks.fs = 120;
     renderPane({ worktreeId: "wt-1" });
 
-    // Whichever moved most recently, per the pane's Math.max of the two sources.
     expect(treeArgs.changeTick).toBe(450);
+  });
+
+  it("follows its own worktree's filesystem tick when it is not workspace-rooted", () => {
+    worktreeTicks.fs = 300;
+    renderPane({ worktreeId: "wt-1" });
+
+    expect(treeArgs.changeTick).toBe(300);
   });
 
   it("ignores the placement worktree's change ticks once workspace-rooted", () => {

--- a/src/panels/file-browser/__tests__/serializer.test.ts
+++ b/src/panels/file-browser/__tests__/serializer.test.ts
@@ -16,10 +16,15 @@ const basePanel: FileBrowserPanelData = {
  * Re-enter the create path with a serialized snapshot fragment. The snapshot is
  * a flat bag shared by every kind, so its `kind` is the open `PanelKind` union
  * — pin the discriminant here rather than spreading it through.
+ *
+ * `worktreeId` rides the base object rather than the per-kind fragment
+ * `serializeFileBrowser` returns, so restore carries it separately; supplying
+ * one here keeps these cases worktree-rooted, which is what their fixtures
+ * describe. The workspace-rooted cases below omit it deliberately.
  */
 function asOptions(snapshot: Partial<PanelSnapshot>): FileBrowserPanelOptions {
   const { kind: _kind, ...rest } = snapshot;
-  return { ...rest, kind: "file-browser" };
+  return { ...rest, kind: "file-browser", worktreeId: "wt-1" };
 }
 
 describe("serializeFileBrowser", () => {
@@ -142,12 +147,66 @@ describe("serializeFileBrowser", () => {
       browserSidebarWidth: 360,
     });
   });
+
+  it("persists workspace rooting so a promoted panel keeps its folder (#11489)", () => {
+    // Promotion into the grid adopts the active worktree as a placement key, so
+    // by save time an absent worktreeId no longer distinguishes the two — the
+    // marker is the only thing that survives to say which folder to browse.
+    const promoted: FileBrowserPanelData = {
+      ...basePanel,
+      worktreeId: "wt-1",
+      browserWorkspaceRooted: true,
+    };
+
+    expect(serializeFileBrowser(promoted)).toEqual({ browserWorkspaceRooted: true });
+
+    const restored = createFileBrowserDefaults({
+      ...asOptions(serializeFileBrowser(promoted)),
+      worktreeId: "wt-1",
+    });
+    expect(restored).toEqual({ browserWorkspaceRooted: true });
+  });
+
+  it("keeps a worktree-rooted panel sparse rather than writing the marker false", () => {
+    const worktreeRooted: FileBrowserPanelData = {
+      ...basePanel,
+      worktreeId: "wt-1",
+      browserWorkspaceRooted: false,
+    };
+
+    expect(serializeFileBrowser(worktreeRooted)).toEqual({});
+  });
 });
 
 describe("createFileBrowserDefaults", () => {
-  it("produces no fields when the opener passes only the kind", () => {
+  it("produces no fields when the opener names a worktree and nothing else", () => {
     // The sidebar entry point opens the browser with nothing but a worktree, so
     // this is the common path — it must not stamp defaults that then persist.
-    expect(createFileBrowserDefaults({ kind: "file-browser" })).toEqual({});
+    expect(createFileBrowserDefaults({ kind: "file-browser", worktreeId: "wt-1" })).toEqual({});
+  });
+
+  it("marks a panel opened without a worktree as workspace-rooted (#11489)", () => {
+    expect(createFileBrowserDefaults({ kind: "file-browser" })).toEqual({
+      browserWorkspaceRooted: true,
+    });
+  });
+
+  it("treats an unresolvable empty worktree id as naming a worktree, not as absent", () => {
+    // Fail closed, matching the pane's presence check: "" names a worktree that
+    // cannot resolve, and browsing the workspace root instead would be the wrong
+    // folder rather than a degraded one.
+    expect(createFileBrowserDefaults({ kind: "file-browser", worktreeId: "" })).toEqual({});
+  });
+
+  it("keeps a restored workspace-rooted panel workspace-rooted despite an adopted worktree", () => {
+    // The shape a promoted panel persists: grid placement stamped a worktreeId
+    // on it (#11290), so only the marker still tells the two apart.
+    expect(
+      createFileBrowserDefaults({
+        kind: "file-browser",
+        worktreeId: "wt-1",
+        browserWorkspaceRooted: true,
+      })
+    ).toEqual({ browserWorkspaceRooted: true });
   });
 });

--- a/src/panels/file-browser/defaults.ts
+++ b/src/panels/file-browser/defaults.ts
@@ -10,6 +10,16 @@ export function createFileBrowserDefaults(
   options: FileBrowserPanelOptions
 ): Partial<FileBrowserPanelData> {
   const width = normalizeFileBrowserSidebarWidth(options.browserSidebarWidth);
+  // Source identity is settled here, once, rather than at each placement site:
+  // promotion into the grid adopts the active worktree so the panel lands in a
+  // rendered index bucket (#11290), and every later mutation spreads the panel
+  // record — so a marker set at creation survives all of them, while re-reading
+  // `worktreeId` at render time would follow the adopted id and silently re-root
+  // the tree (#11489). `=== undefined`, not truthiness: a `worktreeId: ""` names
+  // a worktree that cannot resolve and must refuse rather than quietly fall back
+  // to the workspace root.
+  const workspaceRooted =
+    options.browserWorkspaceRooted === true || options.worktreeId === undefined;
   return {
     // `!= null` rather than truthiness: an explicit `false` for the dotfile
     // toggle is a deliberate choice, and dropping it here would let a later
@@ -38,5 +48,6 @@ export function createFileBrowserDefaults(
     // so a default-width panel stays sparse just like the collapsed bit.
     ...(width != null &&
       width !== FILE_BROWSER_SIDEBAR_DEFAULT_WIDTH && { browserSidebarWidth: width }),
+    ...(workspaceRooted && { browserWorkspaceRooted: true }),
   };
 }

--- a/src/panels/file-browser/serializer.ts
+++ b/src/panels/file-browser/serializer.ts
@@ -29,5 +29,10 @@ export function serializeFileBrowser(t: FileBrowserPanelData): Partial<PanelSnap
     t.browserSidebarWidth !== FILE_BROWSER_SIDEBAR_DEFAULT_WIDTH
       ? { browserSidebarWidth: t.browserSidebarWidth }
       : {}),
+    // Truthiness, and only `true` is written: a worktree-rooted panel simply
+    // omits the field. It must persist even though it is derivable from an
+    // absent `worktreeId` at creation, because a promoted panel carries an
+    // adopted placement `worktreeId` by the time it is saved (#11489).
+    ...(t.browserWorkspaceRooted ? { browserWorkspaceRooted: true } : {}),
   };
 }

--- a/src/panels/file-browser/serializer.ts
+++ b/src/panels/file-browser/serializer.ts
@@ -29,10 +29,12 @@ export function serializeFileBrowser(t: FileBrowserPanelData): Partial<PanelSnap
     t.browserSidebarWidth !== FILE_BROWSER_SIDEBAR_DEFAULT_WIDTH
       ? { browserSidebarWidth: t.browserSidebarWidth }
       : {}),
-    // Truthiness, and only `true` is written: a worktree-rooted panel simply
-    // omits the field. It must persist even though it is derivable from an
-    // absent `worktreeId` at creation, because a promoted panel carries an
-    // adopted placement `worktreeId` by the time it is saved (#11489).
-    ...(t.browserWorkspaceRooted ? { browserWorkspaceRooted: true } : {}),
+    // Literal `true`, matching the deserializer and the pane: a worktree-rooted
+    // panel simply omits the field, and a truthiness test here would launder a
+    // corrupt in-memory value into a valid one, making the redirection durable.
+    // It must persist even though creation derives it from an absent
+    // `worktreeId`, because a promoted panel carries an adopted placement
+    // `worktreeId` by the time it is saved (#11489).
+    ...(t.browserWorkspaceRooted === true ? { browserWorkspaceRooted: true } : {}),
   };
 }

--- a/src/services/actions/definitions/worktreeContextActions.ts
+++ b/src/services/actions/definitions/worktreeContextActions.ts
@@ -498,9 +498,11 @@ export function registerWorktreeContextActions(
           };
         }
 
-        // No `worktreeId` for a workspace root: its absence is what tells both
-        // the pane and main to resolve the view's own workspace folder, which
-        // neither side ever names explicitly.
+        // No `worktreeId` for a workspace root: its absence is what tells the
+        // create path to resolve the view's own workspace folder, which nothing
+        // ever names explicitly. `createFileBrowserDefaults` records that as
+        // `browserWorkspaceRooted`, since grid promotion later stamps a
+        // placement worktreeId onto the panel (#11489).
         await usePanelDialogStore.getState().openPanelDialog({
           kind: "file-browser",
           title: worktree ? `Files — ${worktree.branch ?? worktree.name}` : workspaceTitle,

--- a/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { FilePanelData, PanelInstance, PtyPanelData, TabGroup } from "@shared/types/panel";
+import type {
+  FileBrowserPanelData,
+  FilePanelData,
+  PanelInstance,
+  PtyPanelData,
+  TabGroup,
+} from "@shared/types/panel";
 import { setWorktreeSelectionAccessor } from "@/store/storeAccessors";
 import { agentLifecycleLedger } from "@/services/terminal/lifecycleLedger";
 import { buildWorktreeIndex, NO_WORKTREE } from "../worktreeIndex";
@@ -609,6 +615,121 @@ describe("dock ↔ grid transitions", () => {
       expect(state.panelsById["t1"]!.worktreeId).toBeUndefined();
       expect(state.panelsById["t1"]!.location).toBe("dock");
       expect(state.panelIdsByWorktreeId[NO_WORKTREE]).toEqual(["t1"]);
+    });
+  });
+
+  describe("workspace-rooted file browser survives promotion (#11489)", () => {
+    const activateWorktree = (id: string) => {
+      setWorktreeSelectionAccessor(() => ({ activeWorktreeId: id, restoreWorktreeId: null }));
+    };
+
+    /**
+     * The shape `createFileBrowserDefaults` produces for a browser opened on a
+     * scratch or worktree-less project folder (#11482): no worktreeId, and the
+     * marker that says so. Promotion is expected to adopt a worktreeId for
+     * placement — the marker is what must survive it.
+     */
+    function seedWorkspaceBrowser(id: string, location: "dock" | "dialog" | "grid") {
+      usePanelStore.setState((state) => {
+        const panel: FileBrowserPanelData = {
+          id,
+          kind: "file-browser",
+          title: "Files",
+          location,
+          isVisible: location === "grid",
+          browserWorkspaceRooted: true,
+          ...(location === "dialog" && { excludeFromPersistence: true }),
+        };
+        const panelsById = { ...state.panelsById, [id]: panel };
+        const panelIds = [...state.panelIds, id];
+        return {
+          panelsById,
+          panelIds,
+          panelIdsByWorktreeId: buildWorktreeIndex(panelIds, panelsById),
+        };
+      });
+    }
+
+    const rootingOf = (id: string) => {
+      const panel = usePanelStore.getState().panelsById[id];
+      return panel?.kind === "file-browser" ? panel.browserWorkspaceRooted : undefined;
+    };
+
+    it("keeps the workspace rooting when a dialog browser is promoted to the grid", () => {
+      seedWorkspaceBrowser("fb-dialog", "dialog");
+      activateWorktree("wt-1");
+
+      expect(usePanelStore.getState().promoteDialogPanelToGrid("fb-dialog")).toBe(true);
+
+      // The adoption still happens — that is #11290 — but it is placement only.
+      expect(usePanelStore.getState().panelsById["fb-dialog"]!.worktreeId).toBe("wt-1");
+      expect(usePanelStore.getState().panelIdsByWorktreeId["wt-1"]).toEqual(["fb-dialog"]);
+      expect(rootingOf("fb-dialog")).toBe(true);
+    });
+
+    it("keeps the workspace rooting when a docked browser is promoted to the grid", () => {
+      seedWorkspaceBrowser("fb-dock", "dock");
+      activateWorktree("wt-1");
+
+      expect(usePanelStore.getState().moveTerminalToGrid("fb-dock")).toBe(true);
+
+      expect(usePanelStore.getState().panelsById["fb-dock"]!.worktreeId).toBe("wt-1");
+      expect(rootingOf("fb-dock")).toBe(true);
+    });
+
+    it("keeps the workspace rooting on a drag-style dock-to-grid move", () => {
+      seedWorkspaceBrowser("fb-drag", "dock");
+
+      usePanelStore.getState().moveTerminalToPosition("fb-drag", 0, "grid", "wt-2");
+
+      expect(usePanelStore.getState().panelsById["fb-drag"]!.worktreeId).toBe("wt-2");
+      expect(rootingOf("fb-drag")).toBe(true);
+    });
+
+    it("keeps the workspace rooting when the browser rides a promoted tab group", () => {
+      seedWorkspaceBrowser("fb-group", "dock");
+      usePanelStore.setState((state) => ({
+        tabGroups: new Map(state.tabGroups).set("g1", {
+          id: "g1",
+          panelIds: ["fb-group"],
+          activeTabId: "fb-group",
+          location: "dock",
+          worktreeId: undefined,
+        }),
+      }));
+      activateWorktree("wt-1");
+
+      usePanelStore.getState().moveTabGroupToLocation("g1", "grid");
+
+      expect(usePanelStore.getState().panelsById["fb-group"]!.worktreeId).toBe("wt-1");
+      expect(rootingOf("fb-group")).toBe(true);
+    });
+
+    it("never invents workspace rooting for a worktree-rooted browser", () => {
+      usePanelStore.setState((state) => {
+        const panel: FileBrowserPanelData = {
+          id: "fb-wt",
+          kind: "file-browser",
+          title: "Files",
+          location: "dock",
+          isVisible: false,
+          worktreeId: "wt-3",
+        };
+        const panelsById = { ...state.panelsById, "fb-wt": panel };
+        const panelIds = [...state.panelIds, "fb-wt"];
+        return {
+          panelsById,
+          panelIds,
+          panelIdsByWorktreeId: buildWorktreeIndex(panelIds, panelsById),
+        };
+      });
+      activateWorktree("wt-1");
+
+      usePanelStore.getState().moveTerminalToGrid("fb-wt");
+
+      // A real attribution is never replaced, and nothing marks it workspace-rooted.
+      expect(usePanelStore.getState().panelsById["fb-wt"]!.worktreeId).toBe("wt-3");
+      expect(rootingOf("fb-wt")).toBeUndefined();
     });
   });
 

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -68,6 +68,7 @@ export interface AddTerminalArgs extends AddPanelOptionsBase {
   browserSidebarCollapsed?: boolean;
   browserTreeSnapshot?: FileBrowserTreeSnapshot;
   browserSidebarWidth?: number;
+  browserWorkspaceRooted?: boolean;
   /**
    * Preserved user-initiated focus timestamp from the saved snapshot. The
    * post-hydration focus picker in `useAppHydration` reads this off
@@ -132,6 +133,7 @@ export interface SavedTerminalData {
   browserSidebarCollapsed?: unknown;
   browserTreeSnapshot?: unknown;
   browserSidebarWidth?: unknown;
+  browserWorkspaceRooted?: unknown;
   exitBehavior?: PanelExitBehavior;
   agentSessionId?: string;
   agentLaunchFlags?: string[];


### PR DESCRIPTION
Resolves #11489

`promoteDialogPanelToGrid` backfills a missing `worktreeId` from the active worktree so a worktree-less panel lands in a rendered index bucket (#11290 — the grid renders exactly one bucket, and `panelMatchesWorktreeScope` is worktree-exact outside the dock). #11488 introduced file-browser panels legitimately rooted at a scratch or worktree-less project folder, which carry no `worktreeId` — so promoting one silently re-rooted it to the active worktree's folder.

The problem is that `worktreeId` had come to mean two things at once for a file-browser panel: where the panel is *placed*, and which folder it *browses*. Promotion legitimately needs the first and must not touch the second.

## Approach

Record the browse source on the panel record as `browserWorkspaceRooted`, and settle it **once** at the creation boundary in `createFileBrowserDefaults`:

```ts
const workspaceRooted =
  options.browserWorkspaceRooted === true || options.worktreeId === undefined;
```

This is what let the change stay small. There are five sites that adopt a placement `worktreeId` — `moveTerminalToGrid`, `promoteDialogPanelToGrid`, `moveTabGroupToLocation`, `moveTerminalToPosition`, and `addPanel`'s own dock→grid rescue — and every one of them already spreads the panel record, so a marker set at creation rides through all of them untouched. **None of those files are modified**, which is also why #11290's behaviour is preserved exactly.

The ordering that makes this work is load-bearing and worth knowing about: `addPanel` computes its adopted `effectiveWorktreeId` at line 229 but passes the *raw* `options` to `createDefaults` at line 241, so its own adoption can't pre-empt the creation signal.

The pane then derives `sourceWorktreeId = workspaceRooted ? undefined : worktreeId` and uses it for the worktree-path lookup, the `source` memo, the git/fs change ticks, and the Copy-context gate.

`=== undefined` rather than truthiness is deliberate, matching the pane's existing presence check: a persisted `worktreeId: ""` names a worktree that cannot resolve and must refuse rather than quietly fall back to the workspace root.

## Persistence

The marker round-trips through the file-browser serializer, deserializer, defaults factory and the hydration carrier types. All four boundaries require a literal `true`, so a corrupt value can't be laundered into a durable redirect; only `true` is ever written, keeping an ordinary worktree-rooted panel sparse. No migration is needed — panel snapshots are free-form JSON. It stays out of `BASE_PANEL_FIELDS`, being a per-kind fragment rather than a base field.

## Deliberate calls

**The marker is immutable.** An explicit cross-worktree move does not clear it. A drag onto a worktree card is a *placement* gesture, and silently changing which folder the user is looking at is precisely the bug being fixed — so placement doesn't rewrite content identity. Clearing it would reproduce the original failure in miniature: a panel titled `Files — Scratch one` suddenly showing a worktree's files.

## Follow-ups found while working here, deliberately not folded in

- A promoted workspace-rooted browser carries an adopted placement `worktreeId`. If that worktree is later deleted, `cleanupOrphanedTerminals` (kind-agnostic, matching on any non-empty unknown `worktreeId`) removes the panel on the next hydration, even though its actual root — the workspace — is still valid. Pre-existing mechanism, and narrower to reach than the bug fixed here, but both obvious fixes trade deletion for an invisible stranded panel, so it wants the bucket-semantics design #11489 itself deferred.
- A *worktree*-rooted browser moved from worktree A to B does re-root, and keeps a stale `Files — A` title. Also pre-existing.

## Testing

- `FileBrowserPane.test.tsx` — a promoted panel (placement `worktreeId` set, marker true) browses the workspace root, joins copied paths against it, hides Copy context, and fails closed when the workspace root is unknown. Mutation-checked: reverting the derivation fails exactly these. Change ticks are asserted per source, so a disconnected git *or* fs selector is caught.
- `serializer.test.ts` — creation-boundary derivation, marker precedence, the `worktreeId: ""` fail-closed case, and the promoted-panel round trip.
- `dockGridTransitions.test.ts` — regression locks across all four promotion paths, plus a negative case proving a worktree-rooted browser never gains the marker.
- `registry.fieldcoverage.test.ts` — the field-classification ratchet and both fixtures.

Locally: 1145 tests pass across the panelRegistry, file-browser, stateHydration and panel-store suites; prettier and eslint clean on changed files (no new warnings).