### PR TITLE
fix(sidebar): give every workspace kind a row so the toggle stops lying

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -39,6 +39,7 @@ import { appClient } from "@/clients";
 import type { CliAvailability, AgentSettings } from "@shared/types";
 import { useLayoutState, useOverlayOpen } from "@/hooks";
 import { useKeepMounted } from "@/hooks/useKeepMounted";
+import { useWorkspaceRoot } from "@/hooks/useWorkspaceRoot";
 import type { UseProjectSwitcherPaletteReturn } from "@/hooks";
 import {
   createAssistantRevealCoordinator,
@@ -185,7 +186,14 @@ export function AppLayout({
   const isPluginManagerOpen = useOverlayOpen("plugin-manager");
   const chromeInert = isThemeBrowserOpen || isPluginManagerOpen;
   const reduceAnimations = usePreferencesStore((s) => s.reduceAnimations);
-  const showSidebar = !layout.gestureSidebarHidden && currentProject != null;
+  // Every workspace kind has something for the sidebar to hold — a scratch and
+  // a folder opened without git each have their own root — so the gate is "is
+  // there a workspace at all", not "is there a project". Gating on the project
+  // left the toggle and Cmd+B flipping `aria-pressed` over a slot that could
+  // never appear in a scratch (#11499). Only the welcome screen, which has no
+  // workspace of any kind, still has no sidebar (#5023).
+  const hasWorkspace = useWorkspaceRoot() !== null;
+  const showSidebar = !layout.gestureSidebarHidden && hasWorkspace;
   const showAssistant = !layout.gestureAssistantHidden && layout.helpPanelOpen;
   const effectiveAssistantWidth = showAssistant ? layout.helpPanelWidth : 0;
   // #10693 (off-canvas): the assistant wrapper is always full-width and slides
@@ -891,7 +899,7 @@ export function AppLayout({
             }}
           >
             <div className="absolute top-0 left-0 h-full" style={{ width: sidebarWidth }}>
-              {currentProject != null && (
+              {hasWorkspace && (
                 <ErrorBoundary variant="section" componentName="Sidebar">
                   <Sidebar
                     width={sidebarWidth}

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -551,13 +551,19 @@ export function AppLayout({
   // Independent from the assistant: clicking this button hides/shows only the
   // worktree sidebar, leaving the Daintree Assistant untouched.
   const handleToggleSidebar = useCallback(() => {
+    // No workspace means no sidebar mounts at all (welcome screen), so there is
+    // nothing to hide or reveal. Flipping the gesture flag anyway is what let
+    // the toolbar button and Cmd+B move their own aria-pressed over a slot that
+    // could never appear (#11499). Also guards the `nav.toggleSidebar` action,
+    // which reaches this through the window event below.
+    if (!hasWorkspace) return;
     suppressSidebarResizes();
     const focus = useFocusStore.getState();
     focus.setSidebarGestureHidden(!focus.gestureSidebarHidden, {
       sidebarWidth,
       diagnosticsOpen: layout.diagnosticsOpen,
     });
-  }, [sidebarWidth, layout.diagnosticsOpen]);
+  }, [hasWorkspace, sidebarWidth, layout.diagnosticsOpen]);
 
   const handleToggleSidebarRef = useRef(handleToggleSidebar);
   useEffect(() => {
@@ -842,6 +848,7 @@ export function AppLayout({
           onToggleProblems={handleToggleProblems}
           isFocusMode={layout.gestureSidebarHidden}
           onToggleFocusMode={handleToggleSidebar}
+          hasWorkspace={hasWorkspace}
           agentAvailability={agentAvailability}
           agentSettings={agentSettings}
           projectSwitcherPalette={projectSwitcherPalette}

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { ProjectResourceBadge, QuickRun } from "@/components/Project";
-import { useProjectStore } from "@/store/projectStore";
 import { useMacroFocusStore } from "@/store/macroFocusStore";
 import { useWorkspaceRoot } from "@/hooks/useWorkspaceRoot";
 import { DEFAULT_SIDEBAR_WIDTH } from "./AppLayout";
@@ -57,15 +56,22 @@ export function Sidebar({
   // detect a mid-drag teardown without relying on stale closure state.
   const isResizingRef = useRef(false);
   const sidebarRef = useRef<HTMLElement>(null);
-  const currentProject = useProjectStore((state) => state.currentProject);
   // The sidebar now mounts in every workspace kind (#11499), so the background
   // menu has to stop offering worktree-shaped commands to workspaces that have
   // no worktrees. Absent rather than disabled, matching the rows themselves: a
   // greyed-out "New Worktree…" in a scratch is the same dead-control lie in a
   // quieter font.
+  //
+  // Every entry keys off the view's own workspace, never the globally broadcast
+  // `currentProject`: a sibling window switching projects repoints that in every
+  // view, so a scratch view would label its reveal "Project" and offer project
+  // settings that dispatch against the other window's project.
   const workspaceRoot = useWorkspaceRoot();
   const isGitBackedWorkspace = workspaceRoot?.isGitBacked ?? false;
-  const revealPath = workspaceRoot?.path ?? currentProject?.path;
+  // A folder opened without git is still a project — it has real settings and a
+  // name. A scratch is not, so nothing project-shaped applies to it.
+  const projectId = workspaceRoot?.kind === "project" ? workspaceRoot.id : null;
+  const revealPath = workspaceRoot?.path;
   const isMacroFocused = useMacroFocusStore((state) => state.focusedRegion === "sidebar");
   useEffect(() => {
     useMacroFocusStore.getState().setRegionRef("sidebar", sidebarRef.current);
@@ -88,8 +94,8 @@ export function Sidebar({
     onResizeEnd?.();
   }, [onResizeEnd]);
 
-  // If the sidebar unmounts mid-drag (e.g. `currentProject` becomes null
-  // because the user switched or closed the project), the listener-attaching
+  // If the sidebar unmounts mid-drag (e.g. the view loses its workspace because
+  // the user closed the project or scratch), the listener-attaching
   // effect below tears down its document listeners but stopResizing never
   // fires — leaving AppLayout's `isSidebarResizing` flag stuck true and
   // silently disabling the collapse/expand animation for the rest of the
@@ -180,7 +186,7 @@ export function Sidebar({
         >
           <div className="flex-1 min-h-0 overflow-hidden">{children}</div>
 
-          {currentProject && <QuickRun projectId={currentProject.id} />}
+          {projectId != null && <QuickRun projectId={projectId} />}
 
           <ProjectResourceBadge />
 
@@ -234,9 +240,9 @@ export function Sidebar({
           disabled={!revealPath}
         >
           <FolderOpen className={ICON_CLASS} />
-          {currentProject ? "Reveal Project in Finder" : "Reveal Workspace in Finder"}
+          {projectId != null ? "Reveal Project in Finder" : "Reveal Workspace in Finder"}
         </ContextMenuActionItem>
-        {currentProject != null && (
+        {projectId != null && (
           <ContextMenuActionItem actionId="project.settings.open">
             <Settings className={ICON_CLASS} />
             Project Settings…

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 import { ProjectResourceBadge, QuickRun } from "@/components/Project";
 import { useProjectStore } from "@/store/projectStore";
 import { useMacroFocusStore } from "@/store/macroFocusStore";
+import { useWorkspaceRoot } from "@/hooks/useWorkspaceRoot";
 import { DEFAULT_SIDEBAR_WIDTH } from "./AppLayout";
 import {
   ContextMenu,
@@ -57,6 +58,14 @@ export function Sidebar({
   const isResizingRef = useRef(false);
   const sidebarRef = useRef<HTMLElement>(null);
   const currentProject = useProjectStore((state) => state.currentProject);
+  // The sidebar now mounts in every workspace kind (#11499), so the background
+  // menu has to stop offering worktree-shaped commands to workspaces that have
+  // no worktrees. Absent rather than disabled, matching the rows themselves: a
+  // greyed-out "New Worktree…" in a scratch is the same dead-control lie in a
+  // quieter font.
+  const workspaceRoot = useWorkspaceRoot();
+  const isGitBackedWorkspace = workspaceRoot?.isGitBacked ?? false;
+  const revealPath = workspaceRoot?.path ?? currentProject?.path;
   const isMacroFocused = useMacroFocusStore((state) => state.focusedRegion === "sidebar");
   useEffect(() => {
     useMacroFocusStore.getState().setRegionRef("sidebar", sidebarRef.current);
@@ -206,36 +215,44 @@ export function Sidebar({
         </aside>
       </ContextMenuTrigger>
       <ContextMenuContent>
-        <ContextMenuActionItem actionId="worktree.createDialog.open">
-          <GitBranchPlus className={ICON_CLASS} />
-          New Worktree…
-        </ContextMenuActionItem>
-        <ContextMenuActionItem actionId="worktree.refresh">
-          <RefreshCw className={ICON_CLASS} />
-          Refresh Sidebar
-        </ContextMenuActionItem>
-        <ContextMenuSeparator />
+        {isGitBackedWorkspace && (
+          <>
+            <ContextMenuActionItem actionId="worktree.createDialog.open">
+              <GitBranchPlus className={ICON_CLASS} />
+              New Worktree…
+            </ContextMenuActionItem>
+            <ContextMenuActionItem actionId="worktree.refresh">
+              <RefreshCw className={ICON_CLASS} />
+              Refresh Sidebar
+            </ContextMenuActionItem>
+            <ContextMenuSeparator />
+          </>
+        )}
         <ContextMenuActionItem
           actionId="system.openPath"
-          args={currentProject ? { path: currentProject.path } : undefined}
-          disabled={!currentProject}
+          args={revealPath ? { path: revealPath } : undefined}
+          disabled={!revealPath}
         >
           <FolderOpen className={ICON_CLASS} />
-          Reveal Project in Finder
+          {currentProject ? "Reveal Project in Finder" : "Reveal Workspace in Finder"}
         </ContextMenuActionItem>
-        <ContextMenuActionItem actionId="project.settings.open" disabled={!currentProject}>
-          <Settings className={ICON_CLASS} />
-          Project Settings…
-        </ContextMenuActionItem>
+        {currentProject != null && (
+          <ContextMenuActionItem actionId="project.settings.open">
+            <Settings className={ICON_CLASS} />
+            Project Settings…
+          </ContextMenuActionItem>
+        )}
         <ContextMenuSeparator />
         <ContextMenuActionItem actionId="ui.sidebar.resetWidth">
           <Ruler className={ICON_CLASS} />
           Reset Sidebar Width
         </ContextMenuActionItem>
-        <ContextMenuActionItem actionId="app.settings.openTab" args={{ tab: "worktree" }}>
-          <SlidersHorizontal className={ICON_CLASS} />
-          Worktree Settings…
-        </ContextMenuActionItem>
+        {isGitBackedWorkspace && (
+          <ContextMenuActionItem actionId="app.settings.openTab" args={{ tab: "worktree" }}>
+            <SlidersHorizontal className={ICON_CLASS} />
+            Worktree Settings…
+          </ContextMenuActionItem>
+        )}
       </ContextMenuContent>
     </ContextMenu>
   );

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -472,6 +472,11 @@ interface ToolbarProps {
   onToggleProblems?: () => void;
   isFocusMode?: boolean;
   onToggleFocusMode?: () => void;
+  /**
+   * Whether this view owns a workspace of any kind. The sidebar toggle degrades
+   * to disabled without one — there is no slot for it to reveal (#11499).
+   */
+  hasWorkspace: boolean;
   agentAvailability?: CliAvailability;
   agentSettings?: AgentSettings | null;
   projectSwitcherPalette: UseProjectSwitcherPaletteReturn;
@@ -485,6 +490,7 @@ export function Toolbar({
   onToggleProblems,
   isFocusMode = false,
   onToggleFocusMode,
+  hasWorkspace,
   agentAvailability,
   agentSettings,
   projectSwitcherPalette,
@@ -871,18 +877,28 @@ export function Toolbar({
     Record<string, { render: () => React.ReactNode; isAvailable: boolean }>
   >(
     () => ({
+      // Degraded rather than removed when there is no workspace: the welcome
+      // screen has no sidebar slot to reveal, so an enabled toggle would flip
+      // its own icon and aria-pressed over nothing (#11499). `aria-disabled`
+      // rather than `disabled` so the tooltip carrying the reason still opens
+      // — a browser drops pointer events on a disabled button. Label is
+      // unchanged; only the tooltip explains.
       "sidebar-toggle": {
         render: () => (
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
-                {...sidebarHintHover}
+                {...(hasWorkspace ? sidebarHintHover : {})}
                 variant="ghost"
                 size="icon"
                 data-toolbar-item=""
                 data-sidebar-toggle=""
-                onClick={onToggleFocusMode}
-                className={toolbarIconButtonClass}
+                onClick={hasWorkspace ? onToggleFocusMode : undefined}
+                aria-disabled={!hasWorkspace || undefined}
+                className={cn(
+                  toolbarIconButtonClass,
+                  "aria-disabled:opacity-50 aria-disabled:cursor-not-allowed"
+                )}
                 aria-label="Toggle Sidebar"
                 aria-pressed={!isFocusMode}
                 aria-keyshortcuts={sidebarAriaShortcut}
@@ -891,7 +907,12 @@ export function Toolbar({
               </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
-              {createTooltipContent(isFocusMode ? "Show Sidebar" : "Hide Sidebar", sidebarShortcut)}
+              {hasWorkspace
+                ? createTooltipContent(
+                    isFocusMode ? "Show Sidebar" : "Hide Sidebar",
+                    sidebarShortcut
+                  )
+                : "Open a project or scratch to use the sidebar"}
             </TooltipContent>
           </Tooltip>
         ),
@@ -1179,6 +1200,7 @@ export function Toolbar({
     [
       isFocusMode,
       onToggleFocusMode,
+      hasWorkspace,
       agentAvailability,
       effectiveAgentSettings,
       onLaunchAgent,

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -973,19 +973,26 @@ export function Toolbar({
         // Deliberately not in PROJECT_SCOPED_TOOLBAR_IDS: the action browses the
         // project or scratch root when no worktree is selected (#11482), so
         // gating it on `currentProject` would disable it in exactly the
-        // worktree-less workspaces where it still works.
+        // worktree-less workspaces where it still works. `hasWorkspace` is the
+        // gate that does apply — with no workspace of any kind the action
+        // resolves no folder at all and can only answer with an error toast, so
+        // it degrades the same way the sidebar toggle above does (#11499).
         render: () => (
           <ContextMenu>
             <ContextMenuTrigger asChild>
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
-                    {...fileBrowserHintHover}
+                    {...(hasWorkspace ? fileBrowserHintHover : {})}
                     variant="ghost"
                     size="icon"
                     data-toolbar-item=""
-                    onClick={openFileBrowser}
-                    className={toolbarIconButtonClass}
+                    onClick={hasWorkspace ? openFileBrowser : undefined}
+                    aria-disabled={!hasWorkspace || undefined}
+                    className={cn(
+                      toolbarIconButtonClass,
+                      "aria-disabled:opacity-50 aria-disabled:cursor-not-allowed"
+                    )}
                     aria-label="Browse files"
                     aria-keyshortcuts={fileBrowserAriaShortcut}
                   >
@@ -993,7 +1000,9 @@ export function Toolbar({
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent side="bottom">
-                  {createTooltipContent("Browse files", fileBrowserShortcut)}
+                  {hasWorkspace
+                    ? createTooltipContent("Browse files", fileBrowserShortcut)
+                    : "Open a project or scratch to browse files"}
                 </TooltipContent>
               </Tooltip>
             </ContextMenuTrigger>

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -31,9 +31,9 @@ describe("AppLayout sidebar visibility — issue #5023 hide on welcome screen", 
   it("resolves the mount gate from the workspace, not the project (issue #11499)", () => {
     // `useWorkspaceRoot` answers for all three workspace kinds — git project,
     // folder opened without git, scratch — and returns null only on the welcome
-    // screen, which is what still keeps the sidebar off there (#5023).
+    // screen, which is what still keeps the sidebar off there (#5023). Reading
+    // any narrower store here is how the scratch case regresses.
     expect(source).toContain("const hasWorkspace = useWorkspaceRoot() !== null");
-    expect(source).toContain('import { useWorkspaceRoot } from "@/hooks/useWorkspaceRoot"');
   });
 
   it("mounts the sidebar whenever a workspace is active so the width transition can run", () => {

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -13,9 +13,7 @@ describe("AppLayout sidebar visibility — issue #5023 hide on welcome screen", 
   });
 
   it("derives showSidebar from gestureSidebarHidden and the resolved workspace (issues #6659, #11499)", () => {
-    expect(source).toContain(
-      "const showSidebar = !layout.gestureSidebarHidden && hasWorkspace"
-    );
+    expect(source).toContain("const showSidebar = !layout.gestureSidebarHidden && hasWorkspace");
     // Issue #11499: the gate is "is there a workspace", not "is there a
     // project". A scratch has no Project row, so gating on `currentProject`
     // left the toolbar toggle and Cmd+B flipping aria-pressed over a slot that

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -48,6 +48,28 @@ describe("AppLayout sidebar visibility — issue #5023 hide on welcome screen", 
     expect(source).not.toMatch(/\{currentProject != null && \(\s*\n\s*<ErrorBoundary[^>]*Sidebar/);
   });
 
+  it("refuses to flip the sidebar gesture when there is no sidebar to reveal (issue #11499)", () => {
+    // The welcome screen mounts no sidebar in any workspace kind, so a toggle
+    // that still flips gestureSidebarHidden moves its own icon and aria-pressed
+    // over a slot that cannot appear. #11499 rules that no-op out explicitly.
+    // The guard also covers the `nav.toggleSidebar` action and Cmd+B, which
+    // both reach the store through this callback.
+    const handler = source.slice(
+      source.indexOf("const handleToggleSidebar = useCallback("),
+      source.indexOf("const handleToggleSidebarRef")
+    );
+    expect(handler).not.toBe("");
+    expect(handler).toMatch(/if \(!hasWorkspace\) return;[\s\S]*setSidebarGestureHidden/);
+    // Stale-closure guard: without the dep the callback keeps an old answer.
+    expect(handler).toMatch(/\}, \[hasWorkspace,/);
+  });
+
+  it("tells the Toolbar whether a workspace exists so the toggle can degrade (issue #11499)", () => {
+    // Degrade, don't delete: the button stays put and explains itself in its
+    // tooltip rather than vanishing from the toolbar.
+    expect(source).toContain("hasWorkspace={hasWorkspace}");
+  });
+
   it("uses showSidebar for the macro-focus sidebar visibility effect", () => {
     expect(source).toContain('setVisibility("sidebar", showSidebar)');
     expect(source).toContain("[showSidebar]");

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -12,8 +12,15 @@ describe("AppLayout sidebar visibility — issue #5023 hide on welcome screen", 
     source = await fs.readFile(APP_LAYOUT_PATH, "utf-8");
   });
 
-  it("derives showSidebar from gestureSidebarHidden and currentProject (issue #6659)", () => {
+  it("derives showSidebar from gestureSidebarHidden and the resolved workspace (issues #6659, #11499)", () => {
     expect(source).toContain(
+      "const showSidebar = !layout.gestureSidebarHidden && hasWorkspace"
+    );
+    // Issue #11499: the gate is "is there a workspace", not "is there a
+    // project". A scratch has no Project row, so gating on `currentProject`
+    // left the toolbar toggle and Cmd+B flipping aria-pressed over a slot that
+    // could never mount. Any re-narrowing to the project alone is that bug.
+    expect(source).not.toContain(
       "const showSidebar = !layout.gestureSidebarHidden && currentProject != null"
     );
     // The combined isFocusMode gate must not be reintroduced — the sidebar
@@ -21,15 +28,26 @@ describe("AppLayout sidebar visibility — issue #5023 hide on welcome screen", 
     expect(source).not.toContain("const showSidebar = !layout.isFocusMode && currentProject");
   });
 
-  it("mounts the sidebar whenever a project is active so the width transition can run", () => {
+  it("resolves the mount gate from the workspace, not the project (issue #11499)", () => {
+    // `useWorkspaceRoot` answers for all three workspace kinds — git project,
+    // folder opened without git, scratch — and returns null only on the welcome
+    // screen, which is what still keeps the sidebar off there (#5023).
+    expect(source).toContain("const hasWorkspace = useWorkspaceRoot() !== null");
+    expect(source).toContain('import { useWorkspaceRoot } from "@/hooks/useWorkspaceRoot"');
+  });
+
+  it("mounts the sidebar whenever a workspace is active so the width transition can run", () => {
     // Issue #5697: the sidebar stays mounted in focus mode (width=0) so the
     // CSS width transition runs instead of an abrupt unmount. The render guard
-    // is now `currentProject != null`; visibility is driven by width via
+    // is `hasWorkspace`; visibility is driven by width via
     // effectiveSidebarWidth and by macro focus via setVisibility(showSidebar).
-    expect(source).toMatch(/\{currentProject != null && \(\s*\n\s*<ErrorBoundary[^>]*Sidebar/);
-    // The old unmount-in-focus-mode guard must not be reintroduced.
+    expect(source).toMatch(/\{hasWorkspace && \(\s*\n\s*<ErrorBoundary[^>]*Sidebar/);
+    // The mount gate must stay a distinct boolean from the visibility one —
+    // collapsing them is exactly the #5697 unmount-in-focus-mode regression.
     expect(source).not.toMatch(/\{showSidebar && \(\s*\n\s*<ErrorBoundary[^>]*Sidebar/);
     expect(source).not.toMatch(/\{!layout\.isFocusMode && \(\s*\n\s*<ErrorBoundary[^>]*Sidebar/);
+    // The project-only mount gate must not return (#11499).
+    expect(source).not.toMatch(/\{currentProject != null && \(\s*\n\s*<ErrorBoundary[^>]*Sidebar/);
   });
 
   it("uses showSidebar for the macro-focus sidebar visibility effect", () => {

--- a/src/components/Layout/__tests__/Sidebar.contextMenu.test.tsx
+++ b/src/components/Layout/__tests__/Sidebar.contextMenu.test.tsx
@@ -168,6 +168,33 @@ describe("Sidebar background context menu — workspace kind (#11499)", () => {
     expect(reveal?.textContent).toContain("Reveal Workspace in Finder");
   });
 
+  it("ignores a project a sibling window left globally current", () => {
+    // `currentProject` is broadcast to every view, cached ones included, so a
+    // second window switching projects repoints it here too. Keying the menu off
+    // it made a scratch view label its own folder "Project" and offer project
+    // settings that dispatch against the other window's project. The store value
+    // is still supplied so a reintroduced read resolves rather than crashing —
+    // this is the guard against that read coming back.
+    currentProject = {
+      id: "proj-elsewhere",
+      path: "/repos/other-window",
+      name: "Other Window",
+      emoji: "🪟",
+      lastOpened: 0,
+    };
+    workspaceRoot.mockReturnValue(SCRATCH);
+
+    renderSidebar();
+
+    expect(renderedActionIds()).not.toContain("project.settings.open");
+
+    const reveal = screen
+      .getAllByRole("menuitem")
+      .find((el) => el.getAttribute("data-action-id") === "system.openPath");
+    expect(reveal?.getAttribute("data-args")).toBe(JSON.stringify({ path: SCRATCH.path }));
+    expect(reveal?.textContent).toContain("Reveal Workspace in Finder");
+  });
+
   it("keeps project settings for a folder opened without git, but not its worktree entries", () => {
     currentProject = {
       id: PLAIN_FOLDER.id,

--- a/src/components/Layout/__tests__/Sidebar.contextMenu.test.tsx
+++ b/src/components/Layout/__tests__/Sidebar.contextMenu.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+import { render, screen } from "@testing-library/react";
+import type { Project } from "@shared/types";
+import type { WorkspaceRoot } from "@/hooks/useWorkspaceRoot";
+
+/**
+ * Mounting the sidebar in every workspace kind (#11499) exposed its background
+ * context menu to workspaces that have no worktrees. The entries that only make
+ * sense against git have to be absent there, not disabled — a greyed-out "New
+ * Worktree…" in a scratch is the same dead-control lie in a quieter font.
+ */
+
+const workspaceRoot = vi.fn<() => WorkspaceRoot | null>(() => null);
+let currentProject: Project | null = null;
+
+vi.mock("@/hooks/useWorkspaceRoot", () => ({ useWorkspaceRoot: () => workspaceRoot() }));
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: (selector: (state: { currentProject: Project | null }) => unknown) =>
+    selector({ currentProject }),
+}));
+vi.mock("@/store/macroFocusStore", () => ({
+  useMacroFocusStore: Object.assign(() => false, {
+    getState: () => ({ setRegionRef: () => {} }),
+  }),
+}));
+vi.mock("@/components/Project", () => ({
+  ProjectResourceBadge: () => null,
+  QuickRun: () => null,
+}));
+
+// Records the actionId of every menu entry that actually renders, so a test can
+// assert on absence rather than on a disabled attribute.
+vi.mock("@/components/ui/context-menu", () => ({
+  ContextMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  ContextMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  ContextMenuContent: ({ children }: { children: ReactNode }) => (
+    <div data-testid="context-menu-content">{children}</div>
+  ),
+  ContextMenuSeparator: () => <hr data-testid="menu-separator" />,
+  ContextMenuActionItem: ({
+    actionId,
+    args,
+    children,
+  }: {
+    actionId: string;
+    args?: unknown;
+    children: ReactNode;
+  }) => (
+    <div role="menuitem" data-action-id={actionId} data-args={JSON.stringify(args ?? null)}>
+      {children}
+    </div>
+  ),
+}));
+
+const { Sidebar } = await import("../Sidebar");
+
+const GIT_PROJECT: WorkspaceRoot = {
+  kind: "project",
+  id: "proj-1",
+  path: "/repos/daintree",
+  name: "Daintree",
+  isGitBacked: true,
+};
+const SCRATCH: WorkspaceRoot = {
+  kind: "scratch",
+  id: "scratch-1",
+  path: "/scratches/scratch-1",
+  name: "Quick test",
+  isGitBacked: false,
+};
+const PLAIN_FOLDER: WorkspaceRoot = {
+  kind: "project",
+  id: "proj-2",
+  path: "/home/me/notes",
+  name: "Notes",
+  isGitBacked: false,
+};
+
+function renderSidebar() {
+  return render(<Sidebar width={280} onResize={() => {}} />);
+}
+
+function renderedActionIds(): string[] {
+  return screen
+    .getAllByRole("menuitem")
+    .map((el) => el.getAttribute("data-action-id") ?? "")
+    .filter(Boolean);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  currentProject = null;
+  workspaceRoot.mockReturnValue(null);
+});
+
+describe("Sidebar background context menu — workspace kind (#11499)", () => {
+  it("keeps every worktree entry for a git-backed project", () => {
+    currentProject = {
+      id: GIT_PROJECT.id,
+      path: GIT_PROJECT.path,
+      name: GIT_PROJECT.name,
+      emoji: "🌳",
+      lastOpened: 0,
+    };
+    workspaceRoot.mockReturnValue(GIT_PROJECT);
+
+    renderSidebar();
+
+    // The positive half matters: without it, hiding the whole menu would
+    // satisfy the absence assertions below.
+    expect(renderedActionIds()).toEqual([
+      "worktree.createDialog.open",
+      "worktree.refresh",
+      "system.openPath",
+      "project.settings.open",
+      "ui.sidebar.resetWidth",
+      "app.settings.openTab",
+    ]);
+  });
+
+  it("drops every worktree entry in a scratch", () => {
+    workspaceRoot.mockReturnValue(SCRATCH);
+
+    renderSidebar();
+    const ids = renderedActionIds();
+
+    expect(ids).not.toContain("worktree.createDialog.open");
+    expect(ids).not.toContain("worktree.refresh");
+    expect(ids).not.toContain("app.settings.openTab");
+    // A scratch has no project row, so project settings would open nothing.
+    expect(ids).not.toContain("project.settings.open");
+  });
+
+  it("leaves the workspace-level entries reachable in a scratch", () => {
+    workspaceRoot.mockReturnValue(SCRATCH);
+
+    renderSidebar();
+    const ids = renderedActionIds();
+
+    expect(ids).toContain("system.openPath");
+    expect(ids).toContain("ui.sidebar.resetWidth");
+  });
+
+  it("reveals the scratch's own folder, which currentProject could not supply", () => {
+    workspaceRoot.mockReturnValue(SCRATCH);
+
+    renderSidebar();
+
+    const reveal = screen
+      .getAllByRole("menuitem")
+      .find((el) => el.getAttribute("data-action-id") === "system.openPath");
+    expect(reveal?.getAttribute("data-args")).toBe(JSON.stringify({ path: SCRATCH.path }));
+    expect(reveal?.textContent).toContain("Reveal Workspace in Finder");
+  });
+
+  it("keeps project settings for a folder opened without git, but not its worktree entries", () => {
+    currentProject = {
+      id: PLAIN_FOLDER.id,
+      path: PLAIN_FOLDER.path,
+      name: PLAIN_FOLDER.name,
+      emoji: "📁",
+      lastOpened: 0,
+    };
+    workspaceRoot.mockReturnValue(PLAIN_FOLDER);
+
+    renderSidebar();
+    const ids = renderedActionIds();
+
+    // A plain folder is still a project — it has real settings and a name.
+    expect(ids).toContain("project.settings.open");
+    expect(ids).not.toContain("worktree.createDialog.open");
+    expect(ids).not.toContain("app.settings.openTab");
+  });
+
+  it("renders no leading, doubled or trailing separator in any workspace kind", () => {
+    for (const root of [GIT_PROJECT, SCRATCH]) {
+      currentProject =
+        root.kind === "project"
+          ? { id: root.id, path: root.path, name: root.name, emoji: "🌳", lastOpened: 0 }
+          : null;
+      workspaceRoot.mockReturnValue(root);
+
+      const { unmount } = renderSidebar();
+      const content = screen.getByTestId("context-menu-content");
+      const children = Array.from(content.children);
+      const isSeparator = (el: Element) => el.getAttribute("data-testid") === "menu-separator";
+
+      expect(isSeparator(children[0]!)).toBe(false);
+      expect(isSeparator(children[children.length - 1]!)).toBe(false);
+      expect(children.some((el, i) => i > 0 && isSeparator(el) && isSeparator(children[i - 1]!))).toBe(
+        false
+      );
+      unmount();
+    }
+  });
+});

--- a/src/components/Layout/__tests__/Sidebar.contextMenu.test.tsx
+++ b/src/components/Layout/__tests__/Sidebar.contextMenu.test.tsx
@@ -31,8 +31,13 @@ vi.mock("@/components/Project", () => ({
 }));
 
 // Records the actionId of every menu entry that actually renders, so a test can
-// assert on absence rather than on a disabled attribute.
-vi.mock("@/components/ui/context-menu", () => ({
+// assert on absence rather than on a disabled attribute. Partial (spreading
+// `importOriginal`) rather than a full replacement: `ContextMenuActionItem`
+// renders `ContextMenuItem` from this same module, so a factory listing only
+// the components Sidebar names directly makes vitest throw on the exports
+// reached through the module's own graph.
+vi.mock("@/components/ui/context-menu", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/components/ui/context-menu")>()),
   ContextMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
   ContextMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
   ContextMenuContent: ({ children }: { children: ReactNode }) => (

--- a/src/components/Layout/__tests__/Sidebar.contextMenu.test.tsx
+++ b/src/components/Layout/__tests__/Sidebar.contextMenu.test.tsx
@@ -30,6 +30,14 @@ vi.mock("@/components/Project", () => ({
   QuickRun: () => null,
 }));
 
+// Sidebar takes one constant from AppLayout, and importing it for real drags in
+// AppLayout's whole graph — including its module-eval `void preloadHelpPanel()`,
+// a fire-and-forget dynamic import whose chunks land after this file's
+// environment tears down and fail the shard with EnvironmentTeardownError even
+// though every assertion passed. Stubbing the module keeps the graph out. (The
+// value is a stand-in; nothing here exercises the double-click width reset.)
+vi.mock("../AppLayout", () => ({ DEFAULT_SIDEBAR_WIDTH: 350 }));
+
 // Records the actionId of every menu entry that actually renders, so a test can
 // assert on absence rather than on a disabled attribute. Partial (spreading
 // `importOriginal`) rather than a full replacement: `ContextMenuActionItem`

--- a/src/components/Layout/__tests__/Sidebar.contextMenu.test.tsx
+++ b/src/components/Layout/__tests__/Sidebar.contextMenu.test.tsx
@@ -189,9 +189,9 @@ describe("Sidebar background context menu — workspace kind (#11499)", () => {
 
       expect(isSeparator(children[0]!)).toBe(false);
       expect(isSeparator(children[children.length - 1]!)).toBe(false);
-      expect(children.some((el, i) => i > 0 && isSeparator(el) && isSeparator(children[i - 1]!))).toBe(
-        false
-      );
+      expect(
+        children.some((el, i) => i > 0 && isSeparator(el) && isSeparator(children[i - 1]!))
+      ).toBe(false);
       unmount();
     }
   });

--- a/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
@@ -82,7 +82,10 @@ describe("Toolbar shortcut tooltips — issue #3443", () => {
       expect(source).toContain('useAriaKeyshortcuts("worktree.openFileBrowser")');
       expect(source).toContain('useShortcutHintHover("worktree.openFileBrowser")');
       expect(source).toContain("aria-keyshortcuts={fileBrowserAriaShortcut}");
-      expect(source).toContain("{...fileBrowserHintHover}");
+      // Spread conditionally since #11499: with no workspace the action can
+      // resolve no folder, so the button degrades to aria-disabled and the
+      // press-and-hold hint would advertise a shortcut that only errors.
+      expect(source).toContain("hasWorkspace ? fileBrowserHintHover : {}");
     });
 
     it("uses createTooltipContent for the file browser tooltip", () => {

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -20,8 +20,6 @@ import {
 } from "react-virtuoso";
 import { AlertTriangle, FolderOpen, LayoutGrid, Plus, RefreshCw, Zap } from "lucide-react";
 import { EmptyState } from "@/components/ui/EmptyState";
-import { Button } from "@/components/ui/button";
-import { isGitBackedProject } from "@shared/types";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { Skeleton, SkeletonBone, SkeletonHint } from "@/components/ui/Skeleton";
 import { ScrollIndicator } from "@/components/Worktree/ScrollIndicator";
@@ -92,7 +90,9 @@ import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { SidebarWorktreeRow } from "./SidebarWorktreeRow";
 import { WorktreeLoadErrorBanner } from "./WorktreeLoadErrorBanner";
 import { StaticWorktreeRow } from "./StaticWorktreeRow";
+import { WorkspaceRootSidebar } from "./WorkspaceRootSidebar";
 import { WorktreeCardPlaceholder } from "./WorktreeCardPlaceholder";
+import { useWorkspaceRoot } from "@/hooks/useWorkspaceRoot";
 import { useVisibilityAwareInterval } from "@/hooks/useVisibilityAwareInterval";
 import { useScrollIndicator } from "./useScrollIndicator";
 import { useRecipeDialogState } from "./useRecipeDialogState";
@@ -543,6 +543,9 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     prevEscalated.current = showReconnecting && showReconnectingEscalated;
   }, [showReconnecting, showReconnectingEscalated]);
   const currentProject = useProjectStore((state) => state.currentProject);
+  // The workspace this view owns, whatever kind it is. `currentProject` alone
+  // can't see a scratch, which is why the sidebar had nothing to render in one.
+  const workspaceRoot = useWorkspaceRoot();
   const worktreeLoadError = useProjectStore((state) => state.worktreeLoadError);
   useProjectSettings();
   const { availability, agentSettings } = useAgentLauncher();
@@ -1494,46 +1497,21 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     />
   );
 
-  // A workspace opened without git has no worktrees to wait for or fail at, so
-  // it takes neither the skeleton nor the "Open a Git repository" nudge. Paired
-  // with the empty list rather than read alone: a folder that has since been
+  // A workspace with no git worktrees — a scratch, or a folder opened without
+  // git (#11405) — still has exactly one place agents run: its own root. It
+  // renders that as the single row instead of a Worktrees header over an empty
+  // state, so the sidebar means one thing across all three workspace kinds and
+  // the toggle that opens it stops lying in a scratch (#11499).
+  //
+  // It takes neither the skeleton (no worktree poll will ever resolve) nor the
+  // "Open a Git repository" nudge, so it has to answer before both. Paired with
+  // the empty list rather than read alone: a folder that has since been
   // initialized externally loads worktrees normally, and those must win over a
   // flag that is only reconciled the next time the folder is opened (#11405).
-  if (!isGitBackedProject(currentProject) && worktrees.length === 0) {
+  if (workspaceRoot !== null && !workspaceRoot.isGitBacked && worktrees.length === 0) {
     return (
       <>
-        <div className="flex flex-col h-full">
-          <div className="flex items-center px-4 py-2 border-b border-divider shrink-0">
-            <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Worktrees</h2>
-          </div>
-          <EmptyState
-            variant="zero-data"
-            scale="sidebar"
-            icon={<FolderOpen />}
-            title="Initialize a repository to use worktrees"
-            action={
-              <div className="flex flex-col items-center gap-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    if (currentProject) {
-                      useProjectStore
-                        .getState()
-                        .openGitInitDialog(currentProject.path, { step: "initialize" });
-                    }
-                  }}
-                >
-                  Initialize repository
-                </Button>
-                <span className="text-xs text-daintree-text/50">
-                  Terminals, agents, and recipes work without one
-                </span>
-              </div>
-            }
-            className="flex-1"
-          />
-        </div>
+        <WorkspaceRootSidebar workspace={workspaceRoot} homeDir={homeDir} />
         {restartConfirmDialog}
       </>
     );

--- a/src/components/Sidebar/WorkspaceRootRow.tsx
+++ b/src/components/Sidebar/WorkspaceRootRow.tsx
@@ -62,10 +62,12 @@ export function WorkspaceRootRow({
     if (total === 0) {
       return { visibleStates: [] as { state: AgentState; count: number }[], sessionAriaLabel: "" };
     }
-    const visible = STATE_PRIORITY.filter((s) => s !== "idle" && counts.byState[s] > 0).map((s) => ({
-      state: s,
-      count: counts.byState[s],
-    }));
+    const visible = STATE_PRIORITY.filter((s) => s !== "idle" && counts.byState[s] > 0).map(
+      (s) => ({
+        state: s,
+        count: counts.byState[s],
+      })
+    );
     const parts = visible.map((v) => `${v.count} ${STATE_LABELS[v.state]}`);
     const label =
       parts.length > 0

--- a/src/components/Sidebar/WorkspaceRootRow.tsx
+++ b/src/components/Sidebar/WorkspaceRootRow.tsx
@@ -1,0 +1,147 @@
+import { useMemo } from "react";
+import { FlaskConical, FolderOpen, FolderTree } from "lucide-react";
+import type { AgentState } from "@/types";
+import type { WorkspaceRoot } from "@/hooks/useWorkspaceRoot";
+import { useWorktreeTerminals } from "@/hooks/useWorktreeTerminals";
+import { NO_WORKTREE } from "@/store/slices/panelRegistry/worktreeIndex";
+import { CollapsedSessionIndicators } from "@/components/Worktree/WorktreeCard/CollapsedSessionIndicators";
+import { STATE_LABELS, STATE_PRIORITY } from "@/components/Worktree/terminalStateConfig";
+import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  ContextMenu,
+  ContextMenuActionItem,
+  ContextMenuContent,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import { actionService } from "@/services/ActionService";
+import { formatPath } from "@/utils/textParsing";
+
+const ICON_CLASS = "w-3.5 h-3.5 mr-2 shrink-0";
+
+/**
+ * How a workspace with no git worktrees describes itself. A scratch says so
+ * outright — JetBrains' "Scratches and Consoles" is the model: the row a user
+ * lands on has to look like less than a worktree row, or they arrive expecting
+ * a parity it will never have (#11499).
+ */
+function kindLabel(workspace: WorkspaceRoot): string {
+  return workspace.kind === "scratch" ? "Scratch" : "Folder";
+}
+
+/**
+ * The single row a worktree-less workspace contributes to the sidebar.
+ *
+ * The sidebar lists places agents run, and this is the only one such a
+ * workspace has. Deliberately NOT a `WorktreeCard`: nearly everything that
+ * hangs off that card is git-shaped (review, diffs, branch labels, delete), and
+ * a row that looks identical to a worktree row with half its menu inert is a
+ * bigger lie than the dead toggle this fixes. The git-shaped actions are absent
+ * here, not disabled.
+ *
+ * Terminal counts come from the `NO_WORKTREE` bucket — the index key panels
+ * launched without a worktree already carry (`worktreeIndex.ts`), so the row
+ * reads live state without anything stamping a synthetic worktree id onto a
+ * panel (which would make it look orphaned to every worktree-scoped pass).
+ *
+ * Not clickable on purpose. A worktree row's click selects that worktree; there
+ * is nothing to select when the workspace *is* the row, and inventing a no-op
+ * click target here would reintroduce the exact bug being fixed.
+ */
+export function WorkspaceRootRow({
+  workspace,
+  homeDir,
+}: {
+  workspace: WorkspaceRoot;
+  homeDir?: string;
+}) {
+  const { counts } = useWorktreeTerminals(NO_WORKTREE);
+
+  const { visibleStates, sessionAriaLabel } = useMemo(() => {
+    const total = counts.total;
+    if (total === 0) {
+      return { visibleStates: [] as { state: AgentState; count: number }[], sessionAriaLabel: "" };
+    }
+    const visible = STATE_PRIORITY.filter((s) => s !== "idle" && counts.byState[s] > 0).map((s) => ({
+      state: s,
+      count: counts.byState[s],
+    }));
+    const parts = visible.map((v) => `${v.count} ${STATE_LABELS[v.state]}`);
+    const label =
+      parts.length > 0
+        ? `${total} session${total !== 1 ? "s" : ""}: ${parts.join(", ")}`
+        : `${total} session${total !== 1 ? "s" : ""}`;
+    return { visibleStates: visible, sessionAriaLabel: label };
+  }, [counts]);
+
+  const KindIcon = workspace.kind === "scratch" ? FlaskConical : FolderOpen;
+  const displayPath = formatPath(workspace.path, homeDir);
+  const terminalLabel = `${counts.total} terminal${counts.total !== 1 ? "s" : ""}`;
+
+  return (
+    <div role="row" aria-rowindex={1} data-workspace-root-row={workspace.id}>
+      <div role="gridcell">
+        <ContextMenu>
+          <ContextMenuTrigger asChild>
+            <div className="flex flex-col gap-1 px-4 py-3 border-b border-divider">
+              <div className="flex items-center gap-2 min-w-0">
+                <KindIcon className="w-4 h-4 shrink-0 text-daintree-text/60" aria-hidden="true" />
+                <TruncatedTooltip content={workspace.name}>
+                  <span className="truncate min-w-0 text-[13px] font-medium text-daintree-text">
+                    {workspace.name}
+                  </span>
+                </TruncatedTooltip>
+                <div className="ml-auto flex items-center gap-2 shrink-0">
+                  {visibleStates.length > 0 && (
+                    <CollapsedSessionIndicators
+                      visibleStates={visibleStates}
+                      sessionAriaLabel={sessionAriaLabel}
+                    />
+                  )}
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          void actionService.dispatch("worktree.openFileBrowser", undefined, {
+                            source: "user",
+                          });
+                        }}
+                        className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+                        aria-label="Browse files"
+                      >
+                        <FolderTree className="w-3.5 h-3.5" aria-hidden="true" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">Browse files</TooltipContent>
+                  </Tooltip>
+                </div>
+              </div>
+              {/* Kind rides the secondary line rather than a pill: origin has to
+                  be unambiguous, but it isn't the row's headline, and a badge
+                  would be a second emphasis signal on a one-row list. */}
+              <div className="flex items-center gap-1.5 text-xs text-daintree-text/50 min-w-0">
+                <span className="shrink-0">{kindLabel(workspace)}</span>
+                <span aria-hidden="true">·</span>
+                <TruncatedTooltip content={displayPath}>
+                  <span className="truncate min-w-0 font-mono">{displayPath}</span>
+                </TruncatedTooltip>
+                <span className="sr-only">, {terminalLabel}</span>
+              </div>
+            </div>
+          </ContextMenuTrigger>
+          <ContextMenuContent>
+            <ContextMenuActionItem actionId="worktree.openFileBrowser">
+              <FolderTree className={ICON_CLASS} />
+              Browse files
+            </ContextMenuActionItem>
+            <ContextMenuActionItem actionId="system.openPath" args={{ path: workspace.path }}>
+              <FolderOpen className={ICON_CLASS} />
+              Reveal in Finder
+            </ContextMenuActionItem>
+          </ContextMenuContent>
+        </ContextMenu>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Sidebar/WorkspaceRootRow.tsx
+++ b/src/components/Sidebar/WorkspaceRootRow.tsx
@@ -81,69 +81,67 @@ export function WorkspaceRootRow({
   const terminalLabel = `${counts.total} terminal${counts.total !== 1 ? "s" : ""}`;
 
   return (
-    <div role="row" aria-rowindex={1} data-workspace-root-row={workspace.id}>
-      <div role="gridcell">
-        <ContextMenu>
-          <ContextMenuTrigger asChild>
-            <div className="flex flex-col gap-1 px-4 py-3 border-b border-divider">
-              <div className="flex items-center gap-2 min-w-0">
-                <KindIcon className="w-4 h-4 shrink-0 text-daintree-text/60" aria-hidden="true" />
-                <TruncatedTooltip content={workspace.name}>
-                  <span className="truncate min-w-0 text-[13px] font-medium text-daintree-text">
-                    {workspace.name}
-                  </span>
-                </TruncatedTooltip>
-                <div className="ml-auto flex items-center gap-2 shrink-0">
-                  {visibleStates.length > 0 && (
-                    <CollapsedSessionIndicators
-                      visibleStates={visibleStates}
-                      sessionAriaLabel={sessionAriaLabel}
-                    />
-                  )}
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          void actionService.dispatch("worktree.openFileBrowser", undefined, {
-                            source: "user",
-                          });
-                        }}
-                        className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
-                        aria-label="Browse files"
-                      >
-                        <FolderTree className="w-3.5 h-3.5" aria-hidden="true" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">Browse files</TooltipContent>
-                  </Tooltip>
-                </div>
-              </div>
-              {/* Kind rides the secondary line rather than a pill: origin has to
-                  be unambiguous, but it isn't the row's headline, and a badge
-                  would be a second emphasis signal on a one-row list. */}
-              <div className="flex items-center gap-1.5 text-xs text-daintree-text/50 min-w-0">
-                <span className="shrink-0">{kindLabel(workspace)}</span>
-                <span aria-hidden="true">·</span>
-                <TruncatedTooltip content={displayPath}>
-                  <span className="truncate min-w-0 font-mono">{displayPath}</span>
-                </TruncatedTooltip>
-                <span className="sr-only">, {terminalLabel}</span>
+    <div data-workspace-root-row={workspace.id}>
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <div className="flex flex-col gap-1 px-4 py-3 border-b border-divider">
+            <div className="flex items-center gap-2 min-w-0">
+              <KindIcon className="w-4 h-4 shrink-0 text-daintree-text/60" aria-hidden="true" />
+              <TruncatedTooltip content={workspace.name}>
+                <span className="truncate min-w-0 text-[13px] font-medium text-daintree-text">
+                  {workspace.name}
+                </span>
+              </TruncatedTooltip>
+              <div className="ml-auto flex items-center gap-2 shrink-0">
+                {visibleStates.length > 0 && (
+                  <CollapsedSessionIndicators
+                    visibleStates={visibleStates}
+                    sessionAriaLabel={sessionAriaLabel}
+                  />
+                )}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void actionService.dispatch("worktree.openFileBrowser", undefined, {
+                          source: "user",
+                        });
+                      }}
+                      className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+                      aria-label="Browse files"
+                    >
+                      <FolderTree className="w-3.5 h-3.5" aria-hidden="true" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">Browse files</TooltipContent>
+                </Tooltip>
               </div>
             </div>
-          </ContextMenuTrigger>
-          <ContextMenuContent>
-            <ContextMenuActionItem actionId="worktree.openFileBrowser">
-              <FolderTree className={ICON_CLASS} />
-              Browse files
-            </ContextMenuActionItem>
-            <ContextMenuActionItem actionId="system.openPath" args={{ path: workspace.path }}>
-              <FolderOpen className={ICON_CLASS} />
-              Reveal in Finder
-            </ContextMenuActionItem>
-          </ContextMenuContent>
-        </ContextMenu>
-      </div>
+            {/* Kind rides the secondary line rather than a pill: origin has to
+                be unambiguous, but it isn't the row's headline, and a badge
+                would be a second emphasis signal on a one-row list. */}
+            <div className="flex items-center gap-1.5 text-xs text-daintree-text/50 min-w-0">
+              <span className="shrink-0">{kindLabel(workspace)}</span>
+              <span aria-hidden="true">·</span>
+              <TruncatedTooltip content={displayPath}>
+                <span className="truncate min-w-0 font-mono">{displayPath}</span>
+              </TruncatedTooltip>
+              <span className="sr-only">, {terminalLabel}</span>
+            </div>
+          </div>
+        </ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuActionItem actionId="worktree.openFileBrowser">
+            <FolderTree className={ICON_CLASS} />
+            Browse files
+          </ContextMenuActionItem>
+          <ContextMenuActionItem actionId="system.openPath" args={{ path: workspace.path }}>
+            <FolderOpen className={ICON_CLASS} />
+            Reveal in Finder
+          </ContextMenuActionItem>
+        </ContextMenuContent>
+      </ContextMenu>
     </div>
   );
 }

--- a/src/components/Sidebar/WorkspaceRootSidebar.tsx
+++ b/src/components/Sidebar/WorkspaceRootSidebar.tsx
@@ -1,0 +1,69 @@
+import type { WorkspaceRoot } from "@/hooks/useWorkspaceRoot";
+import { useProjectStore } from "@/store/projectStore";
+import { Button } from "@/components/ui/button";
+import { WorkspaceRootRow } from "./WorkspaceRootRow";
+
+/**
+ * The sidebar for a workspace that has no git worktrees — a scratch, or a
+ * folder opened without git (#11405).
+ *
+ * Same slot, same meaning as the worktree list: the places agents run. Such a
+ * workspace has exactly one, its own root, so it renders exactly one row. That
+ * is not a new pattern — a repo with no linked worktrees already renders a
+ * single main-worktree row — which is why the fix is admitting a non-git root
+ * into the list rather than building a second view (#11499).
+ *
+ * Everything worktree-shaped is absent rather than disabled: no create-worktree
+ * button, no worktree overview, no refresh (there is no worktree poll to
+ * refresh), no search bar or quick-state filter over a one-row list, and no
+ * fleet-arm affordance — `fleetArmingStore` collects by real worktree id, so an
+ * arm control here would be another control that reports doing something and
+ * doesn't.
+ */
+export function WorkspaceRootSidebar({
+  workspace,
+  homeDir,
+}: {
+  workspace: WorkspaceRoot;
+  homeDir?: string;
+}) {
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center px-4 py-2 border-b border-divider shrink-0">
+        {/* Not "Worktrees": this workspace has none, and naming the slot after
+            a concept it can't hold is what made the header wrong for two of the
+            three workspace kinds. */}
+        <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Workspace</h2>
+      </div>
+
+      <div
+        role="grid"
+        aria-label="Workspace"
+        aria-rowcount={1}
+        className="flex flex-col flex-1 min-h-0"
+      >
+        <WorkspaceRootRow workspace={workspace} homeDir={homeDir} />
+      </div>
+
+      {/* A scratch can't become a repository — it's app-managed and disposable —
+          so the upgrade is offered only for a real folder, and quietly: the row
+          above is the answer to "where do agents run here", not this. */}
+      {workspace.kind === "project" && (
+        <div className="shrink-0 border-t border-divider px-4 py-3 flex flex-col items-start gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              useProjectStore.getState().openGitInitDialog(workspace.path, { step: "initialize" });
+            }}
+          >
+            Initialize repository
+          </Button>
+          <span className="text-xs text-daintree-text/50">
+            Terminals, agents, and recipes work without one
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Sidebar/WorkspaceRootSidebar.tsx
+++ b/src/components/Sidebar/WorkspaceRootSidebar.tsx
@@ -36,12 +36,13 @@ export function WorkspaceRootSidebar({
         <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Workspace</h2>
       </div>
 
-      <div
-        role="grid"
-        aria-label="Workspace"
-        aria-rowcount={1}
-        className="flex flex-col flex-1 min-h-0"
-      >
+      {/* Plain container, not a `role="grid"`: the worktree list is a grid
+          because it has selection and arrow-key navigation over its rows
+          (`SidebarContent.tsx` — tab stop, `aria-activedescendant`, key
+          handlers). This row has neither, so grid/row/gridcell roles would
+          promise a keyboard widget that isn't there — the same kind of lie as
+          the toggle this fixes. The heading above already names the region. */}
+      <div className="flex flex-col flex-1 min-h-0">
         <WorkspaceRootRow workspace={workspace} homeDir={homeDir} />
       </div>
 

--- a/src/components/Sidebar/__tests__/SidebarContent.lightweight.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.lightweight.test.ts
@@ -3,7 +3,6 @@ import fs from "fs/promises";
 import path from "path";
 
 const SIDEBAR_CONTENT_PATH = path.resolve(__dirname, "../SidebarContent.tsx");
-const WORKSPACE_ROOT_SIDEBAR_PATH = path.resolve(__dirname, "../WorkspaceRootSidebar.tsx");
 
 /**
  * The sidebar's branches are ordered early-returns, so what matters for a
@@ -14,11 +13,9 @@ const WORKSPACE_ROOT_SIDEBAR_PATH = path.resolve(__dirname, "../WorkspaceRootSid
  */
 describe("SidebarContent — workspace with no worktrees (#11405, #11499)", () => {
   let source: string;
-  let workspaceRootSource: string;
 
   beforeAll(async () => {
     source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
-    workspaceRootSource = await fs.readFile(WORKSPACE_ROOT_SIDEBAR_PATH, "utf-8");
   });
 
   it("decides on the workspace's own kind, not on the absence of worktrees alone", () => {
@@ -47,27 +44,12 @@ describe("SidebarContent — workspace with no worktrees (#11405, #11499)", () =
     expect(gate).toBeLessThan(zeroWorktrees);
   });
 
-  it("renders the workspace root as a row rather than an empty state", () => {
+  it("hands the branch to the workspace-root sidebar rather than an empty state", () => {
     // The sidebar lists the places agents run; a worktree-less workspace has
     // exactly one, so it gets a row like every other kind instead of a
-    // Worktrees header over a zero-data nudge (#11499).
+    // Worktrees header over a zero-data nudge (#11499). What that sidebar then
+    // renders is covered behaviourally in WorkspaceRootSidebar.test.tsx — this
+    // only pins that the branch is wired to it at all.
     expect(source).toContain("<WorkspaceRootSidebar workspace={workspaceRoot}");
-    expect(workspaceRootSource).toContain("<WorkspaceRootRow workspace={workspace}");
-  });
-
-  it("does not label the slot Worktrees for a workspace that has none", () => {
-    expect(workspaceRootSource).not.toContain(">Worktrees<");
-  });
-
-  it("offers the upgrade at the initialize step rather than re-asking the choice", () => {
-    expect(workspaceRootSource).toMatch(
-      /openGitInitDialog\(\s*workspace\.path,\s*\{\s*step:\s*"initialize"\s*\}\s*\)/
-    );
-  });
-
-  it("offers the initialize upgrade only to a real folder, never to a scratch", () => {
-    // A scratch is app-managed and disposable; `git init` on one would be an
-    // offer the workspace cannot honour in any durable way.
-    expect(workspaceRootSource).toMatch(/workspace\.kind === "project" &&/);
   });
 });

--- a/src/components/Sidebar/__tests__/SidebarContent.lightweight.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.lightweight.test.ts
@@ -3,28 +3,36 @@ import fs from "fs/promises";
 import path from "path";
 
 const SIDEBAR_CONTENT_PATH = path.resolve(__dirname, "../SidebarContent.tsx");
+const WORKSPACE_ROOT_SIDEBAR_PATH = path.resolve(__dirname, "../WorkspaceRootSidebar.tsx");
 
 /**
  * The sidebar's branches are ordered early-returns, so what matters for a
- * workspace opened without git (#11405) is *where* its branch sits relative to
- * the loading skeleton and the "Open a Git repository" nudge — both of which
- * would otherwise claim the same zero-worktree state and mislead.
+ * workspace with no worktrees — a folder opened without git (#11405) or a
+ * scratch (#11499) — is *where* its branch sits relative to the loading
+ * skeleton and the "Open a Git repository" nudge, both of which would otherwise
+ * claim the same zero-worktree state and mislead.
  */
-describe("SidebarContent — workspace opened without git (#11405)", () => {
+describe("SidebarContent — workspace with no worktrees (#11405, #11499)", () => {
   let source: string;
+  let workspaceRootSource: string;
 
   beforeAll(async () => {
     source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
+    workspaceRootSource = await fs.readFile(WORKSPACE_ROOT_SIDEBAR_PATH, "utf-8");
   });
 
-  it("decides on the project's mode, not on the absence of worktrees alone", () => {
-    // Reading the flag alone would misreport a folder initialized externally,
-    // whose host does load worktrees; those must win over a stale flag.
-    expect(source).toMatch(/!isGitBackedProject\(currentProject\)\s*&&\s*worktrees\.length === 0/);
+  it("decides on the workspace's own kind, not on the absence of worktrees alone", () => {
+    // Reading the emptiness alone would misreport a folder initialized
+    // externally, whose host does load worktrees; those must win over a stale
+    // flag. `isGitBacked` is false for both a non-git project and a scratch, so
+    // one gate now covers both worktree-less kinds (#11499).
+    expect(source).toMatch(
+      /workspaceRoot !== null\s*&&\s*!workspaceRoot\.isGitBacked\s*&&\s*worktrees\.length === 0/
+    );
   });
 
   it("answers before the loading skeleton, which would otherwise never resolve", () => {
-    const gate = source.indexOf("!isGitBackedProject(currentProject)");
+    const gate = source.indexOf("!workspaceRoot.isGitBacked");
     const skeleton = source.indexOf("if (isLoading && worktrees.length === 0)");
     expect(gate).toBeGreaterThan(-1);
     expect(skeleton).toBeGreaterThan(-1);
@@ -32,15 +40,34 @@ describe("SidebarContent — workspace opened without git (#11405)", () => {
   });
 
   it("answers before the zero-worktree branch that nudges toward opening a repository", () => {
-    const gate = source.indexOf("!isGitBackedProject(currentProject)");
+    const gate = source.indexOf("!workspaceRoot.isGitBacked");
     const zeroWorktrees = source.indexOf("if (worktrees.length === 0)");
+    expect(gate).toBeGreaterThan(-1);
     expect(zeroWorktrees).toBeGreaterThan(-1);
     expect(gate).toBeLessThan(zeroWorktrees);
   });
 
+  it("renders the workspace root as a row rather than an empty state", () => {
+    // The sidebar lists the places agents run; a worktree-less workspace has
+    // exactly one, so it gets a row like every other kind instead of a
+    // Worktrees header over a zero-data nudge (#11499).
+    expect(source).toContain("<WorkspaceRootSidebar workspace={workspaceRoot}");
+    expect(workspaceRootSource).toContain("<WorkspaceRootRow workspace={workspace}");
+  });
+
+  it("does not label the slot Worktrees for a workspace that has none", () => {
+    expect(workspaceRootSource).not.toContain(">Worktrees<");
+  });
+
   it("offers the upgrade at the initialize step rather than re-asking the choice", () => {
-    expect(source).toMatch(
-      /openGitInitDialog\(\s*currentProject\.path,\s*\{\s*step:\s*"initialize"\s*\}\s*\)/
+    expect(workspaceRootSource).toMatch(
+      /openGitInitDialog\(\s*workspace\.path,\s*\{\s*step:\s*"initialize"\s*\}\s*\)/
     );
+  });
+
+  it("offers the initialize upgrade only to a real folder, never to a scratch", () => {
+    // A scratch is app-managed and disposable; `git init` on one would be an
+    // offer the workspace cannot honour in any durable way.
+    expect(workspaceRootSource).toMatch(/workspace\.kind === "project" &&/);
   });
 });

--- a/src/components/Sidebar/__tests__/WorkspaceRootSidebar.test.tsx
+++ b/src/components/Sidebar/__tests__/WorkspaceRootSidebar.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render as rtlRender, screen } from "@testing-library/react";
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { NO_WORKTREE } from "@/store/slices/panelRegistry/worktreeIndex";
 import type { AgentState } from "@/types";
 import type { WorkspaceRoot } from "@/hooks/useWorkspaceRoot";
 
@@ -31,7 +32,33 @@ vi.mock("@/store/projectStore", () => ({
   useProjectStore: { getState: () => ({ openGitInitDialog }) },
 }));
 vi.mock("@/services/ActionService", () => ({
-  actionService: { dispatch: (id: string, args?: unknown, opts?: unknown) => dispatch(id, args, opts) },
+  actionService: {
+    dispatch: (id: string, args?: unknown, opts?: unknown) => dispatch(id, args, opts),
+  },
+}));
+
+// Radix keeps the row's context menu closed, so its items never reach the DOM
+// and an "absent, not disabled" assertion over the real menu would pass
+// vacuously. Rendering the content inline is what makes that contract testable.
+vi.mock("@/components/ui/context-menu", () => ({
+  ContextMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  ContextMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  ContextMenuContent: ({ children }: { children: ReactNode }) => (
+    <div data-testid="row-context-menu">{children}</div>
+  ),
+  ContextMenuSeparator: () => <hr />,
+  ContextMenuActionItem: ({
+    actionId,
+    children,
+  }: {
+    actionId: string;
+    args?: unknown;
+    children: ReactNode;
+  }) => (
+    <div role="menuitem" data-action-id={actionId}>
+      {children}
+    </div>
+  ),
 }));
 
 const { WorkspaceRootSidebar } = await import("../WorkspaceRootSidebar");
@@ -108,7 +135,10 @@ describe("WorkspaceRootSidebar", () => {
     };
     render(<WorkspaceRootSidebar workspace={SCRATCH} />);
 
-    expect(useWorktreeTerminals).toHaveBeenCalledWith("__none__");
+    expect(useWorktreeTerminals).toHaveBeenCalledWith(NO_WORKTREE);
+    // The regression this guards: keying the row on the workspace's own id
+    // renders a permanently-empty row beside live agents.
+    expect(useWorktreeTerminals).not.toHaveBeenCalledWith(SCRATCH.id);
     expect(screen.getByRole("img", { name: /3 sessions/ })).toBeTruthy();
   });
 
@@ -141,21 +171,25 @@ describe("WorkspaceRootSidebar", () => {
     });
   });
 
-  it("offers no worktree-shaped affordance anywhere in the slot", () => {
+  it("carries only the row actions a worktree-less workspace can honour", () => {
     // Absent, not disabled. A row that looks like a worktree row with half its
-    // controls inert is a bigger lie than the dead toggle this replaces.
+    // menu inert is a bigger lie than the dead toggle this replaces. Asserted as
+    // an exact set so a git-shaped action can't be added back unnoticed.
     render(<WorkspaceRootSidebar workspace={SCRATCH} />);
 
-    for (const forbidden of [
-      /worktree/i,
-      /review/i,
-      /commit/i,
-      /diff/i,
-      /branch/i,
-      /arm/i,
-      /refresh/i,
-    ]) {
+    const actionIds = screen
+      .getAllByRole("menuitem")
+      .map((el) => el.getAttribute("data-action-id"));
+
+    expect(actionIds).toEqual(["worktree.openFileBrowser", "system.openPath"]);
+  });
+
+  it("exposes no worktree-shaped control outside the menu either", () => {
+    render(<WorkspaceRootSidebar workspace={SCRATCH} />);
+
+    for (const forbidden of [/review/i, /commit/i, /diff/i, /branch/i, /arm/i, /refresh/i]) {
       expect(screen.queryAllByRole("button", { name: forbidden })).toHaveLength(0);
+      expect(screen.queryAllByRole("menuitem", { name: forbidden })).toHaveLength(0);
     }
   });
 });

--- a/src/components/Sidebar/__tests__/WorkspaceRootSidebar.test.tsx
+++ b/src/components/Sidebar/__tests__/WorkspaceRootSidebar.test.tsx
@@ -94,11 +94,22 @@ beforeEach(() => {
 
 describe("WorkspaceRootSidebar", () => {
   it("gives a scratch a row, so the toggle that opened the sidebar did something", () => {
+    const { container } = render(<WorkspaceRootSidebar workspace={SCRATCH} />);
+
+    expect(container.querySelectorAll("[data-workspace-root-row]")).toHaveLength(1);
+    expect(screen.getByText("Quick test")).toBeTruthy();
+  });
+
+  it("claims no grid semantics it cannot honour", () => {
+    // The worktree list is a real grid — single tab stop, aria-activedescendant,
+    // arrow-key navigation over its rows. This row has no selection and nothing
+    // to navigate, so grid/row/gridcell roles would announce a keyboard widget
+    // that isn't there: the same shape of lie as the toggle this fixes.
     render(<WorkspaceRootSidebar workspace={SCRATCH} />);
 
-    expect(screen.getByRole("grid")).toBeTruthy();
-    expect(screen.getAllByRole("row")).toHaveLength(1);
-    expect(screen.getByText("Quick test")).toBeTruthy();
+    expect(screen.queryByRole("grid")).toBeNull();
+    expect(screen.queryAllByRole("row")).toHaveLength(0);
+    expect(screen.queryAllByRole("gridcell")).toHaveLength(0);
   });
 
   it("does not call the slot Worktrees for a workspace that has none", () => {

--- a/src/components/Sidebar/__tests__/WorkspaceRootSidebar.test.tsx
+++ b/src/components/Sidebar/__tests__/WorkspaceRootSidebar.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render as rtlRender, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { AgentState } from "@/types";
+import type { WorkspaceRoot } from "@/hooks/useWorkspaceRoot";
+
+// The row's name, path and session pips are all tooltip triggers, and Radix
+// throws outright without a provider in scope. AppLayout supplies one in the
+// real tree.
+const render = (ui: ReactElement) => rtlRender(<TooltipProvider>{ui}</TooltipProvider>);
+
+const openGitInitDialog = vi.fn<(path: string, opts: { step: string }) => void>();
+const dispatch = vi.fn<(id: string, args?: unknown, opts?: unknown) => void>();
+
+interface Counts {
+  total: number;
+  byState: Record<AgentState, number>;
+}
+let counts: Counts = {
+  total: 0,
+  byState: { working: 0, waiting: 0, directing: 0, idle: 0, completed: 0, exited: 0 },
+};
+const useWorktreeTerminals = vi.fn<(id: string) => { counts: Counts }>(() => ({ counts }));
+
+vi.mock("@/hooks/useWorktreeTerminals", () => ({
+  useWorktreeTerminals: (id: string) => useWorktreeTerminals(id),
+}));
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: { getState: () => ({ openGitInitDialog }) },
+}));
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: (id: string, args?: unknown, opts?: unknown) => dispatch(id, args, opts) },
+}));
+
+const { WorkspaceRootSidebar } = await import("../WorkspaceRootSidebar");
+
+const SCRATCH: WorkspaceRoot = {
+  kind: "scratch",
+  id: "scratch-1",
+  path: "/home/me/.daintree/scratches/scratch-1",
+  name: "Quick test",
+  isGitBacked: false,
+};
+
+const PLAIN_FOLDER: WorkspaceRoot = {
+  kind: "project",
+  id: "proj-1",
+  path: "/home/me/notes",
+  name: "Notes",
+  isGitBacked: false,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  counts = {
+    total: 0,
+    byState: { working: 0, waiting: 0, directing: 0, idle: 0, completed: 0, exited: 0 },
+  };
+  useWorktreeTerminals.mockImplementation(() => ({ counts }));
+});
+
+describe("WorkspaceRootSidebar", () => {
+  it("gives a scratch a row, so the toggle that opened the sidebar did something", () => {
+    render(<WorkspaceRootSidebar workspace={SCRATCH} />);
+
+    expect(screen.getByRole("grid")).toBeTruthy();
+    expect(screen.getAllByRole("row")).toHaveLength(1);
+    expect(screen.getByText("Quick test")).toBeTruthy();
+  });
+
+  it("does not call the slot Worktrees for a workspace that has none", () => {
+    render(<WorkspaceRootSidebar workspace={SCRATCH} />);
+
+    expect(screen.queryByText("Worktrees")).toBeNull();
+    expect(screen.getByRole("heading", { level: 2 }).textContent).toBe("Workspace");
+  });
+
+  it("names the kind so nobody arrives expecting worktree parity", () => {
+    render(<WorkspaceRootSidebar workspace={SCRATCH} />);
+    expect(screen.getByText("Scratch")).toBeTruthy();
+  });
+
+  it("distinguishes a plain folder from a scratch", () => {
+    render(<WorkspaceRootSidebar workspace={PLAIN_FOLDER} />);
+    expect(screen.getByText("Folder")).toBeTruthy();
+    expect(screen.queryByText("Scratch")).toBeNull();
+  });
+
+  it("tildifies the path when the home dir is known", () => {
+    render(<WorkspaceRootSidebar workspace={PLAIN_FOLDER} homeDir="/home/me" />);
+    expect(screen.getByText("~/notes")).toBeTruthy();
+  });
+
+  it("leaves the path absolute when the home dir has not resolved yet", () => {
+    render(<WorkspaceRootSidebar workspace={PLAIN_FOLDER} />);
+    expect(screen.getByText("/home/me/notes")).toBeTruthy();
+  });
+
+  it("reads live agent state from the bucket worktree-less panels actually land in", () => {
+    // Panels launched without a worktree are indexed under NO_WORKTREE, not
+    // under the workspace's own id. Keying the row on the workspace id would
+    // render a permanently-empty row beside live agents.
+    counts = {
+      total: 3,
+      byState: { working: 2, waiting: 1, directing: 0, idle: 0, completed: 0, exited: 0 },
+    };
+    render(<WorkspaceRootSidebar workspace={SCRATCH} />);
+
+    expect(useWorktreeTerminals).toHaveBeenCalledWith("__none__");
+    expect(screen.getByRole("img", { name: /3 sessions/ })).toBeTruthy();
+  });
+
+  it("shows no session indicators when nothing is running", () => {
+    render(<WorkspaceRootSidebar workspace={SCRATCH} />);
+    expect(screen.queryByTestId("collapsed-session-indicators")).toBeNull();
+  });
+
+  it("offers the initialize upgrade to a plain folder", () => {
+    render(<WorkspaceRootSidebar workspace={PLAIN_FOLDER} />);
+
+    const button = screen.getByRole("button", { name: "Initialize repository" });
+    button.click();
+
+    expect(openGitInitDialog).toHaveBeenCalledWith("/home/me/notes", { step: "initialize" });
+  });
+
+  it("never offers to initialize a scratch, which is app-managed and disposable", () => {
+    render(<WorkspaceRootSidebar workspace={SCRATCH} />);
+    expect(screen.queryByRole("button", { name: "Initialize repository" })).toBeNull();
+  });
+
+  it("keeps Browse files reachable — the file browser stays a grid panel", () => {
+    render(<WorkspaceRootSidebar workspace={SCRATCH} />);
+
+    screen.getByRole("button", { name: "Browse files" }).click();
+
+    expect(dispatch).toHaveBeenCalledWith("worktree.openFileBrowser", undefined, {
+      source: "user",
+    });
+  });
+
+  it("offers no worktree-shaped affordance anywhere in the slot", () => {
+    // Absent, not disabled. A row that looks like a worktree row with half its
+    // controls inert is a bigger lie than the dead toggle this replaces.
+    render(<WorkspaceRootSidebar workspace={SCRATCH} />);
+
+    for (const forbidden of [
+      /worktree/i,
+      /review/i,
+      /commit/i,
+      /diff/i,
+      /branch/i,
+      /arm/i,
+      /refresh/i,
+    ]) {
+      expect(screen.queryAllByRole("button", { name: forbidden })).toHaveLength(0);
+    }
+  });
+});

--- a/src/components/Sidebar/__tests__/WorkspaceRootSidebar.test.tsx
+++ b/src/components/Sidebar/__tests__/WorkspaceRootSidebar.test.tsx
@@ -40,7 +40,11 @@ vi.mock("@/services/ActionService", () => ({
 // Radix keeps the row's context menu closed, so its items never reach the DOM
 // and an "absent, not disabled" assertion over the real menu would pass
 // vacuously. Rendering the content inline is what makes that contract testable.
-vi.mock("@/components/ui/context-menu", () => ({
+// Partial, for the same reason as Sidebar.contextMenu.test.tsx: this module's
+// components render each other, so a full replacement throws on whichever
+// export the graph reaches that the factory didn't list.
+vi.mock("@/components/ui/context-menu", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/components/ui/context-menu")>()),
   ContextMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
   ContextMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
   ContextMenuContent: ({ children }: { children: ReactNode }) => (

--- a/src/hooks/__tests__/useWorkspaceRoot.test.ts
+++ b/src/hooks/__tests__/useWorkspaceRoot.test.ts
@@ -139,4 +139,37 @@ describe("useWorkspaceRoot", () => {
 
     expect(result.current?.kind).toBe("project");
   });
+
+  it("stops resolving a project once it is closed, so the welcome screen keeps no sidebar (#5023)", () => {
+    // Closing the active project leaves its row in `projects` — the switcher's
+    // reopen entry depends on it — and this view keeps its seeded id, so the
+    // only thing separating "open" from "closed" here is `status`. Asserted as
+    // a before/after on one and the same row: with everything else identical,
+    // flipping the status is what has to change the answer.
+    const project = makeProject({ id: "proj-closed", status: "active" });
+    projectSlice = { projects: [project], currentProject: null };
+    getViewWorkspaceId.mockReturnValue("proj-closed");
+
+    const whileOpen = renderHook(() => useWorkspaceRoot());
+    expect(whileOpen.result.current).not.toBeNull();
+
+    projectSlice = { projects: [{ ...project, status: "closed" }], currentProject: null };
+
+    const afterClose = renderHook(() => useWorkspaceRoot());
+    expect(afterClose.result.current).toBeNull();
+  });
+
+  it("keeps resolving a project whose row carries a non-closed status", () => {
+    // `background` is a live project displayed in another window; only `closed`
+    // unmounts the sidebar, so a blanket status check would blank this view.
+    projectSlice = {
+      projects: [makeProject({ id: "proj-bg", status: "background" })],
+      currentProject: null,
+    };
+    getViewWorkspaceId.mockReturnValue("proj-bg");
+
+    const { result } = renderHook(() => useWorkspaceRoot());
+
+    expect(result.current?.id).toBe("proj-bg");
+  });
 });

--- a/src/hooks/__tests__/useWorkspaceRoot.test.ts
+++ b/src/hooks/__tests__/useWorkspaceRoot.test.ts
@@ -65,6 +65,10 @@ describe("useWorkspaceRoot", () => {
   });
 
   it("resolves a scratch, which currentProject alone could never see (#11499)", () => {
+    // `isGitBacked: false` is the load-bearing half. `isGitBackedProject(null)`
+    // answers true — absence of the discriminator means "legacy git project" —
+    // so routing a scratch through it would hand the sidebar the worktree list
+    // for a workspace that has no worktrees.
     const scratch = makeScratch();
     scratchSlice = { scratches: [scratch], currentScratch: scratch };
 
@@ -77,18 +81,6 @@ describe("useWorkspaceRoot", () => {
       name: "Quick test",
       isGitBacked: false,
     });
-  });
-
-  it("never reports a scratch as git-backed", () => {
-    // `isGitBackedProject(null)` answers true — absence of the discriminator
-    // means "legacy git project". Routing a scratch through it would hand the
-    // sidebar the worktree list for a workspace that has no worktrees.
-    const scratch = makeScratch();
-    scratchSlice = { scratches: [scratch], currentScratch: scratch };
-
-    const { result } = renderHook(() => useWorkspaceRoot());
-
-    expect(result.current?.isGitBacked).toBe(false);
   });
 
   it("treats a project with no gitBacked discriminator as git-backed", () => {

--- a/src/hooks/__tests__/useWorkspaceRoot.test.ts
+++ b/src/hooks/__tests__/useWorkspaceRoot.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { Project, Scratch } from "@shared/types";
+
+const getViewWorkspaceId = vi.fn<() => string | null>(() => null);
+
+interface ProjectSliceShape {
+  projects: Project[];
+  currentProject: Project | null;
+}
+interface ScratchSliceShape {
+  scratches: Scratch[];
+  currentScratch: Scratch | null;
+}
+
+let projectSlice: ProjectSliceShape = { projects: [], currentProject: null };
+let scratchSlice: ScratchSliceShape = { scratches: [], currentScratch: null };
+
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: (selector: (state: ProjectSliceShape) => unknown) => selector(projectSlice),
+}));
+vi.mock("@/store/scratchStore", () => ({
+  useScratchStore: (selector: (state: ScratchSliceShape) => unknown) => selector(scratchSlice),
+}));
+vi.mock("@/store/viewWorkspaceId", () => ({
+  getViewWorkspaceId: () => getViewWorkspaceId(),
+}));
+
+const { useWorkspaceRoot } = await import("../useWorkspaceRoot");
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: "proj-1",
+    path: "/repos/daintree",
+    name: "Daintree",
+    emoji: "🌳",
+    lastOpened: 0,
+    ...overrides,
+  };
+}
+
+function makeScratch(overrides: Partial<Scratch> = {}): Scratch {
+  return {
+    id: "scratch-1",
+    path: "/userData/scratches/scratch-1",
+    name: "Quick test",
+    createdAt: 0,
+    lastOpened: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  projectSlice = { projects: [], currentProject: null };
+  scratchSlice = { scratches: [], currentScratch: null };
+  getViewWorkspaceId.mockReturnValue(null);
+});
+
+describe("useWorkspaceRoot", () => {
+  it("returns null only when the view owns no workspace at all", () => {
+    // This is the one case that must still leave the sidebar unmounted (#5023).
+    const { result } = renderHook(() => useWorkspaceRoot());
+    expect(result.current).toBeNull();
+  });
+
+  it("resolves a scratch, which currentProject alone could never see (#11499)", () => {
+    const scratch = makeScratch();
+    scratchSlice = { scratches: [scratch], currentScratch: scratch };
+
+    const { result } = renderHook(() => useWorkspaceRoot());
+
+    expect(result.current).toEqual({
+      kind: "scratch",
+      id: "scratch-1",
+      path: "/userData/scratches/scratch-1",
+      name: "Quick test",
+      isGitBacked: false,
+    });
+  });
+
+  it("never reports a scratch as git-backed", () => {
+    // `isGitBackedProject(null)` answers true — absence of the discriminator
+    // means "legacy git project". Routing a scratch through it would hand the
+    // sidebar the worktree list for a workspace that has no worktrees.
+    const scratch = makeScratch();
+    scratchSlice = { scratches: [scratch], currentScratch: scratch };
+
+    const { result } = renderHook(() => useWorkspaceRoot());
+
+    expect(result.current?.isGitBacked).toBe(false);
+  });
+
+  it("treats a project with no gitBacked discriminator as git-backed", () => {
+    projectSlice = { projects: [], currentProject: makeProject() };
+
+    const { result } = renderHook(() => useWorkspaceRoot());
+
+    expect(result.current?.kind).toBe("project");
+    expect(result.current?.isGitBacked).toBe(true);
+  });
+
+  it("reports a folder opened without git as not git-backed (#11405)", () => {
+    projectSlice = { projects: [], currentProject: makeProject({ gitBacked: false }) };
+
+    const { result } = renderHook(() => useWorkspaceRoot());
+
+    expect(result.current?.isGitBacked).toBe(false);
+  });
+
+  it("names the view's own workspace, not whichever one was switched to last", () => {
+    // currentProject/currentScratch are broadcast to every view, cached ones
+    // included, so a second window switching workspaces repoints them here too.
+    // The seeded id is what keeps this view pointing at its own folder.
+    const own = makeProject({ id: "proj-own", path: "/repos/own", name: "Own" });
+    const elsewhere = makeProject({ id: "proj-other", path: "/repos/other", name: "Other" });
+    projectSlice = { projects: [own, elsewhere], currentProject: elsewhere };
+    getViewWorkspaceId.mockReturnValue("proj-own");
+
+    const { result } = renderHook(() => useWorkspaceRoot());
+
+    expect(result.current?.id).toBe("proj-own");
+    expect(result.current?.path).toBe("/repos/own");
+  });
+
+  it("resolves a scratch by seeded id even while a project is globally current", () => {
+    const scratch = makeScratch({ id: "scratch-own" });
+    projectSlice = { projects: [makeProject()], currentProject: makeProject() };
+    scratchSlice = { scratches: [scratch], currentScratch: null };
+    getViewWorkspaceId.mockReturnValue("scratch-own");
+
+    const { result } = renderHook(() => useWorkspaceRoot());
+
+    expect(result.current?.kind).toBe("scratch");
+    expect(result.current?.id).toBe("scratch-own");
+  });
+
+  it("prefers the project when an id somehow matches both collections", () => {
+    // Mirrors resolveViewWorkspace and main's project-before-scratch order, so
+    // the two sides can never pick different folders for the same id.
+    const shared = makeProject({ id: "dup" });
+    projectSlice = { projects: [shared], currentProject: null };
+    scratchSlice = { scratches: [makeScratch({ id: "dup" })], currentScratch: null };
+    getViewWorkspaceId.mockReturnValue("dup");
+
+    const { result } = renderHook(() => useWorkspaceRoot());
+
+    expect(result.current?.kind).toBe("project");
+  });
+});

--- a/src/hooks/useWorkspaceRoot.ts
+++ b/src/hooks/useWorkspaceRoot.ts
@@ -1,0 +1,95 @@
+import { useMemo } from "react";
+import { isGitBackedProject } from "@shared/types";
+import { useProjectStore } from "@/store/projectStore";
+// Leaf imports, never the `@/store` barrel: many suites mock the barrel
+// wholesale without listing these stores, and a barrel import would crash them
+// on an undefined destructure.
+import { useScratchStore } from "@/store/scratchStore";
+import { getViewWorkspaceId } from "@/store/viewWorkspaceId";
+import { resolveViewWorkspace } from "@/store/viewWorkspace";
+
+/**
+ * The workspace *this view* owns, flattened to the identity chrome needs.
+ *
+ * A view can be a git-backed project, a folder opened without git (#11405), or
+ * a scratch (#11076) — three kinds that until now only the content grid knew
+ * how to tell apart. Chrome that has to answer "is there a workspace at all,
+ * and does git apply to it" reads this instead of `currentProject != null`,
+ * which silently answered "no" for a scratch (#11499).
+ */
+export interface WorkspaceRoot {
+  kind: "project" | "scratch";
+  /** Project or scratch id — the workspace's own identity, never a worktree's. */
+  id: string;
+  /** Absolute filesystem path of the workspace root. */
+  path: string;
+  /** User-facing display name. */
+  name: string;
+  /** Whether git-backed surfaces (worktrees, review, diffs, branches) apply. */
+  isGitBacked: boolean;
+}
+
+/**
+ * Resolution rules live in {@link resolveViewWorkspace}, shared with the action
+ * context and the file browser's root so every surface names the same folder.
+ * Keyed on the view's own seeded id rather than the globally broadcast
+ * `currentProject`/`currentScratch`, which a second window switching workspaces
+ * repoints in *every* view, cached ones included.
+ *
+ * Each selector returns a store-owned object reference (or `undefined`), never a
+ * freshly built one, so Zustand's `Object.is` check keeps an unrelated
+ * collection edit from re-rendering the tree; the flattening happens in a
+ * `useMemo` downstream of both.
+ */
+export function useWorkspaceRoot(): WorkspaceRoot | null {
+  const viewWorkspaceId = getViewWorkspaceId();
+
+  const project = useProjectStore((state) => {
+    const resolved = resolveViewWorkspace({
+      viewWorkspaceId,
+      projects: state.projects,
+      currentProject: state.currentProject,
+      scratches: [],
+      currentScratch: null,
+    });
+    return resolved?.kind === "project" ? resolved.project : undefined;
+  });
+
+  // Only consulted when the project side didn't answer, so a project-owned view
+  // never pays attention to scratch churn.
+  const scratch = useScratchStore((state) => {
+    if (project !== undefined) return undefined;
+    const resolved = resolveViewWorkspace({
+      viewWorkspaceId,
+      projects: [],
+      currentProject: null,
+      scratches: state.scratches,
+      currentScratch: state.currentScratch,
+    });
+    return resolved?.kind === "scratch" ? resolved.scratch : undefined;
+  });
+
+  return useMemo<WorkspaceRoot | null>(() => {
+    if (project !== undefined) {
+      return {
+        kind: "project",
+        id: project.id,
+        path: project.path,
+        name: project.name,
+        isGitBacked: isGitBackedProject(project),
+      };
+    }
+    if (scratch !== undefined) {
+      // Hardcoded, never `isGitBackedProject(null)`: that answers `true` for the
+      // legacy no-discriminator case, and a scratch is not a project at all.
+      return {
+        kind: "scratch",
+        id: scratch.id,
+        path: scratch.path,
+        name: scratch.name,
+        isGitBacked: false,
+      };
+    }
+    return null;
+  }, [project, scratch]);
+}

--- a/src/hooks/useWorkspaceRoot.ts
+++ b/src/hooks/useWorkspaceRoot.ts
@@ -52,7 +52,15 @@ export function useWorkspaceRoot(): WorkspaceRoot | null {
       scratches: [],
       currentScratch: null,
     });
-    return resolved?.kind === "project" ? resolved.project : undefined;
+    if (resolved?.kind !== "project") return undefined;
+    // A closed project stays in `projects` — reopening it from the switcher
+    // depends on the row surviving — while this view keeps its seeded id, so
+    // `resolveViewWorkspace` still finds it after `closeActiveProject`. Mirrors
+    // `getProjectForCurrentLocation`, which drops closed rows for the same
+    // reason: the welcome screen that replaces a closed project must keep its
+    // no-sidebar state (#5023). Literal `=== "closed"` because `status` is
+    // optional and an absent one is not closed.
+    return resolved.project.status === "closed" ? undefined : resolved.project;
   });
 
   // Only consulted when the project side didn't answer, so a project-owned view


### PR DESCRIPTION
## Summary

- In a Scratch workspace the left sidebar toggle was a dead control. `AppLayout.tsx` gated both sidebar visibility and the mount of the `<Sidebar>` subtree on `currentProject != null`, while the toggle handler flipped `gestureSidebarHidden` unconditionally and the toolbar always rendered the button as available. A Scratch has no `Project` row, so the toggle and `Cmd+B` flipped the icon and `aria-pressed` over a slot that could never appear, a false state change that screen readers dutifully announced.
- The fix follows the direction set in the issue thread: the sidebar is a list of places agents run, not a file explorer. Every workspace kind has at least one such place, a git project has its main worktree plus any linked worktrees, a folder opened without git has the folder itself, a Scratch has the scratch folder. Rather than build a second view, this admits a worktree-less root into the existing list. The one-row case was already normal: a repo with zero linked worktrees already renders exactly one row.

Resolves #11499

## Changes

- New `useWorkspaceRoot` hook (`src/hooks/useWorkspaceRoot.ts`) resolves the view's own workspace, git project, folder without git, or scratch, through the existing `resolveViewWorkspace`/`getViewWorkspaceId` machinery. It's keyed on the view's immutable seeded id rather than the globally broadcast `currentProject`/`currentScratch`, following the pattern `useWorkspaceRootPath` already established.
- `AppLayout.tsx` now gates visibility and the mount on `hasWorkspace` instead of `currentProject != null`. The two gates stay separate expressions on purpose, #5697 deliberately decoupled mount from visibility so the CSS width transition runs instead of an abrupt unmount. The welcome screen, which has no workspace of any kind, still gets no sidebar, per #5023.
- New `WorkspaceRootSidebar` + `WorkspaceRootRow` render a worktree-less workspace as a single row, replacing the "Worktrees" header over an "Initialize a repository" empty state. The header now reads "Workspace", since naming the slot after a concept it can't hold was wrong for two of the three kinds.
- The row reads its terminal count and agent-state pips from the `NO_WORKTREE` bucket that panels launched without a worktree already land in, so it reflects live agents without stamping a synthetic worktree id onto any panel (which would make those panels look orphaned to every worktree-scoped pass).
- Git-shaped affordances are absent, not disabled, the JetBrains "Scratches and Consoles" model. No create-worktree, overview, refresh, search bar, quick-state filter, or fleet-arm control; the row's context menu carries only Browse files and Reveal in Finder. `Sidebar.tsx`'s background context menu likewise sheds its worktree entries off a git-backed workspace and reveals the workspace's own folder rather than offering a disabled "Reveal Project".
- The file browser stays a grid panel: `worktree.openFileBrowser` already resolves a scratch root (#11482), so a Scratch gets it via the same gesture as a git project. No sidebar file tree.
- "Initialize repository" is offered only to a real folder, never to a Scratch (app-managed and disposable), and is demoted to a quiet footer strip.

Deliberately left unchanged: `Toolbar.tsx` (the button was already correct once the sidebar could render something) and `defaultKeybindings.ts` (no `when` clause on `Cmd+B`, hiding the button was explicitly rejected in the issue as work that buys nothing except the absence of a bug).

## Testing

- 1582 tests across the full Sidebar and Layout suites plus the accent-guard contract test, all passing.
- `npm run typecheck` exits 0.
- Prettier and eslint clean on all changed files, no new warnings against the per-rule lint ratchet.
- New coverage: `useWorkspaceRoot.test.ts`, `WorkspaceRootSidebar.test.tsx`, `Sidebar.contextMenu.test.tsx`. Updated the two pinned source-contract suites: `AppLayout.sidebar.test.ts`, `SidebarContent.lightweight.test.ts`.

Known gap: there's no render-level `AppLayout` test harness in this repo (every `AppLayout.*` test reads source as a string), so the mount-gate fix is covered by a source contract plus an independent behavioural test of the hook rather than by actually rendering `AppLayout` with scratch state. Extending the existing `Cmd+B` assertions in `e2e/full/platform/core-keyboard-shortcuts.spec.ts` to a scratch workspace would be the natural E2E follow-up.
