### PR TITLE
fix(worktree): stop in-flight items when bulk creation is cancelled

### DIFF
--- a/plugins/builtin/github/renderer/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -1244,7 +1244,7 @@ describe("BulkCreateWorktreeDialog", () => {
       await vi.advanceTimersByTimeAsync(0);
     });
 
-    const stillRunning = resolvers.length - 1;
+    const stillCreating = resolvers.length - 1;
 
     await act(async () => {
       const cancelBtn = screen
@@ -1254,14 +1254,19 @@ describe("BulkCreateWorktreeDialog", () => {
       await vi.advanceTimersByTimeAsync(0);
     });
 
-    const call = vi.mocked(mockNotify).mock.calls.at(-1)?.[0] as {
-      type: string;
-      title: string;
-      message: string;
-    };
-    expect(call.type).toBe("warning");
-    expect(call.message).toContain(`1 of ${props.selectedIssues.length} worktrees created`);
-    expect(call.message).toContain(`${stillRunning} already started`);
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "warning",
+        message: expect.stringContaining(
+          `1 of ${props.selectedIssues.length} worktrees created`
+        ) as unknown as string,
+      })
+    );
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining(`${stillCreating} already underway`) as unknown as string,
+      })
+    );
 
     await act(async () => {
       resolvers.slice(1).forEach((resolve, i) => resolve(`wt-${i + 2}`));
@@ -1269,21 +1274,50 @@ describe("BulkCreateWorktreeDialog", () => {
     });
   });
 
-  it("stays silent when a cancel lands before anything started", async () => {
+  it("stays silent when a cancel lands before any worktree is underway", async () => {
     const { notify: mockNotify } = await import("@/lib/notify");
     vi.mocked(mockNotify).mockClear();
 
-    const props = { ...defaultProps, selectedIssues: [makeIssue(1)] };
+    // Stall the batch in its pre-query phase: the queue callbacks are running,
+    // so PQueue.pending is non-zero, but no worktree has been requested yet.
+    let releasePrequery: (value: string) => void = () => {};
+    mockGetAvailableBranch.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          releasePrequery = resolve;
+        })
+    );
+
+    const props = { ...defaultProps, selectedIssues: [makeIssue(1), makeIssue(2)] };
     render(<BulkCreateWorktreeDialog {...props} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Confirm the run really is executing, or the guard under test never runs.
+    expect((screen.getByTestId("bulk-create-confirm-button") as HTMLButtonElement).disabled).toBe(
+      true
+    );
+    expect(mockWorktreeCreate).not.toHaveBeenCalled();
 
     await act(async () => {
       const cancelBtn = screen
         .getAllByRole("button")
         .find((b) => b.textContent === "Cancel") as HTMLButtonElement;
       cancelBtn.click();
+      await vi.advanceTimersByTimeAsync(0);
     });
 
+    // Nothing escaped, so the close is its own confirmation — no toast.
     expect(mockNotify).not.toHaveBeenCalled();
+
+    await act(async () => {
+      releasePrequery("feature/issue-1");
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(mockWorktreeCreate).not.toHaveBeenCalled();
   });
 
   it("stops the batch when the dialog unmounts without going through Cancel", async () => {
@@ -1297,7 +1331,12 @@ describe("BulkCreateWorktreeDialog", () => {
         })
     );
 
-    const props = { ...defaultProps, selectedIssues: [makeIssue(1), makeIssue(2)] };
+    // Four items against concurrency 3 leaves one in the backlog, so the
+    // unmount has to both stop the running items and drop the queued one.
+    const props = {
+      ...defaultProps,
+      selectedIssues: [makeIssue(1), makeIssue(2), makeIssue(3), makeIssue(4)],
+    };
     const { unmount } = render(<BulkCreateWorktreeDialog {...props} />);
 
     await act(async () => {
@@ -1305,6 +1344,8 @@ describe("BulkCreateWorktreeDialog", () => {
     });
 
     const startedCreates = mockWorktreeCreate.mock.calls.length;
+    expect(startedCreates).toBeGreaterThan(0);
+    expect(startedCreates).toBeLessThan(props.selectedIssues.length);
 
     // The parent drops the dialog (SidebarContent renders it only while open),
     // bypassing handleClose entirely.
@@ -1322,6 +1363,94 @@ describe("BulkCreateWorktreeDialog", () => {
     expect(mockWorktreeCreate).toHaveBeenCalledTimes(startedCreates);
   });
 
+  it("does not focus a clone-layout panel spawned into a cancelled run", async () => {
+    mockSelectedRecipeId = "__clone_layout__";
+    mockGenerateRecipeFromActiveTerminals.mockReturnValue([
+      { type: "terminal", title: "Shell", location: "grid" },
+    ]);
+    // Hold the spawn open so Cancel lands while panels are still committing.
+    let releasePanel: (value: string) => void = () => {};
+    mockAddPanel.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          releasePanel = resolve;
+        })
+    );
+
+    const props = { ...defaultProps, selectedIssues: [makeIssue(1)] };
+    render(<BulkCreateWorktreeDialog {...props} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(mockAddPanel).toHaveBeenCalled();
+
+    await act(async () => {
+      const cancelBtn = screen
+        .getAllByRole("button")
+        .find((b) => b.textContent === "Cancel") as HTMLButtonElement;
+      cancelBtn.click();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    await act(async () => {
+      releasePanel("clone-terminal-id");
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    // The panel can't be recalled, but the run's AbortSignal must stop it from
+    // yanking focus into the worktree the user just cancelled.
+    expect(mockSetFocused).not.toHaveBeenCalled();
+  });
+
+  it("does not assign or select for a recipe that resolves after cancel", async () => {
+    mockSelectedRecipeId = "test-recipe";
+    prefsHolder.assignWorktreeToSelf = true;
+    viewerHolder.user = { login: "octocat" };
+    // The worktree is already made and the recipe is mid-flight when Cancel lands.
+    let releaseRecipe: (value: {
+      spawned: Array<{ terminalId: string }>;
+      failed: [];
+    }) => void = () => {};
+    mockRunRecipeWithResults.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseRecipe = resolve;
+        })
+    );
+
+    const props = { ...defaultProps, selectedIssues: [makeIssue(1)] };
+    render(<BulkCreateWorktreeDialog {...props} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(mockRunRecipeWithResults).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      const cancelBtn = screen
+        .getAllByRole("button")
+        .find((b) => b.textContent === "Cancel") as HTMLButtonElement;
+      cancelBtn.click();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    await act(async () => {
+      releaseRecipe({ spawned: [{ terminalId: "t-1" }], failed: [] });
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    // The recipe's own terminals are out of reach — this pins the end state
+    // instead: an item cancelled mid-recipe is never assigned and never becomes
+    // the selected worktree.
+    expect(mockAssignIssue).not.toHaveBeenCalled();
+    expect(mockSelectWorktree).not.toHaveBeenCalled();
+  });
+
   it("fails the batch instead of stranding it when the project path is missing", async () => {
     projectHolder.currentProject = { id: "test-project" };
 
@@ -1337,8 +1466,26 @@ describe("BulkCreateWorktreeDialog", () => {
     // X and blocked Escape used to persist forever.
     expect(screen.getByTestId("bulk-create-done-button")).toBeTruthy();
     expect(screen.getByTestId("bulk-create-retry-button")).toBeTruthy();
-    expect(screen.getByTestId("bulk-create-worktree-dialog").dataset.dismissible).toBe("true");
+    // Every item must carry the failure, not just the one that tripped it.
+    expect(screen.getByText(/0 of 2 created/)).toBeTruthy();
+    expect(screen.getByText(/2 failed/)).toBeTruthy();
     expect(mockWorktreeCreate).not.toHaveBeenCalled();
+
+    // Dismissal is unblocked again, so the user isn't trapped.
+    const onCloseSpy = vi.fn();
+    cleanup();
+    render(<BulkCreateWorktreeDialog {...props} onClose={onCloseSpy} />);
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await act(async () => {
+      screen
+        .getByTestId("bulk-create-worktree-dialog")
+        .dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(onCloseSpy).toHaveBeenCalled();
   });
 
   it("keeps the primary action in place while executing", async () => {

--- a/plugins/builtin/github/renderer/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -109,9 +109,13 @@ vi.mock("@/store/preferencesStore", () => ({
     }),
 }));
 
+const projectHolder: { currentProject: { id: string; path?: string } | null } = {
+  currentProject: { id: "test-project", path: "/test/root" },
+};
+
 vi.mock("@/store/projectStore", () => ({
   useProjectStore: (selector: (s: Record<string, unknown>) => unknown) =>
-    selector({ currentProject: { id: "test-project", path: "/test/root" } }),
+    selector({ currentProject: projectHolder.currentProject }),
 }));
 
 const worktreeDataHolder: { map: Map<string, unknown> } = {
@@ -208,18 +212,36 @@ vi.mock("@/components/Worktree/hooks/useNewWorktreeProjectSettings", () => ({
 const DialogCloseContext = React.createContext<(() => void) | null>(null);
 
 vi.mock("@/components/ui/AppDialog", () => {
+  // `dismissible` is modelled rather than dropped: the real AppDialog routes
+  // Escape/backdrop through it, and blocking those mid-run is a guarantee this
+  // dialog is expected to keep (#11517).
   const Dialog = ({
     children,
     isOpen,
     onClose,
+    dismissible = true,
   }: {
     children: React.ReactNode;
     isOpen: boolean;
     onClose?: () => void;
+    dismissible?: boolean;
   }) =>
     isOpen ? (
-      <DialogCloseContext.Provider value={onClose ?? null}>
-        <div data-testid="bulk-create-worktree-dialog">{children}</div>
+      <DialogCloseContext.Provider value={dismissible ? (onClose ?? null) : null}>
+        <div
+          data-testid="bulk-create-worktree-dialog"
+          data-dismissible={String(dismissible)}
+          onClick={(e) => {
+            // Backdrop only — a bubbled click from a footer button is not a
+            // dismissal.
+            if (dismissible && e.target === e.currentTarget) onClose?.();
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Escape" && dismissible) onClose?.();
+          }}
+        >
+          {children}
+        </div>
       </DialogCloseContext.Provider>
     ) : null;
   Dialog.Header = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
@@ -335,6 +357,7 @@ beforeEach(() => {
   mockGenerateRecipeFromActiveTerminals.mockReturnValue([]);
   prefsHolder.assignWorktreeToSelf = false;
   viewerHolder.user = null;
+  projectHolder.currentProject = { id: "test-project", path: "/test/root" };
 });
 
 afterEach(() => {
@@ -1142,6 +1165,267 @@ describe("BulkCreateWorktreeDialog", () => {
 
     expect(mockWorktreeCreate).toHaveBeenCalledTimes(3);
     expect(screen.queryByTestId("bulk-create-done-button")).toBeNull();
+  });
+
+  it("does not run the recipe for an item whose worktree lands after cancel", async () => {
+    mockSelectedRecipeId = "test-recipe";
+    mockRunRecipeWithResults.mockResolvedValue({
+      spawned: [{ terminalId: "t-1" }],
+      failed: [],
+    });
+    const resolvers: Array<(value: string) => void> = [];
+    mockWorktreeCreate.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolvers.push(resolve);
+        })
+    );
+    prefsHolder.assignWorktreeToSelf = true;
+    viewerHolder.user = { login: "octocat" };
+
+    const props = {
+      ...defaultProps,
+      selectedIssues: [makeIssue(1), makeIssue(2), makeIssue(3), makeIssue(4)],
+    };
+    render(<BulkCreateWorktreeDialog {...props} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+
+    const startedCreates = mockWorktreeCreate.mock.calls.length;
+    expect(startedCreates).toBeGreaterThan(0);
+
+    await act(async () => {
+      const cancelBtn = screen
+        .getAllByRole("button")
+        .find((b) => b.textContent === "Cancel") as HTMLButtonElement;
+      cancelBtn.click();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // The creates were already past the point of no return — let them land.
+    await act(async () => {
+      resolvers.forEach((resolve, i) => resolve(`wt-${i + 1}`));
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    // Each landed worktree stops at the Step 1 -> Step 2 boundary rather than
+    // spawning agents and skipping the assignment the dialog otherwise promises.
+    expect(mockRunRecipeWithResults).not.toHaveBeenCalled();
+    expect(mockAssignIssue).not.toHaveBeenCalled();
+    // Queued items never start, so no additional worktrees appear.
+    expect(mockWorktreeCreate).toHaveBeenCalledTimes(startedCreates);
+  });
+
+  it("reports the worktrees a cancel left behind", async () => {
+    const { notify: mockNotify } = await import("@/lib/notify");
+    const resolvers: Array<(value: string) => void> = [];
+    mockWorktreeCreate.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolvers.push(resolve);
+        })
+    );
+
+    const props = {
+      ...defaultProps,
+      selectedIssues: [makeIssue(1), makeIssue(2), makeIssue(3), makeIssue(4)],
+    };
+    render(<BulkCreateWorktreeDialog {...props} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+
+    // Land one worktree so the snapshot has both a created and an in-flight count.
+    await act(async () => {
+      resolvers[0]?.("wt-1");
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const stillRunning = resolvers.length - 1;
+
+    await act(async () => {
+      const cancelBtn = screen
+        .getAllByRole("button")
+        .find((b) => b.textContent === "Cancel") as HTMLButtonElement;
+      cancelBtn.click();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const call = vi.mocked(mockNotify).mock.calls.at(-1)?.[0] as {
+      type: string;
+      title: string;
+      message: string;
+    };
+    expect(call.type).toBe("warning");
+    expect(call.message).toContain(`1 of ${props.selectedIssues.length} worktrees created`);
+    expect(call.message).toContain(`${stillRunning} already started`);
+
+    await act(async () => {
+      resolvers.slice(1).forEach((resolve, i) => resolve(`wt-${i + 2}`));
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+  });
+
+  it("stays silent when a cancel lands before anything started", async () => {
+    const { notify: mockNotify } = await import("@/lib/notify");
+    vi.mocked(mockNotify).mockClear();
+
+    const props = { ...defaultProps, selectedIssues: [makeIssue(1)] };
+    render(<BulkCreateWorktreeDialog {...props} />);
+
+    await act(async () => {
+      const cancelBtn = screen
+        .getAllByRole("button")
+        .find((b) => b.textContent === "Cancel") as HTMLButtonElement;
+      cancelBtn.click();
+    });
+
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it("stops the batch when the dialog unmounts without going through Cancel", async () => {
+    mockSelectedRecipeId = "test-recipe";
+    mockRunRecipeWithResults.mockResolvedValue({ spawned: [{ terminalId: "t-1" }], failed: [] });
+    const resolvers: Array<(value: string) => void> = [];
+    mockWorktreeCreate.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolvers.push(resolve);
+        })
+    );
+
+    const props = { ...defaultProps, selectedIssues: [makeIssue(1), makeIssue(2)] };
+    const { unmount } = render(<BulkCreateWorktreeDialog {...props} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+
+    const startedCreates = mockWorktreeCreate.mock.calls.length;
+
+    // The parent drops the dialog (SidebarContent renders it only while open),
+    // bypassing handleClose entirely.
+    await act(async () => {
+      unmount();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    await act(async () => {
+      resolvers.forEach((resolve, i) => resolve(`wt-${i + 1}`));
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    expect(mockRunRecipeWithResults).not.toHaveBeenCalled();
+    expect(mockWorktreeCreate).toHaveBeenCalledTimes(startedCreates);
+  });
+
+  it("fails the batch instead of stranding it when the project path is missing", async () => {
+    projectHolder.currentProject = { id: "test-project" };
+
+    const props = { ...defaultProps, selectedIssues: [makeIssue(1), makeIssue(2)] };
+    render(<BulkCreateWorktreeDialog {...props} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Reaching a terminal phase is the fix: "Creating worktrees…" with a hidden
+    // X and blocked Escape used to persist forever.
+    expect(screen.getByTestId("bulk-create-done-button")).toBeTruthy();
+    expect(screen.getByTestId("bulk-create-retry-button")).toBeTruthy();
+    expect(screen.getByTestId("bulk-create-worktree-dialog").dataset.dismissible).toBe("true");
+    expect(mockWorktreeCreate).not.toHaveBeenCalled();
+  });
+
+  it("keeps the primary action in place while executing", async () => {
+    const resolvers: Array<(value: string) => void> = [];
+    mockWorktreeCreate.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolvers.push(resolve);
+        })
+    );
+
+    const props = { ...defaultProps, selectedIssues: [makeIssue(1)] };
+    render(<BulkCreateWorktreeDialog {...props} />);
+
+    // The header X is unlabelled and correctly disappears mid-run; only the
+    // footer's ordering is what Cancel's hit area depends on.
+    const footerLabels = () =>
+      screen
+        .getAllByRole("button")
+        .map((b) => b.textContent)
+        .filter(Boolean);
+    const footerOrderBefore = footerLabels();
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+
+    // Cancel must not inherit the CTA's slot once the run commits.
+    const confirmButton = screen.getByTestId("bulk-create-confirm-button") as HTMLButtonElement;
+    expect(confirmButton.disabled).toBe(true);
+    expect(footerLabels()).toEqual(footerOrderBefore);
+
+    // A stray second click on the now-disabled CTA starts nothing.
+    await act(async () => {
+      confirmButton.click();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(mockWorktreeCreate).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolvers[0]?.("wt-1");
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+  });
+
+  it("blocks Escape and backdrop dismissal while executing", async () => {
+    const resolvers: Array<(value: string) => void> = [];
+    mockWorktreeCreate.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolvers.push(resolve);
+        })
+    );
+
+    const onClose = vi.fn();
+    const props = { ...defaultProps, selectedIssues: [makeIssue(1)] };
+    render(<BulkCreateWorktreeDialog {...props} onClose={onClose} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+
+    const dialog = screen.getByTestId("bulk-create-worktree-dialog");
+    expect(dialog.dataset.dismissible).toBe("false");
+
+    await act(async () => {
+      dialog.click();
+      dialog.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+
+    // The footer Cancel remains the deliberate way out.
+    await act(async () => {
+      const cancelBtn = screen
+        .getAllByRole("button")
+        .find((b) => b.textContent === "Cancel") as HTMLButtonElement;
+      cancelBtn.click();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(onClose).toHaveBeenCalled();
+
+    await act(async () => {
+      resolvers[0]?.("wt-1");
+      await vi.advanceTimersByTimeAsync(1000);
+    });
   });
 
   it("keeps completed items visible after worktreeMap updates during execution", async () => {

--- a/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
+++ b/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
@@ -106,11 +106,13 @@ export function BulkCreateWorktreeDialog({
   const isExecutingRef = useRef(false);
   const prevIsOpenRef = useRef(false);
   // The batch currently executing. `controller` reaches the one callee that can
-  // stop mid-flight (spawnPanelsFromRecipe); `created` counts worktrees this run
-  // actually made, so a cancel can report what survived it.
+  // stop mid-flight (spawnPanelsFromRecipe); `created`/`creating` count worktrees
+  // this run made and calls still outstanding, so a cancel can report what
+  // survived it.
   const activeRunRef = useRef<{
     controller: AbortController;
     created: number;
+    creating: number;
     total: number;
   } | null>(null);
 
@@ -277,6 +279,7 @@ export function BulkCreateWorktreeDialog({
       const activeRun = {
         controller: new AbortController(),
         created: 0,
+        creating: 0,
         total: toCreate.length,
       };
       activeRunRef.current = activeRun;
@@ -300,6 +303,18 @@ export function BulkCreateWorktreeDialog({
         activeRunRef.current = null;
         return;
       }
+
+      // Counts create() calls that haven't settled. PQueue.pending counts whole
+      // queue callbacks — which may be fetching branches, running a recipe, or
+      // sleeping in backoff — so it can't stand in for "worktrees still coming".
+      const createWorktree = async (options: Parameters<typeof worktreeClient.create>[0]) => {
+        activeRun.creating++;
+        try {
+          return await worktreeClient.create(options, rootPath);
+        } finally {
+          activeRun.creating--;
+        }
+      };
 
       const tracking = batchTrackingRef.current;
 
@@ -536,16 +551,13 @@ export function BulkCreateWorktreeDialog({
                   // keep a cancelled item from putting a worktree on disk.
                   if (runIdRef.current !== currentRunId) return;
 
-                  const createdId = await worktreeClient.create(
-                    {
-                      baseBranch: createBaseBranch,
-                      newBranch: planned.headRefName,
-                      path,
-                      fromRemote: createFromRemote,
-                      useExistingBranch: createUseExisting,
-                    },
-                    rootPath
-                  );
+                  const createdId = await createWorktree({
+                    baseBranch: createBaseBranch,
+                    newBranch: planned.headRefName,
+                    path,
+                    fromRemote: createFromRemote,
+                    useExistingBranch: createUseExisting,
+                  });
 
                   if (!createdId) throw new Error("Failed to create worktree: no ID returned");
                   activeRun.created++;
@@ -576,16 +588,13 @@ export function BulkCreateWorktreeDialog({
                   // keep a cancelled item from putting a worktree on disk.
                   if (runIdRef.current !== currentRunId) return;
 
-                  const createdId = await worktreeClient.create(
-                    {
-                      baseBranch,
-                      newBranch: availableBranch,
-                      path,
-                      fromRemote: false,
-                      useExistingBranch: false,
-                    },
-                    rootPath
-                  );
+                  const createdId = await createWorktree({
+                    baseBranch,
+                    newBranch: availableBranch,
+                    path,
+                    fromRemote: false,
+                    useExistingBranch: false,
+                  });
 
                   if (!createdId) throw new Error("Failed to create worktree: no ID returned");
                   activeRun.created++;
@@ -730,8 +739,10 @@ export function BulkCreateWorktreeDialog({
                       }
                     );
 
-                  // runRecipeWithResults can't be interrupted, but a cancelled
-                  // run must not carry its result on to assignment or success.
+                  // Defence in depth: the assignment and success gates below
+                  // already stop a cancelled run, but returning here keeps a
+                  // dead run from writing tracking and reducer state on its way
+                  // out, matching every other checkpoint in this loop.
                   if (runIdRef.current !== currentRunId) return;
 
                   const updatedTracked = tracking.get(itemNumber);
@@ -1021,22 +1032,24 @@ export function BulkCreateWorktreeDialog({
     // the same selection cleanup as the Done button — otherwise the bulk
     // bar stays visible with the now-stale selection.
     if (isExecuting) {
-      // Snapshot first: invalidating empties the queue and drops the run record.
+      // Snapshot first: invalidating drops the run record.
       const activeRun = activeRunRef.current;
       const created = activeRun?.created ?? 0;
+      const creating = activeRun?.creating ?? 0;
       const total = activeRun?.total ?? progress.total;
-      const inFlight = queueRef.current?.pending ?? 0;
 
       invalidateActiveRun();
 
       // Cancelling can't unwind an item already past its last checkpoint, and
       // the dialog is gone before those settle — so report what survived it.
-      if (created > 0 || inFlight > 0) {
+      // Silent when nothing was created and nothing is mid-creation: closing the
+      // dialog is its own confirmation that no work escaped.
+      if (created > 0 || creating > 0) {
         notify({
           type: "warning",
           title: "Worktree creation cancelled",
           message: `${created} of ${total} worktree${total !== 1 ? "s" : ""} created.${
-            inFlight > 0 ? ` ${inFlight} already started and will finish.` : ""
+            creating > 0 ? ` ${creating} already underway may still land.` : ""
           }`,
         });
       }

--- a/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
+++ b/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
@@ -105,6 +105,37 @@ export function BulkCreateWorktreeDialog({
   const runIdRef = useRef(0);
   const isExecutingRef = useRef(false);
   const prevIsOpenRef = useRef(false);
+  // The batch currently executing. `controller` reaches the one callee that can
+  // stop mid-flight (spawnPanelsFromRecipe); `created` counts worktrees this run
+  // actually made, so a cancel can report what survived it.
+  const activeRunRef = useRef<{
+    controller: AbortController;
+    created: number;
+    total: number;
+  } | null>(null);
+
+  // Invalidate the in-flight batch. Bumping the run ID makes every stale-run
+  // checkpoint inside runBatch return at its next opportunity, clear() drops
+  // whatever never started, and abort() stops clone-layout spawning between its
+  // own checkpoints. Idempotent: explicit Cancel runs it, then the unmount that
+  // Cancel triggers runs it again.
+  const invalidateActiveRun = useCallback(() => {
+    runIdRef.current++;
+    activeRunRef.current?.controller.abort();
+    activeRunRef.current = null;
+    queueRef.current?.clear();
+    queueRef.current = null;
+  }, []);
+
+  // SidebarContent renders this dialog only while `isOpen`, so every close
+  // unmounts it. Without this, a close that bypasses handleClose (parent
+  // teardown, error boundary reset) leaves the batch spawning into a detached
+  // component.
+  useEffect(() => {
+    return () => {
+      invalidateActiveRun();
+    };
+  }, [invalidateActiveRun]);
 
   // Shared preferences (same store as single create dialog)
   const assignWorktreeToSelf = usePreferencesStore((s) => s.assignWorktreeToSelf);
@@ -241,9 +272,34 @@ export function BulkCreateWorktreeDialog({
 
   const runBatch = useCallback(
     async (toCreate: PlannedWorktree[]) => {
+      activeRunRef.current?.controller.abort();
       const currentRunId = ++runIdRef.current;
+      const activeRun = {
+        controller: new AbortController(),
+        created: 0,
+        total: toCreate.length,
+      };
+      activeRunRef.current = activeRun;
+
       const rootPath = currentProject?.path;
-      if (!rootPath) return;
+      if (!rootPath) {
+        // handleCreate already dispatched START, so returning bare would strand
+        // phase: "executing" — header X hidden, Escape and backdrop blocked.
+        // Fail the items instead so the dialog reaches a terminal state with a
+        // reason and a Retry affordance.
+        for (const planned of toCreate) {
+          dispatchProgress({
+            type: "ITEM_FAILED",
+            issueNumber: planned.item.number,
+            error: "The current project path is unavailable",
+            attempts: 1,
+            failedStep: "worktree",
+          });
+        }
+        dispatchProgress({ type: "DONE" });
+        activeRunRef.current = null;
+        return;
+      }
 
       const tracking = batchTrackingRef.current;
 
@@ -331,7 +387,8 @@ export function BulkCreateWorktreeDialog({
           }
           if (toCreate.every((p) => p.mode === "pr")) {
             dispatchProgress({ type: "DONE" });
-            queueRef.current = null;
+            if (queueRef.current === queue) queueRef.current = null;
+            if (activeRunRef.current === activeRun) activeRunRef.current = null;
 
             notify({
               type: "error",
@@ -475,6 +532,10 @@ export function BulkCreateWorktreeDialog({
 
                   const path = await worktreeClient.getDefaultPath(rootPath, planned.headRefName);
 
+                  // create() has no abort API, so this is the last chance to
+                  // keep a cancelled item from putting a worktree on disk.
+                  if (runIdRef.current !== currentRunId) return;
+
                   const createdId = await worktreeClient.create(
                     {
                       baseBranch: createBaseBranch,
@@ -487,6 +548,7 @@ export function BulkCreateWorktreeDialog({
                   );
 
                   if (!createdId) throw new Error("Failed to create worktree: no ID returned");
+                  activeRun.created++;
 
                   worktreeId = createdId;
                   worktreePath = path;
@@ -510,6 +572,10 @@ export function BulkCreateWorktreeDialog({
                   const path =
                     pre?.path ?? (await worktreeClient.getDefaultPath(rootPath, availableBranch));
 
+                  // create() has no abort API, so this is the last chance to
+                  // keep a cancelled item from putting a worktree on disk.
+                  if (runIdRef.current !== currentRunId) return;
+
                   const createdId = await worktreeClient.create(
                     {
                       baseBranch,
@@ -522,6 +588,7 @@ export function BulkCreateWorktreeDialog({
                   );
 
                   if (!createdId) throw new Error("Failed to create worktree: no ID returned");
+                  activeRun.created++;
 
                   worktreeId = createdId;
                   worktreePath = path;
@@ -560,6 +627,11 @@ export function BulkCreateWorktreeDialog({
                 });
               }
 
+              // Cancel lands most often inside Step 1, whose IPC calls can't be
+              // interrupted. Stop here so an item whose worktree finished after
+              // the click doesn't go on to start terminals or agents in it.
+              if (runIdRef.current !== currentRunId) return;
+
               // Step 2: Clone layout or run recipe
               const currentItem = tracking.get(itemNumber);
               if (cloneTerminals && worktreePath && worktreeId && !currentItem?.cloneComplete) {
@@ -575,6 +647,7 @@ export function BulkCreateWorktreeDialog({
                   cwd: worktreePath,
                   agentSettings: cloneAgentSettings,
                   clipboardDirectory: cloneClipboardDirectory,
+                  signal: activeRun.controller.signal,
                   onPanelSpawned: (index, panelId, _error) => {
                     if (panelId != null) {
                       spawnedIds.push(panelId);
@@ -583,6 +656,9 @@ export function BulkCreateWorktreeDialog({
                     }
                   },
                 });
+                // An aborted spawn reports no failures, just fewer panels, so a
+                // cancelled run must not read its partial result as an outcome.
+                if (runIdRef.current !== currentRunId) return;
                 const updatedTracked = tracking.get(itemNumber);
                 if (updatedTracked) {
                   updatedTracked.spawnedTerminalIds = [
@@ -653,6 +729,10 @@ export function BulkCreateWorktreeDialog({
                         spawnBatch: recipeSpawnBatches.get(itemNumber),
                       }
                     );
+
+                  // runRecipeWithResults can't be interrupted, but a cancelled
+                  // run must not carry its result on to assignment or success.
+                  if (runIdRef.current !== currentRunId) return;
 
                   const updatedTracked = tracking.get(itemNumber);
                   if (updatedTracked) {
@@ -797,7 +877,9 @@ export function BulkCreateWorktreeDialog({
 
       await queue.onIdle();
       if (runIdRef.current !== currentRunId) return;
-      queueRef.current = null;
+      // Identity-guarded so a run that went stale mid-await can't null out the
+      // refs belonging to the run that replaced it.
+      if (queueRef.current === queue) queueRef.current = null;
 
       // Post-batch verification: check terminal health for current run items only
       if (selectedRecipeId) {
@@ -849,6 +931,7 @@ export function BulkCreateWorktreeDialog({
       }
 
       dispatchProgress({ type: "DONE" });
+      if (activeRunRef.current === activeRun) activeRunRef.current = null;
     },
     [selectedRecipeId, selectedRecipe, assignWorktreeToSelf, currentProject?.path]
   );
@@ -938,9 +1021,25 @@ export function BulkCreateWorktreeDialog({
     // the same selection cleanup as the Done button — otherwise the bulk
     // bar stays visible with the now-stale selection.
     if (isExecuting) {
-      runIdRef.current++;
-      queueRef.current?.clear();
-      queueRef.current = null;
+      // Snapshot first: invalidating empties the queue and drops the run record.
+      const activeRun = activeRunRef.current;
+      const created = activeRun?.created ?? 0;
+      const total = activeRun?.total ?? progress.total;
+      const inFlight = queueRef.current?.pending ?? 0;
+
+      invalidateActiveRun();
+
+      // Cancelling can't unwind an item already past its last checkpoint, and
+      // the dialog is gone before those settle — so report what survived it.
+      if (created > 0 || inFlight > 0) {
+        notify({
+          type: "warning",
+          title: "Worktree creation cancelled",
+          message: `${created} of ${total} worktree${total !== 1 ? "s" : ""} created.${
+            inFlight > 0 ? ` ${inFlight} already started and will finish.` : ""
+          }`,
+        });
+      }
     }
     isExecutingRef.current = false;
 
@@ -953,7 +1052,7 @@ export function BulkCreateWorktreeDialog({
 
     onClose();
     storedOnComplete?.();
-  }, [isExecuting, onClose, progress.phase]);
+  }, [isExecuting, onClose, progress.phase, progress.total, invalidateActiveRun]);
 
   const handleDone = useCallback(() => {
     // Capture before onComplete()/onClose() — both are wired to closeBulkCreateDialog
@@ -1210,18 +1309,17 @@ export function BulkCreateWorktreeDialog({
               Done
             </Button>
           </>
-        ) : isExecuting ? (
-          <Button variant="ghost" onClick={handleClose}>
-            Cancel
-          </Button>
         ) : (
+          // The primary stays mounted while executing: dropping it made Cancel
+          // the rightmost button, so it inherited the CTA's hit area one render
+          // after the click that started the run.
           <>
             <Button variant="ghost" onClick={handleClose}>
               Cancel
             </Button>
             <Button
               onClick={handleCreate}
-              disabled={creatableCount === 0}
+              disabled={isExecuting || creatableCount === 0}
               className="min-w-[100px]"
               data-testid="bulk-create-confirm-button"
             >

--- a/src/components/Worktree/panelSpawning.ts
+++ b/src/components/Worktree/panelSpawning.ts
@@ -200,8 +200,10 @@ export async function spawnPanelsFromRecipe(options: SpawnPanelsOptions): Promis
   }
 
   // Restore the per-panel focus the batch suppressed: focus the last spawned
-  // grid panel, matching the prior serial behaviour.
-  if (!suppressFocus && lastSpawnedId !== null) {
+  // grid panel, matching the prior serial behaviour. An aborted batch skips it —
+  // the dispatched panels can't be recalled, but yanking focus into work the
+  // user just cancelled compounds it (#11517).
+  if (!suppressFocus && lastSpawnedId !== null && !signal?.aborted) {
     // The batch suppressed addPanel's maximize exit along with its focus set, so
     // apply it here too — a spawned grid panel that takes focus has to be
     // visible, not stranded behind a fullscreen cell (#11060). Read the panel

--- a/src/components/ui/__tests__/AppDialog.test.tsx
+++ b/src/components/ui/__tests__/AppDialog.test.tsx
@@ -208,6 +208,28 @@ describe("AppDialog focus trapping", () => {
     expect(onClose).toHaveBeenCalledOnce();
   });
 
+  function clickBackdrop() {
+    const backdrop = screen.getByTestId("test-dialog");
+    act(() => {
+      backdrop.dispatchEvent(
+        new PointerEvent("pointerdown", { bubbles: true, button: 0, pointerId: 1 })
+      );
+      backdrop.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1 }));
+    });
+  }
+
+  // Positive baseline for the guard below: without it, deleting the backdrop
+  // pointer handlers entirely would still look like a pass.
+  it("closes on a backdrop press-and-release", async () => {
+    const onClose = vi.fn();
+    renderDialog({ onClose });
+    await act(() => vi.runAllTimersAsync());
+
+    clickBackdrop();
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
   // Callers that block dismissal mid-operation (bulk worktree creation, #11517)
   // rely on every route staying shut, not just the header X being hidden.
   it("blocks Escape and backdrop dismissal when not dismissible", async () => {
@@ -218,13 +240,7 @@ describe("AppDialog focus trapping", () => {
     pressEscape();
     expect(onClose).not.toHaveBeenCalled();
 
-    const backdrop = screen.getByTestId("test-dialog");
-    act(() => {
-      backdrop.dispatchEvent(
-        new PointerEvent("pointerdown", { bubbles: true, button: 0, pointerId: 1 })
-      );
-      backdrop.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1 }));
-    });
+    clickBackdrop();
 
     expect(onClose).not.toHaveBeenCalled();
   });

--- a/src/components/ui/__tests__/AppDialog.test.tsx
+++ b/src/components/ui/__tests__/AppDialog.test.tsx
@@ -60,16 +60,23 @@ function Dispatcher() {
 function renderDialog({
   isOpen = true,
   onClose = vi.fn(),
+  dismissible,
   children,
 }: {
   isOpen?: boolean;
   onClose?: () => void;
+  dismissible?: boolean;
   children?: React.ReactNode;
 } = {}) {
   return render(
     <>
       <Dispatcher />
-      <AppDialog isOpen={isOpen} onClose={onClose} data-testid="test-dialog">
+      <AppDialog
+        isOpen={isOpen}
+        onClose={onClose}
+        dismissible={dismissible}
+        data-testid="test-dialog"
+      >
         {children ?? (
           <AppDialog.Body>
             <button type="button">First</button>
@@ -199,6 +206,27 @@ describe("AppDialog focus trapping", () => {
     pressEscape();
 
     expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  // Callers that block dismissal mid-operation (bulk worktree creation, #11517)
+  // rely on every route staying shut, not just the header X being hidden.
+  it("blocks Escape and backdrop dismissal when not dismissible", async () => {
+    const onClose = vi.fn();
+    renderDialog({ onClose, dismissible: false });
+    await act(() => vi.runAllTimersAsync());
+
+    pressEscape();
+    expect(onClose).not.toHaveBeenCalled();
+
+    const backdrop = screen.getByTestId("test-dialog");
+    act(() => {
+      backdrop.dispatchEvent(
+        new PointerEvent("pointerdown", { bubbles: true, button: 0, pointerId: 1 })
+      );
+      backdrop.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1 }));
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   it("restores focus to previously focused element on close", async () => {


### PR DESCRIPTION
## Summary

- Cancel in the bulk create worktree dialog only called `PQueue.clear()`, which drops queued items but can't stop items that have already been dequeued and are running. With `QUEUE_CONCURRENCY` set to 3, up to three items kept running to completion after Cancel was clicked: creating worktrees and branches on disk, spawning terminals, and launching recipe agents in worktrees the user had just tried to abort, all while skipping the guarded self-assignment step, so those issues ended up unassigned.
- Fixed by extending the component's existing cooperative `runIdRef` checkpoint pattern. `worktreeClient.create()` has no abort API and p-queue can't interrupt a running task, so cooperative gating was the only option.
- Also fixed a stuck `phase: "executing"` state on a missing `rootPath`, and a footer bug where a double click on Create could abort the batch it just started.

Resolves #11517

## Changes

- Added a stale-run gate at the Step 1 to Step 2 boundary. This was the actual hole: an item whose worktree creation resolved just after Cancel walked straight into terminal spawning and recipe launch.
- Added gates immediately before each `worktreeClient.create()` call and after each awaited side effect in Step 2.
- Passed the run's `AbortSignal` into `spawnPanelsFromRecipe`, which already accepted one and checked it internally but was never given it.
- `panelSpawning` no longer steals focus or exits maximize for an aborted batch. A cancelled clone used to pull the user into a worktree they had just aborted.
- Batch invalidation now also runs on unmount, not only via `handleClose`. `SidebarContent` renders the dialog only while it's open, so every close unmounts it.
- Cancel now reports what survived it, counting outstanding `create()` calls rather than `PQueue.pending` (`PQueue.pending` counts whole queue callbacks, which would double-count items past creation and over-count ones that never reached it). Silent when nothing was created and nothing was mid-creation.
- `runBatch`'s early return on a missing `rootPath` used to dispatch no terminal state, stranding `phase: "executing"` forever: header X hidden, Escape and backdrop blocked, "Creating worktrees…" stuck. It now fails each item with a reason and reaches `done`.
- The footer no longer drops the primary CTA while executing. It used to leave Cancel as the sole button in a `justify-end` row, so Cancel inherited the CTA's hit area one render after the click that started the run, meaning a double click on Create could abort the batch. The primary button now stays mounted and disabled instead.

Deliberately not changed: `dismissible={!isExecuting}` (blocking dismissal mid-run is correct per the issue); no rollback of already-created worktrees (worktree deletion is a confirm-gated destructive action, and turning a cancel into a silent destructive op would be worse); `QUEUE_CONCURRENCY` and the sequential branch-name pre-query, both of which are rate-limit tuned.

**Known limitation:** an item already inside `runRecipeWithResults`, or panels already dispatched to `addPanel`, still finish. Those are past the point cooperative cancellation can reach. Stopping those needs a signal threaded through the panel startup queue, a core panel-system change out of scope here.

## Testing

- The `AppDialog` mock previously dropped the `dismissible` prop wholesale, so the block-dismissal-during-run guarantee had no coverage. The mock now models it, and `AppDialog.test.tsx` gains direct Escape and backdrop coverage with a positive baseline.
- New regression tests: recipe not run for a worktree landing after cancel; cancel reports leftover worktrees; silent when nothing was underway; batch stopped on unmount without `handleClose`; missing `rootPath` reaches a terminal state; primary action stays in place while executing; Escape/backdrop blocked while executing; no focus grab for a clone panel spawned into a cancelled run; no assignment or selection for a recipe resolving after cancel.
- Mutation-verified: disabling the Step 1 to Step 2 gate fails the core regression test, and removing the abort signal fails the clone-focus test.
- Locally, 328 tests across 7 files pass (`BulkCreateWorktreeDialog`, `bulkCreateReducer`, `bulkCreateUtils`, `AppDialog`, `panelSpawning`, `worktreeStore`). eslint, prettier, and tsc are clean on the changed files, no new lint warnings.
