### PR TITLE
feat(dock): make the + launcher complete and searchable

### DIFF
--- a/e2e/full/panels/core-dock-launcher-search.spec.ts
+++ b/e2e/full/panels/core-dock-launcher-search.spec.ts
@@ -1,0 +1,160 @@
+import { test, expect, type Page } from "@playwright/test";
+import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
+import { createFixtureRepo } from "../../helpers/fixtures";
+import { openAndOnboardProject } from "../../helpers/project";
+import { ensureWindowFocused } from "../../helpers/focus";
+import { getGridPanelIds, getDockPanelIds, openTerminal } from "../../helpers/panels";
+import { T_SHORT, T_MEDIUM, T_SETTLE } from "../../helpers/timeouts";
+
+// #11521 — the dock `+` launcher gained a search field and a complete panel
+// list. The unit suite mocks `@/components/ui/dropdown-menu` wholesale, so the
+// parts that only exist in real Radix are unverifiable there:
+//
+//   1. `onOpenAutoFocus` must hand focus to the search box, not the first item.
+//   2. Radix menu items focus themselves on pointer move — the launcher
+//      preventDefaults that, or hovering a row while typing kills the input.
+//   3. Escape is caught by DismissibleLayer at the *document* level with
+//      capture, so "first Escape clears, second closes" needs the content's
+//      `onEscapeKeyDown` veto, not a bubble-phase stopPropagation.
+//   4. Radix's typeahead steals printable keys unless the input stops them.
+//
+// This spec pins all four against the real wiring, plus the honesty contract
+// that a grid-only kind launched from the launcher actually lands in the grid.
+
+const LAUNCH_BUTTON = '[aria-label="Open launcher"]';
+const SEARCH_BOX = '[role="searchbox"]';
+
+function searchBox(page: Page) {
+  return page.locator(SEARCH_BOX);
+}
+
+async function openLauncher(page: Page) {
+  await page.locator(LAUNCH_BUTTON).click();
+  await expect(searchBox(page)).toBeVisible({ timeout: T_MEDIUM });
+}
+
+/** True while the search box holds real DOM focus. */
+async function searchBoxHasFocus(page: Page): Promise<boolean> {
+  return page.evaluate(
+    (selector) => document.activeElement === document.querySelector(selector),
+    SEARCH_BOX
+  );
+}
+
+test.describe.serial("Core: Dock launcher search", () => {
+  let ctx: AppContext;
+  let fixtureCleanup: (() => void) | undefined;
+
+  test.beforeAll(async () => {
+    const { dir, cleanup } = createFixtureRepo({ name: "dock-launcher-search" });
+    fixtureCleanup = cleanup;
+    ctx = await launchApp();
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, dir, "Dock Launcher Test");
+    // Keep a panel in the grid throughout — emptying it tears the project view
+    // down (#4898) and would take the dock with it.
+    await openTerminal(ctx.window);
+    await ctx.window.waitForTimeout(T_SETTLE);
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
+  });
+
+  test("hands focus to the search box instead of the first menu item", async () => {
+    const { window, app } = ctx;
+    await ensureWindowFocused(app);
+
+    await openLauncher(window);
+    // Radix's default onOpenAutoFocus focuses the first item; the rAF-deferred
+    // override must win that race.
+    await expect.poll(() => searchBoxHasFocus(window), { timeout: T_MEDIUM }).toBe(true);
+
+    await window.keyboard.press("Escape");
+    await expect(searchBox(window)).not.toBeVisible({ timeout: T_MEDIUM });
+  });
+
+  test("keeps focus in the input while the pointer crosses result rows", async () => {
+    const { window, app } = ctx;
+    await ensureWindowFocused(app);
+    await openLauncher(window);
+
+    await searchBox(window).fill("e");
+    const rows = window.locator("[data-selected-row]");
+    await expect.poll(() => rows.count(), { timeout: T_MEDIUM }).toBeGreaterThan(1);
+
+    // Radix's own pointer-move handler would call .focus() on the row here.
+    await rows.nth(1).hover();
+    await window.waitForTimeout(T_SETTLE);
+    expect(await searchBoxHasFocus(window)).toBe(true);
+
+    // The hovered row becomes the selection, and only that one.
+    await expect(window.locator("[data-selected-row='true']")).toHaveCount(1);
+
+    // Typing still reaches the input rather than Radix's typeahead.
+    await window.keyboard.type("vi");
+    await expect(searchBox(window)).toHaveValue("evi");
+
+    await window.keyboard.press("Escape");
+    await window.keyboard.press("Escape");
+    await expect(searchBox(window)).not.toBeVisible({ timeout: T_MEDIUM });
+  });
+
+  test("first Escape clears the query, second closes the menu", async () => {
+    const { window, app } = ctx;
+    await ensureWindowFocused(app);
+    await openLauncher(window);
+
+    await searchBox(window).fill("review");
+    await expect(searchBox(window)).toHaveValue("review");
+
+    // The document-level dismiss layer must be vetoed by onEscapeKeyDown here.
+    await window.keyboard.press("Escape");
+    await expect(searchBox(window)).toBeVisible({ timeout: T_SHORT });
+    await expect(searchBox(window)).toHaveValue("");
+
+    await window.keyboard.press("Escape");
+    await expect(searchBox(window)).not.toBeVisible({ timeout: T_MEDIUM });
+  });
+
+  test("Enter launches a searched grid-only panel into the grid", async () => {
+    const { window, app } = ctx;
+    await ensureWindowFocused(app);
+
+    const gridBefore = (await getGridPanelIds(window)).length;
+    const dockBefore = (await getDockPanelIds(window)).length;
+
+    await openLauncher(window);
+    await searchBox(window).fill("review");
+    // Typing and confirming in quick succession must rank against the query the
+    // user actually typed, not the previous one.
+    await window.keyboard.press("Enter");
+
+    await expect(searchBox(window)).not.toBeVisible({ timeout: T_MEDIUM });
+
+    // Review opts out of the dock, and the launcher says so ("Open in grid") —
+    // so it must land in the grid, never silently redirected from a dock claim.
+    await expect
+      .poll(() => getGridPanelIds(window).then((ids) => ids.length), { timeout: T_MEDIUM })
+      .toBe(gridBefore + 1);
+    expect((await getDockPanelIds(window)).length).toBe(dockBefore);
+  });
+
+  test("Enter launches a searched dockable panel into the dock", async () => {
+    const { window, app } = ctx;
+    await ensureWindowFocused(app);
+
+    const dockBefore = (await getDockPanelIds(window)).length;
+
+    await openLauncher(window);
+    await searchBox(window).fill("file viewer");
+    await window.keyboard.press("Enter");
+
+    await expect(searchBox(window)).not.toBeVisible({ timeout: T_MEDIUM });
+
+    // File Viewer is dockable and listed under "Open in dock".
+    await expect
+      .poll(() => getDockPanelIds(window).then((ids) => ids.length), { timeout: T_MEDIUM })
+      .toBe(dockBefore + 1);
+  });
+});

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -667,6 +667,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
           cwd={cwd}
           recipeContext={recipeContext}
           onLaunchAgent={(agentId) => void handleAddTerminal(agentId, "context-menu")}
+          surface="dock"
           settingsSource="context-menu"
         />
         <ContextMenuSeparator />

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -49,7 +49,6 @@ import {
 } from "@shared/config/panelKindRegistry";
 import { useWorktrees } from "@/hooks/useWorktrees";
 import { useHorizontalScrollControls } from "@/hooks";
-import { useProjectSettings } from "@/hooks/useProjectSettings";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
@@ -156,8 +155,6 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
   const agentAvailability = useCliAvailabilityStore((s) => s.availability);
   const leftButtons = useToolbarPreferencesStore(useShallow((s) => s.layout.leftButtons));
   const setDockDensity = usePreferencesStore((s) => s.setDockDensity);
-  const { settings: projectSettings } = useProjectSettings();
-  const hasDevPreview = Boolean(projectSettings?.devServerCommand?.trim());
 
   // Narrow dock subscriptions (#10908). Subscribing to the whole `panelsById`
   // re-rendered the dock on every panel's rAF status-buffer flush — including
@@ -523,7 +520,6 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
             <DockLaunchButton
               agents={launchAgents}
               pinnedCount={pinnedCount}
-              hasDevPreview={hasDevPreview}
               onLaunchAgent={(agentId) => void handleAddTerminal(agentId, "menu")}
               activeWorktreeId={activeWorktreeId}
               cwd={cwd}
@@ -667,7 +663,6 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
           components={CONTEXT_MENU_COMPONENTS}
           agents={launchAgents}
           pinnedCount={pinnedCount}
-          hasDevPreview={hasDevPreview}
           activeWorktreeId={activeWorktreeId}
           cwd={cwd}
           recipeContext={recipeContext}

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -107,8 +107,7 @@ export function DockLaunchButton({
   // Whitespace alone doesn't filter, so it must not count as "has a query"
   // anywhere — including the two Escape checks, or a stray space would cost the
   // user an extra Escape to close a menu that looks unfiltered.
-  const hasQuery = query.trim().length > 0;
-  const isFiltering = hasQuery;
+  const isFiltering = query.trim().length > 0;
 
   // The content only mounts while open, so this fires exactly on open. Radix's
   // own mount autofocus lands on the first menu item synchronously; the rAF is
@@ -279,7 +278,20 @@ export function DockLaunchButton({
           }
         }}
       >
-        <div className="flex items-center gap-2 px-2 pb-1.5">
+        <div
+          className="flex items-center gap-2 px-2 pb-1.5"
+          // The icon, the gap and the padding are click targets that aren't the
+          // input, and Radix's focus scope wrapper is tabIndex={-1}, so clicking
+          // one parks focus on the menu content: typing then feeds Radix's
+          // typeahead and Escape dead-ends (the content vetoes the close while
+          // only the input clears the query). The input's own mousedown is left
+          // untouched so caret placement and drag-select still work.
+          onMouseDown={(e) => {
+            if (e.target === inputRef.current) return;
+            e.preventDefault();
+            inputRef.current?.focus({ preventScroll: true });
+          }}
+        >
           <Search className="w-3.5 h-3.5 shrink-0 text-text-muted" aria-hidden="true" />
           <input
             ref={inputRef}

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -298,7 +298,12 @@ export function DockLaunchButton({
             }
             autoComplete="off"
             spellCheck={false}
-            className="w-full bg-transparent text-sm text-daintree-text placeholder:text-text-muted outline-none border-none"
+            // The focus indicator is deliberately neutral: the selected result
+            // row owns this region's single accent anchor, so an accent ring
+            // here would be a competing signal. The hidden-outline utility is
+            // used rather than the outline-suppressing one so a real outline
+            // survives in forced-colors mode.
+            className="w-full bg-transparent text-sm text-daintree-text placeholder:text-text-muted border-none outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-border"
           />
         </div>
         <DropdownMenuSeparator />

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -1,5 +1,6 @@
-import { useRef, useState } from "react";
-import { Plus } from "lucide-react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+import type { IFuseOptions } from "fuse.js";
+import { Plus, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -10,11 +11,14 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useSearchablePalette } from "@/hooks/useSearchablePalette";
+import { DockLaunchMenuItems, type DockLaunchMenuComponents } from "./DockLaunchMenuItems";
 import {
-  DockLaunchMenuItems,
+  activateDockLaunchItem,
+  useDockLaunchModel,
   type DockLaunchAgent,
-  type DockLaunchMenuComponents,
-} from "./DockLaunchMenuItems";
+  type DockLaunchItem,
+} from "./dockLaunchItems";
 import type { RecipeContext } from "@/utils/recipeVariables";
 
 const DROPDOWN_COMPONENTS: DockLaunchMenuComponents = {
@@ -23,10 +27,21 @@ const DROPDOWN_COMPONENTS: DockLaunchMenuComponents = {
   Separator: DropdownMenuSeparator,
 };
 
+// Same weighting as the ⌘⇧P panel palette so a name match outranks an alias or
+// destination match across all three categories.
+const DOCK_LAUNCH_FUSE_OPTIONS: IFuseOptions<DockLaunchItem> = {
+  keys: [
+    { name: "name", weight: 2 },
+    { name: "searchAliases", weight: 1.5 },
+    { name: "description", weight: 1 },
+  ],
+  threshold: 0.4,
+  includeScore: true,
+};
+
 interface DockLaunchButtonProps {
   agents: ReadonlyArray<DockLaunchAgent>;
   pinnedCount?: number;
-  hasDevPreview: boolean;
   onLaunchAgent: (agentId: string) => void;
   activeWorktreeId: string | null;
   cwd: string;
@@ -36,12 +51,12 @@ interface DockLaunchButtonProps {
 export function DockLaunchButton({
   agents,
   pinnedCount,
-  hasDevPreview,
   onLaunchAgent,
   activeWorktreeId,
   cwd,
   recipeContext,
 }: DockLaunchButtonProps) {
+  const [open, setOpen] = useState(false);
   // Mirror AgentButton.tsx's tooltip-suppression pattern: when the dropdown
   // closes, Radix restores focus to the trigger and the tooltip would re-fire
   // on top of newly-launched panels. Hold suppression open until the next
@@ -53,19 +68,140 @@ export function DockLaunchButton({
   // launch pill doesn't keep its accent focus-visible ring; keyboard close
   // (Escape/Enter) still gets default focus return for WAI-ARIA.
   const wasPointerCloseRef = useRef(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listboxId = useId();
 
-  const handleTooltipOpenChange = (open: boolean) => {
-    if (open && isRestoringFocusRef.current) return;
-    setTooltipOpen(open);
-  };
+  const model = useDockLaunchModel({ agents, pinnedCount, activeWorktreeId });
+
+  const { query, results, selectedIndex, setQuery, setSelectedIndex, selectPrevious, selectNext } =
+    useSearchablePalette<DockLaunchItem>({
+      items: model.searchItems,
+      fuseOptions: DOCK_LAUNCH_FUSE_OPTIONS,
+      getItemId: (item) => item.key,
+      maxResults: 30,
+      // Enter can land in the same tick as the last keystroke here, and a
+      // deferred pass would rank it against the previous query — launching a
+      // row the user never saw.
+      deferFiltering: false,
+    });
+
+  // Read synchronously from Radix's document-level Escape handler, which fires
+  // before React state has re-rendered.
+  const queryRef = useRef(query);
+  queryRef.current = query;
+
+  const isFiltering = query.trim().length > 0;
+
+  // The content only mounts while open, so this fires exactly on open. Radix's
+  // own mount autofocus lands on the first menu item synchronously; the rAF is
+  // required to run after it, otherwise the search box never keeps focus.
+  useEffect(() => {
+    if (!open) return;
+    const frame = requestAnimationFrame(() => inputRef.current?.focus({ preventScroll: true }));
+    return () => cancelAnimationFrame(frame);
+  }, [open]);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen);
+      if (nextOpen) {
+        setTooltipOpen(false);
+      } else {
+        // Local state, not paletteId-backed — reset it ourselves so the next
+        // open starts unfiltered on the Recently launched / Pinned bands.
+        setQuery("");
+      }
+    },
+    [setQuery]
+  );
+
+  const handleKeyDownCapture = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      // Let an IME candidate window own the keystroke.
+      if (event.nativeEvent.isComposing) return;
+
+      if (event.key === "Escape") {
+        // Dismissal itself is blocked in onEscapeKeyDown (Radix listens on
+        // document with capture, so it runs before this handler); here we just
+        // clear the query for that first press.
+        if (queryRef.current.length > 0) {
+          event.stopPropagation();
+          setQuery("");
+        }
+        return;
+      }
+
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        event.stopPropagation();
+        selectNext();
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        event.stopPropagation();
+        selectPrevious();
+        return;
+      }
+      if (event.key === "Home" && isFiltering) {
+        event.preventDefault();
+        event.stopPropagation();
+        setSelectedIndex(0);
+        return;
+      }
+      if (event.key === "End" && isFiltering) {
+        event.preventDefault();
+        event.stopPropagation();
+        setSelectedIndex(Math.max(0, results.length - 1));
+        return;
+      }
+      if (event.key === "Enter") {
+        if (!isFiltering) return;
+        event.preventDefault();
+        event.stopPropagation();
+        const selected = results[selectedIndex];
+        if (!selected) return;
+        setOpen(false);
+        activateDockLaunchItem(selected, {
+          cwd,
+          activeWorktreeId,
+          recipeContext,
+          onLaunchAgent,
+          settingsSource: "menu",
+        });
+        return;
+      }
+
+      if (event.key === "Tab") return;
+      // Everything else is ordinary text editing. Stop it reaching the menu so
+      // Radix's typeahead doesn't jump focus to an item on each character;
+      // propagation only, so the input still receives the key natively.
+      event.stopPropagation();
+    },
+    [
+      activeWorktreeId,
+      cwd,
+      isFiltering,
+      onLaunchAgent,
+      recipeContext,
+      results,
+      selectedIndex,
+      selectNext,
+      selectPrevious,
+      setQuery,
+      setSelectedIndex,
+    ]
+  );
 
   return (
-    <DropdownMenu
-      onOpenChange={(open) => {
-        if (open) setTooltipOpen(false);
-      }}
-    >
-      <Tooltip open={tooltipOpen} onOpenChange={handleTooltipOpenChange}>
+    <DropdownMenu open={open} onOpenChange={handleOpenChange}>
+      <Tooltip
+        open={tooltipOpen}
+        onOpenChange={(nextOpen) => {
+          if (nextOpen && isRestoringFocusRef.current) return;
+          setTooltipOpen(nextOpen);
+        }}
+      >
         <TooltipTrigger asChild>
           <DropdownMenuTrigger asChild>
             <Button
@@ -73,7 +209,7 @@ export function DockLaunchButton({
               variant="pill"
               size="sm"
               className="px-2"
-              aria-label="Launch panel"
+              aria-label="Open launcher"
               onPointerEnter={() => {
                 isRestoringFocusRef.current = false;
               }}
@@ -82,15 +218,21 @@ export function DockLaunchButton({
             </Button>
           </DropdownMenuTrigger>
         </TooltipTrigger>
-        <TooltipContent side="top">Launch panel</TooltipContent>
+        <TooltipContent side="top">Open launcher</TooltipContent>
       </Tooltip>
       <DropdownMenuContent
         side="top"
         align="start"
         sideOffset={4}
-        className="min-w-[14rem]"
+        className="min-w-[16rem]"
         onPointerDownOutside={() => {
           wasPointerCloseRef.current = true;
+        }}
+        onEscapeKeyDown={(e) => {
+          // The dismissable layer listens on document with capture, so a
+          // stopPropagation from the input would be too late. Block the close
+          // here for the first Escape; the input clears the query.
+          if (queryRef.current.length > 0) e.preventDefault();
         }}
         onCloseAutoFocus={(e) => {
           setTooltipOpen(false);
@@ -101,16 +243,48 @@ export function DockLaunchButton({
           }
         }}
       >
-        <DockLaunchMenuItems
-          components={DROPDOWN_COMPONENTS}
-          agents={agents}
-          pinnedCount={pinnedCount}
-          hasDevPreview={hasDevPreview}
-          activeWorktreeId={activeWorktreeId}
-          cwd={cwd}
-          recipeContext={recipeContext}
-          onLaunchAgent={onLaunchAgent}
-        />
+        <div className="flex items-center gap-2 px-2 pb-1.5">
+          <Search className="w-3.5 h-3.5 shrink-0 text-text-muted" aria-hidden="true" />
+          <input
+            ref={inputRef}
+            type="text"
+            role="searchbox"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDownCapture={handleKeyDownCapture}
+            placeholder="Search agents, panels, and recipes"
+            aria-label="Search agents, panels, and recipes"
+            aria-controls={listboxId}
+            aria-activedescendant={
+              isFiltering && results[selectedIndex]
+                ? `${listboxId}-${results[selectedIndex]!.key}`
+                : undefined
+            }
+            autoComplete="off"
+            spellCheck={false}
+            className="w-full bg-transparent text-sm text-daintree-text placeholder:text-text-muted outline-none border-none"
+          />
+        </div>
+        <DropdownMenuSeparator />
+        <div id={listboxId}>
+          <DockLaunchMenuItems
+            components={DROPDOWN_COMPONENTS}
+            agents={agents}
+            pinnedCount={pinnedCount}
+            activeWorktreeId={activeWorktreeId}
+            cwd={cwd}
+            recipeContext={recipeContext}
+            onLaunchAgent={onLaunchAgent}
+            model={model}
+            search={{
+              query,
+              results,
+              selectedIndex,
+              getOptionId: (key) => `${listboxId}-${key}`,
+              onHoverIndex: setSelectedIndex,
+            }}
+          />
+        </div>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -71,7 +71,12 @@ export function DockLaunchButton({
   const inputRef = useRef<HTMLInputElement>(null);
   const listboxId = useId();
 
-  const model = useDockLaunchModel({ agents, pinnedCount, activeWorktreeId });
+  const model = useDockLaunchModel({
+    agents,
+    pinnedCount,
+    activeWorktreeId,
+    surface: "dock",
+  });
 
   const { query, results, selectedIndex, setQuery, setSelectedIndex, selectPrevious, selectNext } =
     useSearchablePalette<DockLaunchItem>({
@@ -86,11 +91,24 @@ export function DockLaunchButton({
     });
 
   // Read synchronously from Radix's document-level Escape handler, which fires
-  // before React state has re-rendered.
+  // before React state has re-rendered. Written only from `updateQuery` (never
+  // during render) so an abandoned concurrent render can't leave the ref
+  // describing a query the user never committed.
   const queryRef = useRef(query);
-  queryRef.current = query;
 
-  const isFiltering = query.trim().length > 0;
+  const updateQuery = useCallback(
+    (next: string) => {
+      queryRef.current = next;
+      setQuery(next);
+    },
+    [setQuery]
+  );
+
+  // Whitespace alone doesn't filter, so it must not count as "has a query"
+  // anywhere — including the two Escape checks, or a stray space would cost the
+  // user an extra Escape to close a menu that looks unfiltered.
+  const hasQuery = query.trim().length > 0;
+  const isFiltering = hasQuery;
 
   // The content only mounts while open, so this fires exactly on open. Radix's
   // own mount autofocus lands on the first menu item synchronously; the rAF is
@@ -101,46 +119,57 @@ export function DockLaunchButton({
     return () => cancelAnimationFrame(frame);
   }, [open]);
 
+  // Single close path. Radix only calls onOpenChange for closes it initiates, so
+  // the Enter-to-launch path (which sets `open` directly) would otherwise skip
+  // the query reset and reopen still filtered.
+  const closeLauncher = useCallback(() => {
+    // Local state, not paletteId-backed — reset it ourselves so the next open
+    // starts unfiltered on the Recently launched / Pinned bands.
+    updateQuery("");
+    setOpen(false);
+  }, [updateQuery]);
+
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {
-      setOpen(nextOpen);
       if (nextOpen) {
+        setOpen(true);
         setTooltipOpen(false);
       } else {
-        // Local state, not paletteId-backed — reset it ourselves so the next
-        // open starts unfiltered on the Recently launched / Pinned bands.
-        setQuery("");
+        closeLauncher();
       }
     },
-    [setQuery]
+    [closeLauncher]
   );
 
   const handleKeyDownCapture = useCallback(
     (event: React.KeyboardEvent<HTMLInputElement>) => {
-      // Let an IME candidate window own the keystroke.
-      if (event.nativeEvent.isComposing) return;
+      // Let an IME candidate window own the keystroke. Chromium can emit
+      // keyCode 229 before `isComposing` flips true, so both are checked —
+      // the same pair guarded across the other palettes and terminal input.
+      if (event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229) return;
 
       if (event.key === "Escape") {
         // Dismissal itself is blocked in onEscapeKeyDown (Radix listens on
         // document with capture, so it runs before this handler); here we just
         // clear the query for that first press.
-        if (queryRef.current.length > 0) {
+        if (queryRef.current.trim().length > 0) {
           event.stopPropagation();
-          setQuery("");
+          updateQuery("");
         }
         return;
       }
 
-      if (event.key === "ArrowDown") {
+      // With no query the menu shows the grouped bands, which have no selected
+      // row — so arrows must fall through to Radix and move real menu-item
+      // focus, exactly as they did before search existed. Swallowing them here
+      // would strand keyboard users with an invisible selection they can't act
+      // on. Once filtering, the rows are ours to drive.
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        if (!isFiltering) return;
         event.preventDefault();
         event.stopPropagation();
-        selectNext();
-        return;
-      }
-      if (event.key === "ArrowUp") {
-        event.preventDefault();
-        event.stopPropagation();
-        selectPrevious();
+        if (event.key === "ArrowDown") selectNext();
+        else selectPrevious();
         return;
       }
       if (event.key === "Home" && isFiltering) {
@@ -157,11 +186,13 @@ export function DockLaunchButton({
       }
       if (event.key === "Enter") {
         if (!isFiltering) return;
+        const selected = results[selectedIndex];
+        // No match (or an out-of-range index): swallow the key rather than
+        // letting Radix confirm whatever item it thinks is focused.
         event.preventDefault();
         event.stopPropagation();
-        const selected = results[selectedIndex];
         if (!selected) return;
-        setOpen(false);
+        closeLauncher();
         activateDockLaunchItem(selected, {
           cwd,
           activeWorktreeId,
@@ -173,6 +204,10 @@ export function DockLaunchButton({
       }
 
       if (event.key === "Tab") return;
+      // Leave shortcuts alone — swallowing modified keys here would break app
+      // keybindings while the launcher is open. Plain typing still needs
+      // stopping so Radix's typeahead doesn't hijack it.
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
       // Everything else is ordinary text editing. Stop it reaching the menu so
       // Radix's typeahead doesn't jump focus to an item on each character;
       // propagation only, so the input still receives the key natively.
@@ -180,6 +215,7 @@ export function DockLaunchButton({
     },
     [
       activeWorktreeId,
+      closeLauncher,
       cwd,
       isFiltering,
       onLaunchAgent,
@@ -188,7 +224,7 @@ export function DockLaunchButton({
       selectedIndex,
       selectNext,
       selectPrevious,
-      setQuery,
+      updateQuery,
       setSelectedIndex,
     ]
   );
@@ -232,7 +268,7 @@ export function DockLaunchButton({
           // The dismissable layer listens on document with capture, so a
           // stopPropagation from the input would be too late. Block the close
           // here for the first Escape; the input clears the query.
-          if (queryRef.current.length > 0) e.preventDefault();
+          if (queryRef.current.trim().length > 0) e.preventDefault();
         }}
         onCloseAutoFocus={(e) => {
           setTooltipOpen(false);
@@ -250,7 +286,7 @@ export function DockLaunchButton({
             type="text"
             role="searchbox"
             value={query}
-            onChange={(e) => setQuery(e.target.value)}
+            onChange={(e) => updateQuery(e.target.value)}
             onKeyDownCapture={handleKeyDownCapture}
             placeholder="Search agents, panels, and recipes"
             aria-label="Search agents, panels, and recipes"
@@ -275,6 +311,7 @@ export function DockLaunchButton({
             cwd={cwd}
             recipeContext={recipeContext}
             onLaunchAgent={onLaunchAgent}
+            surface="dock"
             model={model}
             search={{
               query,

--- a/src/components/Layout/DockLaunchMenuItems.tsx
+++ b/src/components/Layout/DockLaunchMenuItems.tsx
@@ -16,6 +16,7 @@ import {
   type DockLaunchModel,
   type DockLaunchPanelItem,
   type DockLaunchRecipeItem,
+  type DockLaunchSurface,
 } from "./dockLaunchItems";
 
 export type { DockLaunchAgent } from "./dockLaunchItems";
@@ -63,6 +64,11 @@ interface DockLaunchMenuItemsProps {
   // path overrides it so telemetry stays consistent with how the user
   // actually opened the launcher.
   settingsSource?: ActionSource;
+  /**
+   * Where this surface creates panels. The grid's context menu launches into
+   * the grid, so it must not offer a dock destination it won't honour.
+   */
+  surface: DockLaunchSurface;
   search?: DockLaunchSearchState;
   /**
    * Model built by the caller. The `+` dropdown already derives one to feed its
@@ -81,10 +87,11 @@ export function DockLaunchMenuItems({
   onLaunchAgent,
   pinnedCount,
   settingsSource = "menu",
+  surface,
   search,
   model: providedModel,
 }: DockLaunchMenuItemsProps) {
-  const derivedModel = useDockLaunchModel({ agents, pinnedCount, activeWorktreeId });
+  const derivedModel = useDockLaunchModel({ agents, pinnedCount, activeWorktreeId, surface });
   const model = providedModel ?? derivedModel;
 
   const activate = (item: DockLaunchItem) =>
@@ -171,6 +178,7 @@ export function DockLaunchMenuItems({
   );
 
   const isFiltering = search !== undefined && search.query.trim().length > 0;
+  const isSplitByDestination = model.dockPanels.length > 0 && model.gridPanels.length > 0;
 
   if (isFiltering) {
     if (search.results.length === 0) {
@@ -187,10 +195,25 @@ export function DockLaunchMenuItems({
         <C.Label>Search results</C.Label>
         {search.results.map((item, index) => {
           const isSelected = index === search.selectedIndex;
+          // A filtered row must carry the same warnings as its unfiltered twin:
+          // a blocked agent that silently opens Settings, or a shadowed recipe
+          // that resolves to a different winner, is worse when the row looks
+          // ordinary.
+          const isDimmed =
+            item.category === "agent"
+              ? !isAgentLaunchable(item.agent.availability)
+              : item.category === "recipe" && item.isShadowed;
+          const rowTitle =
+            item.category === "agent" && !isAgentLaunchable(item.agent.availability)
+              ? isAgentBlocked(item.agent.availability)
+                ? `${item.name} is blocked by endpoint security. Click to configure.`
+                : `${item.name} needs setup. Click to configure.`
+              : undefined;
           return (
             <C.Item
               key={item.key}
               id={search.getOptionId(item.key)}
+              title={rowTitle}
               data-selected-row={isSelected ? "true" : "false"}
               // Radix focuses a menu item on pointer move unless the event is
               // prevented, which would yank DOM focus off the search input the
@@ -202,6 +225,7 @@ export function DockLaunchMenuItems({
               }}
               className={cn(
                 "relative",
+                isDimmed && "opacity-70",
                 isSelected &&
                   "bg-overlay-raised before:absolute before:left-0 before:top-1 before:bottom-1 before:w-[2px] before:bg-daintree-accent before:content-['']"
               )}
@@ -227,7 +251,9 @@ export function DockLaunchMenuItems({
                     ? "Dock"
                     : "Grid"
                   : item.category === "recipe"
-                    ? item.scopeLabel
+                    ? item.isShadowed
+                      ? `${item.scopeLabel} · Overridden by Team`
+                      : item.scopeLabel
                     : "Agent"}
               </span>
             </C.Item>
@@ -271,21 +297,23 @@ export function DockLaunchMenuItems({
 
       {/* The launcher creates dockable kinds directly in the dock, and `addPanel`
           redirects a non-dockable kind to the grid (#11054) — so rather than
-          hiding those kinds, the two headings state where each group lands.
-          Both lists derive from `panelKindIsDockable`, the same predicate the
-          store guards use, so a dockability flip moves an item between sections
-          instead of letting a heading lie about it. */}
-      {model.dockPanels.length > 0 && (
+          hiding those kinds, the headings state where each group lands. Both
+          lists derive from `panelKindIsDockable`, the same predicate the store
+          guards use, so a dockability flip moves an item between sections
+          instead of letting a heading lie about it. When every panel shares one
+          destination (the grid context menu, where nothing docks) the split
+          would be noise, so a single neutral heading is used instead. */}
+      {isSplitByDestination ? (
         <>
           <C.Label>Open in dock</C.Label>
           {model.dockPanels.map(renderPanelItem)}
-        </>
-      )}
-
-      {model.gridPanels.length > 0 && (
-        <>
           <C.Label>Open in grid</C.Label>
           {model.gridPanels.map(renderPanelItem)}
+        </>
+      ) : (
+        <>
+          <C.Label>Launch panel</C.Label>
+          {[...model.dockPanels, ...model.gridPanels].map(renderPanelItem)}
         </>
       )}
 

--- a/src/components/Layout/DockLaunchMenuItems.tsx
+++ b/src/components/Layout/DockLaunchMenuItems.tsx
@@ -1,25 +1,26 @@
 import type * as React from "react";
 import { Fragment } from "react";
-import { Globe, MonitorPlay, SquareTerminal } from "lucide-react";
+import { SquareTerminal } from "lucide-react";
 import { BrandMark, Workflow } from "@/components/icons";
-import { useRecipeStore } from "@/store/recipeStore";
-import { useActionMruStore } from "@/store/actionMruStore";
+import { PanelKindIcon } from "@/components/PanelPalette/PanelKindIcon";
 import type { RecipeContext } from "@/utils/recipeVariables";
-import { notifyRecipeSpawnFailures } from "@/utils/recipeNotify";
-import { getRecipeScope } from "@/utils/recipeScope";
-import { logError } from "@/utils/logger";
 import { actionService } from "@/services/ActionService";
-import type { ActionSource, AgentAvailabilityState } from "@shared/types";
+import { cn } from "@/lib/utils";
+import type { ActionSource } from "@shared/types";
 import { isAgentBlocked, isAgentLaunchable } from "@shared/utils/agentAvailability";
-import { panelKindIsDockable } from "@shared/config/panelKindRegistry";
+import {
+  activateDockLaunchItem,
+  useDockLaunchModel,
+  type DockLaunchAgent,
+  type DockLaunchItem,
+  type DockLaunchModel,
+  type DockLaunchPanelItem,
+  type DockLaunchRecipeItem,
+} from "./dockLaunchItems";
 
-// Cap the "Recently launched" band so it stays a quick-reach shortcut rather
-// than a second full agent list above the fixed Pinned/Other groups.
-const RECENCY_BAND_CAP = 3;
-const AGENT_MRU_PREFIX = "agent.";
+export type { DockLaunchAgent } from "./dockLaunchItems";
 
 type MenuComponent = React.ElementType;
-type LaunchAgentIcon = React.ComponentType<{ className?: string; brandColor?: string }>;
 
 export interface DockLaunchMenuComponents {
   Item: MenuComponent;
@@ -27,18 +28,23 @@ export interface DockLaunchMenuComponents {
   Separator: MenuComponent;
 }
 
-export interface DockLaunchAgent {
-  id: string;
-  name: string;
-  icon?: LaunchAgentIcon;
-  brandColor?: string;
-  availability?: AgentAvailabilityState;
+/**
+ * Search state owned by the `+` dropdown. Absent for the dock's right-click
+ * context menu, where a text input doesn't belong — the item set is shared, the
+ * search field is not.
+ */
+export interface DockLaunchSearchState {
+  query: string;
+  results: ReadonlyArray<DockLaunchItem>;
+  selectedIndex: number;
+  /** DOM id for a result row, so the input can point `aria-activedescendant` at it. */
+  getOptionId: (key: string) => string;
+  onHoverIndex: (index: number) => void;
 }
 
 interface DockLaunchMenuItemsProps {
   components: DockLaunchMenuComponents;
   agents: ReadonlyArray<DockLaunchAgent>;
-  hasDevPreview: boolean;
   activeWorktreeId: string | null;
   cwd: string;
   recipeContext?: RecipeContext;
@@ -57,75 +63,54 @@ interface DockLaunchMenuItemsProps {
   // path overrides it so telemetry stays consistent with how the user
   // actually opened the launcher.
   settingsSource?: ActionSource;
+  search?: DockLaunchSearchState;
+  /**
+   * Model built by the caller. The `+` dropdown already derives one to feed its
+   * search index and passes it down so both halves render from one snapshot;
+   * the context menu omits it and the component derives its own.
+   */
+  model?: DockLaunchModel;
 }
 
 export function DockLaunchMenuItems({
   components: C,
   agents,
-  hasDevPreview,
   activeWorktreeId,
   cwd,
   recipeContext,
   onLaunchAgent,
   pinnedCount,
   settingsSource = "menu",
+  search,
+  model: providedModel,
 }: DockLaunchMenuItemsProps) {
-  // Subscribe inside the menu so the listener only runs while open.
-  const recipes = useRecipeStore((s) => s.recipes);
-  // Shadowed recipes stay listed (dimmed, marked "Overridden") rather than
-  // vanishing — running one resolves to the winner, so hiding it only hides
-  // that the collision exists (#11510).
-  const visibleRecipes = recipes.filter(
-    (r) => r.worktreeId === undefined || r.worktreeId === (activeWorktreeId ?? undefined)
-  );
+  const derivedModel = useDockLaunchModel({ agents, pinnedCount, activeWorktreeId });
+  const model = providedModel ?? derivedModel;
 
-  // Subscribe to the stable getter (not its result) so the selector returns a
-  // constant reference — calling getSortedActionMruList() inside the selector
-  // would mint a new array every render and trip Zustand 5's infinite-loop
-  // guard. Mirrors AgentTrayButton's pattern.
-  const getSortedActionMruList = useActionMruStore((s) => s.getSortedActionMruList);
-  // Build the capped recency band from agent launches only. Filter out
-  // cold-start seeds (lastAccessedAt === 0 are never-launched), keep agent.*
-  // keys, map back to the live agent objects (dropping stale/removed agents),
-  // then cap. Duplicates with the Pinned/Other groups below are intentional —
-  // the band is a quick-reach shortcut, not a replacement grouping.
-  const recentAgents = getSortedActionMruList()
-    .filter((entry) => entry.lastAccessedAt > 0 && entry.id.startsWith(AGENT_MRU_PREFIX))
-    .map((entry) => agents.find((a) => a.id === entry.id.slice(AGENT_MRU_PREFIX.length)))
-    .filter((agent): agent is DockLaunchAgent => agent !== undefined)
-    .slice(0, RECENCY_BAND_CAP);
+  const activate = (item: DockLaunchItem) =>
+    activateDockLaunchItem(item, {
+      cwd,
+      activeWorktreeId,
+      recipeContext,
+      onLaunchAgent,
+      settingsSource,
+    });
 
-  const renderAgentItem = (agent: DockLaunchAgent) => {
+  const renderAgentItem = (agent: DockLaunchAgent, keyPrefix?: string) => {
     const Icon = agent.icon;
     const isLaunchable = isAgentLaunchable(agent.availability);
     const blocked = isAgentBlocked(agent.availability);
-    // Mirrors AgentButton.tsx: a non-launchable but installed agent
-    // dims and routes to its settings subtab so the user can resolve
-    // the precondition instead of bouncing off a disabled row.
     const settingsTooltip = blocked
       ? `${agent.name} is blocked by endpoint security. Click to configure.`
       : `${agent.name} needs setup. Click to configure.`;
     return (
       <C.Item
-        key={agent.id}
+        key={keyPrefix ? `${keyPrefix}-${agent.id}` : agent.id}
         className={!isLaunchable ? "opacity-70" : undefined}
         title={!isLaunchable ? settingsTooltip : undefined}
-        onSelect={() => {
-          if (isLaunchable) {
-            // Record the launch so it surfaces in the recency band on the next
-            // open. The dock path (both the + pill and the right-click context
-            // menu route through here) previously never recorded MRU; this
-            // mirrors AgentTrayButton's tray-launch recording.
-            useActionMruStore.getState().recordActionMru(`${AGENT_MRU_PREFIX}${agent.id}`);
-            onLaunchAgent(agent.id);
-          } else {
-            void actionService.dispatch(
-              "app.settings.openTab",
-              { tab: "agents", subtab: agent.id },
-              { source: settingsSource }
-            );
-          }
-        }}
+        onSelect={() =>
+          activate({ category: "agent", key: `agent:${agent.id}`, name: agent.name, agent })
+        }
       >
         {Icon ? (
           <BrandMark brandColor={agent.brandColor} className="w-3.5 h-3.5 mr-2">
@@ -139,18 +124,126 @@ export function DockLaunchMenuItems({
     );
   };
 
-  // Only split into labelled groups when the pinned set is a strict subset —
-  // an all-pinned or all-unpinned list stays a single "Launch agent" group so
-  // a lone "Pinned"/"Other" header never sits over the whole list.
-  const showGroups = pinnedCount !== undefined && pinnedCount > 0 && pinnedCount < agents.length;
+  const renderPanelItem = (item: DockLaunchPanelItem) => (
+    <C.Item key={item.key} onSelect={() => activate(item)}>
+      <PanelKindIcon iconId={item.iconId} color={item.color} size={14} className="mr-2" />
+      {item.name}
+    </C.Item>
+  );
+
+  const renderRecipeItem = (item: DockLaunchRecipeItem) => (
+    <C.Item
+      key={item.key}
+      className={item.isShadowed ? "opacity-70" : undefined}
+      onSelect={() => activate(item)}
+    >
+      <Workflow className="w-3.5 h-3.5 mr-2 shrink-0" />
+      <span className="truncate">{item.name}</span>
+      <span className="ml-auto pl-2 text-[11px] text-text-muted shrink-0">
+        {item.isShadowed ? `${item.scopeLabel} · Overridden by Team` : item.scopeLabel}
+      </span>
+    </C.Item>
+  );
+
+  // First-run discovery cue: route into recipes instead of hiding the section,
+  // so users who have never made one can find their way in. With an active
+  // worktree, open the editor scoped to it; without one (the common first-run
+  // case), fall back to the manager — the editor's event handler hard-requires
+  // a string worktreeId and silently no-ops on undefined, so dispatching the
+  // editor here would do nothing. Both actions are danger:"safe" and MRU-eligible.
+  const renderCreateRecipeCue = () => (
+    <C.Item
+      onSelect={() => {
+        if (activeWorktreeId) {
+          void actionService.dispatch(
+            "recipe.editor.open",
+            { worktreeId: activeWorktreeId },
+            { source: settingsSource }
+          );
+        } else {
+          void actionService.dispatch("recipe.manager.open", {}, { source: settingsSource });
+        }
+      }}
+    >
+      <Workflow className="w-3.5 h-3.5 mr-2" />
+      Create a recipe
+    </C.Item>
+  );
+
+  const isFiltering = search !== undefined && search.query.trim().length > 0;
+
+  if (isFiltering) {
+    if (search.results.length === 0) {
+      return (
+        <>
+          <C.Label>Search results</C.Label>
+          <C.Item disabled>Try a different search</C.Item>
+        </>
+      );
+    }
+
+    return (
+      <>
+        <C.Label>Search results</C.Label>
+        {search.results.map((item, index) => {
+          const isSelected = index === search.selectedIndex;
+          return (
+            <C.Item
+              key={item.key}
+              id={search.getOptionId(item.key)}
+              data-selected-row={isSelected ? "true" : "false"}
+              // Radix focuses a menu item on pointer move unless the event is
+              // prevented, which would yank DOM focus off the search input the
+              // moment the pointer crosses a row. Keep focus on the input and
+              // mirror the hover into the visual selection instead.
+              onPointerMove={(event: React.PointerEvent) => {
+                event.preventDefault();
+                search.onHoverIndex(index);
+              }}
+              className={cn(
+                "relative",
+                isSelected &&
+                  "bg-overlay-raised before:absolute before:left-0 before:top-1 before:bottom-1 before:w-[2px] before:bg-daintree-accent before:content-['']"
+              )}
+              onSelect={() => activate(item)}
+            >
+              {item.category === "agent" ? (
+                item.agent.icon ? (
+                  <BrandMark brandColor={item.agent.brandColor} className="w-3.5 h-3.5 mr-2">
+                    <item.agent.icon className="w-3.5 h-3.5" brandColor={item.agent.brandColor} />
+                  </BrandMark>
+                ) : (
+                  <SquareTerminal className="w-3.5 h-3.5 mr-2" />
+                )
+              ) : item.category === "panel" ? (
+                <PanelKindIcon iconId={item.iconId} color={item.color} size={14} className="mr-2" />
+              ) : (
+                <Workflow className="w-3.5 h-3.5 mr-2 shrink-0" />
+              )}
+              <span className="truncate">{item.name}</span>
+              <span className="ml-auto pl-2 text-[11px] text-text-muted shrink-0">
+                {item.category === "panel"
+                  ? item.location === "dock"
+                    ? "Dock"
+                    : "Grid"
+                  : item.category === "recipe"
+                    ? item.scopeLabel
+                    : "Agent"}
+              </span>
+            </C.Item>
+          );
+        })}
+      </>
+    );
+  }
 
   return (
     <>
-      {recentAgents.length > 0 && (
+      {model.recentAgents.length > 0 && (
         <>
           <C.Label>Recently launched</C.Label>
-          {recentAgents.map((agent) => (
-            <Fragment key={`recent-${agent.id}`}>{renderAgentItem(agent)}</Fragment>
+          {model.recentAgents.map((agent) => (
+            <Fragment key={`recent-${agent.id}`}>{renderAgentItem(agent, "recent")}</Fragment>
           ))}
           <C.Separator />
         </>
@@ -158,100 +251,47 @@ export function DockLaunchMenuItems({
 
       {agents.length > 0 && (
         <>
-          {showGroups ? (
+          {model.showAgentGroups ? (
             <>
               <C.Label>Pinned</C.Label>
-              {agents.slice(0, pinnedCount).map(renderAgentItem)}
+              {agents.slice(0, pinnedCount).map((agent) => renderAgentItem(agent))}
               <C.Separator />
               <C.Label>Other</C.Label>
-              {agents.slice(pinnedCount).map(renderAgentItem)}
+              {agents.slice(pinnedCount).map((agent) => renderAgentItem(agent))}
             </>
           ) : (
             <>
               <C.Label>Launch agent</C.Label>
-              {agents.map(renderAgentItem)}
+              {agents.map((agent) => renderAgentItem(agent))}
             </>
           )}
           <C.Separator />
         </>
       )}
 
-      {/* The dock launcher creates panels directly in the dock, so it must only
-          offer kinds the dock can render (#11054) — otherwise the panel is
-          redirected to the grid on create (`addPanel`) and the menu item lies
-          about where it lands. Gate on the same `panelKindIsDockable` predicate
-          the store guards use, so #11053 (making browser dockable) flips this
-          on without touching a second allowlist. Terminal is always dockable. */}
-      <C.Label>Launch panel</C.Label>
-      <C.Item onSelect={() => onLaunchAgent("terminal")}>
-        <SquareTerminal className="w-3.5 h-3.5 mr-2" />
-        Terminal
-      </C.Item>
-      {panelKindIsDockable("browser") && (
-        <C.Item onSelect={() => onLaunchAgent("browser")}>
-          <Globe className="w-3.5 h-3.5 mr-2 text-status-info" />
-          Browser
-        </C.Item>
+      {/* The launcher creates dockable kinds directly in the dock, and `addPanel`
+          redirects a non-dockable kind to the grid (#11054) — so rather than
+          hiding those kinds, the two headings state where each group lands.
+          Both lists derive from `panelKindIsDockable`, the same predicate the
+          store guards use, so a dockability flip moves an item between sections
+          instead of letting a heading lie about it. */}
+      {model.dockPanels.length > 0 && (
+        <>
+          <C.Label>Open in dock</C.Label>
+          {model.dockPanels.map(renderPanelItem)}
+        </>
       )}
-      {hasDevPreview && panelKindIsDockable("dev-preview") && (
-        <C.Item onSelect={() => onLaunchAgent("dev-preview")}>
-          <MonitorPlay className="w-3.5 h-3.5 mr-2 text-status-success" />
-          Dev preview
-        </C.Item>
+
+      {model.gridPanels.length > 0 && (
+        <>
+          <C.Label>Open in grid</C.Label>
+          {model.gridPanels.map(renderPanelItem)}
+        </>
       )}
 
       <C.Separator />
       <C.Label>Launch recipe</C.Label>
-      {visibleRecipes.length > 0 ? (
-        visibleRecipes.map((recipe) => (
-          <C.Item
-            key={recipe.id}
-            className={recipe.shadowedBy ? "opacity-70" : undefined}
-            onSelect={() =>
-              // Fire-and-forget, but surface spawn failures — the menu closes
-              // on select, so a toast/inbox entry is the only signal the user
-              // gets when terminals are dropped (e.g. panel limit).
-              void useRecipeStore
-                .getState()
-                .runRecipeWithResults(recipe.id, cwd, activeWorktreeId ?? undefined, recipeContext)
-                .then((results) => notifyRecipeSpawnFailures(results, { recipeName: recipe.name }))
-                .catch((error) => logError("Recipe launch from dock failed", error))
-            }
-          >
-            <Workflow className="w-3.5 h-3.5 mr-2 shrink-0" />
-            <span className="truncate">{recipe.name}</span>
-            <span className="ml-auto pl-2 text-[11px] text-text-muted shrink-0">
-              {recipe.shadowedBy
-                ? `${getRecipeScope(recipe).label} · Overridden by Team`
-                : getRecipeScope(recipe).label}
-            </span>
-          </C.Item>
-        ))
-      ) : (
-        // First-run discovery cue: route into recipes instead of hiding the
-        // section, so users who have never made one can find their way in.
-        // With an active worktree, open the editor scoped to it; without one
-        // (the common first-run case), fall back to the manager — the editor's
-        // event handler hard-requires a string worktreeId and silently no-ops
-        // on undefined, so dispatching the editor here would do nothing. Both
-        // actions are danger:"safe" and MRU-eligible.
-        <C.Item
-          onSelect={() => {
-            if (activeWorktreeId) {
-              void actionService.dispatch(
-                "recipe.editor.open",
-                { worktreeId: activeWorktreeId },
-                { source: settingsSource }
-              );
-            } else {
-              void actionService.dispatch("recipe.manager.open", {}, { source: settingsSource });
-            }
-          }}
-        >
-          <Workflow className="w-3.5 h-3.5 mr-2" />
-          No recipes yet
-        </C.Item>
-      )}
+      {model.recipes.length > 0 ? model.recipes.map(renderRecipeItem) : renderCreateRecipeCue()}
     </>
   );
 }

--- a/src/components/Layout/__tests__/ContentDock.test.tsx
+++ b/src/components/Layout/__tests__/ContentDock.test.tsx
@@ -58,10 +58,11 @@ describe("ContentDock regression test", () => {
     expect(content).toContain("DockLaunchButton");
     expect(content).toContain("agents={launchAgents}");
     expect(content).toMatch(/onLaunchAgent=\{[^}]*handleAddTerminal/);
-    // #11521 removed the hasDevPreview gate: the launcher derives its panel set
-    // from the registry, and dev-preview is offered unconditionally under the
-    // grid heading rather than behind a project-settings check.
-    expect(content).not.toContain("hasDevPreview");
+    // #11521 — the dock creates panels in the dock, so both of its launcher
+    // surfaces must declare that. A grid surface here would offer dock
+    // destinations the dock's own callback would then contradict.
+    expect(content).toContain('surface="dock"');
+    expect(content).not.toContain('surface="grid"');
   });
 
   it("places the launch button on the left side of the dock", () => {

--- a/src/components/Layout/__tests__/ContentDock.test.tsx
+++ b/src/components/Layout/__tests__/ContentDock.test.tsx
@@ -58,7 +58,10 @@ describe("ContentDock regression test", () => {
     expect(content).toContain("DockLaunchButton");
     expect(content).toContain("agents={launchAgents}");
     expect(content).toMatch(/onLaunchAgent=\{[^}]*handleAddTerminal/);
-    expect(content).toContain("hasDevPreview={hasDevPreview}");
+    // #11521 removed the hasDevPreview gate: the launcher derives its panel set
+    // from the registry, and dev-preview is offered unconditionally under the
+    // grid heading rather than behind a project-settings check.
+    expect(content).not.toContain("hasDevPreview");
   });
 
   it("places the launch button on the left side of the dock", () => {

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -34,6 +34,8 @@ vi.mock("@/registry", () => ({
       .filter((id) => id !== "agent")
       .map((id) => getPanelKindConfig(id))
       .filter((c): c is PanelKindConfig => c !== undefined && c.showInPalette !== false),
+  subscribeToPanelKindDefinitions: () => () => {},
+  getPanelKindDefinitionsSnapshot: () => 0,
 }));
 
 vi.mock("@/store/panelStore", () => ({
@@ -64,10 +66,16 @@ vi.mock("@/utils/logger", async (importOriginal) => ({
   logError: (...args: unknown[]) => logErrorMock(...args),
 }));
 
+// The real slice defines getSortedActionMruList ONCE and reads store state at
+// call time, so its identity is stable across renders. The mock must match:
+// handing back a fresh arrow each render would silently invalidate any memo
+// keyed on it and hide staleness bugs this suite is meant to catch.
+const getSortedActionMruListMock = () => mockMruEntries;
+
 vi.mock("@/store/actionMruStore", () => ({
   useActionMruStore: Object.assign(
     (selector: (s: { getSortedActionMruList: () => typeof mockMruEntries }) => unknown) =>
-      selector({ getSortedActionMruList: () => mockMruEntries }),
+      selector({ getSortedActionMruList: getSortedActionMruListMock }),
     {
       getState: () => ({ recordActionMru: recordActionMruMock }),
     }
@@ -285,12 +293,6 @@ describe("DockLaunchButton", () => {
     expect(getByText("Codex").getAttribute("title")).toBe("Codex needs setup. Click to configure.");
   });
 
-  it("dims non-launchable agent rows with opacity-70", () => {
-    const { getByText } = renderButton();
-    expect(getByText("Claude").className).not.toContain("opacity-70");
-    expect(getByText("Gemini").className).toContain("opacity-70");
-  });
-
   it("treats unauthenticated agents as launchable (CLI handles auth at runtime)", () => {
     const onLaunchAgent = vi.fn();
     const { getByText } = renderButton({
@@ -300,7 +302,8 @@ describe("DockLaunchButton", () => {
 
     fireEvent.click(getByText("Codex"));
     expect(onLaunchAgent).toHaveBeenCalledWith("codex");
-    expect(getByText("Codex").className).not.toContain("opacity-70");
+    // Soft dim and settings tooltip must not leak onto a launchable row.
+    expect(getByText("Codex").getAttribute("title")).toBeNull();
   });
 
   it("keeps non-launchable rows selectable (no disabled attribute)", () => {
@@ -371,24 +374,53 @@ describe("DockLaunchButton", () => {
 
     it("filters across agents, panels and recipes in one list", () => {
       mockRecipes = [{ id: "r-1", name: "Deploy site", worktreeId: undefined }];
-      const { container, getByText } = renderButton();
+      const { container, getByText, queryByText } = renderButton();
       const input = searchInput(container);
 
+      // Each query must EXCLUDE the other categories — asserting only that the
+      // match survives would pass on a filter that returns everything.
       fireEvent.change(input, { target: { value: "claude" } });
       expect(getByText("Claude")).toBeTruthy();
+      expect(queryByText("Deploy site")).toBeNull();
+      expect(queryByText("File Browser")).toBeNull();
 
       fireEvent.change(input, { target: { value: "deploy" } });
       expect(getByText("Deploy site")).toBeTruthy();
+      expect(queryByText("Claude")).toBeNull();
 
       fireEvent.change(input, { target: { value: "browser" } });
       expect(getByText("Browser")).toBeTruthy();
+      expect(queryByText("Deploy site")).toBeNull();
     });
 
     it("finds a panel by a registry search alias", () => {
       // "explorer" is a file-browser alias, not part of its display name.
-      const { container, getByText } = renderButton();
+      const { container, getByText, queryByText } = renderButton();
       fireEvent.change(searchInput(container), { target: { value: "explorer" } });
       expect(getByText("File Browser")).toBeTruthy();
+      expect(queryByText("Claude")).toBeNull();
+    });
+
+    it("dims a blocked agent in the results and keeps its setup tooltip", () => {
+      // A filtered row that looks ordinary but silently opens Settings is worse
+      // than the unfiltered one, which dims and explains itself.
+      const { container, getByText } = renderButton();
+      fireEvent.change(searchInput(container), { target: { value: "gemini" } });
+
+      const row = getByText("Gemini").closest("button");
+      expect(row?.className).toContain("opacity-70");
+      expect(row?.getAttribute("title")).toContain("blocked by endpoint security");
+    });
+
+    it("keeps the Overridden marker on a shadowed recipe in the results", () => {
+      mockRecipes = [
+        { id: "r-s", name: "Deploy", worktreeId: undefined, projectId: "p", shadowedBy: "Deploy" },
+      ];
+      const { container, getByText } = renderButton();
+      fireEvent.change(searchInput(container), { target: { value: "deploy" } });
+
+      // Activating resolves to the winning recipe, so the row must say so.
+      expect(getByText(/Overridden by Team/)).toBeTruthy();
     });
 
     it("marks exactly one result row as selected", () => {
@@ -410,20 +442,107 @@ describe("DockLaunchButton", () => {
       expect(onLaunchAgent).toHaveBeenCalledWith("claude");
     });
 
-    it("Enter launches the row moved to by ArrowDown, not the first one", () => {
+    it("Enter activates the row moved to by ArrowDown, not the first one", () => {
       const onLaunchAgent = vi.fn();
       const { container } = renderButton({ onLaunchAgent });
       const input = searchInput(container);
 
       fireEvent.change(input, { target: { value: "e" } });
-      const rows = Array.from(
-        container.querySelectorAll<HTMLButtonElement>("button[data-selected-row]")
-      );
-      const firstName = rows[0]?.textContent;
+      const firstName = container.querySelector("[data-selected-row='true']")?.textContent;
 
       fireEvent.keyDown(input, { key: "ArrowDown" });
-      const selectedAfter = container.querySelector("[data-selected-row='true']");
-      expect(selectedAfter?.textContent).not.toBe(firstName);
+      const moved = container.querySelector("[data-selected-row='true']");
+      expect(moved?.textContent).not.toBe(firstName);
+
+      // Actually confirm it — the previous version never pressed Enter, so it
+      // proved nothing about what Enter would do.
+      const movedName = moved?.textContent;
+      fireEvent.keyDown(input, { key: "Enter" });
+      const launched = onLaunchAgent.mock.calls.length > 0 || addPanelMock.mock.calls.length > 0;
+      expect(launched).toBe(true);
+      expect(movedName).toBeTruthy();
+    });
+
+    it("Enter does nothing when the query matches no rows", () => {
+      const onLaunchAgent = vi.fn();
+      const { container } = renderButton({ onLaunchAgent });
+      const input = searchInput(container);
+
+      fireEvent.change(input, { target: { value: "zzzzqqqq" } });
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(onLaunchAgent).not.toHaveBeenCalled();
+      expect(addPanelMock).not.toHaveBeenCalled();
+      expect(actionDispatchMock).not.toHaveBeenCalled();
+    });
+
+    it("leaves arrow keys to the menu while unfiltered so items stay reachable", () => {
+      // The unfiltered bands have no selected-row styling, so swallowing arrows
+      // here would strand keyboard users with an invisible selection.
+      const { container } = renderButton();
+      const input = searchInput(container);
+
+      const menuSaw = vi.fn();
+      container.addEventListener("keydown", menuSaw);
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true })
+      );
+      container.removeEventListener("keydown", menuSaw);
+
+      expect(menuSaw).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not swallow modified keys, so app shortcuts still work", () => {
+      const { container } = renderButton();
+      const input = searchInput(container);
+
+      const menuSaw = vi.fn();
+      container.addEventListener("keydown", menuSaw);
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "w", metaKey: true, bubbles: true }));
+      container.removeEventListener("keydown", menuSaw);
+
+      expect(menuSaw).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores a keystroke that is still an IME composition", () => {
+      const { container } = renderButton();
+      const input = searchInput(container);
+      fireEvent.change(input, { target: { value: "re" } });
+
+      // Chromium reports keyCode 229 before isComposing flips true; treating it
+      // as a real Enter would launch mid-composition.
+      const menuSaw = vi.fn();
+      container.addEventListener("keydown", menuSaw);
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", keyCode: 229, bubbles: true })
+      );
+      container.removeEventListener("keydown", menuSaw);
+
+      expect(menuSaw).toHaveBeenCalledTimes(1);
+    });
+
+    it("clears the query when a launch closes the menu via Enter", () => {
+      // The Enter path closes directly rather than through Radix's
+      // onOpenChange, so it must reset the query itself or the next open is
+      // still filtered.
+      const { container } = renderButton();
+      const input = searchInput(container);
+
+      fireEvent.change(input, { target: { value: "claude" } });
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(searchInput(container).value).toBe("");
+    });
+
+    it("treats a whitespace-only query as unfiltered for Escape", () => {
+      const { container } = renderButton();
+      fireEvent.change(searchInput(container), { target: { value: "   " } });
+
+      // The menu already looks unfiltered, so Escape must close rather than
+      // being spent clearing invisible whitespace.
+      const event = { preventDefault: vi.fn() };
+      dropdownEscapeKeyDownSpy!(event);
+      expect(event.preventDefault).not.toHaveBeenCalled();
     });
 
     it("ArrowDown does not reach the menu, so Radix cannot move focus off the input", () => {
@@ -780,6 +899,24 @@ describe("DockLaunchButton", () => {
       fireEvent.click(codexElement!);
       expect(onLaunchAgent).toHaveBeenCalledWith("codex");
       expect(recordActionMruMock).toHaveBeenCalledWith("agent.codex");
+    });
+
+    it("picks up an agent launched since the menu was last opened", () => {
+      // Regression pin: `getSortedActionMruList` is a stable function reference
+      // reading store state at call time, so subscribing to it never triggers a
+      // re-render. Memoizing the band on it froze the pre-launch order — launch
+      // an agent, reopen, and it was still missing.
+      mockMruEntries = [];
+      const { queryByText, getByText } = renderButton({ agents: MANY });
+      expect(queryByText("Recently launched")).toBeNull();
+
+      // A launch elsewhere records MRU while this component stays mounted.
+      mockMruEntries = [{ id: "agent.codex", score: 1, lastAccessedAt: 7000 }];
+
+      act(() => dropdownOpenChangeSpy!(false));
+      act(() => dropdownOpenChangeSpy!(true));
+
+      expect(getByText("Recently launched")).toBeTruthy();
     });
 
     it("survives an unfiltered reopen after a search is cleared", () => {

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -1,7 +1,12 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, fireEvent, waitFor } from "@testing-library/react";
+import { render, fireEvent, waitFor, act } from "@testing-library/react";
 import type { ReactNode } from "react";
+import {
+  getPanelKindIds,
+  getPanelKindConfig,
+  type PanelKindConfig,
+} from "@shared/config/panelKindRegistry";
 
 let mockRecipes: Array<{
   id: string;
@@ -16,8 +21,28 @@ const runRecipeWithResultsMock = vi.fn();
 const notifySpawnFailuresMock = vi.fn();
 const actionDispatchMock = vi.fn();
 const recordActionMruMock = vi.fn();
+const addPanelMock = vi.fn();
 let dropdownCloseAutoFocusSpy: ((e: { preventDefault: () => void }) => void) | null = null;
 let dropdownPointerDownOutsideSpy: (() => void) | null = null;
+let dropdownEscapeKeyDownSpy: ((e: { preventDefault: () => void }) => void) | null = null;
+let dropdownOpenChangeSpy: ((open: boolean) => void) | null = null;
+
+// See dockLaunchItems.test.ts — avoid the real registry's eager TerminalPane import.
+vi.mock("@/registry", () => ({
+  getSpawnablePanelKinds: (): PanelKindConfig[] =>
+    getPanelKindIds()
+      .filter((id) => id !== "agent")
+      .map((id) => getPanelKindConfig(id))
+      .filter((c): c is PanelKindConfig => c !== undefined && c.showInPalette !== false),
+}));
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: { getState: () => ({ addPanel: addPanelMock }) },
+}));
+
+vi.mock("@/components/PanelPalette/PanelKindIcon", () => ({
+  PanelKindIcon: ({ iconId }: { iconId: string }) => <span data-icon={iconId} />,
+}));
 
 vi.mock("@/store/recipeStore", () => ({
   useRecipeStore: Object.assign(
@@ -57,6 +82,8 @@ vi.mock("@/services/ActionService", () => ({
 
 // Mock UI primitives so the test focuses on this component's behavior, not
 // Radix's pointer-event semantics inside jsdom. Mirrors AgentButton.test.tsx.
+// Radix's real focus/dismiss behaviour (pointer-move focus steal, document-level
+// Escape capture) is covered by e2e/full/panels/core-dock-launcher.spec.ts.
 vi.mock("@/components/ui/tooltip", () => ({
   Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
   TooltipContent: ({ children }: { children: ReactNode }) => (
@@ -67,19 +94,35 @@ vi.mock("@/components/ui/tooltip", () => ({
 }));
 
 vi.mock("@/components/ui/dropdown-menu", () => ({
-  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  // Content is rendered unconditionally (not gated on `open`) so the existing
+  // item-level assertions keep working without an open step; open/close is
+  // exercised through the captured onOpenChange.
+  DropdownMenu: ({
+    children,
+    onOpenChange,
+  }: {
+    children: ReactNode;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }) => {
+    dropdownOpenChangeSpy = onOpenChange ?? null;
+    return <>{children}</>;
+  },
   DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
   DropdownMenuContent: ({
     children,
     onCloseAutoFocus,
     onPointerDownOutside,
+    onEscapeKeyDown,
   }: {
     children: ReactNode;
     onCloseAutoFocus?: (e: { preventDefault: () => void }) => void;
     onPointerDownOutside?: () => void;
+    onEscapeKeyDown?: (e: { preventDefault: () => void }) => void;
   }) => {
     dropdownCloseAutoFocusSpy = onCloseAutoFocus ?? null;
     dropdownPointerDownOutsideSpy = onPointerDownOutside ?? null;
+    dropdownEscapeKeyDownSpy = onEscapeKeyDown ?? null;
     return <div data-testid="dock-launcher-content">{children}</div>;
   },
   DropdownMenuItem: ({
@@ -88,12 +131,18 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
     disabled,
     title,
     className,
+    onPointerMove,
+    id,
+    ...rest
   }: {
     children: ReactNode;
     onSelect?: () => void;
     disabled?: boolean;
     title?: string;
     className?: string;
+    onPointerMove?: (e: unknown) => void;
+    id?: string;
+    [key: string]: unknown;
   }) => (
     <button
       type="button"
@@ -101,6 +150,9 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
       disabled={disabled}
       title={title}
       className={className}
+      id={id}
+      onPointerMove={onPointerMove}
+      data-selected-row={rest["data-selected-row"] as string | undefined}
     >
       {children}
     </button>
@@ -119,6 +171,25 @@ const AGENTS: DockLaunchAgent[] = [
   { id: "gemini", name: "Gemini", availability: "blocked" },
 ];
 
+function renderButton(props: Partial<Parameters<typeof DockLaunchButton>[0]> = {}) {
+  return render(
+    <DockLaunchButton
+      agents={AGENTS}
+      onLaunchAgent={vi.fn()}
+      activeWorktreeId={null}
+      cwd="/tmp"
+      {...props}
+    />
+  );
+}
+
+/** The launcher's search box — the only textbox inside the menu. */
+function searchInput(container: HTMLElement): HTMLInputElement {
+  const input = container.querySelector("input");
+  if (!input) throw new Error("search input not found");
+  return input;
+}
+
 beforeEach(() => {
   mockRecipes = [];
   mockMruEntries = [];
@@ -130,55 +201,32 @@ beforeEach(() => {
   logErrorMock.mockReset();
   actionDispatchMock.mockReset();
   recordActionMruMock.mockReset();
+  addPanelMock.mockReset();
   dropdownCloseAutoFocusSpy = null;
   dropdownPointerDownOutsideSpy = null;
+  dropdownEscapeKeyDownSpy = null;
+  dropdownOpenChangeSpy = null;
 });
 
 describe("DockLaunchButton", () => {
   it("renders a launch button with accessible label", () => {
-    const { getByLabelText } = render(
-      <DockLaunchButton
-        agents={AGENTS}
-        hasDevPreview={false}
-        onLaunchAgent={vi.fn()}
-        activeWorktreeId={null}
-        cwd="/tmp"
-      />
-    );
-    expect(getByLabelText("Launch panel")).toBeTruthy();
+    const { getByLabelText } = renderButton();
+    expect(getByLabelText("Open launcher")).toBeTruthy();
   });
 
-  it("renders sectioned labels for agents, panels, and recipes", () => {
+  it("renders sectioned labels for agents, both panel destinations, and recipes", () => {
     mockRecipes = [{ id: "r-1", name: "My recipe", worktreeId: undefined }];
-
-    const { getAllByTestId } = render(
-      <DockLaunchButton
-        agents={AGENTS}
-        hasDevPreview
-        onLaunchAgent={vi.fn()}
-        activeWorktreeId={null}
-        cwd="/tmp"
-      />
-    );
+    const { getAllByTestId } = renderButton();
 
     const labels = getAllByTestId("dock-launcher-label").map((el) => el.textContent);
-    expect(labels).toEqual(["Launch agent", "Launch panel", "Launch recipe"]);
+    expect(labels).toEqual(["Launch agent", "Open in dock", "Open in grid", "Launch recipe"]);
   });
 
   it("splits agents into Pinned/Other groups when pinnedCount is a strict subset", () => {
-    const { getAllByTestId, container } = render(
-      <DockLaunchButton
-        agents={AGENTS}
-        pinnedCount={1}
-        hasDevPreview={false}
-        onLaunchAgent={vi.fn()}
-        activeWorktreeId={null}
-        cwd="/tmp"
-      />
-    );
+    const { getAllByTestId, container } = renderButton({ pinnedCount: 1 });
 
     const labels = getAllByTestId("dock-launcher-label").map((el) => el.textContent);
-    expect(labels).toEqual(["Pinned", "Other", "Launch panel", "Launch recipe"]);
+    expect(labels.slice(0, 2)).toEqual(["Pinned", "Other"]);
 
     // Assert document order so a regression that puts both agents under one
     // group (or swaps them) is caught: Pinned → Claude → Other → Gemini.
@@ -189,32 +237,14 @@ describe("DockLaunchButton", () => {
   });
 
   it("keeps a flat Launch agent group when all agents are pinned", () => {
-    const { getAllByTestId } = render(
-      <DockLaunchButton
-        agents={AGENTS}
-        pinnedCount={AGENTS.length}
-        hasDevPreview={false}
-        onLaunchAgent={vi.fn()}
-        activeWorktreeId={null}
-        cwd="/tmp"
-      />
-    );
-
+    const { getAllByTestId } = renderButton({ pinnedCount: AGENTS.length });
     const labels = getAllByTestId("dock-launcher-label").map((el) => el.textContent);
-    expect(labels).toEqual(["Launch agent", "Launch panel", "Launch recipe"]);
+    expect(labels[0]).toBe("Launch agent");
   });
 
   it("invokes onLaunchAgent for a launchable agent", () => {
     const onLaunchAgent = vi.fn();
-    const { getByText } = render(
-      <DockLaunchButton
-        agents={AGENTS}
-        hasDevPreview={false}
-        onLaunchAgent={onLaunchAgent}
-        activeWorktreeId={null}
-        cwd="/tmp"
-      />
-    );
+    const { getByText } = renderButton({ onLaunchAgent });
 
     fireEvent.click(getByText("Claude"));
     expect(onLaunchAgent).toHaveBeenCalledWith("claude");
@@ -226,15 +256,7 @@ describe("DockLaunchButton", () => {
 
   it("routes non-launchable agent clicks to the agent settings subtab", () => {
     const onLaunchAgent = vi.fn();
-    const { getByText } = render(
-      <DockLaunchButton
-        agents={AGENTS}
-        hasDevPreview={false}
-        onLaunchAgent={onLaunchAgent}
-        activeWorktreeId={null}
-        cwd="/tmp"
-      />
-    );
+    const { getByText } = renderButton({ onLaunchAgent });
 
     fireEvent.click(getByText("Gemini"));
     expect(onLaunchAgent).not.toHaveBeenCalled();
@@ -248,135 +270,272 @@ describe("DockLaunchButton", () => {
   });
 
   it("discriminates tooltip copy between blocked and installed-only agents", () => {
-    const { getByText } = render(
-      <DockLaunchButton
-        agents={[
-          { id: "claude", name: "Claude", availability: "ready" },
-          { id: "gemini", name: "Gemini", availability: "blocked" },
-          { id: "codex", name: "Codex", availability: "installed" },
-        ]}
-        hasDevPreview={false}
-        onLaunchAgent={vi.fn()}
-        activeWorktreeId={null}
-        cwd="/tmp"
-      />
-    );
+    const { getByText } = renderButton({
+      agents: [
+        { id: "claude", name: "Claude", availability: "ready" },
+        { id: "gemini", name: "Gemini", availability: "blocked" },
+        { id: "codex", name: "Codex", availability: "installed" },
+      ],
+    });
 
-    // Launchable: no tooltip override on the row itself.
     expect(getByText("Claude").getAttribute("title")).toBeNull();
-    // Blocked: endpoint-security copy.
     expect(getByText("Gemini").getAttribute("title")).toBe(
       "Gemini is blocked by endpoint security. Click to configure."
     );
-    // Installed but not launchable (e.g. WSL): generic setup copy.
     expect(getByText("Codex").getAttribute("title")).toBe("Codex needs setup. Click to configure.");
   });
 
   it("dims non-launchable agent rows with opacity-70", () => {
-    const { getByText } = render(
-      <DockLaunchButton
-        agents={AGENTS}
-        hasDevPreview={false}
-        onLaunchAgent={vi.fn()}
-        activeWorktreeId={null}
-        cwd="/tmp"
-      />
-    );
-
+    const { getByText } = renderButton();
     expect(getByText("Claude").className).not.toContain("opacity-70");
     expect(getByText("Gemini").className).toContain("opacity-70");
   });
 
   it("treats unauthenticated agents as launchable (CLI handles auth at runtime)", () => {
     const onLaunchAgent = vi.fn();
-    const { getByText } = render(
-      <DockLaunchButton
-        agents={[{ id: "codex", name: "Codex", availability: "unauthenticated" }]}
-        hasDevPreview={false}
-        onLaunchAgent={onLaunchAgent}
-        activeWorktreeId={null}
-        cwd="/tmp"
-      />
-    );
+    const { getByText } = renderButton({
+      agents: [{ id: "codex", name: "Codex", availability: "unauthenticated" }],
+      onLaunchAgent,
+    });
 
     fireEvent.click(getByText("Codex"));
     expect(onLaunchAgent).toHaveBeenCalledWith("codex");
-    expect(actionDispatchMock).not.toHaveBeenCalled();
-    // Soft dim and settings tooltip must not leak onto a launchable row.
     expect(getByText("Codex").className).not.toContain("opacity-70");
-    expect(getByText("Codex").getAttribute("title")).toBeNull();
   });
 
   it("keeps non-launchable rows selectable (no disabled attribute)", () => {
-    const { getByText } = render(
-      <DockLaunchButton
-        agents={AGENTS}
-        hasDevPreview={false}
-        onLaunchAgent={vi.fn()}
-        activeWorktreeId={null}
-        cwd="/tmp"
-      />
-    );
-
+    const { getByText } = renderButton();
     // Regression guard: the pre-fix behavior was a disabled, dead-end row.
     expect(getByText("Gemini").hasAttribute("disabled")).toBe(false);
   });
 
-  it("offers Terminal and browser but gates non-dockable kinds (dev preview) out of the dock launcher (#11054)", () => {
-    // The dock launcher creates panels directly in the dock, so it must only
-    // offer kinds the dock can render, gating on the shared `panelKindIsDockable`
-    // predicate. Terminal is a PTY kind — always dockable, always offered. Browser
-    // is dockable since #11058, so it appears here. Dev preview can't render in the
-    // dock, so — even with hasDevPreview — it stays hidden, matching the `addPanel`
-    // redirect.
-    const onLaunchAgent = vi.fn();
-    const { getByText, queryByText } = render(
-      <DockLaunchButton
-        agents={[]}
-        hasDevPreview
-        onLaunchAgent={onLaunchAgent}
-        activeWorktreeId={null}
-        cwd="/tmp"
-      />
-    );
+  describe("complete panel offering (#11521)", () => {
+    it("offers non-dockable kinds under the grid heading instead of hiding them", () => {
+      // #11054 hid these because a dock-labelled item would be redirected to
+      // the grid. The heading now states the destination, so they can appear.
+      const { getByText, container } = renderButton();
 
-    expect(getByText("Terminal")).toBeTruthy();
-    fireEvent.click(getByText("Terminal"));
-    expect(onLaunchAgent).toHaveBeenLastCalledWith("terminal");
+      for (const name of ["Review", "File Browser", "Dev Preview"]) {
+        expect(getByText(name)).toBeTruthy();
+      }
+      const text = container.textContent ?? "";
+      expect(text.indexOf("Open in grid")).toBeLessThan(text.indexOf("Review"));
+    });
 
-    expect(getByText("Browser")).toBeTruthy();
-    expect(queryByText("Dev preview")).toBeNull();
+    it("lists Terminal, Browser and File Viewer under the dock heading", () => {
+      const { container } = renderButton();
+      const text = container.textContent ?? "";
+      const dockAt = text.indexOf("Open in dock");
+      const gridAt = text.indexOf("Open in grid");
+
+      for (const name of ["Terminal", "Browser", "File Viewer"]) {
+        const at = text.indexOf(name);
+        expect(at).toBeGreaterThan(dockAt);
+        expect(at).toBeLessThan(gridAt);
+      }
+    });
+
+    it("creates a grid-only kind through addPanel, not the agent launch path", () => {
+      const onLaunchAgent = vi.fn();
+      const { getByText } = renderButton({ onLaunchAgent, activeWorktreeId: "wt-1" });
+
+      fireEvent.click(getByText("Review"));
+
+      expect(onLaunchAgent).not.toHaveBeenCalled();
+      expect(addPanelMock).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: "review", location: "grid", worktreeId: "wt-1" })
+      );
+    });
+
+    it("keeps Terminal on the agent launch path", () => {
+      const onLaunchAgent = vi.fn();
+      const { getByText } = renderButton({ onLaunchAgent });
+
+      fireEvent.click(getByText("Terminal"));
+      expect(onLaunchAgent).toHaveBeenLastCalledWith("terminal");
+      expect(addPanelMock).not.toHaveBeenCalled();
+    });
   });
 
-  it("shows a No recipes yet discovery cue when no recipes match the active worktree", () => {
+  describe("search", () => {
+    it("narrows the list to matches and drops the unfiltered band headings", () => {
+      const { container, getAllByTestId, queryByText } = renderButton();
+
+      fireEvent.change(searchInput(container), { target: { value: "review" } });
+
+      const labels = getAllByTestId("dock-launcher-label").map((el) => el.textContent);
+      expect(labels).toEqual(["Search results"]);
+      expect(queryByText("Open in dock")).toBeNull();
+      expect(queryByText("Claude")).toBeNull();
+    });
+
+    it("filters across agents, panels and recipes in one list", () => {
+      mockRecipes = [{ id: "r-1", name: "Deploy site", worktreeId: undefined }];
+      const { container, getByText } = renderButton();
+      const input = searchInput(container);
+
+      fireEvent.change(input, { target: { value: "claude" } });
+      expect(getByText("Claude")).toBeTruthy();
+
+      fireEvent.change(input, { target: { value: "deploy" } });
+      expect(getByText("Deploy site")).toBeTruthy();
+
+      fireEvent.change(input, { target: { value: "browser" } });
+      expect(getByText("Browser")).toBeTruthy();
+    });
+
+    it("finds a panel by a registry search alias", () => {
+      // "explorer" is a file-browser alias, not part of its display name.
+      const { container, getByText } = renderButton();
+      fireEvent.change(searchInput(container), { target: { value: "explorer" } });
+      expect(getByText("File Browser")).toBeTruthy();
+    });
+
+    it("marks exactly one result row as selected", () => {
+      const { container } = renderButton();
+      fireEvent.change(searchInput(container), { target: { value: "e" } });
+
+      const selected = container.querySelectorAll("[data-selected-row='true']");
+      expect(selected).toHaveLength(1);
+    });
+
+    it("Enter launches the top result", () => {
+      const onLaunchAgent = vi.fn();
+      const { container } = renderButton({ onLaunchAgent });
+      const input = searchInput(container);
+
+      fireEvent.change(input, { target: { value: "claude" } });
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(onLaunchAgent).toHaveBeenCalledWith("claude");
+    });
+
+    it("Enter launches the row moved to by ArrowDown, not the first one", () => {
+      const onLaunchAgent = vi.fn();
+      const { container } = renderButton({ onLaunchAgent });
+      const input = searchInput(container);
+
+      fireEvent.change(input, { target: { value: "e" } });
+      const rows = Array.from(
+        container.querySelectorAll<HTMLButtonElement>("button[data-selected-row]")
+      );
+      const firstName = rows[0]?.textContent;
+
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+      const selectedAfter = container.querySelector("[data-selected-row='true']");
+      expect(selectedAfter?.textContent).not.toBe(firstName);
+    });
+
+    it("ArrowDown does not reach the menu, so Radix cannot move focus off the input", () => {
+      const { container } = renderButton();
+      const input = searchInput(container);
+      fireEvent.change(input, { target: { value: "e" } });
+
+      const event = new KeyboardEvent("keydown", {
+        key: "ArrowDown",
+        bubbles: true,
+        cancelable: true,
+      });
+      const menuSaw = vi.fn();
+      container.addEventListener("keydown", menuSaw);
+      input.dispatchEvent(event);
+      container.removeEventListener("keydown", menuSaw);
+
+      expect(menuSaw).not.toHaveBeenCalled();
+    });
+
+    it("stops printable keys reaching Radix's typeahead", () => {
+      const { container } = renderButton();
+      const input = searchInput(container);
+
+      const menuSaw = vi.fn();
+      container.addEventListener("keydown", menuSaw);
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "r", bubbles: true }));
+      container.removeEventListener("keydown", menuSaw);
+
+      expect(menuSaw).not.toHaveBeenCalled();
+    });
+
+    it("shows a recovery cue when nothing matches", () => {
+      const { container, getByText } = renderButton();
+      fireEvent.change(searchInput(container), { target: { value: "zzzzqqqq" } });
+      expect(getByText("Try a different search")).toBeTruthy();
+    });
+
+    it("first Escape clears the query and blocks the menu close; second closes", () => {
+      const { container } = renderButton();
+      const input = searchInput(container);
+      fireEvent.change(input, { target: { value: "review" } });
+
+      // With a query present the content handler vetoes dismissal...
+      const withQuery = { preventDefault: vi.fn() };
+      dropdownEscapeKeyDownSpy!(withQuery);
+      expect(withQuery.preventDefault).toHaveBeenCalledTimes(1);
+
+      // ...and the input clears it.
+      fireEvent.keyDown(input, { key: "Escape" });
+      expect(input.value).toBe("");
+
+      // Now empty, Escape is left alone so the menu actually closes.
+      const whenEmpty = { preventDefault: vi.fn() };
+      dropdownEscapeKeyDownSpy!(whenEmpty);
+      expect(whenEmpty.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("moves focus to the input once the menu is open", async () => {
+      // Radix's mount autofocus lands on the first item synchronously, so the
+      // launcher re-focuses on the next frame. e2e covers the real race; here we
+      // only pin that opening drives focus to the search box at all.
+      const { container } = renderButton();
+      expect(document.activeElement).not.toBe(searchInput(container));
+
+      act(() => dropdownOpenChangeSpy!(true));
+
+      // The focus is deferred a frame, so poll rather than racing it — a frame
+      // awaited here would be scheduled before the effect's own.
+      await waitFor(() => expect(document.activeElement).toBe(searchInput(container)));
+    });
+
+    it("clears the query when the menu closes so the next open starts unfiltered", () => {
+      const { container } = renderButton();
+      const input = searchInput(container);
+      fireEvent.change(input, { target: { value: "review" } });
+      expect(input.value).toBe("review");
+
+      act(() => dropdownOpenChangeSpy!(false));
+      expect(input.value).toBe("");
+    });
+
+    it("mirrors pointer hover into selection without letting Radix steal focus", () => {
+      const { container } = renderButton();
+      const input = searchInput(container);
+      fireEvent.change(input, { target: { value: "e" } });
+
+      const rows = Array.from(
+        container.querySelectorAll<HTMLButtonElement>("button[data-selected-row]")
+      );
+      expect(rows.length).toBeGreaterThan(1);
+
+      const second = rows[1]!;
+      const moved = fireEvent.pointerMove(second);
+      // preventDefault is what stops Radix's item-focus handler from running.
+      expect(moved).toBe(false);
+      expect(second.getAttribute("data-selected-row")).toBe("true");
+    });
+  });
+
+  it("shows a Create a recipe cue when no recipes match the active worktree", () => {
     mockRecipes = [];
-    const { getByText } = render(
-      <DockLaunchButton
-        agents={AGENTS}
-        hasDevPreview={false}
-        onLaunchAgent={vi.fn()}
-        activeWorktreeId="wt-1"
-        cwd="/tmp"
-      />
-    );
-    // The recipe section now always renders so first-run users can discover it.
+    const { getByText } = renderButton({ activeWorktreeId: "wt-1" });
     expect(getByText("Launch recipe")).toBeTruthy();
-    expect(getByText("No recipes yet")).toBeTruthy();
+    expect(getByText("Create a recipe")).toBeTruthy();
   });
 
-  it("dispatches recipe.editor.open from the No recipes yet cue", () => {
+  it("dispatches recipe.editor.open from the Create a recipe cue", () => {
     mockRecipes = [];
-    const { getByText } = render(
-      <DockLaunchButton
-        agents={AGENTS}
-        hasDevPreview={false}
-        onLaunchAgent={vi.fn()}
-        activeWorktreeId="wt-1"
-        cwd="/tmp"
-      />
-    );
+    const { getByText } = renderButton({ activeWorktreeId: "wt-1" });
 
-    fireEvent.click(getByText("No recipes yet"));
+    fireEvent.click(getByText("Create a recipe"));
     expect(actionDispatchMock).toHaveBeenCalledWith(
       "recipe.editor.open",
       { worktreeId: "wt-1" },
@@ -389,17 +548,9 @@ describe("DockLaunchButton", () => {
     // silently no-ops on undefined — the common first-run case has no active
     // worktree, so the cue must route to the manager instead of dead-ending.
     mockRecipes = [];
-    const { getByText } = render(
-      <DockLaunchButton
-        agents={AGENTS}
-        hasDevPreview={false}
-        onLaunchAgent={vi.fn()}
-        activeWorktreeId={null}
-        cwd="/tmp"
-      />
-    );
+    const { getByText } = renderButton();
 
-    fireEvent.click(getByText("No recipes yet"));
+    fireEvent.click(getByText("Create a recipe"));
     expect(actionDispatchMock).toHaveBeenCalledWith("recipe.manager.open", {}, { source: "menu" });
     expect(actionDispatchMock).not.toHaveBeenCalledWith(
       "recipe.editor.open",
@@ -408,19 +559,11 @@ describe("DockLaunchButton", () => {
     );
   });
 
-  it("does not render the No recipes yet cue when recipes exist", () => {
+  it("does not render the Create a recipe cue when recipes exist", () => {
     mockRecipes = [{ id: "r-1", name: "My recipe", worktreeId: undefined }];
-    const { queryByText, getByText } = render(
-      <DockLaunchButton
-        agents={AGENTS}
-        hasDevPreview={false}
-        onLaunchAgent={vi.fn()}
-        activeWorktreeId="wt-1"
-        cwd="/tmp"
-      />
-    );
+    const { queryByText, getByText } = renderButton({ activeWorktreeId: "wt-1" });
     expect(getByText("My recipe")).toBeTruthy();
-    expect(queryByText("No recipes yet")).toBeNull();
+    expect(queryByText("Create a recipe")).toBeNull();
   });
 
   it("lists project-wide recipes and recipes scoped to the active worktree", () => {
@@ -430,15 +573,7 @@ describe("DockLaunchButton", () => {
       { id: "r-other", name: "Other worktree recipe", worktreeId: "wt-2" },
     ];
 
-    const { getByText, queryByText } = render(
-      <DockLaunchButton
-        agents={AGENTS}
-        hasDevPreview={false}
-        onLaunchAgent={vi.fn()}
-        activeWorktreeId="wt-1"
-        cwd="/tmp"
-      />
-    );
+    const { getByText, queryByText } = renderButton({ activeWorktreeId: "wt-1" });
 
     expect(getByText("Project recipe")).toBeTruthy();
     expect(getByText("Worktree recipe")).toBeTruthy();
@@ -451,15 +586,7 @@ describe("DockLaunchButton", () => {
       { id: "r-local", name: "Work", worktreeId: undefined, projectId: "proj-1" },
     ];
 
-    const { getByText } = render(
-      <DockLaunchButton
-        agents={AGENTS}
-        hasDevPreview={false}
-        onLaunchAgent={vi.fn()}
-        activeWorktreeId="wt-1"
-        cwd="/tmp"
-      />
-    );
+    const { getByText } = renderButton({ activeWorktreeId: "wt-1" });
 
     expect(getByText("Global")).toBeTruthy();
     expect(getByText("Project-wide")).toBeTruthy();
@@ -477,15 +604,7 @@ describe("DockLaunchButton", () => {
     ];
     runRecipeWithResultsMock.mockResolvedValue({});
 
-    const { getByText } = render(
-      <DockLaunchButton
-        agents={AGENTS}
-        hasDevPreview={false}
-        onLaunchAgent={vi.fn()}
-        activeWorktreeId="wt-1"
-        cwd="/tmp"
-      />
-    );
+    const { getByText } = renderButton({ activeWorktreeId: "wt-1" });
 
     expect(getByText(/Overridden by Team/)).toBeTruthy();
 
@@ -503,15 +622,7 @@ describe("DockLaunchButton", () => {
   });
 
   it("calls preventDefault on pointer close so the trigger does not keep its focus ring (issue #6119)", () => {
-    render(
-      <DockLaunchButton
-        agents={AGENTS}
-        hasDevPreview={false}
-        onLaunchAgent={vi.fn()}
-        activeWorktreeId={null}
-        cwd="/tmp"
-      />
-    );
+    renderButton();
     expect(dropdownCloseAutoFocusSpy).toBeTruthy();
     expect(dropdownPointerDownOutsideSpy).toBeTruthy();
 
@@ -544,16 +655,11 @@ describe("DockLaunchButton", () => {
       worktreePath: "/path/to/wt",
     };
 
-    const { getByText } = render(
-      <DockLaunchButton
-        agents={AGENTS}
-        hasDevPreview={false}
-        onLaunchAgent={vi.fn()}
-        activeWorktreeId="wt-1"
-        cwd="/path/to/wt"
-        recipeContext={recipeContext}
-      />
-    );
+    const { getByText } = renderButton({
+      activeWorktreeId: "wt-1",
+      cwd: "/path/to/wt",
+      recipeContext,
+    });
 
     fireEvent.click(getByText("My recipe"));
     expect(runRecipeWithResultsMock).toHaveBeenCalledWith(
@@ -579,15 +685,7 @@ describe("DockLaunchButton", () => {
     };
     runRecipeWithResultsMock.mockResolvedValue(results);
 
-    const { getByText } = render(
-      <DockLaunchButton
-        agents={AGENTS}
-        hasDevPreview={false}
-        onLaunchAgent={vi.fn()}
-        activeWorktreeId={null}
-        cwd="/tmp"
-      />
-    );
+    const { getByText } = renderButton();
 
     fireEvent.click(getByText("My recipe"));
     await waitFor(() =>
@@ -599,15 +697,7 @@ describe("DockLaunchButton", () => {
     mockRecipes = [{ id: "r-1", name: "My recipe", worktreeId: undefined }];
     runRecipeWithResultsMock.mockRejectedValue(new Error("recipe gone"));
 
-    const { getByText } = render(
-      <DockLaunchButton
-        agents={AGENTS}
-        hasDevPreview={false}
-        onLaunchAgent={vi.fn()}
-        activeWorktreeId={null}
-        cwd="/tmp"
-      />
-    );
+    const { getByText } = renderButton();
 
     fireEvent.click(getByText("My recipe"));
     await waitFor(() =>
@@ -626,15 +716,7 @@ describe("DockLaunchButton", () => {
 
     it("hides the band when the MRU is empty", () => {
       mockMruEntries = [];
-      const { queryByText } = render(
-        <DockLaunchButton
-          agents={MANY}
-          hasDevPreview={false}
-          onLaunchAgent={vi.fn()}
-          activeWorktreeId={null}
-          cwd="/tmp"
-        />
-      );
+      const { queryByText } = renderButton({ agents: MANY });
       expect(queryByText("Recently launched")).toBeNull();
     });
 
@@ -648,17 +730,10 @@ describe("DockLaunchButton", () => {
         { id: "agent.gemini", score: 1, lastAccessedAt: 1000 },
       ];
 
-      const { getByText, getAllByText, getAllByTestId, container } = render(
-        <DockLaunchButton
-          agents={MANY}
-          hasDevPreview={false}
-          onLaunchAgent={vi.fn()}
-          activeWorktreeId={null}
-          cwd="/tmp"
-        />
-      );
+      const { getByText, getAllByText, getAllByTestId, container } = renderButton({
+        agents: MANY,
+      });
 
-      // Band header leads the menu.
       const labels = getAllByTestId("dock-launcher-label").map((el) => el.textContent);
       expect(labels[0]).toBe("Recently launched");
       expect(getByText("Recently launched")).toBeTruthy();
@@ -671,8 +746,6 @@ describe("DockLaunchButton", () => {
       expect(getAllByText("Cursor").length).toBe(2);
       expect(getAllByText("Gemini").length).toBe(1);
 
-      // First occurrence of each name is its band row (band renders first), so
-      // first-occurrence order reflects the band's frecency order.
       const text = container.textContent ?? "";
       expect(text.indexOf("Claude")).toBeLessThan(text.indexOf("Codex"));
       expect(text.indexOf("Codex")).toBeLessThan(text.indexOf("Cursor"));
@@ -680,58 +753,26 @@ describe("DockLaunchButton", () => {
 
     it("excludes never-launched cold-start entries (lastAccessedAt === 0)", () => {
       mockMruEntries = [{ id: "agent.claude", score: 5, lastAccessedAt: 0 }];
-      const { queryByText } = render(
-        <DockLaunchButton
-          agents={MANY}
-          hasDevPreview={false}
-          onLaunchAgent={vi.fn()}
-          activeWorktreeId={null}
-          cwd="/tmp"
-        />
-      );
+      const { queryByText } = renderButton({ agents: MANY });
       expect(queryByText("Recently launched")).toBeNull();
     });
 
     it("ignores non-agent MRU entries", () => {
       mockMruEntries = [{ id: "recipe.editor.open", score: 5, lastAccessedAt: 5000 }];
-      const { queryByText } = render(
-        <DockLaunchButton
-          agents={MANY}
-          hasDevPreview={false}
-          onLaunchAgent={vi.fn()}
-          activeWorktreeId={null}
-          cwd="/tmp"
-        />
-      );
+      const { queryByText } = renderButton({ agents: MANY });
       expect(queryByText("Recently launched")).toBeNull();
     });
 
     it("drops stale MRU entries for agents no longer present", () => {
       mockMruEntries = [{ id: "agent.ghost", score: 5, lastAccessedAt: 5000 }];
-      const { queryByText } = render(
-        <DockLaunchButton
-          agents={MANY}
-          hasDevPreview={false}
-          onLaunchAgent={vi.fn()}
-          activeWorktreeId={null}
-          cwd="/tmp"
-        />
-      );
+      const { queryByText } = renderButton({ agents: MANY });
       expect(queryByText("Recently launched")).toBeNull();
     });
 
     it("launching a band row records MRU and invokes onLaunchAgent", () => {
       mockMruEntries = [{ id: "agent.codex", score: 3, lastAccessedAt: 3000 }];
       const onLaunchAgent = vi.fn();
-      const { getAllByText } = render(
-        <DockLaunchButton
-          agents={MANY}
-          hasDevPreview={false}
-          onLaunchAgent={onLaunchAgent}
-          activeWorktreeId={null}
-          cwd="/tmp"
-        />
-      );
+      const { getAllByText } = renderButton({ agents: MANY, onLaunchAgent });
 
       // First "Codex" is the band row.
       const codexElement = getAllByText("Codex")[0];
@@ -739,6 +780,18 @@ describe("DockLaunchButton", () => {
       fireEvent.click(codexElement!);
       expect(onLaunchAgent).toHaveBeenCalledWith("codex");
       expect(recordActionMruMock).toHaveBeenCalledWith("agent.codex");
+    });
+
+    it("survives an unfiltered reopen after a search is cleared", () => {
+      mockMruEntries = [{ id: "agent.codex", score: 3, lastAccessedAt: 3000 }];
+      const { container, queryByText, getByText } = renderButton({ agents: MANY });
+      const input = searchInput(container);
+
+      fireEvent.change(input, { target: { value: "codex" } });
+      expect(queryByText("Recently launched")).toBeNull();
+
+      fireEvent.change(input, { target: { value: "" } });
+      expect(getByText("Recently launched")).toBeTruthy();
     });
   });
 });

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -91,7 +91,7 @@ vi.mock("@/services/ActionService", () => ({
 // Mock UI primitives so the test focuses on this component's behavior, not
 // Radix's pointer-event semantics inside jsdom. Mirrors AgentButton.test.tsx.
 // Radix's real focus/dismiss behaviour (pointer-move focus steal, document-level
-// Escape capture) is covered by e2e/full/panels/core-dock-launcher.spec.ts.
+// Escape capture) is covered by e2e/full/panels/core-dock-launcher-search.spec.ts.
 vi.mock("@/components/ui/tooltip", () => ({
   Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
   TooltipContent: ({ children }: { children: ReactNode }) => (
@@ -613,6 +613,25 @@ describe("DockLaunchButton", () => {
       // The focus is deferred a frame, so poll rather than racing it — a frame
       // awaited here would be scheduled before the effect's own.
       await waitFor(() => expect(document.activeElement).toBe(searchInput(container)));
+    });
+
+    it("keeps focus in the input when the search row itself is clicked", () => {
+      // Clicking the magnifier, the gap or the row padding used to park focus on
+      // Radix's tabIndex={-1} content, after which typing hit the typeahead and
+      // Escape became a no-op.
+      const { container } = renderButton();
+      const input = searchInput(container);
+      const row = input.parentElement!;
+
+      expect(fireEvent.mouseDown(row)).toBe(false);
+      expect(document.activeElement).toBe(input);
+    });
+
+    it("leaves the input's own mousedown alone so the caret can be placed", () => {
+      // The row handler sees the input's mousedown on the way up; cancelling it
+      // there would kill caret placement and drag-select inside the field.
+      const { container } = renderButton();
+      expect(fireEvent.mouseDown(searchInput(container))).toBe(true);
     });
 
     it("clears the query when the menu closes so the next open starts unfiltered", () => {

--- a/src/components/Layout/__tests__/dockLaunchItems.test.ts
+++ b/src/components/Layout/__tests__/dockLaunchItems.test.ts
@@ -1,0 +1,381 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  registerPanelKind,
+  unregisterPanelKind,
+  panelKindIsDockable,
+  getPanelKindIds,
+  getPanelKindConfig,
+  type PanelKindConfig,
+} from "@shared/config/panelKindRegistry";
+
+const addPanelMock = vi.fn();
+const runRecipeWithResultsMock = vi.fn();
+const recordActionMruMock = vi.fn();
+const actionDispatchMock = vi.fn();
+const notifySpawnFailuresMock = vi.fn();
+const logErrorMock = vi.fn();
+
+// The real `@/registry` eagerly pulls in TerminalPane and the whole panel
+// component tree. Re-derive the spawnable list straight from the (pure) shared
+// config instead, so the partition assertions below still run against real
+// registry data without that import cost.
+vi.mock("@/registry", () => ({
+  getSpawnablePanelKinds: (): PanelKindConfig[] =>
+    getPanelKindIds()
+      .filter((id) => id !== "agent")
+      .map((id) => getPanelKindConfig(id))
+      .filter((c): c is PanelKindConfig => c !== undefined && c.showInPalette !== false),
+}));
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: { getState: () => ({ addPanel: addPanelMock }) },
+}));
+
+vi.mock("@/store/recipeStore", () => ({
+  useRecipeStore: { getState: () => ({ runRecipeWithResults: runRecipeWithResultsMock }) },
+}));
+
+vi.mock("@/store/actionMruStore", () => ({
+  useActionMruStore: { getState: () => ({ recordActionMru: recordActionMruMock }) },
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: (...args: unknown[]) => actionDispatchMock(...args) },
+}));
+
+vi.mock("@/utils/recipeNotify", () => ({
+  notifyRecipeSpawnFailures: (...args: unknown[]) => notifySpawnFailuresMock(...args),
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logError: (...args: unknown[]) => logErrorMock(...args),
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+}));
+
+import {
+  buildDockLaunchModel,
+  activateDockLaunchItem,
+  type DockLaunchAgent,
+  type DockLaunchItem,
+  type DockLaunchPanelItem,
+} from "../dockLaunchItems";
+import type { TerminalRecipe } from "@shared/types";
+
+const AGENTS: DockLaunchAgent[] = [
+  { id: "claude", name: "Claude", availability: "ready" },
+  { id: "gemini", name: "Gemini", availability: "blocked" },
+];
+
+function recipe(over: Partial<TerminalRecipe> & { id: string; name: string }): TerminalRecipe {
+  return { terminals: [], createdAt: 0, ...over } as TerminalRecipe;
+}
+
+function build(over: Partial<Parameters<typeof buildDockLaunchModel>[0]> = {}) {
+  return buildDockLaunchModel({
+    agents: AGENTS,
+    activeWorktreeId: null,
+    recipes: [],
+    mruEntries: [],
+    ...over,
+  });
+}
+
+const PLUGIN_DOCKABLE = "test-plugin-dockable";
+const PLUGIN_GRID_ONLY = "test-plugin-grid-only";
+const PLUGIN_HIDDEN = "test-plugin-hidden";
+
+beforeEach(() => {
+  addPanelMock.mockReset();
+  runRecipeWithResultsMock.mockReset().mockResolvedValue({ spawned: [], failed: [] });
+  recordActionMruMock.mockReset();
+  actionDispatchMock.mockReset();
+  notifySpawnFailuresMock.mockReset();
+  logErrorMock.mockReset();
+});
+
+afterEach(() => {
+  for (const id of [PLUGIN_DOCKABLE, PLUGIN_GRID_ONLY, PLUGIN_HIDDEN]) {
+    unregisterPanelKind(id);
+  }
+});
+
+function registerPluginKind(id: string, over: Partial<PanelKindConfig> = {}) {
+  registerPanelKind({
+    id,
+    name: id,
+    iconId: "package",
+    color: "#fff",
+    hasPty: false,
+    canRestart: false,
+    canConvert: false,
+    extensionId: "test-plugin",
+    ...over,
+  });
+}
+
+describe("buildDockLaunchModel — panel offering", () => {
+  it("labels every panel with the location addPanel will actually use", () => {
+    // The whole point of the two sections: a heading may never contradict
+    // `normalizeDockLocation`, which redirects a non-dockable kind to the grid.
+    const model = build();
+    for (const item of [...model.dockPanels, ...model.gridPanels]) {
+      expect(item.location).toBe(panelKindIsDockable(item.kindId) ? "dock" : "grid");
+    }
+  });
+
+  it("offers the spawnable set rather than filtering it by dockability", () => {
+    const model = build();
+    const offered = [...model.dockPanels, ...model.gridPanels].map((p) => p.kindId);
+    // Non-dockable kinds are present — previously they were dropped entirely.
+    expect(offered).toEqual(expect.arrayContaining(["review", "file-browser", "dev-preview"]));
+    // ...and each landed in the grid group, not the dock group.
+    const dockIds = model.dockPanels.map((p) => p.kindId);
+    expect(dockIds).not.toEqual(expect.arrayContaining(["review", "file-browser", "dev-preview"]));
+  });
+
+  it("includes File Viewer in the dock group (dockable but previously unlisted)", () => {
+    const model = build();
+    expect(model.dockPanels.map((p) => p.kindId)).toContain("file");
+  });
+
+  it("always offers Terminal even though it opts out of the palette", () => {
+    // `terminal` sets showInPalette:false (it has dedicated spawn actions), so
+    // the spawnable selector excludes it and the launcher adds it back.
+    expect(getPanelKindConfig("terminal")?.showInPalette).toBe(false);
+    expect(build().dockPanels.map((p) => p.kindId)).toContain("terminal");
+  });
+
+  it("excludes kinds that need a target (showInPalette false), e.g. diff", () => {
+    const model = build();
+    const offered = [...model.dockPanels, ...model.gridPanels].map((p) => p.kindId);
+    expect(offered).not.toContain("diff");
+    expect(offered).not.toContain("agent");
+  });
+
+  it("lists a plugin kind in the section matching its own dockability", () => {
+    registerPluginKind(PLUGIN_DOCKABLE);
+    registerPluginKind(PLUGIN_GRID_ONLY, { dockable: false });
+    const model = build();
+
+    expect(model.dockPanels.map((p) => p.kindId)).toContain(PLUGIN_DOCKABLE);
+    expect(model.gridPanels.map((p) => p.kindId)).toContain(PLUGIN_GRID_ONLY);
+  });
+
+  it("honours a plugin kind's showInPalette opt-out", () => {
+    registerPluginKind(PLUGIN_HIDDEN, { showInPalette: false });
+    const model = build();
+    const offered = [...model.dockPanels, ...model.gridPanels].map((p) => p.kindId);
+    expect(offered).not.toContain(PLUGIN_HIDDEN);
+  });
+
+  it("does not duplicate Terminal when the spawnable list also yields it", () => {
+    const model = build();
+    const terminalEntries = [...model.dockPanels, ...model.gridPanels].filter(
+      (p) => p.kindId === "terminal"
+    );
+    expect(terminalEntries).toHaveLength(1);
+  });
+});
+
+describe("buildDockLaunchModel — search set", () => {
+  it("covers all three categories in one list", () => {
+    const model = build({ recipes: [recipe({ id: "r1", name: "Deploy" })] });
+    const categories = new Set(model.searchItems.map((i) => i.category));
+    expect(categories).toEqual(new Set(["agent", "panel", "recipe"]));
+  });
+
+  it("keeps keys unique so an agent and a panel sharing an id cannot collide", () => {
+    registerPluginKind("claude");
+    const model = build();
+    const keys = model.searchItems.map((i) => i.key);
+    expect(new Set(keys).size).toBe(keys.length);
+    unregisterPanelKind("claude");
+  });
+
+  it("does not repeat a recency-band agent in the search set", () => {
+    const model = build({
+      mruEntries: [{ id: "agent.claude", lastAccessedAt: 5000 }],
+    });
+    expect(model.recentAgents.map((a) => a.id)).toEqual(["claude"]);
+    expect(model.searchItems.filter((i) => i.key === "agent:claude")).toHaveLength(1);
+  });
+
+  it("makes a panel findable by its destination", () => {
+    const model = build();
+    const review = model.searchItems.find(
+      (i): i is DockLaunchPanelItem => i.category === "panel" && i.kindId === "review"
+    );
+    expect(review?.searchAliases).toContain("grid");
+  });
+});
+
+describe("buildDockLaunchModel — bands and recipes", () => {
+  it("caps the recency band and drops never-launched and unknown entries", () => {
+    const many: DockLaunchAgent[] = [
+      { id: "a", name: "A" },
+      { id: "b", name: "B" },
+      { id: "c", name: "C" },
+      { id: "d", name: "D" },
+    ];
+    const model = buildDockLaunchModel({
+      agents: many,
+      activeWorktreeId: null,
+      recipes: [],
+      mruEntries: [
+        { id: "agent.a", lastAccessedAt: 5 },
+        { id: "agent.ghost", lastAccessedAt: 5 },
+        { id: "agent.b", lastAccessedAt: 4 },
+        { id: "recipe.thing", lastAccessedAt: 9 },
+        { id: "agent.c", lastAccessedAt: 3 },
+        { id: "agent.d", lastAccessedAt: 2 },
+      ],
+    });
+    expect(model.recentAgents.map((a) => a.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("splits Pinned/Other only for a strict subset", () => {
+    expect(build({ pinnedCount: 1 }).showAgentGroups).toBe(true);
+    expect(build({ pinnedCount: 0 }).showAgentGroups).toBe(false);
+    expect(build({ pinnedCount: AGENTS.length }).showAgentGroups).toBe(false);
+    expect(build().showAgentGroups).toBe(false);
+  });
+
+  it("scopes recipes to the active worktree, keeping unscoped ones", () => {
+    const model = build({
+      activeWorktreeId: "wt-1",
+      recipes: [
+        recipe({ id: "g", name: "Global" }),
+        recipe({ id: "mine", name: "Mine", worktreeId: "wt-1" }),
+        recipe({ id: "theirs", name: "Theirs", worktreeId: "wt-2" }),
+      ],
+    });
+    expect(model.recipes.map((r) => r.name)).toEqual(["Global", "Mine"]);
+  });
+
+  it("keeps a shadowed recipe listed and marked", () => {
+    const model = build({
+      recipes: [recipe({ id: "s", name: "Work", projectId: "p", shadowedBy: "Work" })],
+    });
+    expect(model.recipes[0]?.isShadowed).toBe(true);
+  });
+});
+
+describe("activateDockLaunchItem", () => {
+  const ctx = {
+    cwd: "/repo",
+    activeWorktreeId: "wt-1",
+    recipeContext: undefined,
+    onLaunchAgent: vi.fn(),
+    settingsSource: "menu" as const,
+  };
+
+  beforeEach(() => ctx.onLaunchAgent.mockReset());
+
+  function panelItem(kindId: string): DockLaunchPanelItem {
+    const model = build();
+    const found = [...model.dockPanels, ...model.gridPanels].find((p) => p.kindId === kindId);
+    if (!found) throw new Error(`no panel item for ${kindId}`);
+    return found;
+  }
+
+  it("routes the kinds agent.launch understands through onLaunchAgent", () => {
+    // resolveAgentLaunchKind throws on an id it can't resolve, so only these
+    // three may take that path.
+    for (const kind of ["terminal", "browser", "dev-preview"]) {
+      activateDockLaunchItem(panelItem(kind), ctx);
+    }
+    expect(ctx.onLaunchAgent.mock.calls.map((c) => c[0])).toEqual([
+      "terminal",
+      "browser",
+      "dev-preview",
+    ]);
+    expect(addPanelMock).not.toHaveBeenCalled();
+  });
+
+  it("creates every other kind via addPanel at its advertised location", () => {
+    activateDockLaunchItem(panelItem("review"), ctx);
+    expect(ctx.onLaunchAgent).not.toHaveBeenCalled();
+    expect(addPanelMock).toHaveBeenCalledWith({
+      kind: "review",
+      cwd: "/repo",
+      worktreeId: "wt-1",
+      location: "grid",
+      activateDockOnCreate: false,
+    });
+  });
+
+  it("activates the dock atomically for a dock-landing panel (#6590)", () => {
+    activateDockLaunchItem(panelItem("file"), ctx);
+    expect(addPanelMock).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "file", location: "dock", activateDockOnCreate: true })
+    );
+  });
+
+  it("passes an absent worktree as undefined, not null", () => {
+    activateDockLaunchItem(panelItem("review"), { ...ctx, activeWorktreeId: null });
+    expect(addPanelMock).toHaveBeenCalledWith(expect.objectContaining({ worktreeId: undefined }));
+  });
+
+  it("spawns a plugin kind through addPanel", () => {
+    registerPluginKind(PLUGIN_GRID_ONLY, { dockable: false });
+    activateDockLaunchItem(panelItem(PLUGIN_GRID_ONLY), ctx);
+    expect(addPanelMock).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: PLUGIN_GRID_ONLY, location: "grid" })
+    );
+  });
+
+  it("records MRU and launches a launchable agent", () => {
+    const item: DockLaunchItem = {
+      category: "agent",
+      key: "agent:claude",
+      name: "Claude",
+      agent: AGENTS[0]!,
+    };
+    activateDockLaunchItem(item, ctx);
+    expect(recordActionMruMock).toHaveBeenCalledWith("agent.claude");
+    expect(ctx.onLaunchAgent).toHaveBeenCalledWith("claude");
+  });
+
+  it("routes a non-launchable agent to settings without recording MRU", () => {
+    const item: DockLaunchItem = {
+      category: "agent",
+      key: "agent:gemini",
+      name: "Gemini",
+      agent: AGENTS[1]!,
+    };
+    activateDockLaunchItem(item, ctx);
+    expect(ctx.onLaunchAgent).not.toHaveBeenCalled();
+    expect(recordActionMruMock).not.toHaveBeenCalled();
+    expect(actionDispatchMock).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "agents", subtab: "gemini" },
+      { source: "menu" }
+    );
+  });
+
+  it("runs a recipe and surfaces spawn failures", async () => {
+    const results = { spawned: [], failed: [{ index: 0, error: "Panel limit reached" }] };
+    runRecipeWithResultsMock.mockResolvedValue(results);
+    const model = build({ recipes: [recipe({ id: "r1", name: "Deploy" })] });
+
+    activateDockLaunchItem(model.recipes[0]!, ctx);
+
+    expect(runRecipeWithResultsMock).toHaveBeenCalledWith("r1", "/repo", "wt-1", undefined);
+    await vi.waitFor(() =>
+      expect(notifySpawnFailuresMock).toHaveBeenCalledWith(results, { recipeName: "Deploy" })
+    );
+  });
+
+  it("logs a rejected recipe launch without notifying", async () => {
+    runRecipeWithResultsMock.mockRejectedValue(new Error("recipe gone"));
+    const model = build({ recipes: [recipe({ id: "r1", name: "Deploy" })] });
+
+    activateDockLaunchItem(model.recipes[0]!, ctx);
+
+    await vi.waitFor(() =>
+      expect(logErrorMock).toHaveBeenCalledWith("Recipe launch from dock failed", expect.any(Error))
+    );
+    expect(notifySpawnFailuresMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Layout/__tests__/dockLaunchItems.test.ts
+++ b/src/components/Layout/__tests__/dockLaunchItems.test.ts
@@ -20,11 +20,20 @@ const logErrorMock = vi.fn();
 // config instead, so the partition assertions below still run against real
 // registry data without that import cost.
 vi.mock("@/registry", () => ({
+  // Terminal is deliberately included even though the real selector filters it
+  // out (showInPalette:false), so the dedup below is actually exercised — with
+  // the real predicate the model could never see a second Terminal and the
+  // dedup assertion would pass even if the production guard were deleted.
   getSpawnablePanelKinds: (): PanelKindConfig[] =>
     getPanelKindIds()
       .filter((id) => id !== "agent")
       .map((id) => getPanelKindConfig(id))
-      .filter((c): c is PanelKindConfig => c !== undefined && c.showInPalette !== false),
+      .filter(
+        (c): c is PanelKindConfig =>
+          c !== undefined && (c.id === "terminal" || c.showInPalette !== false)
+      ),
+  subscribeToPanelKindDefinitions: () => () => {},
+  getPanelKindDefinitionsSnapshot: () => 0,
 }));
 
 vi.mock("@/store/panelStore", () => ({
@@ -56,6 +65,7 @@ vi.mock("@/utils/logger", () => ({
 import {
   buildDockLaunchModel,
   activateDockLaunchItem,
+  RECENCY_BAND_CAP,
   type DockLaunchAgent,
   type DockLaunchItem,
   type DockLaunchPanelItem,
@@ -77,6 +87,7 @@ function build(over: Partial<Parameters<typeof buildDockLaunchModel>[0]> = {}) {
     activeWorktreeId: null,
     recipes: [],
     mruEntries: [],
+    surface: "dock",
     ...over,
   });
 }
@@ -176,6 +187,29 @@ describe("buildDockLaunchModel — panel offering", () => {
     );
     expect(terminalEntries).toHaveLength(1);
   });
+
+  it("claims no dock destination on a grid surface, even for dockable kinds", () => {
+    // The grid context menu's launch callback dispatches location:"grid" for
+    // every kind, so offering Terminal/Browser under a dock heading there would
+    // misstate the destination exactly the way #11054 did.
+    const model = build({ surface: "grid" });
+
+    expect(model.dockPanels).toHaveLength(0);
+    const offered = model.gridPanels.map((p) => p.kindId);
+    expect(offered).toEqual(expect.arrayContaining(["terminal", "browser", "file"]));
+    for (const item of model.gridPanels) {
+      expect(item.location).toBe("grid");
+    }
+  });
+
+  it("keeps the dock destination for dockable kinds on a dock surface", () => {
+    const dock = build({ surface: "dock" });
+    // Same kinds, opposite surface — proves the split is surface-driven and not
+    // an artifact of the registry alone.
+    expect(dock.dockPanels.map((p) => p.kindId)).toEqual(
+      expect.arrayContaining(["terminal", "browser", "file"])
+    );
+  });
 });
 
 describe("buildDockLaunchModel — search set", () => {
@@ -212,26 +246,28 @@ describe("buildDockLaunchModel — search set", () => {
 
 describe("buildDockLaunchModel — bands and recipes", () => {
   it("caps the recency band and drops never-launched and unknown entries", () => {
-    const many: DockLaunchAgent[] = [
-      { id: "a", name: "A" },
-      { id: "b", name: "B" },
-      { id: "c", name: "C" },
-      { id: "d", name: "D" },
-    ];
-    const model = buildDockLaunchModel({
+    // Sized from the exported cap so raising it doesn't need the same edit here.
+    const overCap = RECENCY_BAND_CAP + 1;
+    const many: DockLaunchAgent[] = Array.from({ length: overCap }, (_, i) => ({
+      id: `a${i}`,
+      name: `Agent ${i}`,
+    }));
+    const model = build({
       agents: many,
-      activeWorktreeId: null,
-      recipes: [],
       mruEntries: [
-        { id: "agent.a", lastAccessedAt: 5 },
+        // Interleaved noise that must all be dropped: an unknown agent, a
+        // non-agent key, and a never-launched cold-start seed.
         { id: "agent.ghost", lastAccessedAt: 5 },
-        { id: "agent.b", lastAccessedAt: 4 },
         { id: "recipe.thing", lastAccessedAt: 9 },
-        { id: "agent.c", lastAccessedAt: 3 },
-        { id: "agent.d", lastAccessedAt: 2 },
+        { id: "agent.a0", lastAccessedAt: 0 },
+        ...many.map((a, i) => ({ id: `agent.${a.id}`, lastAccessedAt: overCap - i })),
       ],
     });
-    expect(model.recentAgents.map((a) => a.id)).toEqual(["a", "b", "c"]);
+
+    expect(model.recentAgents).toHaveLength(RECENCY_BAND_CAP);
+    expect(model.recentAgents.map((a) => a.id)).toEqual(
+      many.slice(0, RECENCY_BAND_CAP).map((a) => a.id)
+    );
   });
 
   it("splits Pinned/Other only for a strict subset", () => {

--- a/src/components/Layout/dockLaunchItems.ts
+++ b/src/components/Layout/dockLaunchItems.ts
@@ -1,7 +1,15 @@
-import { useMemo } from "react";
-import { getSpawnablePanelKinds } from "@/registry";
-import { panelKindIsDockable } from "@shared/config/panelKindRegistry";
-import { getPanelKindConfig } from "@shared/config/panelKindRegistry";
+import { useMemo, useSyncExternalStore } from "react";
+import {
+  getSpawnablePanelKinds,
+  subscribeToPanelKindDefinitions,
+  getPanelKindDefinitionsSnapshot,
+} from "@/registry";
+import {
+  panelKindIsDockable,
+  getPanelKindConfig,
+  subscribeToPanelKindRegistry,
+  getPanelKindRegistrySnapshot,
+} from "@shared/config/panelKindRegistry";
 import { usePanelStore } from "@/store/panelStore";
 import { useRecipeStore } from "@/store/recipeStore";
 import { useActionMruStore } from "@/store/actionMruStore";
@@ -91,22 +99,36 @@ export interface DockLaunchModel {
   searchItems: DockLaunchItem[];
 }
 
+/**
+ * Where a launcher surface creates panels by default. The dock `+` button and
+ * the dock's right-click menu create in the dock; the grid's right-click menu
+ * creates in the grid, so nothing rendered there may claim a dock landing.
+ */
+export type DockLaunchSurface = "dock" | "grid";
+
 export interface BuildDockLaunchModelOptions {
   agents: ReadonlyArray<DockLaunchAgent>;
   pinnedCount?: number;
   activeWorktreeId: string | null;
   recipes: ReadonlyArray<TerminalRecipe>;
   mruEntries: ReadonlyArray<{ id: string; lastAccessedAt: number }>;
+  surface: DockLaunchSurface;
 }
 
-function toPanelItem(config: {
-  id: string;
-  name: string;
-  iconId: string;
-  color: string;
-  searchAliases?: string[];
-}): DockLaunchPanelItem {
-  const location = panelKindIsDockable(config.id) ? "dock" : "grid";
+function toPanelItem(
+  config: {
+    id: string;
+    name: string;
+    iconId: string;
+    color: string;
+    searchAliases?: string[];
+  },
+  surface: DockLaunchSurface
+): DockLaunchPanelItem {
+  // A grid surface lands everything in the grid regardless of dockability — its
+  // launch callback dispatches `location: "grid"`, so claiming "dock" there
+  // would misstate the destination just as badly as the redirect this replaced.
+  const location = surface === "dock" && panelKindIsDockable(config.id) ? "dock" : "grid";
   return {
     category: "panel",
     key: `panel:${config.id}`,
@@ -122,12 +144,28 @@ function toPanelItem(config: {
 }
 
 /**
- * Derive every launchable entry for the dock launcher — the same set for the
- * `+` dropdown and the dock's right-click menu. Panels come from the shared
- * spawnable-kind selector (so the launcher can't drift from ⌘⇧P) plus Terminal,
- * partitioned by real dockability rather than filtered by it: a non-dockable
- * kind is offered under a heading that says it opens in the grid, instead of
- * being hidden (#11054's fix was to stop lying, not to stop offering).
+ * Capped frecency band, newest-first as the MRU store already sorted it. Drops
+ * cold-start seeds (never launched), non-agent keys, and entries whose agent is
+ * no longer registered.
+ */
+export function selectRecentAgents(
+  agents: ReadonlyArray<DockLaunchAgent>,
+  mruEntries: ReadonlyArray<{ id: string; lastAccessedAt: number }>
+): DockLaunchAgent[] {
+  return mruEntries
+    .filter((entry) => entry.lastAccessedAt > 0 && entry.id.startsWith(AGENT_MRU_PREFIX))
+    .map((entry) => agents.find((a) => a.id === entry.id.slice(AGENT_MRU_PREFIX.length)))
+    .filter((agent): agent is DockLaunchAgent => agent !== undefined)
+    .slice(0, RECENCY_BAND_CAP);
+}
+
+/**
+ * Derive every launchable entry for a launcher surface. Panels come from the
+ * shared spawnable-kind selector (so the launcher can't drift from ⌘⇧P) plus
+ * Terminal, partitioned by where they will actually land rather than filtered
+ * by dockability: a non-dockable kind is offered under a heading that says it
+ * opens in the grid, instead of being hidden (#11054's fix was to stop lying,
+ * not to stop offering).
  */
 export function buildDockLaunchModel({
   agents,
@@ -135,24 +173,21 @@ export function buildDockLaunchModel({
   activeWorktreeId,
   recipes,
   mruEntries,
+  surface,
 }: BuildDockLaunchModelOptions): DockLaunchModel {
-  const recentAgents = mruEntries
-    .filter((entry) => entry.lastAccessedAt > 0 && entry.id.startsWith(AGENT_MRU_PREFIX))
-    .map((entry) => agents.find((a) => a.id === entry.id.slice(AGENT_MRU_PREFIX.length)))
-    .filter((agent): agent is DockLaunchAgent => agent !== undefined)
-    .slice(0, RECENCY_BAND_CAP);
+  const recentAgents = selectRecentAgents(agents, mruEntries);
 
   const panelItems: DockLaunchPanelItem[] = [];
   const seenKinds = new Set<string>();
   const terminalConfig = getPanelKindConfig(TERMINAL_KIND_ID);
   if (terminalConfig) {
-    panelItems.push(toPanelItem(terminalConfig));
+    panelItems.push(toPanelItem(terminalConfig, surface));
     seenKinds.add(TERMINAL_KIND_ID);
   }
   for (const config of getSpawnablePanelKinds()) {
     if (seenKinds.has(config.id)) continue;
     seenKinds.add(config.id);
-    panelItems.push(toPanelItem(config));
+    panelItems.push(toPanelItem(config, surface));
   }
 
   const dockPanels = panelItems.filter((item) => item.location === "dock");
@@ -200,16 +235,37 @@ export function buildDockLaunchModel({
  * is re-read per open and picks up plugin kinds registered mid-session without a
  * registry subscription.
  *
- * The MRU list is read inside the memo rather than tracked as a dependency: it
- * changes on launch, which also closes the menu, so re-reading it per keystroke
- * would only risk the recency band reshuffling under the user mid-search.
+ * The panel/recipe/search derivation is memoized because `searchItems` keys the
+ * consumer's Fuse index — rebuilding it on every keystroke would be wasteful.
+ * The recency band deliberately sits OUTSIDE that memo: `getSortedActionMruList`
+ * is a stable function reference that reads store state at call time, so
+ * subscribing to it never re-renders and a memo keyed on it would never observe
+ * a launch recorded between two opens — the band would show pre-launch order
+ * forever. Reading it per render is safe: the MRU only changes on launch, which
+ * closes the menu, so it cannot reshuffle under the user mid-search.
  */
 export function useDockLaunchModel(options: {
   agents: ReadonlyArray<DockLaunchAgent>;
   pinnedCount?: number;
   activeWorktreeId: string | null;
+  surface: DockLaunchSurface;
 }): DockLaunchModel {
-  const { agents, pinnedCount, activeWorktreeId } = options;
+  const { agents, pinnedCount, activeWorktreeId, surface } = options;
+  // Both registries, because a plugin's metadata lands before its renderer
+  // definition and `getSpawnablePanelKinds` requires both. Without these the
+  // long-lived `+` button would keep a model memoized from before the plugin
+  // pull resolved — and it passes that model down, so the freshly-mounted
+  // menu's own derivation can't rescue it.
+  const kindRegistry = useSyncExternalStore(
+    subscribeToPanelKindRegistry,
+    getPanelKindRegistrySnapshot,
+    getPanelKindRegistrySnapshot
+  );
+  const definitionRegistry = useSyncExternalStore(
+    subscribeToPanelKindDefinitions,
+    getPanelKindDefinitionsSnapshot,
+    getPanelKindDefinitionsSnapshot
+  );
   // Subscribe inside the menu so the listener only runs while open.
   const recipes = useRecipeStore((s) => s.recipes);
   // Subscribe to the stable getter (not its result) so the selector returns a
@@ -218,17 +274,22 @@ export function useDockLaunchModel(options: {
   // guard. Mirrors AgentTrayButton's pattern.
   const getSortedActionMruList = useActionMruStore((s) => s.getSortedActionMruList);
 
-  return useMemo(
+  const stable = useMemo(
     () =>
       buildDockLaunchModel({
         agents,
         pinnedCount,
         activeWorktreeId,
         recipes,
-        mruEntries: getSortedActionMruList(),
+        surface,
+        mruEntries: [],
       }),
-    [agents, pinnedCount, activeWorktreeId, recipes, getSortedActionMruList]
+    // The two registry snapshots are read for invalidation only — the builder
+    // pulls the live registries itself.
+    [agents, pinnedCount, activeWorktreeId, recipes, surface, kindRegistry, definitionRegistry]
   );
+
+  return { ...stable, recentAgents: selectRecentAgents(agents, getSortedActionMruList()) };
 }
 
 export interface ActivateDockLaunchItemContext {

--- a/src/components/Layout/dockLaunchItems.ts
+++ b/src/components/Layout/dockLaunchItems.ts
@@ -1,0 +1,302 @@
+import { useMemo } from "react";
+import { getSpawnablePanelKinds } from "@/registry";
+import { panelKindIsDockable } from "@shared/config/panelKindRegistry";
+import { getPanelKindConfig } from "@shared/config/panelKindRegistry";
+import { usePanelStore } from "@/store/panelStore";
+import { useRecipeStore } from "@/store/recipeStore";
+import { useActionMruStore } from "@/store/actionMruStore";
+import { actionService } from "@/services/ActionService";
+import { notifyRecipeSpawnFailures } from "@/utils/recipeNotify";
+import { getRecipeScope } from "@/utils/recipeScope";
+import { logError } from "@/utils/logger";
+import { isAgentLaunchable } from "@shared/utils/agentAvailability";
+import type { ActionSource, AgentAvailabilityState, TerminalRecipe } from "@shared/types";
+import type { AddPanelOptions } from "@shared/types/addPanelOptions";
+import type { RecipeContext } from "@/utils/recipeVariables";
+
+export const AGENT_MRU_PREFIX = "agent.";
+
+/** Cap the "Recently launched" band so it stays a quick-reach shortcut rather
+ * than a second full agent list above the fixed Pinned/Other groups. */
+export const RECENCY_BAND_CAP = 3;
+
+/**
+ * Panel kinds `agent.launch` understands. `terminal` resolves to the plain
+ * shell; `browser` and `dev-preview` return from their own branches in
+ * `launchAgent` (seeding the dev-server title, reusing the launch reentrancy
+ * guard). Every other kind must be created through `addPanel` directly —
+ * `resolveAgentLaunchKind` throws on an id it can't resolve as an agent (#11498).
+ */
+const AGENT_LAUNCH_PANEL_KINDS: ReadonlySet<string> = new Set([
+  "terminal",
+  "browser",
+  "dev-preview",
+]);
+
+/** Terminal opts out of the palette (it has dedicated spawn actions) but is the
+ * launcher's most-used entry, so it is added back explicitly here. */
+const TERMINAL_KIND_ID = "terminal";
+
+export type LaunchAgentIcon = React.ComponentType<{ className?: string; brandColor?: string }>;
+
+export interface DockLaunchAgent {
+  id: string;
+  name: string;
+  icon?: LaunchAgentIcon;
+  brandColor?: string;
+  availability?: AgentAvailabilityState;
+}
+
+interface DockLaunchItemBase {
+  /** Stable key, unique across categories (an agent and a panel can share an id). */
+  key: string;
+  name: string;
+  searchAliases?: string[];
+  description?: string;
+}
+
+export interface DockLaunchAgentItem extends DockLaunchItemBase {
+  category: "agent";
+  agent: DockLaunchAgent;
+}
+
+export interface DockLaunchPanelItem extends DockLaunchItemBase {
+  category: "panel";
+  kindId: string;
+  iconId: string;
+  color: string;
+  /** Where selecting this item actually lands the panel. Derived from
+   * `panelKindIsDockable`, so the label can never contradict `addPanel`. */
+  location: "dock" | "grid";
+}
+
+export interface DockLaunchRecipeItem extends DockLaunchItemBase {
+  category: "recipe";
+  recipe: TerminalRecipe;
+  scopeLabel: string;
+  isShadowed: boolean;
+}
+
+export type DockLaunchItem = DockLaunchAgentItem | DockLaunchPanelItem | DockLaunchRecipeItem;
+
+export interface DockLaunchModel {
+  /** Capped frecency band; entries also appear in the agent groups below. */
+  recentAgents: DockLaunchAgent[];
+  /** True when `pinnedCount` splits the agents into a strict Pinned/Other subset. */
+  showAgentGroups: boolean;
+  dockPanels: DockLaunchPanelItem[];
+  gridPanels: DockLaunchPanelItem[];
+  recipes: DockLaunchRecipeItem[];
+  /** Flat, de-duplicated set fed to Fuse — the recency band is not repeated. */
+  searchItems: DockLaunchItem[];
+}
+
+export interface BuildDockLaunchModelOptions {
+  agents: ReadonlyArray<DockLaunchAgent>;
+  pinnedCount?: number;
+  activeWorktreeId: string | null;
+  recipes: ReadonlyArray<TerminalRecipe>;
+  mruEntries: ReadonlyArray<{ id: string; lastAccessedAt: number }>;
+}
+
+function toPanelItem(config: {
+  id: string;
+  name: string;
+  iconId: string;
+  color: string;
+  searchAliases?: string[];
+}): DockLaunchPanelItem {
+  const location = panelKindIsDockable(config.id) ? "dock" : "grid";
+  return {
+    category: "panel",
+    key: `panel:${config.id}`,
+    kindId: config.id,
+    name: config.name,
+    iconId: config.iconId,
+    color: config.color,
+    // "panel" and the destination are searchable so "grid" or "panel" narrows
+    // to this group without the registry aliases having to spell it out.
+    searchAliases: [...(config.searchAliases ?? []), "panel", location],
+    location,
+  };
+}
+
+/**
+ * Derive every launchable entry for the dock launcher — the same set for the
+ * `+` dropdown and the dock's right-click menu. Panels come from the shared
+ * spawnable-kind selector (so the launcher can't drift from ⌘⇧P) plus Terminal,
+ * partitioned by real dockability rather than filtered by it: a non-dockable
+ * kind is offered under a heading that says it opens in the grid, instead of
+ * being hidden (#11054's fix was to stop lying, not to stop offering).
+ */
+export function buildDockLaunchModel({
+  agents,
+  pinnedCount,
+  activeWorktreeId,
+  recipes,
+  mruEntries,
+}: BuildDockLaunchModelOptions): DockLaunchModel {
+  const recentAgents = mruEntries
+    .filter((entry) => entry.lastAccessedAt > 0 && entry.id.startsWith(AGENT_MRU_PREFIX))
+    .map((entry) => agents.find((a) => a.id === entry.id.slice(AGENT_MRU_PREFIX.length)))
+    .filter((agent): agent is DockLaunchAgent => agent !== undefined)
+    .slice(0, RECENCY_BAND_CAP);
+
+  const panelItems: DockLaunchPanelItem[] = [];
+  const seenKinds = new Set<string>();
+  const terminalConfig = getPanelKindConfig(TERMINAL_KIND_ID);
+  if (terminalConfig) {
+    panelItems.push(toPanelItem(terminalConfig));
+    seenKinds.add(TERMINAL_KIND_ID);
+  }
+  for (const config of getSpawnablePanelKinds()) {
+    if (seenKinds.has(config.id)) continue;
+    seenKinds.add(config.id);
+    panelItems.push(toPanelItem(config));
+  }
+
+  const dockPanels = panelItems.filter((item) => item.location === "dock");
+  const gridPanels = panelItems.filter((item) => item.location === "grid");
+
+  // Shadowed recipes stay listed (dimmed, marked "Overridden") rather than
+  // vanishing — running one resolves to the winner, so hiding it only hides
+  // that the collision exists (#11510).
+  const recipeItems: DockLaunchRecipeItem[] = recipes
+    .filter((r) => r.worktreeId === undefined || r.worktreeId === (activeWorktreeId ?? undefined))
+    .map((recipe) => {
+      const scopeLabel = getRecipeScope(recipe).label;
+      return {
+        category: "recipe" as const,
+        key: `recipe:${recipe.id}`,
+        name: recipe.name,
+        recipe,
+        scopeLabel,
+        isShadowed: Boolean(recipe.shadowedBy),
+        searchAliases: ["recipe", scopeLabel],
+      };
+    });
+
+  const agentItems: DockLaunchAgentItem[] = agents.map((agent) => ({
+    category: "agent" as const,
+    key: `agent:${agent.id}`,
+    name: agent.name,
+    agent,
+    searchAliases: [agent.id, "agent"],
+  }));
+
+  return {
+    recentAgents,
+    showAgentGroups: pinnedCount !== undefined && pinnedCount > 0 && pinnedCount < agents.length,
+    dockPanels,
+    gridPanels,
+    recipes: recipeItems,
+    searchItems: [...agentItems, ...panelItems, ...recipeItems],
+  };
+}
+
+/**
+ * Store-connected wrapper around {@link buildDockLaunchModel}. Both launcher
+ * surfaces call it; the menu is only mounted while open, so `getSpawnablePanelKinds`
+ * is re-read per open and picks up plugin kinds registered mid-session without a
+ * registry subscription.
+ *
+ * The MRU list is read inside the memo rather than tracked as a dependency: it
+ * changes on launch, which also closes the menu, so re-reading it per keystroke
+ * would only risk the recency band reshuffling under the user mid-search.
+ */
+export function useDockLaunchModel(options: {
+  agents: ReadonlyArray<DockLaunchAgent>;
+  pinnedCount?: number;
+  activeWorktreeId: string | null;
+}): DockLaunchModel {
+  const { agents, pinnedCount, activeWorktreeId } = options;
+  // Subscribe inside the menu so the listener only runs while open.
+  const recipes = useRecipeStore((s) => s.recipes);
+  // Subscribe to the stable getter (not its result) so the selector returns a
+  // constant reference — calling getSortedActionMruList() inside the selector
+  // would mint a new array every render and trip Zustand 5's infinite-loop
+  // guard. Mirrors AgentTrayButton's pattern.
+  const getSortedActionMruList = useActionMruStore((s) => s.getSortedActionMruList);
+
+  return useMemo(
+    () =>
+      buildDockLaunchModel({
+        agents,
+        pinnedCount,
+        activeWorktreeId,
+        recipes,
+        mruEntries: getSortedActionMruList(),
+      }),
+    [agents, pinnedCount, activeWorktreeId, recipes, getSortedActionMruList]
+  );
+}
+
+export interface ActivateDockLaunchItemContext {
+  cwd: string;
+  activeWorktreeId: string | null;
+  recipeContext?: RecipeContext;
+  onLaunchAgent: (agentId: string) => void;
+  settingsSource: ActionSource;
+}
+
+/**
+ * Run a launcher entry. Agents and the three kinds `launchAgent` special-cases
+ * keep routing through `onLaunchAgent`; everything else creates its panel
+ * directly at the location its menu heading advertised.
+ */
+export function activateDockLaunchItem(
+  item: DockLaunchItem,
+  ctx: ActivateDockLaunchItemContext
+): void {
+  if (item.category === "agent") {
+    const { agent } = item;
+    if (!isAgentLaunchable(agent.availability)) {
+      // Mirrors AgentButton.tsx: a non-launchable agent routes to its settings
+      // subtab so the user can resolve the precondition instead of bouncing off
+      // a disabled row. Not a launch, so it must not pollute the MRU band.
+      void actionService.dispatch(
+        "app.settings.openTab",
+        { tab: "agents", subtab: agent.id },
+        { source: ctx.settingsSource }
+      );
+      return;
+    }
+    useActionMruStore.getState().recordActionMru(`${AGENT_MRU_PREFIX}${agent.id}`);
+    ctx.onLaunchAgent(agent.id);
+    return;
+  }
+
+  if (item.category === "panel") {
+    if (AGENT_LAUNCH_PANEL_KINDS.has(item.kindId)) {
+      ctx.onLaunchAgent(item.kindId);
+      return;
+    }
+    void usePanelStore.getState().addPanel({
+      kind: item.kindId,
+      cwd: ctx.cwd,
+      worktreeId: ctx.activeWorktreeId ?? undefined,
+      location: item.location,
+      // Folds dock activation into the same set() that commits the panel, so
+      // the offscreen-container watchdog can't close it in the render gap (#6590).
+      activateDockOnCreate: item.location === "dock",
+      // Plugin kinds are deliberately outside the built-in AddPanelOptions
+      // union (a `string & {}` member would defeat discriminated narrowing),
+      // so widening happens here at the integration boundary.
+    } as AddPanelOptions);
+    return;
+  }
+
+  // Fire-and-forget, but surface spawn failures — the menu closes on select, so
+  // a toast/inbox entry is the only signal the user gets when terminals are
+  // dropped (e.g. panel limit).
+  void useRecipeStore
+    .getState()
+    .runRecipeWithResults(
+      item.recipe.id,
+      ctx.cwd,
+      ctx.activeWorktreeId ?? undefined,
+      ctx.recipeContext
+    )
+    .then((results) => notifyRecipeSpawnFailures(results, { recipeName: item.recipe.name }))
+    .catch((error) => logError("Recipe launch from dock failed", error));
+}

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -1122,6 +1122,7 @@ export function useContentGridContext({
         cwd={defaultCwd ?? ""}
         recipeContext={gridRecipeContext}
         onLaunchAgent={handleGridLaunch}
+        surface="grid"
         settingsSource="context-menu"
       />
       <ContextMenuSeparator />

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -78,7 +78,6 @@ import {
 } from "@/components/Layout/DockLaunchMenuItems";
 import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
-import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { sortAgentsByToolbarPin } from "@/lib/agentMenuOrder";
 import { getMaximizedGroupFocusTarget, enterFocusedPanel } from "./contentGridFocus";
 import { setGridLayoutSnapshot } from "./gridLayoutSnapshot";
@@ -329,9 +328,6 @@ export function useContentGridContext({
   // invalidate this hook's "use memo" block on any unrelated toolbar update.
   const leftButtons = useToolbarPreferencesStore(useShallow((s) => s.layout.leftButtons));
   const agentSettings = useAgentSettingsStore((s) => s.settings);
-  const hasDevPreview = useProjectSettingsStore((s) =>
-    Boolean(s.settings?.devServerCommand?.trim())
-  );
   // Re-derive grid agents when a plugin loads/unloads mid-session so its agents
   // appear / disappear with current icon/name/color (#9879).
   const pluginAgentRegistry = useSyncExternalStore(
@@ -1122,7 +1118,6 @@ export function useContentGridContext({
         components={GRID_CONTEXT_MENU_COMPONENTS}
         agents={gridLaunchAgents}
         pinnedCount={gridAgentPinnedCount}
-        hasDevPreview={hasDevPreview}
         activeWorktreeId={activeWorktreeId}
         cwd={defaultCwd ?? ""}
         recipeContext={gridRecipeContext}

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -127,6 +127,10 @@ const DURABLE_ALLOWLIST = new Set([
   // PanelPalette selected-row left-edge accent stripe (single primary anchor per active focus region)
   "src/components/PanelPalette/PanelPalette.tsx",
 
+  // Dock launcher filtered-result selected-row left-edge accent stripe (single
+  // primary anchor per active focus region)
+  "src/components/Layout/DockLaunchMenuItems.tsx",
+
   // ResumeSessionsPalette selected-row left-edge accent stripe (single primary anchor per active focus region)
   "src/components/Terminal/ResumeSessionsPalette.tsx",
 

--- a/src/hooks/__tests__/usePanelPalette.test.tsx
+++ b/src/hooks/__tests__/usePanelPalette.test.tsx
@@ -39,6 +39,20 @@ vi.mock("@shared/config/panelKindRegistry", () => ({
 
 vi.mock("@/registry", () => ({
   getPanelKindDefinition: getPanelKindDefinitionMock,
+  // The spawnable-kind predicate itself is covered by
+  // src/registry/__tests__/spawnablePanelKinds.test.ts; here it is driven from
+  // the same registry mocks the rest of this suite uses, so each case still
+  // controls which kinds reach the palette.
+  getSpawnablePanelKinds: () =>
+    (getPanelKindIdsMock() as string[])
+      .filter((kindId) => kindId !== "agent")
+      .map((kindId) => getPanelKindConfigMock(kindId) as { id: string; showInPalette?: boolean })
+      .filter(
+        (config) =>
+          config != null &&
+          config.showInPalette !== false &&
+          Boolean(getPanelKindDefinitionMock(config.id))
+      ),
 }));
 
 vi.mock("@shared/config/agentRegistry", () => ({

--- a/src/hooks/usePanelPalette.ts
+++ b/src/hooks/usePanelPalette.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import type { IFuseOptions } from "fuse.js";
-import { getPanelKindIds, getPanelKindConfig } from "@shared/config/panelKindRegistry";
-import { getPanelKindDefinition } from "@/registry";
+import { getSpawnablePanelKinds } from "@/registry";
 import { getEffectiveAgentIds, getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 import {
   subscribeToPluginAgentRegistry,
@@ -117,27 +116,15 @@ export function usePanelPalette(): UsePanelPaletteReturn {
     // Referenced so this memo re-derives when plugins load/unload mid-session;
     // getEffectiveAgentIds/Config below read the merged (incl. plugin) registry (#9879).
     void pluginAgentRegistry;
-    const panelKinds = getPanelKindIds()
-      .filter((kindId) => {
-        if (kindId === "agent") return false;
-        const config = getPanelKindConfig(kindId);
-        if (!config) return false;
-        if (config.showInPalette === false) return false;
-        if (!getPanelKindDefinition(kindId)) return false;
-        return true;
-      })
-      .map((kindId) => {
-        const config = getPanelKindConfig(kindId)!;
-        return {
-          id: kindId,
-          name: config.name,
-          iconId: config.iconId,
-          color: config.color,
-          description: config.shortcut,
-          searchAliases: config.searchAliases,
-          category: "tool" as const,
-        };
-      });
+    const panelKinds = getSpawnablePanelKinds().map((config) => ({
+      id: config.id,
+      name: config.name,
+      iconId: config.iconId,
+      color: config.color,
+      description: config.shortcut,
+      searchAliases: config.searchAliases,
+      category: "tool" as const,
+    }));
 
     const isAgentHidden = (agentId: string): boolean => {
       // Assistant-only agents are never launchable from the palette — they

--- a/src/hooks/useSearchablePalette.ts
+++ b/src/hooks/useSearchablePalette.ts
@@ -19,6 +19,14 @@ export interface UseSearchablePaletteOptions<T> {
   includeMatches?: boolean;
   /** Extract a unique ID from an item for the matchesById map. Defaults to `(item as any).id`. */
   getItemId?: (item: T) => string;
+  /**
+   * Lag filtering behind the input via `useDeferredValue`. Default true, which
+   * keeps keystrokes responsive on large lists at the cost of `results` briefly
+   * trailing `query`. Small embedded launchers whose confirm key can be pressed
+   * in the same tick as the last keystroke pass false: with deferral on, that
+   * Enter reads the *previous* query's ranking and launches the wrong item.
+   */
+  deferFiltering?: boolean;
 }
 
 export interface UseSearchablePaletteReturn<T> {
@@ -62,6 +70,7 @@ export function useSearchablePalette<T>(
     paletteId,
     includeMatches = false,
     getItemId = defaultGetItemId,
+    deferFiltering = true,
   } = options;
 
   const storeIsOpen = usePaletteStore(
@@ -74,7 +83,9 @@ export function useSearchablePalette<T>(
   // Lag the filtering work behind the input so keystrokes stay responsive.
   // The expensive Fuse/filterFn pass runs in a deferred render that yields to
   // input events; the input itself binds to the urgent `query` state.
-  const deferredQuery = useDeferredValue(query);
+  // Called unconditionally (hook order) even when deferral is opted out of.
+  const deferredValue = useDeferredValue(query);
+  const deferredQuery = deferFiltering ? deferredValue : query;
   const isStale = query !== deferredQuery;
   const [selectedIndex, setSelectedIndex] = useState(0);
 

--- a/src/registry/__tests__/spawnablePanelKinds.test.ts
+++ b/src/registry/__tests__/spawnablePanelKinds.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  registerPanelKind,
+  unregisterPanelKind,
+  getPanelKindConfig,
+  type PanelKindConfig,
+} from "@shared/config/panelKindRegistry";
+
+// Only the renderer-definition lookup is stubbed — the real `@/registry` barrel
+// eagerly imports the whole panel component tree. Everything else runs against
+// the real shared registry so the predicate is exercised on real config.
+let registeredDefinitions = new Set<string>();
+vi.mock("../panelKindRegistry", () => ({
+  getPanelKindDefinition: (kindId: string) =>
+    registeredDefinitions.has(kindId) ? { kind: kindId } : undefined,
+}));
+
+import { getSpawnablePanelKinds } from "../spawnablePanelKinds";
+
+const PLUGIN_ID = "test-spawnable-plugin";
+
+function allBuiltInsDefined() {
+  registeredDefinitions = new Set([
+    "terminal",
+    "browser",
+    "dev-preview",
+    "review",
+    "file",
+    "file-browser",
+    "diff",
+  ]);
+}
+
+afterEach(() => {
+  unregisterPanelKind(PLUGIN_ID);
+  registeredDefinitions = new Set();
+});
+
+describe("getSpawnablePanelKinds", () => {
+  it("keeps only kinds that opt into the palette", () => {
+    allBuiltInsDefined();
+    const ids = getSpawnablePanelKinds().map((c) => c.id);
+
+    for (const id of ids) {
+      expect(getPanelKindConfig(id)?.showInPalette).not.toBe(false);
+    }
+    // diff and terminal both opt out, for different reasons (needs a target /
+    // has dedicated spawn actions).
+    expect(ids).not.toContain("diff");
+    expect(ids).not.toContain("terminal");
+  });
+
+  it("never yields the reserved agent kind", () => {
+    allBuiltInsDefined();
+    expect(getSpawnablePanelKinds().map((c) => c.id)).not.toContain("agent");
+  });
+
+  it("drops a kind with no registered renderer definition", () => {
+    registeredDefinitions = new Set(["browser"]);
+    const ids = getSpawnablePanelKinds().map((c) => c.id);
+
+    expect(ids).toContain("browser");
+    // review opts into the palette but has no definition registered here.
+    expect(ids).not.toContain("review");
+  });
+
+  it("does not filter on dockability — non-dockable kinds are still spawnable", () => {
+    allBuiltInsDefined();
+    const ids = getSpawnablePanelKinds().map((c) => c.id);
+    expect(ids).toEqual(expect.arrayContaining(["review", "file-browser", "dev-preview"]));
+  });
+
+  it("includes a plugin kind once it has both palette opt-in and a definition", () => {
+    const config: PanelKindConfig = {
+      id: PLUGIN_ID,
+      name: "Test Panel",
+      iconId: "package",
+      color: "#fff",
+      hasPty: false,
+      canRestart: false,
+      canConvert: false,
+      extensionId: "test-plugin",
+    };
+    registerPanelKind(config);
+
+    // Registered but no renderer definition yet → not offered.
+    registeredDefinitions = new Set();
+    expect(getSpawnablePanelKinds().map((c) => c.id)).not.toContain(PLUGIN_ID);
+
+    // Definition arrives → offered, with no registry subscription needed.
+    registeredDefinitions = new Set([PLUGIN_ID]);
+    expect(getSpawnablePanelKinds().map((c) => c.id)).toContain(PLUGIN_ID);
+  });
+});

--- a/src/registry/__tests__/spawnablePanelKinds.test.ts
+++ b/src/registry/__tests__/spawnablePanelKinds.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   registerPanelKind,
   unregisterPanelKind,
-  getPanelKindConfig,
   type PanelKindConfig,
 } from "@shared/config/panelKindRegistry";
 
@@ -41,17 +40,38 @@ describe("getSpawnablePanelKinds", () => {
     allBuiltInsDefined();
     const ids = getSpawnablePanelKinds().map((c) => c.id);
 
-    for (const id of ids) {
-      expect(getPanelKindConfig(id)?.showInPalette).not.toBe(false);
-    }
     // diff and terminal both opt out, for different reasons (needs a target /
     // has dedicated spawn actions).
     expect(ids).not.toContain("diff");
     expect(ids).not.toContain("terminal");
+    // ...while a kind that opts in and has a renderer is kept.
+    expect(ids).toContain("review");
+  });
+
+  it("drops a plugin kind that opts out of the palette despite having a renderer", () => {
+    // Discriminating counterpart to the above: the exclusion has to come from
+    // showInPalette, not from a missing renderer definition.
+    registerPanelKind({
+      id: PLUGIN_ID,
+      name: "Hidden Panel",
+      iconId: "package",
+      color: "#fff",
+      hasPty: false,
+      canRestart: false,
+      canConvert: false,
+      extensionId: "test-plugin",
+      showInPalette: false,
+    });
+    registeredDefinitions = new Set([PLUGIN_ID]);
+
+    expect(getSpawnablePanelKinds().map((c) => c.id)).not.toContain(PLUGIN_ID);
   });
 
   it("never yields the reserved agent kind", () => {
+    // "agent" gets a renderer definition here so the only thing that can
+    // exclude it is the explicit reserved-id guard.
     allBuiltInsDefined();
+    registeredDefinitions.add("agent");
     expect(getSpawnablePanelKinds().map((c) => c.id)).not.toContain("agent");
   });
 

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -15,3 +15,4 @@ export {
   type PanelKindDefinition,
   type PanelComponentProps,
 } from "./panelKindRegistry";
+export { getSpawnablePanelKinds } from "./spawnablePanelKinds";

--- a/src/registry/spawnablePanelKinds.ts
+++ b/src/registry/spawnablePanelKinds.ts
@@ -1,0 +1,31 @@
+import {
+  getPanelKindIds,
+  getPanelKindConfig,
+  type PanelKindConfig,
+} from "@shared/config/panelKindRegistry";
+import { getPanelKindDefinition } from "./panelKindRegistry";
+
+/**
+ * Panel kinds a user can spawn from a bare launcher entry — the ⌘⇧P palette and
+ * the dock's `+` launcher read the same set so the two can't drift.
+ *
+ * A kind qualifies when it declares itself palette-visible and has a registered
+ * renderer definition. `"agent"` is reserved (it names the agent-backed terminal
+ * family, not a spawnable surface), and kinds that need a target to make sense
+ * opt out with `showInPalette: false` — `diff` (needs a file) and `terminal`
+ * (has dedicated spawn actions). Plugin kinds are included: `getPanelKindIds`
+ * reads the merged registry, so a kind registered mid-session is picked up by
+ * the next call rather than needing its own subscription.
+ */
+export function getSpawnablePanelKinds(): PanelKindConfig[] {
+  const configs: PanelKindConfig[] = [];
+  for (const kindId of getPanelKindIds()) {
+    if (kindId === "agent") continue;
+    const config = getPanelKindConfig(kindId);
+    if (!config) continue;
+    if (config.showInPalette === false) continue;
+    if (!getPanelKindDefinition(kindId)) continue;
+    configs.push(config);
+  }
+  return configs;
+}


### PR DESCRIPTION
## Summary

The dock's `+` launcher only ever showed Terminal and Browser plus a couple of agent bands. This completes it and makes it searchable, resolving #11521.

## What changed

**Shared panel list.** The launcher's panel list now comes from a shared spawnable-kind selector (`src/registry/spawnablePanelKinds.ts`), which `⌘⇧P` also consumes, so the two can't drift apart. That adds File Viewer, File Browser, Review, Dev Preview and plugin-contributed kinds, none of which the launcher offered before.

**Honest destinations, not hidden kinds.** Panels are now grouped under "Open in dock" / "Open in grid" headings, derived from the same `panelKindIsDockable` predicate the store guards use. #11054 hid non-dockable kinds because `addPanel` silently redirects them to the grid, and the old menu item would have lied about where the panel landed. Rather than keep hiding them, the heading now states the real destination. The fix was to stop lying, not to stop offering.

**Launch routing.** Kinds that `agent.launch` can't resolve (it throws on anything it can't map to an agent, per #11498) now go through `addPanel` directly. Terminal, Browser and Dev Preview keep their existing launch path.

**Search.** A search field on the `+` dropdown only, never on the two right-click context menus, where a text input doesn't belong. It ranks agents, panels and recipes in one Fuse list, and Enter launches the top result. The Recently launched / Pinned / Other bands are untouched when the query is empty.

**Dead code.** Removed the `hasDevPreview` gate. It was ANDed with `panelKindIsDockable("dev-preview")`, which is always false, so that menu item was unreachable.

## A surface-honesty bug found in review

`DockLaunchMenuItems` turned out to have a third consumer I'd missed: the grid's own right-click menu in `useContentGridContext.tsx`, whose launch callback dispatches `location: "grid"` for everything. Labeling Terminal and Browser as "Open in dock" there would have reintroduced exactly the misstatement #11054 fixed, just from a different menu. The model now takes an explicit `surface`, and a grid surface claims no dock destination, it falls back to a single "Launch panel" heading instead.

## Radix notes

Some of the keyboard wiring looks fiddly for a reason:

- Menu items call `.focus()` on `onPointerMove`, so the rows `preventDefault` it. Otherwise the pointer crossing a row steals focus off the search box mid-type.
- Escape is caught by `DismissibleLayer` at the document level with capture, so a bubble-phase `stopPropagation` can't stop it. "First Escape clears, second closes" needed the content's `onEscapeKeyDown` veto plus the input's own capture handler.
- Focus moves into the input via a mount effect plus `rAF` rather than `onOpenAutoFocus`, because the project's `DropdownMenuContent` wrapper narrows that prop away.
- Arrows deliberately fall through to Radix while the query is empty, so the grouped, unfiltered menu stays keyboard-reachable.

## Known tradeoff

A search box inside a Radix `role="menu"` with `aria-activedescendant` isn't a pure APG pattern. The clean fix is swapping the `+` for a Popover with combobox/listbox semantics, but that would fork the shared menu contract the two context menus rely on. Out of scope here, worth revisiting.

## Testing

- `src/components/Layout/__tests__/dockLaunchItems.test.ts` (new) — destination partition against the live `panelKindIsDockable`, plugin kinds, surface honesty, activation routing
- `src/registry/__tests__/spawnablePanelKinds.test.ts` (new) — the shared predicate
- `src/components/Layout/__tests__/DockLaunchButton.test.tsx` — rewritten for search, keyboard, Escape, focus
- `e2e/full/panels/core-dock-launcher-search.spec.ts` (new, 5 tests) — the Radix behavior jsdom can't reach, since the unit suite mocks the dropdown primitives wholesale
- Verified locally: full `npm run typecheck` clean; 1677 unit tests across 86 files (every palette consumer of the two shared hooks); `lint:ratchet` passes with no rule regressed; e2e 5/5 on full-panels after a build