### PR TITLE
fix(actions): stop the shortcut hint stranding over dialogs it opened

### DIFF
--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -461,13 +461,13 @@ export class ActionService {
     const wallClockStartMs = Date.now();
     const monotonicStartMs = typeof performance !== "undefined" ? performance.now() : Date.now();
 
-    // Snapshot the overlay claims owned before run() so the post-run hint can
-    // tell "this action opened a dialog" from "a dialog was already open".
-    // Only the former must suppress — see emitShortcutHint. Skipped entirely
-    // when no hint can be emitted anyway.
-    const overlayClaimsBeforeRun =
+    // Snapshot the overlay epoch before run() so the post-run hint can tell
+    // "an overlay opened while this ran" from "one was already open". Only the
+    // former must suppress — see emitShortcutHint. Skipped entirely when no
+    // hint can be emitted anyway.
+    const overlayEpochBeforeRun =
       source === "user" && !definition.suppressShortcutHint
-        ? new Set(useUIStore.getState().overlayStack)
+        ? useUIStore.getState().overlayClaimEpoch
         : null;
 
     try {
@@ -503,7 +503,7 @@ export class ActionService {
         pluginId: definition.pluginId,
       });
       if (!definition.suppressShortcutHint)
-        this.emitShortcutHint(actionId, source, overlayClaimsBeforeRun);
+        this.emitShortcutHint(actionId, source, overlayEpochBeforeRun);
       return { ok: true, result: result as Result };
     } catch (err) {
       const error: ActionError = {
@@ -738,33 +738,38 @@ export class ActionService {
   }
 
   /**
-   * `overlayClaimsBeforeRun` is the overlay stack as it stood when the action
-   * was dispatched. A claim present now but missing from it means run() opened
-   * an overlay: the hint would render above it (z-toast sits over z-modal) and
-   * the dialog's own `clearDialogOverlays()` already fired *before* this emit,
-   * so nothing would take the hint down for the full auto-dismiss window.
+   * Suppresses the hint when an overlay is on screen that opened while run()
+   * was in flight. Such a hint would render above it (z-toast sits over
+   * z-modal) and the dialog's own `clearDialogOverlays()` already fired
+   * *before* this emit, so nothing would take the hint down for the full
+   * auto-dismiss window — issue #11507.
    *
-   * Comparing identities rather than depth matters — an action that closes one
-   * dialog and opens another leaves the stack the same size but must still
-   * suppress, while an action dispatched inside an already-open dialog that
-   * leaves it open must still hint.
+   * Both halves are load-bearing. The epoch alone would suppress after a
+   * dialog that opened and closed again, where there is nothing left to strand
+   * on; a non-empty stack alone would suppress hints for actions invoked
+   * inside a dialog that was already open and stays open.
+   *
+   * The epoch rather than the stack contents because claim ids are reused: a
+   * dialog reopening at the same tree position keeps its `useId()`, so an
+   * open→close→reopen across one dispatch is invisible to a contents diff.
+   *
+   * The test is temporal, not attributive: claims carry no owning action, so a
+   * dialog opened by a *concurrent* dispatch suppresses this one's hint too.
+   * That is the conservative direction — the hint would have landed over that
+   * dialog either way.
    */
   private emitShortcutHint(
     actionId: ActionId,
     source: ActionSource,
-    overlayClaimsBeforeRun: ReadonlySet<string> | null
+    overlayEpochBeforeRun: number | null
   ): void {
     if (source !== "user") return;
     try {
       // Bail before incrementCount so a suppressed hint doesn't silently
       // consume one of the teaching milestones.
-      if (
-        overlayClaimsBeforeRun !== null &&
-        useUIStore
-          .getState()
-          .overlayStack.some((claimId) => !overlayClaimsBeforeRun.has(claimId))
-      ) {
-        return;
+      if (overlayEpochBeforeRun !== null) {
+        const { overlayStack, overlayClaimEpoch } = useUIStore.getState();
+        if (overlayStack.length > 0 && overlayClaimEpoch !== overlayEpochBeforeRun) return;
       }
 
       const combo = keybindingService.getEffectiveCombo(actionId);

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -14,6 +14,7 @@ import type { AnyActionDefinition } from "./actions/actionTypes";
 import { logWarn } from "@/utils/logger";
 import { keybindingService } from "./KeybindingService";
 import { shortcutHintStore } from "../store/shortcutHintStore";
+import { useUIStore } from "@/store/uiStore";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { WORKBENCH_TIER_TOOLS } from "@shared/config/helpAssistantTierAllowlists";
 import { deriveBand } from "../../shared/utils/actionRiskBand.js";
@@ -460,6 +461,15 @@ export class ActionService {
     const wallClockStartMs = Date.now();
     const monotonicStartMs = typeof performance !== "undefined" ? performance.now() : Date.now();
 
+    // Snapshot the overlay claims owned before run() so the post-run hint can
+    // tell "this action opened a dialog" from "a dialog was already open".
+    // Only the former must suppress — see emitShortcutHint. Skipped entirely
+    // when no hint can be emitted anyway.
+    const overlayClaimsBeforeRun =
+      source === "user" && !definition.suppressShortcutHint
+        ? new Set(useUIStore.getState().overlayStack)
+        : null;
+
     try {
       // Derive (don't mutate — `context` may be a shared object from the
       // context provider) a run-scoped context carrying the dispatch source
@@ -492,7 +502,8 @@ export class ActionService {
         confirmed: options?.confirmed,
         pluginId: definition.pluginId,
       });
-      if (!definition.suppressShortcutHint) this.emitShortcutHint(actionId, source);
+      if (!definition.suppressShortcutHint)
+        this.emitShortcutHint(actionId, source, overlayClaimsBeforeRun);
       return { ok: true, result: result as Result };
     } catch (err) {
       const error: ActionError = {
@@ -726,9 +737,36 @@ export class ActionService {
     return hasAny ? picked : undefined;
   }
 
-  private emitShortcutHint(actionId: ActionId, source: ActionSource): void {
+  /**
+   * `overlayClaimsBeforeRun` is the overlay stack as it stood when the action
+   * was dispatched. A claim present now but missing from it means run() opened
+   * an overlay: the hint would render above it (z-toast sits over z-modal) and
+   * the dialog's own `clearDialogOverlays()` already fired *before* this emit,
+   * so nothing would take the hint down for the full auto-dismiss window.
+   *
+   * Comparing identities rather than depth matters — an action that closes one
+   * dialog and opens another leaves the stack the same size but must still
+   * suppress, while an action dispatched inside an already-open dialog that
+   * leaves it open must still hint.
+   */
+  private emitShortcutHint(
+    actionId: ActionId,
+    source: ActionSource,
+    overlayClaimsBeforeRun: ReadonlySet<string> | null
+  ): void {
     if (source !== "user") return;
     try {
+      // Bail before incrementCount so a suppressed hint doesn't silently
+      // consume one of the teaching milestones.
+      if (
+        overlayClaimsBeforeRun !== null &&
+        useUIStore
+          .getState()
+          .overlayStack.some((claimId) => !overlayClaimsBeforeRun.has(claimId))
+      ) {
+        return;
+      }
+
       const combo = keybindingService.getEffectiveCombo(actionId);
       if (!combo) return;
 

--- a/src/services/__tests__/ActionService.overlayClaim.integration.test.tsx
+++ b/src/services/__tests__/ActionService.overlayClaim.integration.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, act } from "@testing-library/react";
+
+const hintMocks = vi.hoisted(() => {
+  const mockShow = vi.fn();
+  const mockIncrementCount = vi.fn();
+  return {
+    mockShow,
+    mockIncrementCount,
+    mockGetState: vi.fn(() => ({
+      hydrated: true,
+      counts: {} as Record<string, number>,
+      show: mockShow,
+      incrementCount: mockIncrementCount,
+    })),
+    mockGetEffectiveCombo: vi.fn((_actionId: string): string | null => "Cmd+K"),
+    mockGetDisplayCombo: vi.fn((_actionId: string): string => "⌘K"),
+  };
+});
+
+vi.mock("../../store/shortcutHintStore", () => ({
+  shortcutHintStore: { getState: hintMocks.mockGetState },
+}));
+
+vi.mock("../KeybindingService", () => ({
+  keybindingService: {
+    getEffectiveCombo: hintMocks.mockGetEffectiveCombo,
+    getDisplayCombo: hintMocks.mockGetDisplayCombo,
+  },
+}));
+
+vi.mock("@/lib/notify", () => ({ notify: vi.fn() }));
+
+import { ActionService } from "../ActionService";
+import { useOverlayState } from "@/hooks/useOverlayState";
+import { useUIStore } from "@/store/uiStore";
+import type { ActionDefinition, ActionId } from "@shared/types/actions";
+
+/**
+ * Drives the *real* `useOverlayState` hook so the overlay claim is registered
+ * by React's own passive effect, exactly as AppDialog registers it in
+ * production. The sibling unit tests in ActionService.test.ts mutate the store
+ * directly, which proves the comparison logic but not that a mounted dialog's
+ * claim actually lands inside the dispatch window — the gap that let issue
+ * #11507 regress once already.
+ */
+function OverlayHarness({ open }: { open: boolean }) {
+  useOverlayState(open);
+  return null;
+}
+
+function makeDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe("ActionService overlay claim integration", () => {
+  let service: ActionService;
+
+  beforeEach(() => {
+    service = new ActionService();
+    useUIStore.setState({ overlayStack: [] });
+    hintMocks.mockShow.mockClear().mockReturnValue(true);
+    hintMocks.mockIncrementCount.mockClear();
+  });
+
+  afterEach(() => {
+    useUIStore.setState({ overlayStack: [] });
+  });
+
+  const makeAction = (id: string, run: ActionDefinition["run"]): ActionDefinition => ({
+    id: id as ActionId,
+    title: "Test",
+    description: "Test action",
+    category: "test",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    run,
+  });
+
+  it("suppresses the hint when a dialog mounts and claims the overlay mid-dispatch", async () => {
+    const deferred = makeDeferred();
+    const { rerender } = render(<OverlayHarness open={false} />);
+
+    service.register(makeAction("test.mountsDialog", () => deferred.promise));
+    const dispatched = service.dispatch("test.mountsDialog" as ActionId, undefined, {
+      source: "user",
+    });
+
+    // The dialog opens while run() is still pending; act() flushes the real
+    // passive effect that registers the claim.
+    await act(async () => {
+      rerender(<OverlayHarness open />);
+    });
+    expect(useUIStore.getState().overlayStack).toHaveLength(1);
+
+    await act(async () => {
+      deferred.resolve();
+      await dispatched;
+    });
+
+    const result = await dispatched;
+    expect(result.ok).toBe(true);
+    expect(hintMocks.mockShow).not.toHaveBeenCalled();
+    expect(hintMocks.mockIncrementCount).not.toHaveBeenCalled();
+  });
+
+  it("still emits the hint when a dialog was already mounted and stays open", async () => {
+    const deferred = makeDeferred();
+    render(<OverlayHarness open />);
+    expect(useUIStore.getState().overlayStack).toHaveLength(1);
+
+    service.register(makeAction("test.insideMountedDialog", () => deferred.promise));
+    const dispatched = service.dispatch("test.insideMountedDialog" as ActionId, undefined, {
+      source: "user",
+    });
+
+    await act(async () => {
+      deferred.resolve();
+      await dispatched;
+    });
+
+    const result = await dispatched;
+    expect(result.ok).toBe(true);
+    expect(hintMocks.mockIncrementCount).toHaveBeenCalledWith("test.insideMountedDialog");
+    expect(hintMocks.mockShow).toHaveBeenCalledWith("test.insideMountedDialog", "⌘K");
+  });
+
+  it("still emits the hint when the dialog unmounts and releases its claim mid-dispatch", async () => {
+    const deferred = makeDeferred();
+    const { rerender } = render(<OverlayHarness open />);
+    expect(useUIStore.getState().overlayStack).toHaveLength(1);
+
+    service.register(makeAction("test.closesMountedDialog", () => deferred.promise));
+    const dispatched = service.dispatch("test.closesMountedDialog" as ActionId, undefined, {
+      source: "user",
+    });
+
+    await act(async () => {
+      rerender(<OverlayHarness open={false} />);
+    });
+    expect(useUIStore.getState().overlayStack).toHaveLength(0);
+
+    await act(async () => {
+      deferred.resolve();
+      await dispatched;
+    });
+
+    const result = await dispatched;
+    expect(result.ok).toBe(true);
+    expect(hintMocks.mockIncrementCount).toHaveBeenCalledWith("test.closesMountedDialog");
+    expect(hintMocks.mockShow).toHaveBeenCalledWith("test.closesMountedDialog", "⌘K");
+  });
+});

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -32,6 +32,7 @@ const notifyMock = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/notify", () => ({ notify: notifyMock }));
 
 import { ActionService } from "../ActionService";
+import { useUIStore } from "@/store/uiStore";
 import type { ActionDefinition, ActionId } from "@shared/types/actions";
 
 describe("ActionService", () => {
@@ -1820,6 +1821,98 @@ describe("ActionService", () => {
 
       expect(mockShow).not.toHaveBeenCalled();
       expect(mockIncrementCount).not.toHaveBeenCalled();
+    });
+
+    describe("overlay-opening actions", () => {
+      /**
+       * Builds an action whose run() crosses a real macrotask before it
+       * mutates the overlay stack, so the dispatch continuation resumes
+       * *after* the mutation — the ordering a React passive effect produces
+       * in production. A bare `Promise.resolve()` leaves no gap and would
+       * pass whether or not the ordering logic is correct.
+       */
+      const makeOverlayAction = (id: string, mutateOverlays: () => void): ActionDefinition => ({
+        ...makeAction(id),
+        run: async () => {
+          await new Promise<void>((resolve) => {
+            setTimeout(() => {
+              mutateOverlays();
+              resolve();
+            }, 0);
+          });
+        },
+      });
+
+      const { addOverlayClaim, removeOverlayClaim } = useUIStore.getState();
+
+      beforeEach(() => {
+        useUIStore.setState({ overlayStack: [] });
+        mockGetEffectiveCombo.mockReturnValue("Cmd+K");
+        mockGetDisplayCombo.mockReturnValue("⌘K");
+        mockShow.mockReturnValue(true);
+      });
+
+      it("suppresses the hint when the action opens an overlay", async () => {
+        service.register(
+          makeOverlayAction("test.opensDialog", () => addOverlayClaim("dialog-opened"))
+        );
+
+        await service.dispatch("test.opensDialog" as ActionId, undefined, { source: "user" });
+
+        expect(mockShow).not.toHaveBeenCalled();
+        expect(mockIncrementCount).not.toHaveBeenCalled();
+      });
+
+      it("still emits the hint when a pre-existing overlay is left untouched", async () => {
+        addOverlayClaim("dialog-already-open");
+        service.register(makeOverlayAction("test.insideDialog", () => {}));
+
+        await service.dispatch("test.insideDialog" as ActionId, undefined, { source: "user" });
+
+        expect(mockIncrementCount).toHaveBeenCalledWith("test.insideDialog");
+        expect(mockShow).toHaveBeenCalledWith("test.insideDialog", "⌘K");
+      });
+
+      it("suppresses the hint when one overlay replaces another at the same depth", async () => {
+        addOverlayClaim("dialog-a");
+        service.register(
+          makeOverlayAction("test.swapsDialog", () => {
+            removeOverlayClaim("dialog-a");
+            addOverlayClaim("dialog-b");
+          })
+        );
+
+        await service.dispatch("test.swapsDialog" as ActionId, undefined, { source: "user" });
+
+        expect(mockShow).not.toHaveBeenCalled();
+        expect(mockIncrementCount).not.toHaveBeenCalled();
+      });
+
+      it("still emits the hint when an overlay opened during the run has closed again", async () => {
+        service.register(
+          makeOverlayAction("test.transientDialog", () => {
+            addOverlayClaim("dialog-transient");
+            removeOverlayClaim("dialog-transient");
+          })
+        );
+
+        await service.dispatch("test.transientDialog" as ActionId, undefined, { source: "user" });
+
+        expect(mockIncrementCount).toHaveBeenCalledWith("test.transientDialog");
+        expect(mockShow).toHaveBeenCalledWith("test.transientDialog", "⌘K");
+      });
+
+      it("still emits the hint when the action closes the open overlay", async () => {
+        addOverlayClaim("dialog-being-closed");
+        service.register(
+          makeOverlayAction("test.closesDialog", () => removeOverlayClaim("dialog-being-closed"))
+        );
+
+        await service.dispatch("test.closesDialog" as ActionId, undefined, { source: "user" });
+
+        expect(mockIncrementCount).toHaveBeenCalledWith("test.closesDialog");
+        expect(mockShow).toHaveBeenCalledWith("test.closesDialog", "⌘K");
+      });
     });
   });
 

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, afterAll, describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeAll, afterAll, describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { z } from "zod";
 
 const hintMocks = vi.hoisted(() => {
@@ -1852,13 +1852,39 @@ describe("ActionService", () => {
         mockShow.mockReturnValue(true);
       });
 
+      // uiStore is a module-scope singleton — leave it clean so a test added
+      // after this block doesn't inherit claims from here.
+      afterEach(() => {
+        useUIStore.setState({ overlayStack: [] });
+      });
+
       it("suppresses the hint when the action opens an overlay", async () => {
         service.register(
           makeOverlayAction("test.opensDialog", () => addOverlayClaim("dialog-opened"))
         );
 
-        await service.dispatch("test.opensDialog" as ActionId, undefined, { source: "user" });
+        const result = await service.dispatch("test.opensDialog" as ActionId, undefined, {
+          source: "user",
+        });
 
+        // A rejected dispatch also emits no hint, so pin the success path —
+        // otherwise a broken fixture would satisfy the assertions below.
+        expect(result.ok).toBe(true);
+        expect(mockShow).not.toHaveBeenCalled();
+        expect(mockIncrementCount).not.toHaveBeenCalled();
+      });
+
+      it("suppresses the hint when an overlay opens on top of an existing one", async () => {
+        addOverlayClaim("dialog-base");
+        service.register(
+          makeOverlayAction("test.nestsDialog", () => addOverlayClaim("dialog-nested"))
+        );
+
+        const result = await service.dispatch("test.nestsDialog" as ActionId, undefined, {
+          source: "user",
+        });
+
+        expect(result.ok).toBe(true);
         expect(mockShow).not.toHaveBeenCalled();
         expect(mockIncrementCount).not.toHaveBeenCalled();
       });
@@ -1882,8 +1908,11 @@ describe("ActionService", () => {
           })
         );
 
-        await service.dispatch("test.swapsDialog" as ActionId, undefined, { source: "user" });
+        const result = await service.dispatch("test.swapsDialog" as ActionId, undefined, {
+          source: "user",
+        });
 
+        expect(result.ok).toBe(true);
         expect(mockShow).not.toHaveBeenCalled();
         expect(mockIncrementCount).not.toHaveBeenCalled();
       });
@@ -1900,6 +1929,27 @@ describe("ActionService", () => {
 
         expect(mockIncrementCount).toHaveBeenCalledWith("test.transientDialog");
         expect(mockShow).toHaveBeenCalledWith("test.transientDialog", "⌘K");
+      });
+
+      it("suppresses the hint when a claim id is released and re-registered", async () => {
+        // A dialog reopening at the same tree position keeps its useId(), so
+        // the stack reads identically before and after — only the epoch shows
+        // that an overlay opened during the dispatch.
+        addOverlayClaim("dialog-reused-id");
+        service.register(
+          makeOverlayAction("test.reopensDialog", () => {
+            removeOverlayClaim("dialog-reused-id");
+            addOverlayClaim("dialog-reused-id");
+          })
+        );
+
+        const result = await service.dispatch("test.reopensDialog" as ActionId, undefined, {
+          source: "user",
+        });
+
+        expect(result.ok).toBe(true);
+        expect(mockShow).not.toHaveBeenCalled();
+        expect(mockIncrementCount).not.toHaveBeenCalled();
       });
 
       it("still emits the hint when the action closes the open overlay", async () => {

--- a/src/services/actions/definitions/navigationActions.ts
+++ b/src/services/actions/definitions/navigationActions.ts
@@ -29,6 +29,9 @@ export function registerNavigationActions(
     nonRepeatable: true,
     // Opens a modal palette — a post-dispatch hint would land on top of it
     // (ShortcutHint sits at z-toast, above z-modal). Issue #11030.
+    // Not redundant with dispatch()'s overlay-claim check (#11507): this
+    // opener is synchronous, so the continuation can beat the palette's
+    // claim effect. Keep the flag.
     suppressShortcutHint: true,
     run: async () => {
       callbacks.onOpenActionPalette();

--- a/src/services/actions/definitions/panelCoreActions.ts
+++ b/src/services/actions/definitions/panelCoreActions.ts
@@ -222,6 +222,9 @@ export function registerPanelCoreActions(
     nonRepeatable: true,
     // Opens a modal palette — a post-dispatch hint would land on top of it
     // (ShortcutHint sits at z-toast, above z-modal). Issue #11030.
+    // Not redundant with dispatch()'s overlay-claim check (#11507): this
+    // opener is synchronous, so the continuation can beat the palette's
+    // claim effect. Keep the flag.
     suppressShortcutHint: true,
     run: async () => {
       callbacks.onOpenPanelPalette();

--- a/src/services/actions/definitions/terminalSpawnActions.ts
+++ b/src/services/actions/definitions/terminalSpawnActions.ts
@@ -65,6 +65,9 @@ export function registerTerminalSpawnActions(
     nonRepeatable: true,
     // Opens a modal palette — a post-dispatch hint would land on top of it
     // (ShortcutHint sits at z-toast, above z-modal). Issue #11030.
+    // Not redundant with dispatch()'s overlay-claim check (#11507): this
+    // opener is synchronous, so the continuation can beat the palette's
+    // claim effect. Keep the flag.
     suppressShortcutHint: true,
     run: async () => {
       callbacks.onOpenResumeSessionsPalette();

--- a/src/store/__tests__/uiStore.test.ts
+++ b/src/store/__tests__/uiStore.test.ts
@@ -18,6 +18,25 @@ describe("useUIStore overlay stack", () => {
     expect(useUIStore.getState().hasOpenOverlays()).toBe(true);
   });
 
+  it("overlayClaimEpoch advances for each new claim but not for duplicates", () => {
+    const start = useUIStore.getState().overlayClaimEpoch;
+    useUIStore.getState().addOverlayClaim("settings");
+    const afterFirst = useUIStore.getState().overlayClaimEpoch;
+    useUIStore.getState().addOverlayClaim("settings");
+
+    expect(afterFirst).toBeGreaterThan(start);
+    expect(useUIStore.getState().overlayClaimEpoch).toBe(afterFirst);
+  });
+
+  it("overlayClaimEpoch keeps advancing when a released ID is registered again", () => {
+    useUIStore.getState().addOverlayClaim("settings");
+    const afterFirst = useUIStore.getState().overlayClaimEpoch;
+    useUIStore.getState().removeOverlayClaim("settings");
+    useUIStore.getState().addOverlayClaim("settings");
+
+    expect(useUIStore.getState().overlayClaimEpoch).toBeGreaterThan(afterFirst);
+  });
+
   it("addOverlayClaim collapses duplicate registrations for the same ID", () => {
     useUIStore.getState().addOverlayClaim("settings");
     useUIStore.getState().addOverlayClaim("settings");

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -6,6 +6,11 @@ interface UIState {
   // overlay. Idempotent registration: re-adding an id is a no-op and the
   // array reference is preserved so Zustand skips re-renders.
   overlayStack: string[];
+  // Monotonic count of claims ever registered. Claim ids are not unique over
+  // time — a dialog that closes and reopens at the same position keeps its
+  // `useId()` — so comparing stack contents cannot tell "never moved" from
+  // "closed and reopened". Snapshot this to detect the latter.
+  overlayClaimEpoch: number;
   addOverlayClaim: (id: string) => void;
   removeOverlayClaim: (id: string) => void;
   hasOpenOverlays: () => boolean;
@@ -29,6 +34,7 @@ interface UIState {
 
 export const useUIStore = create<UIState>((set, get) => ({
   overlayStack: [],
+  overlayClaimEpoch: 0,
 
   // Idempotent — return the same state reference when the claim is already
   // present so Zustand skips re-renders. Never mutate the existing array; a
@@ -36,7 +42,10 @@ export const useUIStore = create<UIState>((set, get) => ({
   addOverlayClaim: (id) =>
     set((state) => {
       if (state.overlayStack.includes(id)) return state;
-      return { overlayStack: [...state.overlayStack, id] };
+      return {
+        overlayStack: [...state.overlayStack, id],
+        overlayClaimEpoch: state.overlayClaimEpoch + 1,
+      };
     }),
 
   removeOverlayClaim: (id) =>


### PR DESCRIPTION
## Summary

- `ActionService.dispatch()` calls `emitShortcutHint` right after `await definition.run()`. When the action opens a dialog, the dialog's own open transition has already run `clearDialogOverlays()`, which hides the hint, before the emit happens. Nothing takes the hint back down, so it sits at `z-toast` (above `z-modal`) on top of the dialog for the full 2500ms auto-dismiss.
- Fixes this structurally rather than with another per-action flag: `uiStore` gains a monotonic `overlayClaimEpoch`, bumped whenever a new overlay claim registers, and `dispatch()` uses it to detect an overlay that opened mid-flight.

Resolves #11507

## Problem

Repro is the "Browse files" launcher chip, which dispatches `worktree.openFileBrowser`, and `ResumeSessionLine`. Both open a dialog whose open transition clears the shortcut hint before `dispatch()` ever emits it.

This regressed. `785d7fefc` fixed it per call site by calling `hide()` before dispatch and again in a `.finally(hide)`. `cd04b51bb` removed those workarounds on the reasoning that the #11030 dismiss registry already covered it. That reasoning doesn't hold: the registry's clear always runs before the emit, never after. The three palette actions kept working only because they independently carry `suppressShortcutHint: true` on their definitions. `worktree.openFileBrowser` and `file.view` never got that flag, which is the bug reported here.

## Fix

`uiStore` gets a monotonic `overlayClaimEpoch`, incremented each time a new overlay claim registers. `dispatch()` snapshots the epoch before calling `run()`. `emitShortcutHint` suppresses the hint when the overlay stack is non-empty *and* the epoch has moved since the snapshot, meaning an overlay appeared while the action was in flight.

Both conditions are load-bearing:

- The epoch alone would wrongly suppress the hint after a dialog opened and closed again within the same dispatch (nothing left to strand on).
- A non-empty-stack check alone would wrongly kill hints for actions invoked from inside a dialog that was already open before the action ran.

This covers every `AppDialog` and `AppPaletteDialog` consumer automatically, because both call `useOverlayState()` unconditionally. No per-action opt-in, now or for future dialog-opening actions.

An epoch counter beats diffing overlay claim ids because ids get reused: `useOverlayState` mints its id from React's `useId()`, so a dialog that closes and reopens at the same tree position comes back with the same id. An open-close-reopen sequence inside one dispatch would be invisible to an id diff and would recreate the original bug. The epoch can't miss it.

The three existing palette `suppressShortcutHint` flags stay, with a comment explaining they're not redundant with this fix: those openers are synchronous, so the dispatch continuation can resume before React's passive effect that registers the overlay claim has even run. Removing the flags would regress those actions.

## Changes

- `src/store/uiStore.ts`: add monotonic `overlayClaimEpoch`, bumped on overlay claim registration.
- `src/services/ActionService.ts`: snapshot the epoch before `run()`, suppress `emitShortcutHint` when the overlay stack is non-empty and the epoch moved.
- `src/services/actions/definitions/navigationActions.ts`, `panelCoreActions.ts`, `terminalSpawnActions.ts`: comment clarifying the existing `suppressShortcutHint` flags are still needed for synchronous dialog openers.

## Testing

10 new tests: 6 unit, 3 jsdom integration, 2 store invariants. The integration suite drives the real `useOverlayState` hook so React's actual passive effect registers the claim mid-dispatch, which is the timing gap that let this regress silently before (`dialogOverlayClearing.test.tsx` mocks `useOverlayState` to a no-op, and the old per-call-site test mocked `run()` to a bare `Promise.resolve()` with no timing gap).

Every suppression test was mutation-verified: disabling the guard makes all 5 fail, and 5 separate "hint still emits normally" tests pass either way.

Local verification: 637 tests green across 23 suites, prettier clean, eslint 0 errors and 0 new warnings on changed lines.

## Reviewer notes

This adds a module-scope `useUIStore` import to `ActionService.ts`, widening the module graph for the ~145 test suites that import it. Verified safe in the default node vitest environment.
