### PR TITLE
feat(window): restore open project windows after relaunch

### DIFF
--- a/electron/ipc/handlers/projectCrud/switch.ts
+++ b/electron/ipc/handlers/projectCrud/switch.ts
@@ -13,6 +13,7 @@ import { ProjectSwitchService } from "../../../services/ProjectSwitchService.js"
 import { getProjectHistory } from "../../../services/ProjectHistoryService.js";
 import { broadcastProjectSwitchUpdates } from "../../projectSwitchBroadcast.js";
 import { refreshProjectMenuState } from "../../../projectMenuState.js";
+import { scheduleOpenWindowsSave } from "../../../window/openWindowsTracker.js";
 import { notificationService } from "../../../services/NotificationService.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import { logInfo } from "../../../utils/logger.js";
@@ -502,6 +503,13 @@ async function activateProjectView(
   // window open, would background whichever project that window is still
   // displaying while never backgrounding this window's own (#11101).
   await projectStore.setCurrentProject(projectId, outgoingProjectId);
+
+  // Re-persist which project each window is showing (#11492). Placed after the
+  // PVM swap above rather than alongside it because the manifest is built from
+  // `getActiveProjectId()` across every window — it has to read the committed
+  // state, not the switch that is still landing. Debounced, so a burst of
+  // switches collapses to one write.
+  scheduleOpenWindowsSave();
 
   if (options.markActive) {
     projectStore.updateProjectStatus(projectId, "active");

--- a/electron/lifecycle/__tests__/launchIntent.test.ts
+++ b/electron/lifecycle/__tests__/launchIntent.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveLaunchIntent,
+  shouldRestoreWindowFleet,
+  type LaunchIntentSignals,
+} from "../launchIntent.js";
+
+function signals(overrides: Partial<LaunchIntentSignals> = {}): LaunchIntentSignals {
+  return {
+    argv: ["/Applications/Daintree.app/Contents/MacOS/Daintree"],
+    hasCliPathFlag: () => false,
+    extractDirectoryPaths: () => [],
+    pendingOpenDirPaths: [],
+    pendingOpenFilePaths: [],
+    isSafeMode: false,
+    hasPendingCrash: false,
+    ...overrides,
+  };
+}
+
+describe("resolveLaunchIntent", () => {
+  it("treats a bare double-click launch as cold", () => {
+    expect(resolveLaunchIntent(signals())).toBe("cold");
+  });
+
+  it("treats a --cli-path launch as targeted", () => {
+    expect(resolveLaunchIntent(signals({ hasCliPathFlag: () => true }))).toBe("targeted");
+  });
+
+  it("treats a --cli-path that failed to resolve as targeted too", () => {
+    // The user still named something; the flag is the intent, not its outcome.
+    const intent = resolveLaunchIntent(
+      signals({ hasCliPathFlag: () => true, extractDirectoryPaths: () => [] })
+    );
+    expect(intent).toBe("targeted");
+  });
+
+  it("treats a Linux folder URI as targeted", () => {
+    expect(resolveLaunchIntent(signals({ extractDirectoryPaths: () => ["/repos/app"] }))).toBe(
+      "targeted"
+    );
+  });
+
+  it("treats a queued Finder folder drop as targeted", () => {
+    expect(resolveLaunchIntent(signals({ pendingOpenDirPaths: ["/repos/app"] }))).toBe("targeted");
+  });
+
+  it("treats a queued .dntr archive as targeted", () => {
+    expect(resolveLaunchIntent(signals({ pendingOpenFilePaths: ["/tmp/x.dntr"] }))).toBe(
+      "targeted"
+    );
+  });
+
+  it("classifies safe mode as recovery", () => {
+    expect(resolveLaunchIntent(signals({ isSafeMode: true }))).toBe("recovery");
+  });
+
+  it("classifies a pending crash as recovery", () => {
+    expect(resolveLaunchIntent(signals({ hasPendingCrash: true }))).toBe("recovery");
+  });
+
+  it("lets recovery outrank a targeted launch", () => {
+    // Reopening a fleet is how one bad launch becomes a crash loop, so the
+    // recovery classification has to win even when argv names something.
+    const intent = resolveLaunchIntent(signals({ isSafeMode: true, hasCliPathFlag: () => true }));
+    expect(intent).toBe("recovery");
+  });
+
+  it("passes argv through to the injected parsers rather than re-reading process.argv", () => {
+    const argv = ["daintree", "--cli-path=/repos/app"];
+    let sawCli: string[] | null = null;
+    let sawDirs: string[] | null = null;
+    resolveLaunchIntent(
+      signals({
+        argv,
+        hasCliPathFlag: (a) => {
+          sawCli = a;
+          return false;
+        },
+        extractDirectoryPaths: (a) => {
+          sawDirs = a;
+          return [];
+        },
+      })
+    );
+    expect(sawCli).toBe(argv);
+    expect(sawDirs).toBe(argv);
+  });
+});
+
+describe("shouldRestoreWindowFleet", () => {
+  it("restores the fleet only on a plain cold launch", () => {
+    expect(shouldRestoreWindowFleet("cold")).toBe(true);
+    expect(shouldRestoreWindowFleet("targeted")).toBe(false);
+    expect(shouldRestoreWindowFleet("recovery")).toBe(false);
+  });
+});

--- a/electron/lifecycle/__tests__/shutdown.test.ts
+++ b/electron/lifecycle/__tests__/shutdown.test.ts
@@ -253,6 +253,12 @@ const deferredInitQueueMock = vi.hoisted(() => ({
 
 vi.mock("../../window/deferredInitQueue.js", () => deferredInitQueueMock);
 
+const openWindowsTrackerMock = vi.hoisted(() => ({
+  freezeAndSnapshotOpenWindows: vi.fn(),
+}));
+
+vi.mock("../../window/openWindowsTracker.js", () => openWindowsTrackerMock);
+
 // Runs in the post-cleanup tail, outside the hard-timeout race. Mocked so a test
 // can wedge it and prove the run still settles (issue #11104).
 const performanceTraceMock = vi.hoisted(() => ({
@@ -425,6 +431,44 @@ describe("registerShutdownHandler", () => {
     await vi.waitFor(() => {
       expect(appMock.exit).toHaveBeenCalledWith(0);
     });
+  });
+
+  it("snapshots the open-window manifest before the database closes", async () => {
+    // Continuous persistence covers force-quit, but a debounce still owing an
+    // unsaved project switch is only captured here — and the capture has to
+    // beat closeSharedDb, which would otherwise silently reopen the DB (#11492).
+    const { beforeQuitCb } = await setup();
+    await beforeQuitCb(makeEvent());
+
+    expect(openWindowsTrackerMock.freezeAndSnapshotOpenWindows).toHaveBeenCalledTimes(1);
+
+    await vi.waitFor(() => {
+      expect(closeSharedDbMock.closeSharedDb).toHaveBeenCalled();
+    });
+    const snapshotOrder =
+      openWindowsTrackerMock.freezeAndSnapshotOpenWindows.mock.invocationCallOrder[0];
+    const closeOrder = closeSharedDbMock.closeSharedDb.mock.invocationCallOrder[0];
+    expect(snapshotOrder).toBeLessThan(closeOrder);
+
+    await vi.waitFor(() => {
+      expect(appMock.exit).toHaveBeenCalledWith(0);
+    });
+  });
+
+  it("does not snapshot the open-window manifest when the quit is cancelled", async () => {
+    // A cancelled quit must leave the manifest live — freezing is permanent.
+    quitWarningMock.getActiveAgentCount.mockReturnValue(2);
+    quitWarningMock.showQuitWarning.mockResolvedValue(false);
+
+    const mainWindow = {} as Electron.BrowserWindow;
+    const { beforeQuitCb } = await setup({
+      windowRegistry: {
+        getPrimary: () => ({ browserWindow: mainWindow }),
+      } as unknown as ShutdownDeps["windowRegistry"],
+    });
+    await beforeQuitCb(makeEvent());
+
+    expect(openWindowsTrackerMock.freezeAndSnapshotOpenWindows).not.toHaveBeenCalled();
   });
 
   it("halts the deferred init queue after the user confirms quit", async () => {

--- a/electron/lifecycle/__tests__/windowRestore.test.ts
+++ b/electron/lifecycle/__tests__/windowRestore.test.ts
@@ -122,28 +122,51 @@ describe("restoreWindowFleet", () => {
     });
   });
 
-  it("creates the first window alone, before any of the rest start", async () => {
-    // initGlobalServices() flips its guard synchronously at entry, so a second
-    // window overlapping the first races its migrations.
-    const inFlight: number[] = [];
-    let concurrentPeak = 0;
-    let active = 0;
-    h = harness(
-      { records: [record("a"), record("b"), record("c")], hadManifest: true },
-      async () => {
+  describe("fan-out sequencing", () => {
+    /** Records start/end around a tick so overlap is observable. */
+    function traced(records: OpenWindowRecord[]) {
+      const events: string[] = [];
+      let active = 0;
+      let peak = 0;
+      const h = harness({ records, hadManifest: true }, async (projectId) => {
         active++;
-        concurrentPeak = Math.max(concurrentPeak, active);
-        inFlight.push(active);
+        peak = Math.max(peak, active);
+        events.push(`start:${projectId}`);
         await Promise.resolve();
+        await Promise.resolve();
+        events.push(`end:${projectId}`);
         active--;
         return "ok";
-      }
-    );
+      });
+      return { h, events, peakOf: () => peak };
+    }
 
-    await restoreWindowFleet(h.deps);
+    it("finishes the first window before either of the rest starts", async () => {
+      // initGlobalServices() flips its "initialized" guard synchronously at
+      // entry, so a second window overlapping the first sails past the guard and
+      // races its migrations. Completion-before-start is the actual invariant —
+      // merely observing the primary alone at its own first tick proves nothing,
+      // since every call records itself before yielding.
+      const { h, events } = traced([record("a"), record("b"), record("c")]);
+      await restoreWindowFleet(h.deps);
 
-    expect(inFlight[0]).toBe(1);
-    expect(concurrentPeak).toBeGreaterThan(1);
+      expect(events.indexOf("end:a")).toBeLessThan(events.indexOf("start:b"));
+      expect(events.indexOf("end:a")).toBeLessThan(events.indexOf("start:c"));
+    });
+
+    it("runs the background windows together rather than one after another", async () => {
+      const { h, events, peakOf } = traced([record("a"), record("b"), record("c")]);
+      await restoreWindowFleet(h.deps);
+
+      expect(events.indexOf("start:c")).toBeLessThan(events.indexOf("end:b"));
+      expect(peakOf()).toBe(2);
+    });
+
+    it("never overlaps anything with the primary when it is the only window", async () => {
+      const { h, peakOf } = traced([record("a")]);
+      await restoreWindowFleet(h.deps);
+      expect(peakOf()).toBe(1);
+    });
   });
 
   it("restores two windows onto the same project rather than collapsing them", async () => {

--- a/electron/lifecycle/__tests__/windowRestore.test.ts
+++ b/electron/lifecycle/__tests__/windowRestore.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  resolvePrimaryRestoreProjectId,
+  restoreWindowFleet,
+  type CreateWindowResult,
+  type RestoreWindowFleetDeps,
+} from "../windowRestore.js";
+import type { OpenWindowRecord } from "../../services/persistence/windowManifest.js";
+
+const record = (projectId: string | null): OpenWindowRecord => ({ projectId });
+
+interface Harness {
+  deps: RestoreWindowFleetDeps;
+  createWindow: ReturnType<typeof vi.fn>;
+  resumeSaves: ReturnType<typeof vi.fn>;
+  suppressSaves: ReturnType<typeof vi.fn>;
+  onBackgroundWindowFailed: ReturnType<typeof vi.fn>;
+  /** Project ids passed to createWindow, in call order. */
+  openedProjects: () => (string | undefined)[];
+  /** Reveal modes passed to createWindow, in call order. */
+  revealModes: () => (string | undefined)[];
+  /** Whether resumeSaves was told to persist. */
+  persisted: () => boolean;
+}
+
+function harness(
+  overrides: Partial<RestoreWindowFleetDeps> = {},
+  createWindowImpl?: (
+    projectId: string | undefined,
+    opts?: { revealMode?: "show" | "showInactive" }
+  ) => Promise<CreateWindowResult>
+): Harness {
+  const createWindow = vi.fn(createWindowImpl ?? (async () => "ok" as CreateWindowResult));
+  const resumeSaves = vi.fn();
+  const suppressSaves = vi.fn();
+  const onBackgroundWindowFailed = vi.fn();
+
+  const deps: RestoreWindowFleetDeps = {
+    records: [],
+    hadManifest: false,
+    fallbackProjectId: undefined,
+    createWindow,
+    suppressSaves,
+    resumeSaves,
+    onBackgroundWindowFailed,
+    ...overrides,
+  };
+
+  return {
+    deps,
+    createWindow,
+    resumeSaves,
+    suppressSaves,
+    onBackgroundWindowFailed,
+    openedProjects: () => createWindow.mock.calls.map((c) => c[0] as string | undefined),
+    revealModes: () =>
+      createWindow.mock.calls.map((c) => (c[1] as { revealMode?: string } | undefined)?.revealMode),
+    persisted: () => resumeSaves.mock.calls.some((c) => c[0] === true),
+  };
+}
+
+describe("resolvePrimaryRestoreProjectId", () => {
+  it("takes the most-recently-focused record", () => {
+    expect(resolvePrimaryRestoreProjectId([record("a"), record("b")], true, "other")).toBe("a");
+  });
+
+  it("uses the last-active project when there was no manifest at all", () => {
+    expect(resolvePrimaryRestoreProjectId([], false, "last-active")).toBe("last-active");
+  });
+
+  it("never substitutes the last-active project when the manifest filtered to nothing", () => {
+    // The whole point of the hadManifest flag: every project in a real manifest
+    // was deleted, so the user gets a picker — not some unrelated project their
+    // window set never named.
+    expect(resolvePrimaryRestoreProjectId([], true, "unrelated")).toBeUndefined();
+  });
+
+  it("opens a picker when the most-recently-focused window was itself a picker", () => {
+    expect(
+      resolvePrimaryRestoreProjectId([record(null), record("b")], true, "other")
+    ).toBeUndefined();
+  });
+
+  it("resolves to nothing on a first run with no manifest and no last-active project", () => {
+    expect(resolvePrimaryRestoreProjectId([], false, undefined)).toBeUndefined();
+  });
+});
+
+describe("restoreWindowFleet", () => {
+  let h: Harness;
+
+  describe("a plain cold launch with three saved windows", () => {
+    beforeEach(async () => {
+      h = harness({
+        records: [record("a"), record("b"), record("c")],
+        hadManifest: true,
+      });
+      await restoreWindowFleet(h.deps);
+    });
+
+    it("recreates one window per record", () => {
+      expect(h.createWindow).toHaveBeenCalledTimes(3);
+    });
+
+    it("gives each window its own project, in manifest order", () => {
+      expect(h.openedProjects()).toEqual(["a", "b", "c"]);
+    });
+
+    it("reveals only the background windows inactive, so focus lands on the first", () => {
+      const [primary, ...background] = h.revealModes();
+      expect(primary).toBeUndefined();
+      expect(background).toEqual(["showInactive", "showInactive"]);
+    });
+
+    it("persists the fleet once every window is up", () => {
+      expect(h.persisted()).toBe(true);
+    });
+
+    it("holds saves across the whole fan-out", () => {
+      expect(h.suppressSaves).toHaveBeenCalledTimes(1);
+      expect(h.resumeSaves).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("creates the first window alone, before any of the rest start", async () => {
+    // initGlobalServices() flips its guard synchronously at entry, so a second
+    // window overlapping the first races its migrations.
+    const inFlight: number[] = [];
+    let concurrentPeak = 0;
+    let active = 0;
+    h = harness(
+      { records: [record("a"), record("b"), record("c")], hadManifest: true },
+      async () => {
+        active++;
+        concurrentPeak = Math.max(concurrentPeak, active);
+        inFlight.push(active);
+        await Promise.resolve();
+        active--;
+        return "ok";
+      }
+    );
+
+    await restoreWindowFleet(h.deps);
+
+    expect(inFlight[0]).toBe(1);
+    expect(concurrentPeak).toBeGreaterThan(1);
+  });
+
+  it("restores two windows onto the same project rather than collapsing them", async () => {
+    h = harness({ records: [record("same"), record("same")], hadManifest: true });
+    await restoreWindowFleet(h.deps);
+    expect(h.openedProjects()).toEqual(["same", "same"]);
+  });
+
+  it("opens one picker window when every saved project was deleted", async () => {
+    h = harness({ records: [], hadManifest: true, fallbackProjectId: "unrelated" });
+    await restoreWindowFleet(h.deps);
+    expect(h.createWindow).toHaveBeenCalledTimes(1);
+    expect(h.openedProjects()).toEqual([undefined]);
+  });
+
+  it("opens one window seeded the old way when there is no manifest", async () => {
+    h = harness({ records: [], hadManifest: false, fallbackProjectId: "last-active" });
+    await restoreWindowFleet(h.deps);
+    expect(h.openedProjects()).toEqual(["last-active"]);
+  });
+
+  describe("a background window that fails", () => {
+    beforeEach(async () => {
+      h = harness(
+        { records: [record("a"), record("b"), record("c")], hadManifest: true },
+        async (projectId) => {
+          if (projectId === "b") throw new Error("renderer died");
+          return "ok";
+        }
+      );
+      await restoreWindowFleet(h.deps);
+    });
+
+    it("does not stop the other windows from restoring", () => {
+      expect(h.openedProjects()).toEqual(["a", "b", "c"]);
+    });
+
+    it("leaves the stored manifest alone, so the next launch still tries all three", () => {
+      expect(h.persisted()).toBe(false);
+    });
+
+    it("reports the failure", () => {
+      expect(h.onBackgroundWindowFailed).toHaveBeenCalledTimes(1);
+    });
+
+    it("still releases the save hold", () => {
+      expect(h.resumeSaves).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("leaves the manifest alone when a background window reports it is not ok", async () => {
+    // Resolving with a non-"ok" status is not a rejection, so it would sail past
+    // an allSettled check that only looked for rejections.
+    h = harness({ records: [record("a"), record("b")], hadManifest: true }, async (projectId) =>
+      projectId === "b" ? "not-registered" : "ok"
+    );
+    await restoreWindowFleet(h.deps);
+    expect(h.persisted()).toBe(false);
+    expect(h.onBackgroundWindowFailed).not.toHaveBeenCalled();
+  });
+
+  describe("a primary window that cannot come up", () => {
+    it("does not start the background windows when the primary reports exit", async () => {
+      h = harness(
+        { records: [record("a"), record("b")], hadManifest: true },
+        async () => "exit-requested"
+      );
+      await restoreWindowFleet(h.deps);
+      expect(h.createWindow).toHaveBeenCalledTimes(1);
+    });
+
+    it("leaves the stored manifest alone when the primary reports exit", async () => {
+      h = harness(
+        { records: [record("a"), record("b")], hadManifest: true },
+        async () => "exit-requested"
+      );
+      await restoreWindowFleet(h.deps);
+      expect(h.persisted()).toBe(false);
+    });
+
+    it("releases the save hold and rethrows when the primary throws", async () => {
+      h = harness({ records: [record("a"), record("b")], hadManifest: true }, async () => {
+        throw new Error("startup failed");
+      });
+
+      await expect(restoreWindowFleet(h.deps)).rejects.toThrow("startup failed");
+      // The hold must be released even on the throw path, or every later save
+      // in the process would be silently dropped.
+      expect(h.resumeSaves).toHaveBeenCalledTimes(1);
+      expect(h.persisted()).toBe(false);
+    });
+  });
+});

--- a/electron/lifecycle/launchIntent.ts
+++ b/electron/lifecycle/launchIntent.ts
@@ -1,0 +1,64 @@
+/**
+ * One answer to "why did this launch happen", read once before the window
+ * restore decision (#11492).
+ *
+ * The signals already existed, scattered: `hasCliPathFlag()` and
+ * `extractDirectoryPaths()` in appLifecycle.ts, the pre-window `open-file` /
+ * folder queues in setup/environment.ts, and safe-mode / pending-crash on the
+ * crash services. Nothing combined them, so the restore loop had nothing to ask
+ * — and a `--cli-path` launch or a Finder folder-open would otherwise reopen
+ * every window from the last session on top of the one thing the user asked for.
+ *
+ * Pure, with every signal injected, so the matrix is testable without argv,
+ * Electron, or a crash service.
+ */
+
+export type LaunchIntent =
+  /** Plain cold launch — nothing specific was asked for. Restores the fleet. */
+  | "cold"
+  /** The user launched us to open a specific thing. One window, that thing. */
+  | "targeted"
+  /** Safe mode or an unresolved crash. One window, and the manifest is left alone. */
+  | "recovery";
+
+export interface LaunchIntentSignals {
+  /** Raw process argv (or the second-instance command line). */
+  argv: string[];
+  /** True when argv carries `--cli-path`, resolvable or not. */
+  hasCliPathFlag: (argv: string[]) => boolean;
+  /** Folder paths handed over as `file://` URIs (Linux "Open in Daintree"). */
+  extractDirectoryPaths: (argv: string[]) => string[];
+  /** macOS Finder folder drops queued before a window existed. */
+  pendingOpenDirPaths: string[];
+  /** `.dntr` plugin archives queued before the installer was activated. */
+  pendingOpenFilePaths: string[];
+  isSafeMode: boolean;
+  hasPendingCrash: boolean;
+}
+
+/**
+ * Recovery outranks targeted, which outranks cold.
+ *
+ * Recovery wins outright because restoring a fleet is how one bad launch
+ * becomes the crash loop CrashLoopGuard exists to break — and the caller must
+ * also stop *writing* the manifest in this mode, or a one-window safe-mode
+ * session would overwrite the user's real fleet.
+ */
+export function resolveLaunchIntent(signals: LaunchIntentSignals): LaunchIntent {
+  if (signals.isSafeMode || signals.hasPendingCrash) return "recovery";
+
+  if (signals.hasCliPathFlag(signals.argv)) return "targeted";
+  if (signals.extractDirectoryPaths(signals.argv).length > 0) return "targeted";
+  if (signals.pendingOpenDirPaths.length > 0) return "targeted";
+  // A double-clicked `.dntr` archive is still "I launched you to do this one
+  // thing". Treating it as targeted keeps today's single-window behaviour for
+  // every launch that names something, which is the conservative default.
+  if (signals.pendingOpenFilePaths.length > 0) return "targeted";
+
+  return "cold";
+}
+
+/** Only a plain cold launch rebuilds the whole window set. */
+export function shouldRestoreWindowFleet(intent: LaunchIntent): boolean {
+  return intent === "cold";
+}

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -49,6 +49,7 @@ import {
   setWindowsStoreNotifierServiceRef,
 } from "../window/serviceRefs.js";
 import { haltDeferredQueue } from "../window/deferredInitQueue.js";
+import { freezeAndSnapshotOpenWindows } from "../window/openWindowsTracker.js";
 import { closeSharedDb } from "../services/persistence/db.js";
 import { closeTelemetry } from "../services/TelemetryService.js";
 import { isSmokeTest } from "../setup/environment.js";
@@ -168,6 +169,15 @@ async function runShutdownChain(deps: ShutdownDeps): Promise<ShutdownOutcome> {
   // be resumed). Tasks that start during the dialog run against a fully live
   // app and are torn down by the cleanup chain like any other service.
   haltDeferredQueue();
+
+  // Capture the open-window manifest and latch its writes off, for the same
+  // reason and in the same place (#11492). Two hazards this closes: a pending
+  // 500ms debounce owing an unsaved project switch, which the active-shutdown
+  // gate would otherwise refuse and drop; and the updater closing windows one
+  // at a time below, which un-latched would walk the persisted list down to
+  // empty and relaunch into nothing. Synchronous — better-sqlite3 writes
+  // inline, so it adds no await before the chain's own work.
+  freezeAndSnapshotOpenWindows();
 
   // Eager snapshot at quit-intent so the next launch has a post-quit-intent
   // backup regardless of which branch of the cleanup race wins. Without this,

--- a/electron/lifecycle/windowRestore.ts
+++ b/electron/lifecycle/windowRestore.ts
@@ -16,8 +16,10 @@ export interface RestoreWindowFleetDeps {
   /** Windows to restore, most-recently-focused first. Empty means one window. */
   records: OpenWindowRecord[];
   /**
-   * Whether a structurally valid manifest was stored at all — distinct from
-   * whether anything in it survived project-existence filtering.
+   * Whether a stored manifest named at least one window — distinct from whether
+   * any of those windows survived project-existence filtering. A manifest that
+   * was stored naming zero windows reports false; see
+   * `readOpenWindowsManifestSync`.
    */
   hadManifest: boolean;
   /**
@@ -37,11 +39,15 @@ export interface RestoreWindowFleetDeps {
 /**
  * Which project the focused window opens on.
  *
- * A manifest that existed but filtered down to nothing resolves to `undefined`
- * — a project picker — never to `fallbackProjectId`. Falling back there would
- * open a project the user's window set never named, which is the one outcome
- * the issue rules out explicitly: a project that can no longer be restored is
- * skipped, never silently replaced by a different one.
+ * A manifest that named windows but filtered down to nothing resolves to
+ * `undefined` — a project picker — never to `fallbackProjectId`. Falling back
+ * there would open a project the user's window set never named, which is the
+ * one outcome the issue rules out explicitly: a project that can no longer be
+ * restored is skipped, never silently replaced by a different one.
+ *
+ * `hadManifest` is false both when nothing was stored and when what was stored
+ * named zero windows, so closing every window still relaunches into the
+ * last-active project rather than a picker.
  */
 export function resolvePrimaryRestoreProjectId(
   records: OpenWindowRecord[],

--- a/electron/lifecycle/windowRestore.ts
+++ b/electron/lifecycle/windowRestore.ts
@@ -1,0 +1,110 @@
+/**
+ * The startup window-restore fan-out (#11492).
+ *
+ * Extracted from main.ts's `whenReady()` block so the ordering rules below can
+ * be tested — main.ts itself is not importable in a unit test, and these are
+ * exactly the rules that are silent when they break: you don't find out the
+ * fleet stopped restoring until the next relaunch.
+ */
+
+import type { OpenWindowRecord } from "../services/persistence/windowManifest.js";
+
+/** What `createWindow` reports back. Anything but "ok" means: stop. */
+export type CreateWindowResult = "ok" | "exit-requested" | "not-registered";
+
+export interface RestoreWindowFleetDeps {
+  /** Windows to restore, most-recently-focused first. Empty means one window. */
+  records: OpenWindowRecord[];
+  /**
+   * Whether a structurally valid manifest was stored at all — distinct from
+   * whether anything in it survived project-existence filtering.
+   */
+  hadManifest: boolean;
+  /**
+   * The global last-active project, used ONLY when there was no manifest to
+   * read. Never a substitute for a manifest whose projects were all deleted.
+   */
+  fallbackProjectId: string | undefined;
+  createWindow: (
+    projectId: string | undefined,
+    opts?: { revealMode?: "show" | "showInactive" }
+  ) => Promise<CreateWindowResult>;
+  suppressSaves: () => void;
+  resumeSaves: (persistNow: boolean) => void;
+  onBackgroundWindowFailed: (reason: unknown) => void;
+}
+
+/**
+ * Which project the focused window opens on.
+ *
+ * A manifest that existed but filtered down to nothing resolves to `undefined`
+ * — a project picker — never to `fallbackProjectId`. Falling back there would
+ * open a project the user's window set never named, which is the one outcome
+ * the issue rules out explicitly: a project that can no longer be restored is
+ * skipped, never silently replaced by a different one.
+ */
+export function resolvePrimaryRestoreProjectId(
+  records: OpenWindowRecord[],
+  hadManifest: boolean,
+  fallbackProjectId: string | undefined
+): string | undefined {
+  if (records.length > 0) return records[0].projectId ?? undefined;
+  if (hadManifest) return undefined;
+  return fallbackProjectId;
+}
+
+/**
+ * Recreate the window set, then decide whether the result is worth persisting.
+ *
+ * Two orderings are load-bearing:
+ *
+ *  1. The first window is awaited ALONE. `initGlobalServices()` flips its
+ *     "initialized" guard synchronously at entry, before its own awaits, so a
+ *     concurrent second window sails straight past the guard and races the
+ *     first window's migrations and DB open. Once this await returns, global
+ *     init has fully settled and the rest are safe to run together.
+ *  2. Saves stay suppressed until the whole fan-out settles, and the manifest
+ *     is only rewritten if EVERY window came up. A half-restored fleet must not
+ *     overwrite a manifest that is still correct on disk — the next launch would
+ *     then restore only the windows that happened to survive this one.
+ */
+export async function restoreWindowFleet(deps: RestoreWindowFleetDeps): Promise<void> {
+  const primaryProjectId = resolvePrimaryRestoreProjectId(
+    deps.records,
+    deps.hadManifest,
+    deps.fallbackProjectId
+  );
+
+  deps.suppressSaves();
+  let restoredCleanly = false;
+  try {
+    const primaryResult = await deps.createWindow(primaryProjectId);
+    if (primaryResult !== "ok") return;
+
+    let backgroundClean = true;
+    if (deps.records.length > 1) {
+      // Background windows reveal with showInactive(): they finish loading in
+      // an unpredictable order, and a plain show() would hand focus to
+      // whichever renderer parsed its skeleton last.
+      const results = await Promise.allSettled(
+        deps.records
+          .slice(1)
+          .map((record) =>
+            deps.createWindow(record.projectId ?? undefined, { revealMode: "showInactive" })
+          )
+      );
+      for (const result of results) {
+        if (result.status === "rejected") {
+          deps.onBackgroundWindowFailed(result.reason);
+          backgroundClean = false;
+        } else if (result.value !== "ok") {
+          backgroundClean = false;
+        }
+      }
+    }
+
+    restoredCleanly = backgroundClean;
+  } finally {
+    deps.resumeSaves(restoredCleanly);
+  }
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -32,9 +32,12 @@ import {
 } from "./setup/protocols.js";
 import { activateDeepLinkHandler } from "./setup/deepLinkInstall.js";
 import {
+  extractDirectoryPaths,
+  hasCliPathFlag,
   registerAppLifecycleHandlers,
   registerWindowSessionEndHandler,
 } from "./lifecycle/appLifecycle.js";
+import { resolveLaunchIntent, shouldRestoreWindowFleet } from "./lifecycle/launchIntent.js";
 import { registerShutdownHandler } from "./lifecycle/shutdown.js";
 import {
   setMainWindow,
@@ -79,7 +82,13 @@ import {
 } from "./window/powerMonitor.js";
 import { getProjectStatsService } from "./ipc/handlers/projectCrud/index.js";
 import { getIdleTerminalNotificationService } from "./services/IdleTerminalNotificationService.js";
-import { isDemoMode, isSmokeTest, kickOffEarlyPathRefresh } from "./setup/environment.js";
+import {
+  getPendingOpenDirPaths,
+  getPendingOpenFilePaths,
+  isDemoMode,
+  isSmokeTest,
+  kickOffEarlyPathRefresh,
+} from "./setup/environment.js";
 import { store } from "./store.js";
 import { initializeLogger, registerLoggerTransport, setLogLevelOverrides } from "./utils/logger.js";
 import { broadcastToVisibleRenderers } from "./ipc/utils.js";
@@ -93,7 +102,17 @@ import { buildSwitchHydrateResult } from "./services/AppHydrationService.js";
 import { initializeCrashLoopGuard, getCrashLoopGuard } from "./services/CrashLoopGuardService.js";
 import { initializePanelSuspectLedger } from "./services/PanelSuspectLedgerService.js";
 import { initializeGpuCrashMonitor } from "./services/GpuCrashMonitorService.js";
-import { readLastActiveProjectIdSync } from "./services/persistence/readLastProjectId.js";
+import {
+  readLastActiveProjectIdSync,
+  readOpenWindowsManifestSync,
+} from "./services/persistence/readLastProjectId.js";
+import {
+  initOpenWindowsTracker,
+  resumeOpenWindowsSaves,
+  saveOpenWindowsNow,
+  scheduleOpenWindowsSave,
+  suppressOpenWindowsSaves,
+} from "./window/openWindowsTracker.js";
 import { emergencyLogMainFatal } from "./utils/emergencyLog.js";
 
 // CRITICAL: Run IPC sender validation before any handlers are registered
@@ -285,6 +304,14 @@ if (!gotTheLock) {
   const windowRegistry = new WindowRegistry();
   setWindowRegistry(windowRegistry);
   windowRegistry.wireFocusTracking(app);
+  // Re-persist the manifest when focus moves: its order IS the focus order, and
+  // that order decides which window gets focus on the next launch and which get
+  // trimmed by the cap. A second listener rather than a hook inside
+  // wireFocusTracking so the registry's focus bookkeeping stays independent of
+  // persistence — and it is registered after, so the registry has already
+  // recorded the focus by the time this reads it. Debounced, so alt-tabbing
+  // collapses to one write.
+  app.on("browser-window-focus", () => scheduleOpenWindowsSave());
 
   // Read last-active projectId synchronously from SQLite BEFORE creating any window.
   // This allows the initial WebContentsView to use the correct session partition,
@@ -295,17 +322,30 @@ if (!gotTheLock) {
 
   async function createWindow(
     initialProjectPath?: string | null,
-    initialProjectId?: string
-  ): Promise<void> {
+    initialProjectId?: string,
+    opts?: { revealMode?: "show" | "showInactive" }
+  ): Promise<"ok" | "exit-requested"> {
     const { win, appView, loadRenderer, smokeTestTimer, smokeRendererUnresponsive } =
       setupBrowserWindow(__dirname, {
-        onRecreateWindow: () => createWindow(initialProjectPath, initialProjectId),
-        onCreateWindow: (projectPath?: string) => createWindow(projectPath),
+        onRecreateWindow: () => createWindow(initialProjectPath, initialProjectId).then(() => {}),
+        onCreateWindow: (projectPath?: string) => createWindow(projectPath).then(() => {}),
         projectPath: initialProjectPath,
         initialProjectId,
+        revealMode: opts?.revealMode,
       });
     setMainWindow(win);
     const ctx = windowRegistry.register(win, { projectPath: initialProjectPath ?? undefined });
+
+    // Keep the persisted window manifest in step with this window (#11492).
+    // The save listens on `closed`, not `close`: WindowRegistry still holds the
+    // window at `close`, so a manifest built there would re-persist the window
+    // the user just closed. Registered after `register()` so it runs after the
+    // registry's own `once("closed")` unregister hook.
+    // `win.id` is unreadable on a destroyed BrowserWindow, so the id is taken
+    // from the registry context captured here rather than read in the handler.
+    const closedWindowId = ctx.windowId;
+    scheduleOpenWindowsSave();
+    win.on("closed", () => saveOpenWindowsNow(closedWindowId));
     windowRegistry.registerAppViewWebContents(ctx.windowId, appView.webContents.id);
     // Paint-fabric surface views load the same preload as project views; the
     // paintSurface IPC namespace builds its per-window manager lazily and
@@ -314,7 +354,7 @@ if (!gotTheLock) {
 
     const pvm = new ProjectViewManager(win, {
       dirname: __dirname,
-      onRecreateWindow: () => createWindow(initialProjectPath, initialProjectId),
+      onRecreateWindow: () => createWindow(initialProjectPath, initialProjectId).then(() => {}),
       windowRegistry,
       // Resolve to the same value the IPC handler returns so the main-process
       // LRU cap and the renderer's Settings view agree on first boot. Invalid
@@ -527,7 +567,7 @@ if (!gotTheLock) {
       })
     );
 
-    await setupWindowServices(win, {
+    const servicesResult = await setupWindowServices(win, {
       loadRenderer,
       smokeTestTimer,
       smokeRendererUnresponsive,
@@ -537,6 +577,10 @@ if (!gotTheLock) {
       projectViewManager: pvm,
       initialAppView: appView,
     });
+
+    // Global init failed fatally and app.exit(1) is already issued. Stop here
+    // so a restore fan-out doesn't keep building windows into a dying process.
+    if (servicesResult === "exit-requested") return "exit-requested";
 
     // Seed the eviction guard's agent-state cache from the pty-host registry.
     // hasActiveAgent() is read synchronously during LRU scoring, so it can't
@@ -565,11 +609,13 @@ if (!gotTheLock) {
 
     registerWindowForFocusThrottle(win);
     registerWindowSessionEndHandler(win);
+
+    return "ok";
   }
 
   registerAppLifecycleHandlers({
-    onCreateWindow: () => createWindow(),
-    onCreateWindowForPath: (cliPath) => createWindow(cliPath),
+    onCreateWindow: () => createWindow().then(() => {}),
+    onCreateWindowForPath: (cliPath) => createWindow(cliPath).then(() => {}),
     getMainWindow,
     getCliAvailabilityService: getCliAvailabilityServiceRef,
     windowRegistry,
@@ -643,22 +689,84 @@ if (!gotTheLock) {
       //   - per-project state file doesn't exist yet (migration must run on
       //     the renderer-blocking handler path — `buildSwitchHydrateResult`
       //     intentionally skips the migration write)
-      if (lastActiveProjectId) {
-        const guard = getCrashLoopGuard();
-        const crashService = getCrashRecoveryService();
-        if (!guard.isSafeMode() && !crashService.getPendingCrash()) {
-          void projectStore
-            .getProjectState(lastActiveProjectId)
-            .then((state) => {
-              if (state === null) return;
-              return prefetchHydrateResult(lastActiveProjectId, buildSwitchHydrateResult);
-            })
-            .catch((error) => {
-              console.warn("[MAIN] Boot-prime hydrate prefetch failed:", error);
-            });
-        }
+      const launchIntent = resolveLaunchIntent({
+        argv: process.argv,
+        hasCliPathFlag,
+        extractDirectoryPaths,
+        pendingOpenDirPaths: getPendingOpenDirPaths(),
+        pendingOpenFilePaths: getPendingOpenFilePaths(),
+        isSafeMode: getCrashLoopGuard().isSafeMode(),
+        hasPendingCrash: getCrashRecoveryService().getPendingCrash() !== null,
+      });
+
+      // A recovery launch deliberately opens one window. It must not then
+      // persist that as the window set, or safe mode would overwrite the user's
+      // real fleet with the reduced one it opened to diagnose it (#11492).
+      initOpenWindowsTracker({ registry: windowRegistry, readOnly: launchIntent === "recovery" });
+
+      const restoreRecords = shouldRestoreWindowFleet(launchIntent)
+        ? readOpenWindowsManifestSync()
+        : [];
+
+      // The window that gets focus is the manifest's most-recently-focused
+      // record — not `lastActiveProjectId`, which tracks the last project
+      // *switched to* anywhere and can name a different window entirely.
+      const primaryRestoreProjectId =
+        restoreRecords.length > 0
+          ? (restoreRecords[0].projectId ?? undefined)
+          : (lastActiveProjectId ?? undefined);
+
+      if (primaryRestoreProjectId && launchIntent !== "recovery") {
+        void projectStore
+          .getProjectState(primaryRestoreProjectId)
+          .then((state) => {
+            if (state === null) return;
+            return prefetchHydrateResult(primaryRestoreProjectId, buildSwitchHydrateResult);
+          })
+          .catch((error) => {
+            console.warn("[MAIN] Boot-prime hydrate prefetch failed:", error);
+          });
       }
-      await createWindow(undefined, lastActiveProjectId ?? undefined);
+
+      // Hold manifest writes across the whole fan-out. Windows 2..N register
+      // while window 1's debounce is still pending, so an unheld save would
+      // persist a partial fleet — harmless if startup finishes, authoritative
+      // for the next launch if it doesn't.
+      suppressOpenWindowsSaves();
+      let restoredCleanly = false;
+      try {
+        // The first window must complete alone. `initGlobalServices()` flips its
+        // "initialized" guard synchronously at entry, before its own awaits, so
+        // a concurrent second window sails past the guard and races the first
+        // window's migrations and DB open. Once this await returns, global init
+        // has fully settled and the rest are safe to run together.
+        const primaryResult = await createWindow(undefined, primaryRestoreProjectId);
+
+        if (primaryResult === "ok" && restoreRecords.length > 1) {
+          // Background windows reveal with showInactive(): they finish loading
+          // in an unpredictable order, and a plain show() would hand focus to
+          // whichever renderer parsed its skeleton last.
+          const results = await Promise.allSettled(
+            restoreRecords.slice(1).map((record) =>
+              createWindow(undefined, record.projectId ?? undefined, {
+                revealMode: "showInactive",
+              })
+            )
+          );
+          for (const result of results) {
+            if (result.status === "rejected") {
+              console.error("[MAIN] Restoring a background window failed:", result.reason);
+            }
+          }
+        }
+
+        restoredCleanly = primaryResult === "ok";
+      } finally {
+        // Only overwrite the manifest once the fleet is actually up. A failed
+        // fan-out leaves the stored manifest alone — it is still correct, and a
+        // partial rewrite would shrink the set the next launch restores.
+        resumeOpenWindowsSaves(restoredCleanly);
+      }
     } catch (error) {
       console.error("[MAIN] Startup failed:", error);
       // Startup crashes hard-exit without running before-quit, which means

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -38,6 +38,11 @@ import {
   registerWindowSessionEndHandler,
 } from "./lifecycle/appLifecycle.js";
 import { resolveLaunchIntent, shouldRestoreWindowFleet } from "./lifecycle/launchIntent.js";
+import {
+  resolvePrimaryRestoreProjectId,
+  restoreWindowFleet,
+  type CreateWindowResult,
+} from "./lifecycle/windowRestore.js";
 import { registerShutdownHandler } from "./lifecycle/shutdown.js";
 import {
   setMainWindow,
@@ -324,7 +329,7 @@ if (!gotTheLock) {
     initialProjectPath?: string | null,
     initialProjectId?: string,
     opts?: { revealMode?: "show" | "showInactive" }
-  ): Promise<"ok" | "exit-requested"> {
+  ): Promise<CreateWindowResult> {
     const { win, appView, loadRenderer, smokeTestTimer, smokeRendererUnresponsive } =
       setupBrowserWindow(__dirname, {
         onRecreateWindow: () => createWindow(initialProjectPath, initialProjectId).then(() => {}),
@@ -578,9 +583,10 @@ if (!gotTheLock) {
       initialAppView: appView,
     });
 
-    // Global init failed fatally and app.exit(1) is already issued. Stop here
-    // so a restore fan-out doesn't keep building windows into a dying process.
-    if (servicesResult === "exit-requested") return "exit-requested";
+    // The process is exiting, or the window never reached the registry and has
+    // no services. Either way stop here, so a restore fan-out doesn't keep
+    // building windows into a dying process or count this one as restored.
+    if (servicesResult !== "ok") return servicesResult;
 
     // Seed the eviction guard's agent-state cache from the pty-host registry.
     // hasActiveAgent() is read synchronously during LRU scoring, so it can't
@@ -679,16 +685,6 @@ if (!gotTheLock) {
       // through the existing confirm/security gates, never silently.
       activateDeepLinkHandler(windowRegistry);
       setupWebviewCSP();
-      // Prime the hydrate prefetch cache for the last-active project so the
-      // renderer's first `app:boot` invoke resolves as a cache hit instead of
-      // doing an inline disk read. Fire-and-forget — overlaps with window
-      // creation. Skipped when:
-      //   - no last-active project (first run / project unset)
-      //   - safe mode (terminals are suppressed; priming would write empty)
-      //   - pending crash recovery (panelFilter path layers extra constraints)
-      //   - per-project state file doesn't exist yet (migration must run on
-      //     the renderer-blocking handler path — `buildSwitchHydrateResult`
-      //     intentionally skips the migration write)
       const launchIntent = resolveLaunchIntent({
         argv: process.argv,
         hasCliPathFlag,
@@ -701,21 +697,35 @@ if (!gotTheLock) {
 
       // A recovery launch deliberately opens one window. It must not then
       // persist that as the window set, or safe mode would overwrite the user's
-      // real fleet with the reduced one it opened to diagnose it (#11492).
+      // real fleet with the reduced one it opened to diagnose it (#11492). A
+      // targeted launch is NOT read-only: opening one folder from the CLI or
+      // Finder is a genuine one-window session the user asked for, so the
+      // manifest should describe it.
       initOpenWindowsTracker({ registry: windowRegistry, readOnly: launchIntent === "recovery" });
 
-      const restoreRecords = shouldRestoreWindowFleet(launchIntent)
+      const { hadManifest, records: restoreRecords } = shouldRestoreWindowFleet(launchIntent)
         ? readOpenWindowsManifestSync()
-        : [];
+        : { hadManifest: false, records: [] };
 
       // The window that gets focus is the manifest's most-recently-focused
       // record — not `lastActiveProjectId`, which tracks the last project
       // *switched to* anywhere and can name a different window entirely.
-      const primaryRestoreProjectId =
-        restoreRecords.length > 0
-          ? (restoreRecords[0].projectId ?? undefined)
-          : (lastActiveProjectId ?? undefined);
+      const primaryRestoreProjectId = resolvePrimaryRestoreProjectId(
+        restoreRecords,
+        hadManifest,
+        lastActiveProjectId ?? undefined
+      );
 
+      // Prime the hydrate prefetch cache for the window that will take focus so
+      // the renderer's first `app:boot` invoke resolves as a cache hit instead
+      // of doing an inline disk read. Fire-and-forget — overlaps with window
+      // creation. Skipped when:
+      //   - no project to restore (first run / project unset / picker window)
+      //   - safe mode or pending crash recovery (terminals are suppressed and
+      //     the panelFilter path layers extra constraints)
+      //   - per-project state file doesn't exist yet (migration must run on
+      //     the renderer-blocking handler path — `buildSwitchHydrateResult`
+      //     intentionally skips the migration write)
       if (primaryRestoreProjectId && launchIntent !== "recovery") {
         void projectStore
           .getProjectState(primaryRestoreProjectId)
@@ -728,45 +738,17 @@ if (!gotTheLock) {
           });
       }
 
-      // Hold manifest writes across the whole fan-out. Windows 2..N register
-      // while window 1's debounce is still pending, so an unheld save would
-      // persist a partial fleet — harmless if startup finishes, authoritative
-      // for the next launch if it doesn't.
-      suppressOpenWindowsSaves();
-      let restoredCleanly = false;
-      try {
-        // The first window must complete alone. `initGlobalServices()` flips its
-        // "initialized" guard synchronously at entry, before its own awaits, so
-        // a concurrent second window sails past the guard and races the first
-        // window's migrations and DB open. Once this await returns, global init
-        // has fully settled and the rest are safe to run together.
-        const primaryResult = await createWindow(undefined, primaryRestoreProjectId);
-
-        if (primaryResult === "ok" && restoreRecords.length > 1) {
-          // Background windows reveal with showInactive(): they finish loading
-          // in an unpredictable order, and a plain show() would hand focus to
-          // whichever renderer parsed its skeleton last.
-          const results = await Promise.allSettled(
-            restoreRecords.slice(1).map((record) =>
-              createWindow(undefined, record.projectId ?? undefined, {
-                revealMode: "showInactive",
-              })
-            )
-          );
-          for (const result of results) {
-            if (result.status === "rejected") {
-              console.error("[MAIN] Restoring a background window failed:", result.reason);
-            }
-          }
-        }
-
-        restoredCleanly = primaryResult === "ok";
-      } finally {
-        // Only overwrite the manifest once the fleet is actually up. A failed
-        // fan-out leaves the stored manifest alone — it is still correct, and a
-        // partial rewrite would shrink the set the next launch restores.
-        resumeOpenWindowsSaves(restoredCleanly);
-      }
+      await restoreWindowFleet({
+        records: restoreRecords,
+        hadManifest,
+        fallbackProjectId: lastActiveProjectId ?? undefined,
+        createWindow: (projectId, opts) => createWindow(undefined, projectId, opts),
+        suppressSaves: suppressOpenWindowsSaves,
+        resumeSaves: resumeOpenWindowsSaves,
+        onBackgroundWindowFailed: (reason) => {
+          console.error("[MAIN] Restoring a background window failed:", reason);
+        },
+      });
     } catch (error) {
       console.error("[MAIN] Startup failed:", error);
       // Startup crashes hard-exit without running before-quit, which means

--- a/electron/services/persistence/__tests__/readOpenWindowsManifest.test.ts
+++ b/electron/services/persistence/__tests__/readOpenWindowsManifest.test.ts
@@ -32,6 +32,7 @@ vi.mock("better-sqlite3", () => ({
   },
 }));
 
+import { resolvePrimaryRestoreProjectId } from "../../../lifecycle/windowRestore.js";
 import { readOpenWindowsManifestSync } from "../readLastProjectId.js";
 
 const manifestJson = (windows: unknown[]): string =>
@@ -128,10 +129,12 @@ describe("readOpenWindowsManifestSync", () => {
     expect(readOpenWindowsManifestSync()).toEqual({ hadManifest: true, records: [] });
   });
 
-  it("reports a manifest existed when it legitimately names zero windows", () => {
-    // Closing every window persists this; it must not read as "no manifest".
+  it("reports no manifest when the stored manifest names zero windows", () => {
+    // Closing the last window is the quit gesture on Windows and Linux, and its
+    // `closed` save persists exactly this before the shutdown freeze latches.
+    // Honouring it would put every relaunch on the project picker.
     withDb({ manifest: manifestJson([]) });
-    expect(readOpenWindowsManifestSync()).toEqual({ hadManifest: true, records: [] });
+    expect(readOpenWindowsManifestSync()).toEqual({ hadManifest: false, records: [] });
   });
 
   it("reports no manifest when every entry is malformed", () => {
@@ -213,5 +216,28 @@ describe("readOpenWindowsManifestSync", () => {
       throw new Error("no such table: projects");
     });
     expect(readOpenWindowsManifestSync()).toEqual({ hadManifest: false, records: [] });
+  });
+});
+
+// The reader's two "nothing to restore" answers look identical in isolation but
+// launch differently, so the pairing is asserted end to end rather than left to
+// the caller's reading of `hadManifest`.
+describe("the launch a stored manifest produces", () => {
+  const primaryProjectFor = (manifest: string): string | undefined => {
+    withDb({ manifest, existingProjectIds: ["a"] });
+    const { hadManifest, records } = readOpenWindowsManifestSync();
+    return resolvePrimaryRestoreProjectId(records, hadManifest, "last-active");
+  };
+
+  it("opens the last-active project when the manifest named zero windows", () => {
+    expect(primaryProjectFor(manifestJson([]))).toBe("last-active");
+  });
+
+  it("opens a picker when the manifest named only projects that are now deleted", () => {
+    expect(primaryProjectFor(manifestJson([{ projectId: "gone" }]))).toBeUndefined();
+  });
+
+  it("opens the manifest's own project when it still exists", () => {
+    expect(primaryProjectFor(manifestJson([{ projectId: "a" }]))).toBe("a");
   });
 });

--- a/electron/services/persistence/__tests__/readOpenWindowsManifest.test.ts
+++ b/electron/services/persistence/__tests__/readOpenWindowsManifest.test.ts
@@ -128,6 +128,17 @@ describe("readOpenWindowsManifestSync", () => {
     expect(readOpenWindowsManifestSync()).toEqual({ hadManifest: true, records: [] });
   });
 
+  it("reports a manifest existed when it legitimately names zero windows", () => {
+    // Closing every window persists this; it must not read as "no manifest".
+    withDb({ manifest: manifestJson([]) });
+    expect(readOpenWindowsManifestSync()).toEqual({ hadManifest: true, records: [] });
+  });
+
+  it("reports no manifest when every entry is malformed", () => {
+    withDb({ manifest: manifestJson([{ projectId: 42 }, "junk"]) });
+    expect(readOpenWindowsManifestSync()).toEqual({ hadManifest: false, records: [] });
+  });
+
   it("skips the project query entirely when every record is a picker window", () => {
     const onProjectQuery = vi.fn();
     withDb({ manifest: manifestJson([{ projectId: null }, { projectId: null }]), onProjectQuery });

--- a/electron/services/persistence/__tests__/readOpenWindowsManifest.test.ts
+++ b/electron/services/persistence/__tests__/readOpenWindowsManifest.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  OPEN_WINDOWS_KEY,
+  OPEN_WINDOWS_MANIFEST_VERSION,
+  type OpenWindowRecord,
+} from "../windowManifest.js";
+
+// Explicit factories throughout — spreading importOriginal() here would load the
+// real better-sqlite3 binding and electron, which passes locally and fails on CI.
+const existsSync = vi.fn<(p: string) => boolean>(() => true);
+vi.mock("node:fs", () => ({
+  default: { existsSync: (p: string) => existsSync(p) },
+  existsSync: (p: string) => existsSync(p),
+}));
+
+vi.mock("electron", () => ({
+  app: { getPath: () => "/userData" },
+}));
+
+interface Statement {
+  get: (...args: unknown[]) => unknown;
+  all: (...args: unknown[]) => unknown;
+}
+
+const prepare = vi.fn<(sql: string) => Statement>();
+const close = vi.fn();
+const databaseCtor = vi.fn(() => ({ prepare, close }));
+
+vi.mock("better-sqlite3", () => ({
+  default: function Database(this: unknown, ...args: unknown[]) {
+    return databaseCtor(...(args as []));
+  },
+}));
+
+import { readOpenWindowsManifestSync } from "../readLastProjectId.js";
+
+const manifestJson = (windows: unknown[]): string =>
+  JSON.stringify({ version: OPEN_WINDOWS_MANIFEST_VERSION, windows });
+
+/**
+ * Wire the two queries the reader issues: the app_state lookup and the batched
+ * project-existence check.
+ */
+function withDb(opts: {
+  manifest?: string | undefined;
+  existingProjectIds?: string[];
+  onProjectQuery?: (sql: string, ids: unknown[]) => void;
+}) {
+  prepare.mockImplementation((sql: string) => {
+    if (sql.includes("app_state")) {
+      return {
+        get: (key: unknown) =>
+          key === OPEN_WINDOWS_KEY && opts.manifest !== undefined
+            ? { value: opts.manifest }
+            : undefined,
+        all: () => [],
+      };
+    }
+    return {
+      get: () => undefined,
+      all: (...ids: unknown[]) => {
+        opts.onProjectQuery?.(sql, ids);
+        return (opts.existingProjectIds ?? [])
+          .filter((id) => ids.includes(id))
+          .map((id) => ({ id }));
+      },
+    };
+  });
+}
+
+const ids = (records: OpenWindowRecord[]) => records.map((r) => r.projectId);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  existsSync.mockReturnValue(true);
+});
+
+describe("readOpenWindowsManifestSync", () => {
+  it("reports no manifest on first launch, without opening a database", () => {
+    existsSync.mockReturnValue(false);
+    expect(readOpenWindowsManifestSync()).toEqual({ hadManifest: false, records: [] });
+    expect(databaseCtor).not.toHaveBeenCalled();
+  });
+
+  it("opens the database read-only", () => {
+    withDb({ manifest: undefined });
+    readOpenWindowsManifestSync();
+    expect(databaseCtor).toHaveBeenCalledWith(expect.any(String), { readonly: true });
+  });
+
+  it("reports no manifest when the row is absent", () => {
+    withDb({ manifest: undefined });
+    expect(readOpenWindowsManifestSync().hadManifest).toBe(false);
+  });
+
+  it("reports no manifest when the stored payload is corrupt", () => {
+    withDb({ manifest: "{not json" });
+    expect(readOpenWindowsManifestSync()).toEqual({ hadManifest: false, records: [] });
+  });
+
+  it("restores surviving windows and drops the deleted one, preserving order", () => {
+    withDb({
+      manifest: manifestJson([
+        { projectId: "a" },
+        { projectId: null },
+        { projectId: "gone" },
+        { projectId: "b" },
+      ]),
+      existingProjectIds: ["a", "b"],
+    });
+    const result = readOpenWindowsManifestSync();
+    expect(result.hadManifest).toBe(true);
+    expect(ids(result.records)).toEqual(["a", null, "b"]);
+  });
+
+  it("keeps both windows when the same project appears twice", () => {
+    withDb({
+      manifest: manifestJson([{ projectId: "a" }, { projectId: null }, { projectId: "a" }]),
+      existingProjectIds: ["a"],
+    });
+    expect(ids(readOpenWindowsManifestSync().records)).toEqual(["a", null, "a"]);
+  });
+
+  it("still reports a manifest existed when every project was deleted", () => {
+    // The caller needs this to open a picker rather than falling back to the
+    // global last-active project.
+    withDb({ manifest: manifestJson([{ projectId: "gone" }]), existingProjectIds: [] });
+    expect(readOpenWindowsManifestSync()).toEqual({ hadManifest: true, records: [] });
+  });
+
+  it("skips the project query entirely when every record is a picker window", () => {
+    const onProjectQuery = vi.fn();
+    withDb({ manifest: manifestJson([{ projectId: null }, { projectId: null }]), onProjectQuery });
+    const result = readOpenWindowsManifestSync();
+    expect(onProjectQuery).not.toHaveBeenCalled();
+    expect(ids(result.records)).toEqual([null, null]);
+  });
+
+  it("binds project ids as parameters rather than interpolating them", () => {
+    let seenSql = "";
+    let seenIds: unknown[] = [];
+    withDb({
+      manifest: manifestJson([{ projectId: "a'; DROP TABLE projects;--" }]),
+      existingProjectIds: [],
+      onProjectQuery: (sql, boundIds) => {
+        seenSql = sql;
+        seenIds = boundIds;
+      },
+    });
+
+    readOpenWindowsManifestSync();
+
+    expect(seenSql).not.toContain("DROP TABLE");
+    expect(seenSql).toContain("?");
+    expect(seenIds).toEqual(["a'; DROP TABLE projects;--"]);
+  });
+
+  it("binds one placeholder per deduplicated project id", () => {
+    let seenSql = "";
+    let seenIds: unknown[] = [];
+    withDb({
+      manifest: manifestJson([{ projectId: "a" }, { projectId: "b" }, { projectId: "a" }]),
+      existingProjectIds: ["a", "b"],
+      onProjectQuery: (sql, boundIds) => {
+        seenSql = sql;
+        seenIds = boundIds;
+      },
+    });
+
+    readOpenWindowsManifestSync();
+
+    expect(seenIds).toEqual(["a", "b"]);
+    expect(seenSql.match(/\?/g)).toHaveLength(seenIds.length);
+  });
+
+  it("closes the connection it opened", () => {
+    withDb({ manifest: manifestJson([{ projectId: "a" }]), existingProjectIds: ["a"] });
+    readOpenWindowsManifestSync();
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the connection even when a query throws", () => {
+    prepare.mockImplementation(() => {
+      throw new Error("no such table: app_state");
+    });
+    expect(readOpenWindowsManifestSync()).toEqual({ hadManifest: false, records: [] });
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports no manifest when the database cannot be opened", () => {
+    databaseCtor.mockImplementationOnce(() => {
+      throw new Error("database is locked");
+    });
+    expect(readOpenWindowsManifestSync()).toEqual({ hadManifest: false, records: [] });
+  });
+
+  it("reports no manifest when the projects table is missing", () => {
+    prepare.mockImplementation((sql: string) => {
+      if (sql.includes("app_state")) {
+        return { get: () => ({ value: manifestJson([{ projectId: "a" }]) }), all: () => [] };
+      }
+      throw new Error("no such table: projects");
+    });
+    expect(readOpenWindowsManifestSync()).toEqual({ hadManifest: false, records: [] });
+  });
+});

--- a/electron/services/persistence/__tests__/windowManifest.test.ts
+++ b/electron/services/persistence/__tests__/windowManifest.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import {
+  MAX_RESTORED_WINDOWS,
+  filterRestorableWindows,
+  parseOpenWindowsManifest,
+  serializeOpenWindowsManifest,
+  type OpenWindowRecord,
+} from "../windowManifest.js";
+
+const record = (projectId: string | null): OpenWindowRecord => ({ projectId });
+
+describe("parseOpenWindowsManifest", () => {
+  it("round-trips what serialize produced", () => {
+    const records = [record("alpha"), record(null), record("beta")];
+    expect(parseOpenWindowsManifest(serializeOpenWindowsManifest(records))).toEqual(records);
+  });
+
+  it("preserves record order — order is the focus order", () => {
+    const records = [record("c"), record("a"), record("b")];
+    const parsed = parseOpenWindowsManifest(serializeOpenWindowsManifest(records));
+    expect(parsed.map((r) => r.projectId)).toEqual(["c", "a", "b"]);
+  });
+
+  it("keeps duplicate project ids as separate windows", () => {
+    // Two windows can legitimately show the same project, so the manifest is a
+    // list of windows and must never collapse to a set of project ids.
+    const parsed = parseOpenWindowsManifest(
+      serializeOpenWindowsManifest([record("a"), record("a")])
+    );
+    expect(parsed).toHaveLength(2);
+  });
+
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["empty string", ""],
+    ["not JSON", "{not json"],
+    ["a JSON array", "[]"],
+    ["a JSON scalar", '"hello"'],
+    ["JSON null", "null"],
+  ])("returns nothing for %s", (_label, raw) => {
+    expect(parseOpenWindowsManifest(raw)).toEqual([]);
+  });
+
+  it("refuses a version it cannot read rather than guessing at fields", () => {
+    const future = JSON.stringify({ version: 99, windows: [{ projectId: "a" }] });
+    expect(parseOpenWindowsManifest(future)).toEqual([]);
+  });
+
+  it("refuses a manifest with no version", () => {
+    expect(parseOpenWindowsManifest(JSON.stringify({ windows: [{ projectId: "a" }] }))).toEqual([]);
+  });
+
+  it("refuses a manifest whose windows is not an array", () => {
+    expect(parseOpenWindowsManifest(JSON.stringify({ version: 1, windows: {} }))).toEqual([]);
+  });
+
+  it("drops malformed entries but keeps the sound ones around them", () => {
+    const raw = JSON.stringify({
+      version: 1,
+      windows: [
+        { projectId: "good" },
+        { projectId: 42 },
+        "not-an-object",
+        null,
+        { projectId: "" },
+        {},
+        { projectId: null },
+        { projectId: "also-good" },
+      ],
+    });
+    expect(parseOpenWindowsManifest(raw)).toEqual([
+      record("good"),
+      record(null),
+      record("also-good"),
+    ]);
+  });
+
+  it("caps a manifest that would otherwise launch an unbounded fleet", () => {
+    const raw = JSON.stringify({
+      version: 1,
+      windows: Array.from({ length: 200 }, (_, i) => ({ projectId: `p${i}` })),
+    });
+    const parsed = parseOpenWindowsManifest(raw);
+    expect(parsed).toHaveLength(MAX_RESTORED_WINDOWS);
+    // Trimmed from the tail, so the most-recently-focused windows survive.
+    expect(parsed[0].projectId).toBe("p0");
+  });
+
+  it("ignores extra unknown fields on an entry", () => {
+    const raw = JSON.stringify({
+      version: 1,
+      windows: [{ projectId: "a", windowId: 7, bounds: { x: 1 } }],
+    });
+    expect(parseOpenWindowsManifest(raw)).toEqual([record("a")]);
+  });
+});
+
+describe("serializeOpenWindowsManifest", () => {
+  it("stamps the version so a later shape change is detectable", () => {
+    const parsed: unknown = JSON.parse(serializeOpenWindowsManifest([record("a")]));
+    expect(parsed).toMatchObject({ windows: [{ projectId: "a" }] });
+    expect((parsed as { version: unknown }).version).toEqual(expect.any(Number));
+  });
+
+  it("never persists more than the cap", () => {
+    const overflow = Array.from({ length: 50 }, (_, i) => record(`p${i}`));
+    const parsed = JSON.parse(serializeOpenWindowsManifest(overflow)) as {
+      windows: OpenWindowRecord[];
+    };
+    expect(parsed.windows).toHaveLength(MAX_RESTORED_WINDOWS);
+  });
+
+  it("writes only the projectId, never an ephemeral Electron window id", () => {
+    const withExtras = [{ projectId: "a", windowId: 3 } as OpenWindowRecord];
+    expect(serializeOpenWindowsManifest(withExtras)).not.toContain("windowId");
+  });
+});
+
+describe("filterRestorableWindows", () => {
+  it("drops a record whose project no longer exists", () => {
+    const records = [record("gone"), record("here")];
+    expect(filterRestorableWindows(records, new Set(["here"]))).toEqual([record("here")]);
+  });
+
+  it("never substitutes a surviving project for a deleted one", () => {
+    const filtered = filterRestorableWindows([record("gone")], new Set(["other"]));
+    expect(filtered).toEqual([]);
+  });
+
+  it("keeps project-picker windows, which have no project to validate", () => {
+    expect(filterRestorableWindows([record(null)], new Set())).toEqual([record(null)]);
+  });
+
+  it("lets the surviving windows through when one project is missing", () => {
+    const records = [record("a"), record("gone"), record(null), record("b")];
+    expect(filterRestorableWindows(records, new Set(["a", "b"]))).toEqual([
+      record("a"),
+      record(null),
+      record("b"),
+    ]);
+  });
+
+  it("keeps both windows when a duplicated project still exists", () => {
+    expect(filterRestorableWindows([record("a"), record("a")], new Set(["a"]))).toHaveLength(2);
+  });
+});

--- a/electron/services/persistence/__tests__/windowManifest.test.ts
+++ b/electron/services/persistence/__tests__/windowManifest.test.ts
@@ -3,6 +3,7 @@ import {
   MAX_RESTORED_WINDOWS,
   OPEN_WINDOWS_MANIFEST_VERSION,
   filterRestorableWindows,
+  isReadableOpenWindowsManifest,
   parseOpenWindowsManifest,
   serializeOpenWindowsManifest,
   type OpenWindowRecord,
@@ -115,6 +116,58 @@ describe("serializeOpenWindowsManifest", () => {
   it("writes only the projectId, never an ephemeral Electron window id", () => {
     const withExtras = [{ projectId: "a", windowId: 3 } as OpenWindowRecord];
     expect(serializeOpenWindowsManifest(withExtras)).not.toContain("windowId");
+  });
+});
+
+describe("isReadableOpenWindowsManifest", () => {
+  it("accepts a manifest that legitimately names zero windows", () => {
+    // Closing every window persists exactly this. It must stay distinguishable
+    // from having no manifest, or the next launch falls back to the global
+    // last-active project.
+    expect(isReadableOpenWindowsManifest(manifestJson([]))).toBe(true);
+  });
+
+  it("accepts a populated manifest", () => {
+    expect(isReadableOpenWindowsManifest(manifestJson([{ projectId: "a" }]))).toBe(true);
+  });
+
+  it("accepts a manifest of picker windows", () => {
+    expect(isReadableOpenWindowsManifest(manifestJson([{ projectId: null }]))).toBe(true);
+  });
+
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["empty string", ""],
+    ["not JSON", "{not json"],
+    ["a JSON array", "[]"],
+    ["JSON null", "null"],
+  ])("rejects %s", (_label, raw) => {
+    expect(isReadableOpenWindowsManifest(raw)).toBe(false);
+  });
+
+  it("rejects a version it cannot read", () => {
+    const future = JSON.stringify({
+      version: OPEN_WINDOWS_MANIFEST_VERSION + 1,
+      windows: [],
+    });
+    expect(isReadableOpenWindowsManifest(future)).toBe(false);
+  });
+
+  it("rejects a manifest whose windows is not an array", () => {
+    expect(isReadableOpenWindowsManifest(manifestJson([]).replace("[]", "{}"))).toBe(false);
+  });
+
+  it("rejects a non-empty manifest whose every entry is malformed", () => {
+    // Corrupt, not empty — the friendlier answer to corruption is the old
+    // single-window behaviour rather than a bare project picker.
+    expect(isReadableOpenWindowsManifest(manifestJson([{ projectId: 42 }, "junk"]))).toBe(false);
+  });
+
+  it("accepts a manifest where only some entries are malformed", () => {
+    expect(
+      isReadableOpenWindowsManifest(manifestJson([{ projectId: 42 }, { projectId: "a" }]))
+    ).toBe(true);
   });
 });
 

--- a/electron/services/persistence/__tests__/windowManifest.test.ts
+++ b/electron/services/persistence/__tests__/windowManifest.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   MAX_RESTORED_WINDOWS,
+  OPEN_WINDOWS_MANIFEST_VERSION,
   filterRestorableWindows,
   parseOpenWindowsManifest,
   serializeOpenWindowsManifest,
@@ -8,6 +9,11 @@ import {
 } from "../windowManifest.js";
 
 const record = (projectId: string | null): OpenWindowRecord => ({ projectId });
+
+/** Builds a manifest at the CURRENT version, so a version bump can't turn a
+ *  malformed-shape test into a false positive by being rejected on version. */
+const manifestJson = (windows: unknown[]): string =>
+  JSON.stringify({ version: OPEN_WINDOWS_MANIFEST_VERSION, windows });
 
 describe("parseOpenWindowsManifest", () => {
   it("round-trips what serialize produced", () => {
@@ -43,7 +49,10 @@ describe("parseOpenWindowsManifest", () => {
   });
 
   it("refuses a version it cannot read rather than guessing at fields", () => {
-    const future = JSON.stringify({ version: 99, windows: [{ projectId: "a" }] });
+    const future = JSON.stringify({
+      version: OPEN_WINDOWS_MANIFEST_VERSION + 1,
+      windows: [{ projectId: "a" }],
+    });
     expect(parseOpenWindowsManifest(future)).toEqual([]);
   });
 
@@ -52,23 +61,20 @@ describe("parseOpenWindowsManifest", () => {
   });
 
   it("refuses a manifest whose windows is not an array", () => {
-    expect(parseOpenWindowsManifest(JSON.stringify({ version: 1, windows: {} }))).toEqual([]);
+    expect(parseOpenWindowsManifest(manifestJson([]).replace("[]", "{}"))).toEqual([]);
   });
 
   it("drops malformed entries but keeps the sound ones around them", () => {
-    const raw = JSON.stringify({
-      version: 1,
-      windows: [
-        { projectId: "good" },
-        { projectId: 42 },
-        "not-an-object",
-        null,
-        { projectId: "" },
-        {},
-        { projectId: null },
-        { projectId: "also-good" },
-      ],
-    });
+    const raw = manifestJson([
+      { projectId: "good" },
+      { projectId: 42 },
+      "not-an-object",
+      null,
+      { projectId: "" },
+      {},
+      { projectId: null },
+      { projectId: "also-good" },
+    ]);
     expect(parseOpenWindowsManifest(raw)).toEqual([
       record("good"),
       record(null),
@@ -77,21 +83,16 @@ describe("parseOpenWindowsManifest", () => {
   });
 
   it("caps a manifest that would otherwise launch an unbounded fleet", () => {
-    const raw = JSON.stringify({
-      version: 1,
-      windows: Array.from({ length: 200 }, (_, i) => ({ projectId: `p${i}` })),
-    });
-    const parsed = parseOpenWindowsManifest(raw);
-    expect(parsed).toHaveLength(MAX_RESTORED_WINDOWS);
+    const inputIds = Array.from({ length: 200 }, (_, i) => `p${i}`);
+    const parsed = parseOpenWindowsManifest(
+      manifestJson(inputIds.map((id) => ({ projectId: id })))
+    );
     // Trimmed from the tail, so the most-recently-focused windows survive.
-    expect(parsed[0].projectId).toBe("p0");
+    expect(parsed.map((r) => r.projectId)).toEqual(inputIds.slice(0, MAX_RESTORED_WINDOWS));
   });
 
   it("ignores extra unknown fields on an entry", () => {
-    const raw = JSON.stringify({
-      version: 1,
-      windows: [{ projectId: "a", windowId: 7, bounds: { x: 1 } }],
-    });
+    const raw = manifestJson([{ projectId: "a", windowId: 7, bounds: { x: 1 } }]);
     expect(parseOpenWindowsManifest(raw)).toEqual([record("a")]);
   });
 });
@@ -103,12 +104,12 @@ describe("serializeOpenWindowsManifest", () => {
     expect((parsed as { version: unknown }).version).toEqual(expect.any(Number));
   });
 
-  it("never persists more than the cap", () => {
-    const overflow = Array.from({ length: 50 }, (_, i) => record(`p${i}`));
-    const parsed = JSON.parse(serializeOpenWindowsManifest(overflow)) as {
+  it("never persists more than the cap, trimming from the tail", () => {
+    const inputIds = Array.from({ length: 50 }, (_, i) => `p${i}`);
+    const parsed = JSON.parse(serializeOpenWindowsManifest(inputIds.map(record))) as {
       windows: OpenWindowRecord[];
     };
-    expect(parsed.windows).toHaveLength(MAX_RESTORED_WINDOWS);
+    expect(parsed.windows.map((r) => r.projectId)).toEqual(inputIds.slice(0, MAX_RESTORED_WINDOWS));
   });
 
   it("writes only the projectId, never an ephemeral Electron window id", () => {

--- a/electron/services/persistence/readLastProjectId.ts
+++ b/electron/services/persistence/readLastProjectId.ts
@@ -15,6 +15,12 @@ import { app } from "electron";
 import fs from "node:fs";
 import path from "path";
 import type { Project } from "../../../shared/types/project.js";
+import {
+  OPEN_WINDOWS_KEY,
+  filterRestorableWindows,
+  parseOpenWindowsManifest,
+  type OpenWindowRecord,
+} from "./windowManifest.js";
 
 export function readLastActiveProjectIdSync(): string | null {
   try {
@@ -74,5 +80,57 @@ export function readLastActiveProjectIdentitySync(
   } catch {
     // Corrupt DB, missing column, etc. — anonymous skeleton is the fallback.
     return null;
+  }
+}
+
+/**
+ * Synchronous, standalone reader for the open-window manifest (#11492) — the
+ * set of windows to recreate on a cold launch, most-recently-focused first.
+ *
+ * Reads on the same throwaway read-only connection idiom as its siblings above,
+ * because the restore decision runs before `app.whenReady()` resolves and each
+ * record's project id chooses that window's session partition — it has to be
+ * known before the BrowserWindow is built, not corrected afterwards.
+ *
+ * Project existence is validated here, in one batched `IN (...)` query rather
+ * than a query per record, so a deleted project is dropped before any window is
+ * constructed around it. Records for the project picker (`projectId: null`)
+ * always survive.
+ *
+ * Returns [] on first launch, corrupt DB, corrupt manifest, or any error — the
+ * caller falls back to opening a single window.
+ */
+export function readOpenWindowsManifestSync(): OpenWindowRecord[] {
+  try {
+    const dbPath = path.join(app.getPath("userData"), "daintree.db");
+
+    if (!fs.existsSync(dbPath)) {
+      return []; // First launch — no database yet
+    }
+
+    const sqlite = new Database(dbPath, { readonly: true });
+    try {
+      const row = sqlite
+        .prepare("SELECT value FROM app_state WHERE key = ?")
+        .get(OPEN_WINDOWS_KEY) as { value: string } | undefined;
+
+      const records = parseOpenWindowsManifest(row?.value ?? null);
+      if (records.length === 0) return [];
+
+      const projectIds = [...new Set(records.map((r) => r.projectId).filter((id) => id !== null))];
+      if (projectIds.length === 0) return records;
+
+      const placeholders = projectIds.map(() => "?").join(",");
+      const rows = sqlite
+        .prepare(`SELECT id FROM projects WHERE id IN (${placeholders})`)
+        .all(...projectIds) as { id: string }[];
+
+      return filterRestorableWindows(records, new Set(rows.map((r) => r.id)));
+    } finally {
+      sqlite.close();
+    }
+  } catch {
+    // Any error (corrupt DB, missing table, etc.) — restore a single window.
+    return [];
   }
 }

--- a/electron/services/persistence/readLastProjectId.ts
+++ b/electron/services/persistence/readLastProjectId.ts
@@ -97,15 +97,31 @@ export function readLastActiveProjectIdentitySync(
  * constructed around it. Records for the project picker (`projectId: null`)
  * always survive.
  *
- * Returns [] on first launch, corrupt DB, corrupt manifest, or any error — the
- * caller falls back to opening a single window.
+ * `hadManifest` is reported separately from `records` on purpose: a readable
+ * manifest whose every project has since been deleted filters down to an empty
+ * list, and that is NOT the same as having no manifest at all. Collapsing the
+ * two would let the caller fall back to the global last-active project — which
+ * is precisely the "silently opened a different project" behaviour the restore
+ * is required to avoid.
+ *
+ * Both fields report nothing on first launch, corrupt DB, corrupt manifest, or
+ * any error, so the caller opens a single window seeded the old way.
  */
-export function readOpenWindowsManifestSync(): OpenWindowRecord[] {
+export interface OpenWindowsManifestRead {
+  /** A structurally valid manifest was stored, whatever survived filtering. */
+  hadManifest: boolean;
+  /** Windows still restorable, most-recently-focused first. */
+  records: OpenWindowRecord[];
+}
+
+const NO_MANIFEST: OpenWindowsManifestRead = { hadManifest: false, records: [] };
+
+export function readOpenWindowsManifestSync(): OpenWindowsManifestRead {
   try {
     const dbPath = path.join(app.getPath("userData"), "daintree.db");
 
     if (!fs.existsSync(dbPath)) {
-      return []; // First launch — no database yet
+      return NO_MANIFEST; // First launch — no database yet
     }
 
     const sqlite = new Database(dbPath, { readonly: true });
@@ -115,22 +131,25 @@ export function readOpenWindowsManifestSync(): OpenWindowRecord[] {
         .get(OPEN_WINDOWS_KEY) as { value: string } | undefined;
 
       const records = parseOpenWindowsManifest(row?.value ?? null);
-      if (records.length === 0) return [];
+      if (records.length === 0) return NO_MANIFEST;
 
       const projectIds = [...new Set(records.map((r) => r.projectId).filter((id) => id !== null))];
-      if (projectIds.length === 0) return records;
+      if (projectIds.length === 0) return { hadManifest: true, records };
 
       const placeholders = projectIds.map(() => "?").join(",");
       const rows = sqlite
         .prepare(`SELECT id FROM projects WHERE id IN (${placeholders})`)
         .all(...projectIds) as { id: string }[];
 
-      return filterRestorableWindows(records, new Set(rows.map((r) => r.id)));
+      return {
+        hadManifest: true,
+        records: filterRestorableWindows(records, new Set(rows.map((r) => r.id))),
+      };
     } finally {
       sqlite.close();
     }
   } catch {
     // Any error (corrupt DB, missing table, etc.) — restore a single window.
-    return [];
+    return NO_MANIFEST;
   }
 }

--- a/electron/services/persistence/readLastProjectId.ts
+++ b/electron/services/persistence/readLastProjectId.ts
@@ -98,18 +98,19 @@ export function readLastActiveProjectIdentitySync(
  * constructed around it. Records for the project picker (`projectId: null`)
  * always survive.
  *
- * `hadManifest` is reported separately from `records` on purpose: a readable
- * manifest whose every project has since been deleted filters down to an empty
- * list, and that is NOT the same as having no manifest at all. Collapsing the
- * two would let the caller fall back to the global last-active project — which
- * is precisely the "silently opened a different project" behaviour the restore
- * is required to avoid.
+ * `hadManifest` is reported separately from `records` on purpose: a manifest
+ * that named windows whose every project has since been deleted filters down to
+ * an empty list, and that is NOT the same as having no manifest at all.
+ * Collapsing the two would let the caller fall back to the global last-active
+ * project — which is precisely the "silently opened a different project"
+ * behaviour the restore is required to avoid.
  *
- * Both fields report nothing on first launch, corrupt DB, corrupt manifest, or
- * any error, so the caller opens a single window seeded the old way.
+ * Both fields report nothing on first launch, corrupt DB, corrupt manifest, a
+ * manifest that named zero windows, or any error, so the caller opens a single
+ * window seeded the old way.
  */
 export interface OpenWindowsManifestRead {
-  /** A structurally valid manifest was stored, whatever survived filtering. */
+  /** A manifest naming at least one window was stored, whatever survived filtering. */
   hadManifest: boolean;
   /** Windows still restorable, most-recently-focused first. */
   records: OpenWindowRecord[];
@@ -131,15 +132,17 @@ export function readOpenWindowsManifestSync(): OpenWindowsManifestRead {
         .prepare("SELECT value FROM app_state WHERE key = ?")
         .get(OPEN_WINDOWS_KEY) as { value: string } | undefined;
 
-      // Readability is asked separately from the record count: a manifest that
-      // legitimately names zero windows (the user closed them all) must not be
-      // mistaken for having no manifest, or the launch falls back to the global
-      // last-active project.
-      const hadManifest = isReadableOpenWindowsManifest(row?.value ?? null);
-      if (!hadManifest) return NO_MANIFEST;
+      // Two ways to have nothing to restore, both of which fall back to the
+      // global last-active project. Unreadable is corruption. Empty is the
+      // Windows/Linux quit gesture: closing the last window fires its `closed`
+      // save before `window-all-closed` reaches `app.quit()`, so the stored
+      // manifest names zero windows even though the user never asked for a
+      // picker. `hadManifest: true` below therefore means exactly one thing —
+      // the manifest named windows, and project deletion emptied it.
+      if (!isReadableOpenWindowsManifest(row?.value ?? null)) return NO_MANIFEST;
 
       const records = parseOpenWindowsManifest(row?.value ?? null);
-      if (records.length === 0) return { hadManifest: true, records: [] };
+      if (records.length === 0) return NO_MANIFEST;
 
       const projectIds = [...new Set(records.map((r) => r.projectId).filter((id) => id !== null))];
       if (projectIds.length === 0) return { hadManifest: true, records };

--- a/electron/services/persistence/readLastProjectId.ts
+++ b/electron/services/persistence/readLastProjectId.ts
@@ -18,6 +18,7 @@ import type { Project } from "../../../shared/types/project.js";
 import {
   OPEN_WINDOWS_KEY,
   filterRestorableWindows,
+  isReadableOpenWindowsManifest,
   parseOpenWindowsManifest,
   type OpenWindowRecord,
 } from "./windowManifest.js";
@@ -130,8 +131,15 @@ export function readOpenWindowsManifestSync(): OpenWindowsManifestRead {
         .prepare("SELECT value FROM app_state WHERE key = ?")
         .get(OPEN_WINDOWS_KEY) as { value: string } | undefined;
 
+      // Readability is asked separately from the record count: a manifest that
+      // legitimately names zero windows (the user closed them all) must not be
+      // mistaken for having no manifest, or the launch falls back to the global
+      // last-active project.
+      const hadManifest = isReadableOpenWindowsManifest(row?.value ?? null);
+      if (!hadManifest) return NO_MANIFEST;
+
       const records = parseOpenWindowsManifest(row?.value ?? null);
-      if (records.length === 0) return NO_MANIFEST;
+      if (records.length === 0) return { hadManifest: true, records: [] };
 
       const projectIds = [...new Set(records.map((r) => r.projectId).filter((id) => id !== null))];
       if (projectIds.length === 0) return { hadManifest: true, records };

--- a/electron/services/persistence/windowManifest.ts
+++ b/electron/services/persistence/windowManifest.ts
@@ -1,0 +1,116 @@
+/**
+ * The open-window manifest: which project each window was showing when the app
+ * last ran, so a relaunch can rebuild the whole set instead of one window
+ * (#11492).
+ *
+ * Stored as a single JSON value under `app_state.openWindows`, alongside the
+ * `currentProjectId` scalar ProjectStore already keeps there. That table is a
+ * schemaless key/value store, so this needs no drizzle migration.
+ *
+ * NOT to be confused with `electron/store.ts`'s unrelated top-level `appState`
+ * key — same name, different engine (electron-store JSON vs. SQLite).
+ *
+ * Records are ordered most-recently-focused first. Order is the only focus
+ * signal persisted: WindowRegistry keeps focus *history*, not timestamps, so a
+ * `lastFocusedAt` field would have nothing truthful to write into it.
+ *
+ * `projectId: null` is a real record, not a hole — a window sitting on the
+ * project picker restores as a picker window.
+ *
+ * Deliberately dependency-free: the reader that consumes it runs before
+ * `app.whenReady()`, and keeping the shape and its validation clear of the DB
+ * and Electron lets the corruption matrix be unit-tested without either.
+ * The write side lives in windowManifestStore.ts.
+ */
+
+export const OPEN_WINDOWS_KEY = "openWindows";
+export const OPEN_WINDOWS_MANIFEST_VERSION = 1;
+
+/**
+ * Hard cap on restored windows. Two jobs: a corrupt or hand-edited manifest
+ * can't launch an unbounded fleet, and a user who genuinely accumulated dozens
+ * of windows doesn't get a relaunch that spawns dozens of renderers at once.
+ * Applied AFTER focus ordering, so the windows dropped are the ones focused
+ * longest ago.
+ */
+export const MAX_RESTORED_WINDOWS = 8;
+
+export interface OpenWindowRecord {
+  /** Stable project id, or null for a window on the project picker. */
+  projectId: string | null;
+}
+
+export interface OpenWindowsManifest {
+  version: number;
+  windows: OpenWindowRecord[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Parse and validate a stored manifest. Pure — no IO, no DB — so the corruption
+ * matrix is unit-testable.
+ *
+ * Every failure mode collapses to `[]`, which the caller reads as "nothing to
+ * restore, open one window". Being wrong in that direction costs the user a
+ * manual window; being wrong in the other direction opens windows they never
+ * had.
+ */
+export function parseOpenWindowsManifest(raw: string | null | undefined): OpenWindowRecord[] {
+  if (!raw) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+
+  if (!isRecord(parsed)) return [];
+  // A future version's shape is unknown, so it is not merely unsupported — it
+  // is unreadable. Refuse it rather than guessing at fields.
+  if (parsed.version !== OPEN_WINDOWS_MANIFEST_VERSION) return [];
+  if (!Array.isArray(parsed.windows)) return [];
+
+  const records: OpenWindowRecord[] = [];
+  for (const entry of parsed.windows) {
+    if (!isRecord(entry)) continue;
+    const { projectId } = entry;
+    // Anything that isn't a non-empty string or an explicit null is malformed.
+    // Coercing it would invent a project id.
+    if (projectId === null) {
+      records.push({ projectId: null });
+    } else if (typeof projectId === "string" && projectId.length > 0) {
+      records.push({ projectId });
+    }
+    if (records.length >= MAX_RESTORED_WINDOWS) break;
+  }
+
+  return records;
+}
+
+export function serializeOpenWindowsManifest(records: OpenWindowRecord[]): string {
+  const manifest: OpenWindowsManifest = {
+    version: OPEN_WINDOWS_MANIFEST_VERSION,
+    windows: records.slice(0, MAX_RESTORED_WINDOWS).map(({ projectId }) => ({ projectId })),
+  };
+  return JSON.stringify(manifest);
+}
+
+/**
+ * Drop records whose project no longer exists, keeping picker windows.
+ *
+ * Skipping is deliberate and matches VS Code: a deleted project must never be
+ * silently replaced by a different one, and it must not stop the surviving
+ * windows from restoring.
+ */
+export function filterRestorableWindows(
+  records: OpenWindowRecord[],
+  existingProjectIds: ReadonlySet<string>
+): OpenWindowRecord[] {
+  return records.filter(
+    (record) => record.projectId === null || existingProjectIds.has(record.projectId)
+  );
+}

--- a/electron/services/persistence/windowManifest.ts
+++ b/electron/services/persistence/windowManifest.ts
@@ -50,6 +50,38 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
+ * Whether `raw` is a manifest this version can read — regardless of how many
+ * windows survive entry validation.
+ *
+ * Separate from the record count because "no manifest" and "a manifest naming
+ * zero windows" lead to different launches: the first falls back to the global
+ * last-active project, the second must not. Closing every window persists an
+ * empty manifest, so this is a state users reach, not a theoretical one.
+ *
+ * All-malformed entries deliberately read as unreadable rather than empty: that
+ * is corrupt data, and the friendlier answer to corruption is the old
+ * single-window behaviour, not a bare project picker.
+ */
+export function isReadableOpenWindowsManifest(raw: string | null | undefined): boolean {
+  if (!raw) return false;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return false;
+  }
+
+  if (!isRecord(parsed)) return false;
+  if (parsed.version !== OPEN_WINDOWS_MANIFEST_VERSION) return false;
+  if (!Array.isArray(parsed.windows)) return false;
+
+  // An empty list is readable. A non-empty list that yields no usable record is
+  // corrupt.
+  return parsed.windows.length === 0 || parseOpenWindowsManifest(raw).length > 0;
+}
+
+/**
  * Parse and validate a stored manifest. Pure — no IO, no DB — so the corruption
  * matrix is unit-testable.
  *

--- a/electron/services/persistence/windowManifest.ts
+++ b/electron/services/persistence/windowManifest.ts
@@ -53,14 +53,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * Whether `raw` is a manifest this version can read — regardless of how many
  * windows survive entry validation.
  *
- * Separate from the record count because "no manifest" and "a manifest naming
- * zero windows" lead to different launches: the first falls back to the global
- * last-active project, the second must not. Closing every window persists an
- * empty manifest, so this is a state users reach, not a theoretical one.
+ * An empty window list is readable: it is a manifest, just one that named
+ * nothing. What that means for the launch is the reader's call, not this
+ * predicate's — `readOpenWindowsManifestSync` treats it as no manifest, because
+ * closing the last window is the quit gesture on Windows and Linux and persists
+ * exactly this shape.
  *
  * All-malformed entries deliberately read as unreadable rather than empty: that
- * is corrupt data, and the friendlier answer to corruption is the old
- * single-window behaviour, not a bare project picker.
+ * is corrupt data, and keeping it distinguishable from an intentional shape is
+ * what lets the corruption matrix be tested without a DB.
  */
 export function isReadableOpenWindowsManifest(raw: string | null | undefined): boolean {
   if (!raw) return false;

--- a/electron/services/persistence/windowManifestStore.ts
+++ b/electron/services/persistence/windowManifestStore.ts
@@ -1,0 +1,34 @@
+/**
+ * Write side of the open-window manifest (#11492).
+ *
+ * Split from windowManifest.ts so the shape and its validation stay free of the
+ * DB — the sync reader on the pre-`whenReady()` boot path imports the pure half,
+ * and only the tracker (which runs well after global init) pulls in drizzle.
+ */
+
+import { getSharedDb } from "./db.js";
+import { appState as appStateTable } from "./schema.js";
+import {
+  OPEN_WINDOWS_KEY,
+  serializeOpenWindowsManifest,
+  type OpenWindowRecord,
+} from "./windowManifest.js";
+
+/**
+ * Persist the manifest. Synchronous — better-sqlite3 writes inline, which is
+ * what lets the window-`closed` and shutdown-snapshot paths save without
+ * leaving an unawaited promise in flight during teardown.
+ *
+ * Callers own the decision to write at all (see openWindowsTracker's shutdown
+ * freeze — note `getSharedDb()` silently REOPENS a closed database rather than
+ * throwing, so a late write here would resurrect a connection mid-shutdown
+ * instead of failing loudly). This function just performs the write.
+ */
+export function writeOpenWindowsManifest(records: OpenWindowRecord[]): void {
+  const value = serializeOpenWindowsManifest(records);
+  getSharedDb()
+    .insert(appStateTable)
+    .values({ key: OPEN_WINDOWS_KEY, value })
+    .onConflictDoUpdate({ target: appStateTable.key, set: { value } })
+    .run();
+}

--- a/electron/window/WindowRegistry.ts
+++ b/electron/window/WindowRegistry.ts
@@ -267,6 +267,37 @@ export class WindowRegistry {
     return Array.from(this.windows.values());
   }
 
+  /**
+   * Live windows ordered most-recently-focused first.
+   *
+   * `focusHistory` only ever records windows that have actually been focused,
+   * so a window created but never focused (a restored background window, for
+   * instance) is absent from it. Those are appended after the focused ones in
+   * registration order rather than dropped — the open-window manifest (#11492)
+   * has to describe every window, and its cap trims from the tail, so a window
+   * missing from this list would be the first one silently lost.
+   */
+  focusOrder(): WindowContext[] {
+    const ordered: WindowContext[] = [];
+    const seen = new Set<number>();
+
+    for (let i = this.focusHistory.length - 1; i >= 0; i--) {
+      const id = this.focusHistory[i];
+      if (seen.has(id)) continue;
+      const ctx = this.windows.get(id);
+      if (!ctx) continue;
+      seen.add(id);
+      ordered.push(ctx);
+    }
+
+    for (const [id, ctx] of this.windows) {
+      if (seen.has(id)) continue;
+      ordered.push(ctx);
+    }
+
+    return ordered;
+  }
+
   get size(): number {
     return this.windows.size;
   }

--- a/electron/window/__tests__/WindowRegistry.test.ts
+++ b/electron/window/__tests__/WindowRegistry.test.ts
@@ -688,4 +688,96 @@ describe("WindowRegistry", () => {
       expect(mockRevokeByWindowId).toHaveBeenCalledWith(202);
     });
   });
+
+  describe("focusOrder", () => {
+    const ids = (registry: WindowRegistry) => registry.focusOrder().map((c) => c.windowId);
+
+    it("returns nothing when no windows are registered", () => {
+      expect(new WindowRegistry().focusOrder()).toEqual([]);
+    });
+
+    it("orders focused windows most-recent-first", () => {
+      const registry = new WindowRegistry();
+      const app = makeMockApp();
+      registry.wireFocusTracking(app);
+      const w1 = makeMockWindow(1, 100);
+      const w2 = makeMockWindow(2, 200);
+      const w3 = makeMockWindow(3, 300);
+      registry.register(w1);
+      registry.register(w2);
+      registry.register(w3);
+
+      app.emit("browser-window-focus", {}, w1);
+      app.emit("browser-window-focus", {}, w3);
+      app.emit("browser-window-focus", {}, w2);
+
+      expect(ids(registry)).toEqual([2, 3, 1]);
+    });
+
+    it("moves a re-focused window back to the front without duplicating it", () => {
+      const registry = new WindowRegistry();
+      const app = makeMockApp();
+      registry.wireFocusTracking(app);
+      const w1 = makeMockWindow(1, 100);
+      const w2 = makeMockWindow(2, 200);
+      registry.register(w1);
+      registry.register(w2);
+
+      app.emit("browser-window-focus", {}, w1);
+      app.emit("browser-window-focus", {}, w2);
+      app.emit("browser-window-focus", {}, w1);
+
+      expect(ids(registry)).toEqual([1, 2]);
+    });
+
+    it("keeps never-focused windows rather than dropping them", () => {
+      // The open-window manifest describes every window and trims from the
+      // tail, so a restored background window absent from the focus history
+      // would be the first one silently lost.
+      const registry = new WindowRegistry();
+      const app = makeMockApp();
+      registry.wireFocusTracking(app);
+      const w1 = makeMockWindow(1, 100);
+      const w2 = makeMockWindow(2, 200);
+      const w3 = makeMockWindow(3, 300);
+      registry.register(w1);
+      registry.register(w2);
+      registry.register(w3);
+
+      app.emit("browser-window-focus", {}, w3);
+
+      expect(ids(registry)).toEqual([3, 1, 2]);
+    });
+
+    it("falls back to registration order when nothing has been focused", () => {
+      const registry = new WindowRegistry();
+      registry.register(makeMockWindow(1, 100));
+      registry.register(makeMockWindow(2, 200));
+
+      expect(ids(registry)).toEqual([1, 2]);
+    });
+
+    it("drops an unregistered window from the order", () => {
+      const registry = new WindowRegistry();
+      const app = makeMockApp();
+      registry.wireFocusTracking(app);
+      const w1 = makeMockWindow(1, 100);
+      const w2 = makeMockWindow(2, 200);
+      registry.register(w1);
+      registry.register(w2);
+      app.emit("browser-window-focus", {}, w1);
+      app.emit("browser-window-focus", {}, w2);
+
+      registry.unregister(2);
+
+      expect(ids(registry)).toEqual([1]);
+    });
+
+    it("returns the live context objects, so callers can read per-window services", () => {
+      const registry = new WindowRegistry();
+      const ctx = registry.register(makeMockWindow(1, 100));
+
+      expect(registry.focusOrder()[0]).toBe(ctx);
+    });
+  });
 });

--- a/electron/window/__tests__/openWindowsTracker.test.ts
+++ b/electron/window/__tests__/openWindowsTracker.test.ts
@@ -1,0 +1,391 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { OpenWindowRecord } from "../../services/persistence/windowManifest.js";
+
+const writeOpenWindowsManifest = vi.fn<(records: OpenWindowRecord[]) => void>();
+const getActiveShutdown = vi.fn<() => { initiator: string; phase: string } | null>(() => null);
+
+// Both mocks use explicit factories rather than spreading `importOriginal()`:
+// the store module reaches better-sqlite3 and shutdownCoordinator reaches
+// electron, and pulling either in for real turns this into a suite that passes
+// locally and fails on CI. windowManifest.js itself is dependency-free, so the
+// constants below come from the real module.
+vi.mock("../../services/persistence/windowManifestStore.js", () => ({
+  writeOpenWindowsManifest: (records: OpenWindowRecord[]) => writeOpenWindowsManifest(records),
+}));
+
+vi.mock("../../lifecycle/shutdownCoordinator.js", () => ({
+  getActiveShutdown: () => getActiveShutdown(),
+}));
+
+import {
+  buildOpenWindowRecords,
+  freezeAndSnapshotOpenWindows,
+  initOpenWindowsTracker,
+  resetOpenWindowsTrackerForTests,
+  resumeOpenWindowsSaves,
+  saveOpenWindowsNow,
+  scheduleOpenWindowsSave,
+  suppressOpenWindowsSaves,
+} from "../openWindowsTracker.js";
+import { MAX_RESTORED_WINDOWS } from "../../services/persistence/windowManifest.js";
+import type { WindowContext, WindowRegistry } from "../WindowRegistry.js";
+
+interface FakeWindow {
+  windowId: number;
+  projectId: string | null;
+  destroyed?: boolean;
+  throwsOnRead?: boolean;
+  noManager?: boolean;
+}
+
+function makeCtx(win: FakeWindow): WindowContext {
+  return {
+    windowId: win.windowId,
+    webContentsId: win.windowId * 10,
+    browserWindow: { isDestroyed: () => win.destroyed === true },
+    // Deliberately wrong on purpose: every test project id comes from the
+    // ProjectViewManager, so a record built from projectPath would be visibly
+    // wrong rather than accidentally right.
+    projectPath: "/stale/path/from/registration",
+    abortController: new AbortController(),
+    services: win.noManager
+      ? {}
+      : {
+          projectViewManager: {
+            getActiveProjectId: () => {
+              if (win.throwsOnRead) throw new Error("manager disposing");
+              return win.projectId;
+            },
+          },
+        },
+    cleanup: { dispose: () => {} },
+  } as unknown as WindowContext;
+}
+
+/** Registry double whose focusOrder() is the ordering under test. */
+function makeRegistry(wins: FakeWindow[]): WindowRegistry {
+  const contexts = wins.map(makeCtx);
+  return {
+    focusOrder: () => contexts,
+    all: () => contexts,
+  } as unknown as WindowRegistry;
+}
+
+function lastWritten(): OpenWindowRecord[] {
+  const calls = writeOpenWindowsManifest.mock.calls;
+  return calls[calls.length - 1][0];
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  writeOpenWindowsManifest.mockClear();
+  getActiveShutdown.mockReturnValue(null);
+  resetOpenWindowsTrackerForTests();
+});
+
+afterEach(() => {
+  resetOpenWindowsTrackerForTests();
+  vi.useRealTimers();
+});
+
+describe("buildOpenWindowRecords", () => {
+  it("reads each window's project from its view manager, not the stale registration path", () => {
+    const registry = makeRegistry([
+      { windowId: 1, projectId: "switched-to" },
+      { windowId: 2, projectId: "other" },
+    ]);
+    expect(buildOpenWindowRecords(registry)).toEqual([
+      { projectId: "switched-to" },
+      { projectId: "other" },
+    ]);
+  });
+
+  it("keeps two windows showing the same project as two records", () => {
+    const registry = makeRegistry([
+      { windowId: 1, projectId: "shared" },
+      { windowId: 2, projectId: "shared" },
+    ]);
+    expect(buildOpenWindowRecords(registry)).toHaveLength(2);
+  });
+
+  it("records a window with no project as a picker window", () => {
+    const registry = makeRegistry([{ windowId: 1, projectId: null }]);
+    expect(buildOpenWindowRecords(registry)).toEqual([{ projectId: null }]);
+  });
+
+  it("keeps a window whose manager throws, as a picker window", () => {
+    // Losing which project it was on beats losing the window entirely.
+    const registry = makeRegistry([
+      { windowId: 1, projectId: "a" },
+      { windowId: 2, projectId: "b", throwsOnRead: true },
+    ]);
+    expect(buildOpenWindowRecords(registry)).toEqual([{ projectId: "a" }, { projectId: null }]);
+  });
+
+  it("keeps a window whose manager is not built yet", () => {
+    const registry = makeRegistry([{ windowId: 1, projectId: null, noManager: true }]);
+    expect(buildOpenWindowRecords(registry)).toEqual([{ projectId: null }]);
+  });
+
+  it("skips a destroyed window", () => {
+    const registry = makeRegistry([
+      { windowId: 1, projectId: "a", destroyed: true },
+      { windowId: 2, projectId: "b" },
+    ]);
+    expect(buildOpenWindowRecords(registry)).toEqual([{ projectId: "b" }]);
+  });
+
+  it("excludes the window whose teardown is already committed", () => {
+    const registry = makeRegistry([
+      { windowId: 1, projectId: "a" },
+      { windowId: 2, projectId: "closing" },
+      { windowId: 3, projectId: "c" },
+    ]);
+    expect(buildOpenWindowRecords(registry, 2)).toEqual([{ projectId: "a" }, { projectId: "c" }]);
+  });
+
+  it("caps the record list", () => {
+    const registry = makeRegistry(
+      Array.from({ length: MAX_RESTORED_WINDOWS + 5 }, (_, i) => ({
+        windowId: i + 1,
+        projectId: `p${i}`,
+      }))
+    );
+    expect(buildOpenWindowRecords(registry)).toHaveLength(MAX_RESTORED_WINDOWS);
+  });
+});
+
+describe("scheduleOpenWindowsSave", () => {
+  beforeEach(() => {
+    initOpenWindowsTracker({
+      registry: makeRegistry([{ windowId: 1, projectId: "a" }]),
+      readOnly: false,
+    });
+  });
+
+  it("does not write until the debounce elapses", () => {
+    scheduleOpenWindowsSave();
+    expect(writeOpenWindowsManifest).not.toHaveBeenCalled();
+    vi.runAllTimers();
+    expect(writeOpenWindowsManifest).toHaveBeenCalledTimes(1);
+  });
+
+  it("collapses a burst into one write", () => {
+    scheduleOpenWindowsSave();
+    scheduleOpenWindowsSave();
+    scheduleOpenWindowsSave();
+    vi.runAllTimers();
+    expect(writeOpenWindowsManifest).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses a write for a shutdown that lands inside the debounce window", () => {
+    // The updater closes windows one at a time once a quit is committed; a save
+    // landing then would walk the persisted list down to empty.
+    scheduleOpenWindowsSave();
+    getActiveShutdown.mockReturnValue({ initiator: "app-quit", phase: "cleaning" });
+    vi.runAllTimers();
+    expect(writeOpenWindowsManifest).not.toHaveBeenCalled();
+  });
+
+  it("refuses to schedule at all once a shutdown owns the process", () => {
+    getActiveShutdown.mockReturnValue({ initiator: "update-install", phase: "cleaning" });
+    scheduleOpenWindowsSave();
+    vi.runAllTimers();
+    expect(writeOpenWindowsManifest).not.toHaveBeenCalled();
+  });
+
+  it("stays frozen through the handoff phase, not just cleaning", () => {
+    getActiveShutdown.mockReturnValue({ initiator: "update-install", phase: "handoff" });
+    scheduleOpenWindowsSave();
+    vi.runAllTimers();
+    expect(writeOpenWindowsManifest).not.toHaveBeenCalled();
+  });
+
+  it("does nothing before the tracker is initialised", () => {
+    resetOpenWindowsTrackerForTests();
+    scheduleOpenWindowsSave();
+    vi.runAllTimers();
+    expect(writeOpenWindowsManifest).not.toHaveBeenCalled();
+  });
+
+  it("survives a failing write", () => {
+    writeOpenWindowsManifest.mockImplementationOnce(() => {
+      throw new Error("db closed");
+    });
+    scheduleOpenWindowsSave();
+    expect(() => vi.runAllTimers()).not.toThrow();
+  });
+});
+
+describe("recovery launches", () => {
+  it("never overwrites the stored fleet with the one window safe mode opened", () => {
+    initOpenWindowsTracker({
+      registry: makeRegistry([{ windowId: 1, projectId: "only-one" }]),
+      readOnly: true,
+    });
+
+    scheduleOpenWindowsSave();
+    vi.runAllTimers();
+    saveOpenWindowsNow();
+    freezeAndSnapshotOpenWindows();
+
+    expect(writeOpenWindowsManifest).not.toHaveBeenCalled();
+  });
+});
+
+describe("saveOpenWindowsNow", () => {
+  beforeEach(() => {
+    initOpenWindowsTracker({
+      registry: makeRegistry([
+        { windowId: 1, projectId: "a" },
+        { windowId: 2, projectId: "b" },
+      ]),
+      readOnly: false,
+    });
+  });
+
+  it("writes immediately, without waiting on the debounce", () => {
+    saveOpenWindowsNow();
+    expect(writeOpenWindowsManifest).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops a pending debounce so a close does not double-write", () => {
+    scheduleOpenWindowsSave();
+    saveOpenWindowsNow();
+    vi.runAllTimers();
+    expect(writeOpenWindowsManifest).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits the closing window from the manifest it writes", () => {
+    saveOpenWindowsNow(2);
+    expect(lastWritten()).toEqual([{ projectId: "a" }]);
+  });
+
+  it("refuses to write during a shutdown, so closes cannot empty the list", () => {
+    getActiveShutdown.mockReturnValue({ initiator: "app-quit", phase: "cleaning" });
+    saveOpenWindowsNow(1);
+    saveOpenWindowsNow(2);
+    expect(writeOpenWindowsManifest).not.toHaveBeenCalled();
+  });
+});
+
+describe("fan-out suppression", () => {
+  beforeEach(() => {
+    initOpenWindowsTracker({
+      registry: makeRegistry([
+        { windowId: 1, projectId: "a" },
+        { windowId: 2, projectId: "b" },
+      ]),
+      readOnly: false,
+    });
+  });
+
+  it("holds every write while the restore fan-out is in flight", () => {
+    suppressOpenWindowsSaves();
+    scheduleOpenWindowsSave();
+    saveOpenWindowsNow();
+    vi.runAllTimers();
+    expect(writeOpenWindowsManifest).not.toHaveBeenCalled();
+  });
+
+  it("cancels a debounce that was already pending when suppression started", () => {
+    scheduleOpenWindowsSave();
+    suppressOpenWindowsSaves();
+    vi.runAllTimers();
+    expect(writeOpenWindowsManifest).not.toHaveBeenCalled();
+  });
+
+  it("writes one full snapshot when the fan-out completes cleanly", () => {
+    suppressOpenWindowsSaves();
+    resumeOpenWindowsSaves(true);
+    expect(writeOpenWindowsManifest).toHaveBeenCalledTimes(1);
+    expect(lastWritten()).toEqual([{ projectId: "a" }, { projectId: "b" }]);
+  });
+
+  it("leaves the stored manifest alone when the fan-out died partway", () => {
+    // A partial fleet must never overwrite a manifest that is still correct.
+    suppressOpenWindowsSaves();
+    resumeOpenWindowsSaves(false);
+    expect(writeOpenWindowsManifest).not.toHaveBeenCalled();
+  });
+
+  it("re-arms saves after the fan-out, however it ended", () => {
+    suppressOpenWindowsSaves();
+    resumeOpenWindowsSaves(false);
+    scheduleOpenWindowsSave();
+    vi.runAllTimers();
+    expect(writeOpenWindowsManifest).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("freezeAndSnapshotOpenWindows", () => {
+  beforeEach(() => {
+    initOpenWindowsTracker({
+      registry: makeRegistry([
+        { windowId: 1, projectId: "a" },
+        { windowId: 2, projectId: "b" },
+      ]),
+      readOnly: false,
+    });
+  });
+
+  it("captures the window set even though a shutdown already owns the process", () => {
+    // startShutdown() sets the active shutdown before running the chain, so an
+    // ordinary save would refuse here and a pending switch would be lost.
+    getActiveShutdown.mockReturnValue({ initiator: "app-quit", phase: "cleaning" });
+    freezeAndSnapshotOpenWindows();
+    expect(writeOpenWindowsManifest).toHaveBeenCalledTimes(1);
+    expect(lastWritten()).toEqual([{ projectId: "a" }, { projectId: "b" }]);
+  });
+
+  it("captures what a pending debounce still owed", () => {
+    scheduleOpenWindowsSave();
+    getActiveShutdown.mockReturnValue({ initiator: "app-quit", phase: "cleaning" });
+    freezeAndSnapshotOpenWindows();
+    vi.runAllTimers();
+    // Exactly one write: the snapshot. The debounce was folded into it, not
+    // left to fire against a closing database.
+    expect(writeOpenWindowsManifest).toHaveBeenCalledTimes(1);
+  });
+
+  it("latches writes off, so the closes that follow cannot empty the list", () => {
+    freezeAndSnapshotOpenWindows();
+    writeOpenWindowsManifest.mockClear();
+
+    saveOpenWindowsNow(1);
+    saveOpenWindowsNow(2);
+    scheduleOpenWindowsSave();
+    vi.runAllTimers();
+
+    expect(writeOpenWindowsManifest).not.toHaveBeenCalled();
+  });
+
+  it("stays latched even if the shutdown is somehow cleared afterwards", () => {
+    freezeAndSnapshotOpenWindows();
+    writeOpenWindowsManifest.mockClear();
+    getActiveShutdown.mockReturnValue(null);
+
+    scheduleOpenWindowsSave();
+    vi.runAllTimers();
+    expect(writeOpenWindowsManifest).not.toHaveBeenCalled();
+  });
+
+  it("is safe to call twice and only snapshots once", () => {
+    freezeAndSnapshotOpenWindows();
+    freezeAndSnapshotOpenWindows();
+    expect(writeOpenWindowsManifest).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not snapshot mid-fan-out, where the fleet is only partly up", () => {
+    suppressOpenWindowsSaves();
+    freezeAndSnapshotOpenWindows();
+    expect(writeOpenWindowsManifest).not.toHaveBeenCalled();
+  });
+
+  it("survives a failing write without breaking the shutdown chain", () => {
+    writeOpenWindowsManifest.mockImplementationOnce(() => {
+      throw new Error("db closed");
+    });
+    expect(() => freezeAndSnapshotOpenWindows()).not.toThrow();
+  });
+});

--- a/electron/window/__tests__/openWindowsTracker.test.ts
+++ b/electron/window/__tests__/openWindowsTracker.test.ts
@@ -208,26 +208,85 @@ describe("scheduleOpenWindowsSave", () => {
     expect(writeOpenWindowsManifest).not.toHaveBeenCalled();
   });
 
-  it("survives a failing write", () => {
+  it("survives a failing write and logs the cause", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const cause = new Error("db closed");
     writeOpenWindowsManifest.mockImplementationOnce(() => {
-      throw new Error("db closed");
+      throw cause;
     });
+
     scheduleOpenWindowsSave();
     expect(() => vi.runAllTimers()).not.toThrow();
+    expect(warn).toHaveBeenCalledWith(expect.any(String), cause);
+    warn.mockRestore();
+  });
+
+  it("keeps saving after a write failure", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    writeOpenWindowsManifest.mockImplementationOnce(() => {
+      throw new Error("transient");
+    });
+    scheduleOpenWindowsSave();
+    vi.runAllTimers();
+    writeOpenWindowsManifest.mockClear();
+
+    scheduleOpenWindowsSave();
+    vi.runAllTimers();
+    expect(writeOpenWindowsManifest).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
   });
 });
 
 describe("recovery launches", () => {
-  it("never overwrites the stored fleet with the one window safe mode opened", () => {
+  beforeEach(() => {
     initOpenWindowsTracker({
       registry: makeRegistry([{ windowId: 1, projectId: "only-one" }]),
       readOnly: true,
     });
+  });
 
+  it("never overwrites the stored fleet with the one window safe mode opened", () => {
     scheduleOpenWindowsSave();
     vi.runAllTimers();
     saveOpenWindowsNow();
     freezeAndSnapshotOpenWindows();
+
+    expect(writeOpenWindowsManifest).not.toHaveBeenCalled();
+  });
+
+  it("writes nothing across the real recovery startup sequence", () => {
+    // The exact production ordering: read-only tracker, fan-out hold, then a
+    // resume that would normally persist. The fleet on disk must survive it.
+    suppressOpenWindowsSaves();
+    resumeOpenWindowsSaves(true);
+    vi.runAllTimers();
+
+    expect(writeOpenWindowsManifest).not.toHaveBeenCalled();
+  });
+
+  it("still writes nothing after a window closes", () => {
+    saveOpenWindowsNow(1);
+    expect(writeOpenWindowsManifest).not.toHaveBeenCalled();
+  });
+});
+
+describe("a shutdown that lands during the startup fan-out", () => {
+  beforeEach(() => {
+    initOpenWindowsTracker({
+      registry: makeRegistry([{ windowId: 1, projectId: "a" }]),
+      readOnly: false,
+    });
+  });
+
+  it("writes nothing, even though the fan-out resume asks it to", () => {
+    // Quitting mid-restore: the freeze latches while suppression is still held,
+    // so the resume that follows must not write a half-restored fleet.
+    scheduleOpenWindowsSave();
+    suppressOpenWindowsSaves();
+    getActiveShutdown.mockReturnValue({ initiator: "app-quit", phase: "cleaning" });
+    freezeAndSnapshotOpenWindows();
+    resumeOpenWindowsSaves(true);
+    vi.runAllTimers();
 
     expect(writeOpenWindowsManifest).not.toHaveBeenCalled();
   });

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -261,7 +261,14 @@ export function setupBrowserWindow(
       console.warn("[MAIN] Failed to load E2E BrowserWindow sentinel:", err);
     });
     if (isE2EDeferRendererLoad && !win.isDestroyed()) {
-      win.show();
+      // Honours revealMode like showOnce() does: this path reveals the shell
+      // before the renderer loads, so a restored background window would
+      // otherwise take focus here and never reach its showInactive().
+      if (revealMode === "showInactive") {
+        win.showInactive();
+      } else {
+        win.show();
+      }
     }
   }
 

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -136,6 +136,16 @@ export interface SetupBrowserWindowOptions {
   /** Last-active projectId read synchronously from DB before window creation.
    *  Used to assign the correct session partition to the initial view. */
   initialProjectId?: string;
+  /**
+   * How the reveal gate maps the window (#11492). "showInactive" is for the
+   * background windows of a startup restore: they finish loading in an
+   * unpredictable order, and a plain `show()` hands focus to whichever renderer
+   * happens to parse its skeleton last.
+   *
+   * Defaults to "show" — every pre-existing call site is a window the user just
+   * asked for and should get focus.
+   */
+  revealMode?: "show" | "showInactive";
 }
 
 export interface CreateWindowResult {
@@ -150,7 +160,7 @@ export function setupBrowserWindow(
   dirname: string,
   options: SetupBrowserWindowOptions = {}
 ): CreateWindowResult {
-  const { onRecreateWindow, onCreateWindow, projectPath } = options;
+  const { onRecreateWindow, onCreateWindow, projectPath, revealMode = "show" } = options;
   let smokeTestTimer: ReturnType<typeof setTimeout> | undefined;
   let _smokeRendererUnresponsive = false;
 
@@ -426,7 +436,11 @@ export function setupBrowserWindow(
       }
       if (!win.isDestroyed()) {
         markPerformance(PERF_MARKS.MAIN_WINDOW_SHOWN, viaFallback ? { fallback: true } : undefined);
-        win.show();
+        if (revealMode === "showInactive") {
+          win.showInactive();
+        } else {
+          win.show();
+        }
       }
     };
     let fallbackTimer: ReturnType<typeof setTimeout> | null = setTimeout(() => {

--- a/electron/window/openWindowsTracker.ts
+++ b/electron/window/openWindowsTracker.ts
@@ -1,0 +1,195 @@
+/**
+ * Keeps the persisted open-window manifest in step with the live window set
+ * (#11492).
+ *
+ * Continuous persistence rather than a snapshot at quit: our own force-quit
+ * action goes through `app.exit(0)`, which skips `before-quit` entirely, and a
+ * main-process crash skips everything. Those are exactly the exits where you
+ * most want the window set back, so the manifest has to already be correct on
+ * disk before the process dies. Mirrors what windowState.ts does for bounds.
+ *
+ * Three rules make that safe:
+ *
+ *  1. Freeze once a shutdown owns the process. `getActiveShutdown()` goes
+ *     non-null the moment a quit is committed, and the updater then closes
+ *     windows one at a time — un-frozen, those closes would walk the persisted
+ *     list down to empty and the next launch would restore nothing.
+ *  2. Snapshot before freezing. `runShutdownChain()` calls
+ *     `freezeAndSnapshotOpenWindows()`, which bypasses rule 1 exactly once to
+ *     capture whatever a pending debounce still owed — switch a project and
+ *     quit 200ms later and that change would otherwise be lost.
+ *  3. Never save during a recovery launch. Safe mode restores one window on
+ *     purpose; persisting that would overwrite the user's real fleet with it.
+ */
+
+import type { WindowRegistry } from "./WindowRegistry.js";
+import { getActiveShutdown } from "../lifecycle/shutdownCoordinator.js";
+import {
+  MAX_RESTORED_WINDOWS,
+  type OpenWindowRecord,
+} from "../services/persistence/windowManifest.js";
+import { writeOpenWindowsManifest } from "../services/persistence/windowManifestStore.js";
+
+/** Matches windowState.ts's bounds debounce — same class of chatty signal. */
+const SAVE_DEBOUNCE_MS = 500;
+
+interface TrackerState {
+  registry: WindowRegistry;
+  /** Recovery launches observe but never write. */
+  readOnly: boolean;
+}
+
+let state: TrackerState | null = null;
+let saveTimer: ReturnType<typeof setTimeout> | null = null;
+/** Latched at shutdown. Permanent by design — nothing resumes after it. */
+let frozen = false;
+/**
+ * Held across the startup restore fan-out. Windows 2..N register while window
+ * 1's debounce is pending, and a save landing mid-fan-out would persist a
+ * partial fleet — harmless if startup completes, authoritative for the next
+ * launch if it doesn't.
+ */
+let suppressed = false;
+
+export function initOpenWindowsTracker(opts: {
+  registry: WindowRegistry;
+  readOnly: boolean;
+}): void {
+  state = { registry: opts.registry, readOnly: opts.readOnly };
+}
+
+/**
+ * Build the manifest from the live windows, most-recently-focused first.
+ *
+ * Each window's project comes from its ProjectViewManager, never from
+ * `WindowContext.projectPath` — that is stamped once at registration and is
+ * never updated when the window switches project, so it goes stale on the first
+ * switch and would persist the project the window *opened* with rather than the
+ * one it is showing.
+ *
+ * @param excludeWindowId A window whose teardown is already committed. The
+ *   `closed` listener fires after WindowRegistry unregisters, so this is belt
+ *   and braces — but a save triggered from anywhere else during teardown must
+ *   not resurrect a window the user deliberately closed.
+ */
+export function buildOpenWindowRecords(
+  registry: WindowRegistry,
+  excludeWindowId?: number
+): OpenWindowRecord[] {
+  const records: OpenWindowRecord[] = [];
+
+  for (const ctx of registry.focusOrder()) {
+    if (ctx.windowId === excludeWindowId) continue;
+    if (ctx.browserWindow.isDestroyed()) continue;
+
+    let projectId: string | null;
+    try {
+      projectId = ctx.services.projectViewManager?.getActiveProjectId() ?? null;
+    } catch {
+      // A disposing manager can throw. Persist the window as a picker window
+      // rather than dropping it — losing the window is worse than losing which
+      // project it was on.
+      projectId = null;
+    }
+
+    records.push({ projectId });
+    if (records.length >= MAX_RESTORED_WINDOWS) break;
+  }
+
+  return records;
+}
+
+function canSave(): boolean {
+  if (!state) return false;
+  if (frozen || suppressed || state.readOnly) return false;
+  // A shutdown owns the process: the window set is being torn down, not changed.
+  return getActiveShutdown() === null;
+}
+
+function cancelPendingSave(): void {
+  if (saveTimer) {
+    clearTimeout(saveTimer);
+    saveTimer = null;
+  }
+}
+
+function persist(excludeWindowId?: number): void {
+  if (!state) return;
+  try {
+    writeOpenWindowsManifest(buildOpenWindowRecords(state.registry, excludeWindowId));
+  } catch (error) {
+    // Losing the manifest costs the user a manual window next launch. It must
+    // never take down a window close or the shutdown chain with it.
+    console.warn("[openWindowsTracker] Failed to persist the open-window manifest:", error);
+  }
+}
+
+/** Coalesce chatty signals — focus changes, project switches, window opens. */
+export function scheduleOpenWindowsSave(): void {
+  if (!canSave()) return;
+  cancelPendingSave();
+  saveTimer = setTimeout(() => {
+    saveTimer = null;
+    // Re-check: a shutdown or a freeze can land inside the debounce window.
+    if (!canSave()) return;
+    persist();
+  }, SAVE_DEBOUNCE_MS);
+}
+
+/**
+ * Write immediately, dropping any pending debounce.
+ *
+ * Used by the window `closed` listener: better-sqlite3 writes inline, so this
+ * leaves no unawaited promise in flight while the window tears down.
+ */
+export function saveOpenWindowsNow(excludeWindowId?: number): void {
+  cancelPendingSave();
+  if (!canSave()) return;
+  persist(excludeWindowId);
+}
+
+/** Hold saves across the startup restore fan-out. Balanced by `resume`. */
+export function suppressOpenWindowsSaves(): void {
+  suppressed = true;
+  cancelPendingSave();
+}
+
+/**
+ * Release the fan-out hold.
+ *
+ * @param persistNow Write one full snapshot on the way out. Passed false when
+ *   the fan-out died partway, so a partial fleet never overwrites the manifest
+ *   that is still correct on disk.
+ */
+export function resumeOpenWindowsSaves(persistNow: boolean): void {
+  suppressed = false;
+  if (persistNow) saveOpenWindowsNow();
+}
+
+/**
+ * Capture the final window set, then latch saves off for good.
+ *
+ * Called at the top of `runShutdownChain()`, before its first await. Bypasses
+ * the active-shutdown gate deliberately — by the time the chain runs,
+ * `startShutdown()` has already claimed the process, so an ordinary save would
+ * refuse and any debounce still owing would be dropped. This is the one write
+ * allowed to see a shutdown in progress; every later one is refused, which is
+ * what stops the updater's window-by-window close from emptying the list.
+ */
+export function freezeAndSnapshotOpenWindows(): void {
+  cancelPendingSave();
+
+  if (state && !frozen && !suppressed && !state.readOnly) {
+    persist();
+  }
+
+  frozen = true;
+}
+
+/** Test-only: the module singleton outlives tests that don't reset modules. */
+export function resetOpenWindowsTrackerForTests(): void {
+  cancelPendingSave();
+  state = null;
+  frozen = false;
+  suppressed = false;
+}

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -123,15 +123,22 @@ export interface SetupWindowServicesOptions {
   initialAppView?: import("electron").WebContentsView;
 }
 
+/**
+ * @returns "exit-requested" when the process is already on its way out —
+ *   fatally failed global init, or a finished smoke run — and `app.exit()` has
+ *   been issued. Callers that create more than one window (the startup restore
+ *   fan-out, #11492) must stop rather than build windows into a dying process;
+ *   single-window callers can ignore it.
+ */
 export async function setupWindowServices(
   win: BrowserWindow,
   opts: SetupWindowServicesOptions
-): Promise<void> {
+): Promise<"ok" | "exit-requested"> {
   const windowRegistry = opts.windowRegistry;
   const ctx = windowRegistry?.getByWindowId(win.id);
   if (!ctx) {
     console.error("[MAIN] Window not registered before setupWindowServices — skipping");
-    return;
+    return "ok";
   }
 
   markPerformance(PERF_MARKS.WINDOW_SERVICES_START);
@@ -139,7 +146,7 @@ export async function setupWindowServices(
   // ── One-time global initialization (first window only) ──
   if (!getGlobalServicesInitialized()) {
     const result = await initGlobalServices(windowRegistry);
-    if (result === "exit-requested") return;
+    if (result === "exit-requested") return "exit-requested";
   }
 
   // ── Per-window initialization ──
@@ -714,7 +721,7 @@ export async function setupWindowServices(
       getWorkspaceClientRef()?.dispose();
       getPtyClient()?.dispose();
       app.exit(1);
-      return;
+      return "exit-requested";
     }
 
     const smokeClient = getPtyClient()!;
@@ -736,7 +743,7 @@ export async function setupWindowServices(
       /* ignore */
     }
     app.exit(allPassed ? 0 : 1);
-    return;
+    return "exit-requested";
   }
 
   // CLI path handling — skip if this window was opened with an explicit initialProjectPath
@@ -812,4 +819,6 @@ export async function setupWindowServices(
     }
     resetDeferredQueue();
   });
+
+  return "ok";
 }

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -124,21 +124,27 @@ export interface SetupWindowServicesOptions {
 }
 
 /**
- * @returns "exit-requested" when the process is already on its way out —
- *   fatally failed global init, or a finished smoke run — and `app.exit()` has
- *   been issued. Callers that create more than one window (the startup restore
- *   fan-out, #11492) must stop rather than build windows into a dying process;
- *   single-window callers can ignore it.
+ * @returns "ok" when the window is fully wired.
+ *
+ *   "exit-requested" when the process is already on its way out — fatally
+ *   failed global init, or a finished smoke run — and `app.exit()` has been
+ *   issued. "not-registered" when the window never reached the registry, so it
+ *   has no services at all.
+ *
+ *   Callers that create more than one window (the startup restore fan-out,
+ *   #11492) must stop on anything but "ok" rather than build windows into a
+ *   dying process — or count a serviceless window as a restored one and persist
+ *   it. Single-window callers can ignore the result.
  */
 export async function setupWindowServices(
   win: BrowserWindow,
   opts: SetupWindowServicesOptions
-): Promise<"ok" | "exit-requested"> {
+): Promise<"ok" | "exit-requested" | "not-registered"> {
   const windowRegistry = opts.windowRegistry;
   const ctx = windowRegistry?.getByWindowId(win.id);
   if (!ctx) {
     console.error("[MAIN] Window not registered before setupWindowServices — skipping");
-    return "ok";
+    return "not-registered";
   }
 
   markPerformance(PERF_MARKS.WINDOW_SERVICES_START);


### PR DESCRIPTION
## Summary

- Daintree supports multiple independent windows, each bound to a project, but a full relaunch only restored one. `electron/main.ts` called `createWindow()` exactly once, seeded from a single `app_state.currentProjectId` scalar holding whichever project was most recently switched to anywhere, not even the last-focused window.
- This PR persists a manifest of open project windows and recreates the whole set on a plain cold launch, with each window landing back on the same project it showed before.
- Missing or removed projects are handled safely: a manifest that exists but filters down to zero valid windows opens the project picker rather than silently substituting a different project.

Resolves #11492

## Changes

**Manifest** - a versioned, capped (8 entries) JSON manifest stored under a new `app_state.openWindows` key, so no drizzle migration is needed. It's an ordered list of window records rather than a set, since two windows can legitimately show the same project. Order is focus recency, most-recent-first, and the cap trims the least-recently-focused entries. Electron window ids are never persisted (they're ephemeral and get reused), only stable project ids. Each window's project is read from `ProjectViewManager.getActiveProjectId()`, never `WindowContext.projectPath`, which is stamped once at registration and goes stale after the first switch.

**Writes** - continuous, on window open, window close, project switch, and focus change, on a 500ms debounce, mirroring how `windowState.ts` persists window bounds. Not a snapshot at quit, because the force-quit action calls `app.exit(0)`, which skips `before-quit` entirely, and a main-process crash skips everything, exactly the exits where restoring the window set matters most.

**Restore** - the manifest is read synchronously before `whenReady()`, since each record's project id determines that window's session partition and has to be known before the `BrowserWindow` is built. The first window is awaited alone before the rest are created concurrently: `initGlobalServices()` flips its internal `initialized` guard synchronously at entry, before its own async work runs, so a concurrent second window would race past the guard and collide with the first window's database migrations and database open. Background windows reveal with `showInactive()` so a late-finishing renderer can't steal focus.

**Launch intent** - a new resolver combines previously scattered signals (`hasCliPathFlag`, `extractDirectoryPaths`, the pre-window Finder folder/`.dntr` queues, safe mode, a pending crash flag). Only a plain cold launch restores the full set; `--cli-path` and Finder opens keep today's single-window behavior. A recovery launch (safe mode or a pending crash) restores exactly one window and stops writing the manifest, so a degraded session can't overwrite the user's real window set.

**Shutdown** - `runShutdownChain()` snapshots the live window set and then latches further writes off. This lives inside the shutdown chain rather than a `before-quit` listener because `quitAndInstall()` on macOS bypasses `before-quit` entirely, so an update-triggered restart would otherwise never flush the manifest. The snapshot deliberately bypasses the debounce freeze gate once, to capture whatever a pending debounce still owed; every write after that is refused, which stops the updater's window-by-window close sequence from walking the persisted list down to empty.

**Missing projects** - validated in one batched database query in the synchronous manifest reader and skipped silently. A manifest naming zero windows stays distinguishable internally from having no manifest at all.

New: `electron/services/persistence/windowManifest.ts` (shape and validation), `windowManifestStore.ts` (drizzle upsert), `electron/lifecycle/launchIntent.ts`, `electron/lifecycle/windowRestore.ts` (the fan-out), `electron/window/openWindowsTracker.ts` (the live tracker), plus four new test files.

Modified: `electron/main.ts`, `electron/window/WindowRegistry.ts`, `electron/window/createWindow.ts`, `electron/window/windowServices.ts`, `electron/lifecycle/shutdown.ts`, `electron/services/persistence/readLastProjectId.ts`, `electron/ipc/handlers/projectCrud/switch.ts`, plus `WindowRegistry.test.ts` and `shutdown.test.ts`.

**Deferred**: phase 4 of the issue's plan, staggering renderer and workspace-host startup so multiple windows don't all spin up at once, is left as a follow-up. It's a resource-spike improvement rather than a correctness issue: the primary window completes global initialization alone, writes stay suppressed until the fan-out settles, and the 8-window cap bounds the worst case.

## Testing

- Typecheck clean; `eslint` reports 0 errors across all 19 changed files (2 pre-existing warnings in `switch.ts` at lines 112 and 176, from a legacy IPC helper, untouched by this change); prettier clean.
- 456 tests across the new suites and every existing suite covering the changed modules, plus 1761 more in the persistence and IPC-handler suites. All passing.
- Reviewed by Codex across 3 passes, which found 6 issues that got fixed, including two high-severity ones (a failed background restore rewriting the manifest, and an all-deleted manifest silently substituting an unrelated project) and one unsound test.
