### PR TITLE
fix(mcp): route unpinned tool calls by focus order and report the resolved workspace

### DIFF
--- a/electron/services/__tests__/McpServerService.auditLog.test.ts
+++ b/electron/services/__tests__/McpServerService.auditLog.test.ts
@@ -337,6 +337,8 @@ function createMockWindow(options?: {
 
   const projectViewManager = {
     getActiveView: vi.fn((): { webContents: typeof webContents } | null => ({ webContents })),
+
+    getWorkspaceRefForWebContents: vi.fn(() => null),
   };
 
   const windowContext = {

--- a/electron/services/__tests__/McpServerService.auditLog.test.ts
+++ b/electron/services/__tests__/McpServerService.auditLog.test.ts
@@ -351,6 +351,7 @@ function createMockWindow(options?: {
 
   const registry = {
     all: () => [windowContext],
+    focusOrder: () => [windowContext],
     getPrimary: () => windowContext,
     getByWindowId: () => windowContext,
     getByWebContentsId: () => windowContext,

--- a/electron/services/__tests__/McpServerService.authAndToolSurface.test.ts
+++ b/electron/services/__tests__/McpServerService.authAndToolSurface.test.ts
@@ -183,6 +183,7 @@ vi.mock("../SystemSleepService.js", () => ({
 }));
 
 import { McpServerService } from "../McpServerService.js";
+import { RESOLVED_PROJECT_META_KEY } from "../mcp-server/shared.js";
 
 type DispatchRequest = {
   requestId: string;
@@ -241,6 +242,8 @@ function createMockWindow(options?: {
       };
   senderIdOverride?: number;
   hostShellWebContentsId?: number;
+  /** Project this window's view belongs to, for the #11536 result stamp. */
+  projectRef?: { projectId: string; projectPath: string };
 }) {
   const getManifest = options?.getManifest ?? (() => []);
   const dispatchAction =
@@ -337,6 +340,9 @@ function createMockWindow(options?: {
 
   const projectViewManager = {
     getActiveView: vi.fn((): { webContents: typeof webContents } | null => ({ webContents })),
+    getProjectRefForWebContents: vi.fn((id: number) =>
+      options?.projectRef && id === projectViewWcId ? options.projectRef : null
+    ),
   };
 
   const windowContext = {
@@ -351,6 +357,7 @@ function createMockWindow(options?: {
 
   const registry = {
     all: () => [windowContext],
+    focusOrder: () => [windowContext],
     getPrimary: () => windowContext,
     getByWindowId: () => windowContext,
     getByWebContentsId: () => windowContext,
@@ -956,6 +963,7 @@ describe("McpServerService", () => {
 
     const combinedRegistry = {
       all: () => [winA.windowContext, winB.windowContext],
+      focusOrder: () => [winA.windowContext, winB.windowContext],
       getPrimary: () => winA.windowContext,
       getByWindowId: () => winA.windowContext,
       getByWebContentsId: () => winA.windowContext,
@@ -996,6 +1004,69 @@ describe("McpServerService", () => {
     expect(sendsToB).toHaveLength(1);
   });
 
+  it("routes an unpinned external session by focus order and reports the project it landed on (#11536)", async () => {
+    // Registration order is [A, B]; focus order is the opposite. Before the
+    // fix the bridge walked `all()` (Map insertion order) and every external
+    // call landed on A — whichever window happened to register first —
+    // regardless of what the user was actually looking at.
+    const manifest = () => [
+      createManifestEntry({
+        id: "actions.list",
+        title: "List Actions",
+        description: "Read the action registry",
+        kind: "query",
+      }),
+    ];
+    const winA = createMockWindow({
+      getManifest: manifest,
+      dispatchAction: () => ({ ok: true, result: "from-window-A" }),
+      projectRef: { projectId: "proj-a", projectPath: "/repos/a" },
+    });
+    const winB = createMockWindow({
+      getManifest: manifest,
+      dispatchAction: () => ({ ok: true, result: "from-window-B" }),
+      projectRef: { projectId: "proj-b", projectPath: "/repos/b" },
+    });
+
+    const focus = { current: [winB.windowContext, winA.windowContext] };
+    const contextByWcId = new Map([
+      [winA.webContents.id, winA.windowContext],
+      [winB.webContents.id, winB.windowContext],
+    ]);
+    const combinedRegistry = {
+      all: () => [winA.windowContext, winB.windowContext],
+      focusOrder: () => focus.current,
+      getPrimary: () => winA.windowContext,
+      getByWindowId: () => winA.windowContext,
+      getByWebContentsId: (id: number) => contextByWcId.get(id),
+      size: 2,
+    } as never;
+
+    await service.start(combinedRegistry);
+
+    // No help token — an api-key bearer, i.e. the unpinned external path.
+    const external = await connectClient(service.currentPort!);
+    transports.push(external.transport);
+
+    const first = await external.client.callTool({ name: "actions.list", arguments: {} });
+    expect(getTextResult(first).content[0].text).toBe('"from-window-B"');
+    expect(first._meta?.[RESOLVED_PROJECT_META_KEY]).toEqual({
+      projectId: "proj-b",
+      projectPath: "/repos/b",
+    });
+
+    // The user switches windows mid-session. The session stays unpinned by
+    // design (#7003), so the next call follows focus — and says so.
+    focus.current = [winA.windowContext, winB.windowContext];
+
+    const second = await external.client.callTool({ name: "actions.list", arguments: {} });
+    expect(getTextResult(second).content[0].text).toBe('"from-window-A"');
+    expect(second._meta?.[RESOLVED_PROJECT_META_KEY]).toEqual({
+      projectId: "proj-a",
+      projectPath: "/repos/a",
+    });
+  });
+
   it("fails closed when the pinned WebContents has been destroyed (#7002 — never silently re-routes)", async () => {
     const winA = createMockWindow({
       dispatchAction: () => ({ ok: true, result: "from-A" }),
@@ -1006,6 +1077,7 @@ describe("McpServerService", () => {
 
     const combinedRegistry = {
       all: () => [winA.windowContext, winB.windowContext],
+      focusOrder: () => [winA.windowContext, winB.windowContext],
       getPrimary: () => winA.windowContext,
       getByWindowId: () => winA.windowContext,
       getByWebContentsId: () => winA.windowContext,
@@ -1113,6 +1185,7 @@ describe("McpServerService", () => {
 
     const combinedRegistry = {
       all: () => [winA.windowContext, winB.windowContext],
+      focusOrder: () => [winA.windowContext, winB.windowContext],
       getPrimary: () => winA.windowContext,
       getByWindowId: () => winA.windowContext,
       getByWebContentsId: () => winA.windowContext,

--- a/electron/services/__tests__/McpServerService.authAndToolSurface.test.ts
+++ b/electron/services/__tests__/McpServerService.authAndToolSurface.test.ts
@@ -183,7 +183,6 @@ vi.mock("../SystemSleepService.js", () => ({
 }));
 
 import { McpServerService } from "../McpServerService.js";
-import { RESOLVED_PROJECT_META_KEY } from "../mcp-server/shared.js";
 
 type DispatchRequest = {
   requestId: string;
@@ -196,6 +195,7 @@ type DispatchRequest = {
 type TextToolResult = {
   content: Array<{ type: string; text: string }>;
   isError?: boolean;
+  _meta?: Record<string, unknown>;
 };
 
 function createManifestEntry(entry: {
@@ -242,8 +242,8 @@ function createMockWindow(options?: {
       };
   senderIdOverride?: number;
   hostShellWebContentsId?: number;
-  /** Project this window's view belongs to, for the #11536 result stamp. */
-  projectRef?: { projectId: string; projectPath: string };
+  /** Workspace this window's view belongs to, for the #11536 result stamp. */
+  workspaceRef?: { kind: "project" | "scratch"; workspaceId: string; workspacePath: string };
 }) {
   const getManifest = options?.getManifest ?? (() => []);
   const dispatchAction =
@@ -340,8 +340,8 @@ function createMockWindow(options?: {
 
   const projectViewManager = {
     getActiveView: vi.fn((): { webContents: typeof webContents } | null => ({ webContents })),
-    getProjectRefForWebContents: vi.fn((id: number) =>
-      options?.projectRef && id === projectViewWcId ? options.projectRef : null
+    getWorkspaceRefForWebContents: vi.fn((id: number) =>
+      options?.workspaceRef && id === projectViewWcId ? options.workspaceRef : null
     ),
   };
 
@@ -938,6 +938,16 @@ describe("McpServerService", () => {
     // pinning, both sessions would dispatch into whatever the shared
     // `getActiveProjectWebContents()` returns first; with the fix, each
     // session routes to the WebContents that minted it.
+    const pinnedRefA = {
+      kind: "project" as const,
+      workspaceId: "proj-a",
+      workspacePath: "/repos/a",
+    };
+    const pinnedRefB = {
+      kind: "project" as const,
+      workspaceId: "proj-b",
+      workspacePath: "/repos/b",
+    };
     const winA = createMockWindow({
       getManifest: () => [
         createManifestEntry({
@@ -948,6 +958,7 @@ describe("McpServerService", () => {
         }),
       ],
       dispatchAction: () => ({ ok: true, result: "from-window-A" }),
+      workspaceRef: pinnedRefA,
     });
     const winB = createMockWindow({
       getManifest: () => [
@@ -959,14 +970,21 @@ describe("McpServerService", () => {
         }),
       ],
       dispatchAction: () => ({ ok: true, result: "from-window-B" }),
+      workspaceRef: pinnedRefB,
     });
 
+    // Indexed by id rather than always answering window A, so each pinned
+    // session's stamp is resolved through its OWN window's manager.
+    const pinnedContextByWcId = new Map([
+      [winA.webContents.id, winA.windowContext],
+      [winB.webContents.id, winB.windowContext],
+    ]);
     const combinedRegistry = {
       all: () => [winA.windowContext, winB.windowContext],
       focusOrder: () => [winA.windowContext, winB.windowContext],
       getPrimary: () => winA.windowContext,
       getByWindowId: () => winA.windowContext,
-      getByWebContentsId: () => winA.windowContext,
+      getByWebContentsId: (id: number) => pinnedContextByWcId.get(id),
       size: 2,
     } as never;
 
@@ -990,6 +1008,12 @@ describe("McpServerService", () => {
     expect(resA.content[0].text).toBe('"from-window-A"');
     expect(resB.content[0].text).toBe('"from-window-B"');
 
+    // Each pinned result reports its own window's workspace (#11536) — the
+    // stamp is resolved from the responding sender, so it is right on the
+    // pinned path too, not just the focus-following external one.
+    expect(resA._meta?.["org.daintree/resolved-workspace"]).toEqual(pinnedRefA);
+    expect(resB._meta?.["org.daintree/resolved-workspace"]).toEqual(pinnedRefB);
+
     // Both windows' WebContents.send must have been invoked — and only for
     // the dispatch belonging to that window. (Each window also receives one
     // `CHANNELS.MCP_SERVER_GET_MANIFEST_REQUEST` per session — that is fine because pinned
@@ -1004,7 +1028,7 @@ describe("McpServerService", () => {
     expect(sendsToB).toHaveLength(1);
   });
 
-  it("routes an unpinned external session by focus order and reports the project it landed on (#11536)", async () => {
+  it("routes an unpinned external session by focus order and reports the workspace it landed on (#11536)", async () => {
     // Registration order is [A, B]; focus order is the opposite. Before the
     // fix the bridge walked `all()` (Map insertion order) and every external
     // call landed on A — whichever window happened to register first —
@@ -1017,15 +1041,17 @@ describe("McpServerService", () => {
         kind: "query",
       }),
     ];
+    const refA = { kind: "project" as const, workspaceId: "proj-a", workspacePath: "/repos/a" };
+    const refB = { kind: "project" as const, workspaceId: "proj-b", workspacePath: "/repos/b" };
     const winA = createMockWindow({
       getManifest: manifest,
       dispatchAction: () => ({ ok: true, result: "from-window-A" }),
-      projectRef: { projectId: "proj-a", projectPath: "/repos/a" },
+      workspaceRef: refA,
     });
     const winB = createMockWindow({
       getManifest: manifest,
       dispatchAction: () => ({ ok: true, result: "from-window-B" }),
-      projectRef: { projectId: "proj-b", projectPath: "/repos/b" },
+      workspaceRef: refB,
     });
 
     const focus = { current: [winB.windowContext, winA.windowContext] };
@@ -1050,10 +1076,9 @@ describe("McpServerService", () => {
 
     const first = await external.client.callTool({ name: "actions.list", arguments: {} });
     expect(getTextResult(first).content[0].text).toBe('"from-window-B"');
-    expect(first._meta?.[RESOLVED_PROJECT_META_KEY]).toEqual({
-      projectId: "proj-b",
-      projectPath: "/repos/b",
-    });
+    // Read by literal key, as a real external client would: this string is the
+    // wire contract, so renaming it must fail here even if the constant moves.
+    expect(first._meta?.["org.daintree/resolved-workspace"]).toEqual(refB);
 
     // The user switches windows mid-session. The session stays unpinned by
     // design (#7003), so the next call follows focus — and says so.
@@ -1061,10 +1086,7 @@ describe("McpServerService", () => {
 
     const second = await external.client.callTool({ name: "actions.list", arguments: {} });
     expect(getTextResult(second).content[0].text).toBe('"from-window-A"');
-    expect(second._meta?.[RESOLVED_PROJECT_META_KEY]).toEqual({
-      projectId: "proj-a",
-      projectPath: "/repos/a",
-    });
+    expect(second._meta?.["org.daintree/resolved-workspace"]).toEqual(refA);
   });
 
   it("fails closed when the pinned WebContents has been destroyed (#7002 — never silently re-routes)", async () => {

--- a/electron/services/__tests__/McpServerService.lifecycleAndElicitation.test.ts
+++ b/electron/services/__tests__/McpServerService.lifecycleAndElicitation.test.ts
@@ -337,6 +337,8 @@ function createMockWindow(options?: {
 
   const projectViewManager = {
     getActiveView: vi.fn((): { webContents: typeof webContents } | null => ({ webContents })),
+
+    getWorkspaceRefForWebContents: vi.fn(() => null),
   };
 
   const windowContext = {

--- a/electron/services/__tests__/McpServerService.lifecycleAndElicitation.test.ts
+++ b/electron/services/__tests__/McpServerService.lifecycleAndElicitation.test.ts
@@ -351,6 +351,7 @@ function createMockWindow(options?: {
 
   const registry = {
     all: () => [windowContext],
+    focusOrder: () => [windowContext],
     getPrimary: () => windowContext,
     getByWindowId: () => windowContext,
     getByWebContentsId: () => windowContext,

--- a/electron/services/__tests__/McpServerService.promptsAndResources.test.ts
+++ b/electron/services/__tests__/McpServerService.promptsAndResources.test.ts
@@ -345,6 +345,7 @@ function createMockWindow(options?: {
 
   const registry = {
     all: () => [windowContext],
+    focusOrder: () => [windowContext],
     getPrimary: () => windowContext,
     getByWindowId: () => windowContext,
     getByWebContentsId: () => windowContext,

--- a/electron/services/__tests__/McpServerService.promptsAndResources.test.ts
+++ b/electron/services/__tests__/McpServerService.promptsAndResources.test.ts
@@ -331,6 +331,8 @@ function createMockWindow(options?: {
 
   const projectViewManager = {
     getActiveView: vi.fn((): { webContents: typeof webContents } | null => ({ webContents })),
+
+    getWorkspaceRefForWebContents: vi.fn(() => null),
   };
 
   const windowContext = {

--- a/electron/services/__tests__/McpServerService.tierAuthorization.test.ts
+++ b/electron/services/__tests__/McpServerService.tierAuthorization.test.ts
@@ -395,6 +395,8 @@ function createMockWindow(options?: {
 
   const projectViewManager = {
     getActiveView: vi.fn((): { webContents: typeof webContents } | null => ({ webContents })),
+
+    getWorkspaceRefForWebContents: vi.fn(() => null),
   };
 
   const windowContext = {

--- a/electron/services/__tests__/McpServerService.tierAuthorization.test.ts
+++ b/electron/services/__tests__/McpServerService.tierAuthorization.test.ts
@@ -409,6 +409,7 @@ function createMockWindow(options?: {
 
   const registry = {
     all: () => [windowContext],
+    focusOrder: () => [windowContext],
     getPrimary: () => windowContext,
     getByWindowId: () => windowContext,
     getByWebContentsId: () => windowContext,

--- a/electron/services/__tests__/McpServerService.transportAndSchema.test.ts
+++ b/electron/services/__tests__/McpServerService.transportAndSchema.test.ts
@@ -337,6 +337,8 @@ function createMockWindow(options?: {
 
   const projectViewManager = {
     getActiveView: vi.fn((): { webContents: typeof webContents } | null => ({ webContents })),
+
+    getWorkspaceRefForWebContents: vi.fn(() => null),
   };
 
   const windowContext = {

--- a/electron/services/__tests__/McpServerService.transportAndSchema.test.ts
+++ b/electron/services/__tests__/McpServerService.transportAndSchema.test.ts
@@ -351,6 +351,7 @@ function createMockWindow(options?: {
 
   const registry = {
     all: () => [windowContext],
+    focusOrder: () => [windowContext],
     getPrimary: () => windowContext,
     getByWindowId: () => windowContext,
     getByWebContentsId: () => windowContext,

--- a/electron/services/__tests__/McpServerService.waitUntilIdle.test.ts
+++ b/electron/services/__tests__/McpServerService.waitUntilIdle.test.ts
@@ -353,6 +353,7 @@ function createMockWindow(options?: {
 
   const registry = {
     all: () => [windowContext],
+    focusOrder: () => [windowContext],
     getPrimary: () => windowContext,
     getByWindowId: () => windowContext,
     getByWebContentsId: () => windowContext,

--- a/electron/services/__tests__/McpServerService.waitUntilIdle.test.ts
+++ b/electron/services/__tests__/McpServerService.waitUntilIdle.test.ts
@@ -339,6 +339,8 @@ function createMockWindow(options?: {
 
   const projectViewManager = {
     getActiveView: vi.fn((): { webContents: typeof webContents } | null => ({ webContents })),
+
+    getWorkspaceRefForWebContents: vi.fn(() => null),
   };
 
   const windowContext = {

--- a/electron/services/mcp-server/__tests__/rendererBridge.test.ts
+++ b/electron/services/mcp-server/__tests__/rendererBridge.test.ts
@@ -607,6 +607,10 @@ describe("rendererBridge — unpinned routing follows focus order (#11536)", () 
     workspaceRef?: { kind: "project" | "scratch"; workspaceId: string; workspacePath: string } | null;
     /** Simulates a host whose manager predates getWorkspaceRefForWebContents. */
     omitWorkspaceRefAccessor?: boolean;
+    /** Simulates a torn-down view whose accessor throws rather than returning. */
+    throwFromWorkspaceRefAccessor?: boolean;
+    /** Simulates the window lookup itself throwing, before any accessor call. */
+    throwFromServices?: boolean;
   }
 
   function makeContext(options: FakeContextOptions) {
@@ -614,15 +618,29 @@ describe("rendererBridge — unpinned routing follows focus order (#11536)", () 
     const getActiveView = () => (activeWebContents ? { webContents: activeWebContents } : null);
     // Spied so a test can assert the lookup happened per-sender at response
     // time, rather than eagerly at send time.
-    const getWorkspaceRefForWebContents = vi.fn((id: number) =>
-      workspaceRef && activeWebContents && activeWebContents.id === id ? workspaceRef : null
-    );
+    const getWorkspaceRefForWebContents = vi.fn((id: number) => {
+      if (options.throwFromWorkspaceRefAccessor) throw new Error("view torn down");
+      return workspaceRef && activeWebContents && activeWebContents.id === id ? workspaceRef : null;
+    });
     const projectViewManager = options.omitWorkspaceRefAccessor
       ? { getActiveView }
       : { getActiveView, getWorkspaceRefForWebContents };
+    // Routing reads `projectViewManager` first, then response-time resolution
+    // reads it again. Throwing only on the later reads models a window torn
+    // down mid-dispatch, without breaking the routing that must happen first.
+    let serviceReads = 0;
+    const services = options.throwFromServices
+      ? {
+          get projectViewManager() {
+            serviceReads += 1;
+            if (serviceReads > 1) throw new Error("window torn down");
+            return projectViewManager;
+          },
+        }
+      : { projectViewManager };
     return {
       browserWindow: { isDestroyed: () => windowDestroyed },
-      services: { projectViewManager },
+      services,
       activeWebContentsId: activeWebContents?.id ?? null,
       /** Test-only handle on the spy — production reads it via `services`. */
       workspaceRefSpy: getWorkspaceRefForWebContents,
@@ -898,23 +916,88 @@ describe("rendererBridge — unpinned routing follows focus order (#11536)", () 
     expect("dispatchedWorkspace" in envelope).toBe(false);
   });
 
-  it("still resolves the action when the project lookup throws", async () => {
-    const wc = makeWebContents(961);
-    // A manager that predates the accessor: calling it throws a TypeError.
-    const ctx = makeContext({ activeWebContents: wc, omitWorkspaceRefAccessor: true });
-    autoRespond(wc);
+  it("omits the stamp, without logging, when the host manager has no accessor", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const wc = makeWebContents(961);
+      const ctx = makeContext({ activeWebContents: wc, omitWorkspaceRefAccessor: true });
+      autoRespond(wc);
 
-    const focusRef = { current: [ctx] };
-    const bridge = createRendererBridge(
-      pendingManifests,
-      pendingDispatches,
-      () => makeRegistry([ctx], focusRef) as never
-    );
-    bridge.setupListeners([]);
+      const focusRef = { current: [ctx] };
+      const bridge = createRendererBridge(
+        pendingManifests,
+        pendingDispatches,
+        () => makeRegistry([ctx], focusRef) as never
+      );
+      bridge.setupListeners([]);
 
-    const envelope = await bridge.dispatchAction("actions.list", {}, false);
+      const envelope = await bridge.dispatchAction("actions.list", {}, false);
 
-    expect(envelope.result).toEqual({ ok: true, result: "ok" });
-    expect(envelope.dispatchedWorkspace).toBeUndefined();
+      expect(envelope.result).toEqual({ ok: true, result: "ok" });
+      expect(envelope.dispatchedWorkspace).toBeUndefined();
+      // An older/partial manager is an expected shape, not a failure.
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("settles the action and warns once when the workspace accessor throws", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const wc = makeWebContents(981);
+      const ctx = makeContext({ activeWebContents: wc, throwFromWorkspaceRefAccessor: true });
+      autoRespond(wc);
+
+      const focusRef = { current: [ctx] };
+      const bridge = createRendererBridge(
+        pendingManifests,
+        pendingDispatches,
+        () => makeRegistry([ctx], focusRef) as never
+      );
+      bridge.setupListeners([]);
+
+      // The action must still complete — identity is decoration, and the
+      // pending entry's timer is already cleared by the time this runs, so an
+      // escaping throw would strand the promise instead of losing the stamp.
+      const first = await bridge.dispatchAction("actions.list", {}, false);
+      expect(first.result).toEqual({ ok: true, result: "ok" });
+      expect(first.dispatchedWorkspace).toBeUndefined();
+      expect(warn).toHaveBeenCalledTimes(1);
+
+      // Latched: a persistently broken lookup must not log on every dispatch.
+      const second = await bridge.dispatchAction("actions.list", {}, false);
+      expect(second.result).toEqual({ ok: true, result: "ok" });
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("settles the action when the window lookup itself throws mid-dispatch", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const wc = makeWebContents(991);
+      // The window is torn down between routing and the response, so reading
+      // `services.projectViewManager` throws — outside any accessor call.
+      const ctx = makeContext({ activeWebContents: wc, throwFromServices: true });
+      autoRespond(wc);
+
+      const focusRef = { current: [ctx] };
+      const bridge = createRendererBridge(
+        pendingManifests,
+        pendingDispatches,
+        () => makeRegistry([ctx], focusRef) as never
+      );
+      bridge.setupListeners([]);
+
+      const envelope = await bridge.dispatchAction("actions.list", {}, false);
+
+      expect(envelope.result).toEqual({ ok: true, result: "ok" });
+      expect(envelope.dispatchedWorkspace).toBeUndefined();
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/electron/services/mcp-server/__tests__/rendererBridge.test.ts
+++ b/electron/services/mcp-server/__tests__/rendererBridge.test.ts
@@ -483,15 +483,17 @@ describe("rendererBridge — requesting-bearer identity passthrough (#9157)", ()
    * that carries `callerInfo`.
    */
   function makeActiveBridge(wc: FakeWebContents) {
-    const registry = {
-      all: () => [
-        {
-          browserWindow: { isDestroyed: () => false },
-          services: {
-            projectViewManager: { getActiveView: () => ({ webContents: wc }) },
-          },
+    const contexts = [
+      {
+        browserWindow: { isDestroyed: () => false },
+        services: {
+          projectViewManager: { getActiveView: () => ({ webContents: wc }) },
         },
-      ],
+      },
+    ];
+    const registry = {
+      all: () => contexts,
+      focusOrder: () => contexts,
     };
     const bridge = createRendererBridge(
       pendingManifests,
@@ -574,5 +576,272 @@ describe("rendererBridge — requesting-bearer identity passthrough (#9157)", ()
 
     expect(sentPayload).toBeDefined();
     expect(sentPayload?.callerInfo).toBeUndefined();
+  });
+});
+
+describe("rendererBridge — unpinned routing follows focus order (#11536)", () => {
+  let pendingManifests: Map<string, PendingRequest<ActionManifestEntry[]>>;
+  let pendingDispatches: Map<string, PendingRequest<DispatchEnvelope>>;
+
+  beforeEach(() => {
+    mockIpcMain.removeAllListeners();
+    mockWebContentsRegistry.clear();
+    pendingManifests = new Map();
+    pendingDispatches = new Map();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  interface FakeContextOptions {
+    windowDestroyed?: boolean;
+    /** Omitted entirely for a window with no active project view. */
+    activeWebContents?: FakeWebContents | null;
+    projectRef?: { projectId: string; projectPath: string } | null;
+    /** Simulates a host whose manager predates getProjectRefForWebContents. */
+    omitProjectRefAccessor?: boolean;
+  }
+
+  function makeContext(options: FakeContextOptions) {
+    const { windowDestroyed = false, activeWebContents = null, projectRef = null } = options;
+    const projectViewManager: Record<string, unknown> = {
+      getActiveView: () => (activeWebContents ? { webContents: activeWebContents } : null),
+    };
+    if (!options.omitProjectRefAccessor) {
+      projectViewManager.getProjectRefForWebContents = (id: number) =>
+        projectRef && activeWebContents && activeWebContents.id === id ? projectRef : null;
+    }
+    return {
+      browserWindow: { isDestroyed: () => windowDestroyed },
+      services: { projectViewManager },
+    };
+  }
+
+  /**
+   * Registry double whose `all()` and `focusOrder()` deliberately disagree, so a
+   * test that passes under either ordering proves nothing. `focusOrder` reads a
+   * mutable ref to model focus moving between calls.
+   */
+  function makeRegistry(
+    registrationOrder: ReturnType<typeof makeContext>[],
+    focusRef: { current: ReturnType<typeof makeContext>[] }
+  ) {
+    return {
+      all: () => registrationOrder,
+      focusOrder: () => focusRef.current,
+      getByWebContentsId: (id: number) =>
+        registrationOrder.find(
+          (ctx) =>
+            (
+              ctx.services.projectViewManager as {
+                getActiveView: () => { webContents: FakeWebContents } | null;
+              }
+            ).getActiveView()?.webContents.id === id
+        ),
+    };
+  }
+
+  /** Auto-replies to a dispatch request as `wc`, so the promise settles. */
+  function autoRespond(wc: FakeWebContents, senderId = wc.id) {
+    wc.send.mockImplementation((channel: string, payload: { requestId: string }) => {
+      if (channel !== CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST) return;
+      queueMicrotask(() => {
+        mockIpcMain.emit(
+          CHANNELS.MCP_SERVER_DISPATCH_ACTION_RESPONSE,
+          { sender: { id: senderId } },
+          { requestId: payload.requestId, result: { ok: true, result: "ok" } }
+        );
+      });
+    });
+  }
+
+  it("dispatches to the most-recently-focused window, not the first registered", async () => {
+    const wcFirst = makeWebContents(901);
+    const wcFocused = makeWebContents(902);
+    const ctxFirst = makeContext({ activeWebContents: wcFirst });
+    const ctxFocused = makeContext({ activeWebContents: wcFocused });
+    autoRespond(wcFirst);
+    autoRespond(wcFocused);
+
+    // Registered first-to-last as [first, focused]; focus says the opposite.
+    const focusRef = { current: [ctxFocused, ctxFirst] };
+    const bridge = createRendererBridge(
+      pendingManifests,
+      pendingDispatches,
+      () => makeRegistry([ctxFirst, ctxFocused], focusRef) as never
+    );
+    bridge.setupListeners([]);
+
+    await bridge.dispatchAction("actions.list", {}, false);
+
+    expect(wcFocused.send).toHaveBeenCalled();
+    expect(wcFirst.send).not.toHaveBeenCalled();
+  });
+
+  it("re-resolves focus on every call, so a mid-session focus change retargets", async () => {
+    const wcA = makeWebContents(911);
+    const wcB = makeWebContents(912);
+    const ctxA = makeContext({ activeWebContents: wcA });
+    const ctxB = makeContext({ activeWebContents: wcB });
+    autoRespond(wcA);
+    autoRespond(wcB);
+
+    const focusRef = { current: [ctxB, ctxA] };
+    const bridge = createRendererBridge(
+      pendingManifests,
+      pendingDispatches,
+      () => makeRegistry([ctxA, ctxB], focusRef) as never
+    );
+    bridge.setupListeners([]);
+
+    await bridge.dispatchAction("actions.list", {}, false);
+    expect(wcB.send).toHaveBeenCalledTimes(1);
+    expect(wcA.send).not.toHaveBeenCalled();
+
+    // User switches windows between calls.
+    focusRef.current = [ctxA, ctxB];
+    await bridge.dispatchAction("actions.list", {}, false);
+    expect(wcA.send).toHaveBeenCalledTimes(1);
+    expect(wcB.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips destroyed windows and view-less windows ahead of a live one in focus order", async () => {
+    const wcLive = makeWebContents(921);
+    const wcInDestroyedWindow = makeWebContents(922);
+    const wcDestroyedView = makeWebContents(923);
+    wcDestroyedView.isDestroyed.mockReturnValue(true);
+    autoRespond(wcLive);
+
+    const ctxDestroyedWindow = makeContext({
+      windowDestroyed: true,
+      activeWebContents: wcInDestroyedWindow,
+    });
+    const ctxNoView = makeContext({ activeWebContents: null });
+    const ctxDestroyedView = makeContext({ activeWebContents: wcDestroyedView });
+    const ctxLive = makeContext({ activeWebContents: wcLive });
+
+    const focusRef = {
+      current: [ctxDestroyedWindow, ctxNoView, ctxDestroyedView, ctxLive],
+    };
+    const bridge = createRendererBridge(
+      pendingManifests,
+      pendingDispatches,
+      () => makeRegistry([ctxLive], focusRef) as never
+    );
+    bridge.setupListeners([]);
+
+    await bridge.dispatchAction("actions.list", {}, false);
+
+    expect(wcLive.send).toHaveBeenCalled();
+    expect(wcInDestroyedWindow.send).not.toHaveBeenCalled();
+    expect(wcDestroyedView.send).not.toHaveBeenCalled();
+  });
+
+  it("manifest requests follow focus order too", async () => {
+    const wcFirst = makeWebContents(931);
+    const wcFocused = makeWebContents(932);
+    const ctxFirst = makeContext({ activeWebContents: wcFirst });
+    const ctxFocused = makeContext({ activeWebContents: wcFocused });
+    wcFocused.send.mockImplementation((channel: string, payload: { requestId: string }) => {
+      if (channel !== CHANNELS.MCP_SERVER_GET_MANIFEST_REQUEST) return;
+      queueMicrotask(() => {
+        mockIpcMain.emit(
+          CHANNELS.MCP_SERVER_GET_MANIFEST_RESPONSE,
+          { sender: { id: 932 } },
+          { requestId: payload.requestId, manifest: [] }
+        );
+      });
+    });
+
+    const focusRef = { current: [ctxFocused, ctxFirst] };
+    const bridge = createRendererBridge(
+      pendingManifests,
+      pendingDispatches,
+      () => makeRegistry([ctxFirst, ctxFocused], focusRef) as never
+    );
+    bridge.setupListeners([]);
+
+    await bridge.requestManifest();
+
+    expect(wcFocused.send).toHaveBeenCalled();
+    expect(wcFirst.send).not.toHaveBeenCalled();
+  });
+
+  it("stamps the dispatched project on the envelope, resolved from the responding sender", async () => {
+    const wcA = makeWebContents(941);
+    const wcB = makeWebContents(942);
+    const ctxA = makeContext({
+      activeWebContents: wcA,
+      projectRef: { projectId: "proj-a", projectPath: "/repos/a" },
+    });
+    const ctxB = makeContext({
+      activeWebContents: wcB,
+      projectRef: { projectId: "proj-b", projectPath: "/repos/b" },
+    });
+    autoRespond(wcA);
+    autoRespond(wcB);
+
+    const focusRef = { current: [ctxB, ctxA] };
+    const bridge = createRendererBridge(
+      pendingManifests,
+      pendingDispatches,
+      () => makeRegistry([ctxA, ctxB], focusRef) as never
+    );
+    bridge.setupListeners([]);
+
+    const focusedEnvelope = await bridge.dispatchAction("actions.list", {}, false);
+    expect(focusedEnvelope.dispatchedProject).toEqual({
+      projectId: "proj-b",
+      projectPath: "/repos/b",
+    });
+
+    // Focus moves — the stamp must follow the window the call actually hit.
+    focusRef.current = [ctxA, ctxB];
+    const retargetedEnvelope = await bridge.dispatchAction("actions.list", {}, false);
+    expect(retargetedEnvelope.dispatchedProject).toEqual({
+      projectId: "proj-a",
+      projectPath: "/repos/a",
+    });
+  });
+
+  it("omits dispatchedProject when the sender has no registered project", async () => {
+    const wc = makeWebContents(951);
+    const ctx = makeContext({ activeWebContents: wc, projectRef: null });
+    autoRespond(wc);
+
+    const focusRef = { current: [ctx] };
+    const bridge = createRendererBridge(
+      pendingManifests,
+      pendingDispatches,
+      () => makeRegistry([ctx], focusRef) as never
+    );
+    bridge.setupListeners([]);
+
+    const envelope = await bridge.dispatchAction("actions.list", {}, false);
+
+    expect(envelope.result).toEqual({ ok: true, result: "ok" });
+    expect(envelope.dispatchedProject).toBeUndefined();
+    expect("dispatchedProject" in envelope).toBe(false);
+  });
+
+  it("still resolves the action when the project lookup throws", async () => {
+    const wc = makeWebContents(961);
+    // A manager that predates the accessor: calling it throws a TypeError.
+    const ctx = makeContext({ activeWebContents: wc, omitProjectRefAccessor: true });
+    autoRespond(wc);
+
+    const focusRef = { current: [ctx] };
+    const bridge = createRendererBridge(
+      pendingManifests,
+      pendingDispatches,
+      () => makeRegistry([ctx], focusRef) as never
+    );
+    bridge.setupListeners([]);
+
+    const envelope = await bridge.dispatchAction("actions.list", {}, false);
+
+    expect(envelope.result).toEqual({ ok: true, result: "ok" });
+    expect(envelope.dispatchedProject).toBeUndefined();
   });
 });

--- a/electron/services/mcp-server/__tests__/rendererBridge.test.ts
+++ b/electron/services/mcp-server/__tests__/rendererBridge.test.ts
@@ -487,13 +487,19 @@ describe("rendererBridge — requesting-bearer identity passthrough (#9157)", ()
       {
         browserWindow: { isDestroyed: () => false },
         services: {
-          projectViewManager: { getActiveView: () => ({ webContents: wc }) },
+          projectViewManager: {
+            getActiveView: () => ({ webContents: wc }),
+            // Present but empty, so these tests exercise the real "no workspace
+            // registered" path rather than a missing-method error path.
+            getWorkspaceRefForWebContents: () => null,
+          },
         },
       },
     ];
     const registry = {
       all: () => contexts,
       focusOrder: () => contexts,
+      getByWebContentsId: (id: number) => (id === wc.id ? contexts[0] : undefined),
     };
     const bridge = createRendererBridge(
       pendingManifests,
@@ -598,23 +604,28 @@ describe("rendererBridge — unpinned routing follows focus order (#11536)", () 
     windowDestroyed?: boolean;
     /** Omitted entirely for a window with no active project view. */
     activeWebContents?: FakeWebContents | null;
-    projectRef?: { projectId: string; projectPath: string } | null;
-    /** Simulates a host whose manager predates getProjectRefForWebContents. */
-    omitProjectRefAccessor?: boolean;
+    workspaceRef?: { kind: "project" | "scratch"; workspaceId: string; workspacePath: string } | null;
+    /** Simulates a host whose manager predates getWorkspaceRefForWebContents. */
+    omitWorkspaceRefAccessor?: boolean;
   }
 
   function makeContext(options: FakeContextOptions) {
-    const { windowDestroyed = false, activeWebContents = null, projectRef = null } = options;
-    const projectViewManager: Record<string, unknown> = {
-      getActiveView: () => (activeWebContents ? { webContents: activeWebContents } : null),
-    };
-    if (!options.omitProjectRefAccessor) {
-      projectViewManager.getProjectRefForWebContents = (id: number) =>
-        projectRef && activeWebContents && activeWebContents.id === id ? projectRef : null;
-    }
+    const { windowDestroyed = false, activeWebContents = null, workspaceRef = null } = options;
+    const getActiveView = () => (activeWebContents ? { webContents: activeWebContents } : null);
+    // Spied so a test can assert the lookup happened per-sender at response
+    // time, rather than eagerly at send time.
+    const getWorkspaceRefForWebContents = vi.fn((id: number) =>
+      workspaceRef && activeWebContents && activeWebContents.id === id ? workspaceRef : null
+    );
+    const projectViewManager = options.omitWorkspaceRefAccessor
+      ? { getActiveView }
+      : { getActiveView, getWorkspaceRefForWebContents };
     return {
       browserWindow: { isDestroyed: () => windowDestroyed },
       services: { projectViewManager },
+      activeWebContentsId: activeWebContents?.id ?? null,
+      /** Test-only handle on the spy — production reads it via `services`. */
+      workspaceRefSpy: getWorkspaceRefForWebContents,
     };
   }
 
@@ -631,14 +642,7 @@ describe("rendererBridge — unpinned routing follows focus order (#11536)", () 
       all: () => registrationOrder,
       focusOrder: () => focusRef.current,
       getByWebContentsId: (id: number) =>
-        registrationOrder.find(
-          (ctx) =>
-            (
-              ctx.services.projectViewManager as {
-                getActiveView: () => { webContents: FakeWebContents } | null;
-              }
-            ).getActiveView()?.webContents.id === id
-        ),
+        registrationOrder.find((ctx) => ctx.activeWebContentsId === id),
     };
   }
 
@@ -768,17 +772,15 @@ describe("rendererBridge — unpinned routing follows focus order (#11536)", () 
     expect(wcFirst.send).not.toHaveBeenCalled();
   });
 
-  it("stamps the dispatched project on the envelope, resolved from the responding sender", async () => {
+  it("stamps the dispatched workspace on the envelope, resolved from the responding sender", async () => {
     const wcA = makeWebContents(941);
     const wcB = makeWebContents(942);
-    const ctxA = makeContext({
-      activeWebContents: wcA,
-      projectRef: { projectId: "proj-a", projectPath: "/repos/a" },
-    });
-    const ctxB = makeContext({
-      activeWebContents: wcB,
-      projectRef: { projectId: "proj-b", projectPath: "/repos/b" },
-    });
+    const refA = { kind: "project" as const, workspaceId: "proj-a", workspacePath: "/repos/a" };
+    // A scratch is a legitimate target and carries no Project row, so the
+    // stamp has to say so rather than labelling it a project.
+    const refB = { kind: "scratch" as const, workspaceId: "scr-b", workspacePath: "/scratch/b" };
+    const ctxA = makeContext({ activeWebContents: wcA, workspaceRef: refA });
+    const ctxB = makeContext({ activeWebContents: wcB, workspaceRef: refB });
     autoRespond(wcA);
     autoRespond(wcB);
 
@@ -791,23 +793,94 @@ describe("rendererBridge — unpinned routing follows focus order (#11536)", () 
     bridge.setupListeners([]);
 
     const focusedEnvelope = await bridge.dispatchAction("actions.list", {}, false);
-    expect(focusedEnvelope.dispatchedProject).toEqual({
-      projectId: "proj-b",
-      projectPath: "/repos/b",
-    });
+    expect(focusedEnvelope.dispatchedWorkspace).toEqual(refB);
 
     // Focus moves — the stamp must follow the window the call actually hit.
     focusRef.current = [ctxA, ctxB];
     const retargetedEnvelope = await bridge.dispatchAction("actions.list", {}, false);
-    expect(retargetedEnvelope.dispatchedProject).toEqual({
-      projectId: "proj-a",
-      projectPath: "/repos/a",
+    expect(retargetedEnvelope.dispatchedWorkspace).toEqual(refA);
+  });
+
+  it("resolves the workspace at response time, from the responding sender — not at send time", async () => {
+    // Guards the seam: resolving when the request is SENT, or from whatever is
+    // focused when the response arrives, would both pass the tests above.
+    // Here two dispatches are in flight at once and settle in reverse order,
+    // with focus moved in between — only per-sender, response-time resolution
+    // gives each its own workspace.
+    const wcA = makeWebContents(971);
+    const wcB = makeWebContents(972);
+    const refA = { kind: "project" as const, workspaceId: "proj-a", workspacePath: "/repos/a" };
+    const refB = { kind: "project" as const, workspaceId: "proj-b", workspacePath: "/repos/b" };
+    const ctxA = makeContext({ activeWebContents: wcA, workspaceRef: refA });
+    const ctxB = makeContext({ activeWebContents: wcB, workspaceRef: refB });
+
+    const pending: Array<{ id: number; requestId: string }> = [];
+    for (const [wc, id] of [
+      [wcB, 972],
+      [wcA, 971],
+    ] as const) {
+      wc.send.mockImplementation((channel: string, payload: { requestId: string }) => {
+        if (channel !== CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST) return;
+        pending.push({ id, requestId: payload.requestId });
+      });
+    }
+
+    const focusRef = { current: [ctxB, ctxA] };
+    const bridge = createRendererBridge(
+      pendingManifests,
+      pendingDispatches,
+      () => makeRegistry([ctxA, ctxB], focusRef) as never
+    );
+    bridge.setupListeners([]);
+
+    // First call targets B (focused). Its response is deliberately withheld.
+    const bCall = bridge.dispatchAction("actions.list", {}, false);
+    // Focus moves; the second call targets A while B is still in flight.
+    focusRef.current = [ctxA, ctxB];
+    const aCall = bridge.dispatchAction("actions.list", {}, false);
+
+    expect(pending).toHaveLength(2);
+    const bRequest = pending[0];
+    const aRequest = pending[1];
+    expect(bRequest.id).toBe(972);
+    expect(aRequest.id).toBe(971);
+
+    // A spoofed response from the wrong sender must be ignored outright.
+    mockIpcMain.emit(
+      CHANNELS.MCP_SERVER_DISPATCH_ACTION_RESPONSE,
+      { sender: { id: 971 } },
+      { requestId: bRequest.requestId, result: { ok: true, result: "spoofed" } }
+    );
+    expect(ctxB.workspaceRefSpy).not.toHaveBeenCalled();
+    expect(ctxA.workspaceRefSpy).not.toHaveBeenCalled();
+
+    // Settle in reverse order: A (sent last) first, then B.
+    mockIpcMain.emit(
+      CHANNELS.MCP_SERVER_DISPATCH_ACTION_RESPONSE,
+      { sender: { id: 971 } },
+      { requestId: aRequest.requestId, result: { ok: true, result: "from-a" } }
+    );
+    mockIpcMain.emit(
+      CHANNELS.MCP_SERVER_DISPATCH_ACTION_RESPONSE,
+      { sender: { id: 972 } },
+      { requestId: bRequest.requestId, result: { ok: true, result: "from-b" } }
+    );
+
+    // Each envelope reports its OWN sender's workspace, despite the focus
+    // change and the out-of-order settlement.
+    await expect(aCall).resolves.toMatchObject({
+      result: { ok: true, result: "from-a" },
+      dispatchedWorkspace: refA,
+    });
+    await expect(bCall).resolves.toMatchObject({
+      result: { ok: true, result: "from-b" },
+      dispatchedWorkspace: refB,
     });
   });
 
-  it("omits dispatchedProject when the sender has no registered project", async () => {
+  it("omits dispatchedWorkspace when the sender has no registered workspace", async () => {
     const wc = makeWebContents(951);
-    const ctx = makeContext({ activeWebContents: wc, projectRef: null });
+    const ctx = makeContext({ activeWebContents: wc, workspaceRef: null });
     autoRespond(wc);
 
     const focusRef = { current: [ctx] };
@@ -821,14 +894,14 @@ describe("rendererBridge — unpinned routing follows focus order (#11536)", () 
     const envelope = await bridge.dispatchAction("actions.list", {}, false);
 
     expect(envelope.result).toEqual({ ok: true, result: "ok" });
-    expect(envelope.dispatchedProject).toBeUndefined();
-    expect("dispatchedProject" in envelope).toBe(false);
+    expect(envelope.dispatchedWorkspace).toBeUndefined();
+    expect("dispatchedWorkspace" in envelope).toBe(false);
   });
 
   it("still resolves the action when the project lookup throws", async () => {
     const wc = makeWebContents(961);
     // A manager that predates the accessor: calling it throws a TypeError.
-    const ctx = makeContext({ activeWebContents: wc, omitProjectRefAccessor: true });
+    const ctx = makeContext({ activeWebContents: wc, omitWorkspaceRefAccessor: true });
     autoRespond(wc);
 
     const focusRef = { current: [ctx] };
@@ -842,6 +915,6 @@ describe("rendererBridge — unpinned routing follows focus order (#11536)", () 
     const envelope = await bridge.dispatchAction("actions.list", {}, false);
 
     expect(envelope.result).toEqual({ ok: true, result: "ok" });
-    expect(envelope.dispatchedProject).toBeUndefined();
+    expect(envelope.dispatchedWorkspace).toBeUndefined();
   });
 });

--- a/electron/services/mcp-server/__tests__/rendererBridge.test.ts
+++ b/electron/services/mcp-server/__tests__/rendererBridge.test.ts
@@ -604,7 +604,11 @@ describe("rendererBridge — unpinned routing follows focus order (#11536)", () 
     windowDestroyed?: boolean;
     /** Omitted entirely for a window with no active project view. */
     activeWebContents?: FakeWebContents | null;
-    workspaceRef?: { kind: "project" | "scratch"; workspaceId: string; workspacePath: string } | null;
+    workspaceRef?: {
+      kind: "project" | "scratch";
+      workspaceId: string;
+      workspacePath: string;
+    } | null;
     /** Simulates a host whose manager predates getWorkspaceRefForWebContents. */
     omitWorkspaceRefAccessor?: boolean;
     /** Simulates a torn-down view whose accessor throws rather than returning. */

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -27,6 +27,7 @@ import {
   MCP_DEDUP_ALLOWLIST,
   minimumPermittingTier,
   unwrapDispatchResult,
+  RESOLVED_PROJECT_META_KEY,
 } from "../shared.js";
 import { TOOL_RESULT_TEXT_MAX_BYTES } from "../toolCallResult.js";
 import { SessionBindingError, RendererBridgeUnavailableError } from "../rendererBridge.js";
@@ -2875,5 +2876,146 @@ describe("structuredContent for terminal query actions (#10676)", () => {
       );
       expect(structuredOf(result)).toBeUndefined();
     });
+  });
+});
+
+describe("resolved-project result metadata (#11536)", () => {
+  const PROJECT = { projectId: "proj-a", projectPath: "/repos/a" };
+
+  const manifest = [
+    {
+      id: "files.search",
+      title: "Files: search",
+      description: "Search files",
+      category: "files",
+      danger: "safe" as const,
+      source: ["agent"] as const,
+    },
+  ] as unknown as ActionManifestEntry[];
+
+  function metaOf(result: unknown): Record<string, unknown> | undefined {
+    return (result as { _meta?: Record<string, unknown> })._meta;
+  }
+
+  function projectMetaOf(result: unknown): unknown {
+    return metaOf(result)?.[RESOLVED_PROJECT_META_KEY];
+  }
+
+  function textOf(result: unknown): string {
+    return (result as { content: { type: string; text: string }[] }).content[0].text;
+  }
+
+  function depsFor(dispatch: unknown) {
+    return fakeDeps({
+      requestManifest: vi.fn().mockResolvedValue(manifest),
+      getCachedManifest: vi.fn(() => manifest),
+      dispatchAction: vi.fn().mockResolvedValue(dispatch),
+    });
+  }
+
+  it("stamps the dispatched project on a successful result", async () => {
+    const server = createSessionServer(
+      "rp-ok",
+      depsFor({ result: { ok: true, result: { hits: [] } }, dispatchedProject: PROJECT })
+    );
+    await server.connect(makeMockTransport());
+
+    const result = await callTool(server, { name: "files.search", arguments: {} });
+
+    expect(projectMetaOf(result)).toEqual(PROJECT);
+  });
+
+  it("stamps the dispatched project on a renderer-returned action error", async () => {
+    const server = createSessionServer(
+      "rp-err",
+      depsFor({
+        result: { ok: false, error: { code: "VALIDATION_ERROR", message: "nope" } },
+        dispatchedProject: PROJECT,
+      })
+    );
+    await server.connect(makeMockTransport());
+
+    const result = (await callTool(server, {
+      name: "files.search",
+      arguments: {},
+    })) as { isError: boolean };
+
+    // A renderer was reached, so the target is known and worth reporting —
+    // and the error payload itself must survive the stamp untouched.
+    expect(result.isError).toBe(true);
+    expect(projectMetaOf(result)).toEqual(PROJECT);
+    expect(JSON.parse(textOf(result)).code).toBe("VALIDATION_ERROR");
+  });
+
+  it("omits the key entirely when the dispatch reported no project", async () => {
+    const server = createSessionServer("rp-none", depsFor({ result: { ok: true, result: "ok" } }));
+    await server.connect(makeMockTransport());
+
+    const result = await callTool(server, { name: "files.search", arguments: {} });
+
+    // Absent, not null — "unknown" must not be confusable with "no project".
+    expect(projectMetaOf(result)).toBeUndefined();
+    expect(metaOf(result) === undefined || !(RESOLVED_PROJECT_META_KEY in metaOf(result)!)).toBe(
+      true
+    );
+  });
+
+  it("does not stamp a pre-dispatch failure, where no renderer was reached", async () => {
+    const deps = fakeDeps({
+      requestManifest: vi.fn().mockResolvedValue(manifest),
+      getCachedManifest: vi.fn(() => manifest),
+      dispatchAction: vi.fn().mockRejectedValue(new RendererBridgeUnavailableError()),
+    });
+    const server = createSessionServer("rp-nowindow", deps);
+    await server.connect(makeMockTransport());
+
+    const result = (await callTool(server, {
+      name: "files.search",
+      arguments: {},
+    })) as { isError: boolean };
+
+    expect(result.isError).toBe(true);
+    expect(projectMetaOf(result)).toBeUndefined();
+  });
+
+  it("preserves structuredContent alongside the stamp", async () => {
+    const payload = { terminals: [] };
+    const server = createSessionServer(
+      "rp-structured",
+      fakeDeps({
+        requestManifest: vi.fn().mockResolvedValue([
+          {
+            id: "terminal.list",
+            title: "Terminal: list",
+            description: "List terminals",
+            category: "terminal",
+            danger: "safe" as const,
+            source: ["agent"] as const,
+          },
+        ] as unknown as ActionManifestEntry[]),
+        getCachedManifest: vi.fn(
+          () =>
+            [
+              {
+                id: "terminal.list",
+                title: "Terminal: list",
+                description: "List terminals",
+                category: "terminal",
+                danger: "safe" as const,
+                source: ["agent"] as const,
+              },
+            ] as unknown as ActionManifestEntry[]
+        ),
+        dispatchAction: vi
+          .fn()
+          .mockResolvedValue({ result: { ok: true, result: payload }, dispatchedProject: PROJECT }),
+      })
+    );
+    await server.connect(makeMockTransport());
+
+    const result = await callTool(server, { name: "terminal.list", arguments: {} });
+
+    expect(projectMetaOf(result)).toEqual(PROJECT);
+    expect(JSON.parse(textOf(result))).toEqual(payload);
   });
 });

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -3095,8 +3095,9 @@ describe("resolved-workspace result metadata (#11536)", () => {
     const server = createSessionServer(
       "rp-structured",
       fakeDeps({
+        // `terminal.list` is on the curated external allowlist, so the external
+        // tier reaches it on the allowlist alone (#11537 deleted the widening opt-in).
         sessionStore: fakeSessionStore("external"),
-        getFullToolSurface: vi.fn(() => true),
         requestManifest: vi.fn().mockResolvedValue([entry]),
         getCachedManifest: vi.fn(() => [entry]),
         dispatchAction: vi.fn().mockResolvedValue({

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -27,7 +27,8 @@ import {
   MCP_DEDUP_ALLOWLIST,
   minimumPermittingTier,
   unwrapDispatchResult,
-  RESOLVED_PROJECT_META_KEY,
+  RESOLVED_WORKSPACE_META_KEY,
+  withResolvedWorkspace,
 } from "../shared.js";
 import { TOOL_RESULT_TEXT_MAX_BYTES } from "../toolCallResult.js";
 import { SessionBindingError, RendererBridgeUnavailableError } from "../rendererBridge.js";
@@ -2879,8 +2880,12 @@ describe("structuredContent for terminal query actions (#10676)", () => {
   });
 });
 
-describe("resolved-project result metadata (#11536)", () => {
-  const PROJECT = { projectId: "proj-a", projectPath: "/repos/a" };
+describe("resolved-workspace result metadata (#11536)", () => {
+  const WORKSPACE = {
+    kind: "project" as const,
+    workspaceId: "proj-a",
+    workspacePath: "/repos/a",
+  };
 
   const manifest = [
     {
@@ -2897,8 +2902,8 @@ describe("resolved-project result metadata (#11536)", () => {
     return (result as { _meta?: Record<string, unknown> })._meta;
   }
 
-  function projectMetaOf(result: unknown): unknown {
-    return metaOf(result)?.[RESOLVED_PROJECT_META_KEY];
+  function workspaceMetaOf(result: unknown): unknown {
+    return metaOf(result)?.[RESOLVED_WORKSPACE_META_KEY];
   }
 
   function textOf(result: unknown): string {
@@ -2913,24 +2918,66 @@ describe("resolved-project result metadata (#11536)", () => {
     });
   }
 
-  it("stamps the dispatched project on a successful result", async () => {
+  it("stamps the dispatched workspace on a successful result", async () => {
     const server = createSessionServer(
       "rp-ok",
-      depsFor({ result: { ok: true, result: { hits: [] } }, dispatchedProject: PROJECT })
+      depsFor({ result: { ok: true, result: { hits: [] } }, dispatchedWorkspace: WORKSPACE })
     );
     await server.connect(makeMockTransport());
 
     const result = await callTool(server, { name: "files.search", arguments: {} });
 
-    expect(projectMetaOf(result)).toEqual(PROJECT);
+    expect(workspaceMetaOf(result)).toEqual(WORKSPACE);
   });
 
-  it("stamps the dispatched project on a renderer-returned action error", async () => {
+  it("reports a scratch workspace as a scratch", async () => {
+    const scratch = {
+      kind: "scratch" as const,
+      workspaceId: "6f1c9d2e-4a7b-4c3d-9e8f-1a2b3c4d5e6f",
+      workspacePath: "/scratch/one",
+    };
+    const server = createSessionServer(
+      "rp-scratch",
+      depsFor({ result: { ok: true, result: "ok" }, dispatchedWorkspace: scratch })
+    );
+    await server.connect(makeMockTransport());
+
+    const result = await callTool(server, { name: "files.search", arguments: {} });
+
+    expect(workspaceMetaOf(result)).toEqual(scratch);
+  });
+
+  it("merges into an existing _meta without clobbering sibling keys or mutating the input", () => {
+    const original = {
+      content: [{ type: "text" as const, text: "ok" }],
+      _meta: { "vendor.other/trace": "abc" },
+    };
+
+    const stamped = withResolvedWorkspace(original, WORKSPACE);
+
+    expect(stamped._meta).toEqual({
+      "vendor.other/trace": "abc",
+      [RESOLVED_WORKSPACE_META_KEY]: WORKSPACE,
+    });
+    // Additive, never destructive: the caller's object is untouched.
+    expect(original._meta).toEqual({ "vendor.other/trace": "abc" });
+  });
+
+  it("returns the result untouched when the workspace is unknown", () => {
+    const original = { content: [{ type: "text" as const, text: "ok" }] };
+
+    expect(withResolvedWorkspace(original, undefined)).toBe(original);
+  });
+
+  it("stamps the dispatched workspace on a renderer-returned action error", async () => {
     const server = createSessionServer(
       "rp-err",
       depsFor({
-        result: { ok: false, error: { code: "VALIDATION_ERROR", message: "nope" } },
-        dispatchedProject: PROJECT,
+        result: {
+          ok: false,
+          error: { code: "VALIDATION_ERROR", message: "nope", details: { field: "query" } },
+        },
+        dispatchedWorkspace: WORKSPACE,
       })
     );
     await server.connect(makeMockTransport());
@@ -2943,28 +2990,72 @@ describe("resolved-project result metadata (#11536)", () => {
     // A renderer was reached, so the target is known and worth reporting —
     // and the error payload itself must survive the stamp untouched.
     expect(result.isError).toBe(true);
-    expect(projectMetaOf(result)).toEqual(PROJECT);
-    expect(JSON.parse(textOf(result)).code).toBe("VALIDATION_ERROR");
+    expect(workspaceMetaOf(result)).toEqual(WORKSPACE);
+    const parsed = JSON.parse(textOf(result));
+    expect(parsed.code).toBe("VALIDATION_ERROR");
+    expect(parsed.message).toBe("nope");
+    expect(parsed.details).toEqual({ field: "query" });
   });
 
-  it("omits the key entirely when the dispatch reported no project", async () => {
+  it("stamps the screenshot image result, which returns before the generic path", async () => {
+    // browser.captureScreenshot short-circuits into an image content block, so
+    // it needs its own stamp — the generic success return never runs for it.
+    const shotEntry = [
+      {
+        id: "browser.captureScreenshot",
+        name: "browser.captureScreenshot",
+        title: "Capture Browser Screenshot",
+        description: "Capture the focused browser panel as a PNG",
+        category: "browser",
+        kind: "command",
+        danger: "safe",
+        enabled: true,
+        requiresArgs: false,
+      },
+    ] as unknown as ActionManifestEntry[];
+    const server = createSessionServer(
+      "rp-shot",
+      fakeDeps({
+        sessionStore: fakeSessionStore("action"),
+        requestManifest: vi.fn().mockResolvedValue(shotEntry),
+        getCachedManifest: vi.fn(() => shotEntry),
+        dispatchAction: vi.fn().mockResolvedValue({
+          result: { ok: true, result: { pngBase64: "aGVsbG8=", width: 1024, height: 768 } },
+          dispatchedWorkspace: WORKSPACE,
+        }),
+      })
+    );
+    await server.connect(makeMockTransport());
+
+    const result = (await callTool(server, {
+      name: "browser.captureScreenshot",
+      arguments: {},
+    })) as { content: Array<Record<string, unknown>>; isError?: boolean };
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0]).toMatchObject({ type: "image", data: "aGVsbG8=" });
+    expect(workspaceMetaOf(result)).toEqual(WORKSPACE);
+  });
+
+  it("omits the key entirely when the dispatch reported no workspace", async () => {
     const server = createSessionServer("rp-none", depsFor({ result: { ok: true, result: "ok" } }));
     await server.connect(makeMockTransport());
 
     const result = await callTool(server, { name: "files.search", arguments: {} });
 
-    // Absent, not null — "unknown" must not be confusable with "no project".
-    expect(projectMetaOf(result)).toBeUndefined();
-    expect(metaOf(result) === undefined || !(RESOLVED_PROJECT_META_KEY in metaOf(result)!)).toBe(
+    // Absent, not null — "unknown" must not be confusable with "no workspace".
+    expect(workspaceMetaOf(result)).toBeUndefined();
+    expect(metaOf(result) === undefined || !(RESOLVED_WORKSPACE_META_KEY in metaOf(result)!)).toBe(
       true
     );
   });
 
   it("does not stamp a pre-dispatch failure, where no renderer was reached", async () => {
+    const dispatchAction = vi.fn().mockRejectedValue(new RendererBridgeUnavailableError());
     const deps = fakeDeps({
       requestManifest: vi.fn().mockResolvedValue(manifest),
       getCachedManifest: vi.fn(() => manifest),
-      dispatchAction: vi.fn().mockRejectedValue(new RendererBridgeUnavailableError()),
+      dispatchAction,
     });
     const server = createSessionServer("rp-nowindow", deps);
     await server.connect(makeMockTransport());
@@ -2974,48 +3065,53 @@ describe("resolved-project result metadata (#11536)", () => {
       arguments: {},
     })) as { isError: boolean };
 
+    // Prove it really took the no-window dispatch path rather than bailing out
+    // earlier for an unrelated reason.
+    expect(dispatchAction).toHaveBeenCalledTimes(1);
     expect(result.isError).toBe(true);
-    expect(projectMetaOf(result)).toBeUndefined();
+    expect(JSON.parse(textOf(result)).code).toBe(EXECUTION_ERROR_CODE);
+    expect(workspaceMetaOf(result)).toBeUndefined();
   });
 
   it("preserves structuredContent alongside the stamp", async () => {
-    const payload = { terminals: [] };
+    const payload = { terminals: [{ id: "t-1", kind: "terminal", isFocused: true }] };
+    const entry: ActionManifestEntry = {
+      ...({
+        id: "terminal.list",
+        name: "terminal.list",
+        title: "Terminal: list",
+        description: "List terminals",
+        category: "terminal",
+        kind: "query",
+        danger: "safe",
+        enabled: true,
+        requiresArgs: false,
+      } as unknown as ActionManifestEntry),
+      outputSchema: {
+        type: "object",
+        properties: { terminals: { type: "array" } },
+      },
+    };
     const server = createSessionServer(
       "rp-structured",
       fakeDeps({
-        requestManifest: vi.fn().mockResolvedValue([
-          {
-            id: "terminal.list",
-            title: "Terminal: list",
-            description: "List terminals",
-            category: "terminal",
-            danger: "safe" as const,
-            source: ["agent"] as const,
-          },
-        ] as unknown as ActionManifestEntry[]),
-        getCachedManifest: vi.fn(
-          () =>
-            [
-              {
-                id: "terminal.list",
-                title: "Terminal: list",
-                description: "List terminals",
-                category: "terminal",
-                danger: "safe" as const,
-                source: ["agent"] as const,
-              },
-            ] as unknown as ActionManifestEntry[]
-        ),
-        dispatchAction: vi
-          .fn()
-          .mockResolvedValue({ result: { ok: true, result: payload }, dispatchedProject: PROJECT }),
+        sessionStore: fakeSessionStore("external"),
+        getFullToolSurface: vi.fn(() => true),
+        requestManifest: vi.fn().mockResolvedValue([entry]),
+        getCachedManifest: vi.fn(() => [entry]),
+        dispatchAction: vi.fn().mockResolvedValue({
+          result: { ok: true, result: payload },
+          dispatchedWorkspace: WORKSPACE,
+        }),
       })
     );
     await server.connect(makeMockTransport());
 
     const result = await callTool(server, { name: "terminal.list", arguments: {} });
 
-    expect(projectMetaOf(result)).toEqual(PROJECT);
+    // The stamp must not displace structuredContent — both ride the same result.
+    expect(workspaceMetaOf(result)).toEqual(WORKSPACE);
+    expect((result as { structuredContent?: unknown }).structuredContent).toEqual(payload);
     expect(JSON.parse(textOf(result))).toEqual(payload);
   });
 });

--- a/electron/services/mcp-server/rendererBridge.ts
+++ b/electron/services/mcp-server/rendererBridge.ts
@@ -5,7 +5,7 @@ import { getProjectViewManager } from "../../window/windowRef.js";
 import type { ActionContext, ActionManifestEntry } from "../../../shared/types/actions.js";
 import type { McpBearerIdentity } from "../../../shared/types/ipc/mcpServer.js";
 import { CHANNELS } from "../../ipc/channels.js";
-import type { PendingRequest, DispatchEnvelope, DispatchedProjectRef } from "./shared.js";
+import type { PendingRequest, DispatchEnvelope, DispatchedWorkspaceRef } from "./shared.js";
 import { MCP_MANIFEST_REQUEST_TIMEOUT_MS, MCP_DISPATCH_TIMEOUT_MS } from "./shared.js";
 
 export class SessionBindingError extends Error {
@@ -71,6 +71,10 @@ export function createRendererBridge(
   // never double-register one across repeated fetches or a server restart.
   const perWebContentsEvictionWired = new Set<number>();
 
+  // One-shot latch so a persistently broken workspace lookup can't flood the
+  // log on every dispatch (#11536).
+  let warnedWorkspaceResolveFailure = false;
+
   function getActiveProjectWebContents(): Electron.WebContents {
     const registry = getRegistry();
     if (registry) {
@@ -118,7 +122,7 @@ export function createRendererBridge(
   }
 
   /**
-   * Resolve which project a dispatch landed on, for the response envelope
+   * Resolve which workspace a dispatch landed on, for the response envelope
    * (#11536). Routed through the owning window's own ProjectViewManager so the
    * answer is sender-scoped — never `getCurrentProjectId()`, which reports the
    * most-recently-switched project rather than this webContents'.
@@ -127,18 +131,28 @@ export function createRendererBridge(
    * that was already routed through it (the registry-less branch of
    * `getActiveProjectWebContents`); it is deliberately not a routing fallback.
    *
-   * Never throws: identity is decoration on an already-completed action, so a
-   * torn-down view — or a host whose manager predates this accessor — yields
-   * `undefined` and simply omits the field.
+   * Never throws. Identity is decoration on an already-completed action, and
+   * the caller has by now cleared the pending entry's timer, so letting an
+   * exception escape would strand the awaiting promise. Ordinary teardown is
+   * not an error — the accessor already converts a destroyed view to `null`, so
+   * only genuinely unexpected throws are logged, once, to keep a future
+   * refactor from silently degrading this to "never stamps".
    */
-  function resolveDispatchedProject(webContentsId: number): DispatchedProjectRef | undefined {
+  function resolveDispatchedWorkspace(webContentsId: number): DispatchedWorkspaceRef | undefined {
+    const registry = getRegistry();
+    const projectViewManager =
+      registry?.getByWebContentsId(webContentsId)?.services.projectViewManager ??
+      getProjectViewManager();
+    // A host whose manager predates this accessor is an expected shape, not a
+    // failure — resolve to "unknown" without logging.
+    if (typeof projectViewManager?.getWorkspaceRefForWebContents !== "function") return undefined;
     try {
-      const registry = getRegistry();
-      const projectViewManager =
-        registry?.getByWebContentsId(webContentsId)?.services.projectViewManager ??
-        getProjectViewManager();
-      return projectViewManager?.getProjectRefForWebContents(webContentsId) ?? undefined;
-    } catch {
+      return projectViewManager.getWorkspaceRefForWebContents(webContentsId) ?? undefined;
+    } catch (err) {
+      if (!warnedWorkspaceResolveFailure) {
+        warnedWorkspaceResolveFailure = true;
+        console.warn("[MCP] Failed to resolve the dispatched workspace for a tool result:", err);
+      }
       return undefined;
     }
   }
@@ -438,15 +452,15 @@ export function createRendererBridge(
     clearTimeout(pending.timer);
     pending.destroyedCleanup?.();
     pendingDispatches.delete(payload.requestId);
-    // Snapshot the project identity here, synchronously, off the sender we just
-    // validated (#11536). Resolving it later — after the awaiting caller in
-    // sessionServer resumes — would race view eviction and project switching,
-    // and could report a project the dispatch never ran against.
-    const dispatchedProject = resolveDispatchedProject(pending.webContentsId);
+    // Snapshot the workspace identity here, synchronously, off the sender we
+    // just validated (#11536). Resolving it later — after the awaiting caller
+    // in sessionServer resumes — would race view eviction and workspace
+    // switching, and could report a workspace the dispatch never ran against.
+    const dispatchedWorkspace = resolveDispatchedWorkspace(pending.webContentsId);
     pending.resolve({
       result: payload.result,
       confirmationDecision: payload.confirmationDecision,
-      ...(dispatchedProject ? { dispatchedProject } : {}),
+      ...(dispatchedWorkspace ? { dispatchedWorkspace } : {}),
     });
   };
 

--- a/electron/services/mcp-server/rendererBridge.ts
+++ b/electron/services/mcp-server/rendererBridge.ts
@@ -139,14 +139,19 @@ export function createRendererBridge(
    * refactor from silently degrading this to "never stamps".
    */
   function resolveDispatchedWorkspace(webContentsId: number): DispatchedWorkspaceRef | undefined {
-    const registry = getRegistry();
-    const projectViewManager =
-      registry?.getByWebContentsId(webContentsId)?.services.projectViewManager ??
-      getProjectViewManager();
-    // A host whose manager predates this accessor is an expected shape, not a
-    // failure — resolve to "unknown" without logging.
-    if (typeof projectViewManager?.getWorkspaceRefForWebContents !== "function") return undefined;
+    // The whole lookup is guarded, not just the accessor call: the registry
+    // read, the window lookup and the service property access can each throw on
+    // a torn-down window, and by this point the caller has already cleared the
+    // pending entry's timer — so an escaping exception would strand the
+    // awaiting promise rather than merely lose the stamp.
     try {
+      const registry = getRegistry();
+      const projectViewManager =
+        registry?.getByWebContentsId(webContentsId)?.services.projectViewManager ??
+        getProjectViewManager();
+      // A host whose manager predates this accessor is an expected shape, not a
+      // failure — resolve to "unknown" without logging.
+      if (typeof projectViewManager?.getWorkspaceRefForWebContents !== "function") return undefined;
       return projectViewManager.getWorkspaceRefForWebContents(webContentsId) ?? undefined;
     } catch (err) {
       if (!warnedWorkspaceResolveFailure) {

--- a/electron/services/mcp-server/rendererBridge.ts
+++ b/electron/services/mcp-server/rendererBridge.ts
@@ -5,7 +5,7 @@ import { getProjectViewManager } from "../../window/windowRef.js";
 import type { ActionContext, ActionManifestEntry } from "../../../shared/types/actions.js";
 import type { McpBearerIdentity } from "../../../shared/types/ipc/mcpServer.js";
 import { CHANNELS } from "../../ipc/channels.js";
-import type { PendingRequest, DispatchEnvelope } from "./shared.js";
+import type { PendingRequest, DispatchEnvelope, DispatchedProjectRef } from "./shared.js";
 import { MCP_MANIFEST_REQUEST_TIMEOUT_MS, MCP_DISPATCH_TIMEOUT_MS } from "./shared.js";
 
 export class SessionBindingError extends Error {
@@ -74,7 +74,14 @@ export function createRendererBridge(
   function getActiveProjectWebContents(): Electron.WebContents {
     const registry = getRegistry();
     if (registry) {
-      for (const ctx of registry.all()) {
+      // Most-recently-focused first, not registration order (#11536). With
+      // `all()` an unpinned external/api-key client drove whichever window
+      // happened to register first, regardless of what the user was looking
+      // at. `focusOrder()` keeps never-focused windows (appended in
+      // registration order) and falls back to registration order before the
+      // first focus event, so single-window and cold-start behaviour is
+      // unchanged — only the multi-window pick moves to the focused window.
+      for (const ctx of registry.focusOrder()) {
         if (ctx.browserWindow.isDestroyed()) continue;
         const view = ctx.services.projectViewManager?.getActiveView();
         const webContents = view?.webContents;
@@ -108,6 +115,32 @@ export function createRendererBridge(
 
   function normalizeError(err: unknown, fallback: string): Error {
     return err instanceof Error ? err : new Error(fallback);
+  }
+
+  /**
+   * Resolve which project a dispatch landed on, for the response envelope
+   * (#11536). Routed through the owning window's own ProjectViewManager so the
+   * answer is sender-scoped — never `getCurrentProjectId()`, which reports the
+   * most-recently-switched project rather than this webContents'.
+   *
+   * The module-singleton manager is only an identity fallback for a dispatch
+   * that was already routed through it (the registry-less branch of
+   * `getActiveProjectWebContents`); it is deliberately not a routing fallback.
+   *
+   * Never throws: identity is decoration on an already-completed action, so a
+   * torn-down view — or a host whose manager predates this accessor — yields
+   * `undefined` and simply omits the field.
+   */
+  function resolveDispatchedProject(webContentsId: number): DispatchedProjectRef | undefined {
+    try {
+      const registry = getRegistry();
+      const projectViewManager =
+        registry?.getByWebContentsId(webContentsId)?.services.projectViewManager ??
+        getProjectViewManager();
+      return projectViewManager?.getProjectRefForWebContents(webContentsId) ?? undefined;
+    } catch {
+      return undefined;
+    }
   }
 
   function sendManifestRequest(
@@ -405,9 +438,15 @@ export function createRendererBridge(
     clearTimeout(pending.timer);
     pending.destroyedCleanup?.();
     pendingDispatches.delete(payload.requestId);
+    // Snapshot the project identity here, synchronously, off the sender we just
+    // validated (#11536). Resolving it later — after the awaiting caller in
+    // sessionServer resumes — would race view eviction and project switching,
+    // and could report a project the dispatch never ran against.
+    const dispatchedProject = resolveDispatchedProject(pending.webContentsId);
     pending.resolve({
       result: payload.result,
       confirmationDecision: payload.confirmationDecision,
+      ...(dispatchedProject ? { dispatchedProject } : {}),
     });
   };
 

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -858,8 +858,8 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
         // host-issued native grant (`nativeGrantId`) pre-authorizes a dispatch.
         emitToolCallStarted(entry?.danger === "confirm");
 
-        // The project the dispatch actually landed on, resolved renderer-side at
-        // response time (#11536). Only ever set from a completed dispatch, so
+        // The workspace the dispatch actually landed on, resolved renderer-side
+        // at response time (#11536). Only ever set from a completed dispatch, so
         // every failure path below (no window, session binding gone, throw)
         // leaves it undefined and stamps nothing.
         let dispatchedWorkspace: DispatchedWorkspaceRef | undefined;

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -47,6 +47,8 @@ import {
   INVALID_URL_CODE,
   buildToolError,
   buildMcpErrorPayload,
+  withResolvedProject,
+  type DispatchedProjectRef,
 } from "./shared.js";
 import {
   INTERACTIVE_WAIT_UNTIL_IDLE_TIMEOUT_CAP_MS,
@@ -856,10 +858,16 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
         // host-issued native grant (`nativeGrantId`) pre-authorizes a dispatch.
         emitToolCallStarted(entry?.danger === "confirm");
 
+        // The project the dispatch actually landed on, resolved renderer-side at
+        // response time (#11536). Only ever set from a completed dispatch, so
+        // every failure path below (no window, session binding gone, throw)
+        // leaves it undefined and stamps nothing.
+        let dispatchedProject: DispatchedProjectRef | undefined;
         try {
           const envelope = await dispatchAction(actionId, args, dispatchConfirmed);
           outcome = { kind: "result", value: envelope.result };
           confirmationDecision = confirmationDecision ?? envelope.confirmationDecision;
+          dispatchedProject = envelope.dispatchedProject;
         } catch (err) {
           outcome = { kind: "throw", error: err };
           if (err instanceof SessionBindingError) {
@@ -948,28 +956,39 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
           if (actionId === BROWSER_CAPTURE_SCREENSHOT_TOOL) {
             const shot = asScreenshotResult(outcome.value.result);
             if (shot) {
-              return {
-                content: [
-                  { type: "image" as const, data: shot.pngBase64, mimeType: "image/png" },
-                  {
-                    type: "text" as const,
-                    text: `Screenshot captured (${shot.width}×${shot.height})`,
-                  },
-                ],
-              };
+              return withResolvedProject(
+                {
+                  content: [
+                    { type: "image" as const, data: shot.pngBase64, mimeType: "image/png" },
+                    {
+                      type: "text" as const,
+                      text: `Screenshot captured (${shot.width}×${shot.height})`,
+                    },
+                  ],
+                },
+                dispatchedProject
+              );
             }
           }
           const structuredContent = buildStructuredContent(entry, outcome.value.result);
-          return buildToolCallResult(outcome.value.result, {
-            ...(structuredContent ? { structuredContent } : {}),
-          });
+          return withResolvedProject(
+            buildToolCallResult(outcome.value.result, {
+              ...(structuredContent ? { structuredContent } : {}),
+            }),
+            dispatchedProject
+          );
         }
 
-        return buildToolError({
-          code: outcome.value.error.code,
-          message: outcome.value.error.message,
-          details: outcome.value.error.details,
-        });
+        // A renderer was reached and reported a failure, so the target is known
+        // and worth reporting — unlike the pre-dispatch errors above.
+        return withResolvedProject(
+          buildToolError({
+            code: outcome.value.error.code,
+            message: outcome.value.error.message,
+            details: outcome.value.error.details,
+          }),
+          dispatchedProject
+        );
       } finally {
         const settledOutcome = outcome ?? { kind: "throw" as const, error: new Error("unknown") };
         // Compute the duration once so the audit record and the live strip

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -47,8 +47,8 @@ import {
   INVALID_URL_CODE,
   buildToolError,
   buildMcpErrorPayload,
-  withResolvedProject,
-  type DispatchedProjectRef,
+  withResolvedWorkspace,
+  type DispatchedWorkspaceRef,
 } from "./shared.js";
 import {
   INTERACTIVE_WAIT_UNTIL_IDLE_TIMEOUT_CAP_MS,
@@ -862,12 +862,12 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
         // response time (#11536). Only ever set from a completed dispatch, so
         // every failure path below (no window, session binding gone, throw)
         // leaves it undefined and stamps nothing.
-        let dispatchedProject: DispatchedProjectRef | undefined;
+        let dispatchedWorkspace: DispatchedWorkspaceRef | undefined;
         try {
           const envelope = await dispatchAction(actionId, args, dispatchConfirmed);
           outcome = { kind: "result", value: envelope.result };
           confirmationDecision = confirmationDecision ?? envelope.confirmationDecision;
-          dispatchedProject = envelope.dispatchedProject;
+          dispatchedWorkspace = envelope.dispatchedWorkspace;
         } catch (err) {
           outcome = { kind: "throw", error: err };
           if (err instanceof SessionBindingError) {
@@ -956,7 +956,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
           if (actionId === BROWSER_CAPTURE_SCREENSHOT_TOOL) {
             const shot = asScreenshotResult(outcome.value.result);
             if (shot) {
-              return withResolvedProject(
+              return withResolvedWorkspace(
                 {
                   content: [
                     { type: "image" as const, data: shot.pngBase64, mimeType: "image/png" },
@@ -966,28 +966,28 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
                     },
                   ],
                 },
-                dispatchedProject
+                dispatchedWorkspace
               );
             }
           }
           const structuredContent = buildStructuredContent(entry, outcome.value.result);
-          return withResolvedProject(
+          return withResolvedWorkspace(
             buildToolCallResult(outcome.value.result, {
               ...(structuredContent ? { structuredContent } : {}),
             }),
-            dispatchedProject
+            dispatchedWorkspace
           );
         }
 
         // A renderer was reached and reported a failure, so the target is known
         // and worth reporting — unlike the pre-dispatch errors above.
-        return withResolvedProject(
+        return withResolvedWorkspace(
           buildToolError({
             code: outcome.value.error.code,
             message: outcome.value.error.message,
             details: outcome.value.error.details,
           }),
-          dispatchedProject
+          dispatchedWorkspace
         );
       } finally {
         const settledOutcome = outcome ?? { kind: "throw" as const, error: new Error("unknown") };

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -312,30 +312,33 @@ export function buildToolError(input: {
 }
 
 /**
- * `_meta` key carrying the project a tool call actually ran against (#11536).
+ * `_meta` key carrying the workspace a tool call actually ran against (#11536).
  * Namespaced per the MCP `_meta` convention so it can't collide with keys from
- * other servers in an aggregating client.
+ * other servers in an aggregating client. This string is an external contract:
+ * MCP clients read it by name, so changing it is a breaking change.
  */
-export const RESOLVED_PROJECT_META_KEY = "org.daintree/resolved-project";
+export const RESOLVED_WORKSPACE_META_KEY = "org.daintree/resolved-workspace";
 
 /**
- * Stamp the resolved project onto a tool result (#11536).
+ * Stamp the resolved workspace onto a tool result (#11536).
  *
  * Top-level `_meta` rather than `structuredContent`, so it never has to satisfy
  * (or violate) an action's declared output schema. Returns the result untouched
  * when identity couldn't be resolved — the key's absence means "unknown", and
- * failing to resolve it must never alter the action's own outcome.
+ * failing to resolve it must never alter the action's own outcome. Other
+ * `_meta` keys are preserved; only Daintree's own key is overwritten, so a
+ * value already sitting there can't spoof the authoritative stamp.
  */
-export function withResolvedProject<T extends CallToolResult>(
+export function withResolvedWorkspace<T extends CallToolResult>(
   result: T,
-  project: DispatchedProjectRef | undefined
+  workspace: DispatchedWorkspaceRef | undefined
 ): T {
-  if (!project) return result;
+  if (!workspace) return result;
   return {
     ...result,
     _meta: {
       ...(result._meta ?? {}),
-      [RESOLVED_PROJECT_META_KEY]: { ...project },
+      [RESOLVED_WORKSPACE_META_KEY]: { ...workspace },
     },
   };
 }
@@ -865,15 +868,23 @@ export interface PendingRequest<T> {
 }
 
 /**
- * The project a dispatch actually landed on, resolved from the responding
+ * The workspace a dispatch actually landed on, resolved from the responding
  * renderer at response time (#11536). Unpinned external sessions follow window
  * focus on every call, so a long-running agent's calls can retarget mid-session
- * when the user switches project. Reporting the resolved project makes that
+ * when the user switches workspace. Reporting the resolved workspace makes that
  * drift observable to the caller instead of silent.
+ *
+ * "Workspace" because a renderer view can be backed by a project or by a
+ * scratch, which has no Project row; `kind` tells the caller which, so it never
+ * has to guess whether the id is resolvable through project APIs. Structurally
+ * mirrors `WorkspaceRef` in `electron/window/ProjectViewManager.ts` — the wire
+ * contract is declared here so this module stays free of window-layer imports,
+ * and rendererBridge assigning one to the other keeps the two in lockstep.
  */
-export interface DispatchedProjectRef {
-  projectId: string;
-  projectPath: string;
+export interface DispatchedWorkspaceRef {
+  kind: "project" | "scratch";
+  workspaceId: string;
+  workspacePath: string;
 }
 
 export interface DispatchEnvelope {
@@ -881,12 +892,12 @@ export interface DispatchEnvelope {
   confirmationDecision?: McpConfirmationDecision;
   /**
    * Absent when identity could not be resolved (view torn down between
-   * dispatch and response, or a webContents with no registered project).
+   * dispatch and response, or a webContents with no registered workspace).
    * Deliberately optional rather than nullable: "unknown" must not be
-   * confusable with "no project", and a failed lookup never downgrades an
+   * confusable with "no workspace", and a failed lookup never downgrades an
    * otherwise successful action result.
    */
-  dispatchedProject?: DispatchedProjectRef;
+  dispatchedWorkspace?: DispatchedWorkspaceRef;
 }
 
 export interface McpSseSession {

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -311,6 +311,35 @@ export function buildToolError(input: {
   return buildToolCallTextResult(JSON.stringify(payload), { isError: true });
 }
 
+/**
+ * `_meta` key carrying the project a tool call actually ran against (#11536).
+ * Namespaced per the MCP `_meta` convention so it can't collide with keys from
+ * other servers in an aggregating client.
+ */
+export const RESOLVED_PROJECT_META_KEY = "org.daintree/resolved-project";
+
+/**
+ * Stamp the resolved project onto a tool result (#11536).
+ *
+ * Top-level `_meta` rather than `structuredContent`, so it never has to satisfy
+ * (or violate) an action's declared output schema. Returns the result untouched
+ * when identity couldn't be resolved — the key's absence means "unknown", and
+ * failing to resolve it must never alter the action's own outcome.
+ */
+export function withResolvedProject<T extends CallToolResult>(
+  result: T,
+  project: DispatchedProjectRef | undefined
+): T {
+  if (!project) return result;
+  return {
+    ...result,
+    _meta: {
+      ...(result._meta ?? {}),
+      [RESOLVED_PROJECT_META_KEY]: { ...project },
+    },
+  };
+}
+
 export type McpTier = "workbench" | "action" | "system" | "external";
 
 // Tier tool lists live in `shared/config/helpAssistantTierAllowlists.ts`
@@ -835,9 +864,29 @@ export interface PendingRequest<T> {
   destroyedCleanup?: () => void;
 }
 
+/**
+ * The project a dispatch actually landed on, resolved from the responding
+ * renderer at response time (#11536). Unpinned external sessions follow window
+ * focus on every call, so a long-running agent's calls can retarget mid-session
+ * when the user switches project. Reporting the resolved project makes that
+ * drift observable to the caller instead of silent.
+ */
+export interface DispatchedProjectRef {
+  projectId: string;
+  projectPath: string;
+}
+
 export interface DispatchEnvelope {
   result: ActionDispatchResult;
   confirmationDecision?: McpConfirmationDecision;
+  /**
+   * Absent when identity could not be resolved (view torn down between
+   * dispatch and response, or a webContents with no registered project).
+   * Deliberately optional rather than nullable: "unknown" must not be
+   * confusable with "no project", and a failed lookup never downgrades an
+   * otherwise successful action result.
+   */
+  dispatchedProject?: DispatchedProjectRef;
 }
 
 export interface McpSseSession {

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -542,6 +542,36 @@ export class ProjectViewManager {
   }
 
   /**
+   * Live `{ projectId, projectPath }` for a view's webContents, or `null` when
+   * the id is unknown to this manager (#11536). Sender-scoped by construction —
+   * it walks this manager's own reverse mapping, never `activeProjectId` or the
+   * global current-project, so a dispatch that landed on a cached (deactivated)
+   * view still reports the project that view actually belongs to.
+   *
+   * Reads `projectPath` off the live `ViewEntry` rather than a registration-time
+   * copy, so a `rebindProjectPath()` (project moved on disk) is reflected. Fails
+   * closed to `null` if the entry no longer owns the requested webContents or
+   * the view has been torn down — callers treat that as "identity unknown" and
+   * omit the field rather than reporting a stale project.
+   */
+  getProjectRefForWebContents(
+    webContentsId: number
+  ): { projectId: string; projectPath: string } | null {
+    const projectId = this.webContentsToProject.get(webContentsId);
+    if (projectId === undefined) return null;
+    const entry = this.views.get(projectId);
+    if (!entry) return null;
+    try {
+      const wc = entry.view.webContents;
+      if (wc.isDestroyed() || wc.id !== webContentsId) return null;
+    } catch {
+      // View torn down mid-read — identity is unknowable, not stale.
+      return null;
+    }
+    return { projectId: entry.projectId, projectPath: entry.projectPath };
+  }
+
+  /**
    * Record the cold-start preload evaluation cost for a view, keyed by its
    * webContents id (#9770). Called from the perf IPC handler when a view's
    * preload flushes its `preload.eval` span. First-write semantics: the cost is

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -15,6 +15,7 @@
 
 import { BrowserWindow, type WebContentsView } from "electron";
 import { registerProjectView } from "./webContentsRegistry.js";
+import { isValidScratchStateId } from "../services/projectStorePaths.js";
 import { logWarn } from "../utils/logger.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { CHANNELS } from "../ipc/channels.js";
@@ -91,6 +92,18 @@ const DEFAULT_VIEW_LOAD_HARD_TIMEOUT_MS = 30_000;
  * sample period without a new timer.
  */
 const CACHED_VIEW_MEMORY_SAMPLE_INTERVAL_MS = 30_000;
+
+/**
+ * Identity of the workspace a view belongs to (#11536). Views are keyed on an
+ * opaque workspace id that is either a project id or a scratch id, so `kind`
+ * says which — a scratch has no Project row and cannot be looked up through
+ * project APIs.
+ */
+export interface WorkspaceRef {
+  kind: "project" | "scratch";
+  workspaceId: string;
+  workspacePath: string;
+}
 
 /** Safe-scalar view inventory entry for the diagnostics export (#10500). */
 export interface ViewInventoryEntry {
@@ -542,24 +555,30 @@ export class ProjectViewManager {
   }
 
   /**
-   * Live `{ projectId, projectPath }` for a view's webContents, or `null` when
-   * the id is unknown to this manager (#11536). Sender-scoped by construction —
-   * it walks this manager's own reverse mapping, never `activeProjectId` or the
-   * global current-project, so a dispatch that landed on a cached (deactivated)
-   * view still reports the project that view actually belongs to.
+   * Live workspace identity for a view's webContents, or `null` when the id is
+   * unknown to this manager (#11536). Sender-scoped by construction — it walks
+   * this manager's own reverse mapping, never `activeProjectId` or the global
+   * current-project, so a dispatch that landed on a cached (deactivated) view
+   * still reports the workspace that view actually belongs to.
    *
-   * Reads `projectPath` off the live `ViewEntry` rather than a registration-time
-   * copy, so a `rebindProjectPath()` (project moved on disk) is reflected. Fails
-   * closed to `null` if the entry no longer owns the requested webContents or
-   * the view has been torn down — callers treat that as "identity unknown" and
-   * omit the field rather than reporting a stale project.
+   * "Workspace", not "project": views are keyed on an opaque workspace id and
+   * a scratch is seeded through the same `switchTo(id, path)` path, so this can
+   * legitimately describe a scratch with no Project row. `kind` is derived from
+   * the id shape via the owning predicate in `projectStorePaths` — scratch ids
+   * are dashed UUIDs and project ids 64 hex chars, which cannot collide — so a
+   * caller can tell whether the id is resolvable through project APIs instead
+   * of guessing.
+   *
+   * Reads the path off the live `ViewEntry` rather than a registration-time
+   * copy, so a `rebindProjectPath()` (workspace moved on disk) is reflected.
+   * Fails closed to `null` if the entry no longer owns the requested webContents
+   * or the view has been torn down — callers treat that as "identity unknown"
+   * and omit the field rather than reporting a stale workspace.
    */
-  getProjectRefForWebContents(
-    webContentsId: number
-  ): { projectId: string; projectPath: string } | null {
-    const projectId = this.webContentsToProject.get(webContentsId);
-    if (projectId === undefined) return null;
-    const entry = this.views.get(projectId);
+  getWorkspaceRefForWebContents(webContentsId: number): WorkspaceRef | null {
+    const workspaceId = this.webContentsToProject.get(webContentsId);
+    if (workspaceId === undefined) return null;
+    const entry = this.views.get(workspaceId);
     if (!entry) return null;
     try {
       const wc = entry.view.webContents;
@@ -568,7 +587,11 @@ export class ProjectViewManager {
       // View torn down mid-read — identity is unknowable, not stale.
       return null;
     }
-    return { projectId: entry.projectId, projectPath: entry.projectPath };
+    return {
+      kind: isValidScratchStateId(entry.projectId) ? "scratch" : "project",
+      workspaceId: entry.projectId,
+      workspacePath: entry.projectPath,
+    };
   }
 
   /**

--- a/electron/window/__tests__/ProjectViewManager.lifecycle.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.lifecycle.test.ts
@@ -850,67 +850,128 @@ describe("ProjectViewManager — lifecycle invariants", () => {
     });
   });
 
-  describe("getProjectRefForWebContents (#11536)", () => {
-    it("reports the id and path of the project a view belongs to", async () => {
-      const setup = createManager();
+  describe("getWorkspaceRefForWebContents (#11536)", () => {
+    // Every manager here schedules a recurring memory sampler and window
+    // listeners; dispose() is what clears them, so a leaked manager can fire
+    // into later tests.
+    const managers: ManagerSetup[] = [];
+    const track = (setup: ManagerSetup): ManagerSetup => {
+      managers.push(setup);
+      return setup;
+    };
+
+    afterEach(() => {
+      for (const setup of managers.splice(0)) {
+        setup.manager.dispose();
+      }
+    });
+
+    it("reports the id and path of the workspace a view belongs to", async () => {
+      const setup = track(createManager());
       const bWc = await coldSwitch(setup, "proj-b", "/b");
 
-      expect(setup.manager.getProjectRefForWebContents(bWc.id)).toEqual({
-        projectId: "proj-b",
-        projectPath: "/b",
+      expect(setup.manager.getWorkspaceRefForWebContents(bWc.id)).toEqual({
+        kind: "project",
+        workspaceId: "proj-b",
+        workspacePath: "/b",
       });
     });
 
-    it("reports a cached (deactivated) view's own project, not the active one", async () => {
-      const setup = createManager();
+    it("marks a scratch workspace as a scratch, not a project", async () => {
+      // A scratch id is a dashed UUID and has no Project row, so a caller must
+      // not try to resolve it through project APIs.
+      const scratchId = "6f1c9d2e-4a7b-4c3d-9e8f-1a2b3c4d5e6f";
+      const setup = track(createManager());
+      const scratchWc = await coldSwitch(setup, scratchId, "/scratch/one");
+
+      expect(setup.manager.getWorkspaceRefForWebContents(scratchWc.id)).toEqual({
+        kind: "scratch",
+        workspaceId: scratchId,
+        workspacePath: "/scratch/one",
+      });
+    });
+
+    it("reports a cached (deactivated) view's own workspace, not the active one", async () => {
+      const setup = track(createManager());
       // Switching away leaves proj-a's view cached but still registered — an
       // in-flight MCP dispatch can settle against it after the user moves on.
       const bWc = await coldSwitch(setup, "proj-b", "/b");
 
       expect(setup.manager.getActiveProjectId()).toBe("proj-b");
-      expect(setup.manager.getProjectRefForWebContents(setup.initialWc.id)).toEqual({
-        projectId: "proj-a",
-        projectPath: "/a",
+      expect(setup.manager.getWorkspaceRefForWebContents(setup.initialWc.id)).toMatchObject({
+        workspaceId: "proj-a",
+        workspacePath: "/a",
       });
-      expect(setup.manager.getProjectRefForWebContents(bWc.id)).toEqual({
-        projectId: "proj-b",
-        projectPath: "/b",
+      expect(setup.manager.getWorkspaceRefForWebContents(bWc.id)).toMatchObject({
+        workspaceId: "proj-b",
+        workspacePath: "/b",
       });
     });
 
     it("reflects a rebound path rather than the registration-time one", async () => {
-      const setup = createManager();
+      const setup = track(createManager());
       const bWc = await coldSwitch(setup, "proj-b", "/b");
 
       await setup.manager.rebindProjectPath("proj-b", "/moved/b");
 
-      expect(setup.manager.getProjectRefForWebContents(bWc.id)).toEqual({
-        projectId: "proj-b",
-        projectPath: "/moved/b",
+      expect(setup.manager.getWorkspaceRefForWebContents(bWc.id)).toMatchObject({
+        workspaceId: "proj-b",
+        workspacePath: "/moved/b",
       });
     });
 
     it("returns null for an unknown id, a foreign window's view, and after teardown", async () => {
-      const setup = createManager();
-      const other = createManager();
+      const setup = track(createManager());
+      const other = track(createManager());
       const bWc = await coldSwitch(setup, "proj-b", "/b");
 
-      expect(setup.manager.getProjectRefForWebContents(999_999)).toBeNull();
+      // Positive control, so the null assertions below can't pass vacuously.
+      expect(setup.manager.getWorkspaceRefForWebContents(bWc.id)).not.toBeNull();
+
+      expect(setup.manager.getWorkspaceRefForWebContents(999_999)).toBeNull();
       // Sender-scoped: one window's manager must not answer for another's view.
-      expect(other.manager.getProjectRefForWebContents(bWc.id)).toBeNull();
+      expect(other.manager.getWorkspaceRefForWebContents(bWc.id)).toBeNull();
 
       setup.manager.dispose();
-      expect(setup.manager.getProjectRefForWebContents(bWc.id)).toBeNull();
+      expect(setup.manager.getWorkspaceRefForWebContents(bWc.id)).toBeNull();
     });
 
     it("returns null once the view's webContents is destroyed", async () => {
-      const setup = createManager();
+      const setup = track(createManager());
       const bWc = await coldSwitch(setup, "proj-b", "/b");
-      expect(setup.manager.getProjectRefForWebContents(bWc.id)).not.toBeNull();
+      expect(setup.manager.getWorkspaceRefForWebContents(bWc.id)).not.toBeNull();
 
       bWc.isDestroyed.mockReturnValue(true);
 
-      expect(setup.manager.getProjectRefForWebContents(bWc.id)).toBeNull();
+      expect(setup.manager.getWorkspaceRefForWebContents(bWc.id)).toBeNull();
+    });
+
+    it("returns null when the entry no longer owns the requested webContents", async () => {
+      // Pins the ownership guard: a stale reverse mapping must not attribute an
+      // old webContents id to whatever view now holds that project entry.
+      const setup = track(createManager());
+      const bWc = await coldSwitch(setup, "proj-b", "/b");
+      const staleId = bWc.id;
+      expect(setup.manager.getWorkspaceRefForWebContents(staleId)).not.toBeNull();
+
+      bWc.id = staleId + 1_000;
+
+      expect(setup.manager.getWorkspaceRefForWebContents(staleId)).toBeNull();
+    });
+
+    it("returns null when the webContents getter is gone (Electron #50249)", async () => {
+      const setup = track(createManager());
+      const bWc = await coldSwitch(setup, "proj-b", "/b");
+      expect(setup.manager.getWorkspaceRefForWebContents(bWc.id)).not.toBeNull();
+
+      const entry = setup.manager.getAllViews().find((e) => e.projectId === "proj-b");
+      Object.defineProperty(entry!.view, "webContents", {
+        get() {
+          throw new Error("webContents getter gone");
+        },
+      });
+
+      expect(setup.manager.getWorkspaceRefForWebContents(bWc.id)).toBeNull();
     });
   });
 });

--- a/electron/window/__tests__/ProjectViewManager.lifecycle.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.lifecycle.test.ts
@@ -849,4 +849,68 @@ describe("ProjectViewManager — lifecycle invariants", () => {
       setupTwo.ledger.assertNoPortsForDeadViews(setupTwo.manager as never);
     });
   });
+
+  describe("getProjectRefForWebContents (#11536)", () => {
+    it("reports the id and path of the project a view belongs to", async () => {
+      const setup = createManager();
+      const bWc = await coldSwitch(setup, "proj-b", "/b");
+
+      expect(setup.manager.getProjectRefForWebContents(bWc.id)).toEqual({
+        projectId: "proj-b",
+        projectPath: "/b",
+      });
+    });
+
+    it("reports a cached (deactivated) view's own project, not the active one", async () => {
+      const setup = createManager();
+      // Switching away leaves proj-a's view cached but still registered — an
+      // in-flight MCP dispatch can settle against it after the user moves on.
+      const bWc = await coldSwitch(setup, "proj-b", "/b");
+
+      expect(setup.manager.getActiveProjectId()).toBe("proj-b");
+      expect(setup.manager.getProjectRefForWebContents(setup.initialWc.id)).toEqual({
+        projectId: "proj-a",
+        projectPath: "/a",
+      });
+      expect(setup.manager.getProjectRefForWebContents(bWc.id)).toEqual({
+        projectId: "proj-b",
+        projectPath: "/b",
+      });
+    });
+
+    it("reflects a rebound path rather than the registration-time one", async () => {
+      const setup = createManager();
+      const bWc = await coldSwitch(setup, "proj-b", "/b");
+
+      await setup.manager.rebindProjectPath("proj-b", "/moved/b");
+
+      expect(setup.manager.getProjectRefForWebContents(bWc.id)).toEqual({
+        projectId: "proj-b",
+        projectPath: "/moved/b",
+      });
+    });
+
+    it("returns null for an unknown id, a foreign window's view, and after teardown", async () => {
+      const setup = createManager();
+      const other = createManager();
+      const bWc = await coldSwitch(setup, "proj-b", "/b");
+
+      expect(setup.manager.getProjectRefForWebContents(999_999)).toBeNull();
+      // Sender-scoped: one window's manager must not answer for another's view.
+      expect(other.manager.getProjectRefForWebContents(bWc.id)).toBeNull();
+
+      setup.manager.dispose();
+      expect(setup.manager.getProjectRefForWebContents(bWc.id)).toBeNull();
+    });
+
+    it("returns null once the view's webContents is destroyed", async () => {
+      const setup = createManager();
+      const bWc = await coldSwitch(setup, "proj-b", "/b");
+      expect(setup.manager.getProjectRefForWebContents(bWc.id)).not.toBeNull();
+
+      bWc.isDestroyed.mockReturnValue(true);
+
+      expect(setup.manager.getProjectRefForWebContents(bWc.id)).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
Resolves #11536.

## The bug

An unpinned external MCP session resolved its target renderer through `getActiveProjectWebContents()`, which walked `registry.all()` — Map insertion order. So an API-key client drove whichever window registered first, regardless of which one the user was actually looking at. `WindowRegistry.focusOrder()` already existed and already handled the hard parts (never-focused windows appended rather than dropped, registration-order fallback before the first focus event), so the routing fix is a one-line swap onto a primitive that was already hardened for `getPrimary()` in #8610.

The second half is the one that actually bites during long agent runs: nothing told the caller *which* workspace a call landed on. A caller does a series of tool calls, the user switches project midway, and every later call silently retargets. The results look normal.

## What changed

- `getActiveProjectWebContents()` iterates `registry.focusOrder()` instead of `registry.all()`. Both liveness guards and the module-singleton fallback are untouched (#8607 — that fallback is deliberate and is not a routing fallback). This also fixes `requestManifest()`, which shares the resolver.
- Renderer-dispatched `CallToolResult`s now carry `_meta["org.daintree/resolved-workspace"]` = `{ kind, workspaceId, workspacePath }`, so drift is observable instead of silent.
- New `ProjectViewManager.getWorkspaceRefForWebContents()` resolves that identity sender-scoped, off the owning window's own manager — never `getCurrentProjectId()`, which reports the most-recently-switched project rather than this webContents'.

External sessions stay **unpinned**. That was a deliberate call in #7003 — pinning applies only to bearers whose authority is window-scoped — and the issue asks for observability, not pinning.

## Why "workspace" and not "project"

The issue says "project id and path", but `ProjectViewManager` keys views on an opaque *workspace* id and a scratch is seeded through the same `switchTo(id, path)`. Naming the field `projectId` would have reported every scratch as a project, handing callers a dashed-UUID scratch id that no project API can resolve. `kind` is derived from the id shape via `isValidScratchStateId`, whose no-collision guarantee (64-hex project ids vs dashed scratch UUIDs) is documented in `projectStorePaths.ts`.

## Resolution timing

The workspace is snapshotted synchronously inside `dispatchHandler`, off the sender that was just validated against `pending.webContentsId` — not after the awaiting caller in `sessionServer` resumes. Resolving later would race view eviction and workspace switching and could name a workspace the dispatch never ran against. There's a test for exactly this: two concurrent dispatches to different windows, focus moved between the sends, a spoofed wrong-sender response, and out-of-order settlement.

Resolution failure omits the key rather than stamping nulls — "unknown" must not be confusable with "no workspace" — and never downgrades an otherwise successful action. The whole lookup is inside the try: by the time it runs the pending entry's timer is already cleared, so an escaping throw would strand the awaiting promise rather than merely lose the stamp.

The stamp is applied uniformly, so pinned help-session results carry it too. That's the smaller change, not scope creep — `dispatchHandler` populates both paths, so suppressing it for pinned sessions would have needed extra logic.

## Testing

318 targeted tests plus the full `electron/window/__tests__` directory (798) and a full typecheck, all green locally. Mutation-verified rather than assumed: reverting `focusOrder()` → `all()` fails 5 tests including the end-to-end one; deleting the screenshot stamp fails the screenshot test; resolving from the focused window instead of the responding sender fails the response-time test.

Ten registry test doubles needed `focusOrder()` — they defined only `all()` and would have thrown.

## Known gap, not fixed here

Automatic dedup keys don't include routing scope, so a second identical call to a dedup-allowlisted tool (`terminal.new`, `git.push`, …) inside the 120s TTL replays the cached result even if focus has since moved to another workspace. This is pre-existing: the key was already scoped only by session/action/args, and pre-change routing already re-read `getActiveView()` per call, so an in-window project switch could already retarget. Focus-order routing widens the incidence but doesn't create the flaw, and adding a webContents id to the key would weaken the double-spawn protection dedup exists for — that's a product call, so I'm filing it separately rather than smuggling it in here. The new `_meta` stamp at least makes the mismatch visible.

Also note: the issue says `focusOrder()` has no call sites; that's now stale — `openWindowsTracker.ts` picked it up in #11492. Doesn't change the fix.