### PR TITLE
feat(file-browser): let the viewer collapse like the tree

### DIFF
--- a/e2e/full/panels/core-file-browser.spec.ts
+++ b/e2e/full/panels/core-file-browser.spec.ts
@@ -50,8 +50,12 @@ async function dispatchAction(
 }
 
 // Scoped to the file browser's own marker rather than a bare `panel-dialog`:
-// that host is shared, so an unrelated dialog must not satisfy this.
-const BROWSER_DIALOG = `${SEL.fileViewer.dialog}:has([data-testid="file-browser-sidebar-toggle"])`;
+// that host is shared, so an unrelated dialog must not satisfy this. Either
+// column toggle identifies it — each one unmounts with the column it lives in,
+// so neither alone survives every layout the panel can take (#11496).
+const BROWSER_DIALOG =
+  `${SEL.fileViewer.dialog}:has([data-testid="file-browser-sidebar-toggle"],` +
+  ` [data-testid="file-browser-viewer-toggle"])`;
 
 /**
  * Opens the browser through the real action rather than driving the

--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -277,6 +277,8 @@ export interface FileBrowserPanelOptions extends AddPanelOptionsBase {
   browserRootPath?: string;
   /** Whether the tree sidebar starts collapsed; absent or false = open */
   browserSidebarCollapsed?: boolean;
+  /** Whether the viewer column starts collapsed; absent or false = open (#11496) */
+  browserViewerCollapsed?: boolean;
   /** Last-known tree structure to paint before the first live listing (#11367) */
   browserTreeSnapshot?: FileBrowserTreeSnapshot;
   /** Tree column width in px to restore; absent or 288 = the default width */

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -791,6 +791,16 @@ export interface FileBrowserPanelData extends BasePanelData {
    */
   browserSidebarCollapsed?: boolean;
   /**
+   * Whether the viewer column is collapsed, leaving the tree as the whole
+   * panel (#11496). Absent or `false` = open; only `true` is persisted.
+   *
+   * Independent of `browserSidebarCollapsed` on disk, but the two are mutually
+   * exclusive on screen: each column's toggle lives in the *other* column's
+   * header, so a reachable gesture can never hide both. A record holding both
+   * flags resolves tree-hidden/viewer-visible at read time in the pane.
+   */
+  browserViewerCollapsed?: boolean;
+  /**
    * Last-known tree structure, captured when the view goes away and painted
    * back instantly on restore while a live refresh runs (#11367). Derived
    * data, unlike every other field here — but it must live on the panel
@@ -801,8 +811,10 @@ export interface FileBrowserPanelData extends BasePanelData {
   /**
    * Dragged width of the tree column in px. Absent = the 288px default; only a
    * non-default, in-range width is persisted, so an unresized panel stays
-   * sparse. Independent of `browserSidebarCollapsed`: collapsing never clears
-   * it, so re-opening restores the last-dragged width (#11331).
+   * sparse. Independent of both collapse flags: collapsing either column never
+   * clears it, so re-opening restores the last-dragged split (#11331, #11496).
+   * Governs the split layout only — as the sole column the tree simply fills
+   * the panel, so the width is remembered rather than applied.
    */
   browserSidebarWidth?: number;
   /**

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -232,6 +232,8 @@ export interface PanelSnapshot {
   browserRootPath?: string;
   /** Whether a file browser panel's tree sidebar is collapsed (only `true` persisted) */
   browserSidebarCollapsed?: boolean;
+  /** Whether a file browser panel's viewer column is collapsed (only `true` persisted) */
+  browserViewerCollapsed?: boolean;
   /** Last-known tree structure of a file browser panel (#11367) */
   browserTreeSnapshot?: FileBrowserTreeSnapshot;
   /** File browser tree column width in px (only a non-default, in-range value persisted) */

--- a/src/config/__tests__/panelKindSerialisers.test.ts
+++ b/src/config/__tests__/panelKindSerialisers.test.ts
@@ -206,6 +206,37 @@ describe("panelKindSerialisers", () => {
       expect(deserialize()({ id: "fb1" }).browserSidebarCollapsed).toBeUndefined();
     });
 
+    it("restores a collapsed viewer only from a literal true", () => {
+      expect(
+        deserialize()({ id: "fb1", browserViewerCollapsed: true }).browserViewerCollapsed
+      ).toBe(true);
+      expect(
+        deserialize()({ id: "fb1", browserViewerCollapsed: false }).browserViewerCollapsed
+      ).toBeUndefined();
+      expect(
+        deserialize()({ id: "fb1", browserViewerCollapsed: "yes" }).browserViewerCollapsed
+      ).toBeUndefined();
+      expect(
+        deserialize()({ id: "fb1", browserViewerCollapsed: {} }).browserViewerCollapsed
+      ).toBeUndefined();
+      expect(deserialize()({ id: "fb1" }).browserViewerCollapsed).toBeUndefined();
+    });
+
+    it("keeps the two collapse bits independent rather than resolving them here", () => {
+      // "Both collapsed" is unreachable through the UI but reachable on disk, and
+      // the pane is what resolves it at read time. The deserializer must hand
+      // both bits through untouched — silently clearing one here would make the
+      // stored record disagree with what the user last chose (#11496).
+      const restored = deserialize()({
+        id: "fb1",
+        browserSidebarCollapsed: true,
+        browserViewerCollapsed: true,
+      });
+
+      expect(restored.browserSidebarCollapsed).toBe(true);
+      expect(restored.browserViewerCollapsed).toBe(true);
+    });
+
     it("ignores a legacy browserShowIgnored key instead of migrating it", () => {
       // The old field is unknown to the deserializer now; a persisted `true`
       // must not resurface as the inverted new toggle (#10938 / #11330).

--- a/src/config/panelKindSerialisers.ts
+++ b/src/config/panelKindSerialisers.ts
@@ -270,6 +270,10 @@ const BUILT_IN_DESERIALIZERS = {
     // Only a literal `true` restores collapsed: a hand-edited or corrupted
     // snapshot holding a string or object must fall back to the open default.
     browserSidebarCollapsed: saved.browserSidebarCollapsed === true ? true : undefined,
+    // Same literal-`true` rule for the viewer column (#11496). Sanitized
+    // independently: the pane resolves a record holding both flags at read
+    // time, so neither deserializer branch has to know about the other.
+    browserViewerCollapsed: saved.browserViewerCollapsed === true ? true : undefined,
     browserTreeSnapshot: sanitizeTreeSnapshot(saved.browserTreeSnapshot),
     // A finite number is clamped into range; a string/NaN/Infinity from a
     // hand-edited snapshot falls back to the default rather than becoming a

--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -281,6 +281,7 @@ const FILE_BROWSER_FIELD_CLASSIFICATION = {
   browserHideDotfiles: true,
   browserRootPath: true,
   browserSidebarCollapsed: true,
+  browserViewerCollapsed: true,
   // The one derived persisted field: the last-known tree snapshot (#11367)
   // must ride the panel record because nothing renderer-side survives LRU
   // eviction.
@@ -476,7 +477,11 @@ const fileBrowserFixture: FileBrowserPanelData = {
   browserExpandedPaths: ["src"],
   browserHideDotfiles: true,
   browserRootPath: "src",
+  // Both collapse bits, which is not a state the UI can reach but is exactly
+  // what persistence must round-trip unaltered: the two fields are independent
+  // on disk, and the pane resolves the pair at read time (#11496).
   browserSidebarCollapsed: true,
+  browserViewerCollapsed: true,
   browserTreeSnapshot: browserTreeSnapshotFixture,
   // A non-default width (the serializer omits 288), so the coverage spread emits
   // the key instead of dropping it as a default.
@@ -492,6 +497,7 @@ const savedFileBrowser: SavedTerminalData = {
   browserHideDotfiles: true,
   browserRootPath: "src",
   browserSidebarCollapsed: true,
+  browserViewerCollapsed: true,
   browserTreeSnapshot: browserTreeSnapshotFixture,
   browserSidebarWidth: 360,
   browserWorkspaceRooted: true,

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -26,6 +26,7 @@ import { revealCopy } from "@/components/FileViewer/revealCopy";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
 import { copyContextWithFeedback } from "@/hooks/useWorktreeActions";
 import { notify } from "@/lib/notify";
+import { logError } from "@/utils/logger";
 import { actionService } from "@/services/ActionService";
 import { usePanelStore } from "@/store/panelStore";
 import { usePreferencesStore } from "@/store/preferencesStore";
@@ -135,8 +136,11 @@ export function FileBrowserPane({
   // clamp below: a reachable gesture can never set both (each column's toggle
   // lives in the other column's header, so the one that would hide the last
   // column isn't mounted), but a hand-edited or corrupted record could — and
-  // "both collapsed" would render an empty panel with no way back. The tree
-  // wins, being the column that is open by default.
+  // "both collapsed" would render an empty panel with no way back. The older
+  // sidebar bit is the one that decides: with both set the tree stays hidden and
+  // the viewer is forced open, so the panel always has a visible column and the
+  // toggle inside it. Neither stored bit is rewritten — one toggle from here
+  // reaches a consistent layout again.
   const viewerCollapsed = usePanelStore(
     useCallback(
       (state) => {
@@ -341,32 +345,40 @@ export function FileBrowserPane({
   //
   // Positively a file, matching the viewer's own check: the key resolver returns
   // `activate` for whatever row is selected, so directories arrive here too and
-  // must stay a no-op — Enter on a folder expands it, and re-rooting is the
-  // double-click's job.
+  // are deliberately dropped — a folder's Enter does nothing, and re-rooting is
+  // the double-click's job.
   const handleActivate = useCallback(
     (path: string) => {
       const row = rows.find((candidate) => candidate.path === path);
+      // The base-path half is defensive rather than reachable: an unresolved
+      // source renders no tree at all, so nothing can activate a row. It stays
+      // because joining against "" would silently produce a wrong absolute path.
       if (!basePath || row?.isDirectory !== false) return;
 
       const absolutePath = join(basePath, path);
-      const open = () => {
-        void actionService
-          .dispatch("file.openPanel", { path: absolutePath }, { source: "user" })
-          .then((result) => {
-            if (result.ok) return;
-            // Nothing else reports this: the row stays selected and the grid is
-            // unchanged, so a silent failure reads as the keypress being ignored.
-            notify({
-              type: "error",
-              title: "Couldn't open file",
-              message: result.error.message,
-              action: { label: "Retry", onClick: open },
-            });
-          });
-      };
-      open();
+      void (async () => {
+        const result = await actionService.dispatch(
+          "file.openPanel",
+          { path: absolutePath },
+          { source: "user" }
+        );
+        if (!result.ok) {
+          // No toast: the realistic failure is the panel ceiling, and `addPanel`
+          // already raises that warning itself — a second one would report the
+          // same gesture twice.
+          logError("[fileBrowser] failed to open file panel", result.error);
+          return;
+        }
+        // As a dialog this browser is modal, so the panel just opened sits behind
+        // it and the gesture would look like it did nothing. Closing hands the
+        // grid the file the user asked for, which is the point of activating it.
+        if (location === "dialog") {
+          const { usePanelDialogStore } = await import("@/store/panelDialogStore");
+          usePanelDialogStore.getState().closePanelDialogById(id);
+        }
+      })();
     },
-    [basePath, rows]
+    [id, location, basePath, rows]
   );
 
   // Counted separately from the change tick so the toolbar's Refresh also
@@ -518,7 +530,16 @@ export function FileBrowserPane({
   const treeColumnRef = useRef<HTMLDivElement>(null);
   const focusTree = useCallback(() => {
     requestAnimationFrame(() => {
-      treeColumnRef.current?.querySelector<HTMLElement>('[role="tree"]')?.focus();
+      const column = treeColumnRef.current;
+      if (!column) return;
+      // The tree when there are rows to land on, otherwise the first control the
+      // column still has: the loading, error and empty branches render no tree at
+      // all, and querying only for it would drop focus to the document in exactly
+      // the cases this exists to cover.
+      const target =
+        column.querySelector<HTMLElement>('[role="tree"]') ??
+        column.querySelector<HTMLElement>("button");
+      target?.focus();
     });
   }, []);
 

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -370,15 +370,13 @@ export function FileBrowserPane({
           return;
         }
         // As a dialog this browser is modal, so the panel just opened sits behind
-        // it and the gesture would look like it did nothing. Closing hands the
-        // grid the file the user asked for, which is the point of activating it.
-        if (location === "dialog") {
-          const { usePanelDialogStore } = await import("@/store/panelDialogStore");
-          usePanelDialogStore.getState().closePanelDialogById(id);
-        }
+        // it and the gesture would look like it did nothing. `onClose` is the
+        // dialog host's own close for this panel, so this is the same teardown
+        // the close button runs — nothing extra to unwind.
+        if (location === "dialog") onClose?.();
       })();
     },
-    [id, location, basePath, rows]
+    [location, onClose, basePath, rows]
   );
 
   // Counted separately from the change tick so the toolbar's Refresh also

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -1,6 +1,15 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import type React from "react";
-import { Copy, CornerLeftUp, EyeOff, FolderRoot, FolderTree, RefreshCw } from "lucide-react";
+import {
+  Copy,
+  CornerLeftUp,
+  EyeOff,
+  FolderRoot,
+  FolderTree,
+  PanelRightClose,
+  PanelRightOpen,
+  RefreshCw,
+} from "lucide-react";
 import { FolderOpen, Folders } from "@/components/icons";
 import { basename, join } from "@shared/utils/path";
 import { cn } from "@/lib/utils";
@@ -118,6 +127,23 @@ export function FileBrowserPane({
       (state) => {
         const panel = state.panelsById[id];
         return panel?.kind === "file-browser" ? panel.browserSidebarCollapsed === true : false;
+      },
+      [id]
+    )
+  );
+  // Resolved against the sidebar flag rather than read raw, mirroring the width
+  // clamp below: a reachable gesture can never set both (each column's toggle
+  // lives in the other column's header, so the one that would hide the last
+  // column isn't mounted), but a hand-edited or corrupted record could — and
+  // "both collapsed" would render an empty panel with no way back. The tree
+  // wins, being the column that is open by default.
+  const viewerCollapsed = usePanelStore(
+    useCallback(
+      (state) => {
+        const panel = state.panelsById[id];
+        return panel?.kind === "file-browser"
+          ? panel.browserViewerCollapsed === true && panel.browserSidebarCollapsed !== true
+          : false;
       },
       [id]
     )
@@ -307,6 +333,42 @@ export function FileBrowserPane({
     [id, setFileBrowserView]
   );
 
+  // Enter and double-click open the row's file as its own panel (#11496), which
+  // is what makes a collapsed viewer usable: the browser stops being a
+  // self-contained reader and feeds the grid instead. The action reuses a panel
+  // already showing the same file, so repeating the gesture activates that panel
+  // rather than piling up duplicates.
+  //
+  // Positively a file, matching the viewer's own check: the key resolver returns
+  // `activate` for whatever row is selected, so directories arrive here too and
+  // must stay a no-op — Enter on a folder expands it, and re-rooting is the
+  // double-click's job.
+  const handleActivate = useCallback(
+    (path: string) => {
+      const row = rows.find((candidate) => candidate.path === path);
+      if (!basePath || row?.isDirectory !== false) return;
+
+      const absolutePath = join(basePath, path);
+      const open = () => {
+        void actionService
+          .dispatch("file.openPanel", { path: absolutePath }, { source: "user" })
+          .then((result) => {
+            if (result.ok) return;
+            // Nothing else reports this: the row stays selected and the grid is
+            // unchanged, so a silent failure reads as the keypress being ignored.
+            notify({
+              type: "error",
+              title: "Couldn't open file",
+              message: result.error.message,
+              action: { label: "Retry", onClick: open },
+            });
+          });
+      };
+      open();
+    },
+    [basePath, rows]
+  );
+
   // Counted separately from the change tick so the toolbar's Refresh also
   // re-reads the open file, not just the tree.
   const [manualRefreshNonce, setManualRefreshNonce] = useState(0);
@@ -335,9 +397,10 @@ export function FileBrowserPane({
     return !isRowPathVisible(selectedPath, rootPath, isVisible);
   }, [selectedPath, hideDotfiles, alwaysHiddenPatterns, rootPath]);
 
-  // Stable id for the tree column so the toggle's `aria-controls` can name the
-  // region it discloses. Only referenced while the column is mounted (open).
+  // Stable ids for the two columns so each toggle's `aria-controls` can name the
+  // region it discloses. Only referenced while that column is mounted (open).
   const treeSidebarId = useId();
+  const viewerColumnId = useId();
   const handleToggleSidebar = useCallback(() => {
     setFileBrowserView(id, { browserSidebarCollapsed: !sidebarCollapsed });
   }, [id, sidebarCollapsed, setFileBrowserView]);
@@ -430,15 +493,17 @@ export function FileBrowserPane({
   );
 
   // The document listeners outlive the grip on two lifecycles the mouseup can't
-  // cover: the pane unmounting mid-drag (project switch), and the tree column
-  // unmounting because the sidebar collapsed mid-drag (the pane stays mounted,
-  // so its unmount effect never fires). Both drop the listeners here.
+  // cover: the pane unmounting mid-drag (project switch), and the grip
+  // unmounting mid-drag while the pane stays mounted (so its unmount effect
+  // never fires). The grip only exists in the split layout, so either collapse
+  // takes it away — collapsing the tree unmounts the column it lives in, and
+  // collapsing the viewer leaves nothing to resize against (#11496).
   useEffect(() => {
     return () => dragCleanupRef.current?.();
   }, []);
   useEffect(() => {
-    if (sidebarCollapsed) dragCleanupRef.current?.();
-  }, [sidebarCollapsed]);
+    if (sidebarCollapsed || viewerCollapsed) dragCleanupRef.current?.();
+  }, [sidebarCollapsed, viewerCollapsed]);
 
   const handleSetRoot = useCallback(
     (path: string) => {
@@ -456,6 +521,21 @@ export function FileBrowserPane({
       treeColumnRef.current?.querySelector<HTMLElement>('[role="tree"]')?.focus();
     });
   }, []);
+
+  // Collapsing the viewer unmounts everything in it, including its own controls.
+  // The containment check is what keeps the common path intact: the toggle lives
+  // in the tree header, so a click leaves focus on a button that survives the
+  // collapse, and redirecting unconditionally would yank it away. It only hands
+  // focus to the tree when the collapse came from elsewhere (a programmatic or
+  // assistive activation) while something inside the viewer held it, which
+  // would otherwise drop focus to the document.
+  const viewerColumnRef = useRef<HTMLDivElement>(null);
+  const handleToggleViewer = useCallback(() => {
+    const focusWasInViewer =
+      !viewerCollapsed && viewerColumnRef.current?.contains(document.activeElement) === true;
+    setFileBrowserView(id, { browserViewerCollapsed: !viewerCollapsed });
+    if (focusWasInViewer) focusTree();
+  }, [id, viewerCollapsed, setFileBrowserView, focusTree]);
 
   const handleResetRoot = useCallback(() => {
     setFileBrowserView(id, { browserRootPath: "" });
@@ -704,8 +784,17 @@ export function FileBrowserPane({
           <div
             id={treeSidebarId}
             ref={treeColumnRef}
-            className="relative flex min-h-0 shrink-0 flex-col self-stretch border-r border-daintree-border bg-daintree-sidebar"
-            style={{ width: sidebarWidth }}
+            // As the sole column the tree fills the panel instead of holding its
+            // dragged width: a 600px-capped tree beside dead space would keep
+            // exactly the imbalance collapsing the viewer is meant to fix
+            // (#11496). The width is remembered, not applied — reopening the
+            // viewer restores the split. The right border goes with the divider,
+            // since there is nothing on the other side of it.
+            className={cn(
+              "relative flex min-h-0 flex-col self-stretch bg-daintree-sidebar",
+              viewerCollapsed ? "min-w-0 flex-1" : "shrink-0 border-r border-daintree-border"
+            )}
+            style={viewerCollapsed ? undefined : { width: sidebarWidth }}
           >
             {/* py-1.5 + border-overlay + 16px icons match FileViewerToolbar.Root
                 so the two header bars share one height and border token, and the
@@ -786,54 +875,90 @@ export function FileBrowserPane({
               <FileViewerToolbar.IconButton label="Refresh" onClick={handleRefresh}>
                 <SpinningIcon icon={RefreshCw} active={isRefreshing} className="h-4 w-4" />
               </FileViewerToolbar.IconButton>
+              {/* The viewer's disclosure, homed here rather than in the viewer —
+                  the mirror of where the tree's toggle lives (#11496). That
+                  placement is also what makes "both collapsed" unreachable:
+                  each toggle only exists while the column it would leave behind
+                  is on screen. Last in the row so it sits against the divider,
+                  the way the tree's toggle sits first in the viewer's toolbar.
+                  A static label per the toggle-label rule; the icon swap and
+                  `aria-expanded` carry the state, and `aria-controls` is dropped
+                  while the named region is unmounted. */}
+              <FileViewerToolbar.IconButton
+                label="Toggle file viewer"
+                expanded={!viewerCollapsed}
+                controls={viewerCollapsed ? undefined : viewerColumnId}
+                sidebarToggle
+                onClick={handleToggleViewer}
+                data-testid="file-browser-viewer-toggle"
+              >
+                {viewerCollapsed ? (
+                  <PanelRightOpen className="h-4 w-4" />
+                ) : (
+                  <PanelRightClose className="h-4 w-4" />
+                )}
+              </FileViewerToolbar.IconButton>
             </div>
             {renderTree()}
             {/* Straddles the right border between the tree and the viewer. Lives
                 inside the collapsible column, so it unmounts with the tree —
-                no grip while collapsed, per #11331. Styling mirrors the
-                worktree Sidebar / PortalDock handle: a thin pill that thickens
-                on hover, an accent focus anchor for keyboard resize. */}
-            <div
-              role="separator"
-              aria-label="Resize file tree"
-              aria-orientation="vertical"
-              aria-controls={treeSidebarId}
-              aria-valuenow={Math.round(sidebarWidth)}
-              aria-valuemin={FILE_BROWSER_SIDEBAR_MIN_WIDTH}
-              aria-valuemax={FILE_BROWSER_SIDEBAR_MAX_WIDTH}
-              tabIndex={0}
-              data-testid="file-browser-sidebar-resize"
-              className={cn(
-                "group absolute -right-1.5 top-0 bottom-0 z-10 flex w-3 cursor-col-resize items-center justify-center",
-                "transition-colors hover:bg-overlay-soft focus:bg-tint/[0.04] focus:outline-hidden focus:ring-1 focus:ring-daintree-accent/50",
-                isResizing && "bg-overlay-medium"
-              )}
-              onMouseDown={handleResizeStart}
-              onDoubleClick={handleResizeDoubleClick}
-              onKeyDown={handleResizeKeyDown}
-            >
+                no grip while collapsed, per #11331 — and is gated on the viewer
+                too, since a sole column has nothing to resize against (#11496).
+                Styling mirrors the worktree Sidebar / PortalDock handle: a thin
+                pill that thickens on hover, an accent focus anchor for keyboard
+                resize. */}
+            {!viewerCollapsed && (
               <div
+                role="separator"
+                aria-label="Resize file tree"
+                aria-orientation="vertical"
+                aria-controls={treeSidebarId}
+                aria-valuenow={Math.round(sidebarWidth)}
+                aria-valuemin={FILE_BROWSER_SIDEBAR_MIN_WIDTH}
+                aria-valuemax={FILE_BROWSER_SIDEBAR_MAX_WIDTH}
+                tabIndex={0}
+                data-testid="file-browser-sidebar-resize"
                 className={cn(
-                  "h-8 w-px rounded-full transition-[width] delay-100 duration-150 group-hover:w-0.5",
-                  "bg-daintree-text/20 group-hover:bg-daintree-text/35 group-focus:bg-daintree-accent",
-                  isResizing && "bg-daintree-text/50"
+                  "group absolute -right-1.5 top-0 bottom-0 z-10 flex w-3 cursor-col-resize items-center justify-center",
+                  "transition-colors hover:bg-overlay-soft focus:bg-tint/[0.04] focus:outline-hidden focus:ring-1 focus:ring-daintree-accent/50",
+                  isResizing && "bg-overlay-medium"
                 )}
-              />
-            </div>
+                onMouseDown={handleResizeStart}
+                onDoubleClick={handleResizeDoubleClick}
+                onKeyDown={handleResizeKeyDown}
+              >
+                <div
+                  className={cn(
+                    "h-8 w-px rounded-full transition-[width] delay-100 duration-150 group-hover:w-0.5",
+                    "bg-daintree-text/20 group-hover:bg-daintree-text/35 group-focus:bg-daintree-accent",
+                    isResizing && "bg-daintree-text/50"
+                  )}
+                />
+              </div>
+            )}
           </div>
         )}
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-          <FileBrowserViewer
-            filePath={selectedFilePath}
-            rootPath={basePath}
-            fileName={selectedFileName}
-            relativePath={selectedNode?.isDirectory === false ? (selectedPath ?? null) : null}
-            revision={viewerRevision}
-            sidebarCollapsed={sidebarCollapsed}
-            onToggleSidebar={handleToggleSidebar}
-            treeSidebarId={treeSidebarId}
-          />
-        </div>
+        {/* Unmounts entirely when collapsed, the mirror of the tree column: the
+            toggle that brings it back lives in the tree's header, so there is no
+            orphaned control (#11496). */}
+        {!viewerCollapsed && (
+          <div
+            id={viewerColumnId}
+            ref={viewerColumnRef}
+            className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
+          >
+            <FileBrowserViewer
+              filePath={selectedFilePath}
+              rootPath={basePath}
+              fileName={selectedFileName}
+              relativePath={selectedNode?.isDirectory === false ? (selectedPath ?? null) : null}
+              revision={viewerRevision}
+              sidebarCollapsed={sidebarCollapsed}
+              onToggleSidebar={handleToggleSidebar}
+              treeSidebarId={treeSidebarId}
+            />
+          </div>
+        )}
         {isResizing && (
           // Drag shield: while resizing, cover the surface so the HTML-preview
           // iframe (which the divider drags straight over) can't swallow the
@@ -954,6 +1079,7 @@ export function FileBrowserPane({
           selectedPath={selectedPath}
           onSelect={handleSelect}
           onToggleExpanded={handleToggleExpanded}
+          onActivate={handleActivate}
           onRootFolder={handleSetRoot}
           rowContextMenu={rowContextMenu}
           label={`Files in ${title}`}

--- a/src/panels/file-browser/FileTreeView.tsx
+++ b/src/panels/file-browser/FileTreeView.tsx
@@ -15,7 +15,11 @@ export interface FileTreeViewProps {
   selectedPath: string | null;
   onSelect: (path: string) => void;
   onToggleExpanded: (path: string, expand: boolean) => void;
-  /** Fired by Enter on a file row — the viewer already follows selection. */
+  /**
+   * Fired by Enter or a double-click on a file row. Directory rows also reach
+   * this on Enter (the key resolver is row-kind agnostic), so the handler owns
+   * the file check.
+   */
   onActivate?: (path: string) => void;
   /** Fired by double-clicking a directory row: re-root the tree there. */
   onRootFolder?: (path: string) => void;
@@ -157,6 +161,7 @@ export function FileTreeView({
       selectedPath,
       onSelect,
       onToggleExpanded,
+      onActivate,
       onRootFolder,
       rowContextMenu,
       hasDirectories,
@@ -166,6 +171,7 @@ export function FileTreeView({
       selectedPath,
       onSelect,
       onToggleExpanded,
+      onActivate,
       onRootFolder,
       rowContextMenu,
       hasDirectories,
@@ -215,6 +221,7 @@ interface TreeContext {
   selectedPath: string | null;
   onSelect: (path: string) => void;
   onToggleExpanded: (path: string, expand: boolean) => void;
+  onActivate?: ((path: string) => void) | undefined;
   onRootFolder?: ((path: string) => void) | undefined;
   rowContextMenu?: ((row: FlatTreeRow) => React.ReactNode) | undefined;
   hasDirectories: boolean;
@@ -250,7 +257,7 @@ interface FileTreeRowProps {
 }
 
 function FileTreeRow({ row, isSelected, context }: FileTreeRowProps) {
-  const { onSelect, onToggleExpanded, onRootFolder } = context;
+  const { onSelect, onToggleExpanded, onActivate, onRootFolder } = context;
 
   // Defer the folder-load spinner past the anti-flicker gate so a fast
   // expansion flashes nothing. Drives only the indicator — the tree's content
@@ -264,13 +271,20 @@ function FileTreeRow({ row, isSelected, context }: FileTreeRowProps) {
     if (row.isDirectory) onToggleExpanded(row.path, !row.isExpanded);
   };
 
-  // Double-click re-roots the tree at the folder. The two single clicks it
-  // contains toggle expansion twice — a net no-op — so the only observable
-  // effect is the re-root.
-  const handleDoubleClick =
-    row.isDirectory && onRootFolder
+  // Double-click re-roots a folder and opens a file in its own panel (#11496) —
+  // the gesture keeps its "go deeper into this" meaning either way. On a folder
+  // the two single clicks it contains toggle expansion twice (a net no-op), and
+  // on a file they only re-select the row, so in both cases the double-click's
+  // own effect is the only observable one.
+  const handleDoubleClick = row.isDirectory
+    ? onRootFolder
       ? () => {
           onRootFolder(row.path);
+        }
+      : undefined
+    : onActivate
+      ? () => {
+          onActivate(row.path);
         }
       : undefined;
 

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -205,9 +205,27 @@ vi.mock("@/clients/filesClient", () => ({ filesClient: { read: readMock } }));
 // Row activation dispatches `file.openPanel` through here; the default is the
 // success shape so tests that don't care about failure don't have to arrange it.
 const { dispatchMock } = vi.hoisted(() => ({
-  dispatchMock: vi.fn<(id: string, args?: unknown, opts?: unknown) => Promise<unknown>>(),
+  dispatchMock:
+    vi.fn<
+      (
+        id: string,
+        args?: unknown,
+        opts?: unknown
+      ) => Promise<{ ok: true; result: unknown } | { ok: false; error: { message: string } }>
+    >(),
 }));
 vi.mock("@/services/ActionService", () => ({ actionService: { dispatch: dispatchMock } }));
+// Dynamically imported by the pane (a static import would drag panelStore ->
+// panelPersistence -> projectClient in at module scope), so the mock has to be
+// registered even though nothing here imports it directly.
+const { closePanelDialogByIdMock } = vi.hoisted(() => ({
+  closePanelDialogByIdMock: vi.fn<(panelId: string) => void>(),
+}));
+vi.mock("@/store/panelDialogStore", () => ({
+  usePanelDialogStore: {
+    getState: () => ({ closePanelDialogById: closePanelDialogByIdMock }),
+  },
+}));
 vi.mock("@/components/Markdown/MarkdownViewer", () => ({ MarkdownViewer: () => null }));
 vi.mock("@/components/FileViewer/CodeViewer", () => ({
   CodeViewer: () => <div data-testid="code-viewer" />,
@@ -280,8 +298,9 @@ beforeEach(() => {
   mockPanel.browserWorkspaceRooted = undefined;
   treeArgs.changeTick = undefined;
   treeProps.onActivate = undefined;
+  closePanelDialogByIdMock.mockReset();
   dispatchMock.mockReset();
-  dispatchMock.mockResolvedValue({ ok: true, value: { panelId: "file-1" } });
+  dispatchMock.mockResolvedValue({ ok: true, result: { panelId: "file-1" } });
   worktreeTicks.git = undefined;
   worktreeTicks.fs = undefined;
   for (const name of ["matchMedia"] as const) {
@@ -1262,7 +1281,11 @@ describe("FileBrowserPane collapsible viewer (#11496)", () => {
   it("sits last in the tree header, against the divider", () => {
     renderPane();
 
-    const header = viewerToggle().parentElement!;
+    // The header located from the column rather than from the toggle itself:
+    // asking the toggle for its own parent would keep passing if a wrapper
+    // moved the control into the middle of the row.
+    const header = treeColumn().querySelector<HTMLElement>(":scope > div")!;
+    expect(header.contains(viewerToggle())).toBe(true);
     // Mirrors where the tree's toggle sits in the viewer's toolbar (first, also
     // against the divider), so the two disclosures frame the split.
     expect(header.lastElementChild).toBe(viewerToggle());
@@ -1290,11 +1313,14 @@ describe("FileBrowserPane collapsible viewer (#11496)", () => {
     expect(labelWhenOpen).toBeTruthy();
   });
 
-  it("unmounts the viewer column and drops the dangling aria-controls", () => {
+  it("unmounts the viewer column and drops the dangling aria-controls", async () => {
     mockPanel.browserSelectedPath = "src/app.ts";
     const { rerender } = renderPane();
     const controlsId = viewerToggle().getAttribute("aria-controls");
     expect(document.getElementById(controlsId!)).not.toBeNull();
+    // Established BEFORE collapsing: without this the "code viewer is gone"
+    // assertion below would also pass if the selected file never rendered.
+    await waitFor(() => expect(screen.getByTestId("code-viewer")).toBeTruthy());
 
     mockPanel.browserViewerCollapsed = true;
     rerender(paneJsx());
@@ -1372,6 +1398,8 @@ describe("FileBrowserPane collapsible viewer (#11496)", () => {
     const fillToken = classToken(splitColumn.parentElement!.lastElementChild!, (c) =>
       /^flex-1$/.test(c)
     );
+    // Guard against a vacuous undefined === undefined pass below.
+    expect(fillToken).toBeDefined();
 
     fireEvent.click(viewerToggle());
     rerender(paneJsx());
@@ -1385,10 +1413,12 @@ describe("FileBrowserPane collapsible viewer (#11496)", () => {
     expect(classToken(soleColumn, (c) => /^flex-1$/.test(c))).toBe(fillToken);
   });
 
-  it("restores the remembered split when the viewer reopens", () => {
+  it("restores the remembered split and the selected file when the viewer reopens", async () => {
     mockPanel.browserSidebarWidth = 420;
+    mockPanel.browserSelectedPath = "src/app.ts";
     makeStoreStateful();
     const { rerender } = renderPane();
+    await waitFor(() => expect(screen.getByTestId("code-viewer")).toBeTruthy());
 
     fireEvent.click(viewerToggle());
     rerender(paneJsx());
@@ -1400,6 +1430,9 @@ describe("FileBrowserPane collapsible viewer (#11496)", () => {
 
     expect(treeColumn().style.width).toBe("420px");
     expect(screen.getByTestId("file-browser-sidebar-resize")).toBeTruthy();
+    // The selection outlived the unmount, so reopening reads the same file back
+    // rather than returning to the empty state.
+    await waitFor(() => expect(screen.getByTestId("code-viewer")).toBeTruthy());
   });
 
   it("drops the document listeners when the viewer collapses mid-drag", () => {
@@ -1416,52 +1449,107 @@ describe("FileBrowserPane collapsible viewer (#11496)", () => {
     expect(setFileBrowserViewMock).not.toHaveBeenCalled();
   });
 
+  // The redirect runs inside a requestAnimationFrame, so a synchronous assertion
+  // would pass whether or not a frame was ever queued — which is exactly the
+  // regression these two tests exist to catch. Queue the callbacks and flush them
+  // after the collapsed rerender, the order production sees.
+  function queueFrames() {
+    const queued: FrameRequestCallback[] = [];
+    const spy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((cb: FrameRequestCallback) => queued.push(cb));
+    return {
+      spy,
+      count: () => queued.length,
+      flush: () => {
+        const pending = queued.splice(0);
+        act(() => {
+          for (const cb of pending) cb(0);
+        });
+      },
+    };
+  }
+
   it("leaves focus on the toggle when the click itself collapses the viewer", () => {
     makeStoreStateful();
-    const { rerender } = renderPane();
-    const toggle = viewerToggle();
-    act(() => toggle.focus());
+    const frames = queueFrames();
+    try {
+      const { rerender } = renderPane();
+      act(() => viewerToggle().focus());
 
-    fireEvent.click(toggle);
-    rerender(paneJsx());
+      fireEvent.click(viewerToggle());
+      rerender(paneJsx());
+      // No frame requested at all: the toggle lives in the tree header, so it
+      // survives its own collapse and there is nothing to recover from.
+      expect(frames.count()).toBe(0);
+      frames.flush();
 
-    // The toggle lives in the tree header, so it survives its own collapse —
-    // redirecting focus unconditionally would yank it off the button the user
-    // just pressed.
-    expect(document.activeElement).toBe(viewerToggle());
+      // Flushed anyway, so an unconditional redirect would have yanked focus off
+      // the button the user just pressed and failed here.
+      expect(document.activeElement).toBe(viewerToggle());
+    } finally {
+      frames.spy.mockRestore();
+    }
   });
 
   it("hands focus to the tree when a collapse unmounts the focused viewer control", () => {
     makeStoreStateful();
-    const rafSpy = vi
-      .spyOn(window, "requestAnimationFrame")
-      .mockImplementation((cb: FrameRequestCallback) => {
-        cb(0);
-        return 0;
-      });
+    const frames = queueFrames();
     try {
       const { rerender } = renderPane();
       // Focus something inside the viewer, then collapse from elsewhere (an
       // assistive or programmatic activation) — the focused node is about to go.
-      const insideViewer = screen.getByTestId("file-browser-sidebar-toggle");
-      act(() => insideViewer.focus());
+      act(() => screen.getByTestId("file-browser-sidebar-toggle").focus());
 
       act(() => {
         viewerToggle().dispatchEvent(new MouseEvent("click", { bubbles: true }));
       });
       rerender(paneJsx());
+      frames.flush();
 
       expect(document.activeElement).toBe(screen.getByTestId("file-tree-view"));
     } finally {
-      rafSpy.mockRestore();
+      frames.spy.mockRestore();
+    }
+  });
+
+  it("still lands focus in the tree column when there is no tree to focus", () => {
+    // The loading, error and empty branches render no role="tree" at all, so a
+    // redirect that only looked for one would drop focus to the document.
+    treeState.rows = [];
+    makeStoreStateful();
+    const frames = queueFrames();
+    try {
+      const { rerender } = renderPane();
+      // Captured before the collapse: the helper resolves the column through the
+      // viewer's toggle, which is exactly what unmounts here. The column element
+      // itself survives, so hold the reference.
+      const column = treeColumn();
+      act(() => screen.getByTestId("file-browser-sidebar-toggle").focus());
+
+      act(() => {
+        viewerToggle().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      rerender(paneJsx());
+      frames.flush();
+
+      expect(screen.queryByRole("tree")).toBeNull();
+      expect(column.contains(document.activeElement)).toBe(true);
+      expect(document.activeElement).not.toBe(document.body);
+    } finally {
+      frames.spy.mockRestore();
     }
   });
 });
 
 describe("FileBrowserPane row activation (#11496)", () => {
+  // Invoked non-optionally: with `?.` the negative cases below would pass even if
+  // the pane had never wired the prop, proving nothing about their guards.
   const activate = async (path: string) => {
+    const onActivate = treeProps.onActivate;
+    expect(onActivate).toBeTypeOf("function");
     await act(async () => {
-      treeProps.onActivate?.(path);
+      onActivate!(path);
       await Promise.resolve();
     });
   };
@@ -1499,25 +1587,82 @@ describe("FileBrowserPane row activation (#11496)", () => {
     expect(dispatchMock).not.toHaveBeenCalled();
   });
 
-  it("raises a retryable error toast when the open fails", async () => {
+  it("resolves the path against a workspace root, not the placement worktree", async () => {
+    // A promoted workspace-rooted panel carries a placement `worktreeId` whose
+    // path is NOT what it browses (#11489), so reading that instead of the
+    // resolved base would open a file from the wrong folder.
+    workspaceRootPathMock.mockReturnValue("/scratches/one");
+    mockPanel.browserWorkspaceRooted = true;
+    renderPane({ worktreeId: "wt-1" });
+
+    await activate("src/app.ts");
+
+    expect(dispatchMock.mock.calls).toEqual([
+      ["file.openPanel", { path: "/scratches/one/src/app.ts" }, { source: "user" }],
+    ]);
+  });
+
+  it("closes the browser dialog so the panel it opened is not stranded behind it", async () => {
+    // `worktree.openFileBrowser` opens this pane as a modal, so the grid panel
+    // the action just created would sit under a focus-trapping dialog and the
+    // gesture would look like it did nothing.
+    render(
+      <TooltipProvider>
+        <FileBrowserPane
+          id="fb-1"
+          title="Files"
+          worktreeId="wt-1"
+          isFocused
+          location="dialog"
+          onFocus={vi.fn()}
+          onClose={vi.fn()}
+        />
+      </TooltipProvider>
+    );
+
+    await activate("src/app.ts");
+
+    expect(closePanelDialogByIdMock.mock.calls).toEqual([["fb-1"]]);
+  });
+
+  it("leaves the dialog alone when the open failed", async () => {
+    // Closing on failure would dismiss the browser and show nothing in its place.
+    dispatchMock.mockResolvedValue({ ok: false, error: { message: "panel limit reached" } });
+    render(
+      <TooltipProvider>
+        <FileBrowserPane
+          id="fb-1"
+          title="Files"
+          worktreeId="wt-1"
+          isFocused
+          location="dialog"
+          onFocus={vi.fn()}
+          onClose={vi.fn()}
+        />
+      </TooltipProvider>
+    );
+
+    await activate("src/app.ts");
+
+    expect(closePanelDialogByIdMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps a grid-hosted browser open, having no dialog to dismiss", async () => {
+    renderPane();
+
+    await activate("src/app.ts");
+
+    expect(closePanelDialogByIdMock).not.toHaveBeenCalled();
+  });
+
+  it("reports a failed open without raising a second toast over addPanel's own", async () => {
+    // The realistic failure is the panel ceiling, which `addPanel` already warns
+    // about — a toast here would report one gesture twice.
     dispatchMock.mockResolvedValue({ ok: false, error: { message: "panel limit reached" } });
     renderPane();
 
     await activate("src/app.ts");
 
-    // Nothing else reports it: the row stays selected and the grid is unchanged,
-    // so a silent failure reads as the keypress being ignored.
-    const call = notifyMock.mock.calls.at(-1)?.[0];
-    expect(call?.type).toBe("error");
-    expect(call?.message).toBe("panel limit reached");
-    expect(call?.action?.label).toBeTruthy();
-
-    // The recovery action re-enters the whole gesture rather than being inert.
-    dispatchMock.mockResolvedValue({ ok: true, value: { panelId: "file-1" } });
-    await act(async () => {
-      call?.action?.onClick?.();
-      await Promise.resolve();
-    });
-    expect(dispatchMock).toHaveBeenCalledTimes(2);
+    expect(notifyMock).not.toHaveBeenCalled();
   });
 });

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -61,6 +61,7 @@ interface MockPanel {
   browserShowIgnored?: boolean;
   browserRootPath?: string;
   browserSidebarCollapsed?: boolean;
+  browserViewerCollapsed?: boolean;
   browserSidebarWidth?: number;
   browserWorkspaceRooted?: boolean;
 }
@@ -125,12 +126,27 @@ const FOLDER_ROW = {
   depth: 0,
   isExpanded: false,
 };
+// `onActivate` is captured rather than driven through a real row: Enter and
+// double-click both land on it, and the pane's own file-vs-directory guard is
+// what these tests are after.
+const { treeProps } = vi.hoisted(() => ({
+  treeProps: { onActivate: undefined as ((path: string) => void) | undefined },
+}));
 vi.mock("../FileTreeView", () => ({
-  FileTreeView: ({ rowContextMenu }: { rowContextMenu?: (row: unknown) => React.ReactNode }) => (
-    <div data-testid="file-tree-view" role="tree" tabIndex={-1}>
-      {rowContextMenu?.(FOLDER_ROW)}
-    </div>
-  ),
+  FileTreeView: ({
+    rowContextMenu,
+    onActivate,
+  }: {
+    rowContextMenu?: (row: unknown) => React.ReactNode;
+    onActivate?: (path: string) => void;
+  }) => {
+    treeProps.onActivate = onActivate;
+    return (
+      <div data-testid="file-tree-view" role="tree" tabIndex={-1}>
+        {rowContextMenu?.(FOLDER_ROW)}
+      </div>
+    );
+  },
 }));
 
 vi.mock("@/components/ui/context-menu", async (importOriginal) => ({
@@ -186,7 +202,12 @@ vi.mock("@/components/Panel/ContentPanel", () => ({
 // renderers stay out of the suite; CodeViewer surfaces a marker so a selected
 // file's viewer is observable across a collapse.
 vi.mock("@/clients/filesClient", () => ({ filesClient: { read: readMock } }));
-vi.mock("@/services/ActionService", () => ({ actionService: { dispatch: vi.fn() } }));
+// Row activation dispatches `file.openPanel` through here; the default is the
+// success shape so tests that don't care about failure don't have to arrange it.
+const { dispatchMock } = vi.hoisted(() => ({
+  dispatchMock: vi.fn<(id: string, args?: unknown, opts?: unknown) => Promise<unknown>>(),
+}));
+vi.mock("@/services/ActionService", () => ({ actionService: { dispatch: dispatchMock } }));
 vi.mock("@/components/Markdown/MarkdownViewer", () => ({ MarkdownViewer: () => null }));
 vi.mock("@/components/FileViewer/CodeViewer", () => ({
   CodeViewer: () => <div data-testid="code-viewer" />,
@@ -251,12 +272,16 @@ beforeEach(() => {
   treeState.isInitialLoading = false;
   treeState.captureSnapshot = () => null;
   mockPanel.browserSidebarCollapsed = undefined;
+  mockPanel.browserViewerCollapsed = undefined;
   mockPanel.browserSelectedPath = undefined;
   mockPanel.browserRootPath = undefined;
   mockPanel.browserShowIgnored = undefined;
   mockPanel.browserSidebarWidth = undefined;
   mockPanel.browserWorkspaceRooted = undefined;
   treeArgs.changeTick = undefined;
+  treeProps.onActivate = undefined;
+  dispatchMock.mockReset();
+  dispatchMock.mockResolvedValue({ ok: true, value: { panelId: "file-1" } });
   worktreeTicks.git = undefined;
   worktreeTicks.fs = undefined;
   for (const name of ["matchMedia"] as const) {
@@ -1187,5 +1212,312 @@ describe("promoted workspace-rooted browser (#11489)", () => {
     renderPane({ worktreeId: "wt-1" });
 
     expect(treeArgs.changeTick).toBeUndefined();
+  });
+});
+
+describe("FileBrowserPane collapsible viewer (#11496)", () => {
+  const paneJsx = () => (
+    <TooltipProvider>
+      <FileBrowserPane
+        id="fb-1"
+        title="Files"
+        worktreeId="wt-1"
+        isFocused
+        location="grid"
+        onFocus={vi.fn()}
+        onClose={vi.fn()}
+      />
+    </TooltipProvider>
+  );
+
+  // Both toggles write through the store, so a click has to be reflected back
+  // before the next assertion — otherwise every test would only ever see the
+  // pane's initial layout.
+  function makeStoreStateful() {
+    setFileBrowserViewMock.mockImplementation((_id: string, patch: Partial<MockPanel>) => {
+      Object.assign(mockPanel, patch);
+    });
+  }
+
+  const viewerToggle = () => screen.getByTestId("file-browser-viewer-toggle");
+  const treeColumn = () =>
+    document.getElementById(
+      screen.getByTestId("file-browser-sidebar-toggle").getAttribute("aria-controls")!
+    )!;
+
+  it("homes the viewer's toggle in the tree header and names the region it discloses", () => {
+    renderPane();
+
+    const toggle = viewerToggle();
+    // The toggle for each column lives in the other column's header: this one
+    // has to be inside the tree, which is what makes "both collapsed"
+    // unreachable rather than merely discouraged.
+    expect(treeColumn().contains(toggle)).toBe(true);
+    const controlsId = toggle.getAttribute("aria-controls");
+    expect(controlsId).toBeTruthy();
+    expect(document.getElementById(controlsId!)).not.toBeNull();
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("sits last in the tree header, against the divider", () => {
+    renderPane();
+
+    const header = viewerToggle().parentElement!;
+    // Mirrors where the tree's toggle sits in the viewer's toolbar (first, also
+    // against the divider), so the two disclosures frame the split.
+    expect(header.lastElementChild).toBe(viewerToggle());
+  });
+
+  it("carries disclosure semantics rather than a pressed toggle", () => {
+    renderPane();
+
+    const toggle = viewerToggle();
+    // A disclosure, like the tree's: it hides a region, so `aria-expanded` is
+    // the state — not `aria-pressed`, which would describe a mode switch.
+    expect(toggle.hasAttribute("aria-expanded")).toBe(true);
+    expect(toggle.hasAttribute("aria-pressed")).toBe(false);
+  });
+
+  it("keeps one static label across both states", () => {
+    makeStoreStateful();
+    const { rerender } = renderPane();
+    const labelWhenOpen = viewerToggle().getAttribute("aria-label");
+
+    fireEvent.click(viewerToggle());
+    rerender(paneJsx());
+
+    expect(viewerToggle().getAttribute("aria-label")).toBe(labelWhenOpen);
+    expect(labelWhenOpen).toBeTruthy();
+  });
+
+  it("unmounts the viewer column and drops the dangling aria-controls", () => {
+    mockPanel.browserSelectedPath = "src/app.ts";
+    const { rerender } = renderPane();
+    const controlsId = viewerToggle().getAttribute("aria-controls");
+    expect(document.getElementById(controlsId!)).not.toBeNull();
+
+    mockPanel.browserViewerCollapsed = true;
+    rerender(paneJsx());
+
+    // The whole viewer goes, including the file body and the tree's own toggle
+    // that lived in it — the tree header's control is the only way back.
+    expect(screen.queryByTestId("code-viewer")).toBeNull();
+    expect(screen.queryByTestId("file-browser-sidebar-toggle")).toBeNull();
+    expect(screen.getByTestId("file-tree-view")).toBeTruthy();
+    expect(viewerToggle().getAttribute("aria-expanded")).toBe("false");
+    expect(viewerToggle().hasAttribute("aria-controls")).toBe(false);
+    expect(document.getElementById(controlsId!)).toBeNull();
+  });
+
+  it("leaves exactly one collapse control mounted in either collapsed layout", () => {
+    // The structural invariant behind "both collapsed is impossible": whichever
+    // column is hidden takes its sibling's toggle with it, so the only control
+    // on screen is the one that reopens what's missing.
+    mockPanel.browserViewerCollapsed = true;
+    const { unmount } = renderPane();
+    expect(screen.queryByTestId("file-browser-sidebar-toggle")).toBeNull();
+    expect(screen.getByTestId("file-browser-viewer-toggle")).toBeTruthy();
+    unmount();
+
+    // A fresh root rather than a rerender: the mirror layout is a different
+    // mount, and rerendering an unmounted one asserts nothing.
+    mockPanel.browserViewerCollapsed = undefined;
+    mockPanel.browserSidebarCollapsed = true;
+    renderPane();
+    expect(screen.queryByTestId("file-browser-viewer-toggle")).toBeNull();
+    expect(screen.getByTestId("file-browser-sidebar-toggle")).toBeTruthy();
+  });
+
+  it("keeps the viewer visible when a corrupted record collapses both columns", () => {
+    // Unreachable by gesture, reachable on disk. Resolved at read time in favour
+    // of the tree, so the panel can never render empty with no way out.
+    mockPanel.browserSidebarCollapsed = true;
+    mockPanel.browserViewerCollapsed = true;
+    renderPane();
+
+    expect(screen.queryByTestId("file-tree-view")).toBeNull();
+    expect(screen.getByTestId("file-browser-sidebar-toggle")).toBeTruthy();
+  });
+
+  it("toggles the persisted flag on click, inverting the current value", () => {
+    renderPane();
+
+    fireEvent.click(viewerToggle());
+
+    expect(setFileBrowserViewMock).toHaveBeenCalledWith("fb-1", {
+      browserViewerCollapsed: true,
+    });
+  });
+
+  it("re-opens from the collapsed state rather than always collapsing", () => {
+    mockPanel.browserViewerCollapsed = true;
+    renderPane();
+
+    fireEvent.click(viewerToggle());
+
+    expect(setFileBrowserViewMock).toHaveBeenCalledWith("fb-1", {
+      browserViewerCollapsed: false,
+    });
+  });
+
+  it("hands the tree the whole panel, dropping the split width and the grip", () => {
+    mockPanel.browserSidebarWidth = 420;
+    makeStoreStateful();
+    const { rerender } = renderPane();
+
+    // Split layout: a fixed column with a grip against the viewer.
+    const splitColumn = treeColumn();
+    expect(splitColumn.style.width).toBe("420px");
+    expect(screen.getByTestId("file-browser-sidebar-resize")).toBeTruthy();
+    const fillToken = classToken(splitColumn.parentElement!.lastElementChild!, (c) =>
+      /^flex-1$/.test(c)
+    );
+
+    fireEvent.click(viewerToggle());
+    rerender(paneJsx());
+
+    // Sole column: no inline width, nothing to resize against, and it takes the
+    // same fill token the viewer used — so a 600px-capped tree can't strand
+    // dead space beside it.
+    const soleColumn = screen.getByTestId("file-tree-view").closest("[id]")!;
+    expect((soleColumn as HTMLElement).style.width).toBe("");
+    expect(screen.queryByTestId("file-browser-sidebar-resize")).toBeNull();
+    expect(classToken(soleColumn, (c) => /^flex-1$/.test(c))).toBe(fillToken);
+  });
+
+  it("restores the remembered split when the viewer reopens", () => {
+    mockPanel.browserSidebarWidth = 420;
+    makeStoreStateful();
+    const { rerender } = renderPane();
+
+    fireEvent.click(viewerToggle());
+    rerender(paneJsx());
+    // Collapsing must not clear the width, only stop applying it.
+    expect(mockPanel.browserSidebarWidth).toBe(420);
+
+    fireEvent.click(viewerToggle());
+    rerender(paneJsx());
+
+    expect(treeColumn().style.width).toBe("420px");
+    expect(screen.getByTestId("file-browser-sidebar-resize")).toBeTruthy();
+  });
+
+  it("drops the document listeners when the viewer collapses mid-drag", () => {
+    const { rerender } = renderPane();
+
+    fireEvent.mouseDown(screen.getByTestId("file-browser-sidebar-resize"), { clientX: 100 });
+    // Collapsing the viewer takes the grip away without unmounting the pane, so
+    // the same cleanup the tree-collapse path uses has to fire here too.
+    mockPanel.browserViewerCollapsed = true;
+    rerender(paneJsx());
+    setFileBrowserViewMock.mockClear();
+    fireEvent.mouseMove(document, { clientX: 400, buttons: 1 });
+
+    expect(setFileBrowserViewMock).not.toHaveBeenCalled();
+  });
+
+  it("leaves focus on the toggle when the click itself collapses the viewer", () => {
+    makeStoreStateful();
+    const { rerender } = renderPane();
+    const toggle = viewerToggle();
+    act(() => toggle.focus());
+
+    fireEvent.click(toggle);
+    rerender(paneJsx());
+
+    // The toggle lives in the tree header, so it survives its own collapse —
+    // redirecting focus unconditionally would yank it off the button the user
+    // just pressed.
+    expect(document.activeElement).toBe(viewerToggle());
+  });
+
+  it("hands focus to the tree when a collapse unmounts the focused viewer control", () => {
+    makeStoreStateful();
+    const rafSpy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((cb: FrameRequestCallback) => {
+        cb(0);
+        return 0;
+      });
+    try {
+      const { rerender } = renderPane();
+      // Focus something inside the viewer, then collapse from elsewhere (an
+      // assistive or programmatic activation) — the focused node is about to go.
+      const insideViewer = screen.getByTestId("file-browser-sidebar-toggle");
+      act(() => insideViewer.focus());
+
+      act(() => {
+        viewerToggle().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      rerender(paneJsx());
+
+      expect(document.activeElement).toBe(screen.getByTestId("file-tree-view"));
+    } finally {
+      rafSpy.mockRestore();
+    }
+  });
+});
+
+describe("FileBrowserPane row activation (#11496)", () => {
+  const activate = async (path: string) => {
+    await act(async () => {
+      treeProps.onActivate?.(path);
+      await Promise.resolve();
+    });
+  };
+
+  it("opens a file row in its own panel, resolved to an absolute path", async () => {
+    renderPane();
+
+    await activate("src/app.ts");
+
+    // The worktree in the store mock is /repo, so the action gets the same
+    // absolute path a row's "Copy full path" would produce.
+    expect(dispatchMock.mock.calls).toEqual([
+      ["file.openPanel", { path: "/repo/src/app.ts" }, { source: "user" }],
+    ]);
+  });
+
+  it("ignores a directory row, so Enter on a folder stays a no-op", async () => {
+    // The key resolver reports `activate` for whatever row is selected, folders
+    // included, so this guard is the only thing keeping Enter on a folder from
+    // trying to open a directory as a file panel.
+    renderPane();
+
+    await activate("src");
+
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores a path with no row behind it", async () => {
+    // A stale path (the listing changed under a keypress) is not known to be a
+    // file, so it must not be treated as one.
+    renderPane();
+
+    await activate("src/gone.ts");
+
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it("raises a retryable error toast when the open fails", async () => {
+    dispatchMock.mockResolvedValue({ ok: false, error: { message: "panel limit reached" } });
+    renderPane();
+
+    await activate("src/app.ts");
+
+    // Nothing else reports it: the row stays selected and the grid is unchanged,
+    // so a silent failure reads as the keypress being ignored.
+    const call = notifyMock.mock.calls.at(-1)?.[0];
+    expect(call?.type).toBe("error");
+    expect(call?.message).toBe("panel limit reached");
+    expect(call?.action?.label).toBeTruthy();
+
+    // The recovery action re-enters the whole gesture rather than being inert.
+    dispatchMock.mockResolvedValue({ ok: true, value: { panelId: "file-1" } });
+    await act(async () => {
+      call?.action?.onClick?.();
+      await Promise.resolve();
+    });
+    expect(dispatchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -1396,8 +1396,8 @@ describe("FileBrowserPane collapsible viewer (#11496)", () => {
     // Sole column: no inline width, nothing to resize against, and it takes the
     // same fill token the viewer used — so a 600px-capped tree can't strand
     // dead space beside it.
-    const soleColumn = screen.getByTestId("file-tree-view").closest("[id]")!;
-    expect((soleColumn as HTMLElement).style.width).toBe("");
+    const soleColumn = screen.getByTestId("file-tree-view").closest<HTMLElement>("[id]")!;
+    expect(soleColumn.style.width).toBe("");
     expect(screen.queryByTestId("file-browser-sidebar-resize")).toBeNull();
     expect(classToken(soleColumn, (c) => /^flex-1$/.test(c))).toBe(fillToken);
   });

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -215,17 +215,6 @@ const { dispatchMock } = vi.hoisted(() => ({
     >(),
 }));
 vi.mock("@/services/ActionService", () => ({ actionService: { dispatch: dispatchMock } }));
-// Dynamically imported by the pane (a static import would drag panelStore ->
-// panelPersistence -> projectClient in at module scope), so the mock has to be
-// registered even though nothing here imports it directly.
-const { closePanelDialogByIdMock } = vi.hoisted(() => ({
-  closePanelDialogByIdMock: vi.fn<(panelId: string) => void>(),
-}));
-vi.mock("@/store/panelDialogStore", () => ({
-  usePanelDialogStore: {
-    getState: () => ({ closePanelDialogById: closePanelDialogByIdMock }),
-  },
-}));
 vi.mock("@/components/Markdown/MarkdownViewer", () => ({ MarkdownViewer: () => null }));
 vi.mock("@/components/FileViewer/CodeViewer", () => ({
   CodeViewer: () => <div data-testid="code-viewer" />,
@@ -298,7 +287,6 @@ beforeEach(() => {
   mockPanel.browserWorkspaceRooted = undefined;
   treeArgs.changeTick = undefined;
   treeProps.onActivate = undefined;
-  closePanelDialogByIdMock.mockReset();
   dispatchMock.mockReset();
   dispatchMock.mockResolvedValue({ ok: true, result: { panelId: "file-1" } });
   worktreeTicks.git = undefined;
@@ -1355,8 +1343,9 @@ describe("FileBrowserPane collapsible viewer (#11496)", () => {
   });
 
   it("keeps the viewer visible when a corrupted record collapses both columns", () => {
-    // Unreachable by gesture, reachable on disk. Resolved at read time in favour
-    // of the tree, so the panel can never render empty with no way out.
+    // Unreachable by gesture, reachable on disk. The sidebar bit decides, so the
+    // tree stays hidden and the viewer is forced open — whichever column wins,
+    // the point is that the panel can never render empty with no way out.
     mockPanel.browserSidebarCollapsed = true;
     mockPanel.browserViewerCollapsed = true;
     renderPane();
@@ -1602,32 +1591,50 @@ describe("FileBrowserPane row activation (#11496)", () => {
     ]);
   });
 
+  // `onClose` is what the dialog host wires to its own close for this panel, so
+  // asserting on it is asserting the dialog gets dismissed.
+  const renderDialogPane = (onClose: () => void) =>
+    render(
+      <TooltipProvider>
+        <FileBrowserPane
+          id="fb-1"
+          title="Files"
+          worktreeId="wt-1"
+          isFocused
+          location="dialog"
+          onFocus={vi.fn()}
+          onClose={onClose}
+        />
+      </TooltipProvider>
+    );
+
   it("closes the browser dialog so the panel it opened is not stranded behind it", async () => {
     // `worktree.openFileBrowser` opens this pane as a modal, so the grid panel
     // the action just created would sit under a focus-trapping dialog and the
     // gesture would look like it did nothing.
-    render(
-      <TooltipProvider>
-        <FileBrowserPane
-          id="fb-1"
-          title="Files"
-          worktreeId="wt-1"
-          isFocused
-          location="dialog"
-          onFocus={vi.fn()}
-          onClose={vi.fn()}
-        />
-      </TooltipProvider>
-    );
+    const onClose = vi.fn();
+    renderDialogPane(onClose);
 
     await activate("src/app.ts");
 
-    expect(closePanelDialogByIdMock.mock.calls).toEqual([["fb-1"]]);
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("leaves the dialog alone when the open failed", async () => {
+  it("leaves the dialog open when the open failed", async () => {
     // Closing on failure would dismiss the browser and show nothing in its place.
     dispatchMock.mockResolvedValue({ ok: false, error: { message: "panel limit reached" } });
+    const onClose = vi.fn();
+    renderDialogPane(onClose);
+
+    await activate("src/app.ts");
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("never closes a grid-hosted browser, where onClose would destroy the panel", async () => {
+    // Same prop, very different meaning outside a dialog: in the grid it closes
+    // the browser itself, so the location guard is load-bearing.
+    const onClose = vi.fn();
     render(
       <TooltipProvider>
         <FileBrowserPane
@@ -1635,24 +1642,17 @@ describe("FileBrowserPane row activation (#11496)", () => {
           title="Files"
           worktreeId="wt-1"
           isFocused
-          location="dialog"
+          location="grid"
           onFocus={vi.fn()}
-          onClose={vi.fn()}
+          onClose={onClose}
         />
       </TooltipProvider>
     );
 
     await activate("src/app.ts");
 
-    expect(closePanelDialogByIdMock).not.toHaveBeenCalled();
-  });
-
-  it("keeps a grid-hosted browser open, having no dialog to dismiss", async () => {
-    renderPane();
-
-    await activate("src/app.ts");
-
-    expect(closePanelDialogByIdMock).not.toHaveBeenCalled();
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   it("reports a failed open without raising a second toast over addPanel's own", async () => {

--- a/src/panels/file-browser/__tests__/FileTreeView.test.tsx
+++ b/src/panels/file-browser/__tests__/FileTreeView.test.tsx
@@ -124,15 +124,47 @@ describe("FileTreeView context-menu interactions", () => {
     expect(contextMenuSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("re-roots on double-clicking a folder but never a file", () => {
+  it("routes double-click by row kind: folders re-root, files activate", () => {
+    // Both callbacks supplied, so the assertion is that each row picks the right
+    // one — not merely that the unwired branch does nothing (#11496).
     const onRootFolder = vi.fn();
-    const { getByRole } = renderTree({ onRootFolder });
+    const onActivate = vi.fn();
+    const { getByRole } = renderTree({ onRootFolder, onActivate });
 
     fireEvent.doubleClick(getByRole("treeitem", { name: "src" }));
-    fireEvent.doubleClick(getByRole("treeitem", { name: "README.md" }));
+    expect(onRootFolder.mock.calls).toEqual([["src"]]);
+    expect(onActivate).not.toHaveBeenCalled();
 
-    expect(onRootFolder).toHaveBeenCalledTimes(1);
-    expect(onRootFolder).toHaveBeenCalledWith("src");
+    fireEvent.doubleClick(getByRole("treeitem", { name: "README.md" }));
+    expect(onActivate.mock.calls).toEqual([["README.md"]]);
+    // The folder gesture never re-fires: a file double-click must not re-root.
+    expect(onRootFolder.mock.calls).toEqual([["src"]]);
+  });
+
+  it("activates the selected row on Enter and consumes the key", () => {
+    const onActivate = vi.fn();
+    const { getByRole } = renderTree({ selectedPath: "README.md", onActivate });
+
+    const event = new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true });
+    act(() => {
+      getByRole("tree").dispatchEvent(event);
+    });
+
+    expect(onActivate.mock.calls).toEqual([["README.md"]]);
+    // Handled keys are prevented so Enter doesn't also reach an outer surface.
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("reports Enter on a folder to the same handler, leaving the file check to it", () => {
+    // The key resolver is row-kind agnostic, so a directory reaches onActivate
+    // too. Pinned here because the pane's handler is what filters it — if this
+    // ever stopped firing, that guard would look dead and get removed.
+    const onActivate = vi.fn();
+    const { getByRole } = renderTree({ selectedPath: "src", onActivate });
+
+    fireEvent.keyDown(getByRole("tree"), { key: "Enter" });
+
+    expect(onActivate.mock.calls).toEqual([["src"]]);
   });
 
   it("does not re-root from a double-click on the chevron", () => {

--- a/src/panels/file-browser/__tests__/serializer.test.ts
+++ b/src/panels/file-browser/__tests__/serializer.test.ts
@@ -148,6 +148,48 @@ describe("serializeFileBrowser", () => {
     });
   });
 
+  it("round-trips a collapsed viewer but keeps the open default sparse (#11496)", () => {
+    const collapsed: FileBrowserPanelData = { ...basePanel, browserViewerCollapsed: true };
+    expect(createFileBrowserDefaults(asOptions(serializeFileBrowser(collapsed)))).toEqual({
+      browserViewerCollapsed: true,
+    });
+
+    const open: FileBrowserPanelData = { ...basePanel, browserViewerCollapsed: false };
+    expect(serializeFileBrowser(open)).toEqual({});
+    expect(serializeFileBrowser(basePanel)).toEqual({});
+  });
+
+  it("keeps the remembered split width across a collapsed viewer (#11496)", () => {
+    // The sole-column tree ignores the width rather than clearing it, so
+    // reopening the viewer has to land back on the last-dragged split.
+    const both: FileBrowserPanelData = {
+      ...basePanel,
+      browserViewerCollapsed: true,
+      browserSidebarWidth: 360,
+    };
+
+    expect(createFileBrowserDefaults(asOptions(serializeFileBrowser(both)))).toEqual({
+      browserViewerCollapsed: true,
+      browserSidebarWidth: 360,
+    });
+  });
+
+  it("carries both collapse bits through persistence without resolving them", () => {
+    // Unreachable through the UI, reachable on disk. The pane resolves the pair
+    // at read time, so persistence must not quietly drop either side — doing so
+    // would rewrite the user's last choice on the way to a corrupt record.
+    const both: FileBrowserPanelData = {
+      ...basePanel,
+      browserSidebarCollapsed: true,
+      browserViewerCollapsed: true,
+    };
+
+    expect(createFileBrowserDefaults(asOptions(serializeFileBrowser(both)))).toEqual({
+      browserSidebarCollapsed: true,
+      browserViewerCollapsed: true,
+    });
+  });
+
   it("persists workspace rooting so a promoted panel keeps its folder (#11489)", () => {
     // Promotion into the grid adopts the active worktree as a placement key, so
     // by save time an absent worktreeId no longer distinguishes the two — the

--- a/src/panels/file-browser/defaults.ts
+++ b/src/panels/file-browser/defaults.ts
@@ -41,6 +41,7 @@ export function createFileBrowserDefaults(
     // Only a collapsed sidebar materializes a field: `false` and absent are the
     // same open state, so we never stamp a default the serializer then drops.
     ...(options.browserSidebarCollapsed === true && { browserSidebarCollapsed: true }),
+    ...(options.browserViewerCollapsed === true && { browserViewerCollapsed: true }),
     ...(options.browserTreeSnapshot != null && {
       browserTreeSnapshot: options.browserTreeSnapshot,
     }),

--- a/src/panels/file-browser/serializer.ts
+++ b/src/panels/file-browser/serializer.ts
@@ -22,6 +22,9 @@ export function serializeFileBrowser(t: FileBrowserPanelData): Partial<PanelSnap
     // Truthiness, not `!= null`: `false` is the default open state, the same as
     // the field being absent, so only a collapsed sidebar earns a persisted bit.
     ...(t.browserSidebarCollapsed ? { browserSidebarCollapsed: true } : {}),
+    // Same rule for the viewer column (#11496): only a collapsed viewer earns a
+    // bit, so the common two-column panel persists neither flag.
+    ...(t.browserViewerCollapsed ? { browserViewerCollapsed: true } : {}),
     ...(t.browserTreeSnapshot != null && { browserTreeSnapshot: t.browserTreeSnapshot }),
     // Only a non-default width earns a persisted number: 288 is the default, the
     // same as absent, so an unresized or reset-to-default panel stays sparse.

--- a/src/store/slices/panelRegistry/__tests__/fileBrowser.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/fileBrowser.test.ts
@@ -136,6 +136,52 @@ describe("setFileBrowserView", () => {
     expect(store.get().panelsById["panel-1"]).toBe(before);
   });
 
+  it("collapses and re-opens the viewer (#11496)", () => {
+    // The viewer flag needs its own unchanged-comparison in the setter. Folded
+    // into the sidebar's, a viewer-only patch would look unchanged and hit the
+    // bail-out, making every toggle click a silent no-op with nothing persisted.
+    setFileBrowserView("panel-1", { browserViewerCollapsed: true });
+    expect(store.get().panelsById["panel-1"]).toMatchObject({ browserViewerCollapsed: true });
+
+    const collapsed = store.get().panelsById["panel-1"];
+    setFileBrowserView("panel-1", { browserViewerCollapsed: false });
+    expect(store.get().panelsById["panel-1"]).not.toBe(collapsed);
+    expect(store.get().panelsById["panel-1"]).toMatchObject({ browserViewerCollapsed: false });
+  });
+
+  it("treats collapsing an already-open viewer with false as a no-op", () => {
+    const before = store.get().panelsById["panel-1"];
+
+    setFileBrowserView("panel-1", { browserViewerCollapsed: false });
+
+    expect(store.get().panelsById["panel-1"]).toBe(before);
+  });
+
+  it("writes the viewer flag without disturbing the sidebar's own state", () => {
+    // Two independent bits: a collapsed tree must survive a viewer patch, since
+    // the setter compares and merges them separately.
+    setFileBrowserView("panel-1", { browserSidebarCollapsed: true });
+    setFileBrowserView("panel-1", { browserViewerCollapsed: true });
+
+    expect(store.get().panelsById["panel-1"]).toMatchObject({
+      browserSidebarCollapsed: true,
+      browserViewerCollapsed: true,
+    });
+  });
+
+  it("preserves selection, expansion and width when the viewer collapses", () => {
+    setFileBrowserView("panel-1", { browserSelectedPath: "src/app.ts" });
+    setFileBrowserView("panel-1", { browserSidebarWidth: 420 });
+    setFileBrowserView("panel-1", { browserViewerCollapsed: true });
+
+    expect(store.get().panelsById["panel-1"]).toMatchObject({
+      browserViewerCollapsed: true,
+      browserSelectedPath: "src/app.ts",
+      browserExpandedPaths: ["src"],
+      browserSidebarWidth: 420,
+    });
+  });
+
   it("stores a tree snapshot and treats a deep-equal recapture as a no-op (#11367)", () => {
     const snapshot = {
       worktreeId: "wt-1",

--- a/src/store/slices/panelRegistry/fileBrowser.ts
+++ b/src/store/slices/panelRegistry/fileBrowser.ts
@@ -17,6 +17,8 @@ export interface FileBrowserViewPatch {
   browserRootPath?: string;
   /** `true` collapses the tree sidebar; `false` and absent both mean open. */
   browserSidebarCollapsed?: boolean;
+  /** `true` collapses the viewer column; `false` and absent both mean open. */
+  browserViewerCollapsed?: boolean;
   /** Last-known tree structure, captured as the view goes away (#11367). */
   browserTreeSnapshot?: FileBrowserTreeSnapshot;
   /** Tree column width in px; clamped into range before it lands. */
@@ -69,9 +71,15 @@ export const createFileBrowserPanelActions = (
       // `false` and absent are the same open state, so patching `false` onto a
       // never-collapsed panel must not count as a change. Compared as
       // normalized booleans rather than raw optionals for that reason.
-      const collapsedUnchanged =
+      const sidebarCollapsedUnchanged =
         patch.browserSidebarCollapsed === undefined ||
         (patch.browserSidebarCollapsed === true) === (panel.browserSidebarCollapsed === true);
+      // The viewer flag gets its own comparison rather than riding the sidebar's:
+      // folding them together would make a viewer-only patch look unchanged and
+      // bail out below, so every viewer toggle would be a silent no-op (#11496).
+      const viewerCollapsedUnchanged =
+        patch.browserViewerCollapsed === undefined ||
+        (patch.browserViewerCollapsed === true) === (panel.browserViewerCollapsed === true);
       // Deep rather than reference equality: capture builds a fresh snapshot
       // object on every hide, and most hides change nothing — a reference
       // check would dirty the panel entry (and the persisted layout) each time.
@@ -94,7 +102,8 @@ export const createFileBrowserPanelActions = (
         expandedUnchanged &&
         hideDotfilesUnchanged &&
         rootUnchanged &&
-        collapsedUnchanged &&
+        sidebarCollapsedUnchanged &&
+        viewerCollapsedUnchanged &&
         treeSnapshotUnchanged &&
         widthUnchanged
       )
@@ -116,6 +125,9 @@ export const createFileBrowserPanelActions = (
         }),
         ...(patch.browserSidebarCollapsed !== undefined && {
           browserSidebarCollapsed: patch.browserSidebarCollapsed,
+        }),
+        ...(patch.browserViewerCollapsed !== undefined && {
+          browserViewerCollapsed: patch.browserViewerCollapsed,
         }),
         ...(patch.browserTreeSnapshot !== undefined && {
           browserTreeSnapshot: patch.browserTreeSnapshot,

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -1739,6 +1739,29 @@ describe("buildArgsForNonPtyRecreation", () => {
     expect(result.devCommand).toBe("npm start");
   });
 
+  it("carries file-browser layout state through recreation (#11496)", () => {
+    // The hop the per-kind serializer tests can't see: a field can round-trip
+    // through serialize/deserialize and still be dropped here, which is how a
+    // restored panel silently loses the layout the user last chose.
+    const result = buildArgsForNonPtyRecreation(
+      {
+        id: "fb1",
+        kind: "file-browser",
+        title: "Files",
+        browserViewerCollapsed: true,
+        browserSelectedPath: "src/app.ts",
+        browserSidebarWidth: 360,
+        location: "grid",
+      },
+      "file-browser",
+      "/project"
+    );
+
+    expect(result.browserViewerCollapsed).toBe(true);
+    expect(result.browserSelectedPath).toBe("src/app.ts");
+    expect(result.browserSidebarWidth).toBe(360);
+  });
+
   it("falls back to projectRoot when a non-PTY saved cwd is relative", () => {
     const result = buildArgsForNonPtyRecreation(
       {

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -66,6 +66,7 @@ export interface AddTerminalArgs extends AddPanelOptionsBase {
   browserHideDotfiles?: boolean;
   browserRootPath?: string;
   browserSidebarCollapsed?: boolean;
+  browserViewerCollapsed?: boolean;
   browserTreeSnapshot?: FileBrowserTreeSnapshot;
   browserSidebarWidth?: number;
   browserWorkspaceRooted?: boolean;
@@ -131,6 +132,7 @@ export interface SavedTerminalData {
   browserHideDotfiles?: unknown;
   browserRootPath?: unknown;
   browserSidebarCollapsed?: unknown;
+  browserViewerCollapsed?: unknown;
   browserTreeSnapshot?: unknown;
   browserSidebarWidth?: unknown;
   browserWorkspaceRooted?: unknown;


### PR DESCRIPTION
## Summary

- The file browser panel was two columns where only the tree could collapse, so the viewer was structurally the first class half and the tree was just a drawer hanging off it. This makes the two columns symmetric, so tree only mode has a reason to exist.
- The viewer's collapse toggle is homed in the tree's header, mirroring where the tree's own toggle already sits in the viewer toolbar. Each toggle only exists while the column it would leave behind is on screen, which makes both columns collapsed unreachable rather than merely discouraged (a read time tiebreak covers a corrupted record too).
- Enter and double click on a file row now open that file as its own panel via the existing `file.openPanel` action, which is what makes a tree only browser worth having: it turns the panel from a self contained reader into a navigator that feeds the grid.

Resolves #11496

## Changes

- New sparse `browserViewerCollapsed` flag, wired through every persistence mirror: `PanelSnapshot`, `FileBrowserPanelData`, `FileBrowserPanelOptions`, both `statePatcher` carriers (`AddTerminalArgs` and `SavedTerminalData`), the literal `true` deserializer, the serializer, the creation defaults, and the store setter's unchanged comparison plus merge spread. No schema, IPC, codegen, or migration work needed, since the snapshot schema is `.passthrough()` and the renderer deserializer is the sanitization boundary.
- As the sole column the tree fills the panel: no inline split width, no resize grip, while still remembering the width so reopening restores the split.
- Folders keep re-rooting on double click, and folder Enter stays a no-op; only file rows respond to the new activation.
- A dialog hosted browser now closes itself after a successful open, since it's modal and would otherwise trap the panel it just created behind it.
- Focus is handed to the tree when a collapse unmounts a focused viewer control, and stays on the toggle for the ordinary click.

## Testing

- 454 tests pass across 9 covering suites: `registry.fieldcoverage`, `panelKindSerialisers`, file-browser `serializer`/`Pane`/`TreeView`/`Viewer`, `panelRegistry` `fileBrowser` and `dockGridTransitions`, `statePatcher`.
- `npm run typecheck` exits 0.
- Prettier and eslint are clean on changed files, with the per rule lint ratchet verified flat.

## Known limitations

- `file.openPanel` stamps the new panel's `worktreeId` from the globally tracked active worktree rather than the browser's own source, so a file opened from a non focused worktree browser can land in the wrong grid placement bucket. Pre-existing, and extending that MCP surfaced action's schema is out of scope here.
- `activateTerminal` sets `focusedId` but never clears `maximizedId`, so reusing an existing file panel while another panel is maximized focuses it without revealing it. Pre-existing and shared by every `file.openPanel` caller; deserves its own issue.
- No new e2e test: local e2e needs a full app build, and this repo's PR CI runs no Playwright at all (e2e gates releases and on-demand stabilize only), so an added spec couldn't be validated before merge. The existing spec's `BROWSER_DIALOG` selector was broadened to match either column's toggle, so it can't break when a column unmounts.
- Follow up noted in the issue: `dockable: false` on the file-browser panel kind is now questionable, but needs its own chip-form and dock design, deliberately out of scope here.
