### PR TITLE
fix(recipes): show which scope every recipe comes from in the pickers

### DIFF
--- a/plugins/builtin/github/renderer/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -174,6 +174,15 @@ vi.mock("@/store/panelStore", () => ({
 let mockSelectedRecipeId: string | null = null;
 vi.mock("@/components/Worktree/hooks/useRecipePicker", () => ({
   CLONE_LAYOUT_ID: "__clone_layout__",
+  resolveEligibleDefaultRecipeId: (
+    recipes: unknown[],
+    persistedDefaultRecipeId: string | undefined
+  ) => {
+    // Mirror the real implementation: return the persisted ID only if it exists in recipes and is not shadowed
+    return recipes.some((r: any) => r.id === persistedDefaultRecipeId && !r.shadowedBy)
+      ? persistedDefaultRecipeId
+      : undefined;
+  },
   useRecipePicker: () => ({
     selectedRecipeId: mockSelectedRecipeId,
     setSelectedRecipeId: vi.fn(),

--- a/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
+++ b/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
@@ -126,7 +126,7 @@ export function BulkCreateWorktreeDialog({
 
   const { projectSettings } = useNewWorktreeProjectSettings({ isOpen });
   const defaultRecipeId = projectSettings?.defaultWorktreeRecipeId;
-  const globalRecipes = useMemo(() => recipes.filter((r) => !r.worktreeId), [recipes]);
+  const startingLayoutRecipes = useMemo(() => recipes.filter((r) => !r.worktreeId), [recipes]);
 
   // Recipe picker (shared preferences with single create)
   const {
@@ -139,7 +139,7 @@ export function BulkCreateWorktreeDialog({
   } = useRecipePicker({
     isOpen,
     defaultRecipeId,
-    globalRecipes,
+    startingLayoutRecipes,
     lastSelectedWorktreeRecipeId,
     projectId,
     setLastSelectedWorktreeRecipeIdByProject,
@@ -1046,7 +1046,7 @@ export function BulkCreateWorktreeDialog({
             )}
 
             <RecipePickerPopover
-              recipes={globalRecipes}
+              recipes={startingLayoutRecipes}
               selectedRecipeId={selectedRecipeId}
               selectedRecipe={selectedRecipe}
               defaultRecipeId={defaultRecipeId}

--- a/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
+++ b/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
@@ -27,7 +27,11 @@ import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { usePanelStore } from "@/store/panelStore";
-import { useRecipePicker, CLONE_LAYOUT_ID } from "@/components/Worktree/hooks/useRecipePicker";
+import {
+  useRecipePicker,
+  resolveEligibleDefaultRecipeId,
+  CLONE_LAYOUT_ID,
+} from "@/components/Worktree/hooks/useRecipePicker";
 import { RecipePickerPopover } from "@/components/Worktree/views/RecipePickerPopover";
 import { useNewWorktreeProjectSettings } from "@/components/Worktree/hooks/useNewWorktreeProjectSettings";
 import { spawnPanelsFromRecipe } from "@/components/Worktree/panelSpawning";
@@ -125,8 +129,12 @@ export function BulkCreateWorktreeDialog({
   const currentUserAvatar = viewer?.avatarUrl;
 
   const { projectSettings } = useNewWorktreeProjectSettings({ isOpen });
-  const defaultRecipeId = projectSettings?.defaultWorktreeRecipeId;
+  const persistedDefaultRecipeId = projectSettings?.defaultWorktreeRecipeId;
   const startingLayoutRecipes = useMemo(() => recipes.filter((r) => !r.worktreeId), [recipes]);
+  const defaultRecipeId = useMemo(
+    () => resolveEligibleDefaultRecipeId(startingLayoutRecipes, persistedDefaultRecipeId),
+    [startingLayoutRecipes, persistedDefaultRecipeId]
+  );
 
   // Recipe picker (shared preferences with single create)
   const {
@@ -274,8 +282,15 @@ export function BulkCreateWorktreeDialog({
       });
       queueRef.current = queue;
       const currentRunItems = new Set(toCreate.map((p) => p.item.number));
+      // Size the admission batch off the recipe that will actually spawn: the
+      // run path resolves a shadowed id to its winner, so planning from the
+      // displayed row would budget for the wrong terminal count.
+      const effectiveRecipe = selectedRecipe
+        ? (useRecipeStore.getState().getRecipeById(selectedRecipe.id) ?? selectedRecipe)
+        : undefined;
       const ptyTerminalsPerRecipe =
-        selectedRecipe?.terminals.filter((terminal) => terminal.type !== "dev-preview").length ?? 0;
+        effectiveRecipe?.terminals.filter((terminal) => terminal.type !== "dev-preview").length ??
+        0;
       const recipeSpawnBatches = planBulkRecipeSpawnBatches(
         [...currentRunItems],
         ptyTerminalsPerRecipe,

--- a/src/components/Layout/DockLaunchMenuItems.tsx
+++ b/src/components/Layout/DockLaunchMenuItems.tsx
@@ -222,7 +222,7 @@ export function DockLaunchMenuItems({
             <span className="truncate">{recipe.name}</span>
             <span className="ml-auto pl-2 text-[11px] text-text-muted shrink-0">
               {recipe.shadowedBy
-                ? `${getRecipeScope(recipe).label} · Overridden`
+                ? `${getRecipeScope(recipe).label} · Overridden by Team`
                 : getRecipeScope(recipe).label}
             </span>
           </C.Item>

--- a/src/components/Layout/DockLaunchMenuItems.tsx
+++ b/src/components/Layout/DockLaunchMenuItems.tsx
@@ -6,6 +6,7 @@ import { useRecipeStore } from "@/store/recipeStore";
 import { useActionMruStore } from "@/store/actionMruStore";
 import type { RecipeContext } from "@/utils/recipeVariables";
 import { notifyRecipeSpawnFailures } from "@/utils/recipeNotify";
+import { getRecipeScope } from "@/utils/recipeScope";
 import { logError } from "@/utils/logger";
 import { actionService } from "@/services/ActionService";
 import type { ActionSource, AgentAvailabilityState } from "@shared/types";
@@ -71,10 +72,11 @@ export function DockLaunchMenuItems({
 }: DockLaunchMenuItemsProps) {
   // Subscribe inside the menu so the listener only runs while open.
   const recipes = useRecipeStore((s) => s.recipes);
+  // Shadowed recipes stay listed (dimmed, marked "Overridden") rather than
+  // vanishing — running one resolves to the winner, so hiding it only hides
+  // that the collision exists (#11510).
   const visibleRecipes = recipes.filter(
-    (r) =>
-      !r.shadowedBy &&
-      (r.worktreeId === undefined || r.worktreeId === (activeWorktreeId ?? undefined))
+    (r) => r.worktreeId === undefined || r.worktreeId === (activeWorktreeId ?? undefined)
   );
 
   // Subscribe to the stable getter (not its result) so the selector returns a
@@ -204,6 +206,7 @@ export function DockLaunchMenuItems({
         visibleRecipes.map((recipe) => (
           <C.Item
             key={recipe.id}
+            className={recipe.shadowedBy ? "opacity-70" : undefined}
             onSelect={() =>
               // Fire-and-forget, but surface spawn failures — the menu closes
               // on select, so a toast/inbox entry is the only signal the user
@@ -215,8 +218,13 @@ export function DockLaunchMenuItems({
                 .catch((error) => logError("Recipe launch from dock failed", error))
             }
           >
-            <Workflow className="w-3.5 h-3.5 mr-2" />
-            {recipe.name}
+            <Workflow className="w-3.5 h-3.5 mr-2 shrink-0" />
+            <span className="truncate">{recipe.name}</span>
+            <span className="ml-auto pl-2 text-[11px] text-text-muted shrink-0">
+              {recipe.shadowedBy
+                ? `${getRecipeScope(recipe).label} · Overridden`
+                : getRecipeScope(recipe).label}
+            </span>
           </C.Item>
         ))
       ) : (

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -7,6 +7,9 @@ let mockRecipes: Array<{
   id: string;
   name: string;
   worktreeId?: string;
+  projectId?: string;
+  scope?: string;
+  shadowedBy?: string;
 }> = [];
 let mockMruEntries: Array<{ id: string; score: number; lastAccessedAt: number }> = [];
 const runRecipeWithResultsMock = vi.fn();
@@ -440,6 +443,63 @@ describe("DockLaunchButton", () => {
     expect(getByText("Project recipe")).toBeTruthy();
     expect(getByText("Worktree recipe")).toBeTruthy();
     expect(queryByText("Other worktree recipe")).toBeNull();
+  });
+
+  it("distinguishes same-named recipes by scope (#11510)", () => {
+    mockRecipes = [
+      { id: "r-global", name: "Work", worktreeId: undefined, projectId: undefined },
+      { id: "r-local", name: "Work", worktreeId: undefined, projectId: "proj-1" },
+    ];
+
+    const { getByText } = render(
+      <DockLaunchButton
+        agents={AGENTS}
+        hasDevPreview={false}
+        onLaunchAgent={vi.fn()}
+        activeWorktreeId="wt-1"
+        cwd="/tmp"
+      />
+    );
+
+    expect(getByText("Global")).toBeTruthy();
+    expect(getByText("Project-wide")).toBeTruthy();
+  });
+
+  it("keeps a shadowed recipe listed, marked, and launchable (#11510)", async () => {
+    mockRecipes = [
+      {
+        id: "r-shadowed",
+        name: "Work",
+        worktreeId: undefined,
+        projectId: "proj-1",
+        shadowedBy: "Work",
+      },
+    ];
+    runRecipeWithResultsMock.mockResolvedValue({});
+
+    const { getByText } = render(
+      <DockLaunchButton
+        agents={AGENTS}
+        hasDevPreview={false}
+        onLaunchAgent={vi.fn()}
+        activeWorktreeId="wt-1"
+        cwd="/tmp"
+      />
+    );
+
+    expect(getByText(/Overridden by Team/)).toBeTruthy();
+
+    fireEvent.click(getByText("Work"));
+
+    // The raw id goes through; the store resolves it to the winning recipe.
+    await waitFor(() => {
+      expect(runRecipeWithResultsMock).toHaveBeenCalledWith(
+        "r-shadowed",
+        "/tmp",
+        "wt-1",
+        undefined
+      );
+    });
   });
 
   it("calls preventDefault on pointer close so the trigger does not keep its focus ring (issue #6119)", () => {

--- a/src/components/Project/RecipesTab.tsx
+++ b/src/components/Project/RecipesTab.tsx
@@ -24,7 +24,7 @@ import { AppDialog } from "@/components/ui/AppDialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { TerminalRecipe, Worktree } from "@/types";
 import { logError } from "@/utils/logger";
-import { getRecipeScope } from "@/utils/recipeScope";
+import { getRecipeScope, worktreeDisplayName } from "@/utils/recipeScope";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface RecipesTabProps {
@@ -182,11 +182,10 @@ export function RecipesTab({
     }
   };
 
-  const resolveWorktreeName = (worktreeId: string): string | undefined => {
-    const worktree = worktreeMap.get(worktreeId);
-    if (!worktree) return undefined;
-    return worktree.isMainWorktree ? worktree.name : worktree.branch || worktree.name;
-  };
+  // Falls back to the raw id so an orphaned worktree's recipe stays
+  // identifiable here, where the row has the width for it.
+  const resolveWorktreeName = (worktreeId: string): string =>
+    worktreeDisplayName(worktreeMap.get(worktreeId)) ?? worktreeId;
 
   return (
     <>

--- a/src/components/Project/RecipesTab.tsx
+++ b/src/components/Project/RecipesTab.tsx
@@ -24,7 +24,7 @@ import { AppDialog } from "@/components/ui/AppDialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { TerminalRecipe, Worktree } from "@/types";
 import { logError } from "@/utils/logger";
-import { isInRepoRecipeId } from "@shared/utils/recipeFilename";
+import { getRecipeScope } from "@/utils/recipeScope";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface RecipesTabProps {
@@ -182,18 +182,10 @@ export function RecipesTab({
     }
   };
 
-  const getRecipeScope = (recipe: TerminalRecipe): { label: string; isGlobal: boolean } => {
-    if (isInRepoRecipeId(recipe)) return { label: "Team", isGlobal: false };
-    if (recipe.projectId === undefined) return { label: "Global", isGlobal: true };
-    if (!recipe.worktreeId) return { label: "Project-wide", isGlobal: false };
-    const worktree = worktreeMap.get(recipe.worktreeId);
-    if (worktree) {
-      return {
-        label: `Worktree: ${worktree.isMainWorktree ? worktree.name : worktree.branch || worktree.name}`,
-        isGlobal: false,
-      };
-    }
-    return { label: `Worktree: ${recipe.worktreeId}`, isGlobal: false };
+  const resolveWorktreeName = (worktreeId: string): string | undefined => {
+    const worktree = worktreeMap.get(worktreeId);
+    if (!worktree) return undefined;
+    return worktree.isMainWorktree ? worktree.name : worktree.branch || worktree.name;
   };
 
   return (
@@ -282,7 +274,7 @@ export function RecipesTab({
                             <TooltipContent side="bottom">{recipe.name}</TooltipContent>
                           </Tooltip>
                           {(() => {
-                            const scopeInfo = getRecipeScope(recipe);
+                            const scopeInfo = getRecipeScope(recipe, resolveWorktreeName);
                             return (
                               <span
                                 className={`text-[11px] px-1.5 py-0.5 rounded font-medium shrink-0 flex items-center gap-1 ${

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx
@@ -92,7 +92,7 @@ export function RecipeRunnerItem({
                 {recipe.name}
               </span>
               {recipe.shadowedBy && (
-                <span className="text-[11px] text-text-muted shrink-0">Overridden</span>
+                <span className="text-[11px] text-text-muted shrink-0">Overridden by Team</span>
               )}
               {isPinned && <Pin className="h-3 w-3 text-daintree-accent/60 shrink-0" aria-hidden />}
             </div>
@@ -146,7 +146,7 @@ export function RecipeRunnerItem({
           </span>
           <span className="text-[11px] text-text-muted shrink-0">{scopeLabel}</span>
           {recipe.shadowedBy && (
-            <span className="text-[11px] text-text-muted shrink-0">Overridden</span>
+            <span className="text-[11px] text-text-muted shrink-0">Overridden by Team</span>
           )}
           {recipeSummary && recipeSummary !== recipe.name && (
             <span className="text-xs text-text-muted truncate max-w-[30%]">{recipeSummary}</span>

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/context-menu";
 import { cn } from "@/lib/utils";
 import { getRecipeTerminalSummary } from "../utils/recipeUtils";
+import { getRecipeScope } from "@/utils/recipeScope";
 import type { TerminalRecipe } from "@/types";
 
 interface RecipeRunnerItemProps {
@@ -47,6 +48,7 @@ export function RecipeRunnerItem({
 }: RecipeRunnerItemProps) {
   const recipeSummary = getRecipeTerminalSummary(recipe.terminals);
   const isPinned = recipe.showInEmptyState === true;
+  const scopeLabel = getRecipeScope(recipe).label;
 
   if (mode === "grid") {
     return (
@@ -94,11 +96,12 @@ export function RecipeRunnerItem({
               )}
               {isPinned && <Pin className="h-3 w-3 text-daintree-accent/60 shrink-0" aria-hidden />}
             </div>
-            {recipeSummary && recipeSummary !== recipe.name && (
-              <span className="text-xs text-text-muted truncate w-full pl-5.5">
-                {recipeSummary}
-              </span>
-            )}
+            <span className="flex items-center gap-2 w-full pl-5.5 text-xs text-text-muted">
+              <span className="shrink-0">{scopeLabel}</span>
+              {recipeSummary && recipeSummary !== recipe.name && (
+                <span className="truncate">{recipeSummary}</span>
+              )}
+            </span>
           </button>
         </ContextMenuTrigger>
         <RecipeContextMenu
@@ -141,6 +144,7 @@ export function RecipeRunnerItem({
           <span className="flex-1 text-sm font-medium text-daintree-text truncate">
             {recipe.name}
           </span>
+          <span className="text-[11px] text-text-muted shrink-0">{scopeLabel}</span>
           {recipe.shadowedBy && (
             <span className="text-[11px] text-text-muted shrink-0">Overridden</span>
           )}

--- a/src/components/Terminal/RecipeRunner/__tests__/RecipeRunnerItem.test.tsx
+++ b/src/components/Terminal/RecipeRunner/__tests__/RecipeRunnerItem.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { RecipeRunnerItem } from "../RecipeRunnerItem";
 import {
   basePressTreatment,
@@ -18,7 +18,10 @@ const recipe: TerminalRecipe = {
 
 const noop = () => {};
 
-const renderItem = (mode: "grid" | "list", props?: { disabled?: boolean }) =>
+const renderItem = (
+  mode: "grid" | "list",
+  props?: { disabled?: boolean; recipe?: TerminalRecipe; onRun?: (id: string) => void }
+) =>
   render(
     <RecipeRunnerItem
       recipe={recipe}
@@ -85,6 +88,53 @@ describe("RecipeRunnerItem — press feedback", () => {
         .filter((c) => suppressed.has(c));
 
       expect(covered.length).toBeGreaterThan(0);
+    }
+  );
+});
+
+describe("RecipeRunnerItem — scope indicator", () => {
+  it.each(["grid", "list"] as const)(
+    "renders same-named recipes from different scopes distinguishably (%s mode)",
+    (mode) => {
+      const global = { ...recipe, id: "g", name: "Work", projectId: undefined };
+      const local = { ...recipe, id: "l", name: "Work", projectId: "proj-1" };
+
+      const { unmount } = renderItem(mode, { recipe: global });
+      const globalText = screen.getByRole("option").textContent ?? "";
+      unmount();
+
+      renderItem(mode, { recipe: local });
+      const localText = screen.getByRole("option").textContent ?? "";
+
+      expect(globalText).not.toBe(localText);
+    }
+  );
+
+  it.each(["grid", "list"] as const)(
+    "exposes the scope through the option's accessible name, not styling alone (%s mode)",
+    (mode) => {
+      renderItem(mode, { recipe: { ...recipe, projectId: "proj-1" } });
+      // Screen readers flatten an option's descendant text into its name, so a
+      // visible text label is what carries the scope to assistive tech.
+      expect(screen.getByRole("option", { name: /Project-wide/ })).toBeTruthy();
+    }
+  );
+
+  it.each(["grid", "list"] as const)(
+    "keeps a shadowed recipe marked and runnable rather than hiding it (%s mode)",
+    (mode) => {
+      const onRun = vi.fn<(id: string) => void>();
+      renderItem(mode, {
+        recipe: { ...recipe, id: "shadowed", shadowedBy: "Alpha" },
+        onRun,
+      });
+
+      const option = screen.getByRole("option");
+      expect(option.textContent).toContain("Overridden");
+      expect(option.hasAttribute("disabled")).toBe(false);
+
+      fireEvent.click(option);
+      expect(onRun).toHaveBeenCalledWith("shadowed");
     }
   );
 });

--- a/src/components/Terminal/RecipeRunner/__tests__/RecipeRunnerItem.test.tsx
+++ b/src/components/Terminal/RecipeRunner/__tests__/RecipeRunnerItem.test.tsx
@@ -130,7 +130,7 @@ describe("RecipeRunnerItem — scope indicator", () => {
       });
 
       const option = screen.getByRole("option");
-      expect(option.textContent).toContain("Overridden");
+      expect(option.textContent).toContain("Overridden by Team");
       expect(option.hasAttribute("disabled")).toBe(false);
 
       fireEvent.click(option);

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -28,7 +28,11 @@ import { useBranchInput } from "./hooks/useBranchInput";
 import { useBranchValidation } from "./hooks/useBranchValidation";
 import { useBranchPicker } from "./hooks/useBranchPicker";
 import { usePrefixPicker } from "./hooks/usePrefixPicker";
-import { useRecipePicker, CLONE_LAYOUT_ID } from "./hooks/useRecipePicker";
+import {
+  useRecipePicker,
+  resolveEligibleDefaultRecipeId,
+  CLONE_LAYOUT_ID,
+} from "./hooks/useRecipePicker";
 import { useWorktreeFormErrors } from "./hooks/useWorktreeFormErrors";
 import { useWorktreeFormValidation } from "./hooks/useWorktreeFormValidation";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -157,13 +161,8 @@ export function NewWorktreeDialog({
   // Shadowed recipes stay listed (dimmed, marked "Overridden") instead of being
   // hidden — hiding an executable target is the silent failure #11510 is about.
   const startingLayoutRecipes = useMemo(() => recipes.filter((r) => !r.worktreeId), [recipes]);
-  // A shadowed recipe never runs its own terminals, so it stays ineligible as an
-  // implicit default. Mirrors the eligibility rule RecipesTab pins against.
   const defaultRecipeId = useMemo(
-    () =>
-      startingLayoutRecipes.some((r) => r.id === persistedDefaultRecipeId && !r.shadowedBy)
-        ? persistedDefaultRecipeId
-        : undefined,
+    () => resolveEligibleDefaultRecipeId(startingLayoutRecipes, persistedDefaultRecipeId),
     [startingLayoutRecipes, persistedDefaultRecipeId]
   );
 

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -153,10 +153,18 @@ export function NewWorktreeDialog({
   const resourceEnvironments = projectSettings?.resourceEnvironments;
   const hasAnyEnvironments = Object.keys(resourceEnvironments ?? {}).length > 0;
 
-  const defaultRecipeId = projectSettings?.defaultWorktreeRecipeId;
-  const globalRecipes = useMemo(
-    () => recipes.filter((r) => !r.worktreeId && !r.shadowedBy),
-    [recipes]
+  const persistedDefaultRecipeId = projectSettings?.defaultWorktreeRecipeId;
+  // Shadowed recipes stay listed (dimmed, marked "Overridden") instead of being
+  // hidden — hiding an executable target is the silent failure #11510 is about.
+  const startingLayoutRecipes = useMemo(() => recipes.filter((r) => !r.worktreeId), [recipes]);
+  // A shadowed recipe never runs its own terminals, so it stays ineligible as an
+  // implicit default. Mirrors the eligibility rule RecipesTab pins against.
+  const defaultRecipeId = useMemo(
+    () =>
+      startingLayoutRecipes.some((r) => r.id === persistedDefaultRecipeId && !r.shadowedBy)
+        ? persistedDefaultRecipeId
+        : undefined,
+    [startingLayoutRecipes, persistedDefaultRecipeId]
   );
 
   const {
@@ -304,7 +312,7 @@ export function NewWorktreeDialog({
   } = useRecipePicker({
     isOpen,
     defaultRecipeId,
-    globalRecipes,
+    startingLayoutRecipes,
     lastSelectedWorktreeRecipeId,
     projectId,
     initialRecipeId,
@@ -1037,9 +1045,9 @@ export function NewWorktreeDialog({
               hasAnyEnvironments={hasAnyEnvironments}
             />
 
-            {globalRecipes.length > 0 && (
+            {startingLayoutRecipes.length > 0 && (
               <RecipePickerPopover
-                recipes={globalRecipes}
+                recipes={startingLayoutRecipes}
                 selectedRecipeId={selectedRecipeId}
                 selectedRecipe={selectedRecipe}
                 defaultRecipeId={defaultRecipeId}

--- a/src/components/Worktree/QuickCreatePalette.tsx
+++ b/src/components/Worktree/QuickCreatePalette.tsx
@@ -5,8 +5,9 @@ import { PaletteFooterHints } from "@/components/ui/AppPaletteDialog";
 import type { QuickCreateItem, UseQuickCreatePaletteReturn } from "@/hooks/useQuickCreatePalette";
 import { getAutoAssign } from "@shared/types/project";
 import type { TerminalRecipe } from "@/types";
-import { getRecipeScope } from "@/utils/recipeScope";
+import { getRecipeScope, worktreeDisplayName } from "@/utils/recipeScope";
 import { Settings2 } from "lucide-react";
+import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { actionService } from "@/services/ActionService";
 import { Button } from "@/components/ui/button";
@@ -29,6 +30,13 @@ function RecipeListItem({
   isSelected: boolean;
   onClick: () => void;
 }) {
+  // The palette lists recipes from every worktree, so two same-named
+  // worktree-scoped recipes need their worktree names to tell them apart.
+  const worktreeId = item._kind === "recipe" ? item.worktreeId : undefined;
+  const worktreeName = useWorktreeStore((s) =>
+    worktreeId ? worktreeDisplayName(s.worktrees.get(worktreeId)) : undefined
+  );
+
   if (item._kind === "customize") {
     return (
       <button
@@ -89,8 +97,8 @@ function RecipeListItem({
         </div>
       </div>
       <div className="flex items-center gap-2 text-[11px] text-daintree-text/50">
-        <span className="truncate">{getRecipeScope(recipe).label}</span>
-        {recipe.shadowedBy && <span className="shrink-0">Overridden</span>}
+        <span className="truncate">{getRecipeScope(recipe, () => worktreeName).label}</span>
+        {recipe.shadowedBy && <span className="shrink-0">Overridden by Team</span>}
         <span className="ml-auto shrink-0">
           {recipe.terminals.length} terminal{recipe.terminals.length !== 1 ? "s" : ""}
         </span>

--- a/src/components/Worktree/QuickCreatePalette.tsx
+++ b/src/components/Worktree/QuickCreatePalette.tsx
@@ -5,6 +5,7 @@ import { PaletteFooterHints } from "@/components/ui/AppPaletteDialog";
 import type { QuickCreateItem, UseQuickCreatePaletteReturn } from "@/hooks/useQuickCreatePalette";
 import { getAutoAssign } from "@shared/types/project";
 import type { TerminalRecipe } from "@/types";
+import { getRecipeScope } from "@/utils/recipeScope";
 import { Settings2 } from "lucide-react";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { actionService } from "@/services/ActionService";
@@ -68,14 +69,15 @@ function RecipeListItem({
         "border-daintree-border/40 hover:border-daintree-border/60",
         "bg-daintree-bg hover:bg-surface transition-colors",
         isSelected &&
-          "border-overlay bg-overlay-raised text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
+          "border-overlay bg-overlay-raised text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']",
+        recipe.shadowedBy && "opacity-60"
       )}
       aria-selected={isSelected}
       role="option"
     >
-      <div className="flex items-center justify-between text-sm">
-        <span className="font-medium text-daintree-text">{recipe.name}</span>
-        <div className="flex items-center gap-1">
+      <div className="flex items-center justify-between gap-2 text-sm">
+        <span className="font-medium text-daintree-text truncate">{recipe.name}</span>
+        <div className="flex items-center gap-1 shrink-0">
           {uniqueTypes.map((type) => (
             <span
               key={type}
@@ -86,8 +88,12 @@ function RecipeListItem({
           ))}
         </div>
       </div>
-      <div className="text-[11px] text-daintree-text/50">
-        {recipe.terminals.length} terminal{recipe.terminals.length !== 1 ? "s" : ""}
+      <div className="flex items-center gap-2 text-[11px] text-daintree-text/50">
+        <span className="truncate">{getRecipeScope(recipe).label}</span>
+        {recipe.shadowedBy && <span className="shrink-0">Overridden</span>}
+        <span className="ml-auto shrink-0">
+          {recipe.terminals.length} terminal{recipe.terminals.length !== 1 ? "s" : ""}
+        </span>
       </div>
     </button>
   );

--- a/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
+++ b/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
@@ -146,8 +146,11 @@ vi.mock("@/store/worktreeStore", () => ({
 const recipePickerCalls = vi.hoisted(() => ({
   last: null as { startingLayoutRecipes: unknown[]; defaultRecipeId: string | undefined } | null,
 }));
-vi.mock("@/components/Worktree/hooks/useRecipePicker", () => ({
-  CLONE_LAYOUT_ID: "__clone_layout__",
+// Only `useRecipePicker` is stubbed — `resolveEligibleDefaultRecipeId` stays
+// real so the default-eligibility tests exercise the shipping logic rather than
+// a copy of it. The module imports nothing but React, so pulling it in is safe.
+vi.mock("@/components/Worktree/hooks/useRecipePicker", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/components/Worktree/hooks/useRecipePicker")>()),
   useRecipePicker: (args: {
     startingLayoutRecipes: unknown[];
     defaultRecipeId: string | undefined;
@@ -1155,6 +1158,9 @@ describe("NewWorktreeDialog — recipe scope visibility (#11510)", () => {
     renderDialog();
     await advanceTimersGradually(500);
 
+    // Assert the call happened first — a bare optional chain would also pass if
+    // the picker were never invoked at all.
+    expect(recipePickerCalls.last).not.toBeNull();
     expect(recipePickerCalls.last?.defaultRecipeId).toBeUndefined();
   });
 

--- a/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
+++ b/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
@@ -73,8 +73,14 @@ vi.mock("@/store/panelStore", () => ({
 }));
 
 const mockGenerateRecipeFromActiveTerminals = vi.fn().mockReturnValue([]);
+const recipeFixtures = vi.hoisted(() => ({ recipes: [] as unknown[] }));
 vi.mock("@/store/recipeStore", () => {
-  const recipeState = { recipes: [], runRecipeWithResults: vi.fn() };
+  const recipeState = {
+    get recipes() {
+      return recipeFixtures.recipes;
+    },
+    runRecipeWithResults: vi.fn(),
+  };
   return {
     useRecipeStore: Object.assign(
       (selector?: (s: typeof recipeState) => unknown) =>
@@ -137,21 +143,33 @@ vi.mock("@/store/worktreeStore", () => ({
   },
 }));
 
+const recipePickerCalls = vi.hoisted(() => ({
+  last: null as { startingLayoutRecipes: unknown[]; defaultRecipeId: string | undefined } | null,
+}));
 vi.mock("@/components/Worktree/hooks/useRecipePicker", () => ({
   CLONE_LAYOUT_ID: "__clone_layout__",
-  useRecipePicker: () => ({
-    selectedRecipeId: null,
-    setSelectedRecipeId: vi.fn(),
-    recipePickerOpen: false,
-    setRecipePickerOpen: vi.fn(),
-    recipeSelectionTouchedRef: { current: false },
-    selectedRecipe: null,
-  }),
+  useRecipePicker: (args: {
+    startingLayoutRecipes: unknown[];
+    defaultRecipeId: string | undefined;
+  }) => {
+    recipePickerCalls.last = args;
+    return {
+      selectedRecipeId: null,
+      setSelectedRecipeId: vi.fn(),
+      recipePickerOpen: false,
+      setRecipePickerOpen: vi.fn(),
+      recipeSelectionTouchedRef: { current: false },
+      selectedRecipe: null,
+    };
+  },
 }));
 
+const projectSettingsFixture = vi.hoisted(() => ({
+  value: null as { defaultWorktreeRecipeId?: string } | null,
+}));
 vi.mock("@/components/Worktree/hooks/useNewWorktreeProjectSettings", () => ({
   useNewWorktreeProjectSettings: () => ({
-    projectSettings: null,
+    projectSettings: projectSettingsFixture.value,
     configuredBranchPrefix: "",
   }),
 }));
@@ -1073,5 +1091,80 @@ describe("NewWorktreeDialog — self-assign cache mutation", () => {
 
     expect(mockAssignIssue).not.toHaveBeenCalled();
     expect(getGeneration(ISSUE_CACHE_KEY)).toBe(0);
+  });
+});
+
+describe("NewWorktreeDialog — recipe scope visibility (#11510)", () => {
+  const GLOBAL_WORK = { id: "global-work", name: "Work", terminals: [], createdAt: 0 };
+  const SHADOWED_WORK = {
+    id: "project-work",
+    name: "Work",
+    projectId: "project-1",
+    shadowedBy: "Work",
+    terminals: [],
+    createdAt: 0,
+  };
+  const WORKTREE_ONLY = {
+    id: "wt-scoped",
+    name: "Scoped",
+    projectId: "project-1",
+    worktreeId: "wt-1",
+    terminals: [],
+    createdAt: 0,
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockListBranches.mockResolvedValue(TEST_BRANCHES);
+    mockGetRecentBranches.mockResolvedValue([]);
+    mockGetAvailableBranch.mockImplementation((_root: string, name: string) =>
+      Promise.resolve(name)
+    );
+    mockGetDefaultPath.mockImplementation((_root: string, branch: string) =>
+      Promise.resolve(`/test/root-worktrees/${branch}`)
+    );
+    mockGetCurrentUser.mockResolvedValue(null);
+    recipePickerCalls.last = null;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+    vi.clearAllMocks();
+    recipeFixtures.recipes = [];
+    projectSettingsFixture.value = null;
+  });
+
+  it("keeps a shadowed recipe in the picker list instead of hiding it", async () => {
+    recipeFixtures.recipes = [GLOBAL_WORK, SHADOWED_WORK, WORKTREE_ONLY];
+
+    renderDialog();
+    await advanceTimersGradually(500);
+
+    const listed = (recipePickerCalls.last?.startingLayoutRecipes ?? []) as { id: string }[];
+    expect(listed.map((r) => r.id)).toEqual(["global-work", "project-work"]);
+  });
+
+  it("does not promote a shadowed recipe to the implicit default", async () => {
+    // A shadowed recipe never runs its own terminals, so RecipesTab reports the
+    // pinned default as unavailable. The picker has to agree rather than
+    // silently marking the losing row "(default)".
+    recipeFixtures.recipes = [SHADOWED_WORK];
+    projectSettingsFixture.value = { defaultWorktreeRecipeId: "project-work" };
+
+    renderDialog();
+    await advanceTimersGradually(500);
+
+    expect(recipePickerCalls.last?.defaultRecipeId).toBeUndefined();
+  });
+
+  it("still forwards an unshadowed pinned default", async () => {
+    recipeFixtures.recipes = [GLOBAL_WORK];
+    projectSettingsFixture.value = { defaultWorktreeRecipeId: "global-work" };
+
+    renderDialog();
+    await advanceTimersGradually(500);
+
+    expect(recipePickerCalls.last?.defaultRecipeId).toBe("global-work");
   });
 });

--- a/src/components/Worktree/hooks/__tests__/useRecipePicker.test.ts
+++ b/src/components/Worktree/hooks/__tests__/useRecipePicker.test.ts
@@ -18,7 +18,7 @@ function makeRecipe(id: string, name = id): TerminalRecipe {
 const defaultArgs = {
   isOpen: true,
   defaultRecipeId: undefined as string | undefined,
-  globalRecipes: [] as TerminalRecipe[],
+  startingLayoutRecipes: [] as TerminalRecipe[],
   lastSelectedWorktreeRecipeId: undefined as string | null | undefined,
   projectId: "test-project",
   initialRecipeId: undefined as string | null | undefined,
@@ -48,12 +48,16 @@ describe("useRecipePicker", () => {
   it("selects defaultRecipeId when available and no lastSelected", () => {
     const recipes = [makeRecipe("recipe-1")];
     const { result } = renderHook(() =>
-      useRecipePicker({ ...defaultArgs, globalRecipes: recipes, defaultRecipeId: "recipe-1" })
+      useRecipePicker({
+        ...defaultArgs,
+        startingLayoutRecipes: recipes,
+        defaultRecipeId: "recipe-1",
+      })
     );
     expect(result.current.selectedRecipeId).toBe("recipe-1");
   });
 
-  it("falls back to CLONE_LAYOUT_ID when defaultRecipeId is not in globalRecipes", () => {
+  it("falls back to CLONE_LAYOUT_ID when defaultRecipeId is not in startingLayoutRecipes", () => {
     const { result } = renderHook(() =>
       useRecipePicker({ ...defaultArgs, defaultRecipeId: "nonexistent" })
     );
@@ -65,7 +69,7 @@ describe("useRecipePicker", () => {
     const { result } = renderHook(() =>
       useRecipePicker({
         ...defaultArgs,
-        globalRecipes: recipes,
+        startingLayoutRecipes: recipes,
         defaultRecipeId: "recipe-1",
         initialRecipeId: "recipe-2",
       })
@@ -85,7 +89,7 @@ describe("useRecipePicker", () => {
     rerender({
       ...defaultArgs,
       setLastSelectedWorktreeRecipeIdByProject: setter,
-      globalRecipes: [makeRecipe("new-recipe")],
+      startingLayoutRecipes: [makeRecipe("new-recipe")],
     });
     expect(result.current.selectedRecipeId).toBe(CLONE_LAYOUT_ID);
     expect(setter).not.toHaveBeenCalled();
@@ -124,7 +128,7 @@ describe("useRecipePicker", () => {
   it("selectedRecipe is undefined for sentinel IDs", () => {
     const recipes = [makeRecipe("recipe-1")];
     const { result } = renderHook(() =>
-      useRecipePicker({ ...defaultArgs, globalRecipes: recipes })
+      useRecipePicker({ ...defaultArgs, startingLayoutRecipes: recipes })
     );
     expect(result.current.selectedRecipeId).toBe(CLONE_LAYOUT_ID);
     expect(result.current.selectedRecipe).toBeUndefined();

--- a/src/components/Worktree/hooks/useRecipePicker.ts
+++ b/src/components/Worktree/hooks/useRecipePicker.ts
@@ -15,7 +15,7 @@ export interface UseRecipePickerResult {
 export function useRecipePicker({
   isOpen,
   defaultRecipeId,
-  globalRecipes,
+  startingLayoutRecipes,
   lastSelectedWorktreeRecipeId,
   projectId,
   initialRecipeId,
@@ -23,7 +23,7 @@ export function useRecipePicker({
 }: {
   isOpen: boolean;
   defaultRecipeId: string | undefined;
-  globalRecipes: TerminalRecipe[];
+  startingLayoutRecipes: TerminalRecipe[];
   lastSelectedWorktreeRecipeId: string | null | undefined;
   projectId: string;
   initialRecipeId?: string | null;
@@ -48,31 +48,31 @@ export function useRecipePicker({
     if (!projectId) return;
     if (recipeSelectionTouchedRef.current) return;
 
-    if (initialRecipeId && globalRecipes.some((r) => r.id === initialRecipeId)) {
+    if (initialRecipeId && startingLayoutRecipes.some((r) => r.id === initialRecipeId)) {
       setSelectedRecipeId(initialRecipeId);
     } else if (lastSelectedWorktreeRecipeId !== undefined) {
       if (lastSelectedWorktreeRecipeId === null) {
         setSelectedRecipeId(null);
       } else if (lastSelectedWorktreeRecipeId === CLONE_LAYOUT_ID) {
         setSelectedRecipeId(CLONE_LAYOUT_ID);
-      } else if (globalRecipes.some((r) => r.id === lastSelectedWorktreeRecipeId)) {
+      } else if (startingLayoutRecipes.some((r) => r.id === lastSelectedWorktreeRecipeId)) {
         setSelectedRecipeId(lastSelectedWorktreeRecipeId);
       } else {
         if (projectId) setLastSelectedWorktreeRecipeIdByProject(projectId, undefined);
-        if (defaultRecipeId && globalRecipes.some((r) => r.id === defaultRecipeId)) {
+        if (defaultRecipeId && startingLayoutRecipes.some((r) => r.id === defaultRecipeId)) {
           setSelectedRecipeId(defaultRecipeId);
         } else {
           setSelectedRecipeId(CLONE_LAYOUT_ID);
         }
       }
-    } else if (defaultRecipeId && globalRecipes.some((r) => r.id === defaultRecipeId)) {
+    } else if (defaultRecipeId && startingLayoutRecipes.some((r) => r.id === defaultRecipeId)) {
       setSelectedRecipeId(defaultRecipeId);
     } else {
       setSelectedRecipeId(CLONE_LAYOUT_ID);
     }
   }, [
     isOpen,
-    globalRecipes,
+    startingLayoutRecipes,
     lastSelectedWorktreeRecipeId,
     defaultRecipeId,
     projectId,
@@ -84,14 +84,20 @@ export function useRecipePicker({
   useEffect(() => {
     if (!selectedRecipeId) return;
     if (selectedRecipeId === CLONE_LAYOUT_ID) return;
-    if (globalRecipes.some((recipe) => recipe.id === selectedRecipeId)) return;
+    if (startingLayoutRecipes.some((recipe) => recipe.id === selectedRecipeId)) return;
     setSelectedRecipeId(null);
     if (projectId) setLastSelectedWorktreeRecipeIdByProject(projectId, undefined);
-  }, [globalRecipes, selectedRecipeId, projectId, setLastSelectedWorktreeRecipeIdByProject]);
+  }, [
+    startingLayoutRecipes,
+    selectedRecipeId,
+    projectId,
+    setLastSelectedWorktreeRecipeIdByProject,
+  ]);
 
   const selectedRecipe = useMemo(
-    () => (selectedRecipeId ? globalRecipes.find((r) => r.id === selectedRecipeId) : undefined),
-    [selectedRecipeId, globalRecipes]
+    () =>
+      selectedRecipeId ? startingLayoutRecipes.find((r) => r.id === selectedRecipeId) : undefined,
+    [selectedRecipeId, startingLayoutRecipes]
   );
 
   return {

--- a/src/components/Worktree/hooks/useRecipePicker.ts
+++ b/src/components/Worktree/hooks/useRecipePicker.ts
@@ -3,6 +3,20 @@ import type { TerminalRecipe } from "@/types";
 
 export const CLONE_LAYOUT_ID = "__clone_layout__";
 
+/**
+ * A shadowed recipe never runs its own terminals, so it stays ineligible as an
+ * implicit default even though it is still listed and explicitly selectable.
+ * Mirrors the eligibility rule RecipesTab pins its default against.
+ */
+export function resolveEligibleDefaultRecipeId(
+  recipes: TerminalRecipe[],
+  persistedDefaultRecipeId: string | undefined
+): string | undefined {
+  return recipes.some((r) => r.id === persistedDefaultRecipeId && !r.shadowedBy)
+    ? persistedDefaultRecipeId
+    : undefined;
+}
+
 export interface UseRecipePickerResult {
   selectedRecipeId: string | null;
   setSelectedRecipeId: React.Dispatch<React.SetStateAction<string | null>>;

--- a/src/components/Worktree/views/RecipePickerPopover.tsx
+++ b/src/components/Worktree/views/RecipePickerPopover.tsx
@@ -162,7 +162,9 @@ export function RecipePickerPopover({
                     {recipe.terminals.length !== 1 ? "s" : ""}
                   </span>
                   {recipe.shadowedBy && (
-                    <span className="text-xs text-daintree-text/50 shrink-0">Overridden</span>
+                    <span className="text-xs text-daintree-text/50 shrink-0">
+                      Overridden by Team
+                    </span>
                   )}
                   {recipe.id === defaultRecipeId && (
                     <span className="text-xs text-daintree-text/50 shrink-0">(default)</span>

--- a/src/components/Worktree/views/RecipePickerPopover.tsx
+++ b/src/components/Worktree/views/RecipePickerPopover.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Check, ChevronsUpDown, Copy, Play } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { TerminalRecipe } from "@/types";
+import { getRecipeScope } from "@/utils/recipeScope";
 import { CLONE_LAYOUT_ID } from "../hooks/useRecipePicker";
 
 interface RecipePickerPopoverProps {
@@ -147,15 +148,22 @@ export function RecipePickerPopover({
                 onClick={() => handleSelect(recipe.id)}
                 className={cn(
                   "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
-                  recipe.id === selectedRecipeId && "bg-daintree-border"
+                  recipe.id === selectedRecipeId && "bg-daintree-border",
+                  recipe.shadowedBy && "opacity-60"
                 )}
               >
                 <div className="flex items-center gap-2 min-w-0">
                   <span className="truncate">{recipe.name}</span>
                   <span className="text-xs text-daintree-text/50 shrink-0">
+                    {getRecipeScope(recipe).label}
+                  </span>
+                  <span className="text-xs text-daintree-text/50 shrink-0">
                     {recipe.terminals.length} terminal
                     {recipe.terminals.length !== 1 ? "s" : ""}
                   </span>
+                  {recipe.shadowedBy && (
+                    <span className="text-xs text-daintree-text/50 shrink-0">Overridden</span>
+                  )}
                   {recipe.id === defaultRecipeId && (
                     <span className="text-xs text-daintree-text/50 shrink-0">(default)</span>
                   )}

--- a/src/components/Worktree/views/__tests__/RecipePickerPopover.test.tsx
+++ b/src/components/Worktree/views/__tests__/RecipePickerPopover.test.tsx
@@ -97,7 +97,7 @@ describe("RecipePickerPopover — scope indicator (#11510)", () => {
     );
 
     const row = recipeRows()[0];
-    expect(row?.textContent).toContain("Overridden");
+    expect(row?.textContent).toContain("Overridden by Team");
 
     fireEvent.click(row!);
     expect(onSelectRecipe).toHaveBeenCalledWith("shadowed");

--- a/src/components/Worktree/views/__tests__/RecipePickerPopover.test.tsx
+++ b/src/components/Worktree/views/__tests__/RecipePickerPopover.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, within, fireEvent } from "@testing-library/react";
+import { RecipePickerPopover } from "../RecipePickerPopover";
+import type { TerminalRecipe } from "@/types";
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
+function makeRecipe(overrides: Partial<TerminalRecipe> = {}): TerminalRecipe {
+  return {
+    id: "recipe-1",
+    name: "Work",
+    terminals: [{ type: "terminal", env: {} }],
+    createdAt: 0,
+    ...overrides,
+  } as TerminalRecipe;
+}
+
+function renderPicker(recipes: TerminalRecipe[], props?: { defaultRecipeId?: string }) {
+  return render(
+    <RecipePickerPopover
+      recipes={recipes}
+      selectedRecipeId={null}
+      selectedRecipe={undefined}
+      open={true}
+      onOpenChange={vi.fn()}
+      onSelectRecipe={vi.fn()}
+      onMarkTouched={vi.fn()}
+      label="Starting layout"
+      listId="recipe-list"
+      {...props}
+    />
+  );
+}
+
+/** The rows for real recipes, minus the fixed "Clone current layout" / "Empty" entries. */
+function recipeRows() {
+  return within(screen.getByRole("listbox"))
+    .getAllByRole("option")
+    .filter((row) => !/Clone current layout|^Empty$/.test(row.textContent ?? ""));
+}
+
+afterEach(cleanup);
+
+describe("RecipePickerPopover — scope indicator (#11510)", () => {
+  it("distinguishes same-named recipes from different scopes", () => {
+    renderPicker([
+      makeRecipe({ id: "g", name: "Work", projectId: undefined }),
+      makeRecipe({ id: "p", name: "Work", projectId: "proj-1" }),
+    ]);
+
+    const rows = recipeRows();
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.textContent).not.toBe(rows[1]?.textContent);
+    expect(rows[0]?.textContent).toContain("Global");
+    expect(rows[1]?.textContent).toContain("Project-wide");
+  });
+
+  it("labels every row, not just the ones in a name collision", () => {
+    renderPicker([
+      makeRecipe({ id: "a", name: "Alpha", projectId: "proj-1" }),
+      makeRecipe({ id: "b", name: "Beta", projectId: "proj-1", scope: "inrepo" }),
+    ]);
+
+    const labels = recipeRows().map((row) => row.textContent ?? "");
+    expect(labels[0]).toContain("Project-wide");
+    expect(labels[1]).toContain("Team");
+  });
+
+  it("carries the scope in the option's accessible name so it reaches assistive tech", () => {
+    renderPicker([makeRecipe({ id: "g", name: "Work", projectId: undefined })]);
+
+    expect(screen.getByRole("option", { name: /Work.*Global/ })).toBeTruthy();
+  });
+
+  it("lists a shadowed recipe as selectable and marked rather than hiding it", () => {
+    const onSelectRecipe = vi.fn<(id: string | null) => void>();
+    render(
+      <RecipePickerPopover
+        recipes={[makeRecipe({ id: "shadowed", name: "Work", shadowedBy: "Work" })]}
+        selectedRecipeId={null}
+        selectedRecipe={undefined}
+        open={true}
+        onOpenChange={vi.fn()}
+        onSelectRecipe={onSelectRecipe}
+        onMarkTouched={vi.fn()}
+        label="Starting layout"
+        listId="recipe-list"
+      />
+    );
+
+    const row = recipeRows()[0];
+    expect(row?.textContent).toContain("Overridden");
+
+    fireEvent.click(row!);
+    expect(onSelectRecipe).toHaveBeenCalledWith("shadowed");
+  });
+
+  it("marks only the recipe the caller pinned as default", () => {
+    renderPicker(
+      [
+        makeRecipe({ id: "a", name: "Alpha", projectId: "proj-1" }),
+        makeRecipe({ id: "b", name: "Beta", projectId: "proj-1" }),
+      ],
+      { defaultRecipeId: "b" }
+    );
+
+    const labels = recipeRows().map((row) => row.textContent ?? "");
+    expect(labels.filter((t) => t.includes("(default)"))).toHaveLength(1);
+    expect(labels[1]).toContain("(default)");
+  });
+});

--- a/src/hooks/__tests__/useQuickCreatePalette.test.tsx
+++ b/src/hooks/__tests__/useQuickCreatePalette.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { TerminalRecipe } from "@/types";
+
+const mockRecipes = vi.hoisted(() => ({ value: [] as TerminalRecipe[] }));
+const paletteCapture = vi.hoisted(() => ({
+  items: [] as unknown[],
+  selectedIndex: 0,
+}));
+const dispatchMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/store/recipeStore", () => ({
+  useRecipeStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      recipes: mockRecipes.value,
+      // Mirrors the real store: a shadowed recipe resolves to the same-named winner.
+      getRecipeById: (id: string) => {
+        const found = mockRecipes.value.find((r) => r.id === id);
+        if (found?.shadowedBy) {
+          return mockRecipes.value.find((r) => r.name === found.name && !r.shadowedBy) ?? found;
+        }
+        return found;
+      },
+    }),
+}));
+
+vi.mock("@/store/worktreeStore", () => ({
+  useWorktreeSelectionStore: Object.assign(
+    (selector: (s: Record<string, unknown>) => unknown) =>
+      selector({
+        quickCreate: { isOpen: false, issue: { number: 7, title: "Fix the thing" }, pr: null },
+        openCreateDialog: vi.fn(),
+        closeQuickCreate: vi.fn(),
+      }),
+    {
+      getState: () => ({ setPendingWorktree: vi.fn(), selectWorktree: vi.fn() }),
+    }
+  ),
+}));
+
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: Object.assign(
+    (selector: (s: Record<string, unknown>) => unknown) => selector({ currentProject: null }),
+    { getState: () => ({ currentProject: { path: "/repo" } }) }
+  ),
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: (...args: unknown[]) => dispatchMock(...args) },
+}));
+
+vi.mock("../useSearchablePalette", () => ({
+  useSearchablePalette: ({ items }: { items: unknown[] }) => {
+    paletteCapture.items = items;
+    return {
+      isOpen: true,
+      query: "",
+      results: items,
+      totalResults: items.length,
+      selectedIndex: paletteCapture.selectedIndex,
+      matchesById: new Map(),
+      isStale: false,
+      open: vi.fn(),
+      close: vi.fn(),
+      setQuery: vi.fn(),
+      selectPrevious: vi.fn(),
+      selectNext: vi.fn(),
+    };
+  },
+}));
+
+const { useQuickCreatePalette } = await import("../useQuickCreatePalette");
+
+function makeRecipe(overrides: Partial<TerminalRecipe>): TerminalRecipe {
+  return {
+    id: "r",
+    name: "Work",
+    terminals: [{ type: "terminal", env: {} }],
+    createdAt: 0,
+    ...overrides,
+  } as TerminalRecipe;
+}
+
+beforeEach(() => {
+  dispatchMock.mockReset();
+  dispatchMock.mockResolvedValue({ ok: false, error: new Error("stop here") });
+  paletteCapture.items = [];
+  paletteCapture.selectedIndex = 0;
+});
+
+describe("useQuickCreatePalette — shadowed recipes (#11510)", () => {
+  it("lists a shadowed recipe instead of dropping it from the palette", () => {
+    mockRecipes.value = [
+      makeRecipe({ id: "winner", scope: "inrepo" }),
+      makeRecipe({ id: "loser", projectId: "p", shadowedBy: "Work" }),
+    ];
+
+    renderHook(() => useQuickCreatePalette());
+
+    const ids = (paletteCapture.items as Array<{ id: string }>).map((i) => i.id);
+    expect(ids).toContain("loser");
+    expect(ids).toContain("winner");
+  });
+
+  it("derives the auto-assign prompt from the winner, not the shadowed row", () => {
+    // The loser opts out of assignment; the winner asks. Since selecting the
+    // loser runs the winner, the toggle must follow the winner or the user is
+    // never offered the choice that submission will act on.
+    mockRecipes.value = [
+      makeRecipe({ id: "winner", scope: "inrepo", autoAssign: "prompt" }),
+      makeRecipe({ id: "loser", projectId: "p", shadowedBy: "Work", autoAssign: "never" }),
+    ];
+    paletteCapture.selectedIndex = 1;
+
+    const { result } = renderHook(() => useQuickCreatePalette());
+
+    expect(result.current.selectedRecipe?.id).toBe("winner");
+    expect(result.current.selectedRecipe?.autoAssign).toBe("prompt");
+  });
+
+  it("dispatches the selected row's own id and lets the store resolve the winner", async () => {
+    mockRecipes.value = [
+      makeRecipe({ id: "winner", scope: "inrepo" }),
+      makeRecipe({ id: "loser", projectId: "p", shadowedBy: "Work" }),
+    ];
+
+    const { result } = renderHook(() => useQuickCreatePalette());
+    const loser = (paletteCapture.items as Array<{ id: string }>).find((i) => i.id === "loser");
+
+    await act(async () => {
+      result.current.confirmItem(loser as never);
+    });
+
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "worktree.createWithRecipe",
+      expect.objectContaining({ recipeId: "loser" }),
+      expect.anything()
+    );
+  });
+});

--- a/src/hooks/useQuickCreatePalette.ts
+++ b/src/hooks/useQuickCreatePalette.ts
@@ -32,6 +32,7 @@ export type UseQuickCreatePaletteReturn = UseSearchablePaletteReturn<QuickCreate
 
 export function useQuickCreatePalette(): UseQuickCreatePaletteReturn {
   const recipes = useRecipeStore((s) => s.recipes);
+  const getRecipeById = useRecipeStore((s) => s.getRecipeById);
   const { quickCreate, openCreateDialog, closeQuickCreate } = useWorktreeSelectionStore(
     useShallow((s) => ({
       quickCreate: s.quickCreate,
@@ -43,11 +44,12 @@ export function useQuickCreatePalette(): UseQuickCreatePaletteReturn {
   const [assignToSelf, setAssignToSelf] = useState(true);
   const comboCountRef = useRef(0);
 
-  const visibleRecipes = recipes.filter((r) => !r.shadowedBy);
-  const hasRecipes = visibleRecipes.length > 0;
+  // Shadowed recipes stay listed (dimmed, marked "Overridden") rather than
+  // vanishing — the row still launches, resolved to the winner (#11510).
+  const hasRecipes = recipes.length > 0;
   const items: QuickCreateItem[] = hasRecipes
     ? [
-        ...visibleRecipes.map((r): QuickCreateItem => ({ ...r, _kind: "recipe" })),
+        ...recipes.map((r): QuickCreateItem => ({ ...r, _kind: "recipe" })),
         { _kind: "customize", id: "__customize__", name: "Customize…" },
       ]
     : [];
@@ -134,7 +136,9 @@ export function useQuickCreatePalette(): UseQuickCreatePaletteReturn {
       const issuePrefix = issueNumber ? `issue-${issueNumber}-` : "";
       const branchName = buildBranchName(prefix, `${issuePrefix}${slug}`);
 
-      const autoAssign = getAutoAssign(recipe);
+      // A shadowed row launches the winning recipe, so its auto-assign
+      // preference has to come from that winner, not the losing row.
+      const autoAssign = getAutoAssign(getRecipeById(recipe.id) ?? recipe);
       const shouldAssign = autoAssign === "always" || (autoAssign === "prompt" && assignToSelf);
 
       startTransition(async () => {
@@ -278,7 +282,7 @@ export function useQuickCreatePalette(): UseQuickCreatePaletteReturn {
         }
       });
     },
-    [isPending, closeQuickCreate, openCreateDialog, issue, pr, assignToSelf, palette]
+    [isPending, closeQuickCreate, openCreateDialog, issue, pr, assignToSelf, palette, getRecipeById]
   );
 
   const confirmSelection = useCallback(() => {

--- a/src/hooks/useQuickCreatePalette.ts
+++ b/src/hooks/useQuickCreatePalette.ts
@@ -303,6 +303,12 @@ export function useQuickCreatePalette(): UseQuickCreatePaletteReturn {
     isPending,
     assignToSelf,
     setAssignToSelf,
-    selectedRecipe: selectedRecipe && !isCustomize(selectedRecipe) ? selectedRecipe : null,
+    // Resolved to the winner for the same reason `doConfirm` resolves: a
+    // shadowed row launches the winning recipe, so the auto-assign toggle this
+    // drives has to agree with what submission will actually do.
+    selectedRecipe:
+      selectedRecipe && !isCustomize(selectedRecipe)
+        ? (getRecipeById(selectedRecipe.id) ?? selectedRecipe)
+        : null,
   };
 }

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -1847,6 +1847,38 @@ describe("recipeStore", () => {
       expect(state.recipes[0]?.terminals[0]?.env).toEqual({ TOKEN: "" });
     });
 
+    it("leaves a global recipe unshadowed when a project recipe shares its name (#11510)", async () => {
+      // Global and project-local recipes with the same name are two independent
+      // executable targets — neither overrides the other, so neither may be
+      // marked shadowed. `getRecipeById` resolves `shadowedBy` by searching only
+      // `inRepoRecipes`, so a shadow marker here would resolve to the wrong
+      // recipe (or silently to itself). The scope label is what disambiguates.
+      const globalRecipe = {
+        id: "global-work",
+        name: "Work",
+        terminals: [{ type: "terminal" as const, title: "Global shell" }],
+        createdAt: 100,
+      };
+      const projectRecipe = {
+        id: "project-work",
+        name: "Work",
+        projectId: "project-1",
+        terminals: [{ type: "terminal" as const, title: "Project shell" }],
+        createdAt: 200,
+      };
+      globalGetRecipesMock.mockResolvedValueOnce([globalRecipe]);
+      getRecipesMock.mockResolvedValueOnce({ recipes: [projectRecipe], collisions: [] });
+      getInRepoRecipesMock.mockResolvedValueOnce([]);
+
+      await useRecipeStore.getState().loadRecipes("project-1");
+
+      const state = useRecipeStore.getState();
+      expect(state.recipes.map((r) => r.shadowedBy)).toEqual([undefined, undefined]);
+      // Each id still resolves to its own recipe, so picking either row runs it.
+      expect(state.getRecipeById("global-work")?.terminals[0]?.title).toBe("Global shell");
+      expect(state.getRecipeById("project-work")?.terminals[0]?.title).toBe("Project shell");
+    });
+
     it("loadRecipes hydrates in-repo usage metadata into inRepoRecipes so the UI shows persisted frecency (#11354)", async () => {
       const inRepoRecipe = {
         id: "recipe-opaque-abc",

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -1847,6 +1847,72 @@ describe("recipeStore", () => {
       expect(state.recipes[0]?.terminals[0]?.env).toEqual({ TOKEN: "" });
     });
 
+    it("resolves a shadowed recipe to the hydrated mirror, not the redacted canonical copy", async () => {
+      // The git-tracked in-repo file has every env value blanked; the
+      // ProjectFileStore mirror carries the real ones. Launching a shadowed row
+      // has to land on the same hydrated recipe the Team row itself runs.
+      const inRepoRecipe = {
+        id: "recipe-team",
+        name: "Work",
+        scope: "inrepo" as const,
+        terminals: [{ type: "terminal" as const, title: "Shell", env: { TOKEN: "" } }],
+        createdAt: 500,
+      };
+      const mirror = {
+        ...inRepoRecipe,
+        projectId: "project-1",
+        terminals: [{ type: "terminal" as const, title: "Shell", env: { TOKEN: "secret" } }],
+      };
+      const shadowedLocal = {
+        id: "recipe-local",
+        name: "Work",
+        projectId: "project-1",
+        terminals: [{ type: "terminal" as const, title: "Stale" }],
+        createdAt: 100,
+      };
+      globalGetRecipesMock.mockResolvedValueOnce([]);
+      getRecipesMock.mockResolvedValueOnce({ recipes: [mirror, shadowedLocal], collisions: [] });
+      getInRepoRecipesMock.mockResolvedValueOnce([inRepoRecipe]);
+
+      await useRecipeStore.getState().loadRecipes("project-1");
+
+      const resolved = useRecipeStore.getState().getRecipeById("recipe-local");
+      expect(resolved?.id).toBe("recipe-team");
+      expect(resolved?.terminals[0]?.env).toEqual({ TOKEN: "secret" });
+    });
+
+    it("does not resolve a shadowed recipe to a same-named global recipe", async () => {
+      // `recipes` is ordered global-first, so a name-only lookup over the merged
+      // list would hand back the global recipe instead of the Team winner.
+      const inRepoRecipe = {
+        id: "recipe-team",
+        name: "Work",
+        scope: "inrepo" as const,
+        terminals: [{ type: "terminal" as const, title: "Team shell" }],
+        createdAt: 500,
+      };
+      const globalRecipe = {
+        id: "recipe-global",
+        name: "Work",
+        terminals: [{ type: "terminal" as const, title: "Global shell" }],
+        createdAt: 50,
+      };
+      const shadowedLocal = {
+        id: "recipe-local",
+        name: "Work",
+        projectId: "project-1",
+        terminals: [{ type: "terminal" as const, title: "Stale" }],
+        createdAt: 100,
+      };
+      globalGetRecipesMock.mockResolvedValueOnce([globalRecipe]);
+      getRecipesMock.mockResolvedValueOnce({ recipes: [shadowedLocal], collisions: [] });
+      getInRepoRecipesMock.mockResolvedValueOnce([inRepoRecipe]);
+
+      await useRecipeStore.getState().loadRecipes("project-1");
+
+      expect(useRecipeStore.getState().getRecipeById("recipe-local")?.id).toBe("recipe-team");
+    });
+
     it("leaves a global recipe unshadowed when a project recipe shares its name (#11510)", async () => {
       // Global and project-local recipes with the same name are two independent
       // executable targets — neither overrides the other, so neither may be

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -691,7 +691,14 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
   getRecipeById: (id) => {
     const recipe = get().recipes.find((r) => r.id === id);
     if (recipe?.shadowedBy) {
-      return get().inRepoRecipes.find((r) => r.name === recipe.name) ?? recipe;
+      // Resolve through the merged list, not `inRepoRecipes` directly: the
+      // merged entry is the ProjectFileStore mirror, which keeps the local env
+      // values the git-tracked canonical copy redacts. Going straight to
+      // `inRepoRecipes` would launch a shadowed row with blank env while the
+      // Team row it defers to runs hydrated.
+      const winner = get().inRepoRecipes.find((r) => r.name === recipe.name);
+      if (!winner) return recipe;
+      return get().recipes.find((r) => r.id === winner.id) ?? winner;
     }
     return recipe;
   },

--- a/src/utils/__tests__/recipeScope.test.ts
+++ b/src/utils/__tests__/recipeScope.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from "vitest";
+import { getRecipeScope } from "../recipeScope";
+import type { TerminalRecipe } from "@/types";
+
+function makeRecipe(overrides: Partial<TerminalRecipe> = {}): TerminalRecipe {
+  return {
+    id: "recipe-1",
+    name: "Work",
+    terminals: [],
+    ...overrides,
+  } as TerminalRecipe;
+}
+
+describe("getRecipeScope", () => {
+  it("classifies a recipe with no projectId as global", () => {
+    const scope = getRecipeScope(makeRecipe({ projectId: undefined }));
+    expect(scope).toEqual({ label: "Global", isGlobal: true });
+  });
+
+  it("classifies a project-scoped recipe without a worktree as project-wide", () => {
+    const scope = getRecipeScope(makeRecipe({ projectId: "proj-1" }));
+    expect(scope).toEqual({ label: "Project-wide", isGlobal: false });
+  });
+
+  it("classifies an in-repo recipe as team, whichever way it is marked", () => {
+    const byScopeField = getRecipeScope(makeRecipe({ projectId: "proj-1", scope: "inrepo" }));
+    const byLegacyIdPrefix = getRecipeScope(makeRecipe({ id: "inrepo-work", projectId: "proj-1" }));
+    expect(byScopeField.label).toBe("Team");
+    expect(byLegacyIdPrefix.label).toBe("Team");
+  });
+
+  it("treats in-repo as team even when the recipe carries no projectId", () => {
+    // ProjectFileStore mirrors can arrive without a projectId; the in-repo check
+    // has to win over the global check or a Team recipe reads as Global.
+    const scope = getRecipeScope(makeRecipe({ projectId: undefined, scope: "inrepo" }));
+    expect(scope).toEqual({ label: "Team", isGlobal: false });
+  });
+
+  it("names the worktree when a resolver supplies one", () => {
+    const scope = getRecipeScope(makeRecipe({ projectId: "proj-1", worktreeId: "wt-1" }), (id) =>
+      id === "wt-1" ? "feature/login" : undefined
+    );
+    expect(scope.label).toBe("Worktree: feature/login");
+  });
+
+  it("falls back to a bare worktree label rather than printing a raw id", () => {
+    const withoutResolver = getRecipeScope(makeRecipe({ projectId: "p", worktreeId: "wt-abc123" }));
+    const unresolved = getRecipeScope(
+      makeRecipe({ projectId: "p", worktreeId: "wt-abc123" }),
+      () => undefined
+    );
+    expect(withoutResolver.label).toBe("Worktree");
+    expect(unresolved.label).toBe("Worktree");
+  });
+
+  it("does not consult the resolver for non-worktree scopes", () => {
+    const resolve = vi.fn<(id: string) => string | undefined>(() => "unused");
+    getRecipeScope(makeRecipe({ projectId: undefined }), resolve);
+    getRecipeScope(makeRecipe({ projectId: "proj-1" }), resolve);
+    getRecipeScope(makeRecipe({ projectId: "proj-1", scope: "inrepo" }), resolve);
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it("marks only the global scope as global", () => {
+    const recipes = [
+      makeRecipe({ projectId: undefined }),
+      makeRecipe({ projectId: "p" }),
+      makeRecipe({ projectId: "p", scope: "inrepo" }),
+      makeRecipe({ projectId: "p", worktreeId: "wt-1" }),
+    ];
+    expect(recipes.map((r) => getRecipeScope(r).isGlobal)).toEqual([true, false, false, false]);
+  });
+
+  it("distinguishes same-named recipes that differ only by scope", () => {
+    const global = makeRecipe({ id: "g", name: "Work", projectId: undefined });
+    const local = makeRecipe({ id: "l", name: "Work", projectId: "proj-1" });
+    expect(getRecipeScope(global).label).not.toBe(getRecipeScope(local).label);
+  });
+});

--- a/src/utils/recipeScope.ts
+++ b/src/utils/recipeScope.ts
@@ -13,6 +13,14 @@ export interface RecipeScope {
  */
 export type WorktreeNameResolver = (worktreeId: string) => string | undefined;
 
+/** The label a worktree goes by in recipe scope text. */
+export function worktreeDisplayName(
+  worktree: { name: string; branch?: string; isMainWorktree?: boolean } | undefined
+): string | undefined {
+  if (!worktree) return undefined;
+  return worktree.isMainWorktree ? worktree.name : worktree.branch || worktree.name;
+}
+
 /**
  * Classify which of the three recipe scopes a recipe belongs to, using the
  * vocabulary the Settings recipe list established. In-repo is checked before

--- a/src/utils/recipeScope.ts
+++ b/src/utils/recipeScope.ts
@@ -1,0 +1,31 @@
+import { isInRepoRecipeId } from "@shared/utils/recipeFilename";
+import type { TerminalRecipe } from "@/types";
+
+export interface RecipeScope {
+  label: string;
+  isGlobal: boolean;
+}
+
+/**
+ * Resolve a worktree id to a human-readable name. Surfaces that have worktree
+ * data on hand pass one; those that don't fall back to the bare `Worktree`
+ * label rather than printing a raw id.
+ */
+export type WorktreeNameResolver = (worktreeId: string) => string | undefined;
+
+/**
+ * Classify which of the three recipe scopes a recipe belongs to, using the
+ * vocabulary the Settings recipe list established. In-repo is checked before
+ * `projectId` because in-repo recipes can also carry a `projectId` once
+ * ProjectFileStore mirrors them.
+ */
+export function getRecipeScope(
+  recipe: TerminalRecipe,
+  resolveWorktreeName?: WorktreeNameResolver
+): RecipeScope {
+  if (isInRepoRecipeId(recipe)) return { label: "Team", isGlobal: false };
+  if (recipe.projectId === undefined) return { label: "Global", isGlobal: true };
+  if (!recipe.worktreeId) return { label: "Project-wide", isGlobal: false };
+  const name = resolveWorktreeName?.(recipe.worktreeId);
+  return { label: name ? `Worktree: ${name}` : "Worktree", isGlobal: false };
+}


### PR DESCRIPTION
## Summary

- Recipe picker rows only showed name and terminal count, so a global `Work` and a project-local `Work` rendered as identical rows. The only way to tell them apart was picking one and seeing what launched.
- Shadowed recipes were hidden outright in three separate filters. That's the silent failure the issue argues against for executable targets, citing VS Code and git as prior art: list every duplicate with its origin instead of hiding the loser.
- Fixes both, plus four real bugs the hidden shadowed rows had been masking.

Resolves #11510

## Approach

Extracted `getRecipeScope` out of its private closure in `RecipesTab.tsx` into a new file, `src/utils/recipeScope.ts`, keeping the same label vocabulary (`Global`, `Team`, `Project-wide`, `Worktree: <name>`) so Settings and the pickers agree.

Every recipe row in every picker now shows that label as always-visible muted text: the New Worktree picker, the dock launch menu, the quick create palette, the recipe runner (grid and list views), and the plugin bulk-create dialog. Plain visible text rather than an icon or an ARIA-only attribute, because inside a `role="option"` element the text flattens into the accessible name, reaching assistive tech the same way the terminal count and the `(default)` suffix already do.

Deliberately did not extend `mergeRecipes` shadow detection to global-vs-project-local collisions. `shadowedBy` stores a name, not a winner id, and `getRecipeById` resolves it by searching in-repo recipes. Marking a global recipe as shadowed would resolve to the wrong recipe, or silently to itself. Global and project-local are two independent executable targets, and the scope label is what disambiguates them instead. There's a test pinning that invariant.

## Shadowed recipes are shown, not hidden

Instead of hiding shadowed recipes, they now render dimmed and marked `Overridden by Team` — the only pairing `mergeRecipes` ever shadows, matching what `RecipeRunnerItem` already did.

Dropping the three hiding filters exposed four real bugs, all fixed here:

- `getRecipeById` resolved shadowed ids straight out of `inRepoRecipes`, the git-tracked canonical copy, where `buildInRepoRecipePayloadString` blanks every env value. The Team row itself runs the ProjectFileStore mirror with real env values, so the two paths were launching different recipes. Now it resolves the winner's id and returns its entry from the merged list.
- Quick create read its auto-assign preference from the displayed row while submission read the winner row: a loser recipe set to `never` behind a winner set to `prompt` hid the opt-out checkbox from the user while still assigning the issue anyway.
- Bulk create accepted a shadowed pinned default even though single create rejected it, and sized PTY admission batches from the losing row's terminal count, so a 1-terminal row could plan a batch of 10 while 100 PTYs actually spawned.
- A shadowed recipe could become the New Worktree dialog's implicit default, contradicting the `Default recipe unavailable` warning that Settings shows for exactly that state.

## Changes

- `src/utils/recipeScope.ts`: extracted `getRecipeScope`, shared by Settings and all pickers.
- `src/components/Worktree/views/RecipePickerPopover.tsx`, `NewWorktreeDialog.tsx`, `hooks/useRecipePicker.ts`: scope label on every row.
- `src/components/Layout/DockLaunchMenuItems.tsx`, `src/components/Worktree/QuickCreatePalette.tsx`, `src/hooks/useQuickCreatePalette.ts`: same, plus the auto-assign preference fix.
- `src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx`: scope label alongside the existing `Overridden` marker.
- `plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx`: rejects a shadowed pinned default and sizes PTY batches off the winner.
- `src/store/recipeStore.ts`: `getRecipeById` resolves shadowed ids to the winner's entry in the merged list, not the in-repo copy.
- `src/components/Project/RecipesTab.tsx`: now imports `getRecipeScope` instead of defining it locally.

## Testing

New tests: `src/utils/__tests__/recipeScope.test.ts`, `src/components/Worktree/views/__tests__/RecipePickerPopover.test.tsx`, `src/hooks/__tests__/useQuickCreatePalette.test.tsx`. Extended the `recipeStore`, `NewWorktreeDialog`, `RecipeRunnerItem`, and `DockLaunchButton` suites (the dock test fixture type couldn't previously even express `projectId` or `shadowedBy`).

422 targeted tests pass, typecheck is clean, prettier/eslint are clean on all changed files.

Didn't run `e2e/full/worktree/new-worktree-dialog.spec.ts` locally, it needs a full app build. Its assertions target the Clone-layout row and trigger text, both untouched by this change.

