### PR TITLE
fix(terminal): emit cwd-relative @file tokens from drop and paste

### DIFF
--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -273,9 +273,9 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
     } = compartments;
 
     const { handleDragEnter, handleDragOver, handleDragLeave, handleDrop, isDragOverFiles } =
-      useDragDrop(editorViewRef);
+      useDragDrop(editorViewRef, cwd);
 
-    const { imagePasteExtension, filePasteExtension, plainPasteKeymap } = usePasteExtensions();
+    const { imagePasteExtension, filePasteExtension, plainPasteKeymap } = usePasteExtensions(cwd);
 
     useEffect(() => {
       setInitializationState("initializing");

--- a/src/components/Terminal/__tests__/hybridInputParsing.test.ts
+++ b/src/components/Terminal/__tests__/hybridInputParsing.test.ts
@@ -12,8 +12,10 @@ import {
   getAllAtDiffTokens,
   getAllAtTerminalTokens,
   getAllAtSelectionTokens,
+  getAllAtFileTokens,
   formatAtFileToken,
   formatAtFileTokenForCwd,
+  RESERVED_AT_TOKEN_PATHS,
 } from "../hybridInputParsing";
 
 const ALL: ReadonlySet<CompletionTrigger> = new Set(["/", "$", "@"]);
@@ -475,5 +477,36 @@ describe("formatAtFileToken reserved-token collision", () => {
   it("leaves a reserved name alone when it is not the whole path", () => {
     expect(formatAtFileToken("src/terminal")).toBe("@src/terminal");
     expect(formatAtFileToken("terminal.ts")).toBe("@terminal.ts");
+  });
+});
+
+// The formatter and the token scanner are two halves of one contract: whatever
+// `formatAtFileToken` emits, `getAllAtFileTokens` has to read back as exactly
+// the path that went in. Asserting the round trip catches a delimiter the
+// scanner stops at that the formatter forgot to quote, which asserting the
+// literal token text would not.
+describe("formatAtFileToken round-trips through getAllAtFileTokens", () => {
+  it.each([
+    "src/App.tsx",
+    "README.md",
+    "./terminal",
+    "diff:staged",
+    "src/my notes.md",
+    "src/a,b.ts",
+    "src/fn(1).ts",
+    "src/list].ts",
+    "weird;name",
+    "trailing.",
+  ])("recovers %s unchanged", (path) => {
+    const tokens = getAllAtFileTokens(`see ${formatAtFileToken(path)} here`);
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]!.path).toBe(RESERVED_AT_TOKEN_PATHS.has(path) ? `./${path}` : path);
+  });
+
+  it("covers the whole token so the chip can span it", () => {
+    const token = formatAtFileToken("diff:staged");
+    const text = `see ${token} here`;
+    const [parsed] = getAllAtFileTokens(text);
+    expect(text.slice(parsed!.start, parsed!.end)).toBe(token);
   });
 });

--- a/src/components/Terminal/__tests__/hybridInputParsing.test.ts
+++ b/src/components/Terminal/__tests__/hybridInputParsing.test.ts
@@ -435,4 +435,45 @@ describe("formatAtFileTokenForCwd", () => {
   it("leaves an already-relative path alone", () => {
     expect(formatAtFileTokenForCwd("src/App.tsx", cwd)).toBe(formatAtFileToken("src/App.tsx"));
   });
+
+  // The inverse of the case above: the whitespace lives entirely in the prefix
+  // being stripped. Quoting decided before relativizing would needlessly quote
+  // a clean relative path and diverge from autocomplete.
+  it("does not quote when only the stripped cwd prefix carried whitespace", () => {
+    const spacedCwd = "/Users/greg/My Projects/daintree";
+    expect(formatAtFileTokenForCwd(`${spacedCwd}/src/App.tsx`, spacedCwd)).toBe(
+      formatAtFileToken("src/App.tsx")
+    );
+  });
+
+  it("still quotes an outside-cwd absolute path carrying whitespace", () => {
+    const outside = "/Volumes/My Drive/notes.md";
+    expect(formatAtFileTokenForCwd(outside, cwd)).toBe(formatAtFileToken(outside));
+  });
+});
+
+describe("formatAtFileToken reserved-token collision", () => {
+  // Relativizing can reduce a real file to a bare `terminal`/`diff`/`selection`,
+  // which the send path resolves as that provider's content. The emitted token
+  // has to survive every special-token scanner as a plain file reference.
+  it.each(["terminal", "selection", "diff", "diff:staged", "diff:head"])(
+    "does not emit %s as a bare reserved token",
+    (reserved) => {
+      const token = formatAtFileToken(reserved);
+      const text = `look at ${token} please`;
+      expect(getAllAtTerminalTokens(text)).toHaveLength(0);
+      expect(getAllAtSelectionTokens(text)).toHaveLength(0);
+      expect(getAllAtDiffTokens(text)).toHaveLength(0);
+    }
+  );
+
+  it("routes a reserved-name drop through the cwd formatter too", () => {
+    const cwd = "/repo";
+    expect(formatAtFileTokenForCwd(`${cwd}/terminal`, cwd)).toBe(formatAtFileToken("terminal"));
+  });
+
+  it("leaves a reserved name alone when it is not the whole path", () => {
+    expect(formatAtFileToken("src/terminal")).toBe("@src/terminal");
+    expect(formatAtFileToken("terminal.ts")).toBe("@terminal.ts");
+  });
 });

--- a/src/components/Terminal/__tests__/hybridInputParsing.test.ts
+++ b/src/components/Terminal/__tests__/hybridInputParsing.test.ts
@@ -12,6 +12,8 @@ import {
   getAllAtDiffTokens,
   getAllAtTerminalTokens,
   getAllAtSelectionTokens,
+  formatAtFileToken,
+  formatAtFileTokenForCwd,
 } from "../hybridInputParsing";
 
 const ALL: ReadonlySet<CompletionTrigger> = new Set(["/", "$", "@"]);
@@ -380,5 +382,57 @@ describe("getAllAtSelectionTokens", () => {
   it("returns empty for text with no selection tokens", () => {
     const tokens = getAllAtSelectionTokens("just plain text");
     expect(tokens).toHaveLength(0);
+  });
+});
+
+describe("formatAtFileTokenForCwd", () => {
+  const cwd = "/Users/greg/Projects/daintree";
+
+  // The point of the helper: an OS-absolute path (drop/paste) and the
+  // cwd-relative hit autocomplete's file search returns for the same file have
+  // to land on the identical token. Comparing the two producers rather than a
+  // copied literal is what makes this a real invariant.
+  it("agrees with the autocomplete producer for a file under cwd", () => {
+    expect(formatAtFileTokenForCwd(`${cwd}/src/App.tsx`, cwd)).toBe(
+      formatAtFileToken("src/App.tsx")
+    );
+  });
+
+  it("keeps the absolute form for a file outside cwd", () => {
+    const outside = "/etc/hosts";
+    expect(formatAtFileTokenForCwd(outside, cwd)).toBe(formatAtFileToken(outside));
+  });
+
+  // A sibling whose name merely extends the root is outside it — the mangling
+  // a bare `startsWith` would produce (`-sandbox/src/App.tsx`) is the exact
+  // failure `toWorktreeRelative` exists to prevent.
+  it("treats a sibling directory sharing the cwd prefix as outside", () => {
+    const sibling = `${cwd}-sandbox/src/App.tsx`;
+    expect(formatAtFileTokenForCwd(sibling, cwd)).toBe(formatAtFileToken(sibling));
+  });
+
+  it("falls back to absolute when there is no cwd to relativize against", () => {
+    const absolute = `${cwd}/src/App.tsx`;
+    expect(formatAtFileTokenForCwd(absolute, "")).toBe(formatAtFileToken(absolute));
+  });
+
+  // Relativizing must not cost the quoting a whitespace-bearing path needs, and
+  // the quotes belong around the emitted (relative) path, not the original.
+  it("quotes the relative path when the file name carries whitespace", () => {
+    const token = formatAtFileTokenForCwd(`${cwd}/src/my notes.md`, cwd);
+    expect(token).toBe(formatAtFileToken("src/my notes.md"));
+    expect(token).not.toContain(cwd);
+  });
+
+  // Windows hands back backslashes; autocomplete's results are posix. Both
+  // producers have to spell the same file the same way.
+  it("emits forward slashes for a Windows-style path and cwd", () => {
+    expect(formatAtFileTokenForCwd("C:\\repo\\src\\App.tsx", "C:\\repo")).toBe(
+      formatAtFileToken("src/App.tsx")
+    );
+  });
+
+  it("leaves an already-relative path alone", () => {
+    expect(formatAtFileTokenForCwd("src/App.tsx", cwd)).toBe(formatAtFileToken("src/App.tsx"));
   });
 });

--- a/src/components/Terminal/__tests__/hybridInputParsing.test.ts
+++ b/src/components/Terminal/__tests__/hybridInputParsing.test.ts
@@ -497,16 +497,29 @@ describe("formatAtFileToken round-trips through getAllAtFileTokens", () => {
     "src/list].ts",
     "weird;name",
     "trailing.",
+    // Quote chars are the half of the contract relativizing newly exposes: a
+    // quote can now be the token's FIRST char, where the scanner reads it as
+    // opening a quoted path, and one embedded in an otherwise-quoted path is
+    // that path's own terminator unless it is escaped.
+    "'notes.txt",
+    '"notes.txt',
+    "src/it's.txt",
+    'src/say"hi".txt',
+    'src/my "notes".md',
+    '\'mixed "quotes".txt',
   ])("recovers %s unchanged", (path) => {
     const tokens = getAllAtFileTokens(`see ${formatAtFileToken(path)} here`);
     expect(tokens).toHaveLength(1);
     expect(tokens[0]!.path).toBe(RESERVED_AT_TOKEN_PATHS.has(path) ? `./${path}` : path);
   });
 
-  it("covers the whole token so the chip can span it", () => {
-    const token = formatAtFileToken("diff:staged");
-    const text = `see ${token} here`;
-    const [parsed] = getAllAtFileTokens(text);
-    expect(text.slice(parsed!.start, parsed!.end)).toBe(token);
-  });
+  it.each(["diff:staged", '\'mixed "quotes".txt'])(
+    "covers the whole %s token so the chip can span it",
+    (path) => {
+      const token = formatAtFileToken(path);
+      const text = `see ${token} here`;
+      const [parsed] = getAllAtFileTokens(text);
+      expect(text.slice(parsed!.start, parsed!.end)).toBe(token);
+    }
+  );
 });

--- a/src/components/Terminal/hooks/__tests__/useDragDrop.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useDragDrop.test.ts
@@ -1,0 +1,197 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import type { EditorView } from "@codemirror/view";
+import { useDragDrop } from "../useDragDrop";
+
+const CWD = "/Users/greg/Projects/daintree";
+
+function fakeView() {
+  const dispatch = vi.fn();
+  const view = {
+    state: { selection: { main: { head: 0 } } },
+    dispatch,
+  } as unknown as EditorView;
+  return { view, dispatch, ref: { current: view } as React.RefObject<EditorView | null> };
+}
+
+function dropEvent(files: File[]): React.DragEvent {
+  return {
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+    dataTransfer: { files, types: ["Files"] },
+  } as unknown as React.DragEvent;
+}
+
+function fakeFile(name: string, size = 10): File {
+  return { name, size } as unknown as File;
+}
+
+/** The document text the drop inserted, minus the trailing separator space. */
+function insertedToken(dispatch: ReturnType<typeof vi.fn>): string {
+  const insert = dispatch.mock.calls[0]?.[0]?.changes?.insert as string;
+  return insert.trimEnd();
+}
+
+/** The `addFileDropChip` / `addImageChip` payloads carried by the dispatch. */
+function effectValues(dispatch: ReturnType<typeof vi.fn>): Record<string, unknown>[] {
+  const effects = dispatch.mock.calls[0]?.[0]?.effects as { value: Record<string, unknown> }[];
+  return effects.map((e) => e.value);
+}
+
+let pathForFile: ReturnType<typeof vi.fn>;
+let thumbnailFromPath: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  pathForFile = vi.fn((file: File) => `${CWD}/${file.name}`);
+  thumbnailFromPath = vi.fn(async () => ({ thumbnailDataUrl: "data:image/png;base64,x" }));
+  (window as unknown as { electron: unknown }).electron = {
+    webUtils: { getPathForFile: pathForFile },
+    clipboard: { thumbnailFromPath },
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete (window as unknown as { electron?: unknown }).electron;
+});
+
+describe("useDragDrop", () => {
+  it("inserts a cwd-relative @file token for a file dropped from inside the worktree", async () => {
+    pathForFile.mockReturnValue(`${CWD}/src/App.tsx`);
+    const { view, dispatch, ref } = fakeView();
+    const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+    await act(async () => {
+      await result.current.handleDrop(dropEvent([fakeFile("App.tsx")]));
+    });
+
+    expect(view.dispatch).toHaveBeenCalledTimes(1);
+    expect(insertedToken(dispatch)).toBe("@src/App.tsx");
+  });
+
+  it("keeps the absolute @file token for a file dropped from outside the worktree", async () => {
+    const outside = "/etc/hosts.ts";
+    pathForFile.mockReturnValue(outside);
+    const { dispatch, ref } = fakeView();
+    const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+    await act(async () => {
+      await result.current.handleDrop(dropEvent([fakeFile("hosts.ts")]));
+    });
+
+    expect(insertedToken(dispatch)).toBe(`@${outside}`);
+  });
+
+  // The live PTY cwd moves as the user cd's; `handleDrop` is a React prop, so
+  // the rerendered callback is the one that must be consulted.
+  it("relativizes against the cwd current at drop time, not at mount time", async () => {
+    pathForFile.mockReturnValue(`${CWD}/src/App.tsx`);
+    const { dispatch, ref } = fakeView();
+    const { result, rerender } = renderHook(({ cwd }) => useDragDrop(ref, cwd), {
+      initialProps: { cwd: "/somewhere/else" },
+    });
+
+    rerender({ cwd: CWD });
+
+    await act(async () => {
+      await result.current.handleDrop(dropEvent([fakeFile("App.tsx")]));
+    });
+
+    expect(insertedToken(dispatch)).toBe("@src/App.tsx");
+  });
+
+  it("stores the absolute path on the chip while the document text stays relative", async () => {
+    const absolute = `${CWD}/src/App.tsx`;
+    pathForFile.mockReturnValue(absolute);
+    const { dispatch, ref } = fakeView();
+    const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+    await act(async () => {
+      await result.current.handleDrop(dropEvent([fakeFile("App.tsx")]));
+    });
+
+    const [chip] = effectValues(dispatch);
+    expect(chip?.filePath).toBe(absolute);
+    expect(insertedToken(dispatch)).not.toContain(CWD);
+  });
+
+  // The chip's range has to cover exactly the token that was inserted — a
+  // shorter relative token with a range still sized for the absolute one would
+  // leave the decoration overhanging into following text.
+  it("sizes the chip range to the token actually inserted", async () => {
+    pathForFile.mockReturnValue(`${CWD}/src/App.tsx`);
+    const { dispatch, ref } = fakeView();
+    const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+    await act(async () => {
+      await result.current.handleDrop(dropEvent([fakeFile("App.tsx")]));
+    });
+
+    const [chip] = effectValues(dispatch);
+    const token = insertedToken(dispatch);
+    expect((chip?.to as number) - (chip?.from as number)).toBe(token.length);
+  });
+
+  it("keeps consecutive chip ranges aligned with their tokens when several files drop at once", async () => {
+    pathForFile.mockImplementation((file: File) => `${CWD}/src/${file.name}`);
+    const { dispatch, ref } = fakeView();
+    const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+    await act(async () => {
+      await result.current.handleDrop(dropEvent([fakeFile("a.ts"), fakeFile("b.ts")]));
+    });
+
+    const insert = dispatch.mock.calls[0]?.[0]?.changes?.insert as string;
+    for (const chip of effectValues(dispatch)) {
+      const from = chip.from as number;
+      const to = chip.to as number;
+      expect(insert.slice(from, to)).toBe(`@src/${chip.fileName as string}`);
+    }
+  });
+
+  // Images insert a bare path rather than an `@file` token and are out of this
+  // issue's scope — the range math for them must stay untouched.
+  it("leaves a dropped image inserting its absolute path", async () => {
+    const absolute = `${CWD}/shot.png`;
+    pathForFile.mockReturnValue(absolute);
+    const { dispatch, ref } = fakeView();
+    const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+    await act(async () => {
+      await result.current.handleDrop(dropEvent([fakeFile("shot.png")]));
+    });
+
+    const insert = dispatch.mock.calls[0]?.[0]?.changes?.insert as string;
+    expect(insert.trimEnd()).toBe(absolute);
+    const [chip] = effectValues(dispatch);
+    expect((chip?.to as number) - (chip?.from as number)).toBe(absolute.length);
+  });
+
+  // A thumbnail failure demotes the image to the regular file branch, which
+  // does produce an `@file` token and so must relativize like any other file.
+  it("relativizes an image that falls back to the file branch", async () => {
+    pathForFile.mockReturnValue(`${CWD}/shot.png`);
+    thumbnailFromPath.mockRejectedValue(new Error("no thumbnail"));
+    const { dispatch, ref } = fakeView();
+    const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+    await act(async () => {
+      await result.current.handleDrop(dropEvent([fakeFile("shot.png")]));
+    });
+
+    expect(insertedToken(dispatch)).toBe("@shot.png");
+  });
+
+  it("does not dispatch when every dropped file resolves to no path", async () => {
+    pathForFile.mockReturnValue("");
+    const { view, ref } = fakeView();
+    const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+    await act(async () => {
+      await result.current.handleDrop(dropEvent([fakeFile("App.tsx")]));
+    });
+
+    expect(view.dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Terminal/hooks/__tests__/useDragDrop.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useDragDrop.test.ts
@@ -2,17 +2,26 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 import type { EditorView } from "@codemirror/view";
-import { useDragDrop } from "../useDragDrop";
+
+// The hook reaches `useTerminalFileTransfer` for one regex, but that module
+// constructs the `terminalInstanceService` singleton at import time — real
+// heartbeat intervals and window listeners this suite never disposes. Stub it
+// so the suite owns nothing but the hook.
+vi.mock("../../useTerminalFileTransfer", () => ({
+  IMAGE_EXTENSIONS: /\.(png|jpe?g|bmp|tiff?|avif|heic)$/i,
+}));
+
+const { useDragDrop } = await import("../useDragDrop");
 
 const CWD = "/Users/greg/Projects/daintree";
 
-function fakeView() {
+function fakeView(head = 0) {
   const dispatch = vi.fn();
   const view = {
-    state: { selection: { main: { head: 0 } } },
+    state: { selection: { main: { head } } },
     dispatch,
   } as unknown as EditorView;
-  return { view, dispatch, ref: { current: view } as React.RefObject<EditorView | null> };
+  return { view, dispatch, head, ref: { current: view } as React.RefObject<EditorView | null> };
 }
 
 function dropEvent(files: File[]): React.DragEvent {
@@ -37,6 +46,18 @@ function insertedToken(dispatch: ReturnType<typeof vi.fn>): string {
 function effectValues(dispatch: ReturnType<typeof vi.fn>): Record<string, unknown>[] {
   const effects = dispatch.mock.calls[0]?.[0]?.effects as { value: Record<string, unknown> }[];
   return effects.map((e) => e.value);
+}
+
+/**
+ * Every chip range is a document position, so it only lines up if the hook
+ * accumulated offsets against the emitted spelling rather than the original
+ * absolute path. Returns what each range actually covers in the document.
+ */
+function chipSpellings(dispatch: ReturnType<typeof vi.fn>, head: number): string[] {
+  const insert = dispatch.mock.calls[0]?.[0]?.changes?.insert as string;
+  return effectValues(dispatch).map((chip) =>
+    insert.slice((chip.from as number) - head, (chip.to as number) - head)
+  );
 }
 
 let pathForFile: ReturnType<typeof vi.fn>;
@@ -135,19 +156,79 @@ describe("useDragDrop", () => {
 
   it("keeps consecutive chip ranges aligned with their tokens when several files drop at once", async () => {
     pathForFile.mockImplementation((file: File) => `${CWD}/src/${file.name}`);
-    const { dispatch, ref } = fakeView();
+    const { dispatch, ref, head } = fakeView(17);
     const { result } = renderHook(() => useDragDrop(ref, CWD));
 
     await act(async () => {
       await result.current.handleDrop(dropEvent([fakeFile("a.ts"), fakeFile("b.ts")]));
     });
 
-    const insert = dispatch.mock.calls[0]?.[0]?.changes?.insert as string;
-    for (const chip of effectValues(dispatch)) {
-      const from = chip.from as number;
-      const to = chip.to as number;
-      expect(insert.slice(from, to)).toBe(`@src/${chip.fileName as string}`);
-    }
+    expect(effectValues(dispatch)).toHaveLength(2);
+    expect(chipSpellings(dispatch, head)).toEqual(["@src/a.ts", "@src/b.ts"]);
+  });
+
+  // The two branches share one `insertText`/`from` accumulator while emitting
+  // different spellings — a bare absolute path for the image, a shortened
+  // relative token for the file. Interleaving them is where an accumulator
+  // still sized to the absolute path would drift.
+  it("keeps ranges aligned when an image and a file drop together", async () => {
+    pathForFile.mockImplementation((file: File) => `${CWD}/src/${file.name}`);
+    const { dispatch, ref, head } = fakeView(9);
+    const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+    await act(async () => {
+      await result.current.handleDrop(dropEvent([fakeFile("shot.png"), fakeFile("a.ts")]));
+    });
+
+    expect(effectValues(dispatch)).toHaveLength(2);
+    // Image effects are collected ahead of file effects, so compare as a set.
+    expect(chipSpellings(dispatch, head).sort()).toEqual(
+      [`${CWD}/src/shot.png`, "@src/a.ts"].sort()
+    );
+  });
+
+  it("keeps ranges aligned when a file precedes an image", async () => {
+    pathForFile.mockImplementation((file: File) => `${CWD}/src/${file.name}`);
+    const { dispatch, ref, head } = fakeView(4);
+    const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+    await act(async () => {
+      await result.current.handleDrop(dropEvent([fakeFile("a.ts"), fakeFile("shot.png")]));
+    });
+
+    expect(chipSpellings(dispatch, head).sort()).toEqual(
+      [`${CWD}/src/shot.png`, "@src/a.ts"].sort()
+    );
+  });
+
+  it("inserts at the cursor and leaves the caret after everything it inserted", async () => {
+    pathForFile.mockReturnValue(`${CWD}/src/App.tsx`);
+    const { dispatch, ref, head } = fakeView(23);
+    const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+    await act(async () => {
+      await result.current.handleDrop(dropEvent([fakeFile("App.tsx")]));
+    });
+
+    const call = dispatch.mock.calls[0]?.[0];
+    const insert = call?.changes?.insert as string;
+    expect(call?.changes?.from).toBe(head);
+    expect(call?.selection?.anchor).toBe(head + insert.length);
+  });
+
+  // A file named `terminal` at the cwd root relativizes to a bare `terminal`,
+  // which the send path would otherwise resolve as "inject the terminal
+  // buffer" instead of referencing the file.
+  it("keeps a cwd-root file that collides with a reserved token a path", async () => {
+    pathForFile.mockReturnValue(`${CWD}/terminal`);
+    const { dispatch, ref } = fakeView();
+    const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+    await act(async () => {
+      await result.current.handleDrop(dropEvent([fakeFile("terminal")]));
+    });
+
+    expect(insertedToken(dispatch)).toBe("@./terminal");
   });
 
   // Images insert a bare path rather than an `@file` token and are out of this

--- a/src/components/Terminal/hooks/__tests__/usePasteExtensions.test.ts
+++ b/src/components/Terminal/hooks/__tests__/usePasteExtensions.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { EditorView } from "@codemirror/view";
+
+type PasteFile = { path: string; name: string; size: number };
+type PasteCallback = (view: EditorView, files: PasteFile[]) => void;
+
+// The whole module is stubbed rather than partially mocked: pulling the real
+// index in drags the CodeMirror extension graph (and, transitively, electron)
+// into a suite that only needs to observe what the paste callback dispatches.
+const captured: { filePaste: PasteCallback | null } = { filePaste: null };
+
+vi.mock("../../inputEditorExtensions", () => ({
+  createImagePasteHandler: vi.fn(() => ({ kind: "image-paste" })),
+  createPlainPasteKeymap: vi.fn(() => ({ kind: "plain-paste" })),
+  createFilePasteHandler: vi.fn((cb: PasteCallback) => {
+    captured.filePaste = cb;
+    return { kind: "file-paste" };
+  }),
+  addImageChip: { of: vi.fn((value: unknown) => ({ value })) },
+  addFileDropChip: { of: vi.fn((value: unknown) => ({ value })) },
+}));
+
+const { usePasteExtensions } = await import("../usePasteExtensions");
+const { createFilePasteHandler } = await import("../../inputEditorExtensions");
+
+const CWD = "/Users/greg/Projects/daintree";
+
+function fakeView() {
+  const dispatch = vi.fn();
+  const view = {
+    state: { selection: { main: { head: 0 } } },
+    dispatch,
+  } as unknown as EditorView;
+  return { view, dispatch };
+}
+
+function pasted(name: string, path: string): PasteFile {
+  return { path, name, size: 42 };
+}
+
+function insertedToken(dispatch: ReturnType<typeof vi.fn>): string {
+  const insert = dispatch.mock.calls[0]?.[0]?.changes?.insert as string;
+  return insert.trimEnd();
+}
+
+function effectValues(dispatch: ReturnType<typeof vi.fn>): Record<string, unknown>[] {
+  const effects = dispatch.mock.calls[0]?.[0]?.effects as { value: Record<string, unknown> }[];
+  return effects.map((e) => e.value);
+}
+
+beforeEach(() => {
+  captured.filePaste = null;
+  vi.clearAllMocks();
+});
+
+describe("usePasteExtensions", () => {
+  it("inserts a cwd-relative @file token for a file pasted from inside the worktree", () => {
+    renderHook(() => usePasteExtensions(CWD));
+    const { view, dispatch } = fakeView();
+
+    captured.filePaste?.(view, [pasted("App.tsx", `${CWD}/src/App.tsx`)]);
+
+    expect(insertedToken(dispatch)).toBe("@src/App.tsx");
+  });
+
+  it("keeps the absolute @file token for a file pasted from outside the worktree", () => {
+    renderHook(() => usePasteExtensions(CWD));
+    const { view, dispatch } = fakeView();
+    const outside = "/etc/hosts.ts";
+
+    captured.filePaste?.(view, [pasted("hosts.ts", outside)]);
+
+    expect(insertedToken(dispatch)).toBe(`@${outside}`);
+  });
+
+  // The regression this hook's ref exists for. `useEditorFactory` installs the
+  // paste extension once, while building the initial EditorState under an
+  // effect keyed on terminalId alone — so a memo rebuilt on `cwd` would hand
+  // the editor an object it never installs. The extension the editor is
+  // actually holding is the one that has to see the post-`cd` cwd.
+  it("relativizes against the current cwd through the extension installed at mount", () => {
+    const { rerender } = renderHook(({ cwd }) => usePasteExtensions(cwd), {
+      initialProps: { cwd: "/somewhere/else" },
+    });
+    const installed = captured.filePaste;
+
+    rerender({ cwd: CWD });
+
+    const { view, dispatch } = fakeView();
+    installed?.(view, [pasted("App.tsx", `${CWD}/src/App.tsx`)]);
+
+    expect(insertedToken(dispatch)).toBe("@src/App.tsx");
+  });
+
+  it("does not rebuild the paste extension when cwd changes", () => {
+    const { result, rerender } = renderHook(({ cwd }) => usePasteExtensions(cwd), {
+      initialProps: { cwd: "/somewhere/else" },
+    });
+    const first = result.current.filePasteExtension;
+
+    rerender({ cwd: CWD });
+
+    expect(result.current.filePasteExtension).toBe(first);
+    expect(createFilePasteHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("stores the absolute path on the chip while the document text stays relative", () => {
+    renderHook(() => usePasteExtensions(CWD));
+    const { view, dispatch } = fakeView();
+    const absolute = `${CWD}/src/App.tsx`;
+
+    captured.filePaste?.(view, [pasted("App.tsx", absolute)]);
+
+    const [chip] = effectValues(dispatch);
+    expect(chip?.filePath).toBe(absolute);
+    expect(insertedToken(dispatch)).not.toContain(CWD);
+  });
+
+  it("keeps consecutive chip ranges aligned with their tokens when several files paste at once", () => {
+    renderHook(() => usePasteExtensions(CWD));
+    const { view, dispatch } = fakeView();
+
+    captured.filePaste?.(view, [
+      pasted("a.ts", `${CWD}/src/a.ts`),
+      pasted("b.ts", `${CWD}/src/b.ts`),
+    ]);
+
+    const insert = dispatch.mock.calls[0]?.[0]?.changes?.insert as string;
+    for (const chip of effectValues(dispatch)) {
+      const from = chip.from as number;
+      const to = chip.to as number;
+      expect(insert.slice(from, to)).toBe(`@src/${chip.fileName as string}`);
+    }
+  });
+});

--- a/src/components/Terminal/hooks/__tests__/usePasteExtensions.test.ts
+++ b/src/components/Terminal/hooks/__tests__/usePasteExtensions.test.ts
@@ -27,13 +27,13 @@ const { createFilePasteHandler } = await import("../../inputEditorExtensions");
 
 const CWD = "/Users/greg/Projects/daintree";
 
-function fakeView() {
+function fakeView(head = 0) {
   const dispatch = vi.fn();
   const view = {
-    state: { selection: { main: { head: 0 } } },
+    state: { selection: { main: { head } } },
     dispatch,
   } as unknown as EditorView;
-  return { view, dispatch };
+  return { view, dispatch, head };
 }
 
 function pasted(name: string, path: string): PasteFile {
@@ -48,6 +48,14 @@ function insertedToken(dispatch: ReturnType<typeof vi.fn>): string {
 function effectValues(dispatch: ReturnType<typeof vi.fn>): Record<string, unknown>[] {
   const effects = dispatch.mock.calls[0]?.[0]?.effects as { value: Record<string, unknown> }[];
   return effects.map((e) => e.value);
+}
+
+/** What each chip range actually covers in the document. */
+function chipSpellings(dispatch: ReturnType<typeof vi.fn>, head: number): string[] {
+  const insert = dispatch.mock.calls[0]?.[0]?.changes?.insert as string;
+  return effectValues(dispatch).map((chip) =>
+    insert.slice((chip.from as number) - head, (chip.to as number) - head)
+  );
 }
 
 beforeEach(() => {
@@ -120,18 +128,35 @@ describe("usePasteExtensions", () => {
 
   it("keeps consecutive chip ranges aligned with their tokens when several files paste at once", () => {
     renderHook(() => usePasteExtensions(CWD));
-    const { view, dispatch } = fakeView();
+    const { view, dispatch, head } = fakeView(31);
 
     captured.filePaste?.(view, [
       pasted("a.ts", `${CWD}/src/a.ts`),
       pasted("b.ts", `${CWD}/src/b.ts`),
     ]);
 
-    const insert = dispatch.mock.calls[0]?.[0]?.changes?.insert as string;
-    for (const chip of effectValues(dispatch)) {
-      const from = chip.from as number;
-      const to = chip.to as number;
-      expect(insert.slice(from, to)).toBe(`@src/${chip.fileName as string}`);
-    }
+    expect(effectValues(dispatch)).toHaveLength(2);
+    expect(chipSpellings(dispatch, head)).toEqual(["@src/a.ts", "@src/b.ts"]);
+  });
+
+  it("inserts at the cursor and leaves the caret after everything it inserted", () => {
+    renderHook(() => usePasteExtensions(CWD));
+    const { view, dispatch, head } = fakeView(12);
+
+    captured.filePaste?.(view, [pasted("App.tsx", `${CWD}/src/App.tsx`)]);
+
+    const call = dispatch.mock.calls[0]?.[0];
+    const insert = call?.changes?.insert as string;
+    expect(call?.changes?.from).toBe(head);
+    expect(call?.selection?.anchor).toBe(head + insert.length);
+  });
+
+  it("keeps a cwd-root file that collides with a reserved token a path", () => {
+    renderHook(() => usePasteExtensions(CWD));
+    const { view, dispatch } = fakeView();
+
+    captured.filePaste?.(view, [pasted("selection", `${CWD}/selection`)]);
+
+    expect(insertedToken(dispatch)).toBe("@./selection");
   });
 });

--- a/src/components/Terminal/hooks/useDragDrop.ts
+++ b/src/components/Terminal/hooks/useDragDrop.ts
@@ -1,10 +1,10 @@
 import { useCallback, useRef, useState } from "react";
 import type { EditorView } from "@codemirror/view";
 import { IMAGE_EXTENSIONS } from "../useTerminalFileTransfer";
-import { formatAtFileToken } from "../hybridInputParsing";
+import { formatAtFileTokenForCwd } from "../hybridInputParsing";
 import { addImageChip, addFileDropChip } from "../inputEditorExtensions";
 
-export function useDragDrop(editorViewRef: React.RefObject<EditorView | null>) {
+export function useDragDrop(editorViewRef: React.RefObject<EditorView | null>, cwd: string) {
   const dragDepthRef = useRef(0);
   const [isDragOverFiles, setIsDragOverFiles] = useState(false);
 
@@ -87,12 +87,15 @@ export function useDragDrop(editorViewRef: React.RefObject<EditorView | null>) {
               })
             );
           } else {
-            const token = formatAtFileToken(entry.filePath);
+            const token = formatAtFileTokenForCwd(entry.filePath, cwd);
             insertText += token + " ";
             fileEffects.push(
               addFileDropChip.of({
                 from,
                 to: from + token.length,
+                // Chip metadata stays absolute: it feeds the hover tooltip and
+                // the remove-by-path lookup, neither of which has a cwd to
+                // resolve against.
                 filePath: entry.filePath,
                 fileName: entry.fileName,
                 fileSize: entry.fileSize,
@@ -110,7 +113,7 @@ export function useDragDrop(editorViewRef: React.RefObject<EditorView | null>) {
         // Editor may have been destroyed
       }
     },
-    [editorViewRef]
+    [editorViewRef, cwd]
   );
 
   return { handleDragEnter, handleDragOver, handleDragLeave, handleDrop, isDragOverFiles };

--- a/src/components/Terminal/hooks/usePasteExtensions.ts
+++ b/src/components/Terminal/hooks/usePasteExtensions.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import {
   createImagePasteHandler,
   addImageChip,
@@ -6,9 +6,20 @@ import {
   addFileDropChip,
   createPlainPasteKeymap,
 } from "../inputEditorExtensions";
-import { formatAtFileToken } from "../hybridInputParsing";
+import { formatAtFileTokenForCwd } from "../hybridInputParsing";
 
-export function usePasteExtensions() {
+export function usePasteExtensions(cwd: string) {
+  // `useEditorFactory` reads these extensions once, while building the initial
+  // `EditorState`, under an effect keyed on `terminalId` alone — and no
+  // compartment wraps them. A memo that rebuilt the extension when `cwd`
+  // changed would produce an object the editor never installs, so the handler
+  // has to reach the current cwd through a ref instead. Same latest-value ref
+  // pattern `useEditorDomHandlers` uses for its own installed-once handlers.
+  const cwdRef = useRef(cwd);
+  useEffect(() => {
+    cwdRef.current = cwd;
+  }, [cwd]);
+
   const imagePasteExtension = useMemo(
     () =>
       createImagePasteHandler(async (view) => {
@@ -39,13 +50,14 @@ export function usePasteExtensions() {
         const effects: ReturnType<typeof addFileDropChip.of>[] = [];
         let insertText = "";
         for (const file of files) {
-          const token = formatAtFileToken(file.path);
+          const token = formatAtFileTokenForCwd(file.path, cwdRef.current);
           const from = cursor + insertText.length;
           insertText += token + " ";
           effects.push(
             addFileDropChip.of({
               from,
               to: from + token.length,
+              // Absolute on purpose — see the matching note in `useDragDrop`.
               filePath: file.path,
               fileName: file.name,
               fileSize: file.size,

--- a/src/components/Terminal/hybridInputParsing.ts
+++ b/src/components/Terminal/hybridInputParsing.ts
@@ -1,4 +1,5 @@
 import type { CompletionTrigger } from "@shared/types";
+import { toWorktreeRelative } from "@shared/utils/path";
 
 /**
  * One completion menu is open at a time, keyed by the trigger char that opened
@@ -242,6 +243,23 @@ export function getAllAtSelectionTokens(text: string): AtSelectionToken[] {
 export function formatAtFileToken(file: string): string {
   const needsQuotes = /\s/.test(file);
   return `@${needsQuotes ? `"${file}"` : file}`;
+}
+
+/**
+ * The `@file` token for a path the OS handed us absolute — drop and paste, as
+ * opposed to autocomplete, whose file search already returns cwd-relative hits.
+ * Relative is the form the agent can actually use: it costs no tokens on a
+ * prefix the agent already knows, survives a prompt being replayed in another
+ * worktree, and is what a fleet broadcast needs to mean the sibling worktree's
+ * copy of the file rather than this one's.
+ *
+ * `toWorktreeRelative` is the whole policy: it hands back the original path
+ * untouched when the file sits outside `cwd` (or when `cwd` is empty), so an
+ * out-of-tree drop keeps the absolute form that is the only thing that resolves
+ * for it.
+ */
+export function formatAtFileTokenForCwd(file: string, cwd: string): string {
+  return formatAtFileToken(toWorktreeRelative(file, cwd));
 }
 
 export interface SlashCommandToken {

--- a/src/components/Terminal/hybridInputParsing.ts
+++ b/src/components/Terminal/hybridInputParsing.ts
@@ -240,9 +240,28 @@ export function getAllAtSelectionTokens(text: string): AtSelectionToken[] {
 
 // --- @file token ---
 
+/**
+ * Paths that, spelled bare, are Daintree's own `@` tokens rather than files.
+ * `fileChip` uses this to refuse them a file chip; the formatter uses it to
+ * avoid ever producing one for a real file.
+ */
+export const RESERVED_AT_TOKEN_PATHS = new Set([
+  "diff",
+  "diff:staged",
+  "diff:head",
+  "terminal",
+  "selection",
+]);
+
 export function formatAtFileToken(file: string): string {
-  const needsQuotes = /\s/.test(file);
-  return `@${needsQuotes ? `"${file}"` : file}`;
+  // A relative path can land exactly on one of those reserved tokens — a file
+  // named `terminal` sitting at the cwd root relativizes to `terminal`, and
+  // `@terminal` is resolved on send as "paste the terminal buffer here", so
+  // the reference silently becomes something else entirely. `./` keeps it a
+  // path to every reader without changing what it points at.
+  const path = RESERVED_AT_TOKEN_PATHS.has(file) ? `./${file}` : file;
+  const needsQuotes = /\s/.test(path);
+  return `@${needsQuotes ? `"${path}"` : path}`;
 }
 
 /**

--- a/src/components/Terminal/hybridInputParsing.ts
+++ b/src/components/Terminal/hybridInputParsing.ts
@@ -259,8 +259,15 @@ export const RESERVED_AT_TOKEN_PATHS = new Set([
  * has to be quoted or it reads back short — `@./diff:staged` would parse as
  * `./diff`, leaving `:staged` loose in the document and the chip covering only
  * part of the reference.
+ *
+ * A quote char is here for the opposite reason: the scanner treats a quote
+ * *immediately after the `@`* as opening a quoted path, so a file named
+ * `'notes.txt` at the cwd root emits `@'notes.txt`, whose closing quote never
+ * arrives and whose token is dropped whole. Relativizing is what can promote a
+ * name to the token's first character, so quoting quote-bearing paths is what
+ * keeps that reachable case parseable.
  */
-const NEEDS_QUOTED_AT_TOKEN = /[\s,;:)}\]]|[.,;:!?]$/;
+const NEEDS_QUOTED_AT_TOKEN = /['"]|[\s,;:)}\]]|[.,;:!?]$/;
 
 export function formatAtFileToken(file: string): string {
   // A relative path can land exactly on one of the reserved tokens — a file
@@ -269,7 +276,11 @@ export function formatAtFileToken(file: string): string {
   // the reference silently becomes something else entirely. `./` keeps it a
   // path to every reader without changing what it points at.
   const path = RESERVED_AT_TOKEN_PATHS.has(file) ? `./${file}` : file;
-  return `@${NEEDS_QUOTED_AT_TOKEN.test(path) ? `"${path}"` : path}`;
+  if (!NEEDS_QUOTED_AT_TOKEN.test(path)) return `@${path}`;
+  // Wrapping in `"` makes an embedded `"` the token's own terminator, so it has
+  // to be escaped. `\"` is the one escape `getAllAtFileTokens` already skips
+  // while hunting the closing quote and already unescapes on the way out.
+  return `@"${path.replace(/"/g, '\\"')}"`;
 }
 
 /**

--- a/src/components/Terminal/hybridInputParsing.ts
+++ b/src/components/Terminal/hybridInputParsing.ts
@@ -253,15 +253,23 @@ export const RESERVED_AT_TOKEN_PATHS = new Set([
   "selection",
 ]);
 
+/**
+ * What an unquoted token cannot survive: `getAllAtFileTokens` ends one at any
+ * of these and then trims trailing sentence punctuation. A path carrying one
+ * has to be quoted or it reads back short — `@./diff:staged` would parse as
+ * `./diff`, leaving `:staged` loose in the document and the chip covering only
+ * part of the reference.
+ */
+const NEEDS_QUOTED_AT_TOKEN = /[\s,;:)}\]]|[.,;:!?]$/;
+
 export function formatAtFileToken(file: string): string {
-  // A relative path can land exactly on one of those reserved tokens — a file
+  // A relative path can land exactly on one of the reserved tokens — a file
   // named `terminal` sitting at the cwd root relativizes to `terminal`, and
   // `@terminal` is resolved on send as "paste the terminal buffer here", so
   // the reference silently becomes something else entirely. `./` keeps it a
   // path to every reader without changing what it points at.
   const path = RESERVED_AT_TOKEN_PATHS.has(file) ? `./${file}` : file;
-  const needsQuotes = /\s/.test(path);
-  return `@${needsQuotes ? `"${path}"` : path}`;
+  return `@${NEEDS_QUOTED_AT_TOKEN.test(path) ? `"${path}"` : path}`;
 }
 
 /**

--- a/src/components/Terminal/inputEditorExtensions/fileChip.ts
+++ b/src/components/Terminal/inputEditorExtensions/fileChip.ts
@@ -1,6 +1,10 @@
 import { EditorView, Decoration, WidgetType, hoverTooltip } from "@codemirror/view";
 import { StateField } from "@codemirror/state";
-import { getAllAtFileTokens, RESERVED_AT_TOKEN_PATHS, type AtFileToken } from "../hybridInputParsing";
+import {
+  getAllAtFileTokens,
+  RESERVED_AT_TOKEN_PATHS,
+  type AtFileToken,
+} from "../hybridInputParsing";
 import { chipPendingDeleteField, isChipSelected } from "./chipBackspace";
 import { fileDropChipField } from "./fileDropChip";
 import { imageChipField } from "./imageChip";

--- a/src/components/Terminal/inputEditorExtensions/fileChip.ts
+++ b/src/components/Terminal/inputEditorExtensions/fileChip.ts
@@ -1,6 +1,6 @@
 import { EditorView, Decoration, WidgetType, hoverTooltip } from "@codemirror/view";
 import { StateField } from "@codemirror/state";
-import { getAllAtFileTokens, type AtFileToken } from "../hybridInputParsing";
+import { getAllAtFileTokens, RESERVED_AT_TOKEN_PATHS, type AtFileToken } from "../hybridInputParsing";
 import { chipPendingDeleteField, isChipSelected } from "./chipBackspace";
 import { fileDropChipField } from "./fileDropChip";
 import { imageChipField } from "./imageChip";
@@ -8,8 +8,6 @@ import { imageChipField } from "./imageChip";
 interface FileChipState {
   tokens: AtFileToken[];
 }
-
-const RESERVED_TOKEN_PATHS = new Set(["diff", "diff:staged", "diff:head", "terminal", "selection"]);
 
 interface RangeOwner {
   from: number;
@@ -59,7 +57,7 @@ class FileChipWidget extends WidgetType {
 }
 
 function buildFileChipState(text: string): FileChipState {
-  const tokens = getAllAtFileTokens(text).filter((t) => !RESERVED_TOKEN_PATHS.has(t.path));
+  const tokens = getAllAtFileTokens(text).filter((t) => !RESERVED_AT_TOKEN_PATHS.has(t.path));
   return { tokens };
 }
 


### PR DESCRIPTION
## Summary

- Drop and paste now emit the same cwd-relative `@file` form the `@` autocomplete already produces, falling back to absolute for files outside the cwd.
- Root is the live PTY cwd (`panel.cwd`), the same value autocomplete's file search already keys off, so the three producers agree by construction.
- Two related defects caught during review are fixed in the same pass: a bare relativized path colliding with a reserved token, and a quoting gap that dropped part of any colon-bearing path on parse.

Resolves #11575

## Details

All three producers of `@file` tokens call the same `formatAtFileToken` in `hybridInputParsing.ts`. Autocomplete already relativizes before calling it; drop and paste were handing it the raw OS path. The fix adds `formatAtFileTokenForCwd(file, cwd)`, which wraps `formatAtFileToken` with `toWorktreeRelative(file, cwd)`. `useDragDrop.ts` and `usePasteExtensions.ts` now take a `cwd` parameter and use it; `HybridInputBar.tsx` passes its existing live `cwd` prop into both.

`usePasteExtensions.ts` reads `cwd` through a ref rather than a memo dependency. `useEditorFactory` builds the extension list once inside an effect keyed only on `terminalId`, with no compartment mechanism, so a `[cwd]` memo dependency would hand the editor an object it never installs, a silent no-op. The ref sidesteps that.

Two defects review caught, fixed here:

- A file named `terminal`, `diff`, or `selection` sitting at the cwd root relativized to a bare `@terminal`, `@diff`, or `@selection`. The send path resolves those as reserved commands (`@terminal` injects the terminal buffer) rather than as file references, so the reference silently became unrelated content. Fixed by prefixing such paths with `./` before formatting. The reserved set is now exported as `RESERVED_AT_TOKEN_PATHS` from `hybridInputParsing.ts` so `fileChip.ts` can import it instead of keeping its own copy.
- The token scanner ends an unquoted token at `, ; : ) } ]`, but the formatter only quoted on whitespace. `@./diff:staged` round-tripped as `./diff`, dropping `:staged`. Fixed by quoting on the scanner's actual delimiter set, which also covers any path containing a colon.

Scope notes: image insertion paths are untouched on purpose, they use bare paths rather than `@file` tokens, and pasted images live in a temp directory anyway. Chip metadata also stays absolute: it feeds the hover tooltip and the remove-by-path lookup, neither of which has a cwd to resolve against.

Heads up for #11574 (terminal-area file drops, `useTerminalFileTransfer.ts`): that issue asks for the drop path to become consistent with hybrid input behaviour. After this lands, consistent means relative-when-possible, so that fix should reuse `formatAtFileTokenForCwd` rather than copying the old absolute-only pattern.

## Changes

- `src/components/Terminal/hybridInputParsing.ts` — `formatAtFileTokenForCwd`, exported `RESERVED_AT_TOKEN_PATHS`, `./`-prefix on reserved-token collisions, quoting keyed on the scanner's delimiter set.
- `src/components/Terminal/hooks/useDragDrop.ts` — takes `cwd`, relativizes the non-image token.
- `src/components/Terminal/hooks/usePasteExtensions.ts` — takes `cwd`, read through a ref.
- `src/components/Terminal/HybridInputBar.tsx` — passes `cwd` into both hooks.
- `src/components/Terminal/inputEditorExtensions/fileChip.ts` — imports the shared reserved-token set instead of its own duplicate.
- Tests: new `useDragDrop.test.ts` and `usePasteExtensions.test.ts`, extended `hybridInputParsing.test.ts`.

## Testing

240 targeted tests pass: both new hook suites, the parser suite (including a formatter/parser round-trip property test), autocomplete, token resolution, `filePathDetection`, shared path utilities, and the `inputEditorExtensions` suite affected by the shared-constant refactor. ESLint: 0 errors. Prettier clean on all changed files.