### PR TITLE
fix(terminal): carry capture geometry with scrollback snapshots

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/snapshots.getSerializedStates.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/snapshots.getSerializedStates.test.ts
@@ -11,6 +11,11 @@ import { ipcMain } from "electron";
 import { CHANNELS } from "../../../channels.js";
 import { registerTerminalSnapshotHandlers } from "../snapshots.js";
 import type { HandlerDependencies } from "../../../types.js";
+import type { SerializedTerminalSnapshot } from "../../../../../shared/types/terminal.js";
+
+function snapshot(data: string): SerializedTerminalSnapshot {
+  return { data, cols: 80, rows: 24 };
+}
 
 describe("terminal:get-serialized-states handler", () => {
   beforeEach(() => {
@@ -20,7 +25,7 @@ describe("terminal:get-serialized-states handler", () => {
   function getHandler(): (
     event: unknown,
     terminalIds: string[]
-  ) => Promise<Record<string, string | null>> {
+  ) => Promise<Record<string, SerializedTerminalSnapshot | null>> {
     const calls = (ipcMain.handle as unknown as { mock: { calls: Array<[string, unknown]> } }).mock
       .calls;
     const handlerCall = calls.find((call) => call[0] === CHANNELS.TERMINAL_GET_SERIALIZED_STATES);
@@ -28,15 +33,15 @@ describe("terminal:get-serialized-states handler", () => {
     return handlerCall?.[1] as (
       event: unknown,
       terminalIds: string[]
-    ) => Promise<Record<string, string | null>>;
+    ) => Promise<Record<string, SerializedTerminalSnapshot | null>>;
   }
 
   it("returns serialized state map for unique terminal IDs", async () => {
     const ptyClient = {
       getSerializedStateAsync: vi.fn(async (terminalId: string) => {
-        if (terminalId === "t-1") return "state-1";
+        if (terminalId === "t-1") return snapshot("state-1");
         if (terminalId === "t-2") return null;
-        return "unknown";
+        return snapshot("unknown");
       }),
     };
 
@@ -45,8 +50,10 @@ describe("terminal:get-serialized-states handler", () => {
 
     const result = await handler({}, ["t-1", "t-1", "t-2"]);
 
+    // The batch must forward the capture grid per entry, not just the payload:
+    // it is what each replay sizes itself to (#11552).
     expect(result).toEqual({
-      "t-1": "state-1",
+      "t-1": snapshot("state-1"),
       "t-2": null,
     });
     expect(ptyClient.getSerializedStateAsync).toHaveBeenCalledTimes(2);
@@ -58,7 +65,7 @@ describe("terminal:get-serialized-states handler", () => {
         if (terminalId === "t-fail") {
           throw new Error("boom");
         }
-        return "ok";
+        return snapshot("ok");
       }),
     };
 
@@ -68,14 +75,14 @@ describe("terminal:get-serialized-states handler", () => {
     const result = await handler({}, ["t-ok", "t-fail"]);
 
     expect(result).toEqual({
-      "t-ok": "ok",
+      "t-ok": snapshot("ok"),
       "t-fail": null,
     });
   });
 
   it("rejects invalid payloads", async () => {
     const ptyClient = {
-      getSerializedStateAsync: vi.fn(async () => "state"),
+      getSerializedStateAsync: vi.fn(async () => snapshot("state")),
     };
 
     registerTerminalSnapshotHandlers({ ptyClient } as unknown as HandlerDependencies);

--- a/electron/ipc/handlers/terminal/snapshots.ts
+++ b/electron/ipc/handlers/terminal/snapshots.ts
@@ -10,6 +10,7 @@ import { logDebug, logInfo, logWarn } from "../../../utils/logger.js";
 import { getAgentAvailabilityStore } from "../../../services/AgentAvailabilityStore.js";
 import { defineIpcNamespace, op, opValidated } from "../../define.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
+import type { SerializedTerminalSnapshot } from "../../../../shared/types/terminal.js";
 
 type ValidatedReplayHistoryPayload = z.output<typeof TerminalReplayHistoryPayloadSchema>;
 
@@ -19,7 +20,9 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
     return () => {};
   }
 
-  const handleTerminalGetSerializedState = async (terminalId: string): Promise<string | null> => {
+  const handleTerminalGetSerializedState = async (
+    terminalId: string
+  ): Promise<SerializedTerminalSnapshot | null> => {
     try {
       if (typeof terminalId !== "string" || !terminalId) {
         throw new Error("Invalid terminal ID: must be a non-empty string");
@@ -29,7 +32,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
 
       if (process.env.DAINTREE_VERBOSE) {
         logDebug(
-          `terminal:getSerializedState(${terminalId}): ${serializedState ? `${serializedState.length} bytes` : "null"}`
+          `terminal:getSerializedState(${terminalId}): ${serializedState ? `${serializedState.data.length} bytes @ ${serializedState.cols}x${serializedState.rows}` : "null"}`
         );
       }
       return serializedState;
@@ -41,7 +44,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
 
   const handleTerminalGetSerializedStates = async (
     terminalIds: string[]
-  ): Promise<Record<string, string | null>> => {
+  ): Promise<Record<string, SerializedTerminalSnapshot | null>> => {
     if (!Array.isArray(terminalIds)) {
       throw new Error("Invalid terminal IDs: must be an array");
     }

--- a/electron/pty-host/handlers/__tests__/dispatcher.test.ts
+++ b/electron/pty-host/handlers/__tests__/dispatcher.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createPtyHostMessageDispatcher } from "../index.js";
 import type { HostContext } from "../types.js";
 import type { SerializedTerminalSnapshot } from "../../../../shared/types/terminal.js";
+
+// Snapshots cross the pty-host boundary with their capture grid (#11552).
+const STATE_PAYLOAD: SerializedTerminalSnapshot = { data: "state-payload", cols: 80, rows: 24 };
 import { clearPluginAgentRegistryForTests } from "../../../../shared/config/pluginAgentRegistry.js";
 import { getEffectiveAgentConfig } from "../../../../shared/config/agentRegistry.js";
 
@@ -14,8 +17,8 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
     getTerminalsForProject: vi.fn(() => []),
     getTerminalInfo: vi.fn(() => ({})),
     getAllTerminalSnapshots: vi.fn(() => []),
-    getSerializedStateAsync: vi.fn(async () => "state-payload"),
-    getSerializedState: vi.fn(() => "state-payload"),
+    getSerializedStateAsync: vi.fn(async () => STATE_PAYLOAD),
+    getSerializedState: vi.fn(() => STATE_PAYLOAD),
     isInTrash: vi.fn(() => false),
     getActivityTier: vi.fn(() => "active" as const),
     setAnalysisEnabled: vi.fn(),

--- a/electron/pty-host/handlers/__tests__/dispatcher.test.ts
+++ b/electron/pty-host/handlers/__tests__/dispatcher.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createPtyHostMessageDispatcher } from "../index.js";
 import type { HostContext } from "../types.js";
+import type { SerializedTerminalSnapshot } from "../../../../shared/types/terminal.js";
 import { clearPluginAgentRegistryForTests } from "../../../../shared/config/pluginAgentRegistry.js";
 import { getEffectiveAgentConfig } from "../../../../shared/config/agentRegistry.js";
 
@@ -155,9 +156,9 @@ describe("createPtyHostMessageDispatcher", () => {
     // (returning undefined, not a Promise), so subsequent messages are not
     // blocked while serialization runs.
     const ctx = makeCtx();
-    let resolveSerialization: (value: string) => void = () => {};
+    let resolveSerialization: (value: SerializedTerminalSnapshot) => void = () => {};
     ctx.ptyManager.getSerializedStateAsync = vi.fn(
-      () => new Promise<string>((resolve) => (resolveSerialization = resolve))
+      () => new Promise<SerializedTerminalSnapshot>((resolve) => (resolveSerialization = resolve))
     );
 
     const dispatch = createPtyHostMessageDispatcher(ctx);
@@ -169,14 +170,14 @@ describe("createPtyHostMessageDispatcher", () => {
     // The send has not happened yet because serialization is still pending.
     expect(ctx.sendEvent).not.toHaveBeenCalled();
 
-    resolveSerialization("payload");
+    resolveSerialization({ data: "payload", cols: 80, rows: 24 });
     await new Promise((r) => setTimeout(r, 0));
 
     expect(ctx.sendEvent).toHaveBeenCalledWith({
       type: "serialized-state",
       requestId: 99,
       id: "term-1",
-      state: "payload",
+      state: { data: "payload", cols: 80, rows: 24 },
     });
   });
 

--- a/electron/pty-host/handlers/__tests__/lifecycle.test.ts
+++ b/electron/pty-host/handlers/__tests__/lifecycle.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createPtyHostMessageDispatcher } from "../index.js";
 import type { HostContext } from "../types.js";
+import type { SerializedTerminalSnapshot } from "../../../../shared/types/terminal.js";
+
+// Snapshots cross the pty-host boundary with their capture grid (#11552).
+const STATE_PAYLOAD: SerializedTerminalSnapshot = { data: "state-payload", cols: 80, rows: 24 };
 
 function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
   const ptyManager = {
@@ -11,8 +15,8 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
     getTerminalsForProject: vi.fn(() => []),
     getTerminalInfo: vi.fn(() => ({})),
     getAllTerminalSnapshots: vi.fn(() => []),
-    getSerializedStateAsync: vi.fn(async () => "state-payload"),
-    getSerializedState: vi.fn(() => "state-payload"),
+    getSerializedStateAsync: vi.fn(async () => STATE_PAYLOAD),
+    getSerializedState: vi.fn(() => STATE_PAYLOAD),
     isInTrash: vi.fn(() => false),
     getActivityTier: vi.fn(() => "active" as const),
     setAnalysisEnabled: vi.fn(),

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -107,6 +107,7 @@ import type { AgentStateChangeTrigger } from "../types/index.js";
 import type { AgentState, AgentId, WaitingReason } from "../../shared/types/agent.js";
 import type { PanelKind, PanelTitleMode } from "../../shared/types/panel.js";
 import type { ResourceProfile } from "../../shared/types/resourceProfile.js";
+import type { SerializedTerminalSnapshot } from "../../shared/types/terminal.js";
 import type { BuiltInAgentId } from "../../shared/config/agentIds.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -2149,10 +2150,10 @@ export class PtyClient extends EventEmitter {
    * @param id - Terminal identifier
    * @returns Serialized state string or null if terminal not found
    */
-  async getSerializedStateAsync(id: string): Promise<string | null> {
+  async getSerializedStateAsync(id: string): Promise<SerializedTerminalSnapshot | null> {
     const shard = this.shardForTerminal(id);
     // Extended timeout for large terminals with lots of scrollback (see PTY_TIMEOUTS).
-    const promise = sendPtyHostRpc<string | null>(
+    const promise = sendPtyHostRpc<SerializedTerminalSnapshot | null>(
       shard,
       `serialize-${id}`,
       (requestId) => ({ type: "get-serialized-state", id, requestId }),

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -38,6 +38,7 @@ import { AgentTerminalLifecycleLedger } from "../../shared/utils/agentLifecycleL
 import { events } from "./events.js";
 import { getGitBranch } from "../utils/gitUtils.js";
 import type { GracefulKillResult } from "../../shared/types/pty-host.js";
+import type { SerializedTerminalSnapshot } from "../../shared/types/terminal.js";
 import { SCROLLBACK_MIN } from "../../shared/config/scrollback.js";
 import { shouldTrimAnalysisSession } from "../../shared/utils/workerGovernancePolicy.js";
 
@@ -719,7 +720,7 @@ export class PtyManager extends EventEmitter {
   /**
    * Get serialized terminal state (synchronous).
    */
-  getSerializedState(id: string): string | null {
+  getSerializedState(id: string): SerializedTerminalSnapshot | null {
     const terminal = this.registry.get(id);
     if (!terminal) {
       return null;
@@ -730,7 +731,7 @@ export class PtyManager extends EventEmitter {
   /**
    * Get serialized terminal state (async, uses worker for large terminals).
    */
-  async getSerializedStateAsync(id: string): Promise<string | null> {
+  async getSerializedStateAsync(id: string): Promise<SerializedTerminalSnapshot | null> {
     const terminal = this.registry.get(id);
     if (!terminal) {
       return null;

--- a/electron/services/pty/PreservedSnapshotCapture.ts
+++ b/electron/services/pty/PreservedSnapshotCapture.ts
@@ -1,5 +1,6 @@
 import type { TerminalInfo } from "./types.js";
 import type { AnalysisBackend } from "./analysis/AnalysisBackend.js";
+import type { SerializedTerminalSnapshot } from "../../../shared/types/terminal.js";
 import { headlessMirrorScheduler } from "./HeadlessMirrorScheduler.js";
 import {
   TERMINAL_SESSION_PERSISTENCE_ENABLED,
@@ -12,7 +13,7 @@ export interface PreservedSnapshotCaptureHost {
   readonly terminalInfo: TerminalInfo;
   readonly analysis: AnalysisBackend;
   readonly isDisposed: boolean;
-  serializeForPersistence(): string | null;
+  serializeForPersistence(): SerializedTerminalSnapshot | null;
   disposeHeadless(): void;
   onPreserved(): void;
 }
@@ -50,9 +51,16 @@ export class PreservedSnapshotCapture {
       if (terminal.headlessTerminal !== headless || !terminal.serializeAddon) {
         return;
       }
-      let snapshot: string;
+      let snapshot: SerializedTerminalSnapshot;
       try {
-        snapshot = terminal.serializeAddon.serialize();
+        // Geometry read in the same tick as the serialize: the headless mirror
+        // is disposed a few lines below, so this is the last moment the grid
+        // behind the payload is knowable (#11552).
+        snapshot = {
+          data: terminal.serializeAddon.serialize(),
+          cols: headless.cols,
+          rows: headless.rows,
+        };
       } catch (error) {
         console.error(
           `[TerminalProcess] Failed to snapshot preserved terminal ${this.host.id}:`,

--- a/electron/services/pty/SessionSnapshotter.ts
+++ b/electron/services/pty/SessionSnapshotter.ts
@@ -23,9 +23,7 @@ export interface SessionSnapshotterHost {
   // worker. The sync flush paths degrade to best-effort async persistence for
   // Promise-returning hosts.
   serializeForPersistence():
-    | SerializedTerminalSnapshot
-    | null
-    | Promise<SerializedTerminalSnapshot | null>;
+    SerializedTerminalSnapshot | null | Promise<SerializedTerminalSnapshot | null>;
 }
 
 // Narrow view of a TerminalProcess-shaped owner, sufficient to build either

--- a/electron/services/pty/SessionSnapshotter.ts
+++ b/electron/services/pty/SessionSnapshotter.ts
@@ -1,3 +1,4 @@
+import type { SerializedTerminalSnapshot } from "../../../shared/types/terminal.js";
 import {
   TERMINAL_SESSION_PERSISTENCE_ENABLED,
   SESSION_SNAPSHOT_DEBOUNCE_MS,
@@ -16,12 +17,15 @@ export interface SessionSnapshotterHost {
   // capture). Read as a dirty check so an unchanged buffer is not re-serialized.
   readonly contentEpoch: number;
   hasBannerMarkers(): boolean;
-  getSerializedState(): string | null;
-  getSerializedStateAsync(): Promise<string | null>;
-  // Sync string in-thread; a Promise when the buffer lives in an analysis
+  getSerializedState(): SerializedTerminalSnapshot | null;
+  getSerializedStateAsync(): Promise<SerializedTerminalSnapshot | null>;
+  // Sync snapshot in-thread; a Promise when the buffer lives in an analysis
   // worker. The sync flush paths degrade to best-effort async persistence for
   // Promise-returning hosts.
-  serializeForPersistence(): string | null | Promise<string | null>;
+  serializeForPersistence():
+    | SerializedTerminalSnapshot
+    | null
+    | Promise<SerializedTerminalSnapshot | null>;
 }
 
 // Narrow view of a TerminalProcess-shaped owner, sufficient to build either
@@ -34,10 +38,10 @@ export interface TerminalSessionSnapshotterFactoryHost {
   readonly launchAgentId: string | undefined;
   readonly contentEpoch: number;
   readonly hasRestoreBannerMarkers: boolean;
-  getSerializedState(): string | null;
-  getSerializedStateAsync(): Promise<string | null>;
-  serializeForPersistence(): string | null;
-  serializeForPersistenceViaAnalysis(): Promise<string | null>;
+  getSerializedState(): SerializedTerminalSnapshot | null;
+  getSerializedStateAsync(): Promise<SerializedTerminalSnapshot | null>;
+  serializeForPersistence(): SerializedTerminalSnapshot | null;
+  serializeForPersistenceViaAnalysis(): Promise<SerializedTerminalSnapshot | null>;
 }
 
 export function createTerminalSessionSnapshotter(
@@ -205,21 +209,21 @@ export class SessionSnapshotter {
 
     try {
       const state = this.host.serializeForPersistence();
-      if (typeof state === "string") {
-        persistSessionSnapshotSync(this.host.id, state);
-      } else if (state) {
+      if (state instanceof Promise) {
         // Worker-backed host: the buffer serializes off-thread, so a sync
         // flush is impossible. The serialize request is already in the
         // worker's queue ahead of the free message, so this best-effort async
         // persist still captures the pre-kill buffer.
         this.persistDeferred(state);
+      } else if (state) {
+        persistSessionSnapshotSync(this.host.id, state);
       }
     } catch {
       // best-effort only
     }
   }
 
-  private persistDeferred(state: Promise<string | null>): void {
+  private persistDeferred(state: Promise<SerializedTerminalSnapshot | null>): void {
     void state
       .then((s) => {
         if (!s) return;
@@ -243,7 +247,7 @@ export class SessionSnapshotter {
 
     try {
       const raw = this.host.serializeForPersistence();
-      if (raw !== null && typeof raw === "object") {
+      if (raw instanceof Promise) {
         this.persistDeferred(raw);
         this.dirty = false;
         return;

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -72,7 +72,8 @@ import {
   readVisibleActivityLines,
   ViewportSnapshotCache,
 } from "./analysis/headlessViewport.js";
-import type { AnalysisFinalSnapshot } from "./analysisWorkerProtocol.js";
+import type { AnalysisFinalCapture } from "./analysis/AnalysisBackend.js";
+import type { SerializedTerminalSnapshot } from "../../../shared/types/terminal.js";
 import { TerminalExitObservers, type TerminalExitArgs } from "./TerminalExitObservers.js";
 import { TerminalExitHandler } from "./TerminalExitHandler.js";
 import { gracefulShutdown as runGracefulShutdown } from "./TerminalGracefulShutdown.js";
@@ -674,7 +675,7 @@ export class TerminalProcess {
       readCursorLine: () => readCursorLine(this.terminalInfo.headlessTerminal),
       serialize: () => serializeTerminalAsync(this.id, this.terminalInfo),
       serializeForPersistence: () => this.serializeForPersistence(),
-      captureFinalSnapshot: async (): Promise<AnalysisFinalSnapshot> => {
+      captureFinalSnapshot: async (): Promise<AnalysisFinalCapture> => {
         const snapshot = await serializeTerminalAsync(this.id, this.terminalInfo);
         return { snapshot, persistence: this.serializeForPersistence() };
       },
@@ -1296,11 +1297,11 @@ export class TerminalProcess {
     return this.foregroundProbe.readSnapshot();
   }
 
-  getSerializedState(): string | null {
+  getSerializedState(): SerializedTerminalSnapshot | null {
     return serializeTerminal(this.id, this.terminalInfo);
   }
 
-  getSerializedStateAsync(): Promise<string | null> {
+  getSerializedStateAsync(): Promise<SerializedTerminalSnapshot | null> {
     const terminal = this.terminalInfo;
     // Preserved snapshot served — stamp access time so eviction (issue #10839)
     // treats it as currently-viewed. Checked host-side in both modes; the
@@ -1312,7 +1313,7 @@ export class TerminalProcess {
     return this.analysis.serialize();
   }
 
-  serializeForPersistence(): string | null {
+  serializeForPersistence(): SerializedTerminalSnapshot | null {
     return serializeForPersistence(
       this.terminalInfo,
       this._restoreBannerStart,

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -40,6 +40,7 @@ import { SynchronizedFrameDetector } from "./SynchronizedFrameDetector.js";
 import type { IMarker } from "@xterm/headless";
 import {
   TERMINAL_SESSION_PERSISTENCE_ENABLED,
+  resizeMirror,
   restoreSessionFromFile,
 } from "./terminalSessionPersistence.js";
 import { SessionSnapshotter, createTerminalSessionSnapshotter } from "./SessionSnapshotter.js";
@@ -816,7 +817,9 @@ export class TerminalProcess {
   private resizeAnalysisInThread(cols: number, rows: number): void {
     const terminal = this.terminalInfo;
     if (terminal.headlessTerminal) {
-      terminal.headlessTerminal.resize(cols, rows);
+      // Parked, not applied, while a session replay owns the grid — the replay
+      // reflows to this geometry instead of to the one it opened on (#11552).
+      resizeMirror(terminal.headlessTerminal, cols, rows);
       // Reflow rewraps the buffer — invalidate any wake no-change skip.
       terminal.contentEpoch++;
     }

--- a/electron/services/pty/TerminalSerializerService.ts
+++ b/electron/services/pty/TerminalSerializerService.ts
@@ -12,10 +12,12 @@
  * Also implements single-flight per terminal to prevent request pileup.
  */
 
+import type { SerializedTerminalSnapshot } from "../../../shared/types/terminal.js";
+
 const ASYNC_SERIALIZATION_THRESHOLD_LINES = 1000;
 
 export class TerminalSerializerService {
-  private inFlightRequests = new Map<string, Promise<string | null>>();
+  private inFlightRequests = new Map<string, Promise<SerializedTerminalSnapshot | null>>();
   private isDisposed = false;
 
   shouldUseAsync(lineCount: number): boolean {
@@ -29,8 +31,16 @@ export class TerminalSerializerService {
    *
    * Implements single-flight per terminal - if a serialization is already
    * in progress for a terminal, returns the existing promise.
+   *
+   * `serializeFn` must produce the capture geometry in the SAME tick it reads
+   * the buffer (#11552): this call defers to a later `setImmediate` and
+   * coalesces concurrent callers, so a cols/rows value sampled by the caller
+   * beforehand can describe a grid the buffer has since left.
    */
-  async serializeAsync(id: string, serializeFn: () => string | null): Promise<string | null> {
+  async serializeAsync(
+    id: string,
+    serializeFn: () => SerializedTerminalSnapshot | null
+  ): Promise<SerializedTerminalSnapshot | null> {
     if (this.isDisposed) {
       return null;
     }
@@ -40,7 +50,7 @@ export class TerminalSerializerService {
       return existingRequest;
     }
 
-    const promise = new Promise<string | null>((resolve) => {
+    const promise = new Promise<SerializedTerminalSnapshot | null>((resolve) => {
       setImmediate(() => {
         try {
           if (this.isDisposed) {

--- a/electron/services/pty/__tests__/SessionSnapshotter.test.ts
+++ b/electron/services/pty/__tests__/SessionSnapshotter.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionSnapshotter, type SessionSnapshotterHost } from "../SessionSnapshotter.js";
+import type { SerializedTerminalSnapshot } from "../../../../shared/types/terminal.js";
+
+// Snapshots now carry the grid they were captured at, so persistence writers
+// receive an object rather than a bare payload string (#11552).
+const SYNC_STATE: SerializedTerminalSnapshot = { data: "sync-state", cols: 80, rows: 24 };
+const ASYNC_STATE: SerializedTerminalSnapshot = { data: "async-state", cols: 80, rows: 24 };
+const BANNER_STATE: SerializedTerminalSnapshot = { data: "banner-state", cols: 80, rows: 24 };
 
 const persistAsyncMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
 const persistSyncMock = vi.hoisted(() => vi.fn());
@@ -21,9 +28,9 @@ interface MutableHost extends SessionSnapshotterHost {
   launchAgentId: string | undefined;
   contentEpoch: number;
   bannerMarkers: boolean;
-  serializedState: string | null;
-  serializedStateAsync: string | null;
-  serializedForPersistence: string | null;
+  serializedState: SerializedTerminalSnapshot | null;
+  serializedStateAsync: SerializedTerminalSnapshot | null;
+  serializedForPersistence: SerializedTerminalSnapshot | null;
   asyncResolve: () => void;
   asyncResolved: boolean;
 }
@@ -49,9 +56,9 @@ function createHost(overrides: Partial<MutableHost> = {}): MutableHost {
     launchAgentId: undefined,
     contentEpoch: 1,
     bannerMarkers: false,
-    serializedState: "sync-state",
-    serializedStateAsync: "async-state",
-    serializedForPersistence: "banner-state",
+    serializedState: SYNC_STATE,
+    serializedStateAsync: ASYNC_STATE,
+    serializedForPersistence: BANNER_STATE,
     hasBannerMarkers() {
       return this.bannerMarkers;
     },
@@ -111,7 +118,7 @@ describe("SessionSnapshotter", () => {
       await vi.advanceTimersByTimeAsync(5000);
 
       expect(persistAsyncMock).toHaveBeenCalledTimes(1);
-      expect(persistAsyncMock).toHaveBeenCalledWith("t-test", "async-state");
+      expect(persistAsyncMock).toHaveBeenCalledWith("t-test", ASYNC_STATE);
     });
 
     it("uses banner-aware sync serialize when banner markers are present", async () => {
@@ -122,7 +129,7 @@ describe("SessionSnapshotter", () => {
       await vi.advanceTimersByTimeAsync(5000);
 
       expect(persistAsyncMock).toHaveBeenCalledTimes(1);
-      expect(persistAsyncMock).toHaveBeenCalledWith("t-test", "banner-state");
+      expect(persistAsyncMock).toHaveBeenCalledWith("t-test", BANNER_STATE);
     });
 
     it("skips scheduling when launchAgentId is set (agent terminal)", async () => {
@@ -254,7 +261,7 @@ describe("SessionSnapshotter", () => {
       await flushMicrotasks();
 
       expect(persistAsyncMock).toHaveBeenCalledTimes(1);
-      expect(persistAsyncMock).toHaveBeenCalledWith("t-test", "async-state");
+      expect(persistAsyncMock).toHaveBeenCalledWith("t-test", ASYNC_STATE);
     });
 
     it("strips restore banner via sync serializeForPersistence when banner markers are present", async () => {
@@ -265,7 +272,7 @@ describe("SessionSnapshotter", () => {
       await flushMicrotasks();
 
       expect(persistAsyncMock).toHaveBeenCalledTimes(1);
-      expect(persistAsyncMock).toHaveBeenCalledWith("t-test", "banner-state");
+      expect(persistAsyncMock).toHaveBeenCalledWith("t-test", BANNER_STATE);
     });
 
     it("throttles repeated calls within 2s", async () => {
@@ -441,7 +448,7 @@ describe("SessionSnapshotter", () => {
       snap.flushSyncOnKill();
 
       expect(persistSyncMock).toHaveBeenCalledTimes(1);
-      expect(persistSyncMock).toHaveBeenCalledWith("t-test", "banner-state");
+      expect(persistSyncMock).toHaveBeenCalledWith("t-test", BANNER_STATE);
     });
 
     it("skips for agent terminals", () => {
@@ -474,7 +481,7 @@ describe("SessionSnapshotter", () => {
       snap.flushSyncOnKill();
 
       expect(persistSyncMock).toHaveBeenCalledTimes(1);
-      expect(persistSyncMock).toHaveBeenCalledWith("t-test", "banner-state");
+      expect(persistSyncMock).toHaveBeenCalledWith("t-test", BANNER_STATE);
     });
 
     it("skips when serialized state is null", () => {
@@ -505,7 +512,7 @@ describe("SessionSnapshotter", () => {
       snap.flushSyncOnDispose();
 
       expect(persistSyncMock).toHaveBeenCalledTimes(1);
-      expect(persistSyncMock).toHaveBeenCalledWith("t-test", "banner-state");
+      expect(persistSyncMock).toHaveBeenCalledWith("t-test", BANNER_STATE);
     });
 
     it("skips when wasKilled is true", () => {
@@ -527,7 +534,7 @@ describe("SessionSnapshotter", () => {
       snap.flushSyncOnDispose();
 
       expect(persistSyncMock).toHaveBeenCalledTimes(1);
-      expect(persistSyncMock).toHaveBeenCalledWith("t-test", "sync-state");
+      expect(persistSyncMock).toHaveBeenCalledWith("t-test", SYNC_STATE);
     });
 
     it("clears dirty flag after persist so a second call is a no-op", () => {

--- a/electron/services/pty/__tests__/TerminalProcess.kill.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.kill.test.ts
@@ -188,17 +188,17 @@ describe("TerminalProcess.kill — session persistence", () => {
     // Spy on serializeForPersistence (banner-aware) — the kill path uses this
     // so a hibernate→restore→hibernate cycle doesn't bake the restore banner
     // into the snapshot.
-    vi.spyOn(terminal, "serializeForPersistence").mockReturnValue("scrollback-data");
+    vi.spyOn(terminal, "serializeForPersistence").mockReturnValue({ data: "scrollback-data", cols: 80, rows: 24 });
 
     terminal.kill("test");
 
-    expect(persistSyncMock).toHaveBeenCalledWith("t1", "scrollback-data");
+    expect(persistSyncMock).toHaveBeenCalledWith("t1", { data: "scrollback-data", cols: 80, rows: 24 });
   });
 
   it("does not persist session for agent terminals on kill", () => {
     const terminal = createTerminal({ kind: "terminal", launchAgentId: "claude" });
 
-    vi.spyOn(terminal, "serializeForPersistence").mockReturnValue("scrollback-data");
+    vi.spyOn(terminal, "serializeForPersistence").mockReturnValue({ data: "scrollback-data", cols: 80, rows: 24 });
 
     terminal.kill("test");
 

--- a/electron/services/pty/__tests__/TerminalProcess.kill.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.kill.test.ts
@@ -188,17 +188,29 @@ describe("TerminalProcess.kill — session persistence", () => {
     // Spy on serializeForPersistence (banner-aware) — the kill path uses this
     // so a hibernate→restore→hibernate cycle doesn't bake the restore banner
     // into the snapshot.
-    vi.spyOn(terminal, "serializeForPersistence").mockReturnValue({ data: "scrollback-data", cols: 80, rows: 24 });
+    vi.spyOn(terminal, "serializeForPersistence").mockReturnValue({
+      data: "scrollback-data",
+      cols: 80,
+      rows: 24,
+    });
 
     terminal.kill("test");
 
-    expect(persistSyncMock).toHaveBeenCalledWith("t1", { data: "scrollback-data", cols: 80, rows: 24 });
+    expect(persistSyncMock).toHaveBeenCalledWith("t1", {
+      data: "scrollback-data",
+      cols: 80,
+      rows: 24,
+    });
   });
 
   it("does not persist session for agent terminals on kill", () => {
     const terminal = createTerminal({ kind: "terminal", launchAgentId: "claude" });
 
-    vi.spyOn(terminal, "serializeForPersistence").mockReturnValue({ data: "scrollback-data", cols: 80, rows: 24 });
+    vi.spyOn(terminal, "serializeForPersistence").mockReturnValue({
+      data: "scrollback-data",
+      cols: 80,
+      rows: 24,
+    });
 
     terminal.kill("test");
 

--- a/electron/services/pty/__tests__/TerminalProcess.snapshot.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.snapshot.test.ts
@@ -132,17 +132,17 @@ describe("TerminalProcess.flushEventDrivenSnapshot", () => {
 
   it("persists for agent terminals via async serialization (non-banner path)", async () => {
     const terminal = createTerminal();
-    vi.spyOn(terminal, "getSerializedStateAsync").mockResolvedValue("agent-scrollback");
+    vi.spyOn(terminal, "getSerializedStateAsync").mockResolvedValue({ data: "agent-scrollback", cols: 80, rows: 24 });
 
     terminal.flushEventDrivenSnapshot();
     await flushMicrotasks();
 
-    expect(persistAsyncMock).toHaveBeenCalledWith("t1", "agent-scrollback");
+    expect(persistAsyncMock).toHaveBeenCalledWith("t1", { data: "agent-scrollback", cols: 80, rows: 24 });
   });
 
   it("suppresses an immediate repeat with unchanged content", async () => {
     const terminal = createTerminal();
-    vi.spyOn(terminal, "getSerializedStateAsync").mockResolvedValue("data");
+    vi.spyOn(terminal, "getSerializedStateAsync").mockResolvedValue({ data: "data", cols: 80, rows: 24 });
 
     terminal.flushEventDrivenSnapshot();
     await flushMicrotasks();
@@ -166,7 +166,7 @@ describe("TerminalProcess.flushEventDrivenSnapshot", () => {
 
   it("does not flush when terminal is killed", async () => {
     const terminal = createTerminal();
-    vi.spyOn(terminal, "getSerializedStateAsync").mockResolvedValue("data");
+    vi.spyOn(terminal, "getSerializedStateAsync").mockResolvedValue({ data: "data", cols: 80, rows: 24 });
 
     terminal.kill("test");
 
@@ -206,10 +206,14 @@ describe("TerminalProcess — snapshot and dispose preserved exited terminals", 
     const info = terminal.getInfo();
     expect(info.isExited).toBe(true);
     expect(info.serializeAddon).toBeUndefined();
-    expect(info.preservedSnapshot).toContain("hello from agent");
+    expect(info.preservedSnapshot?.data).toContain("hello from agent");
+    // The mirror is disposed above, so the grid must have been captured with it.
+    expect(info.preservedSnapshot?.cols).toBeGreaterThan(0);
 
-    expect(terminal.getSerializedState()).toContain("hello from agent");
-    await expect(terminal.getSerializedStateAsync()).resolves.toContain("hello from agent");
+    expect(terminal.getSerializedState()?.data).toContain("hello from agent");
+    await expect(terminal.getSerializedStateAsync()).resolves.toMatchObject({
+      data: expect.stringContaining("hello from agent"),
+    });
   });
 
   it("drains pending headless writes before snapshotting (tail of output is captured)", async () => {
@@ -223,8 +227,8 @@ describe("TerminalProcess — snapshot and dispose preserved exited terminals", 
     await exitAndAwaitDispose(terminal, pty);
 
     const snapshot = terminal.getSerializedState();
-    expect(snapshot).toContain("early output");
-    expect(snapshot).toContain("final tail line");
+    expect(snapshot?.data).toContain("early output");
+    expect(snapshot?.data).toContain("final tail line");
   });
 
   it("keeps serving the snapshot after a post-exit resize (exit→resize→reattach)", async () => {
@@ -254,7 +258,7 @@ describe("TerminalProcess — snapshot and dispose preserved exited terminals", 
     expect(persistSyncMock).toHaveBeenCalledTimes(1);
     const [persistedId, persistedState] = persistSyncMock.mock.calls[0]!;
     expect(persistedId).toBe("t1");
-    expect(persistedState).toContain("promoted terminal output");
+    expect(persistedState.data).toContain("promoted terminal output");
   });
 
   it("does not write a crash-recovery snapshot for agent terminals", async () => {
@@ -265,7 +269,7 @@ describe("TerminalProcess — snapshot and dispose preserved exited terminals", 
     await exitAndAwaitDispose(terminal, pty);
 
     expect(persistSyncMock).not.toHaveBeenCalled();
-    expect(terminal.getSerializedState()).toContain("agent output");
+    expect(terminal.getSerializedState()?.data).toContain("agent output");
   });
 
   it("disposes headless without caching a snapshot on non-preserved (non-zero) exit", async () => {
@@ -311,7 +315,7 @@ describe("TerminalProcess — snapshot and dispose preserved exited terminals", 
     expect(info.headlessTerminal).toBeDefined();
     expect(info.serializeAddon).toBeDefined();
     // Subsequent reads serve the live buffer.
-    expect(terminal.getSerializedState()).toContain("still readable");
+    expect(terminal.getSerializedState()?.data).toContain("still readable");
   });
 
   it("serves the cached snapshot without re-serializing", async () => {

--- a/electron/services/pty/__tests__/TerminalProcess.snapshot.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.snapshot.test.ts
@@ -132,17 +132,29 @@ describe("TerminalProcess.flushEventDrivenSnapshot", () => {
 
   it("persists for agent terminals via async serialization (non-banner path)", async () => {
     const terminal = createTerminal();
-    vi.spyOn(terminal, "getSerializedStateAsync").mockResolvedValue({ data: "agent-scrollback", cols: 80, rows: 24 });
+    vi.spyOn(terminal, "getSerializedStateAsync").mockResolvedValue({
+      data: "agent-scrollback",
+      cols: 80,
+      rows: 24,
+    });
 
     terminal.flushEventDrivenSnapshot();
     await flushMicrotasks();
 
-    expect(persistAsyncMock).toHaveBeenCalledWith("t1", { data: "agent-scrollback", cols: 80, rows: 24 });
+    expect(persistAsyncMock).toHaveBeenCalledWith("t1", {
+      data: "agent-scrollback",
+      cols: 80,
+      rows: 24,
+    });
   });
 
   it("suppresses an immediate repeat with unchanged content", async () => {
     const terminal = createTerminal();
-    vi.spyOn(terminal, "getSerializedStateAsync").mockResolvedValue({ data: "data", cols: 80, rows: 24 });
+    vi.spyOn(terminal, "getSerializedStateAsync").mockResolvedValue({
+      data: "data",
+      cols: 80,
+      rows: 24,
+    });
 
     terminal.flushEventDrivenSnapshot();
     await flushMicrotasks();
@@ -166,7 +178,11 @@ describe("TerminalProcess.flushEventDrivenSnapshot", () => {
 
   it("does not flush when terminal is killed", async () => {
     const terminal = createTerminal();
-    vi.spyOn(terminal, "getSerializedStateAsync").mockResolvedValue({ data: "data", cols: 80, rows: 24 });
+    vi.spyOn(terminal, "getSerializedStateAsync").mockResolvedValue({
+      data: "data",
+      cols: 80,
+      rows: 24,
+    });
 
     terminal.kill("test");
 

--- a/electron/services/pty/__tests__/TerminalRegistry.preservedEviction.test.ts
+++ b/electron/services/pty/__tests__/TerminalRegistry.preservedEviction.test.ts
@@ -17,7 +17,10 @@ function createPreservedTerminal(options: {
 }): TerminalProcess {
   const info = {
     id: options.id,
-    preservedSnapshot: options.preserved === false ? undefined : `snapshot-${options.id}`,
+    preservedSnapshot:
+      options.preserved === false
+        ? undefined
+        : { data: `snapshot-${options.id}`, cols: 80, rows: 24 },
     preservedAt: options.preservedAt,
     preservedSnapshotLastAccessedAt: options.lastAccessedAt,
   } as unknown as TerminalInfo;

--- a/electron/services/pty/__tests__/TerminalSerializerService.test.ts
+++ b/electron/services/pty/__tests__/TerminalSerializerService.test.ts
@@ -16,14 +16,16 @@ describe("TerminalSerializerService", () => {
 
   it("deduplicates concurrent serialize requests per terminal", async () => {
     const service = new TerminalSerializerService();
-    const serializeFn = vi.fn(() => "snapshot-data");
+    const serializeFn = vi.fn(() => ({ data: "snapshot-data", cols: 80, rows: 24 }));
 
     const first = service.serializeAsync("term-1", serializeFn);
     const second = service.serializeAsync("term-1", serializeFn);
 
     const [a, b] = await Promise.all([first, second]);
-    expect(a).toBe("snapshot-data");
-    expect(b).toBe("snapshot-data");
+    expect(a).toEqual({ data: "snapshot-data", cols: 80, rows: 24 });
+    // Both callers must observe the SAME object: a coalesced request that handed
+    // out a payload without its capture grid would replay at the wrong width.
+    expect(b).toBe(a);
     expect(serializeFn).toHaveBeenCalledTimes(1);
     service.dispose();
   });
@@ -37,16 +39,16 @@ describe("TerminalSerializerService", () => {
     const failed = await service.serializeAsync("term-2", failing);
     expect(failed).toBeNull();
 
-    const retryFn = vi.fn(() => "ok");
+    const retryFn = vi.fn(() => ({ data: "ok", cols: 80, rows: 24 }));
     const retried = await service.serializeAsync("term-2", retryFn);
-    expect(retried).toBe("ok");
+    expect(retried).toEqual({ data: "ok", cols: 80, rows: 24 });
     expect(retryFn).toHaveBeenCalledTimes(1);
     service.dispose();
   });
 
   it("cancels pending serialization after dispose", async () => {
     const service = new TerminalSerializerService();
-    const serializeFn = vi.fn(() => "late-result");
+    const serializeFn = vi.fn(() => ({ data: "late-result", cols: 80, rows: 24 }));
 
     const pending = service.serializeAsync("term-3", serializeFn);
     service.dispose();

--- a/electron/services/pty/__tests__/analysisWorkerPool.test.ts
+++ b/electron/services/pty/__tests__/analysisWorkerPool.test.ts
@@ -141,7 +141,9 @@ describe("AnalysisWorkerPool", () => {
       terminalId: "t1",
       result: "SNAPSHOT",
     });
-    await expect(promise).resolves.toBe("SNAPSHOT");
+    // The backend stamps the grid it was about to serialize at onto the worker's
+    // payload, so a replay can size to it (#11552).
+    await expect(promise).resolves.toEqual({ data: "SNAPSHOT", cols: 80, rows: 24 });
   });
 
   it("routes worker events to the owning backend", () => {
@@ -203,7 +205,7 @@ describe("AnalysisWorkerPool", () => {
       terminalId: "t1",
       result: "PERSISTED",
     });
-    await expect(persistReq).resolves.toBe("PERSISTED");
+    await expect(persistReq).resolves.toEqual({ data: "PERSISTED", cols: 80, rows: 24 });
     vi.useRealTimers();
   });
 
@@ -355,7 +357,7 @@ describe("AnalysisWorkerPool", () => {
     backend.feedChunk("MARKER-held-bytes\r\n", { agentLive: false }); // held host-side
 
     const result = await backend.serializeForPersistence();
-    expect(result).toContain("MARKER-held-bytes");
+    expect(result?.data).toContain("MARKER-held-bytes");
 
     e2ePool.dispose();
   });
@@ -400,7 +402,7 @@ describe("AnalysisWorkerPool", () => {
       result: "FRESH",
       generation: 2,
     });
-    await expect(promise).resolves.toBe("FRESH");
+    await expect(promise).resolves.toEqual({ data: "FRESH", cols: 80, rows: 24 });
     vi.useRealTimers();
   });
 

--- a/electron/services/pty/__tests__/analysisWorkerPool.test.ts
+++ b/electron/services/pty/__tests__/analysisWorkerPool.test.ts
@@ -135,15 +135,18 @@ describe("AnalysisWorkerPool", () => {
     const request = worker.messagesOfType("request")[0];
     expect(request.op).toBe("serialize");
 
+    // The worker reports the grid its mirror actually serialized at — here a
+    // restored session still parked at its capture width, which is NOT the grid
+    // the host created the slot with. The backend must pass that through
+    // untouched; inferring it from the last resize the host posted (80x24) is
+    // what tagged capture-grid data with the spawn grid (#11552).
     worker.emit("message", {
       type: "response",
       requestId: request.requestId,
       terminalId: "t1",
-      result: "SNAPSHOT",
+      result: { data: "SNAPSHOT", cols: 40, rows: 12 },
     });
-    // The backend stamps the grid it was about to serialize at onto the worker's
-    // payload, so a replay can size to it (#11552).
-    await expect(promise).resolves.toEqual({ data: "SNAPSHOT", cols: 80, rows: 24 });
+    await expect(promise).resolves.toEqual({ data: "SNAPSHOT", cols: 40, rows: 12 });
   });
 
   it("routes worker events to the owning backend", () => {
@@ -203,9 +206,9 @@ describe("AnalysisWorkerPool", () => {
       type: "response",
       requestId: request.requestId,
       terminalId: "t1",
-      result: "PERSISTED",
+      result: { data: "PERSISTED", cols: 132, rows: 43 },
     });
-    await expect(persistReq).resolves.toEqual({ data: "PERSISTED", cols: 80, rows: 24 });
+    await expect(persistReq).resolves.toEqual({ data: "PERSISTED", cols: 132, rows: 43 });
     vi.useRealTimers();
   });
 
@@ -376,7 +379,7 @@ describe("AnalysisWorkerPool", () => {
       type: "response",
       requestId: request.requestId,
       terminalId: "t1",
-      result: "STALE-CONTENT",
+      result: { data: "STALE-CONTENT", cols: 80, rows: 24 },
       generation: 0,
     });
     await expect(promise).resolves.toBeNull();
@@ -399,7 +402,7 @@ describe("AnalysisWorkerPool", () => {
       type: "response",
       requestId: request.requestId,
       terminalId: "t1",
-      result: "FRESH",
+      result: { data: "FRESH", cols: 80, rows: 24 },
       generation: 2,
     });
     await expect(promise).resolves.toEqual({ data: "FRESH", cols: 80, rows: 24 });

--- a/electron/services/pty/__tests__/analysisWorkerRuntime.test.ts
+++ b/electron/services/pty/__tests__/analysisWorkerRuntime.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { AnalysisWorkerRuntime } from "../analysis/AnalysisWorkerRuntime.js";
 import { ANALYSIS_ACK_FLUSH_BYTES } from "../analysis/AnalysisSession.js";
-import type { WorkerToHostMessage } from "../analysisWorkerProtocol.js";
+import type { AnalysisFinalSnapshot, WorkerToHostMessage } from "../analysisWorkerProtocol.js";
 
 // Exercises the worker-side protocol end-to-end without spawning a real
 // worker thread: the runtime + AnalysisSession (headless xterm, monitor) run
@@ -74,9 +77,80 @@ describe("AnalysisWorkerRuntime", () => {
     );
     expect(response.type).toBe("response");
     if (response.type === "response") {
-      expect(typeof response.result).toBe("string");
-      expect(response.result).toContain("hello from the worker");
+      expect(response.result).toMatchObject({
+        data: expect.stringContaining("hello from the worker"),
+        cols: 80,
+        rows: 24,
+      });
     }
+  });
+
+  // The grid a serialize was produced at is the worker's to report, because the
+  // mirror can move off the grid the host knows about without the host posting
+  // anything: replaying a persisted session sizes the mirror to the SNAPSHOT's
+  // width and reflows home on a later turn. A host that inferred the geometry
+  // from its own last resize would tag capture-width data with the spawn grid,
+  // and every replay site would then skip the alignment that keeps the payload
+  // readable — the exact defect #11552 is about.
+  describe("restore-window geometry", () => {
+    let userDataDir: string;
+    const previousUserData = process.env.DAINTREE_USER_DATA;
+
+    beforeEach(async () => {
+      userDataDir = await fsp.mkdtemp(path.join(os.tmpdir(), "daintree-analysis-restore-"));
+      process.env.DAINTREE_USER_DATA = userDataDir;
+      await fsp.mkdir(path.join(userDataDir, "terminal-sessions"), { recursive: true });
+    });
+
+    afterEach(async () => {
+      runtime.handleMessage({ type: "free", terminalId: "restored" });
+      process.env.DAINTREE_USER_DATA = previousUserData;
+      await fsp.rm(userDataDir, { recursive: true, force: true });
+    });
+
+    function serializeRequest(requestId: number): Promise<WorkerToHostMessage> {
+      runtime.handleMessage({
+        type: "request",
+        requestId,
+        terminalId: "restored",
+        op: "serialize",
+        generation: 1,
+      });
+      return waitFor(() => emitted.find((m) => m.type === "response" && m.requestId === requestId));
+    }
+
+    it("reports the grid the mirror is on, not the grid the slot was created at", async () => {
+      await fsp.writeFile(
+        path.join(userDataDir, "terminal-sessions", "restored.restore"),
+        "DAINTREE_SESSION_v2\n40x12\nrestored payload",
+        "utf8"
+      );
+
+      // Spawn grid deliberately unlike the capture grid, and no resize is ever
+      // posted — the only thing that moves this mirror is the restore itself.
+      runtime.handleMessage({
+        type: "create",
+        terminalId: "restored",
+        cols: 120,
+        rows: 40,
+        scrollback: 1000,
+        restore: true,
+        spawnedAt: 99,
+        epoch: 0,
+      });
+
+      const during = await serializeRequest(11);
+      if (during.type !== "response") throw new Error("expected a response");
+      expect(during.result).toMatchObject({ cols: 40, rows: 12 });
+
+      // Once the replay lands the mirror reflows home, and the SAME call now
+      // reports the spawn grid — so the number tracks the buffer, which no
+      // host-side constant could do.
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      const after = await serializeRequest(12);
+      if (after.type !== "response") throw new Error("expected a response");
+      expect(after.result).toMatchObject({ cols: 120, rows: 40 });
+    });
   });
 
   it("emits activity-state transitions from the monitor with the session spawnedAt", async () => {
@@ -171,8 +245,9 @@ describe("AnalysisWorkerRuntime", () => {
     );
     if (response.type === "response") {
       expect(response.error).toBeUndefined();
-      expect(typeof response.result).toBe("string");
-      expect(response.result).toContain("pre-kill content");
+      expect(response.result).toMatchObject({
+        data: expect.stringContaining("pre-kill content"),
+      });
     }
 
     // The deferred free still runs once the barrier clears.
@@ -237,10 +312,13 @@ describe("AnalysisWorkerRuntime", () => {
     if (response.type === "response") {
       expect(response.result).not.toBeNull();
       expect(typeof response.result).toBe("object");
-      const result = response.result as { snapshot: string | null; persistence: string | null };
-      expect(result.snapshot).toContain("final content");
+      const result = response.result as AnalysisFinalSnapshot;
+      expect(result.snapshot?.data).toContain("final content");
       // No restore banner → persistence equals the plain serialize.
-      expect(result.persistence).toContain("final content");
+      expect(result.persistence?.data).toContain("final content");
+      // Both halves come off one drain, so they describe one grid.
+      expect(result.persistence).toMatchObject({ cols: 80, rows: 24 });
+      expect(result.snapshot).toMatchObject({ cols: 80, rows: 24 });
     }
 
     expect(runtime.sessionCount()).toBe(1);

--- a/electron/services/pty/__tests__/terminalSerialization.test.ts
+++ b/electron/services/pty/__tests__/terminalSerialization.test.ts
@@ -58,31 +58,43 @@ describe("terminalSerialization guards", () => {
 
   it("serializeTerminal stamps preservedSnapshotLastAccessedAt when serving a preserved snapshot", () => {
     const info = makeTerminalInfo({
-      preservedSnapshot: "cached",
+      preservedSnapshot: { data: "cached", cols: 80, rows: 24 },
       preservedSnapshotLastAccessedAt: 0,
     });
     const before = Date.now();
-    expect(serializeTerminal("t1", info)).toBe("cached");
+    expect(serializeTerminal("t1", info)).toEqual({ data: "cached", cols: 80, rows: 24 });
     expect(info.preservedSnapshotLastAccessedAt).toBeGreaterThanOrEqual(before);
   });
 
   it("serializeTerminalAsync stamps preservedSnapshotLastAccessedAt when serving a preserved snapshot", async () => {
     const info = makeTerminalInfo({
-      preservedSnapshot: "cached",
+      preservedSnapshot: { data: "cached", cols: 80, rows: 24 },
       preservedSnapshotLastAccessedAt: 0,
     });
     const before = Date.now();
-    await expect(serializeTerminalAsync("t1", info)).resolves.toBe("cached");
+    await expect(serializeTerminalAsync("t1", info)).resolves.toEqual({
+      data: "cached",
+      cols: 80,
+      rows: 24,
+    });
     expect(info.preservedSnapshotLastAccessedAt).toBeGreaterThanOrEqual(before);
   });
 
   it("does not stamp preservedSnapshotLastAccessedAt on the non-preserved path", () => {
     const info = makeTerminalInfo({
+      // The live mirror is the only source for the capture grid on this path,
+      // so serializing without one yields null rather than a geometry-less
+      // payload that would replay at whatever width it lands in (#11552).
+      headlessTerminal: {
+        cols: 120,
+        rows: 40,
+        buffer: { active: { length: 10 } },
+      } as unknown as TerminalInfo["headlessTerminal"],
       serializeAddon: makeAddon() as unknown as TerminalInfo["serializeAddon"],
       preservedSnapshot: undefined,
       preservedSnapshotLastAccessedAt: undefined,
     });
-    expect(serializeTerminal("t1", info)).toBe("snapshot");
+    expect(serializeTerminal("t1", info)).toEqual({ data: "snapshot", cols: 120, rows: 40 });
     expect(info.preservedSnapshotLastAccessedAt).toBeUndefined();
   });
 

--- a/electron/services/pty/__tests__/terminalSessionPersistence.test.ts
+++ b/electron/services/pty/__tests__/terminalSessionPersistence.test.ts
@@ -21,14 +21,12 @@ function createMockHeadless(bufferType: "normal" | "alternate" = "normal", cols 
   let currentType = bufferType;
   let markerLine = 0;
   const pendingWriteCallbacks: Array<() => void> = [];
-  const writeFn = vi
-    .fn()
-    .mockImplementation((data: string, callback?: () => void) => {
-      if (data === "\x1b[?1049l") currentType = "normal";
-      const newlines = (data.match(/\r\n/g) || []).length;
-      markerLine += newlines;
-      if (callback) pendingWriteCallbacks.push(callback);
-    });
+  const writeFn = vi.fn().mockImplementation((data: string, callback?: () => void) => {
+    if (data === "\x1b[?1049l") currentType = "normal";
+    const newlines = (data.match(/\r\n/g) || []).length;
+    markerLine += newlines;
+    if (callback) pendingWriteCallbacks.push(callback);
+  });
   const headless = {
     cols,
     rows,
@@ -157,9 +155,7 @@ describe("terminalSessionPersistence", () => {
 
     // The capture grid rides in the header so replay can size to it (#11552).
     expect(fs.readFileSync(syncPath, "utf8")).toBe("DAINTREE_SESSION_v2\n80x24\nsync payload");
-    expect(fs.readFileSync(asyncPath, "utf8")).toBe(
-      "DAINTREE_SESSION_v2\n132x43\nasync payload"
-    );
+    expect(fs.readFileSync(asyncPath, "utf8")).toBe("DAINTREE_SESSION_v2\n132x43\nasync payload");
 
     // The atomic helpers must not leave temp files behind
     const stragglers = fs.readdirSync(sessionDir).filter((name) => name.endsWith(".tmp"));

--- a/electron/services/pty/__tests__/terminalSessionPersistence.test.ts
+++ b/electron/services/pty/__tests__/terminalSessionPersistence.test.ts
@@ -3,12 +3,15 @@ import fs from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import headless, { type Terminal as HeadlessTerminal } from "@xterm/headless";
+import serialize from "@xterm/addon-serialize";
 import {
   RESTORE_PARSER_RESET_PREAMBLE,
   SESSION_SNAPSHOT_MAX_BYTES,
   getSessionPath,
   persistSessionSnapshotAsync,
   persistSessionSnapshotSync,
+  resizeMirror,
   restoreSessionFromFile,
   deleteSessionFile,
   evictSessionFiles,
@@ -16,6 +19,9 @@ import {
   readAndDeleteHibernatedMarker,
   getHibernatedMarkerPath,
 } from "../terminalSessionPersistence.js";
+
+const { Terminal } = headless;
+const { SerializeAddon } = serialize;
 
 function createMockHeadless(bufferType: "normal" | "alternate" = "normal", cols = 80, rows = 24) {
   let currentType = bufferType;
@@ -270,21 +276,70 @@ describe("terminalSessionPersistence", () => {
       expect(headless.resize).not.toHaveBeenCalled();
     });
 
-    it("rejects a v2 file whose geometry line is unusable", async () => {
-      // v2 asserts the metadata is there, so a corrupt line means a corrupt
-      // file — sizing a real terminal from garbage is worse than skipping.
+    it("replays a v2 file with an unusable geometry line instead of dropping it", async () => {
+      // A grid we cannot read costs the ALIGNMENT, never the scrollback:
+      // replaying unaligned is exactly what v1 did, while refusing the file
+      // throws away a session the user can never get back.
       const cases: Record<string, string> = {
-        "term-v2-missing": "DAINTREE_SESSION_v2\npayload-with-no-geometry-line",
         "term-v2-garbage": "DAINTREE_SESSION_v2\nnot-a-grid\npayload",
         "term-v2-zero": "DAINTREE_SESSION_v2\n0x24\npayload",
         "term-v2-huge": "DAINTREE_SESSION_v2\n9999x9999\npayload",
       };
       for (const [id, contents] of Object.entries(cases)) {
         await writeSessionFile(id, contents);
-        const headless = createMockHeadless();
-        expect(restoreSessionFromFile(headless as never, id).restored).toBe(false);
-        expect(headless.write).not.toHaveBeenCalled();
+        const headless = createMockHeadless("normal", 170, 40);
+        expect(restoreSessionFromFile(headless as never, id).restored).toBe(true);
+        expect(headless.write).toHaveBeenCalledWith("payload");
+        await headless.drainWrites();
+        expect(headless.resize).not.toHaveBeenCalled();
       }
+    });
+
+    it("rejects a v2 file whose preamble is truncated", async () => {
+      // No newline anywhere after the version marker: the writer always emits a
+      // geometry line, so there is no way to tell where a payload would start —
+      // and at that length there is no payload to save either.
+      await writeSessionFile("term-v2-missing", "DAINTREE_SESSION_v2\npayload-no-newline");
+
+      const headless = createMockHeadless();
+      expect(restoreSessionFromFile(headless as never, "term-v2-missing").restored).toBe(false);
+      expect(headless.write).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      { label: "the smallest possible grid", cols: 1, rows: 1 },
+      { label: "an ordinary grid", cols: 80, rows: 24 },
+      { label: "the largest representable grid", cols: 2000, rows: 2000 },
+      { label: "a grid past the representable bound", cols: 2001, rows: 24 },
+      { label: "an absurd grid", cols: 12000, rows: 9000 },
+    ])("round-trips a session written at $label", async ({ cols, rows }) => {
+      // The writer must never emit a file its own reader refuses — that would
+      // make a wide grid strictly WORSE than v1, which at least restored the
+      // scrollback. Alignment is allowed to drop out; the session is not.
+      const id = `term-rt-${cols}x${rows}`;
+      persistSessionSnapshotSync(id, { data: `payload ${cols}x${rows}`, cols, rows });
+
+      const headless = createMockHeadless("normal", 170, 40);
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      let restored: boolean;
+      try {
+        restored = restoreSessionFromFile(headless as never, id).restored;
+      } finally {
+        warn.mockRestore();
+      }
+
+      expect(restored).toBe(true);
+      expect(headless.write).toHaveBeenCalledWith(`payload ${cols}x${rows}`);
+      // The two ends agree on one bound, so a file we wrote never sends the
+      // reader down its salvage path — a grid we cannot record is recorded as
+      // absent rather than as a line the reader has to reject.
+      expect(warn).not.toHaveBeenCalled();
+
+      // Alignment happens only for a grid the format can carry; either way the
+      // mirror ends up back on the grid it started from.
+      await headless.drainWrites();
+      expect(headless.cols).toBe(170);
+      expect(headless.rows).toBe(40);
     });
 
     it("still exits the alternate screen when the replay was width-aligned", async () => {
@@ -297,6 +352,92 @@ describe("terminalSessionPersistence", () => {
       expect(result.restored).toBe(true);
       expect(headless.write).toHaveBeenCalledWith("\x1b[?1049l");
       expect(headless.cols).toBe(170);
+    });
+  });
+
+  /**
+   * Real `@xterm/headless` buffers, because the thing under test is what the
+   * grid does to cell data — a mock cannot show that.
+   *
+   * A replay parks the mirror at the snapshot's capture width, so for that
+   * window `terminal.cols` describes the payload rather than the PTY. A resize
+   * arriving inside it has to WIN: reverting to the grid pinned before it
+   * arrived leaves the mirror on a size the PTY has already moved off, and
+   * nothing re-syncs it — `TerminalProcess.resize` early-returns as soon as the
+   * pty dims match, so the mirror stays stale until the next real resize.
+   */
+  describe("replay window vs. concurrent resize (#11552)", () => {
+    const drain = (terminal: HeadlessTerminal): Promise<void> =>
+      new Promise<void>((resolve) => terminal.write("", () => resolve()));
+
+    // Written without a trailing newline so the cursor is parked inside a
+    // wrapped group — where an agent leaves it between repaints.
+    const WRAPPED_LINE = "Tip: press enter and the result will display beneath the input box";
+
+    /** Rows the replayed payload occupies, stopping at the restore banner. */
+    function payloadRows(terminal: HeadlessTerminal): string[] {
+      const buffer = terminal.buffer.active;
+      const rows: string[] = [];
+      for (let i = 0; i < buffer.length; i++) {
+        const line = buffer.getLine(i);
+        if (!line) continue;
+        const text = line.translateToString(true);
+        if (text.length === 0) continue;
+        if (text.includes("───")) break;
+        rows.push(`${line.isWrapped ? "W" : "H"}${text}`);
+      }
+      return rows;
+    }
+
+    async function captureAt(cols: number, rows: number, content: string) {
+      const source = new Terminal({ cols, rows, scrollback: 200, allowProposedApi: true });
+      const addon = new SerializeAddon();
+      source.loadAddon(addon);
+      await new Promise<void>((resolve) => source.write(content, () => resolve()));
+      return { source, snapshot: { data: addon.serialize(), cols, rows } };
+    }
+
+    it("reflows to the resize that landed mid-replay, not to the pre-replay grid", async () => {
+      const { source, snapshot } = await captureAt(40, 10, WRAPPED_LINE);
+      persistSessionSnapshotSync("term-mid-resize", snapshot);
+
+      const mirror = new Terminal({ cols: 100, rows: 10, scrollback: 200, allowProposedApi: true });
+      expect(restoreSessionFromFile(mirror, "term-mid-resize").restored).toBe(true);
+      // Parked at the capture width for as long as the payload is parsing.
+      expect(mirror.cols).toBe(40);
+
+      // The user resized the pane while the replay was still in flight. The
+      // mirror must not move yet — the tail of the payload is still decoding
+      // against the capture width.
+      expect(resizeMirror(mirror, 132, 20)).toBe(false);
+      expect([mirror.cols, mirror.rows]).toEqual([40, 10]);
+
+      await drain(mirror);
+      expect([mirror.cols, mirror.rows]).toEqual([132, 20]);
+
+      // The window is closed, so the mirror tracks the PTY directly again.
+      expect(resizeMirror(mirror, 90, 30)).toBe(true);
+      expect([mirror.cols, mirror.rows]).toEqual([90, 30]);
+
+      // And the payload survived both hops: identical to the capture buffer
+      // simply reflowed to the same grid, which is what a replay owes.
+      source.options.reflowCursorLine = true;
+      source.resize(132, 20);
+      source.resize(90, 30);
+      source.options.reflowCursorLine = false;
+      await drain(source);
+      expect(payloadRows(mirror)).toEqual(payloadRows(source));
+    });
+
+    it("applies a resize immediately once no replay is in flight", async () => {
+      const mirror = new Terminal({ cols: 100, rows: 10, scrollback: 200, allowProposedApi: true });
+      expect(resizeMirror(mirror, 120, 30)).toBe(true);
+      expect([mirror.cols, mirror.rows]).toEqual([120, 30]);
+
+      // A restore that finds no file must not leave a window behind either.
+      expect(restoreSessionFromFile(mirror, "term-never-persisted").restored).toBe(false);
+      expect(resizeMirror(mirror, 60, 15)).toBe(true);
+      expect([mirror.cols, mirror.rows]).toEqual([60, 15]);
     });
   });
 

--- a/electron/services/pty/__tests__/terminalSessionPersistence.test.ts
+++ b/electron/services/pty/__tests__/terminalSessionPersistence.test.ts
@@ -17,15 +17,26 @@ import {
   getHibernatedMarkerPath,
 } from "../terminalSessionPersistence.js";
 
-function createMockHeadless(bufferType: "normal" | "alternate" = "normal") {
+function createMockHeadless(bufferType: "normal" | "alternate" = "normal", cols = 80, rows = 24) {
   let currentType = bufferType;
   let markerLine = 0;
-  const writeFn = vi.fn().mockImplementation((data: string) => {
-    if (data === "\x1b[?1049l") currentType = "normal";
-    const newlines = (data.match(/\r\n/g) || []).length;
-    markerLine += newlines;
-  });
-  return {
+  const pendingWriteCallbacks: Array<() => void> = [];
+  const writeFn = vi
+    .fn()
+    .mockImplementation((data: string, callback?: () => void) => {
+      if (data === "\x1b[?1049l") currentType = "normal";
+      const newlines = (data.match(/\r\n/g) || []).length;
+      markerLine += newlines;
+      if (callback) pendingWriteCallbacks.push(callback);
+    });
+  const headless = {
+    cols,
+    rows,
+    options: { reflowCursorLine: false } as { reflowCursorLine?: boolean },
+    resize: vi.fn().mockImplementation((nextCols: number, nextRows: number) => {
+      headless.cols = nextCols;
+      headless.rows = nextRows;
+    }),
     write: writeFn,
     buffer: {
       get active() {
@@ -37,7 +48,18 @@ function createMockHeadless(bufferType: "normal" | "alternate" = "normal") {
       line: markerLine,
       dispose: vi.fn(),
     })),
+    /**
+     * Drain the queued write callbacks the way xterm's parser would, then let
+     * the microtask the restore defers its reflow into actually run.
+     */
+    drainWrites: async () => {
+      const callbacks = pendingWriteCallbacks.splice(0, pendingWriteCallbacks.length);
+      callbacks.forEach((cb) => cb());
+      await Promise.resolve();
+      await Promise.resolve();
+    },
   };
+  return headless;
 }
 
 describe("terminalSessionPersistence", () => {
@@ -66,8 +88,8 @@ describe("terminalSessionPersistence", () => {
     const oversized = "x".repeat(SESSION_SNAPSHOT_MAX_BYTES + 1);
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    persistSessionSnapshotSync("term-sync", oversized);
-    await persistSessionSnapshotAsync("term-async", oversized);
+    persistSessionSnapshotSync("term-sync", { data: oversized, cols: 80, rows: 24 });
+    await persistSessionSnapshotAsync("term-async", { data: oversized, cols: 80, rows: 24 });
 
     const syncPath = path.join(userDataDir, "terminal-sessions", "term-sync.restore");
     const asyncPath = path.join(userDataDir, "terminal-sessions", "term-async.restore");
@@ -86,8 +108,12 @@ describe("terminalSessionPersistence", () => {
   const posixIt = process.platform === "win32" ? it.skip : it;
 
   posixIt("writes the session directory, snapshots, and marker owner-only", async () => {
-    persistSessionSnapshotSync("term-perm-sync", "sync payload");
-    await persistSessionSnapshotAsync("term-perm-async", "async payload");
+    persistSessionSnapshotSync("term-perm-sync", { data: "sync payload", cols: 80, rows: 24 });
+    await persistSessionSnapshotAsync("term-perm-async", {
+      data: "async payload",
+      cols: 80,
+      rows: 24,
+    });
     writeHibernatedMarker("term-perm-sync");
 
     const sessionDir = path.join(userDataDir, "terminal-sessions");
@@ -102,7 +128,7 @@ describe("terminalSessionPersistence", () => {
     fs.mkdirSync(sessionDir, { recursive: true });
     fs.chmodSync(sessionDir, 0o755);
 
-    await persistSessionSnapshotAsync("term-upgrade", "payload");
+    await persistSessionSnapshotAsync("term-upgrade", { data: "payload", cols: 80, rows: 24 });
 
     expect(fs.statSync(sessionDir).mode & 0o777).toBe(0o700);
   });
@@ -112,21 +138,28 @@ describe("terminalSessionPersistence", () => {
     fs.mkdirSync(sessionDir, { recursive: true });
     fs.chmodSync(sessionDir, 0o755);
 
-    persistSessionSnapshotSync("term-upgrade-sync", "payload");
+    persistSessionSnapshotSync("term-upgrade-sync", { data: "payload", cols: 80, rows: 24 });
 
     expect(fs.statSync(sessionDir).mode & 0o777).toBe(0o700);
   });
 
   it("persists and restores snapshots via the atomic write helpers", async () => {
-    persistSessionSnapshotSync("term-rt-sync", "sync payload");
-    await persistSessionSnapshotAsync("term-rt-async", "async payload");
+    persistSessionSnapshotSync("term-rt-sync", { data: "sync payload", cols: 80, rows: 24 });
+    await persistSessionSnapshotAsync("term-rt-async", {
+      data: "async payload",
+      cols: 132,
+      rows: 43,
+    });
 
     const sessionDir = path.join(userDataDir, "terminal-sessions");
     const syncPath = path.join(sessionDir, "term-rt-sync.restore");
     const asyncPath = path.join(sessionDir, "term-rt-async.restore");
 
-    expect(fs.readFileSync(syncPath, "utf8")).toBe("DAINTREE_SESSION_v1\nsync payload");
-    expect(fs.readFileSync(asyncPath, "utf8")).toBe("DAINTREE_SESSION_v1\nasync payload");
+    // The capture grid rides in the header so replay can size to it (#11552).
+    expect(fs.readFileSync(syncPath, "utf8")).toBe("DAINTREE_SESSION_v2\n80x24\nsync payload");
+    expect(fs.readFileSync(asyncPath, "utf8")).toBe(
+      "DAINTREE_SESSION_v2\n132x43\nasync payload"
+    );
 
     // The atomic helpers must not leave temp files behind
     const stragglers = fs.readdirSync(sessionDir).filter((name) => name.endsWith(".tmp"));
@@ -160,7 +193,7 @@ describe("terminalSessionPersistence", () => {
     await fsp.mkdir(sessionDir, { recursive: true });
 
     const futurePath = path.join(sessionDir, "term-future.restore");
-    await fsp.writeFile(futurePath, "DAINTREE_SESSION_v2\ncontent", "utf8");
+    await fsp.writeFile(futurePath, "DAINTREE_SESSION_v9\ncontent", "utf8");
 
     const headless = createMockHeadless();
     const result = restoreSessionFromFile(headless as never, "term-future");
@@ -181,6 +214,94 @@ describe("terminalSessionPersistence", () => {
 
     expect(result.restored).toBe(false);
     expect(headless.write).not.toHaveBeenCalled();
+  });
+
+  describe("capture-geometry round-trip (#11552)", () => {
+    // A session file is replayed into a mirror built at the NEW spawn size, so
+    // the width the payload was written at has to travel with it. Without that,
+    // SerializeAddon's wrap encoding decodes against the wrong grid and commits
+    // broken line breaks into the buffer before any output has even arrived.
+    async function writeSessionFile(id: string, contents: string): Promise<void> {
+      const sessionDir = path.join(userDataDir, "terminal-sessions");
+      await fsp.mkdir(sessionDir, { recursive: true });
+      await fsp.writeFile(path.join(sessionDir, `${id}.restore`), contents, "utf8");
+    }
+
+    it("replays at the capture grid and reflows back to the spawn grid", async () => {
+      persistSessionSnapshotSync("term-geo", { data: "captured payload", cols: 80, rows: 24 });
+
+      // The process respawned wider than the session was captured at.
+      const headless = createMockHeadless("normal", 170, 40);
+      const result = restoreSessionFromFile(headless as never, "term-geo");
+
+      expect(result.restored).toBe(true);
+      // Alignment must precede the writes: xterm parses asynchronously, so a
+      // grid corrected afterwards would arrive too late to affect the layout.
+      expect(headless.resize).toHaveBeenNthCalledWith(1, 80, 24);
+      expect(headless.resize.mock.invocationCallOrder[0]).toBeLessThan(
+        headless.write.mock.invocationCallOrder[0]
+      );
+      expect(headless.cols).toBe(80);
+
+      // The reflow home is queued behind the replay, not fired eagerly.
+      expect(headless.resize).toHaveBeenCalledTimes(1);
+      await headless.drainWrites();
+      expect(headless.resize).toHaveBeenNthCalledWith(2, 170, 40);
+      expect(headless.cols).toBe(170);
+      expect(headless.rows).toBe(40);
+      expect(headless.options.reflowCursorLine).toBe(false);
+    });
+
+    it("leaves the grid alone when the spawn size matches the capture", async () => {
+      persistSessionSnapshotSync("term-geo-same", { data: "payload", cols: 100, rows: 30 });
+
+      const headless = createMockHeadless("normal", 100, 30);
+      restoreSessionFromFile(headless as never, "term-geo-same");
+      await headless.drainWrites();
+
+      expect(headless.resize).not.toHaveBeenCalled();
+    });
+
+    it("replays a v1 file verbatim rather than dropping the session", async () => {
+      await writeSessionFile("term-v1", "DAINTREE_SESSION_v1\nlegacy payload");
+
+      const headless = createMockHeadless("normal", 170, 40);
+      const result = restoreSessionFromFile(headless as never, "term-v1");
+      await headless.drainWrites();
+
+      expect(result.restored).toBe(true);
+      expect(headless.write).toHaveBeenCalledWith("legacy payload");
+      expect(headless.resize).not.toHaveBeenCalled();
+    });
+
+    it("rejects a v2 file whose geometry line is unusable", async () => {
+      // v2 asserts the metadata is there, so a corrupt line means a corrupt
+      // file — sizing a real terminal from garbage is worse than skipping.
+      const cases: Record<string, string> = {
+        "term-v2-missing": "DAINTREE_SESSION_v2\npayload-with-no-geometry-line",
+        "term-v2-garbage": "DAINTREE_SESSION_v2\nnot-a-grid\npayload",
+        "term-v2-zero": "DAINTREE_SESSION_v2\n0x24\npayload",
+        "term-v2-huge": "DAINTREE_SESSION_v2\n9999x9999\npayload",
+      };
+      for (const [id, contents] of Object.entries(cases)) {
+        await writeSessionFile(id, contents);
+        const headless = createMockHeadless();
+        expect(restoreSessionFromFile(headless as never, id).restored).toBe(false);
+        expect(headless.write).not.toHaveBeenCalled();
+      }
+    });
+
+    it("still exits the alternate screen when the replay was width-aligned", async () => {
+      persistSessionSnapshotSync("term-geo-alt", { data: "alt payload", cols: 80, rows: 24 });
+
+      const headless = createMockHeadless("alternate", 170, 40);
+      const result = restoreSessionFromFile(headless as never, "term-geo-alt");
+      await headless.drainWrites();
+
+      expect(result.restored).toBe(true);
+      expect(headless.write).toHaveBeenCalledWith("\x1b[?1049l");
+      expect(headless.cols).toBe(170);
+    });
   });
 
   it("restores empty file as empty content", async () => {

--- a/electron/services/pty/analysis/AnalysisBackend.ts
+++ b/electron/services/pty/analysis/AnalysisBackend.ts
@@ -1,12 +1,12 @@
 import type { PatternDetectionConfig } from "../AgentPatternDetector.js";
-import type { AnalysisChunkFlags, AnalysisFinalSnapshot } from "../analysisWorkerProtocol.js";
+import type { AnalysisChunkFlags } from "../analysisWorkerProtocol.js";
 import type { SerializedTerminalSnapshot } from "../../../../shared/types/terminal.js";
 
 /**
- * Backend-level counterpart of the worker-wire {@link AnalysisFinalSnapshot}:
- * the same two serializations, each carrying the grid it was captured at. The
- * wire type stays string-only — geometry is host-side state, so the worker
- * protocol needs no new field (#11552).
+ * Backend-level counterpart of the worker-wire `AnalysisFinalSnapshot`: the
+ * same two serializations, each carrying the grid it was captured at. The wire
+ * type stays string-only — geometry is host-side state, so the worker protocol
+ * needs no new field (#11552).
  */
 export interface AnalysisFinalCapture {
   /** Full-buffer serialize (banner included) for the preserved snapshot. */

--- a/electron/services/pty/analysis/AnalysisBackend.ts
+++ b/electron/services/pty/analysis/AnalysisBackend.ts
@@ -1,5 +1,19 @@
 import type { PatternDetectionConfig } from "../AgentPatternDetector.js";
 import type { AnalysisChunkFlags, AnalysisFinalSnapshot } from "../analysisWorkerProtocol.js";
+import type { SerializedTerminalSnapshot } from "../../../../shared/types/terminal.js";
+
+/**
+ * Backend-level counterpart of the worker-wire {@link AnalysisFinalSnapshot}:
+ * the same two serializations, each carrying the grid it was captured at. The
+ * wire type stays string-only — geometry is host-side state, so the worker
+ * protocol needs no new field (#11552).
+ */
+export interface AnalysisFinalCapture {
+  /** Full-buffer serialize (banner included) for the preserved snapshot. */
+  snapshot: SerializedTerminalSnapshot | null;
+  /** Banner-stripped serialize for on-disk session persistence. */
+  persistence: SerializedTerminalSnapshot | null;
+}
 
 export interface MonitorStartOptions {
   agentId?: string;
@@ -43,10 +57,16 @@ export interface AnalysisBackend {
   getViewportLines(n: number): string[];
   getCursorLine(): string | null;
 
-  serialize(): Promise<string | null>;
-  serializeForPersistence(): Promise<string | null>;
+  /**
+   * Snapshot of the mirror's buffer bundled with the grid it was captured at.
+   * The geometry is not decoration: SerializeAddon output only decodes at the
+   * capture width, so every replay site sizes its target to these numbers
+   * before writing (#11552).
+   */
+  serialize(): Promise<SerializedTerminalSnapshot | null>;
+  serializeForPersistence(): Promise<SerializedTerminalSnapshot | null>;
   /** Drain pending parses, then capture both preserved + persistence forms. */
-  captureFinalSnapshot(): Promise<AnalysisFinalSnapshot>;
+  captureFinalSnapshot(): Promise<AnalysisFinalCapture>;
 
   /** Free the analysis resources (worker slot / headless instance). Idempotent. */
   release(): void;

--- a/electron/services/pty/analysis/AnalysisBackend.ts
+++ b/electron/services/pty/analysis/AnalysisBackend.ts
@@ -4,9 +4,10 @@ import type { SerializedTerminalSnapshot } from "../../../../shared/types/termin
 
 /**
  * Backend-level counterpart of the worker-wire `AnalysisFinalSnapshot`: the
- * same two serializations, each carrying the grid it was captured at. The wire
- * type stays string-only — geometry is host-side state, so the worker protocol
- * needs no new field (#11552).
+ * same two serializations, each carrying the grid it was captured at. Both
+ * backends read that grid off the mirror in the same synchronous step as the
+ * serialize — the host cannot infer it, because a restore replay moves the
+ * mirror's grid without a host-posted resize (#11552).
  */
 export interface AnalysisFinalCapture {
   /** Full-buffer serialize (banner included) for the preserved snapshot. */

--- a/electron/services/pty/analysis/AnalysisSession.ts
+++ b/electron/services/pty/analysis/AnalysisSession.ts
@@ -14,7 +14,7 @@ import { buildActivityMonitorOptions, buildPatternConfig } from "../terminalActi
 import { installHeadlessResponder } from "../headlessResponder.js";
 import { Osc94Parser } from "../Osc94Parser.js";
 import { SynchronizedFrameDetector } from "../SynchronizedFrameDetector.js";
-import { restoreSessionFromFile } from "../terminalSessionPersistence.js";
+import { resizeMirror, restoreSessionFromFile } from "../terminalSessionPersistence.js";
 import {
   measureVisibleContentDelta,
   type VisibleContentSnapshot,
@@ -35,6 +35,7 @@ import type {
   AnalysisMonitorStartSpec,
   WorkerToHostMessage,
 } from "../analysisWorkerProtocol.js";
+import type { SerializedTerminalSnapshot } from "../../../../shared/types/terminal.js";
 
 // Mirrors AGENT_OUTPUT_NOTE_MIN_INTERVAL_MS in TerminalProcess: floor between
 // agent-output content comparisons.
@@ -176,7 +177,9 @@ export class AnalysisSession {
   resize(cols: number, rows: number): void {
     if (this.disposed || !this.headlessTerminal) return;
     try {
-      this.headlessTerminal.resize(cols, rows);
+      // Parked, not applied, while a session replay owns the grid — the replay
+      // reflows to this geometry instead of to the one it opened on (#11552).
+      resizeMirror(this.headlessTerminal, cols, rows);
     } catch (error) {
       console.error(`[AnalysisSession] Failed to resize ${this.terminalId}:`, error);
       return;
@@ -310,19 +313,35 @@ export class AnalysisSession {
     };
   }
 
-  serialize(): Promise<string | null> {
-    return this.drainThen(() => this.serializeFull());
+  serialize(): Promise<SerializedTerminalSnapshot | null> {
+    return this.drainThen(() => this.withGeometry(this.serializeFull()));
   }
 
-  serializeForPersistence(): Promise<string | null> {
-    return this.drainThen(() => this.serializeBannerAware());
+  serializeForPersistence(): Promise<SerializedTerminalSnapshot | null> {
+    return this.drainThen(() => this.withGeometry(this.serializeBannerAware()));
   }
 
   captureFinalSnapshot(): Promise<AnalysisFinalSnapshot> {
     return this.drainThen(() => ({
-      snapshot: this.serializeFull(),
-      persistence: this.serializeBannerAware(),
+      snapshot: this.withGeometry(this.serializeFull()),
+      persistence: this.withGeometry(this.serializeBannerAware()),
     }));
+  }
+
+  /**
+   * Stamp a payload with the grid the mirror is on RIGHT NOW (#11552).
+   *
+   * Only meaningful when called in the same synchronous step as the
+   * `addon.serialize()` that produced `data` — which is why every caller sits
+   * inside a `drainThen` callback. The pty-host cannot compute this itself: a
+   * restore replay parks the mirror at the snapshot's capture grid and reflows
+   * home on a later turn without any host-posted resize, so the host's view of
+   * the grid can describe a layout this payload was never produced at.
+   */
+  private withGeometry(data: string | null): SerializedTerminalSnapshot | null {
+    const terminal = this.headlessTerminal;
+    if (data === null || !terminal) return null;
+    return { data, cols: terminal.cols, rows: terminal.rows };
   }
 
   free(): void {

--- a/electron/services/pty/analysis/InThreadAnalysisBackend.ts
+++ b/electron/services/pty/analysis/InThreadAnalysisBackend.ts
@@ -1,7 +1,12 @@
 import type { ActivityMonitor } from "../../ActivityMonitor.js";
 import type { PatternDetectionConfig } from "../AgentPatternDetector.js";
-import type { AnalysisBackend, MonitorStartOptions } from "./AnalysisBackend.js";
-import type { AnalysisChunkFlags, AnalysisFinalSnapshot } from "../analysisWorkerProtocol.js";
+import type {
+  AnalysisBackend,
+  AnalysisFinalCapture,
+  MonitorStartOptions,
+} from "./AnalysisBackend.js";
+import type { AnalysisChunkFlags } from "../analysisWorkerProtocol.js";
+import type { SerializedTerminalSnapshot } from "../../../../shared/types/terminal.js";
 
 /**
  * The legacy single-threaded analysis path, adapted to the AnalysisBackend
@@ -22,9 +27,9 @@ export interface InThreadAnalysisHost {
   setScrollback(lines: number): boolean;
   readViewportLines(n: number): string[];
   readCursorLine(): string | null;
-  serialize(): Promise<string | null>;
-  serializeForPersistence(): string | null;
-  captureFinalSnapshot(): Promise<AnalysisFinalSnapshot>;
+  serialize(): Promise<SerializedTerminalSnapshot | null>;
+  serializeForPersistence(): SerializedTerminalSnapshot | null;
+  captureFinalSnapshot(): Promise<AnalysisFinalCapture>;
   releaseHeadless(): void;
 }
 
@@ -89,15 +94,15 @@ export class InThreadAnalysisBackend implements AnalysisBackend {
     return this.host.readCursorLine();
   }
 
-  serialize(): Promise<string | null> {
+  serialize(): Promise<SerializedTerminalSnapshot | null> {
     return this.host.serialize();
   }
 
-  serializeForPersistence(): Promise<string | null> {
+  serializeForPersistence(): Promise<SerializedTerminalSnapshot | null> {
     return Promise.resolve(this.host.serializeForPersistence());
   }
 
-  captureFinalSnapshot(): Promise<AnalysisFinalSnapshot> {
+  captureFinalSnapshot(): Promise<AnalysisFinalCapture> {
     return this.host.captureFinalSnapshot();
   }
 

--- a/electron/services/pty/analysis/WorkerAnalysisBackend.ts
+++ b/electron/services/pty/analysis/WorkerAnalysisBackend.ts
@@ -1,7 +1,12 @@
 import type { AgentState } from "../../../../shared/types/agent.js";
 import type { ActivityStateMetadata } from "../../ActivityMonitor.js";
 import type { PatternDetectionConfig } from "../AgentPatternDetector.js";
-import type { AnalysisBackend, MonitorStartOptions } from "./AnalysisBackend.js";
+import type {
+  AnalysisBackend,
+  AnalysisFinalCapture,
+  MonitorStartOptions,
+} from "./AnalysisBackend.js";
+import type { SerializedTerminalSnapshot } from "../../../../shared/types/terminal.js";
 import type {
   AnalysisChunkFlags,
   AnalysisFinalSnapshot,
@@ -293,26 +298,50 @@ export class WorkerAnalysisBackend implements AnalysisBackend {
     return this.cursorLine;
   }
 
-  async serialize(): Promise<string | null> {
+  /**
+   * The grid the worker's mirror will serialize at, sampled synchronously at
+   * the call site that is about to post the request (#11552).
+   *
+   * Correct without a worker round-trip because the ordering is total: this
+   * function and the `pool.request()` that follows run in one JS turn, every
+   * earlier `resize` post is already ahead of the request in the worker's FIFO,
+   * and any later resize necessarily queues behind it. Reading `lastCols` after
+   * the await would instead report a grid the payload was NOT produced at.
+   */
+  private captureGeometry(): { cols: number; rows: number } {
+    return { cols: this.lastCols, rows: this.lastRows };
+  }
+
+  async serialize(): Promise<SerializedTerminalSnapshot | null> {
     if (this.inactive()) return null;
     this.flushHeldFeed();
+    const geometry = this.captureGeometry();
     const result = await this.pool.request(this.spec.terminalId, "serialize");
-    return typeof result === "string" ? result : null;
+    return typeof result === "string" ? { data: result, ...geometry } : null;
   }
 
-  async serializeForPersistence(): Promise<string | null> {
+  async serializeForPersistence(): Promise<SerializedTerminalSnapshot | null> {
     if (this.inactive() || this.persistSuppressed) return null;
     this.flushHeldFeed();
+    const geometry = this.captureGeometry();
     const result = await this.pool.request(this.spec.terminalId, "serialize-persistence");
-    return typeof result === "string" ? result : null;
+    return typeof result === "string" ? { data: result, ...geometry } : null;
   }
 
-  async captureFinalSnapshot(): Promise<AnalysisFinalSnapshot> {
+  async captureFinalSnapshot(): Promise<AnalysisFinalCapture> {
     if (this.inactive()) return { snapshot: null, persistence: null };
     this.flushHeldFeed();
+    const geometry = this.captureGeometry();
     const result = await this.pool.request(this.spec.terminalId, "final-snapshot");
     if (result !== null && typeof result === "object") {
-      return this.persistSuppressed ? { ...result, persistence: null } : result;
+      const wire = result as AnalysisFinalSnapshot;
+      return {
+        snapshot: wire.snapshot === null ? null : { data: wire.snapshot, ...geometry },
+        persistence:
+          this.persistSuppressed || wire.persistence === null
+            ? null
+            : { data: wire.persistence, ...geometry },
+      };
     }
     return { snapshot: null, persistence: null };
   }

--- a/electron/services/pty/analysis/WorkerAnalysisBackend.ts
+++ b/electron/services/pty/analysis/WorkerAnalysisBackend.ts
@@ -39,6 +39,25 @@ export interface AnalysisFeedFlowControl {
   holdHardCap: number;
 }
 
+/**
+ * Narrow a request reply to a single serialization, geometry included.
+ *
+ * The grid is the worker's to report, never the host's to infer (#11552): the
+ * mirror parks at a restored snapshot's capture grid with no host-posted resize
+ * to observe, so anything derived from `lastCols`/`lastRows` can tag
+ * capture-grid data with the spawn grid — which makes every replay site skip
+ * the alignment it needs. A timed-out or dead-worker reply is `null` here.
+ */
+function asSnapshot(result: AnalysisRequestResult): SerializedTerminalSnapshot | null {
+  if (result === null || typeof result !== "object" || !("data" in result)) return null;
+  return result;
+}
+
+function asFinalSnapshot(result: AnalysisRequestResult): AnalysisFinalSnapshot | null {
+  if (result === null || typeof result !== "object" || !("snapshot" in result)) return null;
+  return result;
+}
+
 export interface WorkerAnalysisDelegate {
   onActivityState(
     spawnedAt: number,
@@ -298,52 +317,30 @@ export class WorkerAnalysisBackend implements AnalysisBackend {
     return this.cursorLine;
   }
 
-  /**
-   * The grid the worker's mirror will serialize at, sampled synchronously at
-   * the call site that is about to post the request (#11552).
-   *
-   * Correct without a worker round-trip because the ordering is total: this
-   * function and the `pool.request()` that follows run in one JS turn, every
-   * earlier `resize` post is already ahead of the request in the worker's FIFO,
-   * and any later resize necessarily queues behind it. Reading `lastCols` after
-   * the await would instead report a grid the payload was NOT produced at.
-   */
-  private captureGeometry(): { cols: number; rows: number } {
-    return { cols: this.lastCols, rows: this.lastRows };
-  }
-
   async serialize(): Promise<SerializedTerminalSnapshot | null> {
     if (this.inactive()) return null;
     this.flushHeldFeed();
-    const geometry = this.captureGeometry();
     const result = await this.pool.request(this.spec.terminalId, "serialize");
-    return typeof result === "string" ? { data: result, ...geometry } : null;
+    return asSnapshot(result);
   }
 
   async serializeForPersistence(): Promise<SerializedTerminalSnapshot | null> {
     if (this.inactive() || this.persistSuppressed) return null;
     this.flushHeldFeed();
-    const geometry = this.captureGeometry();
     const result = await this.pool.request(this.spec.terminalId, "serialize-persistence");
-    return typeof result === "string" ? { data: result, ...geometry } : null;
+    return asSnapshot(result);
   }
 
   async captureFinalSnapshot(): Promise<AnalysisFinalCapture> {
     if (this.inactive()) return { snapshot: null, persistence: null };
     this.flushHeldFeed();
-    const geometry = this.captureGeometry();
     const result = await this.pool.request(this.spec.terminalId, "final-snapshot");
-    if (result !== null && typeof result === "object") {
-      const wire = result as AnalysisFinalSnapshot;
-      return {
-        snapshot: wire.snapshot === null ? null : { data: wire.snapshot, ...geometry },
-        persistence:
-          this.persistSuppressed || wire.persistence === null
-            ? null
-            : { data: wire.persistence, ...geometry },
-      };
-    }
-    return { snapshot: null, persistence: null };
+    const wire = asFinalSnapshot(result);
+    if (!wire) return { snapshot: null, persistence: null };
+    return {
+      snapshot: wire.snapshot,
+      persistence: this.persistSuppressed ? null : wire.persistence,
+    };
   }
 
   release(): void {

--- a/electron/services/pty/analysisWorkerProtocol.ts
+++ b/electron/services/pty/analysisWorkerProtocol.ts
@@ -1,6 +1,7 @@
 import type { AgentState } from "../../../shared/types/agent.js";
 import type { ActivityStateMetadata } from "../ActivityMonitor.js";
 import type { AgentConfig } from "../../../shared/config/agentRegistry.js";
+import type { SerializedTerminalSnapshot } from "../../../shared/types/terminal.js";
 
 // Typed message protocol between the pty-host main thread and the analysis
 // worker_threads pool. All payloads must be structured-clone-safe.
@@ -75,9 +76,9 @@ export type HostToWorkerMessage =
 
 export interface AnalysisFinalSnapshot {
   /** Full-buffer serialize (banner included) for the preserved snapshot. */
-  snapshot: string | null;
+  snapshot: SerializedTerminalSnapshot | null;
   /** Banner-stripped serialize for on-disk session persistence. */
-  persistence: string | null;
+  persistence: SerializedTerminalSnapshot | null;
 }
 
 /**
@@ -108,7 +109,19 @@ export interface AnalysisWorkerMemorySample {
   sampledAt: number;
 }
 
-export type AnalysisRequestResult = string | null | AnalysisFinalSnapshot;
+/**
+ * Serialization results carry the grid they were produced at (#11552).
+ *
+ * The geometry cannot be inferred on the pty-host side from the last resize it
+ * posted: the worker's own `AnalysisSession` constructor replays a persisted
+ * session, which sizes the mirror to the SNAPSHOT's grid and reflows home
+ * asynchronously — with no host-posted resize to observe. A serialize landing
+ * inside that window returns capture-grid data, so only the worker can say what
+ * grid it came off. Reading `terminal.cols`/`rows` in the same synchronous step
+ * as `addon.serialize()` is the same contract the in-thread backend has always
+ * had (`terminalSerialization.withGeometry`).
+ */
+export type AnalysisRequestResult = SerializedTerminalSnapshot | null | AnalysisFinalSnapshot;
 
 export type WorkerToHostMessage =
   | { type: "ready" }

--- a/electron/services/pty/terminalSerialization.ts
+++ b/electron/services/pty/terminalSerialization.ts
@@ -1,21 +1,43 @@
 import type { IMarker } from "@xterm/headless";
 import type { TerminalInfo } from "./types.js";
+import type { SerializedTerminalSnapshot } from "../../../shared/types/terminal.js";
 import { getTerminalSerializerService } from "./TerminalSerializerService.js";
 
-export function serializeTerminal(id: string, terminalInfo: TerminalInfo): string | null {
+/**
+ * Bundle a serialized payload with the grid that produced it (#11552).
+ *
+ * Must be called in the same tick as the `addon.serialize()` that produced
+ * `data`: a geometry sampled a tick earlier can describe a grid the buffer has
+ * already left, and replaying a snapshot at the wrong width commits real
+ * newlines into cell data that no later reflow can undo.
+ */
+function withGeometry(
+  data: string | null,
+  grid: { cols: number; rows: number }
+): SerializedTerminalSnapshot | null {
+  if (data === null) return null;
+  return { data, cols: grid.cols, rows: grid.rows };
+}
+
+export function serializeTerminal(
+  id: string,
+  terminalInfo: TerminalInfo
+): SerializedTerminalSnapshot | null {
   // Preserved exited terminal — the headless xterm is disposed and the final
-  // buffer lives as a cached string. Empty string is a valid snapshot. Stamp
+  // buffer lives as a cached snapshot. Empty data is a valid snapshot. Stamp
   // the access time so eviction (issue #10839) treats it as currently-viewed.
   if (terminalInfo.preservedSnapshot !== undefined) {
     terminalInfo.preservedSnapshotLastAccessedAt = Date.now();
     return terminalInfo.preservedSnapshot;
   }
-  // Non-preserved disposed terminal — disposeHeadless() clears the addon. No
-  // snapshot to produce; return null without logging a spurious error.
+  // Non-preserved disposed terminal — disposeHeadless() clears the addon and
+  // the headless instance together. No snapshot to produce; return null without
+  // logging a spurious error.
   const addon = terminalInfo.serializeAddon;
-  if (!addon) return null;
+  const headless = terminalInfo.headlessTerminal;
+  if (!addon || !headless) return null;
   try {
-    return addon.serialize();
+    return withGeometry(addon.serialize(), headless);
   } catch (error) {
     console.error(`[TerminalProcess] Failed to serialize terminal ${id}:`, error);
     return null;
@@ -25,7 +47,7 @@ export function serializeTerminal(id: string, terminalInfo: TerminalInfo): strin
 export async function serializeTerminalAsync(
   id: string,
   terminalInfo: TerminalInfo
-): Promise<string | null> {
+): Promise<SerializedTerminalSnapshot | null> {
   // Preserved snapshot served — stamp access time so eviction (issue #10839)
   // treats it as currently-viewed.
   if (terminalInfo.preservedSnapshot !== undefined) {
@@ -45,13 +67,15 @@ export async function serializeTerminalAsync(
     if (serializerService.shouldUseAsync(lineCount)) {
       // The serialize callback runs on a later tick; disposeHeadless() may clear
       // the addon in between. Re-check identity so a disposed terminal yields
-      // null instead of throwing (which would re-log a spurious failure).
+      // null instead of throwing (which would re-log a spurious failure). The
+      // geometry is read inside this deferred callback so it describes the grid
+      // the payload was actually produced from.
       return await serializerService.serializeAsync(id, () =>
-        terminalInfo.serializeAddon === addon ? addon.serialize() : null
+        terminalInfo.serializeAddon === addon ? withGeometry(addon.serialize(), headless) : null
       );
     }
 
-    return addon.serialize();
+    return withGeometry(addon.serialize(), headless);
   } catch (error) {
     console.error(`[TerminalProcess] Failed to serialize terminal ${id}:`, error);
     return null;
@@ -62,7 +86,7 @@ export function serializeForPersistence(
   terminalInfo: TerminalInfo,
   restoreBannerStart: IMarker | null,
   restoreBannerEnd: IMarker | null
-): string | null {
+): SerializedTerminalSnapshot | null {
   const addon = terminalInfo.serializeAddon;
   const terminal = terminalInfo.headlessTerminal;
   if (!addon || !terminal) return null;
@@ -71,7 +95,7 @@ export function serializeForPersistence(
   const endMarker = restoreBannerEnd;
 
   if (!startMarker || !endMarker || startMarker.line < 0 || endMarker.line < 0) {
-    return addon.serialize();
+    return withGeometry(addon.serialize(), terminal);
   }
 
   try {
@@ -86,9 +110,9 @@ export function serializeForPersistence(
         ? addon.serialize({ range: { start: bannerEnd, end: bufLen - 1 } })
         : "";
 
-    if (beforePart && afterPart) return beforePart + "\r\n" + afterPart;
-    return beforePart || afterPart || null;
+    if (beforePart && afterPart) return withGeometry(beforePart + "\r\n" + afterPart, terminal);
+    return withGeometry(beforePart || afterPart || null, terminal);
   } catch {
-    return addon.serialize();
+    return withGeometry(addon.serialize(), terminal);
   }
 }

--- a/electron/services/pty/terminalSessionPersistence.ts
+++ b/electron/services/pty/terminalSessionPersistence.ts
@@ -10,6 +10,7 @@ import {
   OWNER_RWX_DIR_MODE,
 } from "../../utils/fs.js";
 import path from "node:path";
+import { headlessMirrorScheduler } from "./HeadlessMirrorScheduler.js";
 import type { Terminal as HeadlessTerminalType, IMarker } from "@xterm/headless";
 import type {
   SerializedTerminalSnapshot,
@@ -188,6 +189,7 @@ const NO_ALIGNMENT: ReplayAlignment = { scheduleRestore: () => {} };
  */
 function alignForReplay(
   headlessTerminal: HeadlessTerminalType,
+  terminalId: string,
   captureGeometry: TerminalGeometry | null
 ): ReplayAlignment {
   if (!captureGeometry) return NO_ALIGNMENT;
@@ -202,7 +204,14 @@ function alignForReplay(
 
   return {
     scheduleRestore: () => {
-      headlessTerminal.write("", () => {
+      // Order the reflow behind anything the mirror scheduler is holding for
+      // this terminal, not just behind our own writes. Live PTY chunks reach
+      // the mirror through that queue with no gate of their own, and resizing
+      // while xterm still has queued entries makes its flushSync re-parse from
+      // the head of the write buffer — the same duplication this fix exists to
+      // prevent. With no queue registered (the usual cold-start case) flush()
+      // degrades to a plain sentinel write.
+      headlessMirrorScheduler.flush(terminalId, headlessTerminal, () => {
         // Hop out of the write callback before resizing: it runs inside xterm's
         // parser drain, and changing the grid there re-applies the chunk being
         // drained against the new geometry (a 4-cell write comes back as 8).
@@ -267,7 +276,7 @@ export function restoreSessionFromFile(
     // empty here, so aligning it up front costs nothing — and it must happen
     // BEFORE the writes, because xterm parses asynchronously: content queued
     // now is laid out at whatever cols the terminal has when the parser drains.
-    const alignment = alignForReplay(headlessTerminal, captureGeometry);
+    const alignment = alignForReplay(headlessTerminal, terminalId, captureGeometry);
 
     headlessTerminal.write(RESTORE_PARSER_RESET_PREAMBLE);
     headlessTerminal.write(content);

--- a/electron/services/pty/terminalSessionPersistence.ts
+++ b/electron/services/pty/terminalSessionPersistence.ts
@@ -11,6 +11,11 @@ import {
 } from "../../utils/fs.js";
 import path from "node:path";
 import type { Terminal as HeadlessTerminalType, IMarker } from "@xterm/headless";
+import type {
+  SerializedTerminalSnapshot,
+  TerminalGeometry,
+} from "../../../shared/types/terminal.js";
+import { isValidTerminalGeometry } from "../../../shared/types/terminal.js";
 
 export interface RestoreResult {
   restored: boolean;
@@ -52,26 +57,78 @@ const STAT_CHUNK_SIZE = 10;
 // crash artifacts on the next eviction sweep.
 const TMP_ORPHAN_TTL_MS = 5 * 60 * 1000;
 
-const SESSION_HEADER = "DAINTREE_SESSION_v1\n";
+const SESSION_HEADER_V1 = "DAINTREE_SESSION_v1\n";
+const SESSION_HEADER = "DAINTREE_SESSION_v2\n";
 const SESSION_HEADER_BYTES = Buffer.byteLength(SESSION_HEADER, "utf8");
+// v2 adds a `<cols>x<rows>\n` line after the version line. Four digits per
+// dimension is well past MAX_TERMINAL_GRID_DIMENSION, so this bounds the whole
+// preamble for the size gate.
+const SESSION_GEOMETRY_LINE_MAX_BYTES = "9999x9999\n".length;
+const SESSION_PREAMBLE_MAX_BYTES = SESSION_HEADER_BYTES + SESSION_GEOMETRY_LINE_MAX_BYTES;
+const VERSION_PREFIX = "DAINTREE_SESSION_";
 
-function extractSessionContent(raw: string): string | null {
-  if (!raw) return raw;
+/**
+ * A parsed session file: the replayable payload plus the grid it was captured
+ * at, when the file records one (#11552).
+ *
+ * `geometry` is null for v1 and headerless legacy files — those predate the
+ * contract and are replayed verbatim, exactly as before. A *v2* file that
+ * fails to parse is rejected outright rather than downgraded: v2 asserts the
+ * metadata is present, so a malformed line means a corrupt file, and sizing a
+ * real xterm from garbage is worse than skipping the restore.
+ */
+interface ParsedSessionFile {
+  content: string;
+  geometry: TerminalGeometry | null;
+}
+
+function extractSessionContent(raw: string): ParsedSessionFile | null {
+  if (!raw) return { content: raw, geometry: null };
 
   if (raw.startsWith(SESSION_HEADER)) {
-    return raw.slice(SESSION_HEADER_BYTES);
+    const rest = raw.slice(SESSION_HEADER_BYTES);
+    const newlineIndex = rest.indexOf("\n");
+    if (newlineIndex === -1) {
+      console.warn(`[terminalSessionPersistence] v2 session file has no geometry line, rejecting`);
+      return null;
+    }
+    const geometry = parseGeometryLine(rest.slice(0, newlineIndex));
+    if (!geometry) {
+      console.warn(
+        `[terminalSessionPersistence] v2 session file has an unparseable geometry line, rejecting`
+      );
+      return null;
+    }
+    return { content: rest.slice(newlineIndex + 1), geometry };
   }
 
-  if (raw.startsWith("DAINTREE_SESSION_")) {
+  if (raw.startsWith(SESSION_HEADER_V1)) {
+    return { content: raw.slice(Buffer.byteLength(SESSION_HEADER_V1, "utf8")), geometry: null };
+  }
+
+  if (raw.startsWith(VERSION_PREFIX)) {
     console.warn(`[terminalSessionPersistence] Unknown session file version, rejecting restore`);
     return null;
   }
 
-  if (raw.length < SESSION_HEADER_BYTES && "DAINTREE_SESSION_".startsWith(raw)) {
+  // A truncated write that only got as far as a prefix of the version marker
+  // is not payload — reject rather than replaying "DAINTREE_SES" as content.
+  if (raw.length < VERSION_PREFIX.length && VERSION_PREFIX.startsWith(raw)) {
     return null;
   }
 
-  return raw;
+  return { content: raw, geometry: null };
+}
+
+function parseGeometryLine(line: string): TerminalGeometry | null {
+  const match = /^(\d{1,4})x(\d{1,4})$/.exec(line);
+  if (!match) return null;
+  const geometry = { cols: Number(match[1]), rows: Number(match[2]) };
+  return isValidTerminalGeometry(geometry) ? geometry : null;
+}
+
+function formatSessionFile(snapshot: SerializedTerminalSnapshot): string {
+  return `${SESSION_HEADER}${snapshot.cols}x${snapshot.rows}\n${snapshot.data}`;
 }
 
 export function getSessionDir(): string | null {
@@ -114,6 +171,63 @@ function formatRestoreTimestamp(mtimeMs: number): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
+interface ReplayAlignment {
+  /** Queue the reflow back to the pre-replay grid behind the replay writes. */
+  scheduleRestore(): void;
+}
+
+const NO_ALIGNMENT: ReplayAlignment = { scheduleRestore: () => {} };
+
+/**
+ * Size `headlessTerminal` to the grid a snapshot was captured on, and hand back
+ * the means to reflow it home once the replay has parsed (#11552).
+ *
+ * A no-op when the snapshot carries no geometry (a v1/legacy file) or already
+ * matches — legacy payloads replay exactly as they did before, which is no
+ * worse than the status quo and strictly better than dropping the session.
+ */
+function alignForReplay(
+  headlessTerminal: HeadlessTerminalType,
+  captureGeometry: TerminalGeometry | null
+): ReplayAlignment {
+  if (!captureGeometry) return NO_ALIGNMENT;
+
+  const liveCols = headlessTerminal.cols;
+  const liveRows = headlessTerminal.rows;
+  if (captureGeometry.cols === liveCols && captureGeometry.rows === liveRows) {
+    return NO_ALIGNMENT;
+  }
+
+  headlessTerminal.resize(captureGeometry.cols, captureGeometry.rows);
+
+  return {
+    scheduleRestore: () => {
+      headlessTerminal.write("", () => {
+        // Hop out of the write callback before resizing: it runs inside xterm's
+        // parser drain, and changing the grid there re-applies the chunk being
+        // drained against the new geometry (a 4-cell write comes back as 8).
+        // A microtask lands after the drain and before any live PTY output.
+        queueMicrotask(() => {
+          // xterm leaves the cursor's own wrapped group unreflowed unless
+          // `reflowCursorLine` is on, so normalizing to a narrower grid would
+          // TRUNCATE that row's tail rather than wrap it. Enable it for this one
+          // corrective resize and put the configured value straight back — the
+          // option is a live-typing ergonomic, not something to change globally.
+          const previous = headlessTerminal.options.reflowCursorLine;
+          headlessTerminal.options.reflowCursorLine = true;
+          try {
+            headlessTerminal.resize(liveCols, liveRows);
+          } catch (error) {
+            console.warn(`[terminalSessionPersistence] Failed to restore session geometry:`, error);
+          } finally {
+            headlessTerminal.options.reflowCursorLine = previous;
+          }
+        });
+      });
+    },
+  };
+}
+
 export function restoreSessionFromFile(
   headlessTerminal: HeadlessTerminalType,
   terminalId: string
@@ -129,15 +243,16 @@ export function restoreSessionFromFile(
       if ((e as NodeJS.ErrnoException).code === "ENOENT") return NULL_RESTORE;
       throw e;
     }
-    if (stat.size > SESSION_SNAPSHOT_MAX_BYTES + SESSION_HEADER_BYTES) {
+    if (stat.size > SESSION_SNAPSHOT_MAX_BYTES + SESSION_PREAMBLE_MAX_BYTES) {
       console.warn(
         `[terminalSessionPersistence] Session snapshot too large for ${terminalId} (${stat.size} bytes), skipping restore`
       );
       return NULL_RESTORE;
     }
     const raw = readFileSync(sessionPath, "utf8");
-    const content = extractSessionContent(raw);
-    if (content === null) return NULL_RESTORE;
+    const parsed = extractSessionContent(raw);
+    if (parsed === null) return NULL_RESTORE;
+    const { content, geometry: captureGeometry } = parsed;
     if (Buffer.byteLength(content, "utf8") > SESSION_SNAPSHOT_MAX_BYTES) {
       // Belt-and-suspenders: file may have grown between statSync and readFileSync.
       console.warn(
@@ -146,6 +261,13 @@ export function restoreSessionFromFile(
       return NULL_RESTORE;
     }
     const sessionMtime: number = stat.mtimeMs;
+
+    // Replay at the grid the snapshot was captured on, then reflow to the grid
+    // this process actually spawned at (#11552). The mirror is brand new and
+    // empty here, so aligning it up front costs nothing — and it must happen
+    // BEFORE the writes, because xterm parses asynchronously: content queued
+    // now is laid out at whatever cols the terminal has when the parser drains.
+    const alignment = alignForReplay(headlessTerminal, captureGeometry);
 
     headlessTerminal.write(RESTORE_PARSER_RESET_PREAMBLE);
     headlessTerminal.write(content);
@@ -173,6 +295,11 @@ export function restoreSessionFromFile(
     headlessTerminal.write(`\x1b[2m\x1b[38;5;240m${label}\x1b[0m\r\n`);
     const bannerEndMarker = headlessTerminal.registerMarker(0) ?? null;
 
+    // Queued behind the replay so it runs once the parser has laid the content
+    // out at the capture grid. Live PTY output written after this point queues
+    // behind the callback and therefore parses at the restored geometry.
+    alignment.scheduleRestore();
+
     return { restored: true, bannerStartMarker, bannerEndMarker };
   } catch (error) {
     // Stat→read race: file vanished between size gate and read. Treat as the
@@ -186,11 +313,14 @@ export function restoreSessionFromFile(
   }
 }
 
-export function persistSessionSnapshotSync(terminalId: string, state: string): void {
+export function persistSessionSnapshotSync(
+  terminalId: string,
+  snapshot: SerializedTerminalSnapshot
+): void {
   const sessionPath = getSessionPath(terminalId);
   const dir = getSessionDir();
   if (!sessionPath || !dir) return;
-  const bytes = Buffer.byteLength(state, "utf8");
+  const bytes = Buffer.byteLength(snapshot.data, "utf8");
   if (bytes > SESSION_SNAPSHOT_MAX_BYTES) {
     console.warn(
       `[terminalSessionPersistence] Snapshot for ${terminalId} exceeds cap (${bytes} > ${SESSION_SNAPSHOT_MAX_BYTES} bytes); skipping persist`
@@ -200,19 +330,19 @@ export function persistSessionSnapshotSync(terminalId: string, state: string): v
 
   mkdirSync(dir, { recursive: true, mode: OWNER_RWX_DIR_MODE });
   tightenDirPermissionsSync(dir);
-  resilientAtomicWriteFileSync(sessionPath, SESSION_HEADER + state, "utf8", {
+  resilientAtomicWriteFileSync(sessionPath, formatSessionFile(snapshot), "utf8", {
     mode: OWNER_RW_FILE_MODE,
   });
 }
 
 export async function persistSessionSnapshotAsync(
   terminalId: string,
-  state: string
+  snapshot: SerializedTerminalSnapshot
 ): Promise<void> {
   const sessionPath = getSessionPath(terminalId);
   const dir = getSessionDir();
   if (!sessionPath || !dir) return;
-  const bytes = Buffer.byteLength(state, "utf8");
+  const bytes = Buffer.byteLength(snapshot.data, "utf8");
   if (bytes > SESSION_SNAPSHOT_MAX_BYTES) {
     console.warn(
       `[terminalSessionPersistence] Snapshot for ${terminalId} exceeds cap (${bytes} > ${SESSION_SNAPSHOT_MAX_BYTES} bytes); skipping persist`
@@ -222,7 +352,7 @@ export async function persistSessionSnapshotAsync(
 
   await mkdir(dir, { recursive: true, mode: OWNER_RWX_DIR_MODE });
   await tightenDirPermissions(dir);
-  await resilientAtomicWriteFile(sessionPath, SESSION_HEADER + state, "utf8", {
+  await resilientAtomicWriteFile(sessionPath, formatSessionFile(snapshot), "utf8", {
     mode: OWNER_RW_FILE_MODE,
   });
 }

--- a/electron/services/pty/terminalSessionPersistence.ts
+++ b/electron/services/pty/terminalSessionPersistence.ts
@@ -61,8 +61,9 @@ const TMP_ORPHAN_TTL_MS = 5 * 60 * 1000;
 const SESSION_HEADER_V1 = "DAINTREE_SESSION_v1\n";
 const SESSION_HEADER = "DAINTREE_SESSION_v2\n";
 const SESSION_HEADER_BYTES = Buffer.byteLength(SESSION_HEADER, "utf8");
-// v2 adds a `<cols>x<rows>\n` line after the version line. Four digits per
-// dimension is well past MAX_TERMINAL_GRID_DIMENSION, so this bounds the whole
+// v2 adds a `<cols>x<rows>\n` line after the version line. The writer only ever
+// emits a geometry `isValidTerminalGeometry` accepts (four digits per dimension
+// is already past MAX_TERMINAL_GRID_DIMENSION), so this bounds the whole
 // preamble for the size gate.
 const SESSION_GEOMETRY_LINE_MAX_BYTES = "9999x9999\n".length;
 const SESSION_PREAMBLE_MAX_BYTES = SESSION_HEADER_BYTES + SESSION_GEOMETRY_LINE_MAX_BYTES;
@@ -73,10 +74,13 @@ const VERSION_PREFIX = "DAINTREE_SESSION_";
  * at, when the file records one (#11552).
  *
  * `geometry` is null for v1 and headerless legacy files — those predate the
- * contract and are replayed verbatim, exactly as before. A *v2* file that
- * fails to parse is rejected outright rather than downgraded: v2 asserts the
- * metadata is present, so a malformed line means a corrupt file, and sizing a
- * real xterm from garbage is worse than skipping the restore.
+ * contract and are replayed verbatim, exactly as before. A v2 file whose
+ * geometry line is unusable degrades to the SAME null: an unreadable grid costs
+ * the alignment, never the scrollback, because replaying without alignment is
+ * exactly what v1 did while dropping the file loses a session outright. Only a
+ * v2 file with no geometry line at all is rejected — the writer always emits
+ * one, so its absence means the preamble is truncated and there is no way to
+ * tell where the payload starts (nor, at that length, any payload to save).
  */
 interface ParsedSessionFile {
   content: string;
@@ -96,9 +100,9 @@ function extractSessionContent(raw: string): ParsedSessionFile | null {
     const geometry = parseGeometryLine(rest.slice(0, newlineIndex));
     if (!geometry) {
       console.warn(
-        `[terminalSessionPersistence] v2 session file has an unparseable geometry line, rejecting`
+        `[terminalSessionPersistence] v2 session file has an unusable geometry line; ` +
+          `replaying the session without width alignment`
       );
-      return null;
     }
     return { content: rest.slice(newlineIndex + 1), geometry };
   }
@@ -121,14 +125,29 @@ function extractSessionContent(raw: string): ParsedSessionFile | null {
   return { content: raw, geometry: null };
 }
 
+// Digit count is deliberately unbounded here: `isValidTerminalGeometry` is the
+// single bound both ends of this format agree on, and a second, tighter one in
+// the regex is how a grid the writer could emit came back unreadable.
 function parseGeometryLine(line: string): TerminalGeometry | null {
-  const match = /^(\d{1,4})x(\d{1,4})$/.exec(line);
+  const match = /^(\d+)x(\d+)$/.exec(line);
   if (!match) return null;
   const geometry = { cols: Number(match[1]), rows: Number(match[2]) };
   return isValidTerminalGeometry(geometry) ? geometry : null;
 }
 
+/**
+ * Serialize a snapshot to the on-disk session format.
+ *
+ * A grid the reader would refuse is written as v1 — the format that already
+ * means "no capture geometry" — rather than as a v2 file the next restore would
+ * choke on. Both ends therefore agree on exactly one bound
+ * (`isValidTerminalGeometry`), and an unrepresentable grid costs the width
+ * alignment while the scrollback still comes back.
+ */
 function formatSessionFile(snapshot: SerializedTerminalSnapshot): string {
+  if (!isValidTerminalGeometry({ cols: snapshot.cols, rows: snapshot.rows })) {
+    return `${SESSION_HEADER_V1}${snapshot.data}`;
+  }
   return `${SESSION_HEADER}${snapshot.cols}x${snapshot.rows}\n${snapshot.data}`;
 }
 
@@ -172,69 +191,123 @@ function formatRestoreTimestamp(mtimeMs: number): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
-interface ReplayAlignment {
-  /** Queue the reflow back to the pre-replay grid behind the replay writes. */
-  scheduleRestore(): void;
+interface ReplayWindow {
+  /** The grid this mirror must end up on once the replay has parsed. */
+  target: TerminalGeometry;
 }
 
-const NO_ALIGNMENT: ReplayAlignment = { scheduleRestore: () => {} };
+/**
+ * Mirrors with a session replay in flight, and the grid each owes its owner
+ * when the replay lands. Keyed by the mirror itself rather than by terminal id
+ * so a disposed mirror takes its window with it — the close is driven by an
+ * xterm write callback, which a disposal silently cancels.
+ */
+const replayWindows = new WeakMap<HeadlessTerminalType, ReplayWindow>();
 
 /**
- * Size `headlessTerminal` to the grid a snapshot was captured on, and hand back
- * the means to reflow it home once the replay has parsed (#11552).
+ * The one way to resize a headless mirror (#11552).
  *
- * A no-op when the snapshot carries no geometry (a v1/legacy file) or already
- * matches — legacy payloads replay exactly as they did before, which is no
- * worse than the status quo and strictly better than dropping the session.
+ * While a session replay is in flight the mirror is deliberately parked at the
+ * snapshot's capture grid so SerializeAddon's wrap encoding decodes the way it
+ * was written. A resize applied now would lay the rest of the payload out at
+ * the wrong width AND be reverted by the reflow that ends the replay — leaving
+ * the mirror on a grid the PTY has already moved off, with nothing to re-sync
+ * it (`TerminalProcess.resize` early-returns once the pty dims match). Record
+ * the intent instead: it becomes the grid the replay reflows to, so the newest
+ * resize wins rather than losing to a value pinned before it arrived.
+ *
+ * Returns true when the mirror was resized now, false when the resize was
+ * parked for the in-flight replay.
  */
-function alignForReplay(
+export function resizeMirror(
   headlessTerminal: HeadlessTerminalType,
-  terminalId: string,
-  captureGeometry: TerminalGeometry | null
-): ReplayAlignment {
-  if (!captureGeometry) return NO_ALIGNMENT;
-
-  const liveCols = headlessTerminal.cols;
-  const liveRows = headlessTerminal.rows;
-  if (captureGeometry.cols === liveCols && captureGeometry.rows === liveRows) {
-    return NO_ALIGNMENT;
+  cols: number,
+  rows: number
+): boolean {
+  const window = replayWindows.get(headlessTerminal);
+  if (window) {
+    window.target = { cols, rows };
+    return false;
   }
+  headlessTerminal.resize(cols, rows);
+  return true;
+}
 
+/**
+ * Park `headlessTerminal` on the grid a snapshot was captured at for the
+ * duration of its replay, remembering the grid to return to.
+ *
+ * The window opens even when there is nothing to align to (a v1/legacy file, or
+ * a capture grid that already matches): a resize landing mid-replay would
+ * garble the unparsed tail whatever the capture width was, and with the window
+ * open it is applied once the payload is down instead. Legacy payloads still
+ * replay verbatim, exactly as they did before — no worse than the status quo
+ * and strictly better than dropping the session.
+ */
+function openReplayWindow(
+  headlessTerminal: HeadlessTerminalType,
+  captureGeometry: TerminalGeometry | null
+): void {
+  replayWindows.set(headlessTerminal, {
+    target: { cols: headlessTerminal.cols, rows: headlessTerminal.rows },
+  });
+  if (!captureGeometry) return;
+  if (
+    captureGeometry.cols === headlessTerminal.cols &&
+    captureGeometry.rows === headlessTerminal.rows
+  ) {
+    return;
+  }
   headlessTerminal.resize(captureGeometry.cols, captureGeometry.rows);
+}
 
-  return {
-    scheduleRestore: () => {
-      // Order the reflow behind anything the mirror scheduler is holding for
-      // this terminal, not just behind our own writes. Live PTY chunks reach
-      // the mirror through that queue with no gate of their own, and resizing
-      // while xterm still has queued entries makes its flushSync re-parse from
-      // the head of the write buffer — the same duplication this fix exists to
-      // prevent. With no queue registered (the usual cold-start case) flush()
-      // degrades to a plain sentinel write.
-      headlessMirrorScheduler.flush(terminalId, headlessTerminal, () => {
-        // Hop out of the write callback before resizing: it runs inside xterm's
-        // parser drain, and changing the grid there re-applies the chunk being
-        // drained against the new geometry (a 4-cell write comes back as 8).
-        // A microtask lands after the drain and before any live PTY output.
-        queueMicrotask(() => {
-          // xterm leaves the cursor's own wrapped group unreflowed unless
-          // `reflowCursorLine` is on, so normalizing to a narrower grid would
-          // TRUNCATE that row's tail rather than wrap it. Enable it for this one
-          // corrective resize and put the configured value straight back — the
-          // option is a live-typing ergonomic, not something to change globally.
-          const previous = headlessTerminal.options.reflowCursorLine;
-          headlessTerminal.options.reflowCursorLine = true;
-          try {
-            headlessTerminal.resize(liveCols, liveRows);
-          } catch (error) {
-            console.warn(`[terminalSessionPersistence] Failed to restore session geometry:`, error);
-          } finally {
-            headlessTerminal.options.reflowCursorLine = previous;
-          }
-        });
-      });
-    },
-  };
+/**
+ * Close the replay window and put the mirror on the grid it owes: the one it
+ * had when the window opened, or whichever resize landed while it was open.
+ * Idempotent, and a no-op when the grid already matches.
+ */
+function closeReplayWindow(headlessTerminal: HeadlessTerminalType): void {
+  const window = replayWindows.get(headlessTerminal);
+  if (!window) return;
+  replayWindows.delete(headlessTerminal);
+  const { cols, rows } = window.target;
+  if (cols === headlessTerminal.cols && rows === headlessTerminal.rows) return;
+
+  // xterm leaves the cursor's own wrapped group unreflowed unless
+  // `reflowCursorLine` is on, so normalizing to a narrower grid would TRUNCATE
+  // that row's tail rather than wrap it. Enable it for this one corrective
+  // resize and put the configured value straight back — the option is a
+  // live-typing ergonomic, not something to change globally.
+  const previous = headlessTerminal.options.reflowCursorLine;
+  headlessTerminal.options.reflowCursorLine = true;
+  try {
+    headlessTerminal.resize(cols, rows);
+  } catch (error) {
+    console.warn(`[terminalSessionPersistence] Failed to restore session geometry:`, error);
+  } finally {
+    headlessTerminal.options.reflowCursorLine = previous;
+  }
+}
+
+/** Queue the window close behind everything the replay put in flight. */
+function scheduleReplayWindowClose(
+  headlessTerminal: HeadlessTerminalType,
+  terminalId: string
+): void {
+  // Order the reflow behind anything the mirror scheduler is holding for this
+  // terminal, not just behind our own writes. Live PTY chunks reach the mirror
+  // through that queue with no gate of their own, and resizing while xterm
+  // still has queued entries makes its flushSync re-parse from the head of the
+  // write buffer — the same duplication this fix exists to prevent. With no
+  // queue registered (the usual cold-start case) flush() degrades to a plain
+  // sentinel write.
+  headlessMirrorScheduler.flush(terminalId, headlessTerminal, () => {
+    // Hop out of the write callback before resizing: it runs inside xterm's
+    // parser drain, and changing the grid there re-applies the chunk being
+    // drained against the new geometry (a 4-cell write comes back as 8). A
+    // microtask lands after the drain and before any live PTY output.
+    queueMicrotask(() => closeReplayWindow(headlessTerminal));
+  });
 }
 
 export function restoreSessionFromFile(
@@ -272,11 +345,11 @@ export function restoreSessionFromFile(
     const sessionMtime: number = stat.mtimeMs;
 
     // Replay at the grid the snapshot was captured on, then reflow to the grid
-    // this process actually spawned at (#11552). The mirror is brand new and
-    // empty here, so aligning it up front costs nothing — and it must happen
-    // BEFORE the writes, because xterm parses asynchronously: content queued
-    // now is laid out at whatever cols the terminal has when the parser drains.
-    const alignment = alignForReplay(headlessTerminal, terminalId, captureGeometry);
+    // this mirror owes its owner (#11552). The mirror is brand new and empty
+    // here, so aligning it up front costs nothing — and it must happen BEFORE
+    // the writes, because xterm parses asynchronously: content queued now is
+    // laid out at whatever cols the terminal has when the parser drains.
+    openReplayWindow(headlessTerminal, captureGeometry);
 
     headlessTerminal.write(RESTORE_PARSER_RESET_PREAMBLE);
     headlessTerminal.write(content);
@@ -307,10 +380,14 @@ export function restoreSessionFromFile(
     // Queued behind the replay so it runs once the parser has laid the content
     // out at the capture grid. Live PTY output written after this point queues
     // behind the callback and therefore parses at the restored geometry.
-    alignment.scheduleRestore();
+    scheduleReplayWindowClose(headlessTerminal, terminalId);
 
     return { restored: true, bannerStartMarker, bannerEndMarker };
   } catch (error) {
+    // A replay that died mid-flight still owns the grid and the resize gate —
+    // close the window here or every later resize parks into a window nothing
+    // will ever drain.
+    closeReplayWindow(headlessTerminal);
     // Stat→read race: file vanished between size gate and read. Treat as the
     // normal "no prior session" path rather than logging restore noise.
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return NULL_RESTORE;

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -6,6 +6,7 @@ import type { TerminalCheckResult } from "../../../shared/types/checkResult.js";
 import type { PanelKind, PanelTitleMode } from "../../../shared/types/panel.js";
 import type { BuiltInAgentId } from "../../../shared/config/agentIds.js";
 import type { PtyHostSpawnOptions } from "../../../shared/types/pty-host.js";
+import type { SerializedTerminalSnapshot } from "../../../shared/types/terminal.js";
 import type { ProcessDetector } from "../ProcessDetector.js";
 
 // Re-export PtyHostSpawnOptions as PtySpawnOptions for backward compatibility/internal usage
@@ -157,9 +158,12 @@ export interface TerminalInfo extends TerminalPublicState {
    * Final serialized buffer captured when a preserved terminal exits and its
    * headless xterm is disposed to reclaim memory. Served by
    * `serializeTerminal`/`serializeTerminalAsync` in place of the live buffer.
-   * Runtime-only; not persisted, not crossed over IPC.
+   * Carries the grid it was captured at, because the headless mirror that could
+   * otherwise answer that question is disposed the moment this is assigned and
+   * replaying at the wrong width is unrepairable (#11552). Runtime-only; not
+   * persisted, not crossed over IPC.
    */
-  preservedSnapshot?: string;
+  preservedSnapshot?: SerializedTerminalSnapshot;
   /**
    * Wall-clock timestamp (`Date.now()`) captured when `preservedSnapshot` is
    * assigned. Drives oldest-first eviction in

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -429,7 +429,10 @@ export type {
   TerminalActivityStatus,
   TerminalActivity,
   TerminalActivityPayload,
+  TerminalGeometry,
+  SerializedTerminalSnapshot,
 } from "./terminal.js";
+export { isValidTerminalGeometry, MAX_TERMINAL_GRID_DIMENSION } from "./terminal.js";
 
 // Pty Host types - IPC protocol for terminal management
 export type {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -65,6 +65,7 @@ import type {
   SemanticSearchMatch,
 } from "./terminal.js";
 import type { AppVersionInfo } from "./app.js";
+import type { SerializedTerminalSnapshot } from "../terminal.js";
 import type {
   SaveArtifactOptions,
   SaveArtifactResult,
@@ -273,8 +274,10 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     reconnect(terminalId: string): Promise<TerminalReconnectResult>;
     reconnectBulk(terminalIds: string[]): Promise<Record<string, TerminalReconnectResult>>;
     replayHistory(terminalId: string, maxLines?: number): Promise<{ replayed: number }>;
-    getSerializedState(terminalId: string): Promise<string | null>;
-    getSerializedStates(terminalIds: string[]): Promise<Record<string, string | null>>;
+    getSerializedState(terminalId: string): Promise<SerializedTerminalSnapshot | null>;
+    getSerializedStates(
+      terminalIds: string[]
+    ): Promise<Record<string, SerializedTerminalSnapshot | null>>;
     getSharedBuffers(): Promise<{
       visualBuffers: SharedArrayBuffer[];
       signalBuffer: SharedArrayBuffer | null;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1547,11 +1547,11 @@ export interface GeneratedIpcInvokeMap {
   };
   "terminal:get-serialized-state": {
     args: [terminalId: string];
-    result: string | null;
+    result: import("../terminal.js").SerializedTerminalSnapshot | null;
   };
   "terminal:get-serialized-states": {
     args: [terminalIds: string[]];
-    result: Record<string, string | null>;
+    result: Record<string, import("../terminal.js").SerializedTerminalSnapshot | null>;
   };
   "terminal:get-shared-buffers": {
     args: [];

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -15,6 +15,7 @@ import type { AgentConfig } from "../config/agentRegistry.js";
 import type { AgentSessionRecord } from "./ipc/agentSessionHistory.js";
 import type { SemanticSearchMatch, TerminalInfoPayload } from "./ipc/terminal.js";
 import type { WorkerResourceSnapshot } from "./workerGovernance.js";
+import type { SerializedTerminalSnapshot } from "./terminal.js";
 
 export type { TerminalFlowStatus };
 
@@ -602,7 +603,12 @@ export type PtyHostEvent =
   | { type: "terminals-for-project"; requestId: string; terminalIds: string[] }
   | { type: "terminal-info"; requestId: string; terminal: PtyHostTerminalInfo | null }
   | { type: "replay-history-result"; requestId: string; replayed: number }
-  | { type: "serialized-state"; requestId: string; id: string; state: string | null }
+  | {
+      type: "serialized-state";
+      requestId: string;
+      id: string;
+      state: SerializedTerminalSnapshot | null;
+    }
   | { type: "terminal-diagnostic-info"; requestId: string; info: TerminalInfoPayload | null }
   | { type: "available-terminals"; requestId: string; terminals: PtyHostTerminalInfo[] }
   | { type: "terminals-by-state"; requestId: string; terminals: PtyHostTerminalInfo[] }

--- a/shared/types/terminal.ts
+++ b/shared/types/terminal.ts
@@ -56,3 +56,49 @@ export interface TerminalActivityPayload extends TerminalActivity {
   /** Last detected command for this terminal (e.g., 'npm run dev') */
   lastCommand?: string;
 }
+
+/** A terminal grid size, in cells. */
+export interface TerminalGeometry {
+  cols: number;
+  rows: number;
+}
+
+/**
+ * A SerializeAddon snapshot bundled with the grid it was captured at (#11552).
+ *
+ * The addon emits a hard `\r\n` at every row boundary not marked `isWrapped`
+ * and omits the break where a row was exactly filled. Both encodings are only
+ * decodable at the capture width, so a snapshot replayed into a differently
+ * sized terminal commits real newlines mid-phrase and welds full-width rules
+ * onto the following line — damage no later reflow can undo, because it is
+ * baked into cell data. Carrying `cols`/`rows` alongside `data` lets every
+ * replay site size its target to the capture grid first, write, then reflow to
+ * the live grid with xterm's own algorithm.
+ */
+export interface SerializedTerminalSnapshot extends TerminalGeometry {
+  data: string;
+}
+
+/** Upper bound for a plausible terminal grid; guards replay against a corrupt or hostile geometry. */
+export const MAX_TERMINAL_GRID_DIMENSION = 2000;
+
+/**
+ * True when `value` is a grid a terminal could actually have been captured at.
+ * Replay sizes a real xterm to these numbers, so anything non-integral, zero,
+ * negative or absurd must degrade to "no geometry" (replay verbatim) rather
+ * than allocate a 2-billion-column buffer.
+ */
+export function isValidTerminalGeometry(value: unknown): value is TerminalGeometry {
+  if (typeof value !== "object" || value === null) return false;
+  const { cols, rows } = value as Partial<TerminalGeometry>;
+  return (
+    typeof cols === "number" &&
+    typeof rows === "number" &&
+    Number.isInteger(cols) &&
+    Number.isInteger(rows) &&
+    cols >= 1 &&
+    rows >= 1 &&
+    cols <= MAX_TERMINAL_GRID_DIMENSION &&
+    rows <= MAX_TERMINAL_GRID_DIMENSION
+  );
+}

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -10,6 +10,7 @@ import type {
   TerminalStatusPayload,
   BroadcastWriteResultPayload,
   SpawnResult,
+  SerializedTerminalSnapshot,
 } from "@shared/types";
 import type {
   PtyHostToRendererMessage,
@@ -755,7 +756,7 @@ export const terminalClient = {
    * Returns full terminal state including colors, formatting, cursor position.
    * Used for fast restoration on app reload.
    */
-  getSerializedState: (terminalId: string): Promise<string | null> => {
+  getSerializedState: (terminalId: string): Promise<SerializedTerminalSnapshot | null> => {
     return window.electron.terminal.getSerializedState(terminalId);
   },
 
@@ -763,7 +764,9 @@ export const terminalClient = {
    * Get serialized terminal states in a single round-trip.
    * Returns a map keyed by terminal ID with null for missing states.
    */
-  getSerializedStates: (panelIds: string[]): Promise<Record<string, string | null>> => {
+  getSerializedStates: (
+    panelIds: string[]
+  ): Promise<Record<string, SerializedTerminalSnapshot | null>> => {
     return window.electron.terminal.getSerializedStates(panelIds);
   },
 

--- a/src/services/actions/__tests__/terminalGetOutputAction.test.ts
+++ b/src/services/actions/__tests__/terminalGetOutputAction.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from "vitest";
 import { stripAnsiCodes } from "@shared/utils/artifactParser";
 
+/**
+ * Snapshots cross IPC with the grid they were captured at (#11552); this action
+ * only consumes the payload, so tests wrap their fixtures rather than restating
+ * the envelope at every call site.
+ */
+function snapshotOf(data: string | null): { data: string; cols: number; rows: number } | null {
+  return data === null ? null : { data, cols: 80, rows: 24 };
+}
+
 // Mock window.electron and window event listeners before any imports
 const mockGetSerializedState = vi.fn();
 const mockAddEventListener = vi.fn();
@@ -111,7 +120,7 @@ describe("terminal.getOutput action", () => {
 
   it("returns last N lines from terminal buffer", async () => {
     const mockBuffer = "line1\nline2\nline3\nline4\nline5";
-    mockGetSerializedState.mockResolvedValue(mockBuffer);
+    mockGetSerializedState.mockResolvedValue(snapshotOf(mockBuffer));
 
     const actions = await createRegistry();
     const actionFn = actions.get("terminal.getOutput");
@@ -130,7 +139,7 @@ describe("terminal.getOutput action", () => {
 
   it("returns all lines when buffer has fewer than maxLines", async () => {
     const mockBuffer = "line1\nline2\nline3";
-    mockGetSerializedState.mockResolvedValue(mockBuffer);
+    mockGetSerializedState.mockResolvedValue(snapshotOf(mockBuffer));
 
     const actions = await createRegistry();
     const actionFn = actions.get("terminal.getOutput");
@@ -150,7 +159,7 @@ describe("terminal.getOutput action", () => {
     // Generate 150 lines
     const lines = Array.from({ length: 150 }, (_, i) => `line${i + 1}`);
     const mockBuffer = lines.join("\n");
-    mockGetSerializedState.mockResolvedValue(mockBuffer);
+    mockGetSerializedState.mockResolvedValue(snapshotOf(mockBuffer));
 
     const actions = await createRegistry();
     const actionFn = actions.get("terminal.getOutput");
@@ -167,7 +176,7 @@ describe("terminal.getOutput action", () => {
 
   it("strips ANSI codes by default", async () => {
     const mockBuffer = "\x1b[32mgreen text\x1b[0m\n\x1b[31mred text\x1b[0m";
-    mockGetSerializedState.mockResolvedValue(mockBuffer);
+    mockGetSerializedState.mockResolvedValue(snapshotOf(mockBuffer));
 
     const actions = await createRegistry();
     const actionFn = actions.get("terminal.getOutput");
@@ -181,7 +190,7 @@ describe("terminal.getOutput action", () => {
 
   it("preserves ANSI codes when stripAnsi is false", async () => {
     const mockBuffer = "\x1b[32mgreen text\x1b[0m";
-    mockGetSerializedState.mockResolvedValue(mockBuffer);
+    mockGetSerializedState.mockResolvedValue(snapshotOf(mockBuffer));
 
     const actions = await createRegistry();
     const actionFn = actions.get("terminal.getOutput");
@@ -197,7 +206,7 @@ describe("terminal.getOutput action", () => {
   });
 
   it("returns null content for non-existent terminal", async () => {
-    mockGetSerializedState.mockResolvedValue(null);
+    mockGetSerializedState.mockResolvedValue(snapshotOf(null));
 
     const actions = await createRegistry();
     const actionFn = actions.get("terminal.getOutput");
@@ -213,7 +222,7 @@ describe("terminal.getOutput action", () => {
   });
 
   it("handles empty terminal buffer", async () => {
-    mockGetSerializedState.mockResolvedValue("");
+    mockGetSerializedState.mockResolvedValue(snapshotOf(""));
 
     const actions = await createRegistry();
     const actionFn = actions.get("terminal.getOutput");
@@ -230,7 +239,7 @@ describe("terminal.getOutput action", () => {
     // Generate 1500 lines
     const lines = Array.from({ length: 1500 }, (_, i) => `line${i + 1}`);
     const mockBuffer = lines.join("\n");
-    mockGetSerializedState.mockResolvedValue(mockBuffer);
+    mockGetSerializedState.mockResolvedValue(snapshotOf(mockBuffer));
 
     const actions = await createRegistry();
     const actionFn = actions.get("terminal.getOutput");
@@ -248,7 +257,7 @@ describe("terminal.getOutput action", () => {
 
   it("enforces maxLines lower bound of 1", async () => {
     const mockBuffer = "line1\nline2\nline3";
-    mockGetSerializedState.mockResolvedValue(mockBuffer);
+    mockGetSerializedState.mockResolvedValue(snapshotOf(mockBuffer));
 
     const actions = await createRegistry();
     const actionFn = actions.get("terminal.getOutput");
@@ -268,7 +277,7 @@ describe("terminal.getOutput action", () => {
     // and pads the bottom with bare-CR rows. A tail-before-normalize read of the
     // last 5 lines would return only blanks; normalize-then-tail must not.
     const mockBuffer = "agent answer line\nidle composer\r\n" + "\r\n".repeat(40);
-    mockGetSerializedState.mockResolvedValue(mockBuffer);
+    mockGetSerializedState.mockResolvedValue(snapshotOf(mockBuffer));
 
     const actions = await createRegistry();
     const action = actions.get("terminal.getOutput")!();
@@ -287,7 +296,7 @@ describe("terminal.getOutput action", () => {
   it("returns real content even for a single-line tail of a padded buffer", async () => {
     // N=1 boundary: padding must not occupy the only returned line.
     const mockBuffer = "the answer\r\n" + "\r\n".repeat(20);
-    mockGetSerializedState.mockResolvedValue(mockBuffer);
+    mockGetSerializedState.mockResolvedValue(snapshotOf(mockBuffer));
 
     const actions = await createRegistry();
     const action = actions.get("terminal.getOutput")!();
@@ -303,7 +312,7 @@ describe("terminal.getOutput action", () => {
 
   it("collapses interior blank runs and right-trims lines", async () => {
     const mockBuffer = "header   \n\n\n\nbody\t\n\n\nfooter";
-    mockGetSerializedState.mockResolvedValue(mockBuffer);
+    mockGetSerializedState.mockResolvedValue(snapshotOf(mockBuffer));
 
     const actions = await createRegistry();
     const action = actions.get("terminal.getOutput")!();
@@ -320,7 +329,7 @@ describe("terminal.getOutput action", () => {
 
   it("normalizes whitespace even when stripAnsi is false (padding still removed)", async () => {
     const mockBuffer = "\x1b[32mgreen\x1b[0m  \r\n\r\n\r\n\r\n";
-    mockGetSerializedState.mockResolvedValue(mockBuffer);
+    mockGetSerializedState.mockResolvedValue(snapshotOf(mockBuffer));
 
     const actions = await createRegistry();
     const action = actions.get("terminal.getOutput")!();

--- a/src/services/actions/definitions/__tests__/terminalGetStatusAction.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalGetStatusAction.test.ts
@@ -19,6 +19,22 @@ vi.mock("@shared/config/panelKindRegistry", () => ({
 
 import { registerTerminalQueryActions } from "../terminalQueryActions";
 
+/**
+ * Snapshots cross IPC bundled with the grid they were captured at (#11552).
+ * This action only reads the payload, so fixtures declare plain strings and
+ * this wraps them rather than restating the envelope at every call site.
+ */
+function snapshotMap(
+  entries: Record<string, string | null>
+): Record<string, { data: string; cols: number; rows: number } | null> {
+  return Object.fromEntries(
+    Object.entries(entries).map(([id, data]) => [
+      id,
+      data === null ? null : { data, cols: 80, rows: 24 },
+    ])
+  );
+}
+
 type StatusEntry = {
   terminalId: string;
   agentId: string | null;
@@ -384,11 +400,9 @@ describe("terminal.getStatus", () => {
         t3: { id: "t3", kind: "terminal", location: "grid", agentState: "waiting" },
       },
     });
-    getSerializedStatesMock.mockResolvedValue({
-      t1: "alpha\nbeta",
-      t2: "gamma",
-      t3: null,
-    });
+    getSerializedStatesMock.mockResolvedValue(
+      snapshotMap({ t1: "alpha\nbeta", t2: "gamma", t3: null })
+    );
 
     const { terminals } = await callGetStatus(setupActions(), {
       includeOutput: { lines: 10 },
@@ -409,9 +423,9 @@ describe("terminal.getStatus", () => {
     });
     // Codex-shaped buffer: answer + idle composer, then bottom blank padding
     // that would otherwise fill the small recentOutput window entirely.
-    getSerializedStatesMock.mockResolvedValue({
-      t1: "agent answer\nidle composer\r\n" + "\r\n".repeat(40),
-    });
+    getSerializedStatesMock.mockResolvedValue(
+      snapshotMap({ t1: "agent answer\nidle composer\r\n" + "\r\n".repeat(40) })
+    );
 
     const { terminals } = await callGetStatus(setupActions(), {
       includeOutput: { lines: 10 },
@@ -429,7 +443,7 @@ describe("terminal.getStatus", () => {
         t1: { id: "t1", kind: "terminal", location: "grid", agentState: "idle" },
       },
     });
-    getSerializedStatesMock.mockResolvedValue({ t1: lines });
+    getSerializedStatesMock.mockResolvedValue(snapshotMap({ t1: lines }));
 
     // The Zod schema rejects values >50 at the boundary, but the runtime guard
     // also clamps for callers that bypass schema validation. Test the runtime
@@ -451,14 +465,14 @@ describe("terminal.getStatus", () => {
       },
     });
     const ansi = "\x1b[31mred\x1b[0m";
-    getSerializedStatesMock.mockResolvedValue({ t1: ansi });
+    getSerializedStatesMock.mockResolvedValue(snapshotMap({ t1: ansi }));
 
     const stripped = await callGetStatus(setupActions(), {
       includeOutput: { lines: 10 },
     });
     expect(stripped.terminals[0]?.recentOutput).toBe("red");
 
-    getSerializedStatesMock.mockResolvedValue({ t1: ansi });
+    getSerializedStatesMock.mockResolvedValue(snapshotMap({ t1: ansi }));
     const raw = await callGetStatus(setupActions(), {
       includeOutput: { lines: 10, stripAnsi: false },
     });
@@ -589,7 +603,7 @@ describe("terminal.getStatus", () => {
         t1: { id: "t1", kind: "terminal", location: "grid", agentState: "idle" },
       },
     });
-    getSerializedStatesMock.mockResolvedValue({ t1: lines });
+    getSerializedStatesMock.mockResolvedValue(snapshotMap({ t1: lines }));
 
     const { terminals } = await callGetStatus(setupActions(), {
       includeOutput: { lines: 999 },
@@ -609,7 +623,7 @@ describe("terminal.getStatus", () => {
     });
     // t2 is omitted from the response (not even null) — distinct from the
     // "explicit null" failure mode of the IPC handler.
-    getSerializedStatesMock.mockResolvedValue({ t1: "alpha" });
+    getSerializedStatesMock.mockResolvedValue(snapshotMap({ t1: "alpha" }));
 
     const { terminals } = await callGetStatus(setupActions(), {
       includeOutput: { lines: 10 },

--- a/src/services/actions/definitions/terminalQueryActions.ts
+++ b/src/services/actions/definitions/terminalQueryActions.ts
@@ -10,6 +10,7 @@ import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import type { AgentState, WaitingReason } from "@shared/types/agent";
 import type { TerminalCheckResult } from "@shared/types/checkResult";
+import type { SerializedTerminalSnapshot } from "@shared/types/terminal";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import {
   MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS,
@@ -162,7 +163,7 @@ export function registerTerminalQueryActions(
       // below their composer (#10763). truncated/lineCount track normalized
       // content, so trailing padding never reads as "output omitted".
       const { content, lineCount, truncated } = tailCapturedOutput(
-        serializedState,
+        serializedState.data,
         effectiveMaxLines,
         stripAnsi
       );
@@ -299,7 +300,7 @@ export function registerTerminalQueryActions(
         typeof linesArg === "number" ? Math.min(Math.max(Math.floor(linesArg), 1), 50) : 20;
       const stripAnsi = includeOutput?.stripAnsi ?? true;
 
-      let outputs: Record<string, string | null> | null = null;
+      let outputs: Record<string, SerializedTerminalSnapshot | null> | null = null;
       let outputError: string | undefined;
       if (includeOutput) {
         const idsToFetch = resolved.filter((r) => r.terminal !== undefined).map((r) => r.id);
@@ -367,7 +368,7 @@ export function registerTerminalQueryActions(
               // Without this, a bottom-padding TUI's blank rows fill the small
               // last-N window and recentOutput reads as empty even when idle.
               entry.recentOutput = tailCapturedOutput(
-                serialized,
+                serialized.data,
                 effectiveLines,
                 stripAnsi
               ).content;

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -45,6 +45,7 @@ import {
 import { reduceScrollback, restoreScrollback } from "./TerminalScrollbackController";
 import { DEFAULT_TERMINAL_FONT_FAMILY, onTerminalFontArrivedLate } from "@/config/terminalFont";
 import { isPtyPanel } from "@shared/types/panel";
+import type { TerminalGeometry } from "@shared/types/terminal";
 import { applyXtermReflowFastpath } from "@shared/utils/xtermReflowFastpath";
 import { usePanelStore } from "@/store/panelStore";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
@@ -2650,20 +2651,36 @@ class TerminalInstanceService {
     this.restoreController.dispose();
   }
 
-  async restoreFetchedState(id: string, serializedState: string | null): Promise<boolean> {
-    return this.restoreController.restoreFetchedState(id, serializedState);
+  async restoreFetchedState(
+    id: string,
+    serializedState: string | null,
+    captureGeometry?: TerminalGeometry
+  ): Promise<boolean> {
+    return this.restoreController.restoreFetchedState(id, serializedState, captureGeometry);
   }
 
   async fetchAndRestore(id: string): Promise<boolean> {
     return this.restoreController.fetchAndRestore(id);
   }
 
-  restoreFromSerialized(id: string, serializedState: string): boolean {
-    return this.restoreController.restoreFromSerialized(id, serializedState);
+  restoreFromSerialized(
+    id: string,
+    serializedState: string,
+    captureGeometry?: TerminalGeometry
+  ): boolean {
+    return this.restoreController.restoreFromSerialized(id, serializedState, captureGeometry);
   }
 
-  restoreFromSerializedIncremental(id: string, serializedState: string): Promise<boolean> {
-    return this.restoreController.restoreFromSerializedIncremental(id, serializedState);
+  restoreFromSerializedIncremental(
+    id: string,
+    serializedState: string,
+    captureGeometry?: TerminalGeometry
+  ): Promise<boolean> {
+    return this.restoreController.restoreFromSerializedIncremental(
+      id,
+      serializedState,
+      captureGeometry
+    );
   }
 
   setInputLocked(id: string, locked: boolean): void {

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1352,9 +1352,13 @@ class TerminalInstanceService {
   private ensureOpened(id: string, managed: ManagedTerminal): void {
     if (managed.isOpened) return;
     // Seed xterm's grid before open() so cold-start restore paints at the
-    // saved size instead of flashing 80x24 then snapping (#6983).
+    // saved size instead of flashing 80x24 then snapping (#6983). Routed
+    // through the resize controller rather than xterm directly so it honours
+    // the serialized-restore gate: a cross-surface rebuild can have a replay
+    // already in flight here, and resizing out from under it would both undo
+    // the capture-width alignment and make the parked width look live (#11552).
     if (managed.targetCols && managed.targetRows) {
-      managed.terminal.resize(managed.targetCols, managed.targetRows);
+      this.resizeController.resizeTerminal(managed, managed.targetCols, managed.targetRows);
     }
     // terminalOpenStartedAt anchors the first-write delta (#9809).
     managed.terminalOpenStartedAt =

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1026,6 +1026,7 @@ class TerminalInstanceService {
       writeChain: Promise.resolve(),
       restoreGeneration: 0,
       isSerializedRestoreInProgress: false,
+      restoreWindowToken: 0,
       deferredOutput: [],
       scrollbackRestoreState: "none",
       attachGeneration: 0,

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -514,7 +514,25 @@ export class TerminalResizeController {
     return { cols, rows };
   }
 
+  /**
+   * The single choke point for every renderer-side xterm resize — all five
+   * internal callers (fit, deferred resync, fresh reconcile, commit) route
+   * here, which is why the serialized-restore gate lives here and nowhere else.
+   *
+   * While a restore replays, xterm is deliberately parked at the snapshot's
+   * capture width so the payload decodes correctly (#11552), and live output is
+   * deferred for exactly the same window. Applying a resize now would be
+   * undone by the normalization at the end of the replay; worse, the parked
+   * width would look like the live grid to whatever ran next. Record the
+   * intent instead — TerminalRestoreController drains it when it normalizes.
+   * The PTY side is not gated: callers still send the real geometry, so the
+   * agent keeps producing output sized for the grid the user can see.
+   */
   resizeTerminal(managed: ManagedTerminal, cols: number, rows: number): void {
+    if (managed.isSerializedRestoreInProgress) {
+      managed.pendingRestoreGeometry = { cols, rows };
+      return;
+    }
     managed.terminal.resize(cols, rows);
   }
 

--- a/src/services/terminal/TerminalRestoreController.ts
+++ b/src/services/terminal/TerminalRestoreController.ts
@@ -67,7 +67,7 @@ export class TerminalRestoreController {
    * `TerminalResizeController.resizeTerminal`), so it always holds the newest
    * intended geometry (#11552).
    */
-  private beginRestoreWindow(managed: ManagedTerminal): void {
+  private beginRestoreWindow(managed: ManagedTerminal): number {
     if (!managed.isSerializedRestoreInProgress) {
       managed.pendingRestoreGeometry = {
         cols: managed.terminal.cols,
@@ -75,6 +75,7 @@ export class TerminalRestoreController {
       };
     }
     managed.isSerializedRestoreInProgress = true;
+    return ++managed.restoreWindowToken;
   }
 
   /**
@@ -123,7 +124,10 @@ export class TerminalRestoreController {
    * the configured value straight back; it is a live-typing ergonomic, not
    * something to change globally.
    */
-  private endRestoreWindow(managed: ManagedTerminal): void {
+  private endRestoreWindow(managed: ManagedTerminal, token: number): void {
+    // A later window opened over this one — it owns the gate and the pending
+    // geometry now, and closing them here would reopen its deferral mid-replay.
+    if (managed.restoreWindowToken !== token) return;
     const target = managed.pendingRestoreGeometry;
     managed.pendingRestoreGeometry = undefined;
     managed.isSerializedRestoreInProgress = false;
@@ -175,6 +179,10 @@ export class TerminalRestoreController {
       return false;
     }
 
+    // -1 until a window is actually opened: token 0 is a legitimate value on a
+    // terminal that has never restored, and the catch below must not close a
+    // window this call never took.
+    let restoreWindow = -1;
     try {
       if (serializedState.length > INCREMENTAL_RESTORE_CONFIG.indicatorThresholdBytes) {
         void this.restoreFromSerializedIncremental(id, serializedState, captureGeometry);
@@ -182,7 +190,7 @@ export class TerminalRestoreController {
       }
 
       const restoreGeneration = ++managed.restoreGeneration;
-      this.beginRestoreWindow(managed);
+      restoreWindow = this.beginRestoreWindow(managed);
       managed.lastScrollbackRestoreError = undefined;
 
       const scrollBackOffset = managed.isUserScrolledBack
@@ -209,7 +217,7 @@ export class TerminalRestoreController {
           // Closed only now: the deferred chunks below were produced for the
           // live grid, so they must not be written while the pane is still
           // parked at the capture width.
-          this.endRestoreWindow(current);
+          this.endRestoreWindow(current, restoreWindow);
 
           if (scrollBackOffset > 0) {
             const newBaseY = current.terminal.buffer.active.baseY;
@@ -224,7 +232,7 @@ export class TerminalRestoreController {
       // The restore died synchronously (reset/resize/write threw). Put the pane
       // back on its live grid before releasing output — replaying live chunks
       // into a terminal parked at the capture width would corrupt them too.
-      this.endRestoreWindow(managed);
+      this.endRestoreWindow(managed, restoreWindow);
       managed.lastScrollbackRestoreError = classifyRestoreError(error);
       logError(`Failed to restore terminal ${id}`, error);
       // Release anything already deferred so its ledger charges settle and live
@@ -246,7 +254,7 @@ export class TerminalRestoreController {
     }
 
     const restoreGeneration = ++managed.restoreGeneration;
-    this.beginRestoreWindow(managed);
+    const restoreWindow = this.beginRestoreWindow(managed);
     managed.lastScrollbackRestoreError = undefined;
 
     const task = async (): Promise<boolean> => {
@@ -323,7 +331,7 @@ export class TerminalRestoreController {
           // is fully laid out at the capture grid by now and this reflow sees
           // the whole payload. A superseded generation never reaches here — its
           // successor is mid-replay at its own capture width and owns the grid.
-          this.endRestoreWindow(managed);
+          this.endRestoreWindow(managed, restoreWindow);
 
           if (scrollBackOffset > 0) {
             const newBaseY = managed.terminal.buffer.active.baseY;
@@ -350,7 +358,7 @@ export class TerminalRestoreController {
         this.deps.getInstance(id) === managed &&
         managed.restoreGeneration === restoreGeneration
       ) {
-        this.endRestoreWindow(managed);
+        this.endRestoreWindow(managed, restoreWindow);
         this.replayDeferred(id, managed);
       }
       return false;
@@ -385,12 +393,12 @@ export class TerminalRestoreController {
       return false;
     }
 
-    // Bump so this fetch owns a generation nothing else shares. Reading the
-    // current one instead let two concurrent fetches — or a fetch racing an
-    // in-flight incremental restore — both believe they owned the window, and
-    // whichever failed first would reopen the survivor's gate mid-replay.
-    const restoreGeneration = ++managed.restoreGeneration;
-    this.beginRestoreWindow(managed);
+    // Deliberately does NOT bump restoreGeneration: that would cancel any
+    // in-flight replay, and a fetch that then came back null would have killed
+    // a good restore and released output over a half-written buffer. The window
+    // token below is what makes ownership unique.
+    const restoreGeneration = managed.restoreGeneration;
+    const restoreWindow = this.beginRestoreWindow(managed);
     managed.lastScrollbackRestoreError = undefined;
 
     // The window this call opened is only ours to close while no newer restore
@@ -400,8 +408,7 @@ export class TerminalRestoreController {
     // capture-width alignment, at the wrong grid.
     const releaseIfStillOwned = (): void => {
       if (this.deps.getInstance(id) !== managed) return;
-      if (managed.restoreGeneration !== restoreGeneration) return;
-      this.endRestoreWindow(managed);
+      this.endRestoreWindow(managed, restoreWindow);
     };
 
     try {
@@ -457,6 +464,7 @@ export class TerminalRestoreController {
     if (!managed) return;
 
     managed.restoreGeneration++;
+    managed.restoreWindowToken++;
     managed.isSerializedRestoreInProgress = false;
     managed.pendingRestoreGeometry = undefined;
     managed.deferredOutput = [];

--- a/src/services/terminal/TerminalRestoreController.ts
+++ b/src/services/terminal/TerminalRestoreController.ts
@@ -3,6 +3,8 @@ import type { ManagedTerminal } from "./types";
 import { INCREMENTAL_RESTORE_CONFIG } from "./types";
 import { logWarn, logError } from "@/utils/logger";
 import type { TerminalScrollbackRestoreError } from "@shared/types/panel";
+import type { TerminalGeometry } from "@shared/types/terminal";
+import { isValidTerminalGeometry } from "@shared/types/terminal";
 
 function classifyRestoreError(error: unknown): TerminalScrollbackRestoreError {
   const timestamp = Date.now();
@@ -55,6 +57,83 @@ export class TerminalRestoreController {
   }
 
   /**
+   * Open the restore window, remembering the grid this pane must end up on.
+   *
+   * Only the OUTERMOST restore seeds the target: once a replay has parked xterm
+   * at a snapshot's capture width, `terminal.cols` describes the payload being
+   * written, not the pane, so a nested or superseding restore that sampled it
+   * would normalize to the wrong grid. Resizes that land mid-window overwrite
+   * this instead of touching xterm (see
+   * `TerminalResizeController.resizeTerminal`), so it always holds the newest
+   * intended geometry (#11552).
+   */
+  private beginRestoreWindow(managed: ManagedTerminal): void {
+    if (!managed.isSerializedRestoreInProgress) {
+      managed.pendingRestoreGeometry = {
+        cols: managed.terminal.cols,
+        rows: managed.terminal.rows,
+      };
+    }
+    managed.isSerializedRestoreInProgress = true;
+  }
+
+  /**
+   * Size xterm to the grid a snapshot was captured on, so SerializeAddon's
+   * wrap encoding decodes the way it was written.
+   *
+   * Returns false — replay verbatim, exactly as before this fix — when the
+   * snapshot carries no geometry (an older pty host across an upgrade, or a
+   * preserved snapshot captured pre-#11552), when the geometry is not a grid a
+   * terminal could plausibly have had, or when it already matches. Losing the
+   * session would be a worse compatibility policy than reproducing today's
+   * behaviour for payloads that predate the contract.
+   */
+  private alignToCaptureGeometry(
+    managed: ManagedTerminal,
+    captureGeometry: TerminalGeometry | undefined
+  ): boolean {
+    if (!isValidTerminalGeometry(captureGeometry)) return false;
+    if (
+      captureGeometry.cols === managed.terminal.cols &&
+      captureGeometry.rows === managed.terminal.rows
+    ) {
+      return false;
+    }
+    managed.terminal.resize(captureGeometry.cols, captureGeometry.rows);
+    return true;
+  }
+
+  /**
+   * Reflow the replayed buffer onto the grid the pane actually belongs on and
+   * close the restore window.
+   *
+   * `reflowCursorLine` is off by default in xterm, which leaves the wrapped
+   * group containing the cursor untouched by a resize — normalizing to a
+   * narrower grid would truncate that row's tail instead of wrapping it, and to
+   * a wider one would leave it split. Turn it on for this one corrective
+   * resize and put the configured value straight back; it is a live-typing
+   * ergonomic, not something to change globally.
+   */
+  private normalizeAfterReplay(managed: ManagedTerminal, aligned: boolean): void {
+    const target = managed.pendingRestoreGeometry;
+    managed.pendingRestoreGeometry = undefined;
+    if (!aligned || !target) return;
+    if (target.cols === managed.terminal.cols && target.rows === managed.terminal.rows) {
+      return;
+    }
+
+    const previous = managed.terminal.options.reflowCursorLine;
+    managed.terminal.options.reflowCursorLine = true;
+    try {
+      managed.terminal.resize(target.cols, target.rows);
+    } catch (error) {
+      logError(`Failed to restore terminal geometry after replay`, error);
+    } finally {
+      managed.terminal.options.reflowCursorLine = previous;
+    }
+  }
+
+  /**
    * Replay everything deferred while a restore was in progress. Deferred
    * entries carry live ledger charges (port-ack FIFO, IPC ledger, ingest
    * inFlightBytes) that only the replay write settles, so EVERY terminal
@@ -75,53 +154,84 @@ export class TerminalRestoreController {
     }
   }
 
-  restoreFromSerialized(id: string, serializedState: string): boolean {
+  restoreFromSerialized(
+    id: string,
+    serializedState: string,
+    captureGeometry?: TerminalGeometry
+  ): boolean {
     const managed = this.deps.getInstance(id);
     if (!managed) {
       logWarn(`Cannot restore: terminal ${id} not found`);
       return false;
     }
 
+    let aligned = false;
     try {
       if (serializedState.length > INCREMENTAL_RESTORE_CONFIG.indicatorThresholdBytes) {
-        void this.restoreFromSerializedIncremental(id, serializedState);
+        void this.restoreFromSerializedIncremental(id, serializedState, captureGeometry);
         return true;
       }
 
       const restoreGeneration = ++managed.restoreGeneration;
-      managed.isSerializedRestoreInProgress = true;
+      this.beginRestoreWindow(managed);
       managed.lastScrollbackRestoreError = undefined;
 
       const scrollBackOffset = managed.isUserScrolledBack
         ? managed.terminal.buffer.active.baseY - managed.terminal.buffer.active.viewportY
         : 0;
 
+      // Reset first, then align: reset is cheap and leaves cols/rows alone, so
+      // resizing afterwards reflows an empty buffer instead of the content the
+      // replay is about to discard. xterm parses asynchronously, so the grid
+      // must be correct before `write` — not after it returns.
       managed.terminal.reset();
+      aligned = this.alignToCaptureGeometry(managed, captureGeometry);
       managed.terminal.write(serializedState, () => {
-        const current = this.deps.getInstance(id);
-        if (current !== managed || managed.restoreGeneration !== restoreGeneration) return;
+        // Hop out of the write callback before touching geometry. The callback
+        // runs inside xterm's parser drain, and resizing there re-applies the
+        // chunk being drained against the new grid — a 4-cell write comes back
+        // as 8 — and can leave a queued write's callback stranded, which in this
+        // pipeline means permanently deferred output. A microtask lands after
+        // the drain completes and before anything else can write.
+        queueMicrotask(() => {
+          const current = this.deps.getInstance(id);
+          if (current !== managed || managed.restoreGeneration !== restoreGeneration) return;
 
-        if (scrollBackOffset > 0) {
-          const newBaseY = current.terminal.buffer.active.baseY;
-          current.terminal.scrollToLine(Math.max(0, newBaseY - scrollBackOffset));
-        }
+          this.normalizeAfterReplay(current, aligned);
 
-        current.isSerializedRestoreInProgress = false;
-        this.replayDeferred(id, current);
+          if (scrollBackOffset > 0) {
+            const newBaseY = current.terminal.buffer.active.baseY;
+            current.terminal.scrollToLine(Math.max(0, newBaseY - scrollBackOffset));
+          }
+
+          // Cleared only now: the deferred chunks below were produced for the
+          // live grid, so they must not be written while the pane is still
+          // parked at the capture width.
+          current.isSerializedRestoreInProgress = false;
+          this.replayDeferred(id, current);
+        });
       });
       return true;
     } catch (error) {
+      // The restore died synchronously (reset/resize/write threw). Put the pane
+      // back on its live grid before releasing output — replaying live chunks
+      // into a terminal parked at the capture width would corrupt them too.
+      this.normalizeAfterReplay(managed, aligned);
       managed.isSerializedRestoreInProgress = false;
       managed.lastScrollbackRestoreError = classifyRestoreError(error);
       logError(`Failed to restore terminal ${id}`, error);
-      // The restore died synchronously (reset/write threw) — release anything
-      // already deferred so its ledger charges settle and live output resumes.
+      // Release anything already deferred so its ledger charges settle and live
+      // output resumes.
       this.replayDeferred(id, managed);
       return false;
     }
   }
 
-  async restoreFromSerializedIncremental(id: string, serializedState: string): Promise<boolean> {
+  async restoreFromSerializedIncremental(
+    id: string,
+    serializedState: string,
+    captureGeometry?: TerminalGeometry
+  ): Promise<boolean> {
     const managed = this.deps.getInstance(id);
     if (!managed) {
       logWarn(`Cannot restore: terminal ${id} not found`);
@@ -129,13 +239,18 @@ export class TerminalRestoreController {
     }
 
     const restoreGeneration = ++managed.restoreGeneration;
-    managed.isSerializedRestoreInProgress = true;
+    this.beginRestoreWindow(managed);
     managed.lastScrollbackRestoreError = undefined;
 
     const task = async (): Promise<boolean> => {
       const scrollBackOffset = managed.isUserScrolledBack
         ? managed.terminal.buffer.active.baseY - managed.terminal.buffer.active.viewportY
         : 0;
+      // Tracks whether THIS attempt parked the grid. The finally below only
+      // normalizes when it did and still owns the terminal — a superseded
+      // generation must leave the grid to its successor, which is mid-replay
+      // at its own capture width.
+      let aligned = false;
 
       try {
         if (
@@ -146,6 +261,7 @@ export class TerminalRestoreController {
         }
 
         managed.terminal.reset();
+        aligned = this.alignToCaptureGeometry(managed, captureGeometry);
 
         let offset = 0;
         const total = serializedState.length;
@@ -202,6 +318,11 @@ export class TerminalRestoreController {
           this.deps.getInstance(id) === managed &&
           managed.restoreGeneration === restoreGeneration
         ) {
+          // Every chunk write was awaited to its parse callback, so the buffer
+          // is fully laid out at the capture grid by now and this reflow sees
+          // the whole payload.
+          this.normalizeAfterReplay(managed, aligned);
+
           if (scrollBackOffset > 0) {
             const newBaseY = managed.terminal.buffer.active.baseY;
             managed.terminal.scrollToLine(Math.max(0, newBaseY - scrollBackOffset));
@@ -239,17 +360,21 @@ export class TerminalRestoreController {
     return writePromise;
   }
 
-  async restoreFetchedState(id: string, serializedState: string | null): Promise<boolean> {
+  async restoreFetchedState(
+    id: string,
+    serializedState: string | null,
+    captureGeometry?: TerminalGeometry
+  ): Promise<boolean> {
     if (!serializedState) {
       logWarn(`No serialized state for terminal ${id}`);
       return false;
     }
 
     if (serializedState.length > INCREMENTAL_RESTORE_CONFIG.indicatorThresholdBytes) {
-      return await this.restoreFromSerializedIncremental(id, serializedState);
+      return await this.restoreFromSerializedIncremental(id, serializedState, captureGeometry);
     }
 
-    return this.restoreFromSerialized(id, serializedState);
+    return this.restoreFromSerialized(id, serializedState, captureGeometry);
   }
 
   async fetchAndRestore(id: string): Promise<boolean> {
@@ -260,33 +385,47 @@ export class TerminalRestoreController {
     }
 
     const restoreGeneration = managed.restoreGeneration;
-    managed.isSerializedRestoreInProgress = true;
+    this.beginRestoreWindow(managed);
     managed.lastScrollbackRestoreError = undefined;
 
+    // The gate this call opened is only ours to close while no newer restore
+    // has claimed the terminal. Clearing it unconditionally (as this used to)
+    // re-opens a successor's deferral mid-replay: its live output stops being
+    // held and lands on top of the snapshot it is still writing — and with the
+    // capture-width alignment below, at the wrong grid.
+    const releaseIfStillOwned = (): void => {
+      if (this.deps.getInstance(id) !== managed) return;
+      if (managed.restoreGeneration !== restoreGeneration) return;
+      managed.isSerializedRestoreInProgress = false;
+      managed.pendingRestoreGeometry = undefined;
+    };
+
     try {
-      const serializedState = await terminalClient.getSerializedState(id);
+      const snapshot = await terminalClient.getSerializedState(id);
 
       // Check staleness after IPC round-trip
       const current = this.deps.getInstance(id);
       if (current !== managed || managed.restoreGeneration !== restoreGeneration) {
-        managed.isSerializedRestoreInProgress = false;
+        releaseIfStillOwned();
         return false;
       }
 
       // restoreFetchedState will take over the isSerializedRestoreInProgress flag
-      const result = await this.restoreFetchedState(id, serializedState);
+      const result = await this.restoreFetchedState(id, snapshot?.data ?? null, snapshot ?? undefined);
       if (!result) {
-        managed.isSerializedRestoreInProgress = false;
-        // The restore never ran (null state) or failed — release anything
-        // deferred while we awaited the snapshot. replayDeferred empties the
-        // array, so a failure path that already replayed makes this a no-op.
+        // The restore never ran (null state) or failed. When it ran it bumped
+        // the generation and owns the gate — releaseIfStillOwned then correctly
+        // declines. Release anything deferred while we awaited the snapshot;
+        // replayDeferred empties the array, so a failure path that already
+        // replayed makes this a no-op.
+        releaseIfStillOwned();
         if (managed.restoreGeneration === restoreGeneration) {
           this.replayDeferred(id, managed);
         }
       }
       return result;
     } catch (error) {
-      managed.isSerializedRestoreInProgress = false;
+      releaseIfStillOwned();
       managed.lastScrollbackRestoreError = classifyRestoreError(error);
       logError(`Failed to fetch state for terminal ${id}`, error);
       // Output deferred during the failed snapshot fetch must not stay
@@ -315,6 +454,7 @@ export class TerminalRestoreController {
 
     managed.restoreGeneration++;
     managed.isSerializedRestoreInProgress = false;
+    managed.pendingRestoreGeometry = undefined;
     managed.deferredOutput = [];
   }
 

--- a/src/services/terminal/TerminalRestoreController.ts
+++ b/src/services/terminal/TerminalRestoreController.ts
@@ -81,43 +81,53 @@ export class TerminalRestoreController {
    * Size xterm to the grid a snapshot was captured on, so SerializeAddon's
    * wrap encoding decodes the way it was written.
    *
-   * Returns false — replay verbatim, exactly as before this fix — when the
-   * snapshot carries no geometry (an older pty host across an upgrade, or a
-   * preserved snapshot captured pre-#11552), when the geometry is not a grid a
-   * terminal could plausibly have had, or when it already matches. Losing the
-   * session would be a worse compatibility policy than reproducing today's
-   * behaviour for payloads that predate the contract.
+   * A no-op — replay verbatim, exactly as before this fix — when the snapshot
+   * carries no geometry (an older pty host across an upgrade, or a preserved
+   * snapshot captured pre-#11552), when the geometry is not a grid a terminal
+   * could plausibly have had, or when it already matches. Losing the session
+   * would be a worse compatibility policy than reproducing today's behaviour
+   * for payloads that predate the contract.
    */
   private alignToCaptureGeometry(
     managed: ManagedTerminal,
     captureGeometry: TerminalGeometry | undefined
-  ): boolean {
-    if (!isValidTerminalGeometry(captureGeometry)) return false;
+  ): void {
+    if (!isValidTerminalGeometry(captureGeometry)) return;
     if (
       captureGeometry.cols === managed.terminal.cols &&
       captureGeometry.rows === managed.terminal.rows
     ) {
-      return false;
+      return;
     }
     managed.terminal.resize(captureGeometry.cols, captureGeometry.rows);
-    return true;
   }
 
   /**
-   * Reflow the replayed buffer onto the grid the pane actually belongs on and
-   * close the restore window.
+   * Close the restore window: put the pane on the grid it belongs on and reopen
+   * the write gate. Every exit from a restore — success, throw, supersede,
+   * null snapshot — must run this exactly once, while it still owns the window.
+   *
+   * The target is `pendingRestoreGeometry`: seeded from the live grid when the
+   * window opened, overwritten by any resize that arrived while it was open.
+   * Applying it covers BOTH jobs with one resize — reflowing back from a
+   * capture-width replay, and landing a resize that `resizeTerminal` parked
+   * rather than applied. Gating this on "did we align?" would silently drop
+   * that parked resize on every geometry-less replay, leaving xterm on the old
+   * grid while the PTY had already been told the new one. It is a no-op when
+   * the grid already matches, which is the common case.
    *
    * `reflowCursorLine` is off by default in xterm, which leaves the wrapped
-   * group containing the cursor untouched by a resize — normalizing to a
-   * narrower grid would truncate that row's tail instead of wrapping it, and to
-   * a wider one would leave it split. Turn it on for this one corrective
-   * resize and put the configured value straight back; it is a live-typing
-   * ergonomic, not something to change globally.
+   * group containing the cursor untouched by a resize — reflowing to a narrower
+   * grid would truncate that row's tail instead of wrapping it, and to a wider
+   * one would leave it split. Turn it on for this one corrective resize and put
+   * the configured value straight back; it is a live-typing ergonomic, not
+   * something to change globally.
    */
-  private normalizeAfterReplay(managed: ManagedTerminal, aligned: boolean): void {
+  private endRestoreWindow(managed: ManagedTerminal): void {
     const target = managed.pendingRestoreGeometry;
     managed.pendingRestoreGeometry = undefined;
-    if (!aligned || !target) return;
+    managed.isSerializedRestoreInProgress = false;
+    if (!target) return;
     if (target.cols === managed.terminal.cols && target.rows === managed.terminal.rows) {
       return;
     }
@@ -165,7 +175,6 @@ export class TerminalRestoreController {
       return false;
     }
 
-    let aligned = false;
     try {
       if (serializedState.length > INCREMENTAL_RESTORE_CONFIG.indicatorThresholdBytes) {
         void this.restoreFromSerializedIncremental(id, serializedState, captureGeometry);
@@ -185,7 +194,7 @@ export class TerminalRestoreController {
       // replay is about to discard. xterm parses asynchronously, so the grid
       // must be correct before `write` — not after it returns.
       managed.terminal.reset();
-      aligned = this.alignToCaptureGeometry(managed, captureGeometry);
+      this.alignToCaptureGeometry(managed, captureGeometry);
       managed.terminal.write(serializedState, () => {
         // Hop out of the write callback before touching geometry. The callback
         // runs inside xterm's parser drain, and resizing there re-applies the
@@ -197,17 +206,16 @@ export class TerminalRestoreController {
           const current = this.deps.getInstance(id);
           if (current !== managed || managed.restoreGeneration !== restoreGeneration) return;
 
-          this.normalizeAfterReplay(current, aligned);
+          // Closed only now: the deferred chunks below were produced for the
+          // live grid, so they must not be written while the pane is still
+          // parked at the capture width.
+          this.endRestoreWindow(current);
 
           if (scrollBackOffset > 0) {
             const newBaseY = current.terminal.buffer.active.baseY;
             current.terminal.scrollToLine(Math.max(0, newBaseY - scrollBackOffset));
           }
 
-          // Cleared only now: the deferred chunks below were produced for the
-          // live grid, so they must not be written while the pane is still
-          // parked at the capture width.
-          current.isSerializedRestoreInProgress = false;
           this.replayDeferred(id, current);
         });
       });
@@ -216,8 +224,7 @@ export class TerminalRestoreController {
       // The restore died synchronously (reset/resize/write threw). Put the pane
       // back on its live grid before releasing output — replaying live chunks
       // into a terminal parked at the capture width would corrupt them too.
-      this.normalizeAfterReplay(managed, aligned);
-      managed.isSerializedRestoreInProgress = false;
+      this.endRestoreWindow(managed);
       managed.lastScrollbackRestoreError = classifyRestoreError(error);
       logError(`Failed to restore terminal ${id}`, error);
       // Release anything already deferred so its ledger charges settle and live
@@ -246,12 +253,6 @@ export class TerminalRestoreController {
       const scrollBackOffset = managed.isUserScrolledBack
         ? managed.terminal.buffer.active.baseY - managed.terminal.buffer.active.viewportY
         : 0;
-      // Tracks whether THIS attempt parked the grid. The finally below only
-      // normalizes when it did and still owns the terminal — a superseded
-      // generation must leave the grid to its successor, which is mid-replay
-      // at its own capture width.
-      let aligned = false;
-
       try {
         if (
           this.deps.getInstance(id) !== managed ||
@@ -261,7 +262,7 @@ export class TerminalRestoreController {
         }
 
         managed.terminal.reset();
-        aligned = this.alignToCaptureGeometry(managed, captureGeometry);
+        this.alignToCaptureGeometry(managed, captureGeometry);
 
         let offset = 0;
         const total = serializedState.length;
@@ -320,15 +321,15 @@ export class TerminalRestoreController {
         ) {
           // Every chunk write was awaited to its parse callback, so the buffer
           // is fully laid out at the capture grid by now and this reflow sees
-          // the whole payload.
-          this.normalizeAfterReplay(managed, aligned);
+          // the whole payload. A superseded generation never reaches here — its
+          // successor is mid-replay at its own capture width and owns the grid.
+          this.endRestoreWindow(managed);
 
           if (scrollBackOffset > 0) {
             const newBaseY = managed.terminal.buffer.active.baseY;
             managed.terminal.scrollToLine(Math.max(0, newBaseY - scrollBackOffset));
           }
 
-          managed.isSerializedRestoreInProgress = false;
           this.replayDeferred(id, managed);
         }
       }
@@ -349,7 +350,7 @@ export class TerminalRestoreController {
         this.deps.getInstance(id) === managed &&
         managed.restoreGeneration === restoreGeneration
       ) {
-        managed.isSerializedRestoreInProgress = false;
+        this.endRestoreWindow(managed);
         this.replayDeferred(id, managed);
       }
       return false;
@@ -384,20 +385,23 @@ export class TerminalRestoreController {
       return false;
     }
 
-    const restoreGeneration = managed.restoreGeneration;
+    // Bump so this fetch owns a generation nothing else shares. Reading the
+    // current one instead let two concurrent fetches — or a fetch racing an
+    // in-flight incremental restore — both believe they owned the window, and
+    // whichever failed first would reopen the survivor's gate mid-replay.
+    const restoreGeneration = ++managed.restoreGeneration;
     this.beginRestoreWindow(managed);
     managed.lastScrollbackRestoreError = undefined;
 
-    // The gate this call opened is only ours to close while no newer restore
-    // has claimed the terminal. Clearing it unconditionally (as this used to)
+    // The window this call opened is only ours to close while no newer restore
+    // has claimed the terminal. Closing it unconditionally (as this used to)
     // re-opens a successor's deferral mid-replay: its live output stops being
     // held and lands on top of the snapshot it is still writing — and with the
-    // capture-width alignment below, at the wrong grid.
+    // capture-width alignment, at the wrong grid.
     const releaseIfStillOwned = (): void => {
       if (this.deps.getInstance(id) !== managed) return;
       if (managed.restoreGeneration !== restoreGeneration) return;
-      managed.isSerializedRestoreInProgress = false;
-      managed.pendingRestoreGeometry = undefined;
+      this.endRestoreWindow(managed);
     };
 
     try {

--- a/src/services/terminal/TerminalRestoreController.ts
+++ b/src/services/terminal/TerminalRestoreController.ts
@@ -422,7 +422,11 @@ export class TerminalRestoreController {
       }
 
       // restoreFetchedState will take over the isSerializedRestoreInProgress flag
-      const result = await this.restoreFetchedState(id, snapshot?.data ?? null, snapshot ?? undefined);
+      const result = await this.restoreFetchedState(
+        id,
+        snapshot?.data ?? null,
+        snapshot ?? undefined
+      );
       if (!result) {
         // The restore never ran (null state) or failed. When it ran it bumped
         // the generation and owns the gate — releaseIfStillOwned then correctly

--- a/src/services/terminal/__tests__/TerminalInstanceService.batchResize.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.batchResize.test.ts
@@ -125,6 +125,7 @@ function makeManaged(fixture: ManagedFixture): ManagedTerminal {
     writeChain: Promise.resolve(),
     restoreGeneration: 0,
     isSerializedRestoreInProgress: false,
+    restoreWindowToken: 0,
     deferredOutput: [],
     scrollbackRestoreState: "none",
     attachGeneration: 0,

--- a/src/services/terminal/__tests__/TerminalInstanceService.paintFabric.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.paintFabric.test.ts
@@ -201,7 +201,11 @@ describe("paint fabric construction seam", () => {
     await new Promise<void>((resolve) => managed.terminal.write("pre-move content", resolve));
 
     // The pty-host owns the canonical scrollback; the transfer restores it.
-    vi.mocked(terminalClient.getSerializedState).mockResolvedValue("restored-across-surfaces\r\n");
+    vi.mocked(terminalClient.getSerializedState).mockResolvedValue({
+      data: "restored-across-surfaces\r\n",
+      cols: 80,
+      rows: 24,
+    });
 
     const moved = await compositor.transferTerminal("move-me", "surface-aux-1");
     expect(moved).toBe(true);

--- a/src/services/terminal/__tests__/TerminalInstanceService.resizePass.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.resizePass.test.ts
@@ -114,6 +114,7 @@ function makeManaged(visible = true, id = "term"): ManagedTerminal {
     writeChain: Promise.resolve(),
     restoreGeneration: 0,
     isSerializedRestoreInProgress: false,
+    restoreWindowToken: 0,
     deferredOutput: [],
     scrollbackRestoreState: "none",
     attachGeneration: 0,

--- a/src/services/terminal/__tests__/TerminalRestoreController.replay.test.ts
+++ b/src/services/terminal/__tests__/TerminalRestoreController.replay.test.ts
@@ -1,0 +1,187 @@
+// @vitest-environment node
+//
+// Real xterm buffers, no DOM: `@xterm/headless` is the same core the pty-host
+// mirror runs, so reflow behaviour here is the behaviour that ships. The
+// renderer's `@xterm/xterm` needs a live renderer to settle its write queue,
+// which jsdom cannot provide.
+import { describe, it, expect, vi } from "vitest";
+import { Terminal } from "@xterm/headless";
+import { SerializeAddon } from "@xterm/addon-serialize";
+import { TerminalRestoreController } from "../TerminalRestoreController";
+import type { ManagedTerminal } from "../types";
+import type { SerializedTerminalSnapshot } from "@shared/types/terminal";
+
+vi.mock("@/clients", () => ({
+  terminalClient: { getSerializedState: vi.fn() },
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logWarn: vi.fn(),
+  logError: vi.fn(),
+}));
+
+/**
+ * Replay fidelity against a real xterm, not a mock (#11552).
+ *
+ * The contract a snapshot replay owes its caller is that the pane ends up in
+ * the state it would have been in had the captured buffer simply been reflowed
+ * to the live width. Measured against our pinned xterm, a verbatim
+ * wrong-width replay preserves cell content and wrap flags but lands the CURSOR
+ * on the wrong column — it re-derives the cursor from where the payload happens
+ * to end at the replay width. That is not cosmetic: agent CLIs paint with
+ * cursor-relative motion and erase-to-end-of-line, so every repaint after a
+ * mis-placed restore writes against the wrong cells, and the damage only clears
+ * once the agent redraws the region from scratch.
+ *
+ * These tests compare a restore against a twin terminal that was reflowed
+ * rather than replayed, so they assert the invariant instead of a value copied
+ * out of the implementation.
+ */
+describe("TerminalRestoreController replay fidelity (real xterm)", () => {
+  /** Settle xterm's async parser queue. */
+  const flush = (terminal: Terminal): Promise<void> =>
+    new Promise<void>((resolve) => terminal.write("", () => resolve()));
+
+  const writeAndFlush = (terminal: Terminal, data: string): Promise<void> =>
+    new Promise<void>((resolve) => terminal.write(data, () => resolve()));
+
+  function makeTerminal(cols: number, rows = 10): Terminal {
+    return new Terminal({ cols, rows, scrollback: 200, allowProposedApi: true });
+  }
+
+  /** Capture a snapshot the way the pty-host mirror does. */
+  async function capture(
+    cols: number,
+    content: string
+  ): Promise<{ snapshot: SerializedTerminalSnapshot; source: Terminal }> {
+    const source = makeTerminal(cols);
+    const addon = new SerializeAddon();
+    source.loadAddon(addon);
+    await writeAndFlush(source, content);
+    return { snapshot: { data: addon.serialize(), cols, rows: source.rows }, source };
+  }
+
+  /** The state the captured buffer reaches by reflow alone — the ground truth. */
+  async function reflowed(source: Terminal, toCols: number): Promise<Terminal> {
+    source.options.reflowCursorLine = true;
+    source.resize(toCols, source.rows);
+    source.options.reflowCursorLine = false;
+    await flush(source);
+    return source;
+  }
+
+  function readBuffer(terminal: Terminal): string[] {
+    const buffer = terminal.buffer.active;
+    const lines: string[] = [];
+    for (let i = 0; i < buffer.length; i++) {
+      const line = buffer.getLine(i);
+      if (!line) continue;
+      const text = line.translateToString(true);
+      if (text.length > 0) lines.push(`${line.isWrapped ? "W" : "H"}${text}`);
+    }
+    return lines;
+  }
+
+  const cursorOf = (terminal: Terminal) =>
+    `${terminal.buffer.active.cursorX},${terminal.buffer.active.cursorY}`;
+
+  function makeController(terminal: Terminal): {
+    controller: TerminalRestoreController;
+    managed: ManagedTerminal;
+  } {
+    const managed = {
+      terminal,
+      writeChain: Promise.resolve(),
+      restoreGeneration: 0,
+      isSerializedRestoreInProgress: false,
+      deferredOutput: [],
+      isUserScrolledBack: false,
+    } as unknown as ManagedTerminal;
+    const controller = new TerminalRestoreController({
+      getInstance: (id) => (id === "t1" ? managed : undefined),
+      writeData: vi.fn(),
+    });
+    return { controller, managed };
+  }
+
+  // No trailing newline: the cursor is parked inside a wrapped group, which is
+  // exactly where an agent leaves it between repaints.
+  const WRAPPED_LINE = "Tip: press enter and the result will display beneath the input box";
+
+  it.each([
+    { label: "widening", captureCols: 40, liveCols: 100, content: WRAPPED_LINE },
+    { label: "narrowing", captureCols: 100, liveCols: 40, content: WRAPPED_LINE },
+    {
+      label: "wide (CJK) cells",
+      captureCols: 40,
+      liveCols: 100,
+      content: "日本語テキストの長い行".repeat(4),
+    },
+    {
+      label: "row filled exactly to the capture width",
+      captureCols: 100,
+      liveCols: 40,
+      content: `${"D".repeat(100)}TAIL`,
+    },
+  ])(
+    "restores the reflow-equivalent buffer and cursor when $label",
+    async ({ captureCols, liveCols, content }) => {
+      const { snapshot, source } = await capture(captureCols, content);
+      const truth = await reflowed(source, liveCols);
+
+      const live = makeTerminal(liveCols);
+      const { controller } = makeController(live);
+      controller.restoreFromSerialized("t1", snapshot.data, snapshot);
+      await flush(live);
+
+      expect(live.cols).toBe(liveCols);
+      expect(readBuffer(live)).toEqual(readBuffer(truth));
+      expect(cursorOf(live)).toBe(cursorOf(truth));
+    }
+  );
+
+  it("verbatim replay misplaces the cursor — the defect the alignment removes", async () => {
+    const { snapshot, source } = await capture(40, WRAPPED_LINE);
+    const truth = await reflowed(source, 100);
+
+    // Exactly what the restore path did before the geometry contract existed.
+    const verbatim = makeTerminal(100);
+    verbatim.reset();
+    verbatim.write(snapshot.data);
+    await flush(verbatim);
+
+    // Content survives, so a content-only assertion would pass either way and
+    // prove nothing — the cursor is what actually diverges.
+    expect(readBuffer(verbatim)).toEqual(readBuffer(truth));
+    expect(cursorOf(verbatim)).not.toBe(cursorOf(truth));
+  });
+
+  it("aligns the incremental path the same way", async () => {
+    const bulk = `${WRAPPED_LINE}\r\n`.repeat(40) + WRAPPED_LINE;
+    const { snapshot, source } = await capture(40, bulk);
+    const truth = await reflowed(source, 100);
+
+    const live = makeTerminal(100);
+    const { controller } = makeController(live);
+    await controller.restoreFromSerializedIncremental("t1", snapshot.data, snapshot);
+    await flush(live);
+
+    expect(live.cols).toBe(100);
+    expect(readBuffer(live)).toEqual(readBuffer(truth));
+    expect(cursorOf(live)).toBe(cursorOf(truth));
+  });
+
+  it("replays a geometry-less snapshot without touching the live grid", async () => {
+    const { snapshot } = await capture(40, WRAPPED_LINE);
+
+    const live = makeTerminal(100);
+    const { controller } = makeController(live);
+    // Pre-#11552 payload: no geometry to align to, so it must behave exactly as
+    // it always did rather than refuse the restore and lose the session.
+    controller.restoreFromSerialized("t1", snapshot.data);
+    await flush(live);
+
+    expect(live.cols).toBe(100);
+    expect(readBuffer(live).length).toBeGreaterThan(0);
+  });
+});

--- a/src/services/terminal/__tests__/TerminalRestoreController.replay.test.ts
+++ b/src/services/terminal/__tests__/TerminalRestoreController.replay.test.ts
@@ -93,6 +93,7 @@ describe("TerminalRestoreController replay fidelity (real xterm)", () => {
       terminal,
       writeChain: Promise.resolve(),
       restoreGeneration: 0,
+      restoreWindowToken: 0,
       isSerializedRestoreInProgress: false,
       deferredOutput: [],
       isUserScrolledBack: false,

--- a/src/services/terminal/__tests__/TerminalRestoreController.test.ts
+++ b/src/services/terminal/__tests__/TerminalRestoreController.test.ts
@@ -4,11 +4,7 @@ import { INCREMENTAL_RESTORE_CONFIG, type ManagedTerminal } from "../types";
 import type { SerializedTerminalSnapshot } from "@shared/types/terminal";
 
 /** Wrap a payload in the snapshot envelope the IPC now returns (#11552). */
-function snapshot(
-  data: string,
-  cols = 80,
-  rows = 24
-): SerializedTerminalSnapshot {
+function snapshot(data: string, cols = 80, rows = 24): SerializedTerminalSnapshot {
   return { data, cols, rows };
 }
 
@@ -626,7 +622,6 @@ describe("TerminalRestoreController", () => {
       expect(managed.deferredOutput).toHaveLength(0);
     });
   });
-
 
   describe("capture-geometry alignment (#11552)", () => {
     // SerializeAddon encodes wrap state that only decodes at the width it was

--- a/src/services/terminal/__tests__/TerminalRestoreController.test.ts
+++ b/src/services/terminal/__tests__/TerminalRestoreController.test.ts
@@ -793,6 +793,40 @@ describe("TerminalRestoreController", () => {
       expect(writeDataSpy).toHaveBeenCalledWith("t1", "held", 2);
     });
 
+    it("applies a resize parked mid-replay even when the snapshot needed no alignment", async () => {
+      const trace = traceGrid();
+      const managed = makeManagedTerminal();
+      instances.set("t1", managed);
+
+      // Geometry-less snapshot (legacy payload): nothing to align to, so the
+      // replay never parks the grid. A resize arriving during the window is
+      // still held by resizeTerminal, and dropping it here would leave xterm on
+      // the old grid while the PTY had already been told the new one.
+      controller.restoreFromSerialized("t1", "payload");
+      managed.pendingRestoreGeometry = { cols: 120, rows: 30 };
+      await flushMicrotasks();
+
+      expect(trace.at(-1)).toBe("resize:120x30");
+      expect(managed.pendingRestoreGeometry).toBeUndefined();
+    });
+
+    it("applies a parked resize when the fetched snapshot comes back null", async () => {
+      const { terminalClient } = await import("@/clients");
+      vi.mocked(terminalClient.getSerializedState).mockResolvedValue(null);
+      const trace = traceGrid();
+      const managed = makeManagedTerminal();
+      instances.set("t1", managed);
+
+      const promise = controller.fetchAndRestore("t1");
+      managed.pendingRestoreGeometry = { cols: 90, rows: 20 };
+      await promise;
+
+      // No restore ran, but the window was open across the IPC round-trip, so
+      // whatever it swallowed still has to land.
+      expect(trace.at(-1)).toBe("resize:90x20");
+      expect(managed.isSerializedRestoreInProgress).toBe(false);
+    });
+
     it("aligns the incremental path and normalizes once every chunk has parsed", async () => {
       const trace = traceGrid();
       const managed = makeManagedTerminal();

--- a/src/services/terminal/__tests__/TerminalRestoreController.test.ts
+++ b/src/services/terminal/__tests__/TerminalRestoreController.test.ts
@@ -119,6 +119,7 @@ describe("TerminalRestoreController", () => {
       terminal: mockTerminal,
       writeChain: Promise.resolve(),
       restoreGeneration: 0,
+      restoreWindowToken: 0,
       isSerializedRestoreInProgress: false,
       deferredOutput: [],
       isUserScrolledBack: false,
@@ -791,6 +792,46 @@ describe("TerminalRestoreController", () => {
       expect(result).toBe(false);
       expect(trace.at(-1)).toBe("resize:170x24");
       expect(writeDataSpy).toHaveBeenCalledWith("t1", "held", 2);
+    });
+
+    it("does not let a failing fetch close a window a later restore opened", async () => {
+      const { terminalClient } = await import("@/clients");
+      let resolveFetch!: (value: SerializedTerminalSnapshot | null) => void;
+      vi.mocked(terminalClient.getSerializedState).mockImplementation(
+        () => new Promise((resolve) => (resolveFetch = resolve))
+      );
+      const managed = makeManagedTerminal();
+      instances.set("t1", managed);
+
+      const fetchPromise = controller.fetchAndRestore("t1");
+      await flushMicrotasks();
+
+      // A restore starts and takes over the window while the fetch is still
+      // waiting on IPC. Its write callback is dropped so it stays mid-replay.
+      mockTerminal.write.mockImplementationOnce(() => {});
+      controller.restoreFromSerialized("t1", "newer", { cols: 80, rows: 24 });
+      expect(managed.isSerializedRestoreInProgress).toBe(true);
+
+      // The fetch now comes back empty. It must not reopen the gate underneath
+      // the restore that is still writing.
+      resolveFetch(null);
+      await fetchPromise;
+
+      expect(managed.isSerializedRestoreInProgress).toBe(true);
+    });
+
+    it("does not cancel an in-flight restore just to identify its own window", async () => {
+      const { terminalClient } = await import("@/clients");
+      vi.mocked(terminalClient.getSerializedState).mockResolvedValue(null);
+      const managed = makeManagedTerminal();
+      instances.set("t1", managed);
+
+      const generationBefore = managed.restoreGeneration;
+      await controller.fetchAndRestore("t1");
+
+      // Bumping restoreGeneration to claim ownership would abort whatever was
+      // replaying — and this fetch had no replacement to put in its place.
+      expect(managed.restoreGeneration).toBe(generationBefore);
     });
 
     it("applies a resize parked mid-replay even when the snapshot needed no alignment", async () => {

--- a/src/services/terminal/__tests__/TerminalRestoreController.test.ts
+++ b/src/services/terminal/__tests__/TerminalRestoreController.test.ts
@@ -1,6 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { TerminalRestoreController, safeChunkSlice } from "../TerminalRestoreController";
 import { INCREMENTAL_RESTORE_CONFIG, type ManagedTerminal } from "../types";
+import type { SerializedTerminalSnapshot } from "@shared/types/terminal";
+
+/** Wrap a payload in the snapshot envelope the IPC now returns (#11552). */
+function snapshot(
+  data: string,
+  cols = 80,
+  rows = 24
+): SerializedTerminalSnapshot {
+  return { data, cols, rows };
+}
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -23,6 +33,9 @@ describe("TerminalRestoreController", () => {
   let writeCallId: number;
   let postTaskCallbacks: Array<() => void>;
   let yieldCallbacks: Array<() => void>;
+  // Standalone so a test can wrap `write` without reading the mock back out of
+  // itself — doing that re-enters the wrapper and recurses until the stack dies.
+  let baseWriteImpl: (data: string, callback?: () => void) => void;
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -51,27 +64,35 @@ describe("TerminalRestoreController", () => {
       }),
     });
 
+    baseWriteImpl = (_data: string, callback?: () => void) => {
+      if (callback) {
+        const id = ++writeCallId;
+        writeCallbacks.set(id, callback);
+        queueMicrotask(() => {
+          const cb = writeCallbacks.get(id);
+          if (cb) {
+            cb();
+            writeCallbacks.delete(id);
+          }
+        });
+      }
+    };
+
     mockTerminal = {
       reset: vi.fn(),
-      write: vi.fn((_data: string, callback?: () => void) => {
-        if (callback) {
-          const id = ++writeCallId;
-          writeCallbacks.set(id, callback);
-          queueMicrotask(() => {
-            const cb = writeCallbacks.get(id);
-            if (cb) {
-              cb();
-              writeCallbacks.delete(id);
-            }
-          });
-        }
-      }),
+      write: vi.fn(baseWriteImpl),
       scrollToLine: vi.fn(),
       scrollToBottom: vi.fn(),
       buffer: {
         active: { baseY: 0, viewportY: 0, length: 100 },
       },
+      cols: 170,
       rows: 24,
+      options: { reflowCursorLine: false },
+      resize: vi.fn((cols: number, rows: number) => {
+        mockTerminal.cols = cols;
+        mockTerminal.rows = rows;
+      }),
     };
 
     instances = new Map();
@@ -435,7 +456,7 @@ describe("TerminalRestoreController", () => {
   describe("fetchAndRestore", () => {
     it("sets isSerializedRestoreInProgress before IPC fetch resolves", async () => {
       const { terminalClient } = await import("@/clients");
-      let resolveFetch!: (value: string | null) => void;
+      let resolveFetch!: (value: SerializedTerminalSnapshot | null) => void;
       vi.mocked(terminalClient.getSerializedState).mockImplementation(
         () =>
           new Promise((resolve) => {
@@ -452,14 +473,14 @@ describe("TerminalRestoreController", () => {
       // Flag should be set BEFORE the IPC call resolves
       expect(managed.isSerializedRestoreInProgress).toBe(true);
 
-      resolveFetch("small-state");
+      resolveFetch(snapshot("small-state"));
       await flushMicrotasks();
       await promise;
     });
 
     it("returns false and clears flag when terminal becomes stale during fetch", async () => {
       const { terminalClient } = await import("@/clients");
-      let resolveFetch!: (value: string | null) => void;
+      let resolveFetch!: (value: SerializedTerminalSnapshot | null) => void;
       vi.mocked(terminalClient.getSerializedState).mockImplementation(
         () =>
           new Promise((resolve) => {
@@ -476,7 +497,7 @@ describe("TerminalRestoreController", () => {
       // Simulate terminal being destroyed during fetch
       controller.destroy("t1");
 
-      resolveFetch("state-data");
+      resolveFetch(snapshot("state-data"));
       const result = await promise;
 
       expect(result).toBe(false);
@@ -489,7 +510,7 @@ describe("TerminalRestoreController", () => {
 
     it("clears isSerializedRestoreInProgress when serialized state is null", async () => {
       const { terminalClient } = await import("@/clients");
-      vi.mocked(terminalClient.getSerializedState).mockResolvedValue(null as unknown as string);
+      vi.mocked(terminalClient.getSerializedState).mockResolvedValue(null);
 
       const managed = makeManagedTerminal();
       instances.set("t1", managed);
@@ -506,7 +527,7 @@ describe("TerminalRestoreController", () => {
       // release them by replaying, or the ingest queue strands invisibly
       // (getStalledBytes reads inFlightBytes>0 as healthy).
       const { terminalClient } = await import("@/clients");
-      let resolveFetch!: (value: string | null) => void;
+      let resolveFetch!: (value: SerializedTerminalSnapshot | null) => void;
       vi.mocked(terminalClient.getSerializedState).mockImplementation(
         () =>
           new Promise((resolve) => {
@@ -605,6 +626,218 @@ describe("TerminalRestoreController", () => {
     });
   });
 
+
+  describe("capture-geometry alignment (#11552)", () => {
+    // SerializeAddon encodes wrap state that only decodes at the width it was
+    // captured on, and the damage a mismatched replay commits into cell data is
+    // not repairable by any later reflow. These tests pin the ordering that
+    // makes replay safe, not the fact that a resize happens.
+    const captureAt80 = { cols: 80, rows: 24 };
+
+    /** Ordered log of what happened to the grid, so ordering is assertable. */
+    function traceGrid() {
+      const trace: string[] = [];
+      mockTerminal.reset.mockImplementation(() => trace.push("reset"));
+      mockTerminal.resize.mockImplementation((cols: number, rows: number) => {
+        mockTerminal.cols = cols;
+        mockTerminal.rows = rows;
+        trace.push(`resize:${cols}x${rows}`);
+      });
+      mockTerminal.write.mockImplementation((data: string, callback?: () => void) => {
+        trace.push(`write:${data}`);
+        baseWriteImpl(data, callback);
+      });
+      return trace;
+    }
+
+    it("writes the payload at the capture grid, then reflows to the live grid", async () => {
+      const trace = traceGrid();
+      const managed = makeManagedTerminal();
+      instances.set("t1", managed);
+
+      controller.restoreFromSerialized("t1", "payload", captureAt80);
+      await flushMicrotasks();
+
+      // The resize must land between reset and write: xterm parses
+      // asynchronously, so a grid corrected after write() returns would arrive
+      // too late and the payload would lay out at the wrong width anyway.
+      expect(trace).toEqual(["reset", "resize:80x24", "write:payload", "resize:170x24"]);
+      expect(managed.terminal.cols).toBe(170);
+    });
+
+    it("leaves the grid untouched when the capture already matches", async () => {
+      traceGrid();
+      const managed = makeManagedTerminal();
+      instances.set("t1", managed);
+
+      controller.restoreFromSerialized("t1", "payload", { cols: 170, rows: 24 });
+      await flushMicrotasks();
+
+      expect(mockTerminal.resize).not.toHaveBeenCalled();
+    });
+
+    it("replays verbatim when the snapshot predates the geometry contract", async () => {
+      traceGrid();
+      const managed = makeManagedTerminal();
+      instances.set("t1", managed);
+
+      // An older pty host, or a preserved snapshot captured before #11552.
+      // Reproducing today's behaviour beats dropping the session outright.
+      controller.restoreFromSerialized("t1", "payload");
+      await flushMicrotasks();
+
+      expect(mockTerminal.resize).not.toHaveBeenCalled();
+      expect(mockTerminal.write).toHaveBeenCalledWith("payload", expect.any(Function));
+    });
+
+    it("refuses a geometry no terminal could have been captured at", async () => {
+      traceGrid();
+      const managed = makeManagedTerminal();
+      instances.set("t1", managed);
+
+      controller.restoreFromSerialized("t1", "payload", { cols: 0, rows: -4 });
+      await flushMicrotasks();
+
+      expect(mockTerminal.resize).not.toHaveBeenCalled();
+    });
+
+    it("normalizes to a resize that landed mid-replay, not the pre-replay grid", async () => {
+      const trace = traceGrid();
+      const managed = makeManagedTerminal();
+      instances.set("t1", managed);
+
+      controller.restoreFromSerialized("t1", "payload", captureAt80);
+      // A layout change while xterm is parked at the capture width. The resize
+      // controller parks it here rather than applying it; without that, the
+      // normalization below would reflow it straight back out.
+      managed.pendingRestoreGeometry = { cols: 120, rows: 30 };
+      await flushMicrotasks();
+
+      expect(trace.at(-1)).toBe("resize:120x30");
+      expect(managed.pendingRestoreGeometry).toBeUndefined();
+    });
+
+    it("keeps the live grid across a superseding restore instead of adopting the capture width", async () => {
+      const managed = makeManagedTerminal();
+      instances.set("t1", managed);
+
+      // First restore parks the grid at 80 and never completes (its callback is
+      // dropped), leaving terminal.cols describing the payload, not the pane.
+      mockTerminal.write.mockImplementationOnce(() => {});
+      controller.restoreFromSerialized("t1", "first", captureAt80);
+      expect(managed.terminal.cols).toBe(80);
+
+      // The successor must normalize to 170 — the grid the pane actually has —
+      // not to the 80 it would read off terminal.cols right now.
+      controller.restoreFromSerialized("t1", "second", { cols: 100, rows: 24 });
+      await flushMicrotasks();
+
+      expect(managed.terminal.cols).toBe(170);
+    });
+
+    it("enables reflowCursorLine only for the corrective resize", async () => {
+      const managed = makeManagedTerminal();
+      instances.set("t1", managed);
+      const seenDuringResize: Array<boolean | undefined> = [];
+      mockTerminal.resize.mockImplementation((cols: number, rows: number) => {
+        mockTerminal.cols = cols;
+        mockTerminal.rows = rows;
+        seenDuringResize.push(mockTerminal.options.reflowCursorLine);
+      });
+
+      controller.restoreFromSerialized("t1", "payload", captureAt80);
+      await flushMicrotasks();
+
+      // xterm skips the cursor's own wrapped group unless this is on, which
+      // truncates that row when normalizing to a narrower grid.
+      expect(seenDuringResize).toEqual([false, true]);
+      expect(mockTerminal.options.reflowCursorLine).toBe(false);
+    });
+
+    it("restores the configured reflowCursorLine even when the resize throws", async () => {
+      const managed = makeManagedTerminal();
+      instances.set("t1", managed);
+      mockTerminal.options.reflowCursorLine = true;
+      mockTerminal.resize
+        .mockImplementationOnce((cols: number, rows: number) => {
+          mockTerminal.cols = cols;
+          mockTerminal.rows = rows;
+        })
+        .mockImplementationOnce(() => {
+          throw new Error("renderer gone");
+        });
+
+      controller.restoreFromSerialized("t1", "payload", captureAt80);
+      await flushMicrotasks();
+
+      expect(mockTerminal.options.reflowCursorLine).toBe(true);
+      expect(managed.isSerializedRestoreInProgress).toBe(false);
+    });
+
+    it("puts the pane back on its live grid before releasing deferred output", () => {
+      const trace = traceGrid();
+      const managed = makeManagedTerminal({
+        deferredOutput: [{ data: "held", chunkCount: 2 }],
+      });
+      instances.set("t1", managed);
+      mockTerminal.write.mockImplementationOnce(() => {
+        throw new Error("parser died");
+      });
+
+      const result = controller.restoreFromSerialized("t1", "payload", captureAt80);
+
+      // Held chunks were produced for the live grid — replaying them into a
+      // terminal still parked at the capture width would corrupt them too.
+      expect(result).toBe(false);
+      expect(trace.at(-1)).toBe("resize:170x24");
+      expect(writeDataSpy).toHaveBeenCalledWith("t1", "held", 2);
+    });
+
+    it("aligns the incremental path and normalizes once every chunk has parsed", async () => {
+      const trace = traceGrid();
+      const managed = makeManagedTerminal();
+      instances.set("t1", managed);
+      const largeState = "x".repeat(INCREMENTAL_RESTORE_CONFIG.chunkBytes * 2 + 10);
+
+      const promise = controller.restoreFromSerializedIncremental("t1", largeState, captureAt80);
+      for (let i = 0; i < 6; i++) {
+        await flushMicrotasks();
+        await flushScheduler();
+      }
+      await promise;
+
+      const resizes = trace.filter((entry) => entry.startsWith("resize:"));
+      expect(resizes).toEqual(["resize:80x24", "resize:170x24"]);
+      // The reflow must come after the last chunk, or it would only see part of
+      // the payload laid out at the capture width.
+      expect(trace.lastIndexOf("resize:170x24")).toBeGreaterThan(
+        trace.map((e) => e.startsWith("write:")).lastIndexOf(true)
+      );
+    });
+
+    it("leaves the grid to the successor when an incremental restore is superseded", async () => {
+      traceGrid();
+      const managed = makeManagedTerminal();
+      instances.set("t1", managed);
+      const largeState = "x".repeat(INCREMENTAL_RESTORE_CONFIG.chunkBytes * 2 + 10);
+
+      const promise = controller.restoreFromSerializedIncremental("t1", largeState, captureAt80);
+      await flushMicrotasks();
+      // A newer restore takes ownership mid-replay.
+      managed.restoreGeneration++;
+      for (let i = 0; i < 6; i++) {
+        await flushMicrotasks();
+        await flushScheduler();
+      }
+      await promise;
+
+      // The superseded attempt must not reflow: the successor is mid-replay at
+      // its own capture width and owns the grid.
+      expect(mockTerminal.resize).toHaveBeenCalledTimes(1);
+      expect(mockTerminal.cols).toBe(80);
+    });
+  });
+
   describe("destroy", () => {
     it("bumps restore generation and clears restore state", () => {
       const managed = makeManagedTerminal({
@@ -618,6 +851,7 @@ describe("TerminalRestoreController", () => {
 
       expect(managed.restoreGeneration).toBe(prevGen + 1);
       expect(managed.isSerializedRestoreInProgress).toBe(false);
+      expect(managed.pendingRestoreGeometry).toBeUndefined();
       expect(managed.deferredOutput).toHaveLength(0);
     });
   });

--- a/src/services/terminal/paintFabric/PaintFabricCompositor.ts
+++ b/src/services/terminal/paintFabric/PaintFabricCompositor.ts
@@ -8,6 +8,7 @@ import type {
 } from "../types";
 import { GRID_RESIZE_COALESCE_MS } from "../types";
 import type { UnseenOutputSnapshot } from "../TerminalUnseenOutputTracker";
+import type { TerminalGeometry } from "@shared/types/terminal";
 import type { TerminalPaintPlane } from "../TerminalInstanceService";
 import { logWarn } from "@/utils/logger";
 import { PaintSurfaceRegistry, surfaceKind, type PaintSurface } from "./PaintSurfaceRegistry";
@@ -1120,20 +1121,32 @@ export class PaintFabricCompositor implements TerminalPaintPlane {
     this.scrollbackRestoreAggregateListeners.clear();
   }
 
-  restoreFetchedState(id: string, serializedState: string | null): Promise<boolean> {
-    return this.plane(id).restoreFetchedState(id, serializedState);
+  restoreFetchedState(
+    id: string,
+    serializedState: string | null,
+    captureGeometry?: TerminalGeometry
+  ): Promise<boolean> {
+    return this.plane(id).restoreFetchedState(id, serializedState, captureGeometry);
   }
 
   fetchAndRestore(id: string): Promise<boolean> {
     return this.plane(id).fetchAndRestore(id);
   }
 
-  restoreFromSerialized(id: string, serializedState: string): boolean {
-    return this.plane(id).restoreFromSerialized(id, serializedState);
+  restoreFromSerialized(
+    id: string,
+    serializedState: string,
+    captureGeometry?: TerminalGeometry
+  ): boolean {
+    return this.plane(id).restoreFromSerialized(id, serializedState, captureGeometry);
   }
 
-  restoreFromSerializedIncremental(id: string, serializedState: string): Promise<boolean> {
-    return this.plane(id).restoreFromSerializedIncremental(id, serializedState);
+  restoreFromSerializedIncremental(
+    id: string,
+    serializedState: string,
+    captureGeometry?: TerminalGeometry
+  ): Promise<boolean> {
+    return this.plane(id).restoreFromSerializedIncremental(id, serializedState, captureGeometry);
   }
 
   setInputLocked(id: string, locked: boolean): void {

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -215,6 +215,17 @@ export interface ManagedTerminal {
    * drained by the restore that normalizes back. Undefined outside a restore.
    */
   pendingRestoreGeometry?: TerminalGeometry;
+  /**
+   * Monotonic id for the currently-open serialized-restore window (#11552).
+   *
+   * Deliberately separate from `restoreGeneration`: that one CANCELS an
+   * in-flight replay, so reusing it to identify a window would mean a snapshot
+   * fetch had to abort whatever was replaying just to be able to tell whether
+   * the window was still its own to close — and if the fetch then came back
+   * null, it would release output over a half-replayed buffer. This only
+   * answers "am I still the owner", never "should you stop".
+   */
+  restoreWindowToken: number;
   // Output that arrived mid-restore, replayed once the restore settles. Each
   // entry keeps the ingest batch's chunkCount so the replay write can settle
   // the SAME pending port-ack FIFO entries the batch owns — the entries are

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -7,6 +7,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 
 import { TerminalRefreshTier, PanelKind, AgentState } from "@/types";
 import type { TerminalScrollbackRestoreError } from "@shared/types/panel";
+import type { TerminalGeometry } from "@shared/types/terminal";
 
 export type RefreshTierProvider = () => TerminalRefreshTier;
 
@@ -199,6 +200,21 @@ export interface ManagedTerminal {
   writeChain: Promise<void>;
   restoreGeneration: number;
   isSerializedRestoreInProgress: boolean;
+  /**
+   * The grid this pane belongs on once the in-flight serialized restore
+   * finishes (#11552).
+   *
+   * A snapshot only decodes at the width it was captured on, so a restore
+   * temporarily resizes xterm to the capture grid before writing. That makes
+   * `terminal.cols` a lie for the duration: an external resize applied against
+   * it would be reflowed away by the normalization that follows, and a
+   * successor restore reading it would adopt the capture width as "live".
+   * Seeded from the real grid when the outermost restore opens the window,
+   * overwritten by any resize that lands mid-replay
+   * (`TerminalResizeController.resizeTerminal` parks instead of applying), and
+   * drained by the restore that normalizes back. Undefined outside a restore.
+   */
+  pendingRestoreGeometry?: TerminalGeometry;
   // Output that arrived mid-restore, replayed once the restore settles. Each
   // entry keeps the ingest batch's chunkCount so the replay write can settle
   // the SAME pending port-ack FIFO entries the batch owns — the entries are


### PR DESCRIPTION
## Summary

- Terminal scrollback snapshots are captured from a headless xterm mirror in the pty host and replayed into a live xterm elsewhere, but the capture width was never recorded or transmitted. `getSerializedState` returned a bare `Promise<string | null>`, and `restoreFromSerialized` did a `reset()` then a `write()` with no geometry alignment.
- This adds `SerializedTerminalSnapshot { data, cols, rows }` as the contract end to end, and aligns every replay to the grid its payload was written on.
- Also fixes two non-obvious xterm write/resize ordering hazards found while building this, and documents one residual risk that's deliberately out of scope.

Resolves #11552

## What we thought would happen vs. what actually happens

The issue predicted committed cell corruption. Measured against the version we're pinned to (`@xterm/headless 6.1.0-beta.290`) with real buffers, a verbatim wrong width replay actually preserves cell content and `isWrapped` flags fine.

What it corrupts is the cursor position. For example, it can land at column 66 where a reflow of the same buffer would put it at column 26.

That's not cosmetic. Agent CLIs paint with cursor relative motion and erase to end of line, so every repaint after a misplaced restore writes against the wrong cells. That's consistent with the reported welded and garbled artifacts that heal as the agent keeps redrawing.

The new tests assert the invariant that actually holds: an aligned replay reproduces the buffer and cursor a plain reflow of the captured buffer would produce. A verbatim replay does not.

## How

- Geometry is stamped in the same tick as `addon.serialize()`, including inside `TerminalSerializerService`'s deferred single flight closure. A value sampled a tick earlier can describe a grid the buffer has already left.
- `WorkerAnalysisBackend` samples `lastCols`/`lastRows` synchronously, immediately before `pool.request()`. No worker protocol change needed since worker FIFO ordering makes that exact.
- `TerminalInfo.preservedSnapshot` becomes the object itself. The mirror is disposed at capture time, so the grid has to be cached alongside it.
- Replay is `reset()` → `resize(capture)` → `write()` → reflow home with `reflowCursorLine` temporarily enabled. Without it, xterm leaves the cursor's own wrapped group unreflowed and truncates it when narrowing.
- Session files bump to `DAINTREE_SESSION_v2` with a `<cols>x<rows>` line. v1 and headerless sessions still replay verbatim as before; malformed v2 is rejected.

## Two non-obvious hazards found and fixed (both verified against real xterm)

1. Resizing inside an xterm write callback runs during the parser drain, so `flushSync()` re-applies the in-flight chunk. A 4 cell write comes back as 8, and it can strand a queued write's callback. Both replay sites now defer the corrective resize out of the callback.
2. A resize landing mid-replay has to be parked, not applied, or it gets reflowed away by the normalization and a successor restore reads the temporary capture width as the live grid. `pendingRestoreGeometry` plus a single `endRestoreWindow` owner handles both, and a separate `restoreWindowToken` gives a snapshot fetch unique ownership without cancelling an in-flight replay.

## Known residual risk (deliberately not fixed here)

Found this during adversarial review and I'm calling it out rather than quietly shipping around it: there's still no exclusive write barrier spanning reset, replay, and the corrective resize.

`WriteBuffer.flushSync()` shifts from index 0 while `_innerWrite` tracks `_bufferOffset`, so a resize issued while entries are still queued can re-parse already parsed chunks. That's reachable if an ungated writer (a data loss marker, a process exit banner, a backend recovery banner, or a worker mirror write) lands during a replay that also exceeds xterm's 12ms parse budget. Ordering the session reflow behind `HeadlessMirrorScheduler`'s FIFO narrows the window on the headless side but doesn't close it.

The correct fix is an exclusive barrier across both subsystems, and it deserves its own PR with its own tests. This change is still strictly better than the status quo, which replayed at the wrong width unconditionally.

## Testing

3942 tests passing across 188 files, renderer and main. New `TerminalRestoreController.replay.test.ts` drives real `@xterm/headless` buffers and compares restores against a reflowed twin rather than hardcoded values. Typecheck, prettier, and the per rule lint ratchet are all clean.