### PR TITLE
fix(pr): re-poll CI for PRs in a terminal state

### DIFF
--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -79,6 +79,29 @@ const STAGNANT_POLL_DECAY_AT_20 = 20;
 const RESOLVED_REVALIDATION_DECAY_INTERVAL_MS = 60 * 1000;
 const RESOLVED_REVALIDATION_MAX_DECAY_INTERVAL_MS = 120 * 1000;
 
+// Terminal CI states go stale too (#11513). Re-running a failed job pushes no
+// commit, so the PR's updated_at never moves and the open-PR probe reports it
+// unchanged — and a terminal status isn't `pending`, so the compensating loop
+// in revalidateResolvedPRs skipped it as well. Re-check resolved PRs on a slow
+// cadence weighted toward failures, which is the state users actually re-run.
+// Each attempt rides the revalidation tick's existing getCIStatuses batch
+// (~2 GraphQL points), so a permanently failing PR adds ~40 points/hour and a
+// green one ~12 — negligible against the 5000/hr primary limit documented
+// above. These are minimum elapsed times, not timers: an eligible PR waits up
+// to one revalidation interval before the next tick picks it up.
+const TERMINAL_CI_RECHECK_FAILURE_INTERVAL_MS = 3 * 60 * 1000; // 3 minutes
+const TERMINAL_CI_RECHECK_SUCCESS_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
+
+// Null for every non-terminal status, so `undefined` (unknown / no CI checks —
+// nothing to re-poll for, #6240) and `pending` (owned by the boost cadence
+// above) are structurally ineligible for the slow pass rather than excluded by
+// a condition someone could later widen.
+function terminalCiRecheckIntervalMs(status: CIStatusState | undefined): number | null {
+  if (status === "failure") return TERMINAL_CI_RECHECK_FAILURE_INTERVAL_MS;
+  if (status === "success") return TERMINAL_CI_RECHECK_SUCCESS_INTERVAL_MS;
+  return null;
+}
+
 // Rate-limit block constants extracted from the GitHub-specific service so the
 // polling loops consult the active provider's rate-limit state through
 // ForgeProviderImpl.getRateLimit() rather than the gitHubRateLimitService singleton.
@@ -106,6 +129,13 @@ interface InternalLinkedPR {
   // probe-driven revalidation cycle seeds them.
   headSha?: string;
   updatedAt?: string;
+  // Wall-clock stamp of the last getCIStatuses attempt, taken at enqueue rather
+  // than on resolve so a rejected or slow batch still counts against the
+  // terminal re-check interval — otherwise a failing provider would re-fire the
+  // same PR on every revalidation tick. Undefined until the first attempt,
+  // which reads as "due" so entries detected before this field existed (or
+  // seeded by a re-detection) self-heal on the next tick.
+  lastCiCheckAt?: number;
 }
 
 export interface PRDetectionResult {
@@ -145,6 +175,10 @@ class PullRequestService {
   // declaration time so it's correct before the singleton's first checkForPRs.
   private ciEnrichmentEnabled: boolean = process.env.DAINTREE_INSTANCE_ROLE !== "worker";
   private lastCheckAt: number = Number.NEGATIVE_INFINITY;
+  // Separate from `lastCheckAt`: that one throttles PR *detection*, and reusing
+  // it would let a recent detection poll suppress the focus CI catch-up (they
+  // fetch different things).
+  private lastFocusCiCheckAt: number = Number.NEGATIVE_INFINITY;
   private startupDelayTimer: NodeJS.Timeout | null = null;
   private startupDelayResolve: (() => void) | null = null;
 
@@ -796,6 +830,7 @@ class PullRequestService {
     this.boostExpiresAt = null;
     this.clearStagnantPollCounts();
     this.lastCheckAt = Number.NEGATIVE_INFINITY;
+    this.lastFocusCiCheckAt = Number.NEGATIVE_INFINITY;
     this.invalidateProvider();
   }
 
@@ -820,6 +855,12 @@ class PullRequestService {
     if (!focused || !this.isPolling) {
       return;
     }
+
+    // CI freshness is independent of PR-detection resolution, so this runs
+    // before the unresolved-candidate gate below — that gate is false in the
+    // common steady state (every worktree already has its PR), which is exactly
+    // when the CI catch-up matters most (#11513).
+    this.recheckResolvedCIOnFocus();
 
     if (!this.hasUnresolvedCandidates() || !this.isEnabled) {
       return;
@@ -847,6 +888,58 @@ class PullRequestService {
     void this.checkForPRs()
       .catch((err) => this.handleError(formatErrorMessage(err, "PR focus catch-up failed")))
       .finally(() => this.scheduleNextPoll());
+  }
+
+  /**
+   * Re-enrich CI for every resolved PR on focus regain — the moment the user is
+   * actually looking at the sidebar. This is the only trigger that covers
+   * entries `sweepStaleCiStatus` cleared to `undefined` on blur: those are
+   * neither `pending` nor probe-flagged, so both revalidation triggers skip them
+   * and CI that finished while the window was blurred would never surface
+   * (#11513). Unlike the slow terminal pass this deliberately includes
+   * `undefined` — the issue asks for exactly that backfill.
+   *
+   * Hooked off the focus signal rather than `setCIEnrichmentEnabled(true)`
+   * because that setter early-returns when the flag is already `true` — which is
+   * the state of a workspace-host restarted while the app was blurred, since
+   * WorkspaceHostProcess replays monitor config but not the PR focus cadence, so
+   * the fresh service keeps the attended `true` default and never sees a flip.
+   */
+  private recheckResolvedCIOnFocus(): void {
+    if (!this.ciEnrichmentEnabled || !this.isEnabled) return;
+    const repo = this.repoRef;
+    if (!repo || !this.ciStatusLoader) return;
+
+    // Throttle rapid alt-tabbing, mirroring the detection catch-up above.
+    // `now < lastFocusCiCheckAt` rebases a backwards clock jump instead of
+    // suppressing catch-up until real time overtakes the stale stamp.
+    const now = Date.now();
+    if (
+      now >= this.lastFocusCiCheckAt &&
+      now - this.lastFocusCiCheckAt < FOCUS_CATCHUP_THROTTLE_MS
+    ) {
+      return;
+    }
+
+    // Resolved worktrees only: detectedPRs can still hold an entry for a
+    // worktree mid-re-detection, and re-checking that burns quota on a PR
+    // binding about to be replaced.
+    const enrichedPRNumbers = new Set<number>();
+    for (const worktreeId of this.resolvedWorktrees) {
+      const detectedPR = this.detectedPRs.get(worktreeId);
+      if (!detectedPR || enrichedPRNumbers.has(detectedPR.number)) continue;
+      enrichedPRNumbers.add(detectedPR.number);
+      // Synchronous fire-and-forget, matching revalidateResolvedPRs — every
+      // load enqueued in this loop coalesces into one getCIStatuses batch.
+      this.enrichPRWithCIStatus(detectedPR, repo);
+    }
+
+    if (enrichedPRNumbers.size === 0) {
+      // Nothing went out, so don't arm the throttle — otherwise a focus regain
+      // with no resolved PRs would swallow the next one.
+      return;
+    }
+    this.lastFocusCiCheckAt = now;
   }
 
   /**
@@ -1084,6 +1177,22 @@ class PullRequestService {
       return RESOLVED_REVALIDATION_DECAY_INTERVAL_MS;
     }
     return RESOLVED_REVALIDATION_BOOST_INTERVAL_MS;
+  }
+
+  // Is this PR's terminal CI status old enough to re-check? Gated purely on
+  // elapsed time, never on the cached status itself: a guard keyed off the
+  // status is exactly what froze the stale-green badge in #6149, because a
+  // status that never re-fetches can never stop matching its own skip
+  // condition. Elapsed time always advances, so this cannot wedge.
+  private isTerminalCiRecheckDue(pr: InternalLinkedPR, now: number): boolean {
+    const interval = terminalCiRecheckIntervalMs(pr.ciStatus);
+    if (interval === null) return false;
+    const last = pr.lastCiCheckAt;
+    // Never attempted, or the system clock moved backwards (correction / DST
+    // via a bad Date source) — rebase by treating it as due rather than letting
+    // a stamp from the future suppress re-checks until real time catches up.
+    if (last === undefined || now < last) return true;
+    return now - last >= interval;
   }
 
   private clearStagnantPollCounts(): void {
@@ -1393,16 +1502,24 @@ class PullRequestService {
 
       // CI status can change without the PR's metadata changing — a re-run does
       // not bump updated_at, so the probe reports those PRs unchanged. Keep
-      // polling CI for any in-flight PR not already enriched above, so green/red
+      // polling CI for any PR not already enriched above, so green/red
       // transitions still surface promptly even on an otherwise-quiet tick.
+      //
+      // Pending keeps its every-tick cadence (the boost bands above tune it,
+      // and re-tuning it is an explicit non-goal of #11513). Terminal states get
+      // a slow, failure-weighted pass on top: without it a re-run of a failed
+      // build is invisible to both triggers — not probe-flagged, not pending —
+      // and the cross sticks until the next push.
+      //
       // Skipped entirely when enrichment is disabled (unattended instance): the
-      // sweep on disable already cleared pending entries, so this loop would be
-      // a no-op anyway, but the guard keeps it from re-fetching after a
-      // re-detection re-seeds a pending state mid-blur.
+      // sweep on disable already cleared pending entries, so the pending half
+      // would be a no-op anyway, but the guard keeps both from re-fetching after
+      // a re-detection re-seeds state mid-blur.
       if (this.ciEnrichmentEnabled) {
+        const now = Date.now();
         for (const detectedPR of this.detectedPRs.values()) {
           if (enrichedPRNumbers.has(detectedPR.number)) continue;
-          if (detectedPR.ciStatus === "pending") {
+          if (detectedPR.ciStatus === "pending" || this.isTerminalCiRecheckDue(detectedPR, now)) {
             enrichedPRNumbers.add(detectedPR.number);
             this.enrichPRWithCIStatus(detectedPR, repo);
           }
@@ -1825,6 +1942,11 @@ class PullRequestService {
     // in a `for` loop per detected PR, so all loads enqueue in the same tick and
     // coalesce into one `getCIStatuses` batch. Do NOT add an `await` before this
     // call — it would drain the microtask queue and defeat the coalescing.
+    //
+    // Stamp the attempt, not the outcome: isTerminalCiRecheckDue reads this to
+    // pace the slow terminal re-check, and pacing on resolve would retry every
+    // tick for as long as the provider keeps rejecting.
+    pr.lastCiCheckAt = Date.now();
     loader
       .load(pr.number)
       .then((ciStatus) => {

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -932,17 +932,24 @@ class PullRequestService {
     // Resolved worktrees only: detectedPRs can still hold an entry for a
     // worktree mid-re-detection, and re-checking that burns quota on a PR
     // binding about to be replaced.
-    const enrichedPRNumbers = new Set<number>();
+    // Dedup by object, not PR number: sibling worktrees on one branch share a
+    // single InternalLinkedPR (so they collapse to one entry either way), but
+    // two worktrees that resolve the same PR through separate detection cycles
+    // hold DISTINCT objects. Number-dedup would enrich only the first and leave
+    // the other holding a stale status that a later blur sweep acts on. This
+    // costs no extra API call — BatchLoader single-flights by key, so both
+    // objects settle off one request.
+    const enrichedPRs = new Set<InternalLinkedPR>();
     for (const worktreeId of this.resolvedWorktrees) {
       const detectedPR = this.detectedPRs.get(worktreeId);
-      if (!detectedPR || enrichedPRNumbers.has(detectedPR.number)) continue;
-      enrichedPRNumbers.add(detectedPR.number);
+      if (!detectedPR || enrichedPRs.has(detectedPR)) continue;
+      enrichedPRs.add(detectedPR);
       // Synchronous fire-and-forget, matching revalidateResolvedPRs — every
       // load enqueued in this loop coalesces into one getCIStatuses batch.
       this.enrichPRWithCIStatus(detectedPR, repo);
     }
 
-    if (enrichedPRNumbers.size === 0) {
+    if (enrichedPRs.size === 0) {
       // Nothing went out, so don't arm the throttle — otherwise a focus regain
       // with no resolved PRs would swallow the next one.
       return;
@@ -1984,10 +1991,16 @@ class PullRequestService {
             ? ciStatus.state
             : undefined;
         pr._ciStatus = ciStatus ?? undefined;
-        // An authoritative result landed (including a confirmed "no checks"),
-        // so the blur-sweep backfill debt is settled. A rejection skips this and
-        // leaves the flag set, keeping the entry eligible on the next tick.
-        pr.needsCiBackfill = undefined;
+        // Only a positive result settles the blur-sweep backfill debt. A `null`
+        // is not trustworthy here: when the batch call itself fails, the
+        // loader's per-PR fallback converts a transient error into a resolved
+        // `null`, so clearing on null would strand a swept badge on a network
+        // blip — and a swept entry was `pending`, so it demonstrably had checks.
+        // Worst case we retry it once per tick until the provider answers or a
+        // re-detection replaces the entry.
+        if (ciStatus) {
+          pr.needsCiBackfill = undefined;
+        }
         if (pr.ciStatus !== undefined) {
           pr.stagnantPollCount = prevCiStatus === pr.ciStatus ? pr.stagnantPollCount + 1 : 0;
         }

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -136,6 +136,14 @@ interface InternalLinkedPR {
   // which reads as "due" so entries detected before this field existed (or
   // seeded by a re-detection) self-heal on the next tick.
   lastCiCheckAt?: number;
+  // Set by sweepStaleCiStatus when a pending badge is cleared to `undefined` on
+  // blur. That state is invisible to every other trigger — it isn't `pending`,
+  // isn't terminal, and a CI re-run doesn't bump updated_at for the probe — so
+  // without an explicit marker the badge stays blank until the next push. The
+  // focus catch-up normally backfills it, but that's a single edge-triggered
+  // event: throttled, rate-limited, or rejected, it's gone. This flag keeps the
+  // entry eligible on the periodic tick until an authoritative result lands.
+  needsCiBackfill?: boolean;
 }
 
 export interface PRDetectionResult {
@@ -1005,6 +1013,10 @@ class PullRequestService {
       pr.ciStatus = undefined;
       pr._ciStatus = undefined;
       pr.stagnantPollCount = 0;
+      // Mark for backfill: this entry is now indistinguishable from "no CI
+      // configured", which nothing re-polls. The flag is what makes it
+      // recoverable once enrichment comes back (#11513).
+      pr.needsCiBackfill = true;
     }
 
     // updateBoostFromDetectedPRs runs unconditionally — with no pending entries
@@ -1519,7 +1531,11 @@ class PullRequestService {
         const now = Date.now();
         for (const detectedPR of this.detectedPRs.values()) {
           if (enrichedPRNumbers.has(detectedPR.number)) continue;
-          if (detectedPR.ciStatus === "pending" || this.isTerminalCiRecheckDue(detectedPR, now)) {
+          if (
+            detectedPR.ciStatus === "pending" ||
+            detectedPR.needsCiBackfill === true ||
+            this.isTerminalCiRecheckDue(detectedPR, now)
+          ) {
             enrichedPRNumbers.add(detectedPR.number);
             this.enrichPRWithCIStatus(detectedPR, repo);
           }
@@ -1968,6 +1984,10 @@ class PullRequestService {
             ? ciStatus.state
             : undefined;
         pr._ciStatus = ciStatus ?? undefined;
+        // An authoritative result landed (including a confirmed "no checks"),
+        // so the blur-sweep backfill debt is settled. A rejection skips this and
+        // leaves the flag set, keeping the entry eligible on the next tick.
+        pr.needsCiBackfill = undefined;
         if (pr.ciStatus !== undefined) {
           pr.stagnantPollCount = prevCiStatus === pr.ciStatus ? pr.stagnantPollCount + 1 : 0;
         }
@@ -1995,7 +2015,16 @@ class PullRequestService {
             });
           }
         }
+        const boostWasArmed = this.boostExpiresAt !== null;
         this.updateBoostFromDetectedPRs();
+        // Enrichment is fire-and-forget, so a terminal→pending flip (a CI
+        // re-run) only becomes visible here — after revalidateResolvedPRs
+        // already re-armed its timer at the 90s baseline. Without this the
+        // freshly-armed boost wouldn't take effect until that stale tick fired,
+        // making the first re-run poll up to 90s away instead of 30s (#11513).
+        if (!boostWasArmed && this.boostExpiresAt !== null) {
+          this.scheduleRevalidation();
+        }
       })
       .catch(() => {
         // CI status fetch is best-effort; failure does not invalidate the PR detection

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -2939,30 +2939,43 @@ describe("PullRequestService", () => {
       pullRequestService.destroy();
     });
 
-    it("eventually re-checks a successful PR too", async () => {
-      const { getCIStatuses } = makeUnchangedProbeHarness(
-        new Map([
-          [1, ciState("failure")],
-          [2, ciState("success")],
-        ])
-      );
+    it("turns a green badge red when a re-run fails", async () => {
+      const ciByNumber = new Map([
+        [1, ciState("failure")],
+        [2, ciState("success")],
+      ]);
+      const { getCIStatuses } = makeUnchangedProbeHarness(ciByNumber);
 
-      const { pullRequestService } = await detectAndSettle(["feature/a", "feature/b"]);
+      const { pullRequestService, events } = await detectAndSettle(["feature/a", "feature/b"]);
+      const svc = pullRequestService as unknown as {
+        detectedPRs: Map<string, { ciStatus?: string }>;
+      };
+      expect(svc.detectedPRs.get("wt-2")?.ciStatus).toBe("success");
       getCIStatuses.mockClear();
 
-      const seen = new Set<number>();
-      for (let elapsed = 0; elapsed < 60 && !seen.has(2); elapsed++) {
+      const detected: DaintreeEventMap["sys:pr:detected"][] = [];
+      const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
+
+      // The green PR's next run breaks, with no push behind it.
+      ciByNumber.set(2, ciState("failure"));
+
+      for (
+        let elapsed = 0;
+        elapsed < 60 && svc.detectedPRs.get("wt-2")?.ciStatus !== "failure";
+        elapsed++
+      ) {
         jump(MINUTE);
         await revalidate(pullRequestService);
-        for (const call of getCIStatuses.mock.calls) {
-          for (const n of call[1]) seen.add(n);
-        }
       }
 
-      // A green badge is not a fixed point — it re-checks on its own cadence, so
-      // a re-run that turns it red still surfaces (#6149).
-      expect(seen.has(2)).toBe(true);
+      // A green badge is not a fixed point — asserting the badge actually flips
+      // rather than merely that PR 2 was queried, so a regression that fetches
+      // but declines to apply the result over a cached success is still caught
+      // (#6149).
+      expect(svc.detectedPRs.get("wt-2")?.ciStatus).toBe("failure");
+      expect(detected.filter((d) => d.worktreeId === "wt-2").at(-1)?.prCiStatus).toBe("failure");
 
+      unsubscribe();
       pullRequestService.destroy();
     });
 
@@ -2980,6 +2993,11 @@ describe("PullRequestService", () => {
 
       const detected: DaintreeEventMap["sys:pr:detected"][] = [];
       const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
+
+      // Seed a stagnation count the transition has to actually clear — starting
+      // from 0 would let an implementation that never resets it still pass.
+      const pr = svc.detectedPRs.get("wt-1");
+      if (pr) pr.stagnantPollCount = 17;
 
       // The user re-runs the failed job: no push, so updated_at never moves and
       // the probe still reports the PR unchanged.
@@ -3007,15 +3025,24 @@ describe("PullRequestService", () => {
       const { getCIStatuses } = makeUnchangedProbeHarness(new Map([[1, ciState("failure")]]));
 
       const { pullRequestService } = await detectAndSettle(["feature/a"]);
+      const svc = pullRequestService as unknown as {
+        detectedPRs: Map<string, { ciStatus?: string }>;
+      };
       getCIStatuses.mockClear();
-      // Every re-check from here on fails at the provider.
-      getCIStatuses.mockRejectedValue(new Error("transient GraphQL failure"));
+      // Every re-check from here on comes back with the key omitted, which the
+      // loader surfaces as a per-key rejection. Rejecting the whole call instead
+      // would fall through to the per-PR getCIStatus path, whose default mock
+      // resolves null and would quietly retire the PR from terminal state.
+      getCIStatuses.mockResolvedValue(new Map<number, CIStatus | null>());
 
       for (let elapsed = 0; elapsed < 60 && getCIStatuses.mock.calls.length === 0; elapsed++) {
         jump(MINUTE);
         await revalidate(pullRequestService);
       }
       expect(getCIStatuses).toHaveBeenCalledTimes(1);
+      // The rejection left the cached status alone, so the PR is still terminal
+      // and still a candidate — the only thing holding it back is the pacing.
+      expect(svc.detectedPRs.get("wt-1")?.ciStatus).toBe("failure");
 
       // The attempt is stamped on enqueue, so a rejected batch waits out the
       // interval instead of re-firing on every tick.
@@ -3060,9 +3087,11 @@ describe("PullRequestService", () => {
       pullRequestService.destroy();
     });
 
-    it("never re-checks a PR with no CI checks", async () => {
+    it("does not periodically re-check a PR with no CI checks", async () => {
       // `null` from the provider is a confirmed "no CI configured" → undefined
-      // status. There is nothing to re-poll for, so it must not burn quota.
+      // status. There is nothing to re-poll for, so the slow pass must not burn
+      // quota on it (#6240). Focus regain is the deliberate exception, since a
+      // blur-swept badge is indistinguishable from this state.
       const { getCIStatuses } = makeUnchangedProbeHarness(new Map([[1, null]]));
 
       const { pullRequestService } = await detectAndSettle(["feature/a"]);
@@ -3119,6 +3148,40 @@ describe("PullRequestService", () => {
       pullRequestService.destroy();
     });
 
+    it("backfills a swept CI status on the periodic tick when focus is missed", async () => {
+      const ciByNumber = new Map([[1, ciState("pending")]]);
+      const { getCIStatuses } = makeUnchangedProbeHarness(ciByNumber);
+
+      const { pullRequestService } = await detectAndSettle(["feature/a"]);
+      const svc = pullRequestService as unknown as {
+        detectedPRs: Map<string, { ciStatus?: string }>;
+      };
+
+      pullRequestService.setCIEnrichmentEnabled(false);
+      expect(svc.detectedPRs.get("wt-1")?.ciStatus).toBeUndefined();
+
+      ciByNumber.set(1, ciState("success"));
+      getCIStatuses.mockClear();
+
+      // Focus regain WITHOUT the catch-up landing — it can be lost to the 5s
+      // throttle after a quick alt-tab, to a rate-limit pause, or to a rejected
+      // batch. The swept entry is neither pending nor terminal, so before the
+      // backfill marker nothing would ever pick it up again.
+      pullRequestService.setCIEnrichmentEnabled(true);
+      await revalidate(pullRequestService);
+
+      expect(getCIStatuses).toHaveBeenCalledWith(expect.anything(), [1]);
+      expect(svc.detectedPRs.get("wt-1")?.ciStatus).toBe("success");
+
+      // Debt settled: the entry drops back to the ordinary terminal cadence
+      // instead of re-fetching on every tick forever.
+      getCIStatuses.mockClear();
+      await revalidate(pullRequestService);
+      expect(getCIStatuses).not.toHaveBeenCalled();
+
+      pullRequestService.destroy();
+    });
+
     it("runs the focus catch-up even when enrichment was already enabled", async () => {
       const { getCIStatuses } = makeUnchangedProbeHarness(new Map([[1, ciState("failure")]]));
 
@@ -3154,6 +3217,81 @@ describe("PullRequestService", () => {
       expect(afterFirst).toBe(1);
       expect(getCIStatuses).toHaveBeenCalledTimes(afterFirst);
 
+      // ...but the throttle must RELEASE. An implementation that allowed the
+      // first catch-up and suppressed every later one would satisfy the
+      // assertions above while breaking the feature.
+      jump(MINUTE);
+      pullRequestService.setFocusCadence(true);
+      await flushLoaders();
+
+      expect(getCIStatuses).toHaveBeenCalledTimes(afterFirst + 1);
+
+      pullRequestService.destroy();
+    });
+
+    it("re-arms the focus catch-up after a reset", async () => {
+      const { getCIStatuses } = makeUnchangedProbeHarness(new Map([[1, ciState("failure")]]));
+
+      const { pullRequestService } = await detectAndSettle(["feature/a"]);
+      getCIStatuses.mockClear();
+
+      pullRequestService.setFocusCadence(true);
+      await flushLoaders();
+      expect(getCIStatuses).toHaveBeenCalledTimes(1);
+
+      // A project switch clears the throttle stamp along with the rest of the
+      // state, so the next lifecycle isn't born inside a stale throttle window.
+      pullRequestService.reset();
+      expect(
+        (pullRequestService as unknown as { lastFocusCiCheckAt: number }).lastFocusCiCheckAt
+      ).toBe(Number.NEGATIVE_INFINITY);
+
+      pullRequestService.destroy();
+    });
+
+    it("does not spend quota on focus while a rate-limit pause is active", async () => {
+      const { getCIStatuses } = makeUnchangedProbeHarness(new Map([[1, ciState("failure")]]));
+
+      const { pullRequestService } = await detectAndSettle(["feature/a"]);
+      getCIStatuses.mockClear();
+
+      // A recorded primary/secondary pause parks the service until nextRetryAt.
+      const svc = pullRequestService as unknown as { nextRetryAt: number };
+      svc.nextRetryAt = Date.now() + 30 * MINUTE;
+
+      pullRequestService.setFocusCadence(true);
+      await flushLoaders();
+      expect(getCIStatuses).not.toHaveBeenCalled();
+
+      // ...and resumes once the pause expires, rather than staying wedged.
+      svc.nextRetryAt = 0;
+      pullRequestService.setFocusCadence(true);
+      await flushLoaders();
+      expect(getCIStatuses).toHaveBeenCalledTimes(1);
+
+      pullRequestService.destroy();
+    });
+
+    it("issues one CI lookup for two worktrees sharing a PR", async () => {
+      const { getCIStatuses } = makeUnchangedProbeHarness(new Map([[1, ciState("failure")]]));
+
+      // Both worktrees sit on the branch that resolves to PR 1.
+      const { pullRequestService, events } = await detectAndSettle(["feature/a", "feature/a"]);
+      getCIStatuses.mockClear();
+
+      const detected: DaintreeEventMap["sys:pr:detected"][] = [];
+      const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
+
+      pullRequestService.setFocusCadence(true);
+      await flushLoaders();
+
+      // Deduplicated to a single batch entry, and each worktree still gets its
+      // own phase-2 emit so neither badge is left behind.
+      expect(getCIStatuses).toHaveBeenCalledWith(expect.anything(), [1]);
+      expect(detected.filter((d) => d.worktreeId === "wt-1")).toHaveLength(1);
+      expect(detected.filter((d) => d.worktreeId === "wt-2")).toHaveLength(1);
+
+      unsubscribe();
       pullRequestService.destroy();
     });
 

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -3182,6 +3182,75 @@ describe("PullRequestService", () => {
       pullRequestService.destroy();
     });
 
+    it("keeps the backfill debt when the CI lookup fails outright", async () => {
+      const ciByNumber = new Map([[1, ciState("pending")]]);
+      const { getCIStatuses } = makeUnchangedProbeHarness(ciByNumber);
+
+      const { pullRequestService } = await detectAndSettle(["feature/a"]);
+      const svc = pullRequestService as unknown as {
+        detectedPRs: Map<string, { ciStatus?: string; needsCiBackfill?: boolean }>;
+      };
+
+      pullRequestService.setCIEnrichmentEnabled(false);
+      expect(svc.detectedPRs.get("wt-1")?.needsCiBackfill).toBe(true);
+
+      // The whole batch call fails. The loader's per-PR fallback launders that
+      // into a resolved `null`, which is indistinguishable from a confirmed
+      // "no checks" — so treating null as authoritative would clear the debt
+      // and strand the badge permanently on a transient blip.
+      getCIStatuses.mockRejectedValue(new Error("provider unreachable"));
+      pullRequestService.setCIEnrichmentEnabled(true);
+      await revalidate(pullRequestService);
+
+      expect(svc.detectedPRs.get("wt-1")?.ciStatus).toBeUndefined();
+      expect(svc.detectedPRs.get("wt-1")?.needsCiBackfill).toBe(true);
+
+      // Provider recovers → the retained debt gets the badge back.
+      getCIStatuses.mockReset();
+      getCIStatuses.mockImplementation(async (_repo: RepoRef, prNumbers: number[]) => {
+        const map = new Map<number, CIStatus | null>();
+        for (const n of prNumbers) map.set(n, ciByNumber.get(n) ?? null);
+        return map;
+      });
+      ciByNumber.set(1, ciState("success"));
+      await revalidate(pullRequestService);
+
+      expect(svc.detectedPRs.get("wt-1")?.ciStatus).toBe("success");
+      expect(svc.detectedPRs.get("wt-1")?.needsCiBackfill).toBeUndefined();
+
+      pullRequestService.destroy();
+    });
+
+    it("re-arms revalidation when a re-run newly arms the boost", async () => {
+      const ciByNumber = new Map([[1, ciState("failure")]]);
+      makeUnchangedProbeHarness(ciByNumber);
+
+      const { pullRequestService } = await detectAndSettle(["feature/a"]);
+      const svc = pullRequestService as unknown as {
+        scheduleRevalidation: () => void;
+        boostExpiresAt: number | null;
+      };
+      expect(svc.boostExpiresAt).toBeNull();
+
+      const scheduleSpy = vi.spyOn(svc, "scheduleRevalidation");
+
+      ciByNumber.set(1, ciState("pending"));
+      for (let elapsed = 0; elapsed < 60 && svc.boostExpiresAt === null; elapsed++) {
+        jump(MINUTE);
+        await revalidate(pullRequestService);
+      }
+      expect(svc.boostExpiresAt).not.toBeNull();
+
+      // Enrichment is fire-and-forget, so the tick that discovered the re-run
+      // had already re-armed its own timer at the baseline before the pending
+      // result landed. Without an explicit reschedule the freshly-armed boost
+      // wouldn't take effect until that stale interval elapsed.
+      expect(scheduleSpy).toHaveBeenCalled();
+
+      scheduleSpy.mockRestore();
+      pullRequestService.destroy();
+    });
+
     it("runs the focus catch-up even when enrichment was already enabled", async () => {
       const { getCIStatuses } = makeUnchangedProbeHarness(new Map([[1, ciState("failure")]]));
 

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -2796,4 +2796,426 @@ describe("PullRequestService", () => {
       });
     });
   });
+
+  describe("terminal CI re-enrichment (#11513)", () => {
+    const MINUTE = 60 * 1000;
+
+    // Two resolved worktrees on distinct branches → PRs 1 and 2, with a
+    // caller-controlled CI state per PR number so a test can simulate a re-run
+    // landing between polls. probeOpenPRList always reports "unchanged", which
+    // is the steady state this issue is about: metadata revalidation is skipped,
+    // so CI selection is the only thing that can trigger a re-fetch.
+    function makeUnchangedProbeHarness(ciByNumber: Map<number, CIStatus | null>) {
+      const numberByBranch = new Map([
+        ["feature/a", 1],
+        ["feature/b", 2],
+      ]);
+      const batchSpy = vi.fn(async (_repo: RepoRef, branches: string[]) => {
+        const map = new Map<string, ForgePR | null>();
+        for (const branch of branches) {
+          const number = numberByBranch.get(branch);
+          map.set(branch, number ? makeMockForgePR({ number, headRef: branch }) : null);
+        }
+        return map;
+      });
+      const mockImpl = mockForgeProviderResolved(undefined, batchSpy);
+
+      const getCIStatuses = vi.fn(async (_repo: RepoRef, prNumbers: number[]) => {
+        const map = new Map<number, CIStatus | null>();
+        for (const n of prNumbers) map.set(n, ciByNumber.get(n) ?? null);
+        return map;
+      });
+      const findPRsByNumbers = vi.fn(async (_repo: RepoRef, prNumbers: number[]) => {
+        const map = new Map<number, ForgePR | null>();
+        for (const n of prNumbers) map.set(n, makeMockForgePR({ number: n }));
+        return map;
+      });
+      const probeOpenPRList = vi.fn(async () => ({ kind: "unchanged" as const }));
+      mockImpl.batchLookups = { findPRsByNumbers, getCIStatuses, probeOpenPRList };
+
+      return { getCIStatuses, findPRsByNumbers, probeOpenPRList };
+    }
+
+    function ciState(state: "success" | "failure" | "pending"): CIStatus {
+      return {
+        state,
+        total: 1,
+        passed: state === "success" ? 1 : 0,
+        failed: state === "failure" ? 1 : 0,
+        pending: state === "pending" ? 1 : 0,
+        rawData: null,
+      };
+    }
+
+    // Resolve `branches` into detected PRs and let the first CI enrichment land,
+    // so every PR carries a status and a fresh attempt timestamp. Returns with
+    // the CI spy cleared, ready for the assertions under test.
+    async function detectAndSettle(branches: string[]) {
+      const { pullRequestService } = await import("../PullRequestService.js");
+      const { events } = await import("../events.js");
+
+      pullRequestService.initialize("/repo", "test-project-id");
+      branches.forEach((branch, index) => {
+        events.emit(
+          "sys:worktree:update",
+          makeWorktreeSnapshot({ worktreeId: `wt-${index + 1}`, branch })
+        );
+      });
+
+      await pullRequestService.refresh();
+      await flushLoaders();
+
+      // start() is what normally arms this; the focus paths under test gate on
+      // it, and calling start() here would schedule jittered startup timers.
+      (pullRequestService as unknown as { isPolling: boolean }).isPolling = true;
+
+      return { pullRequestService, events };
+    }
+
+    async function revalidate(service: unknown): Promise<void> {
+      await (
+        service as unknown as { revalidateResolvedPRs: () => Promise<void> }
+      ).revalidateResolvedPRs();
+      await flushLoaders();
+    }
+
+    // Jump the clock without firing timers — advancing time normally would run
+    // the self-rescheduling revalidation chain and add calls the assertions
+    // aren't about.
+    function jump(ms: number): void {
+      vi.setSystemTime(Date.now() + ms);
+    }
+
+    it("does not re-check a terminal PR before its interval elapses", async () => {
+      const { getCIStatuses } = makeUnchangedProbeHarness(
+        new Map([
+          [1, ciState("failure")],
+          [2, ciState("success")],
+        ])
+      );
+
+      const { pullRequestService } = await detectAndSettle(["feature/a", "feature/b"]);
+      getCIStatuses.mockClear();
+
+      // Back-to-back tick: both PRs were just enriched, so neither is due.
+      await revalidate(pullRequestService);
+      expect(getCIStatuses).not.toHaveBeenCalled();
+
+      // Still short of the shorter (failure) interval.
+      jump(2 * MINUTE);
+      await revalidate(pullRequestService);
+      expect(getCIStatuses).not.toHaveBeenCalled();
+
+      pullRequestService.destroy();
+    });
+
+    it("re-checks a failed PR before a successful one", async () => {
+      const { getCIStatuses } = makeUnchangedProbeHarness(
+        new Map([
+          [1, ciState("failure")],
+          [2, ciState("success")],
+        ])
+      );
+
+      const { pullRequestService } = await detectAndSettle(["feature/a", "feature/b"]);
+      getCIStatuses.mockClear();
+
+      // Failure weighting is the point: at some elapsed time the failed PR is
+      // due and the successful one is not. Walk forward a minute at a time
+      // until the first re-check fires and assert what it contained.
+      let firstBatch: number[] | null = null;
+      for (let elapsed = 0; elapsed < 60 && firstBatch === null; elapsed++) {
+        jump(MINUTE);
+        await revalidate(pullRequestService);
+        if (getCIStatuses.mock.calls.length > 0) {
+          firstBatch = getCIStatuses.mock.calls[0]?.[1] ?? null;
+        }
+      }
+
+      // The failed PR re-checks strictly sooner — the success PR is absent from
+      // the first batch entirely.
+      expect(firstBatch).toEqual([1]);
+
+      pullRequestService.destroy();
+    });
+
+    it("eventually re-checks a successful PR too", async () => {
+      const { getCIStatuses } = makeUnchangedProbeHarness(
+        new Map([
+          [1, ciState("failure")],
+          [2, ciState("success")],
+        ])
+      );
+
+      const { pullRequestService } = await detectAndSettle(["feature/a", "feature/b"]);
+      getCIStatuses.mockClear();
+
+      const seen = new Set<number>();
+      for (let elapsed = 0; elapsed < 60 && !seen.has(2); elapsed++) {
+        jump(MINUTE);
+        await revalidate(pullRequestService);
+        for (const call of getCIStatuses.mock.calls) {
+          for (const n of call[1]) seen.add(n);
+        }
+      }
+
+      // A green badge is not a fixed point — it re-checks on its own cadence, so
+      // a re-run that turns it red still surfaces (#6149).
+      expect(seen.has(2)).toBe(true);
+
+      pullRequestService.destroy();
+    });
+
+    it("surfaces a re-run that flips a failed PR back to pending", async () => {
+      const ciByNumber = new Map([[1, ciState("failure")]]);
+      const { getCIStatuses } = makeUnchangedProbeHarness(ciByNumber);
+
+      const { pullRequestService, events } = await detectAndSettle(["feature/a"]);
+      const svc = pullRequestService as unknown as {
+        detectedPRs: Map<string, { ciStatus?: string; stagnantPollCount: number }>;
+        boostExpiresAt: number | null;
+      };
+      expect(svc.detectedPRs.get("wt-1")?.ciStatus).toBe("failure");
+      getCIStatuses.mockClear();
+
+      const detected: DaintreeEventMap["sys:pr:detected"][] = [];
+      const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
+
+      // The user re-runs the failed job: no push, so updated_at never moves and
+      // the probe still reports the PR unchanged.
+      ciByNumber.set(1, ciState("pending"));
+
+      for (let elapsed = 0; elapsed < 60 && getCIStatuses.mock.calls.length === 0; elapsed++) {
+        jump(MINUTE);
+        await revalidate(pullRequestService);
+      }
+
+      expect(svc.detectedPRs.get("wt-1")?.ciStatus).toBe("pending");
+      expect(detected.at(-1)?.prCiStatus).toBe("pending");
+      // The cross→pending transition now arms the boost, which it never could
+      // while terminal states were excluded from re-enrichment.
+      expect(svc.boostExpiresAt).not.toBeNull();
+      // A stale terminal stagnation count must not land the re-run straight in
+      // the slowest decay band.
+      expect(svc.detectedPRs.get("wt-1")?.stagnantPollCount).toBe(0);
+
+      unsubscribe();
+      pullRequestService.destroy();
+    });
+
+    it("paces the next attempt off the request, not the response", async () => {
+      const { getCIStatuses } = makeUnchangedProbeHarness(new Map([[1, ciState("failure")]]));
+
+      const { pullRequestService } = await detectAndSettle(["feature/a"]);
+      getCIStatuses.mockClear();
+      // Every re-check from here on fails at the provider.
+      getCIStatuses.mockRejectedValue(new Error("transient GraphQL failure"));
+
+      for (let elapsed = 0; elapsed < 60 && getCIStatuses.mock.calls.length === 0; elapsed++) {
+        jump(MINUTE);
+        await revalidate(pullRequestService);
+      }
+      expect(getCIStatuses).toHaveBeenCalledTimes(1);
+
+      // The attempt is stamped on enqueue, so a rejected batch waits out the
+      // interval instead of re-firing on every tick.
+      await revalidate(pullRequestService);
+      await revalidate(pullRequestService);
+      expect(getCIStatuses).toHaveBeenCalledTimes(1);
+
+      pullRequestService.destroy();
+    });
+
+    it("re-checks a terminal PR when the system clock jumps backwards", async () => {
+      const { getCIStatuses } = makeUnchangedProbeHarness(new Map([[1, ciState("success")]]));
+
+      const { pullRequestService } = await detectAndSettle(["feature/a"]);
+      getCIStatuses.mockClear();
+
+      // A clock correction leaves the last-attempt stamp in the future. Elapsed
+      // time can never reach the interval again, so without a rebase the PR
+      // would be wedged out of re-checks for the length of the jump.
+      jump(-2 * 60 * MINUTE);
+      await revalidate(pullRequestService);
+
+      expect(getCIStatuses).toHaveBeenCalledWith(expect.anything(), [1]);
+
+      pullRequestService.destroy();
+    });
+
+    it("leaves the pending cadence untouched", async () => {
+      const { getCIStatuses } = makeUnchangedProbeHarness(new Map([[1, ciState("pending")]]));
+
+      const { pullRequestService } = await detectAndSettle(["feature/a"]);
+      getCIStatuses.mockClear();
+
+      // Pending re-polls every tick. The attempt timestamp the terminal pass
+      // introduced must not throttle it — that cadence is deliberately tuned
+      // and re-tuning it is an explicit non-goal of this issue.
+      await revalidate(pullRequestService);
+      await revalidate(pullRequestService);
+
+      expect(getCIStatuses).toHaveBeenCalledTimes(2);
+
+      pullRequestService.destroy();
+    });
+
+    it("never re-checks a PR with no CI checks", async () => {
+      // `null` from the provider is a confirmed "no CI configured" → undefined
+      // status. There is nothing to re-poll for, so it must not burn quota.
+      const { getCIStatuses } = makeUnchangedProbeHarness(new Map([[1, null]]));
+
+      const { pullRequestService } = await detectAndSettle(["feature/a"]);
+      const svc = pullRequestService as unknown as {
+        detectedPRs: Map<string, { ciStatus?: string }>;
+      };
+      expect(svc.detectedPRs.get("wt-1")?.ciStatus).toBeUndefined();
+      getCIStatuses.mockClear();
+
+      for (let elapsed = 0; elapsed < 60; elapsed++) {
+        jump(MINUTE);
+        await revalidate(pullRequestService);
+      }
+
+      expect(getCIStatuses).not.toHaveBeenCalled();
+
+      pullRequestService.destroy();
+    });
+
+    it("backfills a CI status swept to unknown on blur once focus returns", async () => {
+      const ciByNumber = new Map([[1, ciState("pending")]]);
+      const { getCIStatuses } = makeUnchangedProbeHarness(ciByNumber);
+
+      const { pullRequestService, events } = await detectAndSettle(["feature/a"]);
+      const svc = pullRequestService as unknown as {
+        detectedPRs: Map<string, { ciStatus?: string }>;
+        hasUnresolvedCandidates: () => boolean;
+      };
+
+      // Blur sweeps the in-flight badge to unknown.
+      pullRequestService.setCIEnrichmentEnabled(false);
+      expect(svc.detectedPRs.get("wt-1")?.ciStatus).toBeUndefined();
+
+      // CI finished while the window was blurred.
+      ciByNumber.set(1, ciState("success"));
+      getCIStatuses.mockClear();
+
+      const detected: DaintreeEventMap["sys:pr:detected"][] = [];
+      const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
+
+      pullRequestService.setCIEnrichmentEnabled(true);
+      pullRequestService.setFocusCadence(true);
+      await flushLoaders();
+
+      // The swept entry is neither pending nor probe-flagged, so only the focus
+      // pass can reach it — and it must, because every candidate is already
+      // resolved, which is what made the old catch-up skip this entirely.
+      expect(svc.hasUnresolvedCandidates()).toBe(false);
+      expect(getCIStatuses).toHaveBeenCalledWith(expect.anything(), [1]);
+      expect(svc.detectedPRs.get("wt-1")?.ciStatus).toBe("success");
+      expect(detected.at(-1)?.prCiStatus).toBe("success");
+
+      unsubscribe();
+      pullRequestService.destroy();
+    });
+
+    it("runs the focus catch-up even when enrichment was already enabled", async () => {
+      const { getCIStatuses } = makeUnchangedProbeHarness(new Map([[1, ciState("failure")]]));
+
+      const { pullRequestService } = await detectAndSettle(["feature/a"]);
+      getCIStatuses.mockClear();
+
+      // A workspace-host restarted while the app was blurred keeps the attended
+      // `true` default (its focus cadence is never replayed), so focus regain
+      // brings no flag transition. Hooking the catch-up off the enrichment
+      // setter would silently skip that host.
+      pullRequestService.setFocusCadence(true);
+      await flushLoaders();
+
+      expect(getCIStatuses).toHaveBeenCalledWith(expect.anything(), [1]);
+
+      pullRequestService.destroy();
+    });
+
+    it("throttles repeated focus catch-ups", async () => {
+      const { getCIStatuses } = makeUnchangedProbeHarness(new Map([[1, ciState("failure")]]));
+
+      const { pullRequestService } = await detectAndSettle(["feature/a"]);
+      getCIStatuses.mockClear();
+
+      pullRequestService.setFocusCadence(true);
+      await flushLoaders();
+      const afterFirst = getCIStatuses.mock.calls.length;
+
+      // Rapid alt-tabbing must not burst the CI fan-out.
+      pullRequestService.setFocusCadence(true);
+      await flushLoaders();
+
+      expect(afterFirst).toBe(1);
+      expect(getCIStatuses).toHaveBeenCalledTimes(afterFirst);
+
+      pullRequestService.destroy();
+    });
+
+    it("stamps the focus catch-up so the next tick does not duplicate it", async () => {
+      const { getCIStatuses } = makeUnchangedProbeHarness(new Map([[1, ciState("failure")]]));
+
+      const { pullRequestService } = await detectAndSettle(["feature/a"]);
+      getCIStatuses.mockClear();
+
+      pullRequestService.setFocusCadence(true);
+      await flushLoaders();
+      expect(getCIStatuses).toHaveBeenCalledTimes(1);
+
+      // The focus pass goes through the same enrichment entry point, so it
+      // re-paces the terminal interval rather than stacking on top of it.
+      await revalidate(pullRequestService);
+      expect(getCIStatuses).toHaveBeenCalledTimes(1);
+
+      pullRequestService.destroy();
+    });
+
+    it("keeps both paths inert while CI enrichment is disabled", async () => {
+      const { getCIStatuses } = makeUnchangedProbeHarness(new Map([[1, ciState("failure")]]));
+
+      const { pullRequestService } = await detectAndSettle(["feature/a"]);
+      pullRequestService.setCIEnrichmentEnabled(false);
+      getCIStatuses.mockClear();
+
+      // Well past both terminal intervals.
+      jump(60 * MINUTE);
+      await revalidate(pullRequestService);
+      pullRequestService.setFocusCadence(true);
+      await flushLoaders();
+
+      expect(getCIStatuses).not.toHaveBeenCalled();
+
+      pullRequestService.destroy();
+    });
+
+    it("keeps both paths inert on worker instances", async () => {
+      const prev = process.env.DAINTREE_INSTANCE_ROLE;
+      process.env.DAINTREE_INSTANCE_ROLE = "worker";
+      try {
+        const { getCIStatuses } = makeUnchangedProbeHarness(new Map([[1, ciState("failure")]]));
+
+        const { pullRequestService } = await detectAndSettle(["feature/a"]);
+        const svc = pullRequestService as unknown as { ciEnrichmentEnabled: boolean };
+
+        jump(60 * MINUTE);
+        await revalidate(pullRequestService);
+        // A stray focus signal must not enable enrichment as a side effect.
+        pullRequestService.setFocusCadence(true);
+        await flushLoaders();
+
+        expect(svc.ciEnrichmentEnabled).toBe(false);
+        expect(getCIStatuses).not.toHaveBeenCalled();
+
+        pullRequestService.destroy();
+      } finally {
+        if (prev === undefined) delete process.env.DAINTREE_INSTANCE_ROLE;
+        else process.env.DAINTREE_INSTANCE_ROLE = prev;
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Once a PR's CI status reached a terminal state, `PullRequestService` never re-polled it. The bug clustered on failures because failure is exactly the state you re-run.
- Adds a slow, failure-weighted recheck for terminal PRs, riding the existing revalidation tick with no new timer or API surface.
- Fixes two related staleness gaps around window blur/focus and hardens the backfill path against errors that were being laundered into a false "resolved" result.

Resolves #11513

## The bug

The compensating loop in `revalidateResolvedPRs` only re-enriched PRs where `ciStatus === "pending"`. The cheap `probeOpenPRList` REST probe detects change via `updated_at`, and a CI re-run without a new push never bumps that timestamp. So a red cross stuck until the next push or a manual refresh.

## What changed

- **Slow terminal recheck.** Failures get rechecked every 3 minutes, successes every 10. It rides the existing 90s revalidation tick and coalesces into the same batched `getCIStatuses` call, so there's no new timer and no new API surface. Cost works out to roughly 40 GraphQL points/hour per continuously failing PR and 12/hour per green one, against the 5000/hr budget.
- **Elapsed time, not cached status, gates the recheck.** The clock is stamped at enqueue. Keying the skip off status is exactly what froze the stale-green badge in #6149, so this uses a clock that always advances and structurally can't wedge the same way. A rejected batch just waits out the interval rather than re-firing every tick.
- **Focus regain re-enriches every resolved PR**, including entries the blur sweep had cleared to unknown. This hooks off `setFocusCadence(true)` rather than `setCIEnrichmentEnabled(true)`, because that setter no-ops when the flag is already on, which is exactly the state after a `WorkspaceHostProcess` restart replays monitor config but not the PR focus cadence.
- **Blur-swept entries get an explicit backfill marker** so the periodic tick can recover them if the focus catch-up misses them (5s throttle, a rate-limited pause, a failed batch). The marker only clears on a positive result: a failed batch call falls through to a per-PR path that can launder transient errors into a resolved `null`, and treating that as authoritative would strand the badge on a network blip instead of a real state.
- **Revalidation reschedules when enrichment newly arms the boost.** Enrichment is fire-and-forget, so without this a re-run's terminal-to-pending flip could land up to 90 seconds after the tick had already re-armed at the baseline interval instead of the 30s boost.

## Deliberately unchanged

- The pending cadence (30s boost decaying to 60s/120s, 90s baseline). It's already well tuned and this isn't a poll-more request.
- `undefined` CI status stays out of the slow pass, per #6240: "no checks" isn't "passed". Focus regain is the one deliberate exception, since a blur-swept badge is indistinguishable from that state.
- No new cache-write path and no second emit target. `enrichPRWithCIStatus`'s existing `sys:pr:detected` re-emit is still the only exit, per #11253.
- No renderer changes. `undefined` already reads as unknown and a fresh terminal value already renders correctly.

## Known limitation

The periodic revalidation loop still dedups by PR number rather than object identity, matching the existing convention it shares with the untouched pending branch. Two worktrees that resolve the same PR through separate detection cycles hold distinct objects, so one can lag with a stale status. This is fixed on the focus path, where it costs nothing since `BatchLoader` single-flights by key, but left alone on the periodic path to avoid disturbing the tuned pending cadence. The focus pass converges every object on each focus regain, so the residual window is small.

## Testing

- `PullRequestService.test.ts`: 93 tests, 20 new, covering the terminal recheck cadence, the enqueue-time gate, focus re-enrichment, the backfill marker, and reschedule-on-arm.
- Full local run: 977 tests across 47 covering test files, including every `workspace-host/__tests__` suite, `forgeResolution.test.ts`, `forgeRemoteSelection.test.ts`, and `ForgeIntegrationsTab.test.tsx`.
- `eslint` on both changed files: 0 errors (20 pre-existing `no-explicit-any` warnings below line 2800, none added here).
- `prettier --check`: clean.
- Mutation check: disabling both new behavior hooks turned 9 of the new tests red, confirming they're load-bearing.
