### PR TITLE
feat(toolbar): add a file browser toggle to the toolbar buttons

### DIFF
--- a/shared/types/toolbar.ts
+++ b/shared/types/toolbar.ts
@@ -31,6 +31,7 @@ export type ToolbarButtonId =
   | BuiltInAgentId
   | "terminal"
   | "browser"
+  | "file-browser"
   | "dev-server"
   | "voice-recording"
   | "forge-stats"
@@ -52,6 +53,12 @@ export type ToolbarButtonId =
  *   - `false`      → user explicitly hid this button
  *   - `true`       → user explicitly pinned this button
  *   - `undefined`  → visible
+ *
+ * A built-in can still *ship* hidden by seeding an explicit `false` — see
+ * `file-browser` in `toolbarPreferencesStore`, which offers the button in
+ * Settings without changing anyone's existing toolbar (#11495). That seed is
+ * load-bearing, not redundant with the v12 migration: a fresh install never
+ * runs `migrate`.
  *
  * Plugin contributions default to tray-only (#11304) — they always appear in
  * the plugin tray, and `true` additionally promotes one to its own top-level
@@ -105,6 +112,7 @@ export const TOOLBAR_BUTTON_PRIORITIES: Record<ToolbarButtonId, ToolbarButtonPri
   ) as Record<BuiltInAgentId, ToolbarButtonPriority>),
   terminal: 3,
   browser: 3,
+  "file-browser": 3,
   "dev-server": 3,
   "command-palette": 4,
   "resume-sessions": 4,

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -28,7 +28,7 @@ import {
   X,
 } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
-import { Folders } from "@/components/icons";
+import { FolderTree, Folders } from "@/components/icons";
 import { buildPluginToolbarMeta } from "./pluginToolbarMeta";
 import { TOOLBAR_BUTTON_METADATA, isToolbarButtonVisible } from "./toolbarButtonMetadata";
 import { ToolbarContextMenuItems } from "./ToolbarContextMenuItems";
@@ -600,12 +600,36 @@ export function Toolbar({
   const problemsShortcut = useKeybindingDisplay("panel.toggleDiagnostics");
   const terminalShortcut = useKeybindingDisplay("agent.terminal");
   const browserShortcut = useKeybindingDisplay("agent.browser");
+  const fileBrowserShortcut = useKeybindingDisplay("worktree.openFileBrowser");
   const sidebarAriaShortcut = useAriaKeyshortcuts("nav.toggleSidebar");
   const copyTreeAriaShortcut = useAriaKeyshortcuts("worktree.copyTree");
+  const fileBrowserAriaShortcut = useAriaKeyshortcuts("worktree.openFileBrowser");
 
   const sidebarHintHover = useShortcutHintHover("nav.toggleSidebar");
   const devServerHintHover = useShortcutHintHover("devServer.start");
   const copyTreeHintHover = useShortcutHintHover("worktree.copyTree");
+  const fileBrowserHintHover = useShortcutHintHover("worktree.openFileBrowser");
+
+  // The one launcher button whose action can legitimately refuse: it resolves
+  // its own target (focused worktree, else the project or scratch root), and a
+  // workspace with nothing to browse makes it throw. `dispatch` turns that into
+  // `ok: false` rather than a rejection, so without this the press would do
+  // nothing at all. Mirrors `LauncherQuickActions`, which offers the same action.
+  // A named function expression so the retry action can name itself.
+  const openFileBrowser = useCallback(function openFileBrowser() {
+    void actionService
+      .dispatch("worktree.openFileBrowser", undefined, { source: "user" })
+      .then((result) => {
+        if (result.ok) return;
+        notify({
+          type: "error",
+          title: "Couldn't open the file browser",
+          message: "No folder resolved for this workspace. Select a worktree and try again.",
+          context: { eventKind: "uiFeedback" },
+          action: { label: "Retry", onClick: openFileBrowser },
+        });
+      });
+  }, []);
 
   const handleOpenProjectSettings = useCallback(() => {
     projectSwitcher.close();
@@ -924,6 +948,41 @@ export function Toolbar({
         ),
         isAvailable: true,
       },
+      "file-browser": {
+        // Deliberately not in PROJECT_SCOPED_TOOLBAR_IDS: the action browses the
+        // project or scratch root when no worktree is selected (#11482), so
+        // gating it on `currentProject` would disable it in exactly the
+        // worktree-less workspaces where it still works.
+        render: () => (
+          <ContextMenu>
+            <ContextMenuTrigger asChild>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    {...fileBrowserHintHover}
+                    variant="ghost"
+                    size="icon"
+                    data-toolbar-item=""
+                    onClick={openFileBrowser}
+                    className={toolbarIconButtonClass}
+                    aria-label="Browse files"
+                    aria-keyshortcuts={fileBrowserAriaShortcut}
+                  >
+                    <FolderTree />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  {createTooltipContent("Browse files", fileBrowserShortcut)}
+                </TooltipContent>
+              </Tooltip>
+            </ContextMenuTrigger>
+            <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
+              <ToolbarContextMenuItems buttonId="file-browser" side="left" />
+            </ContextMenuContent>
+          </ContextMenu>
+        ),
+        isAvailable: true,
+      },
       "dev-server": {
         render: () =>
           currentProject ? (
@@ -1148,6 +1207,10 @@ export function Toolbar({
       pluginConfigs,
       devServerShortcut,
       devServerHintHover,
+      openFileBrowser,
+      fileBrowserShortcut,
+      fileBrowserAriaShortcut,
+      fileBrowserHintHover,
     ]
   );
 
@@ -1363,6 +1426,7 @@ export function Toolbar({
       ...Object.fromEntries(LAUNCHABLE_AGENT_IDS.map((id) => [id, () => onLaunchAgent(id)])),
       terminal: () => onLaunchAgent("terminal"),
       browser: () => onLaunchAgent("browser"),
+      "file-browser": openFileBrowser,
       "dev-server": () => {
         void actionService.dispatch("devServer.start", undefined, { source: "user" });
       },
@@ -1400,6 +1464,7 @@ export function Toolbar({
     }),
     [
       onLaunchAgent,
+      openFileBrowser,
       handleCopyTreeOverflow,
       onSettings,
       onToggleProblems,
@@ -1418,6 +1483,7 @@ export function Toolbar({
     problems: problemsShortcut,
     terminal: terminalShortcut,
     browser: browserShortcut,
+    "file-browser": fileBrowserShortcut,
   };
 
   const renderOverflowMenu = (

--- a/src/components/Layout/__tests__/Toolbar.overflow.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.overflow.test.ts
@@ -94,6 +94,28 @@ describe("Toolbar overflow menu state preservation — issue #9821", () => {
       expect(source).toMatch(/terminal:\s*terminalShortcut/);
       expect(source).toMatch(/browser:\s*browserShortcut/);
     });
+
+    it("wires the file browser's shortcut hint like the other launchers (#11495)", () => {
+      expect(source).toContain('useKeybindingDisplay("worktree.openFileBrowser")');
+      expect(source).toMatch(/"file-browser":\s*fileBrowserShortcut/);
+    });
+  });
+
+  describe("file browser overflow item — issue #11495", () => {
+    it("reuses the visible button's handler rather than re-dispatching inline", () => {
+      // One handler for the button, the overflow item, and the Retry action, so
+      // the refusal path can't drift between them.
+      expect(source).toMatch(/"file-browser":\s*openFileBrowser,/);
+    });
+
+    it("surfaces the refusal instead of pressing silently", () => {
+      // `worktree.openFileBrowser` resolves its own target and throws when a
+      // workspace has nothing to browse; dispatch converts that to ok:false, so
+      // without this branch the press would do nothing at all.
+      expect(source).toMatch(/if \(result\.ok\) return;/);
+      expect(source).toContain("Couldn't open the file browser");
+      expect(source).toMatch(/label: "Retry", onClick: openFileBrowser/);
+    });
   });
 
   describe("review fixes", () => {

--- a/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
@@ -68,6 +68,26 @@ describe("Toolbar shortcut tooltips — issue #3443", () => {
     it("uses dynamic hook for devServer.start", () => {
       expect(source).toContain('useKeybindingDisplay("devServer.start")');
     });
+
+    it("uses dynamic hook for worktree.openFileBrowser", () => {
+      expect(source).toContain('useKeybindingDisplay("worktree.openFileBrowser")');
+    });
+  });
+
+  describe("file browser button accessibility — issue #11495", () => {
+    it("announces its shortcut and shows the hover hint like its siblings", () => {
+      // The three-hook set every shortcut-bearing toolbar button carries: the
+      // tooltip display string, the aria-keyshortcuts value for screen readers,
+      // and the press-and-hold hover hint.
+      expect(source).toContain('useAriaKeyshortcuts("worktree.openFileBrowser")');
+      expect(source).toContain('useShortcutHintHover("worktree.openFileBrowser")');
+      expect(source).toContain("aria-keyshortcuts={fileBrowserAriaShortcut}");
+      expect(source).toContain("{...fileBrowserHintHover}");
+    });
+
+    it("uses createTooltipContent for the file browser tooltip", () => {
+      expect(source).toContain('createTooltipContent("Browse files", fileBrowserShortcut)');
+    });
   });
 
   describe("no hardcoded shortcut strings in tooltips", () => {

--- a/src/components/Layout/toolbarButtonMetadata.ts
+++ b/src/components/Layout/toolbarButtonMetadata.ts
@@ -11,7 +11,7 @@ import {
   SquareMenu,
   SquareTerminal,
 } from "lucide-react";
-import { Folders, History, Package } from "@/components/icons";
+import { FolderTree, Folders, History, Package } from "@/components/icons";
 import {
   BUILT_IN_AGENT_IDS,
   isBuiltInAgentId,
@@ -73,6 +73,11 @@ export const TOOLBAR_BUTTON_METADATA: Partial<Record<AnyToolbarButtonId, Toolbar
     label: "Browser",
     icon: Globe,
     description: "Open browser panel",
+  },
+  "file-browser": {
+    label: "Browse files",
+    icon: FolderTree,
+    description: "Open the file browser for the active worktree or workspace",
   },
   "dev-server": {
     label: "Dev preview",

--- a/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
@@ -319,6 +319,38 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     expect(toggleButtonVisibilityMock).toHaveBeenCalledWith("copy-tree", "right");
   });
 
+  it("lists the hidden-by-default file browser with its switch off (#11495)", () => {
+    // The whole point of the issue: the button has to be *offered* in Settings
+    // while staying off the toolbar until the user opts in. A fixture of its own
+    // rather than the shared default, so the visible-count and drag-array
+    // expectations elsewhere in this file stay put.
+    mockToolbarState = makeToolbarState({
+      leftButtons: ["terminal", "browser", "file-browser", "dev-server"],
+      rightButtons: ["settings"],
+      pinnedButtons: { "file-browser": false },
+    });
+
+    const { getByLabelText } = render(<ToolbarSettingsTab />);
+    const toggle = getByLabelText("Toggle Browse files visibility");
+
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("routes the file browser opt-in to toggleButtonVisibility on its own side", () => {
+    mockToolbarState = makeToolbarState({
+      leftButtons: ["terminal", "file-browser"],
+      rightButtons: ["settings"],
+      pinnedButtons: { "file-browser": false },
+    });
+
+    const { getByLabelText } = render(<ToolbarSettingsTab />);
+    fireEvent.click(getByLabelText("Toggle Browse files visibility"));
+
+    expect(toggleButtonVisibilityMock).toHaveBeenCalledTimes(1);
+    expect(toggleButtonVisibilityMock).toHaveBeenCalledWith("file-browser", "left");
+    expect(setAgentPinnedMock).not.toHaveBeenCalled();
+  });
+
   it("reflects pinned agents in the side visible-count summary", () => {
     mockAgentSettings = agentSettings({
       claude: { pinned: true },

--- a/src/hooks/__tests__/useToolbarOverflow.test.ts
+++ b/src/hooks/__tests__/useToolbarOverflow.test.ts
@@ -92,6 +92,22 @@ describe("computeOverflow", () => {
     expect(result.visibleIds).toEqual(["terminal"]);
   });
 
+  it("collapses dev-server before a newly enabled file browser (#11495)", () => {
+    // Why file-browser sits before dev-server in the default left order rather
+    // than at the end: the four launchers share priority 3, so the tie is broken
+    // by position and the last one goes first. Placed last, the button a user had
+    // just switched on would be the first thing to vanish — an opt-in that looks
+    // broken. This asserts the resulting order, not the constant itself.
+    const ordered: ToolbarButtonId[] = ["terminal", "browser", "file-browser", "dev-server"];
+    const widths = makeWidths(ordered, 40);
+    // Total 160 in a 130 container. The removal loop stops only once the running
+    // width is *strictly* under target, so the container needs real slack past
+    // the three survivors (120) — at exactly 120 it evicts a second button.
+    const result = computeOverflow(130, widths, ordered, TOOLBAR_BUTTON_PRIORITIES);
+    expect(result.overflowIds).toEqual(["dev-server"]);
+    expect(result.visibleIds).toContain("file-browser");
+  });
+
   describe("pinnedIds — issue #8158", () => {
     it("keeps a pinned item visible even when the container is too narrow", () => {
       const ordered: ToolbarButtonId[] = ["voice-recording", "settings", "copy-tree"];

--- a/src/store/__tests__/toolbarPreferencesStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.crossViewMerge.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
  */
 describe("toolbarPreferencesStore cross-view write merge (#11351)", () => {
   const STORAGE_KEY = "daintree-toolbar-preferences";
-  const VERSION = 11;
+  const VERSION = 12;
   const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
 
   type Layout = {

--- a/src/store/__tests__/toolbarPreferencesStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.crossViewMerge.test.ts
@@ -123,6 +123,51 @@ describe("toolbarPreferencesStore cross-view write merge (#11351)", () => {
     expect(written.state.launcher.alwaysShowDevServer).toBe(true);
   });
 
+  it("does not revert a sibling's file-browser opt-in from an untouched default (#11495)", async () => {
+    // `file-browser` ships hidden, so every fresh view holds `false` without the
+    // user having chosen it. If the null baseline normalizes to `{}`, that
+    // untouched `false` reads as this view's own edit and overwrites a sibling
+    // view that legitimately turned the button on.
+    const backing = installLocalStorage({});
+    const { useToolbarPreferencesStore: store } = await import("../toolbarPreferencesStore");
+
+    // A sibling view enabled the file browser — the toggle deletes the key.
+    backing.set(
+      STORAGE_KEY,
+      siblingBlob({
+        layout: { leftButtons: [], rightButtons: [], pinnedButtons: {} },
+      })
+    );
+
+    // This view changes something unrelated and must not carry its own default over.
+    store.getState().setAlwaysShowDevServer(true);
+
+    const written = readBlob(backing);
+    expect(written.state.layout.pinnedButtons["file-browser"]).toBeUndefined();
+    expect(written.state.launcher.alwaysShowDevServer).toBe(true);
+  });
+
+  it("still writes its own explicit file-browser hide over a sibling's opt-in", async () => {
+    // The mirror of the case above: when the user in THIS view actually turns the
+    // button off, that is a real edit and must win. Distinguishing the two is the
+    // whole point of separating "no stored map" from "an explicitly empty one".
+    const backing = installLocalStorage({});
+    const { useToolbarPreferencesStore: store } = await import("../toolbarPreferencesStore");
+
+    // Start from the opt-in state so the toggle records a departure from it.
+    store.getState().toggleButtonVisibility("file-browser", "left");
+    expect(store.getState().layout.pinnedButtons["file-browser"]).toBeUndefined();
+
+    backing.set(
+      STORAGE_KEY,
+      siblingBlob({ layout: { leftButtons: [], rightButtons: [], pinnedButtons: {} } })
+    );
+
+    store.getState().toggleButtonVisibility("file-browser", "left");
+
+    expect(readBlob(backing).state.layout.pinnedButtons["file-browser"]).toBe(false);
+  });
+
   it("does not resurrect a pin a sibling deleted that this view still holds unchanged", async () => {
     const backing = installLocalStorage({
       [STORAGE_KEY]: JSON.stringify({

--- a/src/store/__tests__/toolbarPreferencesStore.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AnyToolbarButtonId, PluginToolbarButtonId } from "@/../../shared/types/toolbar";
+import type {
+  AnyToolbarButtonId,
+  PluginToolbarButtonId,
+  ToolbarPinnedState,
+} from "@/../../shared/types/toolbar";
 
 // Mirror the production agent IDs so the v5 migration is exercised against
 // the real set, not a subset. Keeping the mock in sync guards against
@@ -76,6 +80,26 @@ function installStorageMock() {
 
 function setStoredState(state: Record<string, unknown>, version = 2) {
   storageMock.setItem(STORAGE_KEY, JSON.stringify({ state, version }));
+}
+
+/**
+ * `pinnedButtons` minus the hides that ship as defaults — currently just
+ * `file-browser`, which the store seeds and the v12 migration stamps onto every
+ * older profile so a new built-in can be offered in Settings without appearing
+ * on anyone's toolbar (#11495).
+ *
+ * The per-version cases below assert what their own migration step produced, so
+ * they compare against this rather than the raw map; the seed itself is covered
+ * by the v11→v12 block. Filtering in one place is what keeps the next
+ * ships-hidden button a one-line change here instead of an edit to every
+ * expectation in the file.
+ */
+function pinsWithoutShippedHides(pinned: ToolbarPinnedState): Record<string, boolean> {
+  const rest: Record<string, boolean> = {};
+  for (const [key, value] of Object.entries(pinned)) {
+    if (key !== "file-browser" && typeof value === "boolean") rest[key] = value;
+  }
+  return rest;
 }
 
 async function loadStore() {
@@ -365,7 +389,7 @@ describe("toolbarPreferencesStore", () => {
       store.getState().setLeftButtons([...store.getState().layout.leftButtons].reverse());
 
       store.getState().reset();
-      expect(store.getState().layout.pinnedButtons).toEqual({});
+      expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({});
       expect(store.getState().layout.leftButtons).toEqual(defaults.leftButtons);
       expect(store.getState().layout.rightButtons).toEqual(defaults.rightButtons);
     });
@@ -419,7 +443,7 @@ describe("toolbarPreferencesStore", () => {
 
       const store = await loadStore();
       // v9→v10 renames "github-stats" to "forge-stats" after the v8 conversion.
-      expect(store.getState().layout.pinnedButtons).toEqual({
+      expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({
         terminal: false,
         "forge-stats": false,
         "copy-tree": false,
@@ -466,7 +490,7 @@ describe("toolbarPreferencesStore", () => {
       );
 
       const store = await loadStore();
-      expect(store.getState().layout.pinnedButtons).toEqual({});
+      expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({});
     });
 
     it("includes dev-server in default left buttons", async () => {
@@ -696,7 +720,7 @@ describe("toolbarPreferencesStore", () => {
       const store = await loadStore();
       const { layout } = store.getState();
       // Agent IDs stripped at v5, then v8 converts the remainder to a map.
-      expect(layout.pinnedButtons).toEqual({ "copy-tree": false });
+      expect(pinsWithoutShippedHides(layout.pinnedButtons)).toEqual({ "copy-tree": false });
       // Ordering arrays untouched.
       expect(layout.leftButtons).toContain("claude");
       expect(layout.leftButtons).toContain("gemini");
@@ -731,7 +755,9 @@ describe("toolbarPreferencesStore", () => {
 
       const store = await loadStore();
       // All built-in agent IDs stripped; non-agent entry survives into pinnedButtons.
-      expect(store.getState().layout.pinnedButtons).toEqual({ "copy-tree": false });
+      expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({
+        "copy-tree": false,
+      });
     });
 
     it("v4→v5 leaves non-agent hidden entries untouched into pinnedButtons", async () => {
@@ -751,7 +777,7 @@ describe("toolbarPreferencesStore", () => {
       );
 
       const store = await loadStore();
-      expect(store.getState().layout.pinnedButtons).toEqual({
+      expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({
         "forge-stats": false,
         "copy-tree": false,
       });
@@ -778,7 +804,9 @@ describe("toolbarPreferencesStore", () => {
       );
 
       const store = await loadStore();
-      expect(store.getState().layout.pinnedButtons).toEqual({ "copy-tree": false });
+      expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({
+        "copy-tree": false,
+      });
       // Ordering arrays untouched.
       expect(store.getState().layout.leftButtons).toContain("claude");
     });
@@ -852,7 +880,7 @@ describe("toolbarPreferencesStore", () => {
       expect(layout.leftButtons).toContain("terminal");
       expect(layout.leftButtons).toContain("browser");
       expect(layout.rightButtons).toContain("settings");
-      expect(layout.pinnedButtons).toEqual({});
+      expect(pinsWithoutShippedHides(layout.pinnedButtons)).toEqual({});
     });
 
     it("sanitizeButtonList strips assistant-toggle when set via setRightButtons", async () => {
@@ -918,7 +946,7 @@ describe("toolbarPreferencesStore", () => {
       // v0→v1: resets defaultSelection that was "dev-server"
       expect(store.getState().launcher.defaultSelection).toBeUndefined();
       // v7→v8: replaces the hiddenButtons array with the pinnedButtons map.
-      expect(store.getState().layout.pinnedButtons).toEqual({});
+      expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({});
     });
 
     describe("v7→v8 hiddenButtons → pinnedButtons", () => {
@@ -940,7 +968,7 @@ describe("toolbarPreferencesStore", () => {
 
         const store = await loadStore();
         const { layout } = store.getState();
-        expect(layout.pinnedButtons).toEqual({
+        expect(pinsWithoutShippedHides(layout.pinnedButtons)).toEqual({
           terminal: false,
           "copy-tree": false,
         });
@@ -968,7 +996,7 @@ describe("toolbarPreferencesStore", () => {
         );
 
         const store = await loadStore();
-        expect(store.getState().layout.pinnedButtons).toEqual({});
+        expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({});
       });
 
       it("synthesizes a v8 layout shape when v7 state lacks the layout block", async () => {
@@ -983,7 +1011,7 @@ describe("toolbarPreferencesStore", () => {
         const store = await loadStore();
         // merge() should fall back to defaults rather than crash; pinnedButtons
         // must still be the canonical empty map.
-        expect(store.getState().layout.pinnedButtons).toEqual({});
+        expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({});
         expect(store.getState().layout.leftButtons).toBeDefined();
       });
 
@@ -1008,7 +1036,7 @@ describe("toolbarPreferencesStore", () => {
         );
 
         const store = await loadStore();
-        expect(store.getState().layout.pinnedButtons).toEqual({
+        expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({
           terminal: true,
           "copy-tree": false,
         });
@@ -1031,7 +1059,9 @@ describe("toolbarPreferencesStore", () => {
         );
 
         const store = await loadStore();
-        expect(store.getState().layout.pinnedButtons).toEqual({ "copy-tree": false });
+        expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({
+          "copy-tree": false,
+        });
       });
     });
 
@@ -1082,7 +1112,7 @@ describe("toolbarPreferencesStore", () => {
         );
 
         const store = await loadStore();
-        expect(store.getState().layout.pinnedButtons).toEqual({
+        expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({
           "copy-tree": false,
           terminal: false,
         });
@@ -1162,7 +1192,9 @@ describe("toolbarPreferencesStore", () => {
         );
 
         const store = await loadStore();
-        expect(store.getState().layout.pinnedButtons).toEqual({ "forge-stats": false });
+        expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({
+          "forge-stats": false,
+        });
         expect(store.getState().layout.rightButtons).toContain("forge-stats");
       });
 
@@ -1227,14 +1259,17 @@ describe("toolbarPreferencesStore", () => {
         );
         expect(rightButtons.indexOf("forge-stats")).toBeLessThan(rightButtons.indexOf("settings"));
         // The pin map is a Record — unique keys by construction, left untouched.
-        expect(pinnedButtons).toEqual({ "forge-stats": false });
+        expect(pinsWithoutShippedHides(pinnedButtons)).toEqual({ "forge-stats": false });
       });
 
-      it("heals duplicates on an already-current v11 blob via merge() (#10937)", async () => {
+      it("heals duplicates on an already-current blob via merge() (#10937)", async () => {
         // The durable guard lives in `sanitizeButtonList`, run on every
         // hydration through `merge()` — not only the version-gated migration —
-        // so a blob already stamped v11 that still carries duplicates (a stale
-        // dev build re-corrupting a shared profile) is repaired regardless.
+        // so a blob already stamped at the current version that still carries
+        // duplicates (a stale dev build re-corrupting a shared profile) is
+        // repaired regardless. Stamped current on purpose: at an older version
+        // the migrate chain would run too, and this case is about `merge()`
+        // healing on its own.
         storageMock.setItem(
           STORAGE_KEY,
           JSON.stringify({
@@ -1246,7 +1281,7 @@ describe("toolbarPreferencesStore", () => {
               },
               launcher: { alwaysShowDevServer: false },
             },
-            version: 11,
+            version: 12,
           })
         );
 
@@ -1255,6 +1290,195 @@ describe("toolbarPreferencesStore", () => {
           store.getState().layout.rightButtons.filter((id) => id === "forge-stats")
         ).toHaveLength(1);
       });
+    });
+
+    describe("v11→v12 file-browser ships hidden (#11495)", () => {
+      it("hides file-browser for a profile that has never seen the button", async () => {
+        storageMock.setItem(
+          STORAGE_KEY,
+          JSON.stringify({
+            state: {
+              layout: {
+                leftButtons: ["terminal", "browser", "dev-server"],
+                rightButtons: ["settings"],
+                pinnedButtons: {},
+              },
+              launcher: { alwaysShowDevServer: false },
+            },
+            version: 11,
+          })
+        );
+
+        const store = await loadStore();
+        const { leftButtons, rightButtons, pinnedButtons } = store.getState().layout;
+        expect(pinnedButtons["file-browser"]).toBe(false);
+        // Offered in Settings (so it needs a position) but not on the toolbar.
+        expect(
+          [...leftButtons, ...rightButtons].filter((id) => id === "file-browser")
+        ).toHaveLength(1);
+      });
+
+      it("hides file-browser even for a heavily customized layout, with no carve-out", async () => {
+        // The reflexive instinct is to infer "this user would want it" from what
+        // they already show. #10709: a newly-introduced default belongs in the
+        // safe state for every pre-existing profile, unconditionally — otherwise
+        // the migration hands some users a toolbar change they never asked for.
+        storageMock.setItem(
+          STORAGE_KEY,
+          JSON.stringify({
+            state: {
+              layout: {
+                leftButtons: ["browser", "terminal"],
+                rightButtons: ["copy-tree", "settings", "problems"],
+                pinnedButtons: { "copy-tree": false, terminal: true, "acme.tool": true },
+              },
+              launcher: { alwaysShowDevServer: true, defaultSelection: "browser" },
+            },
+            version: 11,
+          })
+        );
+
+        const store = await loadStore();
+        const { pinnedButtons } = store.getState().layout;
+        const { launcher } = store.getState();
+        expect(pinnedButtons["file-browser"]).toBe(false);
+        // Every unrelated preference survives the step untouched.
+        expect(pinsWithoutShippedHides(pinnedButtons)).toEqual({
+          "copy-tree": false,
+          terminal: true,
+          "acme.tool": true,
+        });
+        expect(launcher.alwaysShowDevServer).toBe(true);
+      });
+
+      it("overwrites a stray pre-v12 file-browser opt-in", async () => {
+        // `file-browser` was not a shipped built-in before v12, so a `true` here
+        // can only be junk (a hand-edited profile, or a dev build that carried
+        // the id early). Treating it as a user choice would let exactly the
+        // toolbar change this migration exists to prevent through.
+        storageMock.setItem(
+          STORAGE_KEY,
+          JSON.stringify({
+            state: {
+              layout: {
+                leftButtons: ["terminal", "file-browser"],
+                rightButtons: ["settings"],
+                pinnedButtons: { "file-browser": true },
+              },
+              launcher: { alwaysShowDevServer: false },
+            },
+            version: 11,
+          })
+        );
+
+        const store = await loadStore();
+        expect(store.getState().layout.pinnedButtons["file-browser"]).toBe(false);
+      });
+
+      it("synthesizes a layout when a pre-v12 blob has none", async () => {
+        storageMock.setItem(
+          STORAGE_KEY,
+          JSON.stringify({
+            state: { launcher: { alwaysShowDevServer: false } },
+            version: 11,
+          })
+        );
+
+        const store = await loadStore();
+        expect(store.getState().layout.pinnedButtons["file-browser"]).toBe(false);
+      });
+
+      it("keeps an opt-in made after the migration ran", async () => {
+        // Already at the current version, so `migrate` does not run again — a
+        // user who turned the button on must not have it switched back off on
+        // every subsequent launch.
+        storageMock.setItem(
+          STORAGE_KEY,
+          JSON.stringify({
+            state: {
+              layout: {
+                leftButtons: ["terminal", "file-browser"],
+                rightButtons: ["settings"],
+                pinnedButtons: {},
+              },
+              launcher: { alwaysShowDevServer: false },
+            },
+            version: 12,
+          })
+        );
+
+        const store = await loadStore();
+        // No entry at all is the "visible" state for a built-in, which is what
+        // `toggleButtonVisibility` leaves behind when a user re-enables it.
+        expect(store.getState().layout.pinnedButtons["file-browser"]).toBeUndefined();
+      });
+    });
+  });
+
+  describe("file-browser defaults (#11495)", () => {
+    it("offers file-browser on the left between browser and dev-server, hidden", async () => {
+      // No stored state on purpose: a fresh install never runs `migrate`, so the
+      // store's own defaults are the only thing standing between a new user and
+      // a toolbar button the issue says must be opt-in.
+      const store = await loadStore();
+      const { leftButtons, pinnedButtons } = store.getState().layout;
+
+      expect(pinnedButtons["file-browser"]).toBe(false);
+      expect(leftButtons.indexOf("browser")).toBeLessThan(leftButtons.indexOf("file-browser"));
+      expect(leftButtons.indexOf("file-browser")).toBeLessThan(leftButtons.indexOf("dev-server"));
+    });
+
+    it("keeps file-browser on the side the user moved it to across hydration", async () => {
+      // `mergeButtonList` re-materializes a default that is missing from its home
+      // side. Without the cross-side check that means a switched button lands on
+      // BOTH sides — `sanitizeButtonList` dedupes within a side, never across —
+      // so it would render twice and the side switch would look like it failed.
+      storageMock.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            layout: {
+              leftButtons: ["terminal", "browser", "dev-server"],
+              rightButtons: ["file-browser", "settings"],
+              pinnedButtons: {},
+            },
+            launcher: { alwaysShowDevServer: false },
+          },
+          version: 12,
+        })
+      );
+
+      const store = await loadStore();
+      const { leftButtons, rightButtons } = store.getState().layout;
+      expect(rightButtons).toContain("file-browser");
+      expect(leftButtons).not.toContain("file-browser");
+      expect([...leftButtons, ...rightButtons].filter((id) => id === "file-browser")).toHaveLength(
+        1
+      );
+    });
+
+    it("does not re-home any moved default, not just file-browser", async () => {
+      // The same hydration bug applies to every default. `terminal` is the
+      // longest-standing left-side default, so it is the honest regression probe.
+      storageMock.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            layout: {
+              leftButtons: ["browser"],
+              rightButtons: ["terminal", "settings"],
+              pinnedButtons: {},
+            },
+            launcher: { alwaysShowDevServer: false },
+          },
+          version: 12,
+        })
+      );
+
+      const store = await loadStore();
+      const { leftButtons, rightButtons } = store.getState().layout;
+      expect(leftButtons).not.toContain("terminal");
+      expect(rightButtons).toContain("terminal");
     });
   });
 });

--- a/src/store/__tests__/toolbarPreferencesStore.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.test.ts
@@ -1148,14 +1148,20 @@ describe("toolbarPreferencesStore", () => {
     });
 
     describe("v9→v10 forge-stats rename", () => {
-      it("renames github-stats in position arrays and pinned keys", async () => {
+      // These two cases previously shared one fixture that placed `github-stats`
+      // on both sides at once and asserted `forge-stats` on both afterwards. The
+      // rename covering each array is the real subject; the duplication was only
+      // a shortcut for exercising both branches, and hydration now collapses a
+      // cross-side pair (the duplicate-pill defect behind #10937/#10938) — so the
+      // fixture is split rather than the heal weakened.
+      it("renames github-stats in the left array and the pinned keys", async () => {
         storageMock.setItem(
           STORAGE_KEY,
           JSON.stringify({
             state: {
               layout: {
                 leftButtons: ["terminal", "github-stats"],
-                rightButtons: ["github-stats", "settings"],
+                rightButtons: ["settings"],
                 pinnedButtons: { "github-stats": false, "copy-tree": false },
               },
               launcher: { alwaysShowDevServer: false },
@@ -1165,14 +1171,35 @@ describe("toolbarPreferencesStore", () => {
         );
 
         const store = await loadStore();
-        const { leftButtons, rightButtons, pinnedButtons } = store.getState().layout;
+        const { leftButtons, pinnedButtons } = store.getState().layout;
         expect(leftButtons).toContain("forge-stats");
         expect(leftButtons).not.toContain("github-stats");
-        expect(rightButtons).toContain("forge-stats");
-        expect(rightButtons).not.toContain("github-stats");
         expect(pinnedButtons["forge-stats"]).toBe(false);
         expect(pinnedButtons["copy-tree"]).toBe(false);
         expect(pinnedButtons).not.toHaveProperty("github-stats");
+      });
+
+      it("renames github-stats in the right array", async () => {
+        storageMock.setItem(
+          STORAGE_KEY,
+          JSON.stringify({
+            state: {
+              layout: {
+                leftButtons: ["terminal"],
+                rightButtons: ["github-stats", "settings"],
+                pinnedButtons: { "github-stats": false },
+              },
+              launcher: { alwaysShowDevServer: false },
+            },
+            version: 9,
+          })
+        );
+
+        const store = await loadStore();
+        const { rightButtons, pinnedButtons } = store.getState().layout;
+        expect(rightButtons).toContain("forge-stats");
+        expect(rightButtons).not.toContain("github-stats");
+        expect(pinnedButtons["forge-stats"]).toBe(false);
       });
 
       it("is a no-op on already-renamed v10-shaped state", async () => {
@@ -1455,6 +1482,88 @@ describe("toolbarPreferencesStore", () => {
       expect([...leftButtons, ...rightButtons].filter((id) => id === "file-browser")).toHaveLength(
         1
       );
+    });
+
+    it("stays hidden for a current-version blob whose layout carries no pin map", async () => {
+      // A blob already stamped v12 never reaches `migrate`, so `merge()` is the
+      // only thing standing between a missing pin map and a visible button.
+      // Falling back to `{}` here would read as "no pins" — i.e. visible.
+      storageMock.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            layout: { leftButtons: ["terminal", "file-browser"], rightButtons: ["settings"] },
+            launcher: { alwaysShowDevServer: false },
+          },
+          version: 12,
+        })
+      );
+
+      const store = await loadStore();
+      expect(store.getState().layout.pinnedButtons["file-browser"]).toBe(false);
+    });
+
+    it("hydrates cleanly with no persisted blob at all", async () => {
+      // zustand calls `merge` even when storage is empty. This used to throw
+      // inside the merge and get swallowed, leaving the right state by accident
+      // and `hasHydrated()` stuck false — assert the outcome is now deliberate.
+      const store = await loadStore();
+
+      expect(store.persist.hasHydrated()).toBe(true);
+      expect(store.getState().layout.pinnedButtons["file-browser"]).toBe(false);
+      expect(store.getState().layout.leftButtons).toContain("file-browser");
+    });
+
+    it("heals a default already duplicated onto both sides by the old hydration", async () => {
+      // Profiles corrupted before the cross-side fix carry the id twice. The
+      // survivor is the non-home side, which is where the user had dragged it.
+      storageMock.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            layout: {
+              leftButtons: ["terminal", "browser", "file-browser"],
+              rightButtons: ["file-browser", "settings"],
+              pinnedButtons: {},
+            },
+            launcher: { alwaysShowDevServer: false },
+          },
+          version: 12,
+        })
+      );
+
+      const store = await loadStore();
+      const { leftButtons, rightButtons } = store.getState().layout;
+      expect([...leftButtons, ...rightButtons].filter((id) => id === "file-browser")).toHaveLength(
+        1
+      );
+      expect(rightButtons).toContain("file-browser");
+      expect(leftButtons).not.toContain("file-browser");
+    });
+
+    it("heals a right-side default duplicated onto the left, keeping the moved copy", async () => {
+      // Mirror direction: `copy-tree` is a right-side default, so a both-sides
+      // pair means the user moved it left and the left copy is the survivor.
+      storageMock.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            layout: {
+              leftButtons: ["terminal", "copy-tree"],
+              rightButtons: ["copy-tree", "settings"],
+              pinnedButtons: {},
+            },
+            launcher: { alwaysShowDevServer: false },
+          },
+          version: 12,
+        })
+      );
+
+      const store = await loadStore();
+      const { leftButtons, rightButtons } = store.getState().layout;
+      expect([...leftButtons, ...rightButtons].filter((id) => id === "copy-tree")).toHaveLength(1);
+      expect(leftButtons).toContain("copy-tree");
+      expect(rightButtons).not.toContain("copy-tree");
     });
 
     it("does not re-home any moved default, not just file-browser", async () => {

--- a/src/store/__tests__/toolbarPreferencesStore.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.test.ts
@@ -1514,6 +1514,43 @@ describe("toolbarPreferencesStore", () => {
       expect(store.getState().layout.leftButtons).toContain("file-browser");
     });
 
+    it("restores the hidden default on a re-hydrate onto a blob with no pin map", async () => {
+      // zustand hands `merge` the LIVE state on a second `rehydrate()`, not the
+      // creator defaults, so resolving a missing pin map from current state would
+      // carry the previous blob's opt-in into one that has none.
+      storageMock.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            layout: {
+              leftButtons: ["terminal", "file-browser"],
+              rightButtons: ["settings"],
+              pinnedButtons: {},
+            },
+            launcher: { alwaysShowDevServer: false },
+          },
+          version: 12,
+        })
+      );
+
+      const store = await loadStore();
+      expect(store.getState().layout.pinnedButtons["file-browser"]).toBeUndefined();
+
+      storageMock.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            layout: { leftButtons: ["terminal", "file-browser"], rightButtons: ["settings"] },
+            launcher: { alwaysShowDevServer: false },
+          },
+          version: 12,
+        })
+      );
+      await store.persist.rehydrate();
+
+      expect(store.getState().layout.pinnedButtons["file-browser"]).toBe(false);
+    });
+
     it("heals a default already duplicated onto both sides by the old hydration", async () => {
       // Profiles corrupted before the cross-side fix carry the id twice. The
       // survivor is the non-home side, which is where the user had dragged it.

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -22,6 +22,7 @@ const DEFAULT_LEFT_BUTTONS: ToolbarButtonId[] = [
   ...(LAUNCHABLE_AGENT_IDS as unknown as ToolbarButtonId[]),
   "terminal",
   "browser",
+  "file-browser",
   "dev-server",
 ];
 
@@ -41,7 +42,12 @@ const DEFAULT_PREFERENCES: ToolbarPreferences = {
   layout: {
     leftButtons: DEFAULT_LEFT_BUTTONS,
     rightButtons: DEFAULT_RIGHT_BUTTONS,
-    pinnedButtons: {},
+    // `file-browser` is offered in Settings but ships hidden, so adding it to
+    // the defaults above doesn't change any existing toolbar (#11495). Seeding
+    // the `false` here is not redundant with the v12 migration: a fresh install
+    // has no persisted blob, so `migrate` never runs and this object is the only
+    // source of truth for that profile.
+    pinnedButtons: { "file-browser": false },
   },
   launcher: {
     alwaysShowDevServer: false,
@@ -67,24 +73,35 @@ function sanitizeButtonList(buttons: AnyToolbarButtonId[]): AnyToolbarButtonId[]
  * Merge persisted button list with defaults, adding any new buttons that
  * were added to defaults after the user's preferences were saved.
  * New buttons are added at their default position.
+ *
+ * `otherSidePersisted` is the opposite side's persisted list, and it is what
+ * makes a side switch survive a reload. `sanitizeButtonList` dedupes within a
+ * side but cannot see across the two, so without this check a default that the
+ * user dragged to the other side reads as "missing" here and gets
+ * re-materialized on its home side — leaving the id on BOTH sides, rendering
+ * twice. Defaults own insertion and ordering; a persisted position on either
+ * side always wins over the default one.
  */
 function mergeButtonList(
   persisted: AnyToolbarButtonId[] | undefined,
-  defaults: AnyToolbarButtonId[]
+  defaults: AnyToolbarButtonId[],
+  otherSidePersisted: AnyToolbarButtonId[] | undefined
 ): AnyToolbarButtonId[] {
-  if (!persisted) return defaults;
+  const onOtherSide = new Set(otherSidePersisted ?? []);
+  // No list of our own: still honor a default the user parked on the other side.
+  if (!persisted) return defaults.filter((id) => !onOtherSide.has(id));
 
-  const persistedSet = new Set(persisted);
+  const positioned = new Set([...persisted, ...onOtherSide]);
   const result = [...persisted];
 
-  // Find buttons in defaults that aren't in persisted (new buttons)
+  // Find buttons in defaults that aren't positioned on either side (new buttons)
   for (let i = 0; i < defaults.length; i++) {
     const buttonId = defaults[i]!;
-    if (!persistedSet.has(buttonId)) {
+    if (!positioned.has(buttonId)) {
       // Insert at the same position as in defaults, or at end if beyond length
       const insertIndex = Math.min(i, result.length);
       result.splice(insertIndex, 0, buttonId);
-      persistedSet.add(buttonId); // Track that we've added it
+      positioned.add(buttonId); // Track that we've added it
     }
   }
 
@@ -155,7 +172,7 @@ function toToolbarPersisted(
  * merged, so they're taken verbatim (last-writer-wins).
  *
  * Migration coexistence: `onDisk` is read raw (no `migrate`), so the reconciler
- * must never diff against a foreign schema version — the 11-step migrate chain
+ * must never diff against a foreign schema version — the 12-step migrate chain
  * reshapes the persisted blob (e.g. v7 `hiddenButtons` array → v8 `pinnedButtons`
  * map, v10 `github-stats` → `forge-stats`). Two guards cover the app-upgrade
  * window: a foreign on-disk version skips the merge outright; a foreign
@@ -371,7 +388,7 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
     }),
     {
       name: "daintree-toolbar-preferences",
-      version: 11,
+      version: 12,
       storage: createSafeJSONStorage<ToolbarPreferencesPersistedState>({
         mergeOnWrite: mergeToolbarPreferencesPersistedWrite,
       }),
@@ -562,6 +579,30 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
             layout.rightButtons = dedupe(layout.rightButtons);
           }
         }
+        if (version < 12) {
+          // `file-browser` joined the built-in buttons (#11495). It's offered in
+          // Settings → Toolbar but must not appear on anyone's existing toolbar,
+          // so every pre-v12 profile gets an explicit hide.
+          //
+          // Unconditional, with no carve-out for what the user already shows:
+          // inferring "this user probably wants it" from their current layout is
+          // the trap #10709 documents — a newly-introduced default belongs in the
+          // safe state for every pre-existing install, without exception.
+          //
+          // Only `pinnedButtons` is touched. Position is left to `merge()`, whose
+          // `mergeButtonList` already inserts a newly-defaulted id on every
+          // hydration; pushing it into the arrays here as well is how a profile
+          // ends up with the same id twice (#10938).
+          const layout = state.layout as { pinnedButtons?: Record<string, boolean> } | undefined;
+          if (layout) {
+            layout.pinnedButtons = { ...(layout.pinnedButtons ?? {}), "file-browser": false };
+          } else {
+            state.layout = { pinnedButtons: { "file-browser": false } } as unknown as Record<
+              string,
+              unknown
+            >;
+          }
+        }
         return state as unknown as ToolbarPreferencesState;
       },
       partialize: (state) => ({
@@ -579,11 +620,13 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
           layout: {
             leftButtons: mergeButtonList(
               persisted.layout?.leftButtons,
-              currentState.layout.leftButtons
+              currentState.layout.leftButtons,
+              persisted.layout?.rightButtons
             ),
             rightButtons: mergeButtonList(
               persisted.layout?.rightButtons,
-              currentState.layout.rightButtons
+              currentState.layout.rightButtons,
+              persisted.layout?.leftButtons
             ),
             pinnedButtons: persisted.layout?.pinnedButtons ?? {},
           },

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -710,7 +710,12 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
             // layout that carries no pin map would otherwise surface a
             // ships-hidden button. An explicitly stored `{}` still wins, which is
             // how a genuine opt-in survives.
-            pinnedButtons: persisted.layout?.pinnedButtons ?? currentState.layout.pinnedButtons,
+            //
+            // The constant rather than `currentState.layout.pinnedButtons`: on a
+            // re-`rehydrate()` zustand passes live state here, not the creator
+            // defaults, so reading from it would carry the previous blob's pins
+            // into a blob that has none.
+            pinnedButtons: persisted.layout?.pinnedButtons ?? { ...DEFAULT_PINNED_BUTTONS },
           },
         };
       },

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -38,16 +38,27 @@ const DEFAULT_RIGHT_BUTTONS: ToolbarButtonId[] = [
   "problems",
 ];
 
+/**
+ * Built-ins that ship hidden: offered in Settings → Toolbar, but absent from the
+ * toolbar until the user opts in (#11495).
+ *
+ * Every path that materializes "no persisted pin map" has to resolve to this,
+ * not to `{}` — the defaults, the hydration merge, and the cross-view baseline
+ * alike. `{}` means "the user has no pins", which for a built-in reads as
+ * *visible*; using it for a missing map is what would leak the button onto a
+ * toolbar. An explicitly stored `{}` is different and must be respected: that is
+ * exactly what `toggleButtonVisibility` leaves behind when a user turns the
+ * button on.
+ */
+const DEFAULT_PINNED_BUTTONS: ToolbarPinnedState = { "file-browser": false };
+
 const DEFAULT_PREFERENCES: ToolbarPreferences = {
   layout: {
     leftButtons: DEFAULT_LEFT_BUTTONS,
     rightButtons: DEFAULT_RIGHT_BUTTONS,
-    // `file-browser` is offered in Settings but ships hidden, so adding it to
-    // the defaults above doesn't change any existing toolbar (#11495). Seeding
-    // the `false` here is not redundant with the v12 migration: a fresh install
-    // has no persisted blob, so `migrate` never runs and this object is the only
-    // source of truth for that profile.
-    pinnedButtons: { "file-browser": false },
+    // Not redundant with the v12 migration: a fresh install has no persisted
+    // blob, so `migrate` never runs and this is the only source of truth.
+    pinnedButtons: DEFAULT_PINNED_BUTTONS,
   },
   launcher: {
     alwaysShowDevServer: false,
@@ -56,6 +67,9 @@ const DEFAULT_PREFERENCES: ToolbarPreferences = {
 };
 
 const FIXED_BUTTON_IDS: ToolbarButtonId[] = ["sidebar-toggle", "assistant-toggle", "portal-toggle"];
+
+/** Home side lookup, used to pick the survivor when an id sits on both sides. */
+const DEFAULT_LEFT_BUTTON_SET = new Set<AnyToolbarButtonId>(DEFAULT_LEFT_BUTTONS);
 
 function sanitizeButtonList(buttons: AnyToolbarButtonId[]): AnyToolbarButtonId[] {
   const filtered = buttons.filter((id) => !FIXED_BUTTON_IDS.includes(id as ToolbarButtonId));
@@ -67,6 +81,44 @@ function sanitizeButtonList(buttons: AnyToolbarButtonId[]): AnyToolbarButtonId[]
   // `setRightButtons` do too, so this is the durable, version-independent guard
   // against duplicate pills (`merge()` runs every load; `migrate()` does not).
   return Array.from(new Set(filtered));
+}
+
+/**
+ * Split an id that ended up on BOTH sides back onto one.
+ *
+ * Hydration before #11495 re-materialized a default that was missing from its
+ * home side, so moving one across sides left a copy on each — and because
+ * `sanitizeButtonList` only dedupes within a list, the pair round-tripped to disk
+ * and rendered twice. `mergeButtonList` no longer creates that, but profiles
+ * already carrying it still need the repair, which is why this runs on every
+ * hydration instead of in a version-gated migration (#10938).
+ *
+ * The survivor reconstructs the move that caused the duplicate: a default on both
+ * sides is kept on the side that is NOT its home, because that is where the user
+ * dragged it. Anything else (plugin ids, unknowns) keeps its left-hand
+ * occurrence, so the outcome is at least deterministic.
+ */
+function healCrossSideDuplicates(
+  persistedLeft: AnyToolbarButtonId[] | undefined,
+  persistedRight: AnyToolbarButtonId[] | undefined
+): {
+  leftButtons: AnyToolbarButtonId[] | undefined;
+  rightButtons: AnyToolbarButtonId[] | undefined;
+} {
+  if (!persistedLeft || !persistedRight) {
+    return { leftButtons: persistedLeft, rightButtons: persistedRight };
+  }
+  const rightSet = new Set(persistedRight);
+  const onBothSides = persistedLeft.filter((id) => rightSet.has(id));
+  if (onBothSides.length === 0) {
+    return { leftButtons: persistedLeft, rightButtons: persistedRight };
+  }
+  const keepOnRight = new Set(onBothSides.filter((id) => DEFAULT_LEFT_BUTTON_SET.has(id)));
+  const keepOnLeft = new Set(onBothSides.filter((id) => !keepOnRight.has(id)));
+  return {
+    leftButtons: persistedLeft.filter((id) => !keepOnRight.has(id)),
+    rightButtons: persistedRight.filter((id) => !keepOnLeft.has(id)),
+  };
 }
 
 /**
@@ -153,7 +205,16 @@ function toToolbarPersisted(
     layout: {
       leftButtons: sanitizeButtonList(asButtonList(layout?.leftButtons) ?? DEFAULT_LEFT_BUTTONS),
       rightButtons: sanitizeButtonList(asButtonList(layout?.rightButtons) ?? DEFAULT_RIGHT_BUTTONS),
-      pinnedButtons: normalizePinnedButtons(layout?.pinnedButtons),
+      // Absent falls back to defaults like the two lists above; an explicitly
+      // stored map (including `{}`) is normalized as-is. The distinction decides
+      // whether a ships-hidden button survives a cross-view merge: normalizing a
+      // *missing* map to `{}` would make a sibling view's untouched
+      // `file-browser: false` look like a fresh edit and revert another view's
+      // opt-in (#11495).
+      pinnedButtons:
+        layout?.pinnedButtons === undefined
+          ? { ...DEFAULT_PINNED_BUTTONS }
+          : normalizePinnedButtons(layout.pinnedButtons),
     },
     launcher: {
       alwaysShowDevServer:
@@ -593,6 +654,12 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
           // `mergeButtonList` already inserts a newly-defaulted id on every
           // hydration; pushing it into the arrays here as well is how a profile
           // ends up with the same id twice (#10938).
+          //
+          // Spelled out rather than spread from `DEFAULT_PINNED_BUTTONS` on
+          // purpose: a shipped migration step has to keep doing exactly what it
+          // did when it shipped. Pointing it at the live constant would make the
+          // next ships-hidden button silently re-stamp itself here, overwriting a
+          // choice its own migration step should own.
           const layout = state.layout as { pinnedButtons?: Record<string, boolean> } | undefined;
           if (layout) {
             layout.pinnedButtons = { ...(layout.pinnedButtons ?? {}), "file-browser": false };
@@ -613,22 +680,37 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
         },
       }),
       merge: (persistedState, currentState) => {
-        const persisted = persistedState as Partial<ToolbarPreferencesState>;
+        // `persistedState` really is undefined on a fresh install — zustand calls
+        // `merge` even with nothing in storage. Guarding here instead of letting
+        // the dereference throw into zustand's exception-swallowing thenable is
+        // what makes the ships-hidden default an explicit outcome rather than a
+        // side effect of where the throw landed, and it lets `hasHydrated()`
+        // resolve at all.
+        const persisted = (persistedState ?? {}) as Partial<ToolbarPreferencesState>;
+        const healed = healCrossSideDuplicates(
+          persisted.layout?.leftButtons,
+          persisted.layout?.rightButtons
+        );
         return {
           ...currentState,
           ...persisted,
           layout: {
             leftButtons: mergeButtonList(
-              persisted.layout?.leftButtons,
+              healed.leftButtons,
               currentState.layout.leftButtons,
-              persisted.layout?.rightButtons
+              healed.rightButtons
             ),
             rightButtons: mergeButtonList(
-              persisted.layout?.rightButtons,
+              healed.rightButtons,
               currentState.layout.rightButtons,
-              persisted.layout?.leftButtons
+              healed.leftButtons
             ),
-            pinnedButtons: persisted.layout?.pinnedButtons ?? {},
+            // Defaults, never `{}` — see `DEFAULT_PINNED_BUTTONS`. A blob already
+            // stamped at the current version skips `migrate` entirely, so a
+            // layout that carries no pin map would otherwise surface a
+            // ships-hidden button. An explicitly stored `{}` still wins, which is
+            // how a genuine opt-in survives.
+            pinnedButtons: persisted.layout?.pinnedButtons ?? currentState.layout.pinnedButtons,
           },
         };
       },

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -660,15 +660,25 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
           // did when it shipped. Pointing it at the live constant would make the
           // next ships-hidden button silently re-stamp itself here, overwriting a
           // choice its own migration step should own.
-          const layout = state.layout as { pinnedButtons?: Record<string, boolean> } | undefined;
-          if (layout) {
-            layout.pinnedButtons = { ...(layout.pinnedButtons ?? {}), "file-browser": false };
-          } else {
-            state.layout = { pinnedButtons: { "file-browser": false } } as unknown as Record<
-              string,
-              unknown
-            >;
-          }
+          //
+          // Narrowed rather than asserted, unlike the older steps above: `state`
+          // is already `Record<string, unknown>`, so `in`/`typeof` guards reach
+          // the same place without a type assertion — and the lint ratchet scores
+          // `no-unsafe-type-assertion` per rule, so a new one costs a baseline
+          // bump the ratchet exists to prevent.
+          const layout = state.layout;
+          const hasLayout = typeof layout === "object" && layout !== null && !Array.isArray(layout);
+          const existingPins = hasLayout && "pinnedButtons" in layout ? layout.pinnedButtons : null;
+          const carriedPins =
+            typeof existingPins === "object" &&
+            existingPins !== null &&
+            !Array.isArray(existingPins)
+              ? existingPins
+              : {};
+          state.layout = {
+            ...(hasLayout ? layout : {}),
+            pinnedButtons: { ...carriedPins, "file-browser": false },
+          };
         }
         return state as unknown as ToolbarPreferencesState;
       },


### PR DESCRIPTION
## Summary

In Settings > Toolbar you could show, hide, and reorder the Terminal, Browser, and Dev preview buttons, but there was no entry for the file browser, even though it's a first-class panel kind with its own action and keybinding. This adds a `file-browser` toolbar button to that list: toggleable, draggable, side-switchable. It ships hidden by default, so nobody's existing toolbar changes until they opt in. Clicking it dispatches the existing `worktree.openFileBrowser` action, the same one bound to `Cmd+Alt+F`.

Resolves #11495

## Changes

- Added `file-browser` to `ToolbarButtonId` and to `TOOLBAR_BUTTON_PRIORITIES` at priority 3, between `browser` and `dev-server` in the default left order. Equal priority means position breaks the overflow tie, so dev preview collapses before a button the user just switched on.
- Ships hidden via a matched pair: a `DEFAULT_PINNED_BUTTONS` seed in the store defaults, and a new v12 migration step. Neither alone is enough. A fresh install has no persisted blob, so `migrate` never runs, while existing installs need the stamp. The v12 step is unconditional, with no carve-out based on what the user already shows.
- `ToolbarSettingsTab.tsx` needed zero changes. It's already generic over the defaults arrays and the metadata registry, so the row, its switch, drag, and side-switching all come for free.
- Reuses the existing `worktree.openFileBrowser` action and its `Cmd+Alt+F` binding unchanged. The button, the overflow item, and the error toast's Retry action all share one handler. The action legitimately refuses in a workspace with nothing to browse, so a failed dispatch surfaces an error toast rather than doing nothing, mirroring `LauncherQuickActions`.
- Deliberately not added to `PROJECT_SCOPED_TOOLBAR_IDS`: the action falls back to the project or scratch root when no worktree is selected (#11482), so project-gating it would disable it in exactly the worktree-less workspaces where it works.

## Also fixed

Found these while reviewing, all in the persistence layer. A ships-hidden built-in only stays hidden if every code path that produces "no persisted pin map" resolves to the defaults rather than to an empty object, since an empty object reads as "no pins", i.e. visible.

- The cross-view baseline normalised a null blob's `pinnedButtons` field to an empty object, so one view's untouched default looked like a fresh edit and reverted another view's opt-in. `persistWriteMerge.ts` documents that a null baseline must normalise to persisted defaults; `pinnedButtons` was the one field not doing that.
- The store's `merge()` fell back to an empty object for a current-version blob carrying no pin map, which skips the `migrate` step entirely.
- `merge()` dereferenced an undefined persisted state on a fresh install and relied on zustand swallowing the throw, leaving `hasHydrated()` stuck false.
- Cross-side duplication: hydration re-inserted a default missing from its home side, so moving one across sides left a copy on both, because `sanitizeButtonList` only dedupes within a side, never across sides, and it rendered twice. Now prevented, and already-corrupted profiles are healed on hydration.

An explicitly stored empty map still wins, since that's a genuine opt-out.

## Testing

361 tests pass across 12 toolbar-related test suites, including new coverage for the v12 migration (untouched and heavily customised profiles, a stray opt-in, a layout-less blob, post-migration opt-in preserved), fresh-install defaults, re-hydrating onto a blob with no pin map, side-switch persistence, cross-side healing in both directions, the Settings row and switch wiring, and equal-priority overflow ordering.

Full project `tsc --noEmit` is clean, eslint shows 0 errors with no ratchet regression, and prettier is clean.

Out of scope: the file-browser panel kind stays `dockable: false` per #11486.