### PR TITLE
fix(agent-launch): reject unknown agent ids instead of degrading to a plain terminal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -304,10 +304,10 @@ function AppInner() {
   const handleLaunchAgent = useCallback(
     async (type: string) => {
       // launchAgent throws on an unresolvable worktreeId (#10812) or an agent id
-      // that resolves to no agent (#11498). UI surfaces pass no explicit
-      // worktreeId (they fall back to the active one) and launch ids sourced from
-      // the live registry, so both are only reachable via a stale-state race —
-      // keep it a quiet no-op rather than an unhandled rejection.
+      // that resolves to no agent (#11498). This callback passes no explicit
+      // worktreeId (falling back to the active one) and its callers supply
+      // built-in or synthetic ids, so both are only reachable via a stale-state
+      // race — keep it a quiet no-op rather than an unhandled rejection.
       try {
         await launchAgent(type);
       } catch (error) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -303,10 +303,11 @@ function AppInner() {
 
   const handleLaunchAgent = useCallback(
     async (type: string) => {
-      // launchAgent now throws on an unresolvable worktreeId (#10812). UI surfaces
-      // pass no explicit worktreeId (they fall back to the active one), so this is
-      // only reachable via a stale activeWorktreeId race — keep it a quiet no-op,
-      // matching the pre-fix silent behavior, rather than an unhandled rejection.
+      // launchAgent throws on an unresolvable worktreeId (#10812) or an agent id
+      // that resolves to no agent (#11498). UI surfaces pass no explicit
+      // worktreeId (they fall back to the active one) and launch ids sourced from
+      // the live registry, so both are only reachable via a stale-state race —
+      // keep it a quiet no-op rather than an unhandled rejection.
       try {
         await launchAgent(type);
       } catch (error) {

--- a/src/hooks/__tests__/useAgentLauncher.agentIdResolution.test.ts
+++ b/src/hooks/__tests__/useAgentLauncher.agentIdResolution.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment node
+/**
+ * Tests assertKnownAgentId from useAgentLauncher.ts — the guard that stops an
+ * unresolvable agent id from degrading into a plain shell terminal (#11498).
+ * Extracted so the reject-unknown-id contract is guarded at the source:
+ * restoring the silent fallback must fail a test here, not only show up as a
+ * mystery terminal at runtime. The hook calls it immediately after
+ * `isRegisteredAgent`, before any settings init or panel creation — that wiring
+ * is covered by the ActionService propagation test in
+ * agentActions.adversarial.test.ts, same as resolveLaunchWorktree's.
+ */
+import { describe, expect, it } from "vitest";
+import { assertKnownAgentId } from "../useAgentLauncher";
+
+describe("assertKnownAgentId", () => {
+  it("accepts a registered built-in agent id", () => {
+    expect(() => assertKnownAgentId("claude", true)).not.toThrow();
+  });
+
+  it("accepts a dynamically registered plugin/user agent id", () => {
+    // Plugin ids are unknown at schema-definition time; the effective registry
+    // is what makes them valid, so the guard trusts the resolved flag.
+    expect(() => assertKnownAgentId("acme-agent", true)).not.toThrow();
+  });
+
+  it("accepts 'terminal' even though it is not a registered agent", () => {
+    expect(() => assertKnownAgentId("terminal", false)).not.toThrow();
+  });
+
+  it("throws on an unregistered id and names it (#11498)", () => {
+    expect(() => assertKnownAgentId("claudee", false)).toThrow("Unknown agent ID 'claudee'");
+  });
+
+  it("offers both recovery paths so an MCP client can self-correct", () => {
+    expect(() => assertKnownAgentId("nope", false)).toThrow("agent.listAvailable");
+    expect(() => assertKnownAgentId("nope", false)).toThrow("terminal.new");
+  });
+
+  it("fails closed for browser/dev-preview, which must be handled before this guard", () => {
+    // Their dedicated panel branches return earlier in launchAgent. Reaching
+    // the guard means one was bypassed — better to throw than to fall through
+    // to the generic terminal branch that #11498 was about.
+    expect(() => assertKnownAgentId("browser", false)).toThrow("Unknown agent ID 'browser'");
+    expect(() => assertKnownAgentId("dev-preview", false)).toThrow(
+      "Unknown agent ID 'dev-preview'"
+    );
+  });
+});

--- a/src/hooks/__tests__/useAgentLauncher.agentIdResolution.test.ts
+++ b/src/hooks/__tests__/useAgentLauncher.agentIdResolution.test.ts
@@ -1,48 +1,81 @@
 // @vitest-environment node
 /**
- * Tests assertKnownAgentId from useAgentLauncher.ts — the guard that stops an
- * unresolvable agent id from degrading into a plain shell terminal (#11498).
- * Extracted so the reject-unknown-id contract is guarded at the source:
- * restoring the silent fallback must fail a test here, not only show up as a
- * mystery terminal at runtime. The hook calls it immediately after
- * `isRegisteredAgent`, before any settings init or panel creation — that wiring
- * is covered by the ActionService propagation test in
- * agentActions.adversarial.test.ts, same as resolveLaunchWorktree's.
+ * Tests resolveAgentLaunchKind from useAgentLauncher.ts — the classifier that
+ * stops an unresolvable agent id from degrading into a plain shell terminal
+ * (#11498). It returns the kind (rather than asserting) so the hook's call site
+ * is load-bearing; these tests cover the classification itself, and the hook
+ * cannot drop the call without breaking its own `isAgent`.
  */
 import { describe, expect, it } from "vitest";
-import { assertKnownAgentId } from "../useAgentLauncher";
+import { BUILT_IN_ACTION_IDS } from "@shared/config/actionIds";
+import { resolveAgentLaunchKind } from "../useAgentLauncher";
 
-describe("assertKnownAgentId", () => {
-  it("accepts a registered built-in agent id", () => {
-    expect(() => assertKnownAgentId("claude", true)).not.toThrow();
+const NEWLINE = String.fromCharCode(10);
+const CARRIAGE_RETURN = String.fromCharCode(13);
+
+/** Grab the error a rejected id produces, so one throw can be inspected. */
+function launchError(agentId: string): Error {
+  try {
+    resolveAgentLaunchKind(agentId, false);
+  } catch (error) {
+    if (error instanceof Error) return error;
+    throw error;
+  }
+  throw new Error(`Expected '${agentId}' to be rejected`);
+}
+
+describe("resolveAgentLaunchKind", () => {
+  it("classifies any id the registry resolved as an agent", () => {
+    // The helper only sees the resolved flag, so built-in, user, and plugin ids
+    // are indistinguishable here by design — the effective registry decides.
+    expect(resolveAgentLaunchKind("claude", true)).toBe("agent");
+    expect(resolveAgentLaunchKind("acme-plugin-agent", true)).toBe("agent");
   });
 
-  it("accepts a dynamically registered plugin/user agent id", () => {
-    // Plugin ids are unknown at schema-definition time; the effective registry
-    // is what makes them valid, so the guard trusts the resolved flag.
-    expect(() => assertKnownAgentId("acme-agent", true)).not.toThrow();
+  it("classifies 'terminal' as a plain terminal even though it is unregistered", () => {
+    expect(resolveAgentLaunchKind("terminal", false)).toBe("terminal");
   });
 
-  it("accepts 'terminal' even though it is not a registered agent", () => {
-    expect(() => assertKnownAgentId("terminal", false)).not.toThrow();
+  it("prefers the agent kind when something registered the 'terminal' id", () => {
+    // Plugin/user registries only reserve built-in agent ids, so "terminal" is
+    // registerable. Resolving it as an agent preserves the pre-#11498 behavior.
+    expect(resolveAgentLaunchKind("terminal", true)).toBe("agent");
   });
 
-  it("throws on an unregistered id and names it (#11498)", () => {
-    expect(() => assertKnownAgentId("claudee", false)).toThrow("Unknown agent ID 'claudee'");
+  it("rejects an unregistered id, naming the id it was given (#11498)", () => {
+    const agentId = "clyde-the-agent";
+    expect(launchError(agentId).message).toContain(agentId);
   });
 
-  it("offers both recovery paths so an MCP client can self-correct", () => {
-    expect(() => assertKnownAgentId("nope", false)).toThrow("agent.listAvailable");
-    expect(() => assertKnownAgentId("nope", false)).toThrow("terminal.new");
+  it("rejects a near-miss of the plain-terminal id rather than falling through", () => {
+    expect(() => resolveAgentLaunchKind("Terminal", false)).toThrow();
+    expect(() => resolveAgentLaunchKind(" terminal ", false)).toThrow();
   });
 
-  it("fails closed for browser/dev-preview, which must be handled before this guard", () => {
-    // Their dedicated panel branches return earlier in launchAgent. Reaching
-    // the guard means one was bypassed — better to throw than to fall through
-    // to the generic terminal branch that #11498 was about.
-    expect(() => assertKnownAgentId("browser", false)).toThrow("Unknown agent ID 'browser'");
-    expect(() => assertKnownAgentId("dev-preview", false)).toThrow(
-      "Unknown agent ID 'dev-preview'"
-    );
+  it("fails closed for panel kinds that must be handled before this classifier", () => {
+    // browser/dev-preview return from their own branches earlier in launchAgent.
+    // Reaching this classifier means one was bypassed — rejecting beats falling
+    // through to the generic terminal branch that #11498 was about.
+    expect(() => resolveAgentLaunchKind("browser", false)).toThrow();
+    expect(() => resolveAgentLaunchKind("dev-preview", false)).toThrow();
+  });
+
+  it("names only real dispatchable actions as recovery paths", () => {
+    // The message crosses to MCP clients as the sole recovery hint, so every
+    // action-shaped token in it has to be something a client can actually call.
+    const suggested = launchError("nope").message.match(/\b[a-z]+\.[a-zA-Z]+\b/g) ?? [];
+    expect(suggested.length).toBeGreaterThan(0);
+    for (const actionId of suggested) {
+      expect(BUILT_IN_ACTION_IDS).toContain(actionId);
+    }
+  });
+
+  it("keeps an untrusted id printable and bounded in the error", () => {
+    // Ids reach here straight from an MCP caller, so a newline could forge a log
+    // line and an unbounded id would bloat the error crossing the boundary.
+    const message = launchError(`bad${NEWLINE}ID${"x".repeat(500)}`).message;
+    expect(message.includes(NEWLINE)).toBe(false);
+    expect(message.includes(CARRIAGE_RETURN)).toBe(false);
+    expect(message.length).toBeLessThan(300);
   });
 });

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -94,24 +94,36 @@ export function resolveLaunchWorktree<T>(
 }
 
 /**
- * Reject a launch whose agent id resolves to nothing. Without this, an
- * unregistered id left `isAgent` false and fell through to the generic terminal
- * branch, spawning a plain shell and reporting success — a typo'd id from MCP
- * looked identical to a launched agent (#11498). Throwing (rather than
+ * Classify a launch id, rejecting one that resolves to no agent. Without this,
+ * an unregistered id left `isAgent` false and fell through to the generic
+ * terminal branch, spawning a plain shell and reporting success — a typo'd id
+ * from MCP looked identical to a launched agent (#11498). Throwing (rather than
  * returning null) is what makes it visible: `ActionService` serializes a
- * rejection as `ok:false`/`EXECUTION_ERROR`, while a null resolves as a
+ * rejection as `ok:false`/`EXECUTION_ERROR`, while a resolved null reads as a
  * terminal-less success.
  *
- * `"terminal"` is the one legitimately unregistered id — it is the deliberate
- * plain-shell launch. `"browser"` and `"dev-preview"` return earlier from their
- * own panel branches and never reach here, so they are not allowed through:
- * this stays correct standalone, and fails closed if either branch is ever
- * bypassed.
+ * Returns the kind rather than just asserting so the call site stays
+ * load-bearing: deleting it breaks `isAgent` instead of quietly restoring the
+ * fallback this fixes.
+ *
+ * `"terminal"` is the deliberate plain-shell launch, accepted unregistered
+ * because no built-in agent claims that id. A plugin or user agent may still
+ * register it, in which case it resolves as an agent — unchanged from before.
+ * `"browser"` and `"dev-preview"` return from their own panel branches earlier
+ * and never reach here, so they are not accepted: this stays correct standalone
+ * and fails closed if either branch is ever bypassed.
  */
-export function assertKnownAgentId(agentId: string, isRegistered: boolean): void {
-  if (isRegistered || agentId === "terminal") return;
+export function resolveAgentLaunchKind(
+  agentId: string,
+  isRegistered: boolean
+): "agent" | "terminal" {
+  if (isRegistered) return "agent";
+  if (agentId === "terminal") return "terminal";
+  // The id can arrive from an LLM via MCP, so keep it printable and bounded —
+  // otherwise it can forge log lines or bloat the error crossing the boundary.
+  const safeId = sanitizeTerminalName(agentId).slice(0, 80);
   throw new Error(
-    `Unknown agent ID '${agentId}'. Call agent.listAvailable for registered agent IDs, ` +
+    `Unknown agent ID '${safeId}'. Call agent.listAvailable for registered agent IDs, ` +
       `then retry, or use terminal.new to open a plain terminal.`
   );
 }
@@ -289,9 +301,11 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
       // useRef avoids the react batching window that useState would have.
       if (launchingAgentsRef.current.has(agentId)) return null;
       launchingAgentsRef.current.add(agentId);
-      markRendererPerformance("agentlaunch.begin", { agentId });
 
       try {
+        // Inside the try: a throw between the add above and the `finally` would
+        // strand the entry and leave this agentId unlaunchable for the session.
+        markRendererPerformance("agentlaunch.begin", { agentId });
         const targetWorktreeId = launchOptions?.worktreeId ?? activeWorktreeId;
         const targetWorktree = resolveLaunchWorktree(targetWorktreeId, worktreeMap, isInitialized);
 
@@ -347,12 +361,12 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
           }
         }
 
-        // Get agent config from registry, fall back for "terminal" type
+        // Get agent config from registry, fall back for "terminal" type.
+        // Rejects an id that resolves to no agent before any settings init,
+        // command generation, or panel creation — inside the try so the
+        // `finally` always releases the reentrancy entry.
         const agentConfig = getAgentConfig(agentId);
-        const isAgent = isRegisteredAgent(agentId);
-        // Fail before any settings init, command generation, or panel creation.
-        // Inside the try so the `finally` always releases the reentrancy entry.
-        assertKnownAgentId(agentId, isAgent);
+        const isAgent = resolveAgentLaunchKind(agentId, isRegisteredAgent(agentId)) === "agent";
 
         let command: string | undefined;
         let launchFlags: string[] | undefined;

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -93,6 +93,29 @@ export function resolveLaunchWorktree<T>(
   return targetWorktree ?? null;
 }
 
+/**
+ * Reject a launch whose agent id resolves to nothing. Without this, an
+ * unregistered id left `isAgent` false and fell through to the generic terminal
+ * branch, spawning a plain shell and reporting success — a typo'd id from MCP
+ * looked identical to a launched agent (#11498). Throwing (rather than
+ * returning null) is what makes it visible: `ActionService` serializes a
+ * rejection as `ok:false`/`EXECUTION_ERROR`, while a null resolves as a
+ * terminal-less success.
+ *
+ * `"terminal"` is the one legitimately unregistered id — it is the deliberate
+ * plain-shell launch. `"browser"` and `"dev-preview"` return earlier from their
+ * own panel branches and never reach here, so they are not allowed through:
+ * this stays correct standalone, and fails closed if either branch is ever
+ * bypassed.
+ */
+export function assertKnownAgentId(agentId: string, isRegistered: boolean): void {
+  if (isRegistered || agentId === "terminal") return;
+  throw new Error(
+    `Unknown agent ID '${agentId}'. Call agent.listAvailable for registered agent IDs, ` +
+      `then retry, or use terminal.new to open a plain terminal.`
+  );
+}
+
 export interface LaunchAgentOptions {
   location?: AddPanelOptions["location"];
   cwd?: string;
@@ -327,6 +350,9 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
         // Get agent config from registry, fall back for "terminal" type
         const agentConfig = getAgentConfig(agentId);
         const isAgent = isRegisteredAgent(agentId);
+        // Fail before any settings init, command generation, or panel creation.
+        // Inside the try so the `finally` always releases the reentrancy entry.
+        assertKnownAgentId(agentId, isAgent);
 
         let command: string | undefined;
         let launchFlags: string[] | undefined;

--- a/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
@@ -709,7 +709,8 @@ describe("agent.launch dispatch integration", () => {
 
     // Plugin agent ids are dynamic and unknown at schema-definition time, so the
     // schema must let them through; existence is resolved downstream in the
-    // launcher (an unresolved id falls back to a plain terminal, never a crash).
+    // launcher, which rejects an id that resolves to no agent (#11498) rather
+    // than degrading it to a plain terminal.
     const result = await service.dispatch(
       "agent.launch",
       { agentId: "acme-agent", worktreeId: "wt-1", location: "grid" },

--- a/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
@@ -695,7 +695,7 @@ describe("agent.launch dispatch integration", () => {
     expect(callbacks.onLaunchAgent).not.toHaveBeenCalled();
   });
 
-  it("accepts an unknown (plugin-contributed) agentId through the schema so plugin agents launch (#10560)", async () => {
+  it("accepts a non-built-in agentId through the schema and forwards it for downstream resolution (#10560)", async () => {
     const { ActionService } = await import("../../../ActionService");
     const service = new ActionService();
 


### PR DESCRIPTION
## Summary

`launchAgent` in `src/hooks/useAgentLauncher.ts` resolved `agentConfig`/`isAgent` from a bare `agentId` with no existence check. An unregistered or misspelled id left `isAgent` false and fell through to the generic terminal branch, spawning a plain shell titled "Terminal" and returning a `terminalId`, indistinguishable from a successful agent launch. The only rejecting guard (`if (isAgent && !command)`) was scoped to *registered* agents.

This is reachable from the MCP tool `agent.launch`, whose `AgentIdSchema` deliberately accepts any non-empty string so plugin agent ids validate. The schema's own comment says it isn't the authoritative boundary for that, and the actual problem was that nothing else was either.

Resolves #11498

## The fix

A new exported `resolveAgentLaunchKind(agentId, isRegistered): "agent" | "terminal"` classifier, called immediately after the effective-registry lookup and inside the existing `try` block, so the `finally` clause still releases the reentrancy entry. It throws for anything that resolves to no agent.

Throwing rather than returning `null` is the load-bearing part: `ActionService` serializes a rejection as `ok: false` / `EXECUTION_ERROR`, whereas a resolved `null` reads as a terminal-less success, the same trap #10812 fixed for unresolvable worktree ids. This mirrors the existing `resolveLaunchWorktree` function in the same file.

The function returns the kind rather than just asserting, so the call site stays load-bearing: deleting the call breaks `isAgent` instead of quietly restoring the fallback. I verified `isAgent` is exactly equivalent to the old `isRegisteredAgent(agentId)` check for every reachable input, including the case where a plugin or user agent registers the `"terminal"` id (plugin and user registries only reserve *built-in* ids).

`"terminal"` is the one id accepted unregistered, since it's the deliberate plain-shell launch. `"browser"` and `"dev-preview"` return from their own panel branches earlier and never reach the classifier, so it rejects those too: correct on its own, and fails closed if either branch is ever bypassed.

Two smaller things fixed in passing, both in the same function:
- The id is stripped of control characters and capped at 80 characters before interpolation, since it arrives straight from an LLM via MCP and could otherwise forge a log line or bloat the error.
- `markRendererPerformance` moved inside the `try` block. It previously sat between the reentrancy-ref add and the `try`, so a throw there would strand the entry and leave that `agentId` unlaunchable for the rest of the session.

No new `spawnStatus` value, no schema change, no action id change, so none of the action-manifest snapshot, plugin-sdk api-surface, MCP tier-allowlist, or IPC codegen guards are involved.

### Why there's no user-visible error

Every UI launch id comes from `LAUNCHABLE_AGENT_IDS` or the live registry, so a user can't reach this except through a stale-state race. `App.tsx` already catches and logs, matching the quiet no-op #10812 deliberately chose for the same class of race.

### Blast radius

`launchAgent` has exactly two call sites, both in `App.tsx`. Every persisted-agent path bypasses this hook: cold hydration and worktree-delete rollback call `addPanel` directly, `terminal.restart`/`fleet.restart` go through the panel store's restart and spawn, duplication and recipes build commands independently, and journal resume uses `buildResumePanelOptions`. So a panel whose plugin agent was later uninstalled is not newly rejected by this fix. There is no `agent.restart` action.

## Testing

New `src/hooks/__tests__/useAgentLauncher.agentIdResolution.test.ts`, 8 invariant-based cases following the existing zero-mock pure-helper pattern of the four sibling `useAgentLauncher.*Resolution` test files. One case extracts every action-shaped token from the thrown error message and asserts each one exists in `BUILT_IN_ACTION_IDS`, so the recovery hint can't rot into naming a tool that doesn't exist.

Locally: 257 tests across 11 related files pass, 0 eslint errors on changed files, prettier clean.

## Follow-ups found but deliberately left out of this PR

Worth their own issues:

- `recipeStore.ts` still has the same degrade-to-shell bug class on its own spawn path, which bypasses this hook.
- `workflow.startWorkOnIssue` validates the agent only after creating the worktree and running recipes.
- The MCP layer classifies every `EXECUTION_ERROR` as retriable, which is wrong for a structural bad-id error.
- `"terminal"`, `"browser"`, and `"dev-preview"` aren't reserved from plugin or user agent registration.
- The plugin-agent boot race can transiently reject a valid plugin id before `usePluginAgents()` populates the renderer mirror.