### PR TITLE
fix(actions): stop project.getSettings returning decrypted secrets over MCP

### DIFF
--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -82,7 +82,7 @@ export type {
 export type { BrowserHistory } from "./browser.js";
 
 // Project types
-export { isGitBackedProject } from "./project.js";
+export { isGitBackedProject, pickAgentVisibleProjectSettings } from "./project.js";
 export type {
   ProjectStatus,
   Project,
@@ -99,6 +99,8 @@ export type {
   RecipeNameCollision,
   RunCommand,
   ProjectSettings,
+  AgentVisibleProjectSettings,
+  AgentVisibleProjectSettingsKey,
   ProjectTerminalSettings,
   CopyTreeSettings,
   FleetSavedScope,

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -708,6 +708,119 @@ export const PROJECT_SETTINGS_SHAREABILITY = {
   exposeDaintreeMcpToAgents: "local",
 } as const satisfies Record<keyof ProjectSettings, FieldShareability>;
 
+/**
+ * Whether a `ProjectSettings` field may cross an agent-facing boundary (the
+ * `project.getSettings` action, which is reachable from every MCP tier).
+ *
+ * This is a disclosure policy and is deliberately separate from
+ * `PROJECT_SETTINGS_SHAREABILITY`, which is a persistence policy: `local` does
+ * not imply secret, and `shareable` does not imply safe to hand an agent.
+ */
+export type ProjectSettingsAgentExposure = "exposed" | "internal";
+
+/**
+ * Disclosure classification for each field of `ProjectSettings`.
+ *
+ * The `satisfies Record<keyof ProjectSettings, ...>` constraint makes adding a new
+ * `ProjectSettings` field without classifying it a compile-time error, so the agent
+ * surface cannot widen by accident. Classify new fields `internal` unless an agent
+ * can genuinely act on them.
+ *
+ * `internal` covers four kinds of field:
+ * - Secrets and bulk data: the environment-variable maps (`getProjectSettings` resolves
+ *   secure storage into `environmentVariables` in plaintext) and `projectIconSvg` (250KB
+ *   of markup). `resourceEnvironments` joins them because it stores raw provisioning and
+ *   `connect` shell strings that routinely embed credentials.
+ * - Access-control state: `daintreeMcpTier` (`project.saveSettings` already strips it from
+ *   writes to block self-elevation; it should not be readable either).
+ * - Renderer-only UI state: dismissal flags, editor/viewer preferences, saved fleet scopes.
+ * - Deprecated aliases normalized away on read.
+ */
+export const PROJECT_SETTINGS_AGENT_EXPOSURE = {
+  runCommands: "exposed",
+  environmentVariables: "internal",
+  secureEnvironmentVariables: "internal",
+  insecureEnvironmentVariables: "internal",
+  unresolvedSecureEnvironmentVariables: "internal",
+  excludedPaths: "exposed",
+  projectIconSvg: "internal",
+  defaultWorktreeRecipeId: "exposed",
+  devServerCommand: "exposed",
+  devServerDismissed: "internal",
+  devServerAutoDetected: "internal",
+  cloudSyncWarningDismissed: "internal",
+  devServerLoadTimeout: "exposed",
+  turbopackEnabled: "exposed",
+  copyTreeSettings: "exposed",
+  commandOverrides: "internal",
+  gitInitDefaults: "internal",
+  preferredEditor: "internal",
+  preferredImageViewer: "internal",
+  branchPrefixMode: "exposed",
+  branchPrefixCustom: "exposed",
+  forgeRemote: "exposed",
+  githubRemote: "internal",
+  forgeProviderOverride: "exposed",
+  worktreePathPattern: "exposed",
+  fleetSavedScopes: "internal",
+  terminalSettings: "exposed",
+  notificationOverrides: "exposed",
+  resourceEnvironment: "internal",
+  resourceEnvironments: "internal",
+  activeResourceEnvironment: "exposed",
+  defaultWorktreeMode: "exposed",
+  browserAllowedHosts: "exposed",
+  daintreeMcpTier: "internal",
+  exposeDaintreeMcpToAgents: "internal",
+} as const satisfies Record<keyof ProjectSettings, ProjectSettingsAgentExposure>;
+
+/**
+ * Keys of `ProjectSettings` classified `exposed` in `PROJECT_SETTINGS_AGENT_EXPOSURE`.
+ *
+ * The `-?` is load-bearing: most `ProjectSettings` fields are optional, and indexing a
+ * mapped type that preserves optionality would union `undefined` into the key type.
+ */
+export type AgentVisibleProjectSettingsKey = {
+  [K in keyof ProjectSettings]-?: (typeof PROJECT_SETTINGS_AGENT_EXPOSURE)[K] extends "exposed"
+    ? K
+    : never;
+}[keyof ProjectSettings];
+
+/** The subset of `ProjectSettings` an agent-facing surface may return. */
+export type AgentVisibleProjectSettings = Pick<ProjectSettings, AgentVisibleProjectSettingsKey>;
+
+/**
+ * Build a fresh, agent-safe view of a project's settings.
+ *
+ * Iterating the classification table rather than the input object is what makes this
+ * fail closed: a key present at runtime but absent from the table (a field added to the
+ * persisted payload, or anything a caller tacked on) is dropped rather than forwarded.
+ *
+ * Always returns a new object — callers hand this the renderer's cached settings value,
+ * so filtering in place would corrupt the cache every other consumer reads.
+ *
+ * The result is `Partial` rather than `AgentVisibleProjectSettings` because absent
+ * optional fields are omitted rather than emitted as `undefined`, and because a nullish
+ * payload (a project with nothing persisted yet) projects to an empty object rather
+ * than throwing.
+ */
+export function pickAgentVisibleProjectSettings(
+  settings: ProjectSettings | null | undefined
+): Partial<AgentVisibleProjectSettings> {
+  const visible: Partial<AgentVisibleProjectSettings> = {};
+  if (!settings) return visible;
+  for (const key of Object.keys(PROJECT_SETTINGS_AGENT_EXPOSURE) as Array<keyof ProjectSettings>) {
+    if (PROJECT_SETTINGS_AGENT_EXPOSURE[key] !== "exposed") continue;
+    const value = settings[key];
+    if (value === undefined) continue;
+    // Widening assignment: `value` came straight off `settings[key]`, so the key and
+    // value types line up per-iteration — the cast is the loop's genericity concession,
+    // matching `ProjectIdentityFiles.writeInRepoSettings`.
+    (visible as Record<keyof ProjectSettings, unknown>)[key] = value;
+  }
+  return visible;
+}
+
 /** Tier of Daintree MCP access exposed to agents in a project. */
 export type DaintreeMcpTier = "off" | "workbench" | "action" | "system";
 

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -732,9 +732,16 @@ export type ProjectSettingsAgentExposure = "exposed" | "internal";
  *   of markup). `resourceEnvironments` joins them because it stores raw provisioning and
  *   `connect` shell strings that routinely embed credentials.
  * - Access-control state: `daintreeMcpTier` (`project.saveSettings` already strips it from
- *   writes to block self-elevation; it should not be readable either).
+ *   writes to block self-elevation; it should not be readable either) and
+ *   `browserAllowedHosts`, which is the browser panel's approval list.
  * - Renderer-only UI state: dismissal flags, editor/viewer preferences, saved fleet scopes.
  * - Deprecated aliases normalized away on read.
+ *
+ * Accepted residual exposure: `runCommands`, `devServerCommand` and `terminalSettings`
+ * carry user-authored command strings, which a user *could* have inlined a credential
+ * into (`API_TOKEN=… npm run dev`). They stay `exposed` because they are the operational
+ * core of this surface — the "runner config" the action exists to report — and unlike
+ * `resourceEnvironments` they describe local repo commands rather than remote access.
  */
 export const PROJECT_SETTINGS_AGENT_EXPOSURE = {
   runCommands: "exposed",
@@ -769,7 +776,7 @@ export const PROJECT_SETTINGS_AGENT_EXPOSURE = {
   resourceEnvironments: "internal",
   activeResourceEnvironment: "exposed",
   defaultWorktreeMode: "exposed",
-  browserAllowedHosts: "exposed",
+  browserAllowedHosts: "internal",
   daintreeMcpTier: "internal",
   exposeDaintreeMcpToAgents: "internal",
 } as const satisfies Record<keyof ProjectSettings, ProjectSettingsAgentExposure>;
@@ -790,6 +797,34 @@ export type AgentVisibleProjectSettingsKey = {
 export type AgentVisibleProjectSettings = Pick<ProjectSettings, AgentVisibleProjectSettingsKey>;
 
 /**
+ * Fields of a `RunCommand` an agent-facing surface may see.
+ *
+ * `runCommands` needs its own pass because the settings codec keeps each entry whole
+ * after checking only `id` and `command`, so an entry persisted with extra keys would
+ * otherwise ride along inside an `exposed` field.
+ */
+const AGENT_VISIBLE_RUN_COMMAND_KEYS = [
+  "id",
+  "name",
+  "command",
+  "icon",
+  "description",
+  "preferredLocation",
+  "preferredAutoRestart",
+  "isFrameworkDefault",
+] as const satisfies ReadonlyArray<keyof RunCommand>;
+
+function pickAgentVisibleRunCommand(command: RunCommand): RunCommand {
+  const visible: Partial<Record<keyof RunCommand, unknown>> = {};
+  for (const key of AGENT_VISIBLE_RUN_COMMAND_KEYS) {
+    const value = command[key];
+    if (value === undefined) continue;
+    visible[key] = value;
+  }
+  return visible as RunCommand;
+}
+
+/**
  * Build a fresh, agent-safe view of a project's settings.
  *
  * Iterating the classification table rather than the input object is what makes this
@@ -799,26 +834,28 @@ export type AgentVisibleProjectSettings = Pick<ProjectSettings, AgentVisibleProj
  * Always returns a new object — callers hand this the renderer's cached settings value,
  * so filtering in place would corrupt the cache every other consumer reads.
  *
- * The result is `Partial` rather than `AgentVisibleProjectSettings` because absent
- * optional fields are omitted rather than emitted as `undefined`, and because a nullish
- * payload (a project with nothing persisted yet) projects to an empty object rather
- * than throwing.
+ * `runCommands` is always present, matching both `ProjectSettings` and the schema
+ * `project.getSettings` advertises; a nullish or malformed payload yields an empty list
+ * rather than an absent key.
  */
 export function pickAgentVisibleProjectSettings(
   settings: ProjectSettings | null | undefined
-): Partial<AgentVisibleProjectSettings> {
-  const visible: Partial<AgentVisibleProjectSettings> = {};
-  if (!settings) return visible;
+): AgentVisibleProjectSettings {
+  const visible: Partial<Record<keyof ProjectSettings, unknown>> = {};
   for (const key of Object.keys(PROJECT_SETTINGS_AGENT_EXPOSURE) as Array<keyof ProjectSettings>) {
     if (PROJECT_SETTINGS_AGENT_EXPOSURE[key] !== "exposed") continue;
-    const value = settings[key];
+    const value = settings?.[key];
     if (value === undefined) continue;
     // Widening assignment: `value` came straight off `settings[key]`, so the key and
     // value types line up per-iteration — the cast is the loop's genericity concession,
     // matching `ProjectIdentityFiles.writeInRepoSettings`.
-    (visible as Record<keyof ProjectSettings, unknown>)[key] = value;
+    visible[key] = value;
   }
-  return visible;
+  const runCommands = settings?.runCommands;
+  visible.runCommands = Array.isArray(runCommands)
+    ? runCommands.map(pickAgentVisibleRunCommand)
+    : [];
+  return visible as AgentVisibleProjectSettings;
 }
 
 /** Tier of Daintree MCP access exposed to agents in a project. */

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -3511,7 +3511,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "project",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Read the operational subset of a project's persisted settings (run commands, dev server command, worktree path pattern, branch prefix, forge remote, notification overrides, terminal overrides, etc.). Args: \`projectId\` (optional) — a project id from \`project.getAll\` (the \`id\` field); defaults to the active project's id. Returns only that fixed field set: environment variables (including secure ones), the project icon SVG, resource environment definitions, the MCP access tier, and renderer-only UI preferences are deliberately omitted and cannot be read through this action. Errors when no projectId is given and no project is active.",
+    "description": "Read the operational subset of a project's persisted settings (run commands, dev server command, worktree path pattern, branch prefix, forge remote, notification overrides, terminal overrides, etc.). Args: \`projectId\` (optional) — a project id from \`project.getAll\` (the \`id\` field); defaults to the active project's id. Returns only that fixed field set: environment variables (including secure ones), the project icon SVG, resource environment definitions, access-control state (MCP tier, browser allow-list), and renderer-only UI preferences are deliberately omitted and cannot be read through this action. Errors when no projectId is given and no project is active.",
     "examples": undefined,
     "id": "project.getSettings",
     "keywords": undefined,

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -3511,7 +3511,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "project",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Read a project's persisted settings (notification overrides, runner config, worktree path pattern, etc.). Args: \`projectId\` (optional) — a project id from \`project.getAll\` (the \`id\` field); defaults to the active project's id. Returns the settings object as an open-ended key/value map. Errors when no projectId is given and no project is active.",
+    "description": "Read the operational subset of a project's persisted settings (run commands, dev server command, worktree path pattern, branch prefix, forge remote, notification overrides, terminal overrides, etc.). Args: \`projectId\` (optional) — a project id from \`project.getAll\` (the \`id\` field); defaults to the active project's id. Returns only that fixed field set: environment variables (including secure ones), the project icon SVG, resource environment definitions, the MCP access tier, and renderer-only UI preferences are deliberately omitted and cannot be read through this action. Errors when no projectId is given and no project is active.",
     "examples": undefined,
     "id": "project.getSettings",
     "keywords": undefined,

--- a/src/services/actions/__tests__/actionDefinitions.project-system-preferences.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.project-system-preferences.adversarial.test.ts
@@ -454,15 +454,11 @@ describe("project action hardening", () => {
   });
 
   it("passes through project client queries and dispatches settings events", async () => {
-    mocks.projectClient.getSettings.mockResolvedValueOnce({ theme: "dark" });
     mocks.projectClient.detectRunners.mockResolvedValueOnce(["dev"]);
     mocks.projectClient.getStats.mockResolvedValueOnce({ files: 12 });
     const dispatchEvent = vi.spyOn(window, "dispatchEvent");
     const { service } = buildService(registerProjectActions);
 
-    await expect(
-      service.dispatch("project.getSettings", { projectId: "project-1" })
-    ).resolves.toEqual({ ok: true, result: { theme: "dark" } });
     await expect(
       service.dispatch("project.detectRunners", { projectId: "project-1" })
     ).resolves.toEqual({ ok: true, result: { runners: ["dev"] } });
@@ -474,6 +470,56 @@ describe("project action hardening", () => {
     expect(openSettings).toEqual({ ok: true, result: undefined });
     expect(dispatchEvent).toHaveBeenCalledWith(expect.any(CustomEvent));
     expect(dispatchEvent.mock.calls.at(-1)?.[0].type).toBe("daintree:open-settings-tab");
+  });
+
+  // #11524: project.getSettings is not a passthrough — it projects to an
+  // agent-safe field set. Dispatching through the real ActionService is the
+  // point: nothing between run() and the MCP wire filters the result.
+  it("project.getSettings does not dispatch decrypted secrets or the icon blob", async () => {
+    mocks.projectClient.getSettings.mockResolvedValueOnce({
+      runCommands: [{ id: "r1", label: "dev", command: "npm run dev" }],
+      devServerCommand: "npm run dev",
+      environmentVariables: { STRIPE_SECRET_KEY: "sk-live-secret" },
+      secureEnvironmentVariables: ["STRIPE_SECRET_KEY"],
+      projectIconSvg: "<svg />",
+    });
+    const { service } = buildService(registerProjectActions);
+
+    const result = await service.dispatch("project.getSettings", { projectId: "project-1" });
+
+    expect(result.ok).toBe(true);
+    expect(result).toEqual({
+      ok: true,
+      result: {
+        runCommands: [{ id: "r1", label: "dev", command: "npm run dev" }],
+        devServerCommand: "npm run dev",
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain("sk-live-secret");
+  });
+
+  it("advertises an MCP output schema that omits the sensitive fields", async () => {
+    const { service } = buildService(registerProjectActions);
+
+    const entry = service.get("project.getSettings");
+
+    // The schema is documentation, not enforcement — but a schema that still
+    // advertised these fields would mean the exposure table had drifted.
+    expect(entry?.outputSchema).toBeDefined();
+    for (const exposed of ["runCommands", "worktreePathPattern", "notificationOverrides"]) {
+      expect(entry?.outputSchema).toHaveProperty(["properties", exposed]);
+    }
+    for (const hidden of [
+      "environmentVariables",
+      "secureEnvironmentVariables",
+      "insecureEnvironmentVariables",
+      "unresolvedSecureEnvironmentVariables",
+      "projectIconSvg",
+      "resourceEnvironments",
+      "daintreeMcpTier",
+    ]) {
+      expect(entry?.outputSchema).not.toHaveProperty(["properties", hidden]);
+    }
   });
 
   it("project.saveSettings merges partial input over current settings", async () => {

--- a/src/services/actions/__tests__/actionDefinitions.project-system-preferences.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.project-system-preferences.adversarial.test.ts
@@ -477,7 +477,7 @@ describe("project action hardening", () => {
   // point: nothing between run() and the MCP wire filters the result.
   it("project.getSettings does not dispatch decrypted secrets or the icon blob", async () => {
     mocks.projectClient.getSettings.mockResolvedValueOnce({
-      runCommands: [{ id: "r1", label: "dev", command: "npm run dev" }],
+      runCommands: [{ id: "r1", name: "dev", command: "npm run dev" }],
       devServerCommand: "npm run dev",
       environmentVariables: { STRIPE_SECRET_KEY: "sk-live-secret" },
       secureEnvironmentVariables: ["STRIPE_SECRET_KEY"],
@@ -491,7 +491,7 @@ describe("project action hardening", () => {
     expect(result).toEqual({
       ok: true,
       result: {
-        runCommands: [{ id: "r1", label: "dev", command: "npm run dev" }],
+        runCommands: [{ id: "r1", name: "dev", command: "npm run dev" }],
         devServerCommand: "npm run dev",
       },
     });
@@ -517,6 +517,7 @@ describe("project action hardening", () => {
       "projectIconSvg",
       "resourceEnvironments",
       "daintreeMcpTier",
+      "browserAllowedHosts",
     ]) {
       expect(entry?.outputSchema).not.toHaveProperty(["properties", hidden]);
     }

--- a/src/services/actions/definitions/__tests__/projectActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/projectActions.adversarial.test.ts
@@ -106,6 +106,90 @@ describe("projectActions adversarial", () => {
       const { run } = setupActions();
       await expect(run("project.getSettings", undefined)).rejects.toThrow("No active project");
     });
+
+    // #11524: this action sits on every MCP tier's allowlist, and
+    // ProjectSettingsManager resolves secure storage into `environmentVariables`
+    // in plaintext before returning. Returning the client payload verbatim
+    // handed agents the user's API keys.
+    it("strips secrets and bulk data from the settings it returns", async () => {
+      projectClientMock.getSettings.mockResolvedValue({
+        runCommands: [{ id: "r1", label: "dev", command: "npm run dev" }],
+        worktreePathPattern: "../{project}-{branch}",
+        notificationOverrides: { completedEnabled: false },
+        terminalSettings: { shell: "/bin/zsh", scrollbackLines: 5000 },
+        environmentVariables: { OPENAI_API_KEY: "sk-live-secret", PUBLIC_URL: "https://x.test" },
+        secureEnvironmentVariables: ["OPENAI_API_KEY"],
+        insecureEnvironmentVariables: ["LEGACY_TOKEN"],
+        unresolvedSecureEnvironmentVariables: ["ROTATED_KEY"],
+        projectIconSvg: "<svg>...250KB...</svg>",
+      });
+      const { run } = setupActions();
+
+      const result = await run("project.getSettings", { projectId: "proj-1" });
+
+      // Exact equality rather than key-by-key absence checks: this also proves
+      // nothing unexpected rode along, and that the operational fields survive
+      // untouched.
+      expect(result).toEqual({
+        runCommands: [{ id: "r1", label: "dev", command: "npm run dev" }],
+        worktreePathPattern: "../{project}-{branch}",
+        notificationOverrides: { completedEnabled: false },
+        terminalSettings: { shell: "/bin/zsh", scrollbackLines: 5000 },
+      });
+      // The secret must be absent from the payload entirely, not merely
+      // relocated under another key — serialize and search.
+      expect(JSON.stringify(result)).not.toContain("sk-live-secret");
+    });
+
+    it("drops internal and unclassified fields rather than forwarding them", async () => {
+      projectClientMock.getSettings.mockResolvedValue({
+        runCommands: [],
+        daintreeMcpTier: "system",
+        resourceEnvironments: { prod: { connect: "ssh -i ~/.ssh/id_ed25519 deploy@prod" } },
+        commandOverrides: [{ id: "c1" }],
+        preferredEditor: { command: "code" },
+        fleetSavedScopes: [{ kind: "snapshot", id: "s1" }],
+        gitInitDefaults: { createInitialCommit: true },
+        githubRemote: "origin",
+        devServerDismissed: true,
+        // A field nobody has classified yet: the projection is driven by the
+        // exposure table, so anything new defaults to hidden.
+        someFutureSetting: "should-not-leak",
+      });
+      const { run } = setupActions();
+
+      const result = await run("project.getSettings", { projectId: "proj-1" });
+
+      // Everything above except `runCommands` is classified internal, and the
+      // unclassified key has no entry at all — the projection keeps none of it.
+      expect(result).toEqual({ runCommands: [] });
+      expect(JSON.stringify(result)).not.toContain("id_ed25519");
+    });
+
+    it("returns a fresh object so the client's cached settings stay intact", async () => {
+      const cached = {
+        runCommands: [],
+        environmentVariables: { API_KEY: "sk-live-secret" },
+        projectIconSvg: "<svg />",
+      };
+      projectClientMock.getSettings.mockResolvedValue(cached);
+      const { run } = setupActions();
+
+      const result = await run("project.getSettings", { projectId: "proj-1" });
+
+      expect(result).not.toBe(cached);
+      // projectClient caches and hands the same object to the settings UI, which
+      // needs the full payload — filtering in place would corrupt it.
+      expect(cached.environmentVariables).toEqual({ API_KEY: "sk-live-secret" });
+      expect(cached.projectIconSvg).toBe("<svg />");
+    });
+
+    it("projects an empty object when the project has no persisted settings", async () => {
+      projectClientMock.getSettings.mockResolvedValue(undefined);
+      const { run } = setupActions();
+
+      await expect(run("project.getSettings", { projectId: "proj-1" })).resolves.toEqual({});
+    });
   });
 
   describe("project.detectRunners", () => {

--- a/src/services/actions/definitions/__tests__/projectActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/projectActions.adversarial.test.ts
@@ -30,6 +30,7 @@ import { registerProjectActions } from "../projectActions";
 
 function setupActions(): {
   run: (id: string, args?: unknown, ctx?: Record<string, unknown>) => Promise<unknown>;
+  define: (id: string) => AnyActionDefinition;
 } {
   const actions: ActionRegistry = new Map();
   const callbacks: ActionCallbacks = {
@@ -37,13 +38,14 @@ function setupActions(): {
     onConfirmCloseActiveProject: vi.fn(),
   } as unknown as ActionCallbacks;
   registerProjectActions(actions, callbacks);
+  const define = (id: string): AnyActionDefinition => {
+    const factory = actions.get(id);
+    if (!factory) throw new Error(`missing ${id}`);
+    return factory() as AnyActionDefinition;
+  };
   return {
-    run: async (id, args, ctx) => {
-      const factory = actions.get(id);
-      if (!factory) throw new Error(`missing ${id}`);
-      const def = factory() as AnyActionDefinition;
-      return def.run(args, (ctx ?? {}) as never);
-    },
+    define,
+    run: async (id, args, ctx) => define(id).run(args, (ctx ?? {}) as never),
   };
 }
 
@@ -223,6 +225,24 @@ describe("projectActions adversarial", () => {
       await expect(run("project.getSettings", { projectId: "proj-1" })).resolves.toEqual({
         runCommands: [],
       });
+    });
+
+    // The codec validates only `id` and `command`, so a hand-edited settings.json
+    // can persist a nameless run command. `mcpOutputSchema` is on, so clients may
+    // validate structuredContent against the advertised schema — the projection
+    // must not invent a name, and the schema must not demand one.
+    it("emits a nameless run command that the advertised output schema accepts", async () => {
+      projectClientMock.getSettings.mockResolvedValue({
+        runCommands: [{ id: "r1", command: "npm run dev" }],
+      });
+      const { run, define } = setupActions();
+
+      const result = await run("project.getSettings", { projectId: "proj-1" });
+
+      expect(result).toEqual({ runCommands: [{ id: "r1", command: "npm run dev" }] });
+      const schema = define("project.getSettings").resultSchema;
+      expect(schema).toBeDefined();
+      expect(() => schema?.parse(result)).not.toThrow();
     });
   });
 

--- a/src/services/actions/definitions/__tests__/projectActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/projectActions.adversarial.test.ts
@@ -113,7 +113,7 @@ describe("projectActions adversarial", () => {
     // handed agents the user's API keys.
     it("strips secrets and bulk data from the settings it returns", async () => {
       projectClientMock.getSettings.mockResolvedValue({
-        runCommands: [{ id: "r1", label: "dev", command: "npm run dev" }],
+        runCommands: [{ id: "r1", name: "dev", command: "npm run dev" }],
         worktreePathPattern: "../{project}-{branch}",
         notificationOverrides: { completedEnabled: false },
         terminalSettings: { shell: "/bin/zsh", scrollbackLines: 5000 },
@@ -131,7 +131,7 @@ describe("projectActions adversarial", () => {
       // nothing unexpected rode along, and that the operational fields survive
       // untouched.
       expect(result).toEqual({
-        runCommands: [{ id: "r1", label: "dev", command: "npm run dev" }],
+        runCommands: [{ id: "r1", name: "dev", command: "npm run dev" }],
         worktreePathPattern: "../{project}-{branch}",
         notificationOverrides: { completedEnabled: false },
         terminalSettings: { shell: "/bin/zsh", scrollbackLines: 5000 },
@@ -152,6 +152,7 @@ describe("projectActions adversarial", () => {
         gitInitDefaults: { createInitialCommit: true },
         githubRemote: "origin",
         devServerDismissed: true,
+        browserAllowedHosts: ["internal.corp.test"],
         // A field nobody has classified yet: the projection is driven by the
         // exposure table, so anything new defaults to hidden.
         someFutureSetting: "should-not-leak",
@@ -164,6 +165,34 @@ describe("projectActions adversarial", () => {
       // unclassified key has no entry at all — the projection keeps none of it.
       expect(result).toEqual({ runCommands: [] });
       expect(JSON.stringify(result)).not.toContain("id_ed25519");
+      expect(JSON.stringify(result)).not.toContain("internal.corp.test");
+    });
+
+    // The codec keeps each run command whole after validating only `id` and
+    // `command`, so an entry carrying extra persisted keys would otherwise ride
+    // along inside an exposed field.
+    it("projects run command entries down to their known fields", async () => {
+      projectClientMock.getSettings.mockResolvedValue({
+        runCommands: [
+          {
+            id: "r1",
+            name: "deploy",
+            command: "npm run deploy",
+            preferredLocation: "dock",
+            deployToken: "sk-live-secret",
+          },
+        ],
+      });
+      const { run } = setupActions();
+
+      const result = await run("project.getSettings", { projectId: "proj-1" });
+
+      expect(result).toEqual({
+        runCommands: [
+          { id: "r1", name: "deploy", command: "npm run deploy", preferredLocation: "dock" },
+        ],
+      });
+      expect(JSON.stringify(result)).not.toContain("sk-live-secret");
     });
 
     it("returns a fresh object so the client's cached settings stay intact", async () => {
@@ -184,11 +213,16 @@ describe("projectActions adversarial", () => {
       expect(cached.projectIconSvg).toBe("<svg />");
     });
 
-    it("projects an empty object when the project has no persisted settings", async () => {
+    // runCommands is required by both ProjectSettings and the advertised output
+    // schema, so a missing payload must still satisfy it rather than yielding a
+    // result a validating MCP client would reject.
+    it("still satisfies the required runCommands field with no persisted settings", async () => {
       projectClientMock.getSettings.mockResolvedValue(undefined);
       const { run } = setupActions();
 
-      await expect(run("project.getSettings", { projectId: "proj-1" })).resolves.toEqual({});
+      await expect(run("project.getSettings", { projectId: "proj-1" })).resolves.toEqual({
+        runCommands: [],
+      });
     });
   });
 

--- a/src/services/actions/definitions/projectActions.ts
+++ b/src/services/actions/definitions/projectActions.ts
@@ -22,7 +22,18 @@ import { formatErrorMessage } from "@shared/utils/errorMessage";
  * `pickAgentVisibleProjectSettings` in `run()`.
  */
 const agentVisibleProjectSettingsShape: Record<AgentVisibleProjectSettingsKey, z.ZodType> = {
-  runCommands: z.array(z.unknown()),
+  runCommands: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      command: z.string(),
+      icon: z.string().optional(),
+      description: z.string().optional(),
+      preferredLocation: z.enum(["dock", "grid"]).optional(),
+      preferredAutoRestart: z.boolean().optional(),
+      isFrameworkDefault: z.boolean().optional(),
+    })
+  ),
   excludedPaths: z.array(z.string()).optional(),
   defaultWorktreeRecipeId: z.string().optional(),
   devServerCommand: z.string().optional(),
@@ -45,7 +56,6 @@ const agentVisibleProjectSettingsShape: Record<AgentVisibleProjectSettingsKey, z
   notificationOverrides: z.record(z.string(), z.unknown()).optional(),
   activeResourceEnvironment: z.string().optional(),
   defaultWorktreeMode: z.string().optional(),
-  browserAllowedHosts: z.array(z.string()).optional(),
 };
 
 export function registerProjectActions(actions: ActionRegistry, callbacks: ActionCallbacks): void {
@@ -244,7 +254,7 @@ export function registerProjectActions(actions: ActionRegistry, callbacks: Actio
     id: "project.getSettings",
     title: "Get Project Settings",
     description:
-      "Read the operational subset of a project's persisted settings (run commands, dev server command, worktree path pattern, branch prefix, forge remote, notification overrides, terminal overrides, etc.). Args: `projectId` (optional) — a project id from `project.getAll` (the `id` field); defaults to the active project's id. Returns only that fixed field set: environment variables (including secure ones), the project icon SVG, resource environment definitions, the MCP access tier, and renderer-only UI preferences are deliberately omitted and cannot be read through this action. Errors when no projectId is given and no project is active.",
+      "Read the operational subset of a project's persisted settings (run commands, dev server command, worktree path pattern, branch prefix, forge remote, notification overrides, terminal overrides, etc.). Args: `projectId` (optional) — a project id from `project.getAll` (the `id` field); defaults to the active project's id. Returns only that fixed field set: environment variables (including secure ones), the project icon SVG, resource environment definitions, access-control state (MCP tier, browser allow-list), and renderer-only UI preferences are deliberately omitted and cannot be read through this action. Errors when no projectId is given and no project is active.",
     category: "project",
     kind: "query",
     danger: "safe",

--- a/src/services/actions/definitions/projectActions.ts
+++ b/src/services/actions/definitions/projectActions.ts
@@ -1,6 +1,7 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import type { ActionContext } from "@shared/types/actions";
-import type { ProjectSettings } from "@shared/types";
+import type { AgentVisibleProjectSettingsKey, ProjectSettings } from "@shared/types";
+import { pickAgentVisibleProjectSettings } from "@shared/types";
 import { z } from "zod";
 import { projectClient } from "@/clients";
 import { useProjectStore } from "@/store/projectStore";
@@ -9,6 +10,43 @@ import { notify, EVENT_KIND_TO_SETTING_KEY, EVENT_KIND_LABEL } from "@/lib/notif
 import type { NotificationEventKind } from "@/lib/notify";
 import { switchToLastProject } from "@/lib/projectHistoryNav";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+
+/**
+ * Wire shape of `project.getSettings`.
+ *
+ * Typing the shape as `Record<AgentVisibleProjectSettingsKey, z.ZodType>` is what keeps
+ * this honest: omitting a key classified `exposed`, or adding one that isn't, is a
+ * compile error, so the advertised schema cannot drift from
+ * `PROJECT_SETTINGS_AGENT_EXPOSURE`. The schema is documentation only —
+ * `ActionService.dispatch` never parses results — so the actual filtering is done by
+ * `pickAgentVisibleProjectSettings` in `run()`.
+ */
+const agentVisibleProjectSettingsShape: Record<AgentVisibleProjectSettingsKey, z.ZodType> = {
+  runCommands: z.array(z.unknown()),
+  excludedPaths: z.array(z.string()).optional(),
+  defaultWorktreeRecipeId: z.string().optional(),
+  devServerCommand: z.string().optional(),
+  devServerLoadTimeout: z.number().optional(),
+  turbopackEnabled: z.boolean().optional(),
+  copyTreeSettings: z.record(z.string(), z.unknown()).optional(),
+  branchPrefixMode: z.enum(["none", "username", "custom"]).optional(),
+  branchPrefixCustom: z.string().optional(),
+  forgeRemote: z.string().optional(),
+  forgeProviderOverride: z.string().nullable().optional(),
+  worktreePathPattern: z.string().optional(),
+  terminalSettings: z
+    .object({
+      shell: z.string().optional(),
+      shellArgs: z.array(z.string()).optional(),
+      defaultWorkingDirectory: z.string().optional(),
+      scrollbackLines: z.number().optional(),
+    })
+    .optional(),
+  notificationOverrides: z.record(z.string(), z.unknown()).optional(),
+  activeResourceEnvironment: z.string().optional(),
+  defaultWorktreeMode: z.string().optional(),
+  browserAllowedHosts: z.array(z.string()).optional(),
+};
 
 export function registerProjectActions(actions: ActionRegistry, callbacks: ActionCallbacks): void {
   actions.set("project.switcherPalette", () => ({
@@ -206,18 +244,26 @@ export function registerProjectActions(actions: ActionRegistry, callbacks: Actio
     id: "project.getSettings",
     title: "Get Project Settings",
     description:
-      "Read a project's persisted settings (notification overrides, runner config, worktree path pattern, etc.). Args: `projectId` (optional) — a project id from `project.getAll` (the `id` field); defaults to the active project's id. Returns the settings object as an open-ended key/value map. Errors when no projectId is given and no project is active.",
+      "Read the operational subset of a project's persisted settings (run commands, dev server command, worktree path pattern, branch prefix, forge remote, notification overrides, terminal overrides, etc.). Args: `projectId` (optional) — a project id from `project.getAll` (the `id` field); defaults to the active project's id. Returns only that fixed field set: environment variables (including secure ones), the project icon SVG, resource environment definitions, the MCP access tier, and renderer-only UI preferences are deliberately omitted and cannot be read through this action. Errors when no projectId is given and no project is active.",
     category: "project",
     kind: "query",
     danger: "safe",
     scope: "renderer",
     argsSchema: z.object({ projectId: z.string().optional() }).optional(),
-    resultSchema: z.object({}).catchall(z.unknown()),
+    resultSchema: z.object(agentVisibleProjectSettingsShape),
+    mcpOutputSchema: true,
     run: async (args: unknown, ctx: ActionContext) => {
       const { projectId } = (args ?? {}) as { projectId?: string };
       const resolvedProjectId = projectId ?? ctx.projectId;
       if (!resolvedProjectId) throw new Error("No active project");
-      return await projectClient.getSettings(resolvedProjectId);
+      const settings = await projectClient.getSettings(resolvedProjectId);
+      // Project down to the agent-safe field set before returning. This action is on
+      // every MCP tier's allowlist, and the settings payload carries decrypted secure
+      // env vars (ProjectSettingsManager resolves them) plus a 250KB icon blob.
+      // `resultSchema` cannot do this — dispatch never validates results — so the
+      // filtering has to happen here, on a fresh object (projectClient caches the value
+      // it returns and the renderer's settings UI legitimately needs the full payload).
+      return pickAgentVisibleProjectSettings(settings);
     },
   }));
 

--- a/src/services/actions/definitions/projectActions.ts
+++ b/src/services/actions/definitions/projectActions.ts
@@ -25,7 +25,12 @@ const agentVisibleProjectSettingsShape: Record<AgentVisibleProjectSettingsKey, z
   runCommands: z.array(
     z.object({
       id: z.string(),
-      name: z.string(),
+      // Only `id` and `command` are codec-guaranteed: `decode` in
+      // projectSettingsCodec admits any entry with those two as strings, and the
+      // projection copies through only the keys that are present. Advertising
+      // `name` as required would make a nameless persisted entry emit
+      // `structuredContent` that violates this schema.
+      name: z.string().optional(),
       command: z.string(),
       icon: z.string().optional(),
       description: z.string().optional(),


### PR DESCRIPTION
## Summary

`project.getSettings` sits on the allowlist for every MCP tier (workbench via `shared/config/helpAssistantTierAllowlists.ts`, external via `electron/services/mcp-server/shared.ts`) and was returning `projectClient.getSettings()` verbatim. `ProjectSettingsManager` resolves secure storage into `environmentVariables` in plaintext before returning it, so any MCP caller could read every API key a user had deliberately moved out of `settings.json`. It also shipped `projectIconSvg`, up to 250KB of markup, on every call.

The obvious fix, narrowing the action's `resultSchema`, doesn't work: the schema is documentation only. `ActionService.dispatch` returns `run()`'s value unvalidated, and `tierAuth`'s `buildStructuredContent` just casts it onto the wire. Narrowing the schema changes nothing at runtime, and this exact half-fix already shipped once in #10870. The filtering has to happen inside `run()`.

Resolves #11524

## Changes

- Added `PROJECT_SETTINGS_AGENT_EXPOSURE` in `shared/types/project.ts`, typed `satisfies Record<keyof ProjectSettings, ...>` and mirroring the existing `PROJECT_SETTINGS_SHAREABILITY` idiom, so adding a new `ProjectSettings` field without classifying it is now a compile error.
- Added `pickAgentVisibleProjectSettings`, which iterates the table rather than the payload so unknown or future fields fail closed, and builds a fresh object rather than filtering in place, since `projectClient` caches the returned value and the settings UI needs the full payload.
- Hidden from agents: the four environment-variable fields, `projectIconSvg`, `resourceEnvironments` (raw provision/connect shell strings that routinely embed credentials), `daintreeMcpTier` and `browserAllowedHosts` (access-control state), renderer-only UI state, and deprecated aliases.
- Run commands get their own nested pass: the settings codec keeps each entry whole after checking only `id` and `command`, so an entry with extra persisted keys would otherwise ride along inside an exposed field.
- Replaced `resultSchema` with the exact exposed field set, now advertised via `mcpOutputSchema`, typed `Record<AgentVisibleProjectSettingsKey, z.ZodType>` so it can't drift from the table.
- Deliberate call: `runCommands`, `devServerCommand`, and `terminalSettings` stay exposed even though a user could inline a credential into a command string. They're the runner config this action exists to report, and unlike `resourceEnvironments` they describe local repo commands rather than remote access. That residual exposure is documented in the table.

## Testing

Dispatch-level regression tests confirm a mocked payload's secrets are absent from the result (exact `toEqual` assertions plus a serialize-and-search for the secret value), that unclassified fields are dropped, that the client's cached object isn't mutated, and that the advertised `outputSchema` omits the sensitive field names. 388 tests pass across the affected modules; typecheck and scoped lint/format are clean.

## Follow-ups found, not fixed here

Each of these is a separate pre-existing issue:

- `agentSettings.get` returns `customPresets[].env` and `globalEnv` at the workbench tier.
- Sandboxed plugins can dispatch `env.project.get`/`env.global.get` directly, since neither sets `denyPluginDispatch`.
- Action and external tiers can read any env var via a spawned terminal plus `terminal.getOutput`.
- `project.saveSettings` takes an unrestricted record and can wipe every secure-storage key.
- CopyTree injects the raw `resourceConnectCommand` into agent terminals.
- `worktree.resource.status` can echo secrets from command output.
- The MCP audit-log redactor's key pattern misses "passphrase".
