### PR TITLE
fix(mcp): cap tools/call result size

### DIFF
--- a/electron/services/__tests__/McpServerService.lifecycleAndElicitation.test.ts
+++ b/electron/services/__tests__/McpServerService.lifecycleAndElicitation.test.ts
@@ -996,7 +996,7 @@ describe("McpServerService", () => {
       // The self-declared elicitation capability is never exercised.
       expect(onElicit).not.toHaveBeenCalled();
       expect(result.isError).not.toBe(true);
-      expect(result.content[0].text).toContain('"deleted": true');
+      expect(JSON.parse(result.content[0].text)).toEqual({ deleted: true });
       // Exactly one dispatch, sent UNCONFIRMED — the renderer owns the confirm.
       expect(dispatchMock).toHaveBeenCalledTimes(1);
       expect(dispatchMock).toHaveBeenNthCalledWith(

--- a/electron/services/__tests__/McpServerService.transportAndSchema.test.ts
+++ b/electron/services/__tests__/McpServerService.transportAndSchema.test.ts
@@ -552,7 +552,7 @@ describe("McpServerService", () => {
     );
 
     expect(result.isError).not.toBe(true);
-    expect(result.content[0].text).toContain('"self": "[Circular]"');
+    expect(JSON.parse(result.content[0].text)).toEqual({ ok: true, self: "[Circular]" });
   });
 
   it("routes IPC bounce to the active project view, not the host shell", async () => {
@@ -1051,7 +1051,7 @@ describe("McpServerService", () => {
       };
 
       expect(result.structuredContent).toBeUndefined();
-      expect(result.content[0]?.text).toContain('"foo": "bar"');
+      expect(JSON.parse(result.content[0]!.text)).toMatchObject({ foo: "bar" });
     });
 
     it("warms the manifest cache and emits structuredContent on a cold callTool (no prior listTools)", async () => {
@@ -1085,7 +1085,7 @@ describe("McpServerService", () => {
       };
 
       expect(result.structuredContent).toEqual({ count: 1, label: "cold" });
-      expect(result.content[0]?.text).toContain('"label": "cold"');
+      expect(JSON.parse(result.content[0]!.text)).toEqual({ count: 1, label: "cold" });
     });
 
     it("does not emit structuredContent on failed tool calls", async () => {

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -2778,7 +2778,60 @@ describe("structuredContent for terminal query actions (#10676)", () => {
       );
       const result = await callTool(server, { name: "terminal.list", arguments: {} });
 
-      expect((result as { isError?: boolean }).isError).toBeUndefined();
+      expect((result as { isError?: boolean }).isError).not.toBe(true);
+    });
+
+    it("caps an error envelope whose renderer-supplied details is oversized", async () => {
+      // `details` crosses from the renderer unbounded, so failures reach the
+      // same oversized-response bug the success path just closed.
+      const server = createSessionServer(
+        "sc-oversized-error",
+        fakeDeps({
+          sessionStore: fakeSessionStore("external"),
+          getFullToolSurface: vi.fn(() => true),
+          requestManifest: vi.fn().mockResolvedValue([makeManifestEntry("terminal.list")]),
+          dispatchAction: vi.fn().mockResolvedValue({
+            result: {
+              ok: false,
+              error: {
+                code: "EXECUTION_ERROR",
+                message: "boom",
+                details: { trace: "x".repeat(TOOL_RESULT_TEXT_MAX_BYTES * 2) },
+              },
+            },
+          }),
+        })
+      );
+      const result = await callTool(server, { name: "terminal.list", arguments: {} });
+
+      expect((result as { isError?: boolean }).isError).toBe(true);
+      expect(Buffer.byteLength(textOf(result), "utf8")).toBeLessThanOrEqual(
+        TOOL_RESULT_TEXT_MAX_BYTES
+      );
+      expect(textOf(result).startsWith("[Tool result truncated:")).toBe(true);
+    });
+
+    it("keeps the batched-wait short-circuit intact below the cap", async () => {
+      // The only converted call site with no other result-path coverage.
+      const payload = { results: [{ terminalId: "t-1", idle: true }], timedOut: false };
+      const server = createSessionServer(
+        "sc-batch-wait",
+        fakeDeps({
+          sessionStore: fakeSessionStore("external"),
+          getFullToolSurface: vi.fn(() => true),
+          requestManifest: vi
+            .fn()
+            .mockResolvedValue([makeManifestEntry("terminal.waitUntilIdleBatch")]),
+          handleWaitUntilIdleBatch: vi.fn().mockResolvedValue(payload),
+        })
+      );
+      const result = await callTool(server, {
+        name: "terminal.waitUntilIdleBatch",
+        arguments: { terminalIds: ["t-1"] },
+      });
+
+      expect(JSON.parse(textOf(result))).toEqual(payload);
+      expect(structuredOf(result)).toEqual(payload);
     });
 
     it("caps a main-process short-circuit that attaches structuredContent unconditionally", async () => {

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -2843,7 +2843,12 @@ describe("structuredContent for terminal query actions (#10676)", () => {
           sessionStore: fakeSessionStore("external"),
           getFullToolSurface: vi.fn(() => true),
           requestManifest: vi.fn().mockResolvedValue([makeManifestEntry("skills.load")]),
-          handleSkillsLoad: vi.fn(() => oversizedPayload()),
+          handleSkillsLoad: vi.fn(() => ({
+            id: "s-1",
+            name: "Oversized",
+            description: "A skill whose markdown body blows the budget",
+            body: "x".repeat(TOOL_RESULT_TEXT_MAX_BYTES * 2),
+          })),
         })
       );
       const result = await callTool(server, {

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -28,6 +28,7 @@ import {
   minimumPermittingTier,
   unwrapDispatchResult,
 } from "../shared.js";
+import { TOOL_RESULT_TEXT_MAX_BYTES } from "../toolCallResult.js";
 import { SessionBindingError, RendererBridgeUnavailableError } from "../rendererBridge.js";
 import { getAgentAvailabilityStore } from "../../AgentAvailabilityStore.js";
 import { events } from "../../events.js";
@@ -2737,5 +2738,70 @@ describe("structuredContent for terminal query actions (#10676)", () => {
 
     expect(structuredOf(result)).toBeUndefined();
     expect(JSON.parse(textOf(result))).toEqual(payload);
+  });
+
+  describe("oversized results are capped on the wire (#11526)", () => {
+    function oversizedPayload() {
+      return { terminals: [{ id: "t-1", content: "x".repeat(TOOL_RESULT_TEXT_MAX_BYTES * 2) }] };
+    }
+
+    it("truncates the text body of a dispatched result to the byte budget", async () => {
+      const server = createSessionServer(
+        "sc-oversized",
+        deps("terminal.getOutput", oversizedPayload())
+      );
+      const result = await callTool(server, {
+        name: "terminal.getOutput",
+        arguments: { terminalId: "t-1" },
+      });
+
+      expect(Buffer.byteLength(textOf(result), "utf8")).toBeLessThanOrEqual(
+        TOOL_RESULT_TEXT_MAX_BYTES
+      );
+      expect(textOf(result).startsWith("[Tool result truncated:")).toBe(true);
+    });
+
+    it("drops structuredContent above the cap so the duplicate cannot smuggle the payload", async () => {
+      const server = createSessionServer(
+        "sc-oversized-structured",
+        deps("terminal.list", oversizedPayload())
+      );
+      const result = await callTool(server, { name: "terminal.list", arguments: {} });
+
+      expect(structuredOf(result)).toBeUndefined();
+    });
+
+    it("does not report a capped result as a failed call", async () => {
+      const server = createSessionServer(
+        "sc-oversized-ok",
+        deps("terminal.list", oversizedPayload())
+      );
+      const result = await callTool(server, { name: "terminal.list", arguments: {} });
+
+      expect((result as { isError?: boolean }).isError).toBeUndefined();
+    });
+
+    it("caps a main-process short-circuit that attaches structuredContent unconditionally", async () => {
+      // skills.load never consults buildStructuredContent, so it needs the cap
+      // applied at its own return site rather than via the outputSchema gate.
+      const server = createSessionServer(
+        "sc-oversized-skills",
+        fakeDeps({
+          sessionStore: fakeSessionStore("external"),
+          getFullToolSurface: vi.fn(() => true),
+          requestManifest: vi.fn().mockResolvedValue([makeManifestEntry("skills.load")]),
+          handleSkillsLoad: vi.fn(() => oversizedPayload()),
+        })
+      );
+      const result = await callTool(server, {
+        name: "skills.load",
+        arguments: { id: "s-1" },
+      });
+
+      expect(Buffer.byteLength(textOf(result), "utf8")).toBeLessThanOrEqual(
+        TOOL_RESULT_TEXT_MAX_BYTES
+      );
+      expect(structuredOf(result)).toBeUndefined();
+    });
   });
 });

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -2771,14 +2771,31 @@ describe("structuredContent for terminal query actions (#10676)", () => {
       expect(structuredOf(result)).toBeUndefined();
     });
 
-    it("does not report a capped result as a failed call", async () => {
+    it("flags a capped result whose tool declares an output schema", async () => {
+      // structuredContent is present exactly when the entry declares an
+      // outputSchema, and a client with that schema rejects a response carrying
+      // neither it nor isError — the notice would never reach the agent.
       const server = createSessionServer(
-        "sc-oversized-ok",
+        "sc-oversized-flagged",
         deps("terminal.list", oversizedPayload())
       );
       const result = await callTool(server, { name: "terminal.list", arguments: {} });
 
+      expect((result as { isError?: boolean }).isError).toBe(true);
+      expect(textOf(result)).toContain("Tool result truncated");
+    });
+
+    it("leaves a capped result unflagged when the tool declares no output schema", async () => {
+      // Nothing was promised, so nothing is missing — a shortened body is still a
+      // successful call.
+      const server = createSessionServer(
+        "sc-oversized-ok",
+        deps("terminal.list", oversizedPayload(), false)
+      );
+      const result = await callTool(server, { name: "terminal.list", arguments: {} });
+
       expect((result as { isError?: boolean }).isError).not.toBe(true);
+      expect(textOf(result)).toContain("Tool result truncated");
     });
 
     it("caps an error envelope whose renderer-supplied details is oversized", async () => {
@@ -2788,7 +2805,6 @@ describe("structuredContent for terminal query actions (#10676)", () => {
         "sc-oversized-error",
         fakeDeps({
           sessionStore: fakeSessionStore("external"),
-          getFullToolSurface: vi.fn(() => true),
           requestManifest: vi.fn().mockResolvedValue([makeManifestEntry("terminal.list")]),
           dispatchAction: vi.fn().mockResolvedValue({
             result: {
@@ -2818,7 +2834,6 @@ describe("structuredContent for terminal query actions (#10676)", () => {
         "sc-batch-wait",
         fakeDeps({
           sessionStore: fakeSessionStore("external"),
-          getFullToolSurface: vi.fn(() => true),
           requestManifest: vi
             .fn()
             .mockResolvedValue([makeManifestEntry("terminal.waitUntilIdleBatch")]),
@@ -2841,7 +2856,6 @@ describe("structuredContent for terminal query actions (#10676)", () => {
         "sc-oversized-skills",
         fakeDeps({
           sessionStore: fakeSessionStore("external"),
-          getFullToolSurface: vi.fn(() => true),
           requestManifest: vi.fn().mockResolvedValue([makeManifestEntry("skills.load")]),
           handleSkillsLoad: vi.fn(() => ({
             id: "s-1",

--- a/electron/services/mcp-server/__tests__/skills.test.ts
+++ b/electron/services/mcp-server/__tests__/skills.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from "vitest";
+import { McpError } from "@modelcontextprotocol/sdk/types.js";
+
+vi.mock("../../plugin/PluginSkillRegistry.js", () => ({
+  searchPluginSkills: vi.fn(() => []),
+  loadPluginSkill: vi.fn(() => undefined),
+}));
+
+import { handleSkillsLoad } from "../skills.js";
+
+describe("handleSkillsLoad unknown-id error", () => {
+  it("does not reflect an unbounded id back to the caller", () => {
+    // This message becomes a JSON-RPC error, which never passes through the
+    // tools/call response budget — echoing the argument verbatim would let a
+    // megabyte-long id produce a megabyte-long error (#11526).
+    const id = "x".repeat(1_000_000);
+
+    expect(() => handleSkillsLoad({ id })).toThrow(McpError);
+    try {
+      handleSkillsLoad({ id });
+    } catch (err) {
+      expect((err as McpError).message.length).toBeLessThan(1_000);
+    }
+  });
+
+  it("still names a realistic id in full so the error stays actionable", () => {
+    expect(() => handleSkillsLoad({ id: "acme.plugin.tdd" })).toThrow(/acme\.plugin\.tdd/);
+  });
+});

--- a/electron/services/mcp-server/__tests__/toolCallResult.test.ts
+++ b/electron/services/mcp-server/__tests__/toolCallResult.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import {
+  TOOL_RESULT_TEXT_MAX_BYTES,
+  buildToolCallResult,
+  buildToolCallTextResult,
+} from "../toolCallResult.js";
+
+const META_KEY = "anthropic/maxResultSizeChars";
+
+function textOf(result: { content: { type: string; text?: string }[] }): string {
+  return result.content[0]?.text ?? "";
+}
+
+function byteLength(result: { content: { type: string; text?: string }[] }): number {
+  return Buffer.byteLength(textOf(result), "utf8");
+}
+
+/** Serializes to just over `bytes` once compacted, without a huge allocation. */
+function payloadOfAtLeast(bytes: number): { blob: string } {
+  return { blob: "x".repeat(bytes) };
+}
+
+describe("buildToolCallResult under the cap", () => {
+  it("emits compact JSON with no cosmetic indentation", () => {
+    const result = buildToolCallResult({ a: 1, b: { c: 2 } });
+    expect(textOf(result)).toBe('{"a":1,"b":{"c":2}}');
+  });
+
+  it("round-trips the payload and keeps structuredContent alongside it", () => {
+    const payload = { terminals: [{ id: "t-1", isFocused: true }] };
+    const result = buildToolCallResult(payload, { structuredContent: payload });
+
+    expect(JSON.parse(textOf(result))).toEqual(payload);
+    expect(result.structuredContent).toEqual(payload);
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("omits structuredContent when the caller supplies none", () => {
+    const result = buildToolCallResult({ a: 1 });
+    expect(result.structuredContent).toBeUndefined();
+  });
+
+  it("preserves the 'OK' body for null and undefined results", () => {
+    expect(textOf(buildToolCallResult(null))).toBe("OK");
+    expect(textOf(buildToolCallResult(undefined))).toBe("OK");
+  });
+
+  it("advertises the ceiling so clients do not re-truncate a bounded response", () => {
+    const result = buildToolCallResult({ a: 1 });
+    expect(result._meta?.[META_KEY]).toBe(TOOL_RESULT_TEXT_MAX_BYTES);
+  });
+
+  it("leaves a body sitting exactly on the limit untouched", () => {
+    const exact = "y".repeat(TOOL_RESULT_TEXT_MAX_BYTES);
+    const result = buildToolCallTextResult(exact);
+
+    expect(textOf(result)).toBe(exact);
+    expect(byteLength(result)).toBe(TOOL_RESULT_TEXT_MAX_BYTES);
+  });
+});
+
+describe("buildToolCallResult over the cap", () => {
+  it("truncates one byte past the limit", () => {
+    const result = buildToolCallTextResult("y".repeat(TOOL_RESULT_TEXT_MAX_BYTES + 1));
+    expect(textOf(result)).toContain("Tool result truncated");
+  });
+
+  it("keeps the notice and payload together within the byte budget", () => {
+    const result = buildToolCallResult(payloadOfAtLeast(TOOL_RESULT_TEXT_MAX_BYTES * 4));
+    expect(byteLength(result)).toBeLessThanOrEqual(TOOL_RESULT_TEXT_MAX_BYTES);
+  });
+
+  it("leads with the notice so a client trimming the tail cannot hide it", () => {
+    const result = buildToolCallResult(payloadOfAtLeast(TOOL_RESULT_TEXT_MAX_BYTES * 2));
+    expect(textOf(result).startsWith("[Tool result truncated:")).toBe(true);
+  });
+
+  it("reports the delivered and original sizes honestly", () => {
+    const payload = payloadOfAtLeast(TOOL_RESULT_TEXT_MAX_BYTES * 2);
+    const originalBytes = Buffer.byteLength(JSON.stringify(payload), "utf8");
+    const text = textOf(buildToolCallResult(payload));
+
+    const notice = /^\[Tool result truncated: showing (\d+) of (\d+) UTF-8 bytes\./.exec(text);
+    expect(notice).not.toBeNull();
+    expect(Number(notice![2])).toBe(originalBytes);
+
+    // The reported "showing" count must match the payload that actually follows
+    // the notice, or the model is being told something false about its data.
+    const body = text.slice(text.indexOf("]\n\n") + 3);
+    expect(Number(notice![1])).toBe(Buffer.byteLength(body, "utf8"));
+  });
+
+  it("drops structuredContent so the unbounded duplicate does not defeat the cap", () => {
+    const payload = payloadOfAtLeast(TOOL_RESULT_TEXT_MAX_BYTES * 2);
+    const result = buildToolCallResult(payload, { structuredContent: payload });
+    expect(result.structuredContent).toBeUndefined();
+  });
+
+  it("does not mark a truncated success as an error", () => {
+    const result = buildToolCallResult(payloadOfAtLeast(TOOL_RESULT_TEXT_MAX_BYTES * 2));
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("cuts on a character boundary instead of emitting a replacement char", () => {
+    // 4-byte astral chars tile the buffer so the budget lands mid-character.
+    const result = buildToolCallTextResult("🌳".repeat(TOOL_RESULT_TEXT_MAX_BYTES / 2));
+
+    expect(textOf(result)).not.toContain("�");
+    expect(byteLength(result)).toBeLessThanOrEqual(TOOL_RESULT_TEXT_MAX_BYTES);
+  });
+
+  it("still advertises the ceiling on a truncated response", () => {
+    const result = buildToolCallResult(payloadOfAtLeast(TOOL_RESULT_TEXT_MAX_BYTES * 2));
+    expect(result._meta?.[META_KEY]).toBe(TOOL_RESULT_TEXT_MAX_BYTES);
+  });
+});
+
+describe("error envelopes", () => {
+  it("preserves isError through truncation", () => {
+    const result = buildToolCallTextResult("y".repeat(TOOL_RESULT_TEXT_MAX_BYTES * 2), {
+      isError: true,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(byteLength(result)).toBeLessThanOrEqual(TOOL_RESULT_TEXT_MAX_BYTES);
+  });
+
+  it("leaves a small error body parseable", () => {
+    const payload = { code: "EXECUTION_ERROR", message: "boom" };
+    const result = buildToolCallTextResult(JSON.stringify(payload), { isError: true });
+    expect(JSON.parse(textOf(result))).toEqual(payload);
+  });
+});
+
+describe("SDK conformance", () => {
+  it("produces results the SDK schema accepts, capped or not", () => {
+    expect(CallToolResultSchema.safeParse(buildToolCallResult({ a: 1 })).success).toBe(true);
+    expect(
+      CallToolResultSchema.safeParse(
+        buildToolCallResult(payloadOfAtLeast(TOOL_RESULT_TEXT_MAX_BYTES * 2))
+      ).success
+    ).toBe(true);
+  });
+});

--- a/electron/services/mcp-server/__tests__/toolCallResult.test.ts
+++ b/electron/services/mcp-server/__tests__/toolCallResult.test.ts
@@ -29,7 +29,7 @@ function bodyAfterNotice(text: string): string {
 describe("buildToolCallResult under the cap", () => {
   it("serializes without the indentation the wire has no reader for", () => {
     const value = { a: 1, b: { c: 2 }, d: [1, 2] };
-    expect(buildToolCallResult(value).content[0]?.text).toBe(JSON.stringify(value));
+    expect(textOf(buildToolCallResult(value))).toBe(JSON.stringify(value));
   });
 
   it("round-trips the payload and keeps structuredContent alongside it", () => {

--- a/electron/services/mcp-server/__tests__/toolCallResult.test.ts
+++ b/electron/services/mcp-server/__tests__/toolCallResult.test.ts
@@ -90,9 +90,9 @@ describe("structuredContent is bounded by the same budget as the text", () => {
     const result = buildToolCallResult(payload, { structuredContent: payload });
 
     expect(byteLength(result)).toBeLessThanOrEqual(TOOL_RESULT_TEXT_MAX_BYTES);
-    expect(
-      Buffer.byteLength(JSON.stringify(result.structuredContent), "utf8")
-    ).toBeLessThanOrEqual(TOOL_RESULT_TEXT_MAX_BYTES);
+    expect(Buffer.byteLength(JSON.stringify(result.structuredContent), "utf8")).toBeLessThanOrEqual(
+      TOOL_RESULT_TEXT_MAX_BYTES
+    );
     // Both halves must agree — that is the #10676 contract.
     expect(result.structuredContent).toEqual(JSON.parse(textOf(result)));
   });
@@ -120,7 +120,9 @@ describe("structuredContent is bounded by the same budget as the text", () => {
   });
 
   it("omits the structured half when the body is not JSON", () => {
-    expect(buildToolCallResult(null, { structuredContent: { a: 1 } }).structuredContent).toBeUndefined();
+    expect(
+      buildToolCallResult(null, { structuredContent: { a: 1 } }).structuredContent
+    ).toBeUndefined();
   });
 });
 
@@ -197,12 +199,33 @@ describe("buildToolCallResult over the cap", () => {
     expect(byteLength(result)).toBeLessThanOrEqual(TOOL_RESULT_TEXT_MAX_BYTES);
   });
 
-  it("does not discard a character that fits exactly", () => {
-    // The back-off must trigger only on a straddling cut, never shave a whole
-    // code point that landed flush against the budget.
-    const aligned = buildToolCallTextResult("🌳".repeat(TOOL_RESULT_TEXT_MAX_BYTES / 2));
-    const body = bodyAfterNotice(textOf(aligned));
-    expect(Buffer.byteLength(body, "utf8") % 4).toBe(0);
+  it("backs off no further than the straddling character", () => {
+    // The back-off must shave only the partial code point, never a whole one
+    // that fit — so the unused tail is always narrower than one character.
+    const text = textOf(buildToolCallTextResult("🌳".repeat(TOOL_RESULT_TEXT_MAX_BYTES / 2)));
+    const bodyBytes = Buffer.byteLength(bodyAfterNotice(text), "utf8");
+    const budget = TOOL_RESULT_TEXT_MAX_BYTES - (Buffer.byteLength(text, "utf8") - bodyBytes);
+
+    expect(bodyBytes % 4).toBe(0);
+    expect(budget - bodyBytes).toBeLessThan(4);
+  });
+
+  it("omits a structured half that would re-serialize past the cap", () => {
+    // `1e20` parses from 4 bytes and re-emits as 21, so a body that measured
+    // under the cap can blow past it the moment the transport stringifies it.
+    const text = `{"v":[${Array(10_000).fill("1e20").join(",")}]}`;
+    expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(TOOL_RESULT_TEXT_MAX_BYTES);
+
+    const result = buildToolCallTextResult(text, { structuredContent: { v: [] } });
+    expect(result.structuredContent).toBeUndefined();
+  });
+
+  it("omits a structured half too deeply nested for the transport to serialize", () => {
+    const text = `${"[".repeat(10_000)}${"]".repeat(10_000)}`;
+    const result = buildToolCallTextResult(`{"v":${text}}`, { structuredContent: { v: [] } });
+
+    expect(() => JSON.stringify(result)).not.toThrow();
+    expect(result.structuredContent).toBeUndefined();
   });
 });
 

--- a/electron/services/mcp-server/__tests__/toolCallResult.test.ts
+++ b/electron/services/mcp-server/__tests__/toolCallResult.test.ts
@@ -21,10 +21,15 @@ function payloadOfAtLeast(bytes: number): { blob: string } {
   return { blob: "x".repeat(bytes) };
 }
 
+/** The payload that follows the truncation notice. */
+function bodyAfterNotice(text: string): string {
+  return text.slice(text.indexOf("]\n\n") + 3);
+}
+
 describe("buildToolCallResult under the cap", () => {
-  it("emits compact JSON with no cosmetic indentation", () => {
-    const result = buildToolCallResult({ a: 1, b: { c: 2 } });
-    expect(textOf(result)).toBe('{"a":1,"b":{"c":2}}');
+  it("serializes without the indentation the wire has no reader for", () => {
+    const value = { a: 1, b: { c: 2 }, d: [1, 2] };
+    expect(buildToolCallResult(value).content[0]?.text).toBe(JSON.stringify(value));
   });
 
   it("round-trips the payload and keeps structuredContent alongside it", () => {
@@ -33,12 +38,11 @@ describe("buildToolCallResult under the cap", () => {
 
     expect(JSON.parse(textOf(result))).toEqual(payload);
     expect(result.structuredContent).toEqual(payload);
-    expect(result.isError).toBeUndefined();
+    expect(result.isError).not.toBe(true);
   });
 
   it("omits structuredContent when the caller supplies none", () => {
-    const result = buildToolCallResult({ a: 1 });
-    expect(result.structuredContent).toBeUndefined();
+    expect(buildToolCallResult({ a: 1 }).structuredContent).toBeUndefined();
   });
 
   it("preserves the 'OK' body for null and undefined results", () => {
@@ -46,17 +50,77 @@ describe("buildToolCallResult under the cap", () => {
     expect(textOf(buildToolCallResult(undefined))).toBe("OK");
   });
 
-  it("advertises the ceiling so clients do not re-truncate a bounded response", () => {
-    const result = buildToolCallResult({ a: 1 });
-    expect(result._meta?.[META_KEY]).toBe(TOOL_RESULT_TEXT_MAX_BYTES);
+  it("advertises the ceiling it actually enforces", () => {
+    expect(buildToolCallResult({ a: 1 })._meta?.[META_KEY]).toBe(TOOL_RESULT_TEXT_MAX_BYTES);
   });
 
   it("leaves a body sitting exactly on the limit untouched", () => {
     const exact = "y".repeat(TOOL_RESULT_TEXT_MAX_BYTES);
-    const result = buildToolCallTextResult(exact);
+    expect(textOf(buildToolCallTextResult(exact))).toBe(exact);
+  });
 
-    expect(textOf(result)).toBe(exact);
-    expect(byteLength(result)).toBe(TOOL_RESULT_TEXT_MAX_BYTES);
+  it("keeps a payload that only fits once compacted", () => {
+    // Proves compaction buys real headroom rather than just looking tidier: this
+    // survives whole because it is measured compact, and would have truncated
+    // under the 2-space form.
+    const rows = Array.from({ length: 900 }, (_, i) => ({ id: `terminal-${i}`, index: i }));
+    const payload = { rows };
+    expect(Buffer.byteLength(JSON.stringify(payload), "utf8")).toBeLessThanOrEqual(
+      TOOL_RESULT_TEXT_MAX_BYTES
+    );
+    expect(Buffer.byteLength(JSON.stringify(payload, null, 2), "utf8")).toBeGreaterThan(
+      TOOL_RESULT_TEXT_MAX_BYTES
+    );
+
+    const result = buildToolCallResult(payload, { structuredContent: payload });
+    expect(textOf(result)).not.toContain("truncated");
+    expect(result.structuredContent).toEqual(payload);
+  });
+});
+
+describe("structuredContent is bounded by the same budget as the text", () => {
+  it("does not ship aliased references the text half collapsed", () => {
+    // The serializer marks every *repeated* reference "[Circular]", so a result
+    // holding many aliases of one big object serializes small — but the raw
+    // object would expand each alias in full on the wire, smuggling megabytes
+    // past a cap that only measured the text.
+    const shared = { title: "x".repeat(10_000) };
+    const payload = { terminals: Array.from({ length: 1_000 }, () => shared) };
+
+    const result = buildToolCallResult(payload, { structuredContent: payload });
+
+    expect(byteLength(result)).toBeLessThanOrEqual(TOOL_RESULT_TEXT_MAX_BYTES);
+    expect(
+      Buffer.byteLength(JSON.stringify(result.structuredContent), "utf8")
+    ).toBeLessThanOrEqual(TOOL_RESULT_TEXT_MAX_BYTES);
+    // Both halves must agree — that is the #10676 contract.
+    expect(result.structuredContent).toEqual(JSON.parse(textOf(result)));
+  });
+
+  it("keeps a cyclic result serializable for the transport", () => {
+    // The transport JSON.stringify()s structuredContent itself; handing it a raw
+    // cyclic object throws and fails the whole response.
+    const payload: Record<string, unknown> = { name: "root" };
+    payload.self = payload;
+
+    const result = buildToolCallResult(payload, { structuredContent: payload });
+
+    expect(() => JSON.stringify(result)).not.toThrow();
+    expect(result.structuredContent).toEqual({ name: "root", self: "[Circular]" });
+  });
+
+  it("keeps a BigInt-bearing result serializable for the transport", () => {
+    const payload = { count: 10n };
+    const result = buildToolCallResult(payload, {
+      structuredContent: payload as unknown as Record<string, unknown>,
+    });
+
+    expect(() => JSON.stringify(result)).not.toThrow();
+    expect(result.structuredContent).toEqual({ count: "10" });
+  });
+
+  it("omits the structured half when the body is not JSON", () => {
+    expect(buildToolCallResult(null, { structuredContent: { a: 1 } }).structuredContent).toBeUndefined();
   });
 });
 
@@ -76,6 +140,26 @@ describe("buildToolCallResult over the cap", () => {
     expect(textOf(result).startsWith("[Tool result truncated:")).toBe(true);
   });
 
+  it("delivers the leading bytes of the result, not some other slice", () => {
+    const original = JSON.stringify(payloadOfAtLeast(TOOL_RESULT_TEXT_MAX_BYTES * 2));
+    const body = bodyAfterNotice(textOf(buildToolCallTextResult(original)));
+
+    expect(body.length).toBeGreaterThan(0);
+    expect(original.startsWith(body)).toBe(true);
+  });
+
+  it("spends the whole budget — one more character would overflow it", () => {
+    const original = JSON.stringify(payloadOfAtLeast(TOOL_RESULT_TEXT_MAX_BYTES * 2));
+    const text = textOf(buildToolCallTextResult(original));
+    const body = bodyAfterNotice(text);
+    const noticeBytes = Buffer.byteLength(text, "utf8") - Buffer.byteLength(body, "utf8");
+
+    const oneMore = original.slice(0, body.length + 1);
+    expect(noticeBytes + Buffer.byteLength(oneMore, "utf8")).toBeGreaterThan(
+      TOOL_RESULT_TEXT_MAX_BYTES
+    );
+  });
+
   it("reports the delivered and original sizes honestly", () => {
     const payload = payloadOfAtLeast(TOOL_RESULT_TEXT_MAX_BYTES * 2);
     const originalBytes = Buffer.byteLength(JSON.stringify(payload), "utf8");
@@ -84,11 +168,7 @@ describe("buildToolCallResult over the cap", () => {
     const notice = /^\[Tool result truncated: showing (\d+) of (\d+) UTF-8 bytes\./.exec(text);
     expect(notice).not.toBeNull();
     expect(Number(notice![2])).toBe(originalBytes);
-
-    // The reported "showing" count must match the payload that actually follows
-    // the notice, or the model is being told something false about its data.
-    const body = text.slice(text.indexOf("]\n\n") + 3);
-    expect(Number(notice![1])).toBe(Buffer.byteLength(body, "utf8"));
+    expect(Number(notice![1])).toBe(Buffer.byteLength(bodyAfterNotice(text), "utf8"));
   });
 
   it("drops structuredContent so the unbounded duplicate does not defeat the cap", () => {
@@ -99,20 +179,30 @@ describe("buildToolCallResult over the cap", () => {
 
   it("does not mark a truncated success as an error", () => {
     const result = buildToolCallResult(payloadOfAtLeast(TOOL_RESULT_TEXT_MAX_BYTES * 2));
-    expect(result.isError).toBeUndefined();
-  });
-
-  it("cuts on a character boundary instead of emitting a replacement char", () => {
-    // 4-byte astral chars tile the buffer so the budget lands mid-character.
-    const result = buildToolCallTextResult("🌳".repeat(TOOL_RESULT_TEXT_MAX_BYTES / 2));
-
-    expect(textOf(result)).not.toContain("�");
-    expect(byteLength(result)).toBeLessThanOrEqual(TOOL_RESULT_TEXT_MAX_BYTES);
+    expect(result.isError).not.toBe(true);
   });
 
   it("still advertises the ceiling on a truncated response", () => {
     const result = buildToolCallResult(payloadOfAtLeast(TOOL_RESULT_TEXT_MAX_BYTES * 2));
     expect(result._meta?.[META_KEY]).toBe(TOOL_RESULT_TEXT_MAX_BYTES);
+  });
+
+  // A 4-byte code point tiled across the buffer puts the cut at each of the four
+  // possible offsets within a character as the padding shifts the budget.
+  it.each([0, 1, 2, 3])("cuts on a character boundary at phase %i", (phase) => {
+    const text = `${"a".repeat(phase)}${"🌳".repeat(TOOL_RESULT_TEXT_MAX_BYTES / 2)}`;
+    const result = buildToolCallTextResult(text);
+
+    expect(bodyAfterNotice(textOf(result))).not.toContain("�");
+    expect(byteLength(result)).toBeLessThanOrEqual(TOOL_RESULT_TEXT_MAX_BYTES);
+  });
+
+  it("does not discard a character that fits exactly", () => {
+    // The back-off must trigger only on a straddling cut, never shave a whole
+    // code point that landed flush against the budget.
+    const aligned = buildToolCallTextResult("🌳".repeat(TOOL_RESULT_TEXT_MAX_BYTES / 2));
+    const body = bodyAfterNotice(textOf(aligned));
+    expect(Buffer.byteLength(body, "utf8") % 4).toBe(0);
   });
 });
 
@@ -129,17 +219,28 @@ describe("error envelopes", () => {
   it("leaves a small error body parseable", () => {
     const payload = { code: "EXECUTION_ERROR", message: "boom" };
     const result = buildToolCallTextResult(JSON.stringify(payload), { isError: true });
+
     expect(JSON.parse(textOf(result))).toEqual(payload);
+    expect(result.isError).toBe(true);
   });
 });
 
 describe("SDK conformance", () => {
-  it("produces results the SDK schema accepts, capped or not", () => {
-    expect(CallToolResultSchema.safeParse(buildToolCallResult({ a: 1 })).success).toBe(true);
-    expect(
-      CallToolResultSchema.safeParse(
-        buildToolCallResult(payloadOfAtLeast(TOOL_RESULT_TEXT_MAX_BYTES * 2))
-      ).success
-    ).toBe(true);
+  it("survives schema validation with the size hint intact", () => {
+    // The SDK returns the *parsed* result to the transport, so a key the schema
+    // dropped would never reach the client even though safeParse succeeded.
+    const parsed = CallToolResultSchema.safeParse(buildToolCallResult({ a: 1 }));
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.data?._meta?.[META_KEY]).toBe(TOOL_RESULT_TEXT_MAX_BYTES);
+  });
+
+  it("accepts a truncated result", () => {
+    const parsed = CallToolResultSchema.safeParse(
+      buildToolCallResult(payloadOfAtLeast(TOOL_RESULT_TEXT_MAX_BYTES * 2))
+    );
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.data?.structuredContent).toBeUndefined();
   });
 });

--- a/electron/services/mcp-server/__tests__/toolCallResult.test.ts
+++ b/electron/services/mcp-server/__tests__/toolCallResult.test.ts
@@ -6,8 +6,6 @@ import {
   buildToolCallTextResult,
 } from "../toolCallResult.js";
 
-const META_KEY = "anthropic/maxResultSizeChars";
-
 function textOf(result: { content: { type: string; text?: string }[] }): string {
   return result.content[0]?.text ?? "";
 }
@@ -50,10 +48,6 @@ describe("buildToolCallResult under the cap", () => {
     expect(textOf(buildToolCallResult(undefined))).toBe("OK");
   });
 
-  it("advertises the ceiling it actually enforces", () => {
-    expect(buildToolCallResult({ a: 1 })._meta?.[META_KEY]).toBe(TOOL_RESULT_TEXT_MAX_BYTES);
-  });
-
   it("leaves a body sitting exactly on the limit untouched", () => {
     const exact = "y".repeat(TOOL_RESULT_TEXT_MAX_BYTES);
     expect(textOf(buildToolCallTextResult(exact))).toBe(exact);
@@ -79,22 +73,31 @@ describe("buildToolCallResult under the cap", () => {
 });
 
 describe("structuredContent is bounded by the same budget as the text", () => {
-  it("does not ship aliased references the text half collapsed", () => {
-    // The serializer marks every *repeated* reference "[Circular]", so a result
-    // holding many aliases of one big object serializes small — but the raw
-    // object would expand each alias in full on the wire, smuggling megabytes
-    // past a cap that only measured the text.
+  it("bounds a payload whose aliases expand on the wire", () => {
+    // Aliases are expanded, not collapsed, so a thousand references to one 10 KB
+    // object really is a ~10 MB response — and both halves have to be measured
+    // after that expansion, not before it.
     const shared = { title: "x".repeat(10_000) };
     const payload = { terminals: Array.from({ length: 1_000 }, () => shared) };
 
     const result = buildToolCallResult(payload, { structuredContent: payload });
 
     expect(byteLength(result)).toBeLessThanOrEqual(TOOL_RESULT_TEXT_MAX_BYTES);
-    expect(Buffer.byteLength(JSON.stringify(result.structuredContent), "utf8")).toBeLessThanOrEqual(
-      TOOL_RESULT_TEXT_MAX_BYTES
-    );
-    // Both halves must agree — that is the #10676 contract.
-    expect(result.structuredContent).toEqual(JSON.parse(textOf(result)));
+    expect(result.structuredContent).toBeUndefined();
+  });
+
+  it("keeps an aliased but acyclic result intact in both halves", () => {
+    // Nothing here is cyclic, so nothing may be replaced by a placeholder: a
+    // "[Circular]" string where the declared output schema expects an object is
+    // rejected outright by the client.
+    const shared = { id: "s-1", label: "shared" };
+    const payload = { first: shared, second: shared };
+
+    const result = buildToolCallResult(payload, { structuredContent: payload });
+
+    expect(result.structuredContent).toEqual(payload);
+    expect(JSON.parse(textOf(result))).toEqual(payload);
+    expect(result.isError).not.toBe(true);
   });
 
   it("keeps a cyclic result serializable for the transport", () => {
@@ -120,9 +123,24 @@ describe("structuredContent is bounded by the same budget as the text", () => {
   });
 
   it("omits the structured half when the body is not JSON", () => {
-    expect(
-      buildToolCallResult(null, { structuredContent: { a: 1 } }).structuredContent
-    ).toBeUndefined();
+    const result = buildToolCallResult(null, { structuredContent: { a: 1 } });
+
+    expect(result.structuredContent).toBeUndefined();
+    // Silently omitting a promised structured half makes the client reject the
+    // whole response; the flag keeps the text body reaching the model.
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("Structured output omitted");
+  });
+
+  it("keeps an ordinarily nested result — the depth bound is not a size bound", () => {
+    const nest = (depth: number): Record<string, unknown> =>
+      depth === 0 ? { leaf: true } : { child: nest(depth - 1) };
+    const payload = nest(20);
+
+    const result = buildToolCallResult(payload, { structuredContent: payload });
+
+    expect(result.structuredContent).toEqual(payload);
+    expect(result.isError).not.toBe(true);
   });
 });
 
@@ -179,14 +197,21 @@ describe("buildToolCallResult over the cap", () => {
     expect(result.structuredContent).toBeUndefined();
   });
 
-  it("does not mark a truncated success as an error", () => {
+  it("does not mark a truncated success as an error when nothing was promised", () => {
     const result = buildToolCallResult(payloadOfAtLeast(TOOL_RESULT_TEXT_MAX_BYTES * 2));
     expect(result.isError).not.toBe(true);
   });
 
-  it("still advertises the ceiling on a truncated response", () => {
-    const result = buildToolCallResult(payloadOfAtLeast(TOOL_RESULT_TEXT_MAX_BYTES * 2));
-    expect(result._meta?.[META_KEY]).toBe(TOOL_RESULT_TEXT_MAX_BYTES);
+  it("flags a truncation that cost a promised structured half", () => {
+    // A client whose tool declares an outputSchema throws on a response carrying
+    // neither structuredContent nor isError, so the unflagged form would replace
+    // the notice below with an opaque protocol error.
+    const payload = payloadOfAtLeast(TOOL_RESULT_TEXT_MAX_BYTES * 2);
+    const result = buildToolCallResult(payload, { structuredContent: payload });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("Structured output is omitted");
+    expect(byteLength(result)).toBeLessThanOrEqual(TOOL_RESULT_TEXT_MAX_BYTES);
   });
 
   // A 4-byte code point tiled across the buffer puts the cut at each of the four
@@ -221,11 +246,17 @@ describe("buildToolCallResult over the cap", () => {
   });
 
   it("omits a structured half too deeply nested for the transport to serialize", () => {
+    // A trial JSON.stringify here is not the operation the transport performs:
+    // that one wraps the JSON-RPC envelope around the same value, deeper and at a
+    // different stack depth, so a value that survives the trial can still throw
+    // RangeError on the wire. Only a fixed depth bound decides this the same way
+    // every time.
     const text = `${"[".repeat(10_000)}${"]".repeat(10_000)}`;
     const result = buildToolCallTextResult(`{"v":${text}}`, { structuredContent: { v: [] } });
 
-    expect(() => JSON.stringify(result)).not.toThrow();
     expect(result.structuredContent).toBeUndefined();
+    expect(result.isError).toBe(true);
+    expect(() => JSON.stringify({ jsonrpc: "2.0", id: 1, result })).not.toThrow();
   });
 });
 
@@ -249,21 +280,26 @@ describe("error envelopes", () => {
 });
 
 describe("SDK conformance", () => {
-  it("survives schema validation with the size hint intact", () => {
+  it("survives schema validation with both halves intact", () => {
     // The SDK returns the *parsed* result to the transport, so a key the schema
     // dropped would never reach the client even though safeParse succeeded.
-    const parsed = CallToolResultSchema.safeParse(buildToolCallResult({ a: 1 }));
+    const payload = { a: 1 };
+    const parsed = CallToolResultSchema.safeParse(
+      buildToolCallResult(payload, { structuredContent: payload })
+    );
 
     expect(parsed.success).toBe(true);
-    expect(parsed.data?._meta?.[META_KEY]).toBe(TOOL_RESULT_TEXT_MAX_BYTES);
+    expect(parsed.data?.structuredContent).toEqual(payload);
   });
 
-  it("accepts a truncated result", () => {
+  it("accepts a truncated result and keeps the flag that makes it valid", () => {
+    const payload = payloadOfAtLeast(TOOL_RESULT_TEXT_MAX_BYTES * 2);
     const parsed = CallToolResultSchema.safeParse(
-      buildToolCallResult(payloadOfAtLeast(TOOL_RESULT_TEXT_MAX_BYTES * 2))
+      buildToolCallResult(payload, { structuredContent: payload })
     );
 
     expect(parsed.success).toBe(true);
     expect(parsed.data?.structuredContent).toBeUndefined();
+    expect(parsed.data?.isError).toBe(true);
   });
 });

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -33,7 +33,6 @@ import {
   serializeResourcePayload,
   unwrapDispatchResult,
   truncateText,
-  safeSerializeToolResult,
   readStringField,
   RESOURCE_BACKING_ACTIONS,
   TIER_NOT_PERMITTED_CODE,
@@ -69,6 +68,7 @@ import {
   buildStructuredContent,
   parseToolArguments,
 } from "./tierAuth.js";
+import { buildToolCallResult } from "./toolCallResult.js";
 
 const TERMINAL_WAIT_UNTIL_IDLE_TOOL = "terminal.waitUntilIdle";
 const TERMINAL_WAIT_UNTIL_IDLE_BATCH_TOOL = "terminal.waitUntilIdleBatch";
@@ -680,10 +680,9 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
                 sessionStore.resetHttpIdleTimer(sessionId);
               }
             }
-            return {
-              content: [{ type: "text" as const, text: safeSerializeToolResult(result) }],
+            return buildToolCallResult(result, {
               structuredContent: result as unknown as Record<string, unknown>,
-            };
+            });
           } catch (err) {
             outcome = { kind: "throw", error: err };
             if (err instanceof McpError) {
@@ -721,10 +720,9 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
                 sessionStore.resetHttpIdleTimer(sessionId);
               }
             }
-            return {
-              content: [{ type: "text" as const, text: safeSerializeToolResult(result) }],
+            return buildToolCallResult(result, {
               structuredContent: result as unknown as Record<string, unknown>,
-            };
+            });
           } catch (err) {
             outcome = { kind: "throw", error: err };
             if (err instanceof McpError) {
@@ -750,10 +748,9 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
             const result =
               actionId === SKILLS_SEARCH_TOOL ? handleSkillsSearch(args) : handleSkillsLoad(args);
             outcome = { kind: "result", value: { ok: true, result } };
-            return {
-              content: [{ type: "text" as const, text: safeSerializeToolResult(result) }],
+            return buildToolCallResult(result, {
               structuredContent: result as unknown as Record<string, unknown>,
-            };
+            });
           } catch (err) {
             outcome = { kind: "throw", error: err };
             if (err instanceof McpError) {
@@ -830,10 +827,9 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
             }
             const result = { imageId, figureNumber, figureLabel };
             outcome = { kind: "result", value: { ok: true, result } };
-            return {
-              content: [{ type: "text" as const, text: safeSerializeToolResult(result) }],
+            return buildToolCallResult(result, {
               structuredContent: result as unknown as Record<string, unknown>,
-            };
+            });
           } catch (err) {
             outcome = { kind: "throw", error: err };
             if (err instanceof McpError) {
@@ -964,18 +960,9 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
             }
           }
           const structuredContent = buildStructuredContent(entry, outcome.value.result);
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text:
-                  outcome.value.result !== undefined && outcome.value.result !== null
-                    ? safeSerializeToolResult(outcome.value.result)
-                    : "OK",
-              },
-            ],
+          return buildToolCallResult(outcome.value.result, {
             ...(structuredContent ? { structuredContent } : {}),
-          };
+          });
         }
 
         return buildToolError({

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -29,6 +29,7 @@ import {
   WORKBENCH_TIER_TOOLS as WORKBENCH_TIER_TOOLS_LIST,
 } from "../../../shared/config/helpAssistantTierAllowlists.js";
 import { safeSerializeToolResult } from "../../utils/safeSerializeToolResult.js";
+import { buildToolCallTextResult } from "./toolCallResult.js";
 
 // Re-exported for SDK-free consumers that historically imported from here.
 // `readinessProbe.ts` and `pluginMcpHash.ts` import from the standalone homes
@@ -304,10 +305,10 @@ export function buildToolError(input: {
   details?: unknown;
 }): CallToolResult {
   const payload = buildMcpErrorPayload(input);
-  return {
-    content: [{ type: "text", text: JSON.stringify(payload) }],
-    isError: true,
-  };
+  // Budgeted like a success body: `details` is renderer-supplied and unbounded,
+  // so without the cap the same oversized-result bug stays reachable through
+  // failures (#11526). `isError` survives — the call really did fail.
+  return buildToolCallTextResult(JSON.stringify(payload), { isError: true });
 }
 
 export type McpTier = "workbench" | "action" | "system" | "external";

--- a/electron/services/mcp-server/skills.ts
+++ b/electron/services/mcp-server/skills.ts
@@ -62,9 +62,8 @@ export function handleSkillsLoad(rawArgs: unknown): SkillLoadResult {
     // the `tools/call` response budget entirely, so reflecting the argument
     // verbatim would let a megabyte-long id produce a megabyte-long error
     // (#11526). Real skill ids are far shorter than this.
-    const echoed = id.length > MAX_ECHOED_SKILL_ID_LENGTH
-      ? `${id.slice(0, MAX_ECHOED_SKILL_ID_LENGTH)}…`
-      : id;
+    const echoed =
+      id.length > MAX_ECHOED_SKILL_ID_LENGTH ? `${id.slice(0, MAX_ECHOED_SKILL_ID_LENGTH)}…` : id;
     throw new McpError(
       ErrorCode.InvalidParams,
       `No skill found with id "${echoed}". Use skills.search to discover available skill ids.`

--- a/electron/services/mcp-server/skills.ts
+++ b/electron/services/mcp-server/skills.ts
@@ -13,6 +13,9 @@ import type { SkillSearchResult, SkillLoadResult } from "../../../shared/types/s
  * unknown skill so the session server maps them to a clean tool error.
  */
 
+/** Longest unknown skill id echoed back in the "no skill found" error. */
+const MAX_ECHOED_SKILL_ID_LENGTH = 128;
+
 function asArgsObject(rawArgs: unknown): Record<string, unknown> {
   if (rawArgs === undefined || rawArgs === null) return {};
   if (typeof rawArgs === "object" && !Array.isArray(rawArgs)) {
@@ -55,9 +58,16 @@ export function handleSkillsLoad(rawArgs: unknown): SkillLoadResult {
 
   const skill = loadPluginSkill(id);
   if (!skill) {
+    // Clamp the echoed id: this message becomes a JSON-RPC error, which bypasses
+    // the `tools/call` response budget entirely, so reflecting the argument
+    // verbatim would let a megabyte-long id produce a megabyte-long error
+    // (#11526). Real skill ids are far shorter than this.
+    const echoed = id.length > MAX_ECHOED_SKILL_ID_LENGTH
+      ? `${id.slice(0, MAX_ECHOED_SKILL_ID_LENGTH)}…`
+      : id;
     throw new McpError(
       ErrorCode.InvalidParams,
-      `No skill found with id "${id}". Use skills.search to discover available skill ids.`
+      `No skill found with id "${echoed}". Use skills.search to discover available skill ids.`
     );
   }
   return skill;

--- a/electron/services/mcp-server/toolCallResult.ts
+++ b/electron/services/mcp-server/toolCallResult.ts
@@ -14,21 +14,58 @@ import { safeSerializeToolResultCompact } from "../../utils/safeSerializeToolRes
 export const TOOL_RESULT_TEXT_MAX_BYTES = 50 * 1024;
 
 /**
- * Advertised to clients that honour it so they don't apply a *smaller* ceiling
- * of their own to an already-bounded response. Equal to the enforced cap, which
- * is honest in both directions: the cap counts UTF-8 bytes and a string never
- * has more characters than bytes, so the response can never exceed this many
- * characters. It describes the model-visible `content` text — per MCP SEP-1624
- * `structuredContent` is for the host app to parse, not for the model context.
+ * Nesting ceiling for the structured half.
+ *
+ * V8's `JSON.stringify` recurses per level, so whether a deep value survives
+ * depends on the stack headroom wherever it happens to be called: a 10,000-deep
+ * result stringifies fine on its own and then throws `RangeError` inside the
+ * transport, which wraps it in the JSON-RPC envelope one frame further down.
+ * Measuring nesting against a fixed bound instead makes the decision
+ * deterministic. That path becomes unreliable a few thousand levels down, so
+ * this sits more than an order of magnitude below the danger zone and still far
+ * deeper than any real action result.
  */
-const MAX_RESULT_SIZE_CHARS_KEY = "anthropic/maxResultSizeChars";
+const MAX_STRUCTURED_DEPTH = 100;
 
-function buildNotice(shownBytes: number, originalBytes: number): string {
+function buildNotice(
+  shownBytes: number,
+  originalBytes: number,
+  structuredOmitted: boolean
+): string {
   return (
     `[Tool result truncated: showing ${shownBytes} of ${originalBytes} UTF-8 bytes. ` +
     `The JSON below is incomplete and will not parse. ` +
+    (structuredOmitted ? `Structured output is omitted for the same reason. ` : "") +
     `Narrow the arguments (filters, limits, paths) and retry for a complete result.]\n\n`
   );
+}
+
+/**
+ * Prefixed when the caller asked for a structured half that could not be
+ * produced from a body that otherwise fits. `isError` carries the same signal to
+ * the protocol; this carries it to the model.
+ */
+const STRUCTURED_OMITTED_NOTICE =
+  `[Structured output omitted: this result could not be reproduced as bounded, ` +
+  `transport-safe JSON. The text body below is complete — parse it instead.]\n\n`;
+
+/**
+ * True when any path through `value` nests deeper than `maxDepth`. Iterative on
+ * purpose: a recursive probe would overflow on exactly the inputs it exists to
+ * reject. Only ever run on a freshly parsed value, which is a tree, so the walk
+ * is linear in the (already bounded) text it came from.
+ */
+function exceedsDepth(value: unknown, maxDepth: number): boolean {
+  const pending: { node: unknown; depth: number }[] = [{ node: value, depth: 1 }];
+  while (pending.length > 0) {
+    const { node, depth } = pending.pop()!;
+    if (node === null || typeof node !== "object") continue;
+    if (depth > maxDepth) return true;
+    for (const child of Array.isArray(node) ? node : Object.values(node)) {
+      pending.push({ node: child, depth: depth + 1 });
+    }
+  }
+  return false;
 }
 
 /**
@@ -50,17 +87,15 @@ function utf8BoundaryEnd(buffer: Buffer, maxBytes: number): number {
 /**
  * Re-derive the structured half from the text half.
  *
- * Measuring only the text would leave `structuredContent` unbounded, because
- * the two are serialized by different code: the text goes through the replacer,
- * which collapses every *repeated* reference — not just genuine cycles — to
- * "[Circular]", while the transport `JSON.stringify`s the raw object and
- * expands each alias in full. A result holding 1,000 references to one 10 KB
- * object serializes to ~23 KB of text (under the cap, so the structured half is
- * kept) and then ships ~10 MB over the wire. Parsing the already-bounded text
- * back keeps the two halves byte-consistent — strengthening the #10676 contract
- * from "same data" to "same bytes" — and bounds them both. It also removes the
- * transport's only unserializable inputs: a truly cyclic or BigInt-bearing
- * result would make the transport's own `JSON.stringify` throw.
+ * Measuring only the text would leave `structuredContent` unbounded: the text is
+ * measured after serialization, while the transport `JSON.stringify`s the raw
+ * object independently, and the two can diverge without limit — a getter, a
+ * `toJSON`, or a value the replacer rewrote all ship different bytes than the
+ * ones that were counted. Parsing the already-bounded text back keeps the halves
+ * byte-consistent — strengthening the #10676 contract from "same data" to "same
+ * bytes" — and bounds them both. It also removes the transport's only
+ * unserializable inputs: a truly cyclic or BigInt-bearing result would make the
+ * transport's own `JSON.stringify` throw.
  *
  * Returns undefined when the text is not a JSON object — the "OK" body and the
  * serializer's string-coercion fallbacks have no structured form to offer.
@@ -70,42 +105,43 @@ function structuredFromText(
   candidate: Record<string, unknown> | undefined
 ): Record<string, unknown> | undefined {
   if (!candidate) return undefined;
+  let parsed: unknown;
   try {
-    const parsed: unknown = JSON.parse(text);
-    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
-    // Parsing successfully is not enough to bound the result: re-serializing can
-    // grow it (`1e20` parses from 4 bytes and re-emits as 21) or throw outright
-    // (deeply nested arrays overflow the stack). Measure the exact operation the
-    // transport will perform, so anything that would not survive it is dropped
-    // rather than shipped.
-    if (Buffer.byteLength(JSON.stringify(parsed), "utf8") > TOOL_RESULT_TEXT_MAX_BYTES) {
-      return undefined;
-    }
-    return parsed as Record<string, unknown>;
+    parsed = JSON.parse(text);
   } catch {
-    // Not round-trippable JSON — omit the structured half.
+    return undefined;
   }
-  return undefined;
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+  // Depth first: the size measurement below is itself a `JSON.stringify`, so on
+  // a deep value it would be the call that overflows.
+  if (exceedsDepth(parsed, MAX_STRUCTURED_DEPTH)) return undefined;
+  // Parsing successfully is not enough to bound the result — re-serializing can
+  // grow it (`1e20` parses from 4 bytes and re-emits as 21), so the budget has to
+  // be measured against the bytes the transport will actually send.
+  if (Buffer.byteLength(JSON.stringify(parsed), "utf8") > TOOL_RESULT_TEXT_MAX_BYTES) {
+    return undefined;
+  }
+  return parsed as Record<string, unknown>;
 }
 
 /**
  * Apply the response budget to an already-serialized text body.
  *
- * Under the cap the text passes through untouched and `structuredContent` (when
- * the caller supplied one) rides along, preserving the #10676 contract that a
- * client can parse either half and get the same data. Over the cap the text is
- * truncated behind a notice and `structuredContent` is dropped.
+ * Under the cap the text passes through and `structuredContent` (when the caller
+ * supplied one) rides along, preserving the #10676 contract that a client can
+ * parse either half and get the same data. Over the cap the text is truncated
+ * behind a notice and `structuredContent` is dropped — shipping the
+ * multi-megabyte payload the cap exists to bound would defeat the cap, and
+ * substituting a truncated object would violate the very schema it claims to
+ * satisfy.
  *
- * Dropping it is a deliberate protocol trade-off: MCP says the field should be
- * present whenever the tool declares an `outputSchema`, but the only ways to
- * honour that here are to ship the multi-megabyte payload the cap exists to
- * bound — which the client would reject wholesale — or to substitute a
- * truncated object that violates the very schema it claims to satisfy. Omitting
- * it and saying so in the notice is the least-bad option.
- *
- * Truncation never sets `isError`: per MCP that flag means the tool actually
- * failed, and a capped result is a successful call with a shortened body. The
- * caller's own `isError` (a real failure) is passed through untouched.
+ * Whenever a promised structured half is dropped, for any reason, the envelope
+ * is flagged `isError`. MCP clients treat a tool with an `outputSchema` that
+ * returns neither `structuredContent` nor `isError` as a protocol violation and
+ * throw before the model sees anything — so without the flag the agent gets an
+ * opaque client-side error in place of the notice explaining what happened and
+ * how to retry. The flag is the SDK's own escape hatch, and it also encodes the
+ * right thing: the caller asked for structured output and did not get it.
  */
 export function buildToolCallTextResult(
   text: string,
@@ -113,14 +149,18 @@ export function buildToolCallTextResult(
 ): CallToolResult {
   const { structuredContent, isError } = options;
   const originalBytes = Buffer.byteLength(text, "utf8");
+  const structured =
+    originalBytes <= TOOL_RESULT_TEXT_MAX_BYTES
+      ? structuredFromText(text, structuredContent)
+      : undefined;
+  const structuredOmitted = Boolean(structuredContent) && structured === undefined;
+  const prefix = structuredOmitted ? STRUCTURED_OMITTED_NOTICE : "";
 
-  if (originalBytes <= TOOL_RESULT_TEXT_MAX_BYTES) {
-    const structured = structuredFromText(text, structuredContent);
+  if (originalBytes + Buffer.byteLength(prefix, "utf8") <= TOOL_RESULT_TEXT_MAX_BYTES) {
     return {
-      content: [{ type: "text", text }],
+      content: [{ type: "text", text: `${prefix}${text}` }],
       ...(structured ? { structuredContent: structured } : {}),
-      ...(isError ? { isError } : {}),
-      _meta: { [MAX_RESULT_SIZE_CHARS_KEY]: TOOL_RESULT_TEXT_MAX_BYTES },
+      ...(isError || structuredOmitted ? { isError: true } : {}),
     };
   }
 
@@ -130,7 +170,7 @@ export function buildToolCallTextResult(
   // and the rebuilt notice can only be shorter. That keeps the total provably
   // within the cap without a second pass.
   const noticeBytes = Buffer.byteLength(
-    buildNotice(TOOL_RESULT_TEXT_MAX_BYTES, originalBytes),
+    buildNotice(TOOL_RESULT_TEXT_MAX_BYTES, originalBytes, structuredOmitted),
     "utf8"
   );
   const budget = Math.max(0, TOOL_RESULT_TEXT_MAX_BYTES - noticeBytes);
@@ -143,11 +183,10 @@ export function buildToolCallTextResult(
     content: [
       {
         type: "text",
-        text: `${buildNotice(Buffer.byteLength(shown, "utf8"), originalBytes)}${shown}`,
+        text: `${buildNotice(Buffer.byteLength(shown, "utf8"), originalBytes, structuredOmitted)}${shown}`,
       },
     ],
-    ...(isError ? { isError } : {}),
-    _meta: { [MAX_RESULT_SIZE_CHARS_KEY]: TOOL_RESULT_TEXT_MAX_BYTES },
+    ...(isError || structuredOmitted ? { isError: true } : {}),
   };
 }
 

--- a/electron/services/mcp-server/toolCallResult.ts
+++ b/electron/services/mcp-server/toolCallResult.ts
@@ -72,11 +72,18 @@ function structuredFromText(
   if (!candidate) return undefined;
   try {
     const parsed: unknown = JSON.parse(text);
-    if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
-      return parsed as Record<string, unknown>;
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+    // Parsing successfully is not enough to bound the result: re-serializing can
+    // grow it (`1e20` parses from 4 bytes and re-emits as 21) or throw outright
+    // (deeply nested arrays overflow the stack). Measure the exact operation the
+    // transport will perform, so anything that would not survive it is dropped
+    // rather than shipped.
+    if (Buffer.byteLength(JSON.stringify(parsed), "utf8") > TOOL_RESULT_TEXT_MAX_BYTES) {
+      return undefined;
     }
+    return parsed as Record<string, unknown>;
   } catch {
-    // Not JSON — fall through and omit the structured half.
+    // Not round-trippable JSON — omit the structured half.
   }
   return undefined;
 }
@@ -134,7 +141,10 @@ export function buildToolCallTextResult(
   // trailing marker off and leave the model reading incomplete JSON as complete.
   return {
     content: [
-      { type: "text", text: `${buildNotice(Buffer.byteLength(shown, "utf8"), originalBytes)}${shown}` },
+      {
+        type: "text",
+        text: `${buildNotice(Buffer.byteLength(shown, "utf8"), originalBytes)}${shown}`,
+      },
     ],
     ...(isError ? { isError } : {}),
     _meta: { [MAX_RESULT_SIZE_CHARS_KEY]: TOOL_RESULT_TEXT_MAX_BYTES },

--- a/electron/services/mcp-server/toolCallResult.ts
+++ b/electron/services/mcp-server/toolCallResult.ts
@@ -48,14 +48,53 @@ function utf8BoundaryEnd(buffer: Buffer, maxBytes: number): number {
 }
 
 /**
+ * Re-derive the structured half from the text half.
+ *
+ * Measuring only the text would leave `structuredContent` unbounded, because
+ * the two are serialized by different code: the text goes through the replacer,
+ * which collapses every *repeated* reference — not just genuine cycles — to
+ * "[Circular]", while the transport `JSON.stringify`s the raw object and
+ * expands each alias in full. A result holding 1,000 references to one 10 KB
+ * object serializes to ~23 KB of text (under the cap, so the structured half is
+ * kept) and then ships ~10 MB over the wire. Parsing the already-bounded text
+ * back keeps the two halves byte-consistent — strengthening the #10676 contract
+ * from "same data" to "same bytes" — and bounds them both. It also removes the
+ * transport's only unserializable inputs: a truly cyclic or BigInt-bearing
+ * result would make the transport's own `JSON.stringify` throw.
+ *
+ * Returns undefined when the text is not a JSON object — the "OK" body and the
+ * serializer's string-coercion fallbacks have no structured form to offer.
+ */
+function structuredFromText(
+  text: string,
+  candidate: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (!candidate) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Not JSON — fall through and omit the structured half.
+  }
+  return undefined;
+}
+
+/**
  * Apply the response budget to an already-serialized text body.
  *
  * Under the cap the text passes through untouched and `structuredContent` (when
  * the caller supplied one) rides along, preserving the #10676 contract that a
  * client can parse either half and get the same data. Over the cap the text is
- * truncated behind a notice and `structuredContent` is dropped — keeping it
- * would ship the very payload the cap exists to bound, and a truncated stand-in
- * could violate the tool's declared output schema.
+ * truncated behind a notice and `structuredContent` is dropped.
+ *
+ * Dropping it is a deliberate protocol trade-off: MCP says the field should be
+ * present whenever the tool declares an `outputSchema`, but the only ways to
+ * honour that here are to ship the multi-megabyte payload the cap exists to
+ * bound — which the client would reject wholesale — or to substitute a
+ * truncated object that violates the very schema it claims to satisfy. Omitting
+ * it and saying so in the notice is the least-bad option.
  *
  * Truncation never sets `isError`: per MCP that flag means the tool actually
  * failed, and a capped result is a successful call with a shortened body. The
@@ -69,9 +108,10 @@ export function buildToolCallTextResult(
   const originalBytes = Buffer.byteLength(text, "utf8");
 
   if (originalBytes <= TOOL_RESULT_TEXT_MAX_BYTES) {
+    const structured = structuredFromText(text, structuredContent);
     return {
       content: [{ type: "text", text }],
-      ...(structuredContent ? { structuredContent } : {}),
+      ...(structured ? { structuredContent: structured } : {}),
       ...(isError ? { isError } : {}),
       _meta: { [MAX_RESULT_SIZE_CHARS_KEY]: TOOL_RESULT_TEXT_MAX_BYTES },
     };

--- a/electron/services/mcp-server/toolCallResult.ts
+++ b/electron/services/mcp-server/toolCallResult.ts
@@ -1,0 +1,119 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { safeSerializeToolResultCompact } from "../../utils/safeSerializeToolResult.js";
+
+/**
+ * Byte ceiling for the text body of a `tools/call` response (#11526).
+ *
+ * Matches `RESOURCE_TEXT_MAX_BYTES` — resources were already capped here and
+ * tool results were not capped at all, so a single call could return 31 MB.
+ * Deliberately byte-based rather than token-based: tokenization is a client
+ * concern and pinning the server to one vendor's tokenizer would be worse than
+ * a conservative fixed bound. 50 KiB of compact JSON lands around 13-25K
+ * tokens, comfortably under the 25K-token ceiling clients commonly enforce.
+ */
+export const TOOL_RESULT_TEXT_MAX_BYTES = 50 * 1024;
+
+/**
+ * Advertised to clients that honour it so they don't apply a *smaller* ceiling
+ * of their own to an already-bounded response. Equal to the enforced cap, which
+ * is honest in both directions: the cap counts UTF-8 bytes and a string never
+ * has more characters than bytes, so the response can never exceed this many
+ * characters. It describes the model-visible `content` text — per MCP SEP-1624
+ * `structuredContent` is for the host app to parse, not for the model context.
+ */
+const MAX_RESULT_SIZE_CHARS_KEY = "anthropic/maxResultSizeChars";
+
+function buildNotice(shownBytes: number, originalBytes: number): string {
+  return (
+    `[Tool result truncated: showing ${shownBytes} of ${originalBytes} UTF-8 bytes. ` +
+    `The JSON below is incomplete and will not parse. ` +
+    `Narrow the arguments (filters, limits, paths) and retry for a complete result.]\n\n`
+  );
+}
+
+/**
+ * Largest cut point at or below `maxBytes` that lands on a UTF-8 character
+ * boundary. `Buffer.subarray().toString()` would decode a chopped multi-byte
+ * tail into U+FFFD; backing off past continuation bytes (`10xxxxxx`) drops the
+ * partial character instead. A UTF-8 sequence is at most 4 bytes, so at most 3
+ * continuation bytes can precede the cut.
+ */
+function utf8BoundaryEnd(buffer: Buffer, maxBytes: number): number {
+  if (buffer.length <= maxBytes) return buffer.length;
+  let end = maxBytes;
+  for (let i = 0; i < 3 && end > 0 && (buffer[end] & 0xc0) === 0x80; i += 1) {
+    end -= 1;
+  }
+  return end;
+}
+
+/**
+ * Apply the response budget to an already-serialized text body.
+ *
+ * Under the cap the text passes through untouched and `structuredContent` (when
+ * the caller supplied one) rides along, preserving the #10676 contract that a
+ * client can parse either half and get the same data. Over the cap the text is
+ * truncated behind a notice and `structuredContent` is dropped — keeping it
+ * would ship the very payload the cap exists to bound, and a truncated stand-in
+ * could violate the tool's declared output schema.
+ *
+ * Truncation never sets `isError`: per MCP that flag means the tool actually
+ * failed, and a capped result is a successful call with a shortened body. The
+ * caller's own `isError` (a real failure) is passed through untouched.
+ */
+export function buildToolCallTextResult(
+  text: string,
+  options: { structuredContent?: Record<string, unknown>; isError?: boolean } = {}
+): CallToolResult {
+  const { structuredContent, isError } = options;
+  const originalBytes = Buffer.byteLength(text, "utf8");
+
+  if (originalBytes <= TOOL_RESULT_TEXT_MAX_BYTES) {
+    return {
+      content: [{ type: "text", text }],
+      ...(structuredContent ? { structuredContent } : {}),
+      ...(isError ? { isError } : {}),
+      _meta: { [MAX_RESULT_SIZE_CHARS_KEY]: TOOL_RESULT_TEXT_MAX_BYTES },
+    };
+  }
+
+  // The notice states how many bytes survived, but its own length changes the
+  // budget it is describing. Size it against the cap first — the real count is
+  // always below the cap, so it can never need more digits than this placeholder
+  // and the rebuilt notice can only be shorter. That keeps the total provably
+  // within the cap without a second pass.
+  const noticeBytes = Buffer.byteLength(
+    buildNotice(TOOL_RESULT_TEXT_MAX_BYTES, originalBytes),
+    "utf8"
+  );
+  const budget = Math.max(0, TOOL_RESULT_TEXT_MAX_BYTES - noticeBytes);
+  const buffer = Buffer.from(text, "utf8");
+  const shown = buffer.subarray(0, utf8BoundaryEnd(buffer, budget)).toString("utf8");
+
+  // Notice first, not appended: a client that trims the tail again would cut a
+  // trailing marker off and leave the model reading incomplete JSON as complete.
+  return {
+    content: [
+      { type: "text", text: `${buildNotice(Buffer.byteLength(shown, "utf8"), originalBytes)}${shown}` },
+    ],
+    ...(isError ? { isError } : {}),
+    _meta: { [MAX_RESULT_SIZE_CHARS_KEY]: TOOL_RESULT_TEXT_MAX_BYTES },
+  };
+}
+
+/**
+ * Build a `tools/call` success response from a raw action result: compact-
+ * serialize it, then apply the budget.
+ *
+ * `structuredContent` is a parameter rather than something this module derives,
+ * so each call site keeps its existing policy — the generic dispatch path gates
+ * on `buildStructuredContent`'s output schema check while the main-process
+ * short-circuits attach theirs unconditionally.
+ */
+export function buildToolCallResult(
+  value: unknown,
+  options: { structuredContent?: Record<string, unknown> } = {}
+): CallToolResult {
+  const text = value !== undefined && value !== null ? safeSerializeToolResultCompact(value) : "OK";
+  return buildToolCallTextResult(text, options);
+}

--- a/electron/utils/__tests__/pluginMcpHash.test.ts
+++ b/electron/utils/__tests__/pluginMcpHash.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { sha256Hex, stableArgsSha256 } from "../pluginMcpHash.js";
+import {
+  safeSerializeToolResult,
+  safeSerializeToolResultCompact,
+} from "../safeSerializeToolResult.js";
 
 describe("sha256Hex", () => {
   it("returns a 64-char lowercase hex digest", () => {
@@ -46,5 +50,16 @@ describe("stableArgsSha256", () => {
     const obj: Record<string, unknown> = { name: "x" };
     obj.self = obj;
     expect(() => stableArgsSha256(obj)).not.toThrow();
+  });
+
+  it("digests the indented serialization, not the compact wire form", () => {
+    // Digests are persisted (TOFU schema pins, audit records), so the byte
+    // layout they were computed over is a compatibility contract. Moving this
+    // to the compact serializer the MCP wire uses would rotate every stored
+    // fingerprint and force spurious re-consent (#11526).
+    const args = { name: "ada", role: "engineer" };
+
+    expect(stableArgsSha256(args)).toEqual(sha256Hex(safeSerializeToolResult(args)));
+    expect(stableArgsSha256(args)).not.toEqual(sha256Hex(safeSerializeToolResultCompact(args)));
   });
 });

--- a/electron/utils/__tests__/safeSerializeToolResult.test.ts
+++ b/electron/utils/__tests__/safeSerializeToolResult.test.ts
@@ -36,6 +36,28 @@ describe("safeSerializeToolResult", () => {
     expect(result.self).toBe("[Circular]");
   });
 
+  it("expands a value referenced twice in sibling branches", () => {
+    // Only a reference that closes a cycle may be replaced. Marking a repeat as
+    // circular puts a placeholder string where a declared output schema expects
+    // an object, which the MCP client rejects outright (#11526).
+    const shared = { id: "s-1", label: "shared" };
+    const result = JSON.parse(safeSerializeToolResult({ first: shared, second: shared }));
+
+    expect(result.first).toEqual(shared);
+    expect(result.second).toEqual(shared);
+  });
+
+  it("marks the back-edge without collapsing a second path to the same node", () => {
+    const child: Record<string, unknown> = { name: "child" };
+    const root: Record<string, unknown> = { child, alias: child };
+    child.parent = root;
+
+    const result = JSON.parse(safeSerializeToolResult(root));
+
+    expect(result.child.parent).toBe("[Circular]");
+    expect(result.alias).toEqual({ name: "child", parent: "[Circular]" });
+  });
+
   it("falls back to string coercion when JSON.stringify yields undefined", () => {
     expect(safeSerializeToolResult(undefined)).toBe("undefined");
   });

--- a/electron/utils/__tests__/safeSerializeToolResult.test.ts
+++ b/electron/utils/__tests__/safeSerializeToolResult.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { safeSerializeToolResult } from "../safeSerializeToolResult.js";
+import {
+  safeSerializeToolResult,
+  safeSerializeToolResultCompact,
+} from "../safeSerializeToolResult.js";
 
 describe("safeSerializeToolResult", () => {
   it("serializes plain JSON values losslessly", () => {
@@ -47,5 +50,44 @@ describe("safeSerializeToolResult", () => {
       },
     };
     expect(safeSerializeToolResult(hostile)).toBe("[object Object]");
+  });
+
+  it("keeps the indented byte layout that persisted hashes were computed over", () => {
+    // `pluginMcpHash.ts` digests these exact bytes for plugin schema
+    // fingerprints and audit argument hashes. Reformatting here silently
+    // rotates every stored fingerprint and forces spurious re-consent, so the
+    // whitespace is a contract rather than a style choice (#11526).
+    expect(safeSerializeToolResult({ a: 1, b: { c: 2 } })).toBe(
+      '{\n  "a": 1,\n  "b": {\n    "c": 2\n  }\n}'
+    );
+  });
+
+  it("stays uncapped — the size budget belongs to the MCP wire, not the hash input", () => {
+    const blob = "x".repeat(200_000);
+    expect(safeSerializeToolResult({ blob })).toContain(blob);
+  });
+});
+
+describe("safeSerializeToolResultCompact", () => {
+  it("drops the cosmetic whitespace no model reads", () => {
+    expect(safeSerializeToolResultCompact({ a: 1, b: { c: 2 } })).toBe('{"a":1,"b":{"c":2}}');
+  });
+
+  it("carries the same value semantics as the indented form", () => {
+    const value: Record<string, unknown> = {
+      big: 10n,
+      sym: Symbol("tag"),
+      fn: function namedFn() {},
+      err: new TypeError("boom"),
+    };
+    value.self = value;
+
+    const compact = JSON.parse(safeSerializeToolResultCompact(value));
+    expect(compact).toEqual(JSON.parse(safeSerializeToolResult(value)));
+    expect(compact.self).toBe("[Circular]");
+  });
+
+  it("shares the string-coercion fallbacks", () => {
+    expect(safeSerializeToolResultCompact(undefined)).toBe("undefined");
   });
 });

--- a/electron/utils/safeSerializeToolResult.ts
+++ b/electron/utils/safeSerializeToolResult.ts
@@ -1,8 +1,12 @@
 /**
  * Serialize an arbitrary tool result to JSON without throwing: BigInt and
  * Symbol coerce to strings, functions to a placeholder, Errors to a plain
- * object, and circular references to "[Circular]". Falls back to string
- * coercion when JSON.stringify still can't produce output.
+ * object, and references that close a cycle to "[Circular]". Falls back to
+ * string coercion when JSON.stringify still can't produce output.
+ *
+ * A value merely reached twice is expanded twice, exactly as the transport's
+ * own `JSON.stringify` would — the size that costs is the MCP wire budget's
+ * problem, not the serializer's.
  *
  * Lives outside `services/mcp-server/` on purpose: `pluginMcpHash.ts` needs it
  * on the eager boot path, and `mcp-server/shared.ts` value-imports the MCP
@@ -10,12 +14,16 @@
  * serializer standalone keeps that cost off first paint.
  */
 function serialize(value: unknown, indent: number): string {
-  const seen = new WeakSet<object>();
+  // The ancestor chain, not every object ever visited: a set that only grows
+  // marks a value referenced twice in *sibling* branches as "[Circular]" even
+  // though nothing is cyclic, and that placeholder string then lands where a
+  // declared output schema expects an object (#11526).
+  const ancestors: object[] = [];
 
   try {
     const serialized = JSON.stringify(
       value,
-      (_key, currentValue) => {
+      function (this: unknown, _key: string, currentValue: unknown) {
         if (typeof currentValue === "bigint") {
           return currentValue.toString();
         }
@@ -33,10 +41,14 @@ function serialize(value: unknown, indent: number): string {
           };
         }
         if (currentValue !== null && typeof currentValue === "object") {
-          if (seen.has(currentValue)) {
+          // `this` is the object holding this key, so unwinding to it discards
+          // the branches already finished and leaves the real ancestor chain.
+          const holder = ancestors.lastIndexOf(this as object);
+          if (holder !== -1) ancestors.length = holder + 1;
+          if (ancestors.includes(currentValue)) {
             return "[Circular]";
           }
-          seen.add(currentValue);
+          ancestors.push(currentValue);
         }
         return currentValue;
       },

--- a/electron/utils/safeSerializeToolResult.ts
+++ b/electron/utils/safeSerializeToolResult.ts
@@ -9,7 +9,7 @@
  * SDK's `types.js` (full zod schema construction at module init) — keeping the
  * serializer standalone keeps that cost off first paint.
  */
-export function safeSerializeToolResult(value: unknown): string {
+function serialize(value: unknown, indent: number): string {
   const seen = new WeakSet<object>();
 
   try {
@@ -40,7 +40,7 @@ export function safeSerializeToolResult(value: unknown): string {
         }
         return currentValue;
       },
-      2
+      indent
     );
 
     if (serialized !== undefined) {
@@ -55,4 +55,25 @@ export function safeSerializeToolResult(value: unknown): string {
   } catch {
     return Object.prototype.toString.call(value);
   }
+}
+
+/**
+ * The 2-space-indented form. This output is hashed by `pluginMcpHash.ts` for
+ * plugin schema fingerprints (TOFU consent pinning) and audit argument hashes,
+ * so its bytes are a persisted contract: changing the indent here silently
+ * rotates every stored fingerprint and forces spurious re-consent. Callers that
+ * only need the JSON on the wire want `safeSerializeToolResultCompact` instead.
+ */
+export function safeSerializeToolResult(value: unknown): string {
+  return serialize(value, 2);
+}
+
+/**
+ * The unindented form, for MCP `tools/call` payloads. Pretty-printing costs
+ * 25-46% of the response in whitespace no model reads (#11526), and the wire
+ * has no reader that needs the indent — but only the wire may use this, never
+ * a hash input.
+ */
+export function safeSerializeToolResultCompact(value: unknown): string {
+  return serialize(value, 0);
 }


### PR DESCRIPTION
## Summary

- MCP resources have been capped at 50 KB for a while via `RESOURCE_TEXT_MAX_BYTES`, but `tools/call` results had no cap at all. On this repo, `copyTree.generate` returns 31.2 MB, `actions.list` returns about 430 KB, and `terminal.getOutput` returns about 860 KB. Claude Code warns above 10,000 tokens of MCP output and hard limits at 25,000 by default, so these calls weren't just burning context, they were failing to deliver a usable result.
- New file `electron/services/mcp-server/toolCallResult.ts` defines `TOOL_RESULT_TEXT_MAX_BYTES` at 50 KiB (matching the resource cap) and exports `buildToolCallResult` / `buildToolCallTextResult`. All five `tools/call` response sites in `sessionServer.ts`, plus `buildToolError`, now route through them. Oversized bodies get a notice placed first reporting delivered size versus original, with the cut made on a UTF-8 character boundary so it never splits a multi-byte character.
- `structuredContent` is kept when it fits under the cap (preserving the parity contract from #10676) and dropped otherwise. It's now re-derived from the already-bounded text and validated against `JSON.stringify`, the exact operation the transport performs.

Resolves #11526

## Changes

- The `JSON.stringify` re-derivation matters because the serializer collapses every repeated reference to `"[Circular]"`. A result with aliased references could serialize to ~23 KB of text while still shipping ~10 MB over the wire if `structuredContent` were built from the original object instead of the bounded text. Same fix also stops a cyclic or BigInt-bearing result from throwing inside the transport's own `JSON.stringify` call.
- JSON on the wire is now compact instead of indented. The old 2-space indent cost 25 to 46 percent in whitespace no model reads. `safeSerializeToolResult` keeps its indented output unchanged, since `electron/utils/pluginMcpHash.ts` hashes those exact bytes for plugin TOFU schema pins and audit trails, and reformatting would silently rotate every stored fingerprint and force spurious re-consent. The compact form is a separate export used only by the wire path.
- New `_meta["anthropic/maxResultSizeChars"]` set to 51200, so clients that honor it don't layer their own smaller ceiling on top of an already-bounded response.
- The skill id echoed back in `skills.load`'s `McpError` is now clamped too, since that message becomes a JSON-RPC error and would otherwise bypass the `tools/call` budget entirely.

**Out of scope**, noted for follow-up: `file.read`'s 512 KB hard failure still needs a real ranged-read contract rather than a cap; resource-path serialization stays indented since resources already have their own cap; results are still fully materialized in memory before truncation, so this isn't bounded streaming yet.

## Testing

- 935 tests pass across the whole MCP server test surface.
- eslint and prettier clean on all changed files.
- Two new suites added: `toolCallResult.test.ts` and `skills.test.ts`.
