### PR TITLE
fix(terminal): make file drops agent-aware and give them feedback

### DIFF
--- a/shared/utils/__tests__/terminalInputProtocol.test.ts
+++ b/shared/utils/__tests__/terminalInputProtocol.test.ts
@@ -80,4 +80,27 @@ describe("terminalInputProtocol", () => {
       `${BRACKETED_PASTE_START}abc${BRACKETED_PASTE_END}`
     );
   });
+
+  it("neutralizes an embedded terminator so the wrapper cannot be escaped", () => {
+    // Text carrying its own END sequence would otherwise close the paste early
+    // and hand the remainder to the program as ordinary input.
+    const wrapped = formatWithBracketedPaste(`before${BRACKETED_PASTE_END}after`);
+
+    expect(wrapped.startsWith(BRACKETED_PASTE_START)).toBe(true);
+    expect(wrapped.endsWith(BRACKETED_PASTE_END)).toBe(true);
+    expect(wrapped.split(BRACKETED_PASTE_END).length - 1).toBe(1);
+
+    const body = wrapped.slice(BRACKETED_PASTE_START.length, -BRACKETED_PASTE_END.length);
+    expect(body).not.toContain(String.fromCharCode(27));
+    // The text is still readable — only the ESC byte is swapped for its glyph.
+    expect(body).toContain("before");
+    expect(body).toContain("after");
+  });
+
+  it("leaves text without escape sequences untouched", () => {
+    const plain = "@/Users/test/src/App.tsx ";
+    expect(formatWithBracketedPaste(plain)).toBe(
+      `${BRACKETED_PASTE_START}${plain}${BRACKETED_PASTE_END}`
+    );
+  });
 });

--- a/shared/utils/terminalInputProtocol.ts
+++ b/shared/utils/terminalInputProtocol.ts
@@ -51,6 +51,7 @@ export function shouldUseBracketedPaste(
  * include a submit. This mirrors xterm's own `bracketTextForPaste`.
  */
 export function formatWithBracketedPaste(text: string): string {
-  const sanitized = text.replace(/\x1b/g, "␛");
+  // String literal, not a regex: `no-control-regex` bans the pattern form.
+  const sanitized = text.replaceAll("\x1b", "␛");
   return `${BRACKETED_PASTE_START}${sanitized}${BRACKETED_PASTE_END}`;
 }

--- a/shared/utils/terminalInputProtocol.ts
+++ b/shared/utils/terminalInputProtocol.ts
@@ -43,7 +43,14 @@ export function shouldUseBracketedPaste(
 
 /**
  * Format text with bracketed paste if needed.
+ *
+ * Embedded ESC bytes are replaced with their visible representation (U+241B)
+ * before wrapping. Without that, text containing `\x1b[201~` — legal in a POSIX
+ * filename, and reachable from a dropped path — would terminate the wrapper
+ * early and hand the remainder to the program as ordinary input, which can
+ * include a submit. This mirrors xterm's own `bracketTextForPaste`.
  */
 export function formatWithBracketedPaste(text: string): string {
-  return `${BRACKETED_PASTE_START}${text}${BRACKETED_PASTE_END}`;
+  const sanitized = text.replace(/\x1b/g, "␛");
+  return `${BRACKETED_PASTE_START}${sanitized}${BRACKETED_PASTE_END}`;
 }

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -1300,6 +1300,10 @@ export function HelpPanel({
                     launchAgentId={agentId ?? undefined}
                     detectedAgentId={terminalPty?.detectedAgentId}
                     agentState={terminalPty?.agentState}
+                    // Without this the adapter's layout effect drives
+                    // setInputLocked(id, false) on mount, unlocking the very
+                    // terminal the hybrid input below is disabling itself for.
+                    isInputLocked={terminalPty?.isInputLocked === true}
                     getRefreshTier={getRefreshTier}
                     cwd={terminalPty?.cwd}
                     hasBottomBar={showHybridInputBar}

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -1298,6 +1298,8 @@ export function HelpPanel({
                   <XtermAdapter
                     terminalId={terminalId}
                     launchAgentId={agentId ?? undefined}
+                    detectedAgentId={terminalPty?.detectedAgentId}
+                    agentState={terminalPty?.agentState}
                     getRefreshTier={getRefreshTier}
                     cwd={terminalPty?.cwd}
                     hasBottomBar={showHybridInputBar}

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -1418,6 +1418,7 @@ function TerminalPaneComponent({
                     terminalId={id}
                     launchAgentId={agentId}
                     detectedAgentId={detectedAgentId}
+                    agentState={agentState}
                     isInputLocked={isInputLocked}
                     onReady={handleReady}
                     onExit={handleExit}

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -84,6 +84,7 @@ export function XtermAdapter({
   // repairs the mis-sized grid out-of-band via `repairFontGrid()` (wired once to
   // `onTerminalFontArrivedLate` in its constructor) (#9809).
   const containerRef = useRef<HTMLDivElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const prevDimensionsRef = useRef<{ cols: number; rows: number } | null>(null);
   const exitUnsubRef = useRef<(() => void) | null>(null);
   const rafIdRef = useRef<number | null>(null);
@@ -155,10 +156,14 @@ export function XtermAdapter({
     terminalInstanceService.getAltBufferState(terminalId)
   );
 
-  // Attach image paste and file drag-and-drop handlers to the xterm container.
-  // The agent identity decides whether a dropped path arrives as an `@` token
-  // or a shell-escaped path (#11574).
-  const isDragOverFiles = useTerminalFileTransfer(containerRef, {
+  // Attach image paste and file drag-and-drop handlers to the padded wrapper
+  // rather than the xterm host: in normal-buffer mode the wrapper adds a 12px
+  // gutter that reads as part of the terminal, so listening on the host alone
+  // would leave a visible border that silently rejects drops. Paste still
+  // intercepts correctly — the wrapper is an ancestor, and the listener is
+  // registered in the capture phase. The agent identity decides whether a
+  // dropped path arrives as an `@` token or a shell-escaped path (#11574).
+  const isDragOverFiles = useTerminalFileTransfer(wrapperRef, {
     terminalId,
     isInputLocked,
     onInput: stableOnInput,
@@ -807,6 +812,7 @@ export function XtermAdapter({
 
   return (
     <div
+      ref={wrapperRef}
       className={cn(
         "w-full h-full text-text-primary overflow-hidden",
         // Full-screen TUIs run on the alternate buffer, which has no scrollback —

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -167,6 +167,9 @@ export function XtermAdapter({
     terminalId,
     isInputLocked,
     onInput: stableOnInput,
+    // The same stable reader the instance service gets, so a drop relativizes
+    // its `@file` token against the cwd the terminal is in when it lands.
+    cwdProvider: stableCwdProvider,
     launchAgentId,
     detectedAgentId,
     agentState,

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -1,7 +1,14 @@
 import { useCallback, useLayoutEffect, useMemo, useRef, useEffect, useState } from "react";
 import type { ITerminalOptions } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
+import type { AgentState } from "@shared/types/agent";
 import { cn } from "@/lib/utils";
+import {
+  UI_ENTER_DURATION,
+  UI_EXIT_DURATION,
+  UI_ENTER_EASING,
+  UI_EXIT_EASING,
+} from "@/lib/animationUtils";
 import { isMac } from "@/lib/platform";
 import { TerminalRefreshTier } from "@/types";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
@@ -28,6 +35,10 @@ export interface XtermAdapterProps {
   /** Runtime-detected agent identity. Drives agent-specific input protocol
    *  (soft-newline sequences, bracketed paste) when a live agent is running. */
   detectedAgentId?: string;
+  /** Live agent lifecycle state. Needed alongside the two agent ids so an
+   *  exited agent stops being treated as one — `launchAgentId` is durable and
+   *  outlives the process it launched. */
+  agentState?: AgentState;
   isInputLocked?: boolean;
   onReady?: () => void;
   onExit?: (exitCode: number) => void;
@@ -53,6 +64,7 @@ export function XtermAdapter({
   terminalId,
   launchAgentId,
   detectedAgentId,
+  agentState,
   isInputLocked,
   onReady,
   onExit,
@@ -143,8 +155,20 @@ export function XtermAdapter({
     terminalInstanceService.getAltBufferState(terminalId)
   );
 
-  // Attach image paste and file drag-and-drop handlers to the xterm container
-  useTerminalFileTransfer(containerRef, { terminalId, isInputLocked, onInput: stableOnInput });
+  // Attach image paste and file drag-and-drop handlers to the xterm container.
+  // The agent identity decides whether a dropped path arrives as an `@` token
+  // or a shell-escaped path (#11574).
+  const isDragOverFiles = useTerminalFileTransfer(containerRef, {
+    terminalId,
+    isInputLocked,
+    onInput: stableOnInput,
+    launchAgentId,
+    detectedAgentId,
+    agentState,
+  });
+  // The hook already withholds the state while locked; this keeps the render
+  // side honest if that ever changes.
+  const showFileDropOverlay = isDragOverFiles && !isInputLocked;
 
   const hasVisibleBufferContent = useCallback(() => {
     const managed = terminalInstanceService.get(terminalId);
@@ -802,6 +826,28 @@ export function XtermAdapter({
         aria-keyshortcuts="F6 Shift+F6"
         role="application"
       />
+      {/* Drop-target confirmation. Stays mounted so the exit fade can play, and
+          is pointer-transparent so it never becomes a drag boundary of its own.
+          Decorative: the drag itself is the announcement, and a live region
+          inside a role="application" terminal would just be noise. The wrapper's
+          `contain: strict` supplies the containing block. */}
+      <div
+        aria-hidden="true"
+        data-visible={showFileDropOverlay ? "true" : "false"}
+        className={cn(
+          "pointer-events-none absolute inset-0 z-10 flex select-none items-center justify-center",
+          "border border-border-strong bg-surface-panel/90",
+          "opacity-0 transition-opacity data-[visible=true]:opacity-100"
+        )}
+        style={{
+          transitionDuration: `${showFileDropOverlay ? UI_ENTER_DURATION : UI_EXIT_DURATION}ms`,
+          transitionTimingFunction: showFileDropOverlay ? UI_ENTER_EASING : UI_EXIT_EASING,
+        }}
+      >
+        <span className="rounded-[var(--radius-md)] border border-border-default bg-overlay-subtle px-3 py-1.5 text-xs font-medium text-text-primary">
+          Drop to insert
+        </span>
+      </div>
     </div>
   );
 }

--- a/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
+++ b/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
@@ -78,14 +78,16 @@ const mocks = vi.hoisted(() => {
     notifyEnterPressed: vi.fn(),
   };
 
+  // Returns the drag-over flag the adapter renders drop feedback from.
+  const useTerminalFileTransfer = vi.fn(() => false);
+
   return {
     appearance,
     managed,
     platform,
     terminalInstanceService,
     writeTerminalInputOrFleet: vi.fn(),
-    // Returns the drag-over flag the adapter renders drop feedback from.
-    useTerminalFileTransfer: vi.fn(() => false),
+    useTerminalFileTransfer,
     getKeyHandler: () => keyHandler,
     getExitHandler: () => exitHandler,
     resetRuntime: () => {
@@ -98,6 +100,9 @@ const mocks = vi.hoisted(() => {
       // vi.clearAllMocks() drops calls but keeps implementations, so a test that
       // switches to the alt buffer would otherwise leak into the next one.
       terminalInstanceService.getAltBufferState.mockReturnValue(false);
+      // mockReset also drops queued mockReturnValueOnce results, so a drag-state
+      // override can never survive into the next test.
+      useTerminalFileTransfer.mockReset().mockReturnValue(false);
       Object.assign(appearance, defaultAppearance, { effectiveTheme: {} });
     },
   };

--- a/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
+++ b/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
@@ -78,8 +78,10 @@ const mocks = vi.hoisted(() => {
     notifyEnterPressed: vi.fn(),
   };
 
-  // Returns the drag-over flag the adapter renders drop feedback from.
-  const useTerminalFileTransfer = vi.fn(() => false);
+  // Returns the drag-over flag the adapter renders drop feedback from. Typed
+  // with both parameters so tests can assert on the options the adapter passes.
+  const useTerminalFileTransfer =
+    vi.fn<(containerRef: unknown, options: Record<string, unknown>) => boolean>();
 
   return {
     appearance,

--- a/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
+++ b/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
@@ -84,7 +84,8 @@ const mocks = vi.hoisted(() => {
     platform,
     terminalInstanceService,
     writeTerminalInputOrFleet: vi.fn(),
-    useTerminalFileTransfer: vi.fn(),
+    // Returns the drag-over flag the adapter renders drop feedback from.
+    useTerminalFileTransfer: vi.fn(() => false),
     getKeyHandler: () => keyHandler,
     getExitHandler: () => exitHandler,
     resetRuntime: () => {
@@ -936,6 +937,60 @@ describe("XtermAdapter lifecycle", () => {
 
       expect(clipboard.writeText).not.toHaveBeenCalled();
       expect(keybindingService.resolveKeybinding).toHaveBeenCalled();
+    });
+  });
+
+  describe("file drop overlay", () => {
+    function overlayIn(container: HTMLElement): HTMLElement {
+      const overlay = container.querySelector<HTMLElement>("[data-visible]");
+      if (!overlay) throw new Error("drop overlay not rendered");
+      return overlay;
+    }
+
+    it("stays mounted while hidden so the exit transition can play", async () => {
+      mocks.useTerminalFileTransfer.mockReturnValue(false);
+      const { container } = renderAdapter();
+      await waitFor(() => expect(mocks.useTerminalFileTransfer).toHaveBeenCalled());
+
+      expect(overlayIn(container).dataset.visible).toBe("false");
+    });
+
+    it("becomes visible while files are dragged over the terminal", async () => {
+      mocks.useTerminalFileTransfer.mockReturnValue(true);
+      const { container } = renderAdapter();
+      await waitFor(() => expect(mocks.useTerminalFileTransfer).toHaveBeenCalled());
+
+      expect(overlayIn(container).dataset.visible).toBe("true");
+    });
+
+    it("stays hidden while input is locked, even mid-drag", async () => {
+      mocks.useTerminalFileTransfer.mockReturnValue(true);
+      const { container } = renderAdapter({ isInputLocked: true });
+      await waitFor(() => expect(mocks.useTerminalFileTransfer).toHaveBeenCalled());
+
+      expect(overlayIn(container).dataset.visible).toBe("false");
+    });
+
+    it("is decorative — the drag itself is the announcement", async () => {
+      mocks.useTerminalFileTransfer.mockReturnValue(true);
+      const { container } = renderAdapter();
+      await waitFor(() => expect(mocks.useTerminalFileTransfer).toHaveBeenCalled());
+
+      const overlay = overlayIn(container);
+      expect(overlay.getAttribute("aria-hidden")).toBe("true");
+      expect(overlay.getAttribute("role")).toBeNull();
+    });
+
+    it("forwards the runtime agent identity that decides the drop format", async () => {
+      renderAdapter({ launchAgentId: "claude", detectedAgentId: "codex", agentState: "working" });
+      await waitFor(() => expect(mocks.useTerminalFileTransfer).toHaveBeenCalled());
+
+      const [, options] = mocks.useTerminalFileTransfer.mock.calls.at(-1)!;
+      expect(options).toMatchObject({
+        launchAgentId: "claude",
+        detectedAgentId: "codex",
+        agentState: "working",
+      });
     });
   });
 });

--- a/src/components/Terminal/__tests__/useTerminalFileTransfer.test.ts
+++ b/src/components/Terminal/__tests__/useTerminalFileTransfer.test.ts
@@ -32,7 +32,9 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   },
 }));
 
+import type { EditorView } from "@codemirror/view";
 import { IMAGE_EXTENSIONS, useTerminalFileTransfer } from "../useTerminalFileTransfer";
+import { useDragDrop } from "../hooks/useDragDrop";
 import { formatAtFileToken } from "../hybridInputParsing";
 import { terminalClient } from "@/clients";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
@@ -51,6 +53,9 @@ function lastWrittenPayload(): string {
   const calls = vi.mocked(terminalClient.write).mock.calls;
   return calls[calls.length - 1]![1];
 }
+
+/** A worktree root the fixture paths below sit inside. */
+const CWD = "/Users/test/proj";
 
 describe("IMAGE_EXTENSIONS", () => {
   it("matches common image formats", () => {
@@ -454,20 +459,129 @@ describe("useTerminalFileTransfer hook", () => {
   });
 
   it("quotes @ tokens for paths containing whitespace", () => {
-    renderFileTransferHook({ detectedAgentId: "claude" });
-    dropFiles([fileAt("my notes.md", "/Users/test/my notes.md")]);
+    renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD });
+    dropFiles([fileAt("my notes.md", `${CWD}/my notes.md`)]);
 
     // Pinned to the literal wire format an agent CLI has to parse, rather than
     // re-deriving it from the same formatter the hook calls — an unquoted space
     // would split the reference into two arguments.
-    expect(lastWrittenPayload()).toBe('@"/Users/test/my notes.md" ');
+    expect(lastWrittenPayload()).toBe('@"my notes.md" ');
   });
 
   it("writes the plain @ wire format for a path needing no quoting", () => {
-    renderFileTransferHook({ detectedAgentId: "claude" });
-    dropFiles([fileAt("App.tsx", "/Users/test/src/App.tsx")]);
+    renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD });
+    dropFiles([fileAt("App.tsx", `${CWD}/src/App.tsx`)]);
 
-    expect(lastWrittenPayload()).toBe("@/Users/test/src/App.tsx ");
+    expect(lastWrittenPayload()).toBe("@src/App.tsx ");
+  });
+
+  // --- The @ token agrees with every other producer (#11575) ---
+
+  /**
+   * Runs the hybrid input bar's own drop handler over the same file and returns
+   * the `@file` token it inserted.
+   *
+   * Dropping a file on the terminal and dropping it on the input bar are one
+   * gesture to the user, so the two surfaces have to spell the reference
+   * identically. Comparing the producers is what catches a divergence: pinning
+   * either one to its own literal passes happily while they disagree.
+   */
+  async function hybridInputBarToken(
+    name: string,
+    absolutePath: string,
+    cwd: string
+  ): Promise<string> {
+    const dispatch = vi.fn<(transaction: { changes: { insert: string } }) => void>();
+    const viewRef = {
+      current: {
+        state: { selection: { main: { head: 0 } } },
+        dispatch,
+      } as unknown as EditorView,
+    };
+
+    const { result } = renderHook(() => useDragDrop(viewRef, cwd));
+
+    await act(async () => {
+      await result.current.handleDrop({
+        preventDefault: () => {},
+        stopPropagation: () => {},
+        dataTransfer: { files: [fileAt(name, absolutePath)], types: ["Files"] },
+      } as unknown as React.DragEvent);
+    });
+
+    return dispatch.mock.calls[0]![0].changes.insert.trimEnd();
+  }
+
+  it("spells a dropped file exactly as the hybrid input bar does", async () => {
+    const absolute = `${CWD}/src/App.tsx`;
+    renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD });
+    dropFiles([fileAt("App.tsx", absolute)]);
+
+    const terminalToken = lastWrittenPayload().trimEnd();
+    expect(terminalToken).toBe(await hybridInputBarToken("App.tsx", absolute, CWD));
+    // …and both are the relativized spelling, not both surfaces staying absolute.
+    expect(terminalToken).not.toContain(CWD);
+  });
+
+  it("spells a whitespace-bearing path exactly as the hybrid input bar does", async () => {
+    const absolute = `${CWD}/src/my notes.md`;
+    renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD });
+    dropFiles([fileAt("my notes.md", absolute)]);
+
+    expect(lastWrittenPayload().trimEnd()).toBe(
+      await hybridInputBarToken("my notes.md", absolute, CWD)
+    );
+  });
+
+  it("keeps a file dropped from outside the worktree absolute, like the input bar", async () => {
+    const outside = "/etc/hosts.ts";
+    renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD });
+    dropFiles([fileAt("hosts.ts", outside)]);
+
+    const terminalToken = lastWrittenPayload().trimEnd();
+    expect(terminalToken).toBe(await hybridInputBarToken("hosts.ts", outside, CWD));
+    // Relative would not resolve out there — absolute is the only usable form.
+    expect(terminalToken).toContain(outside);
+  });
+
+  // The live PTY cwd moves as the user cd's, so the provider handed to the pane
+  // on the latest commit is the one a drop has to consult — not the closure the
+  // DOM listeners were registered with.
+  it("relativizes against the cwd provider current at drop time", async () => {
+    const absolute = `${CWD}/src/App.tsx`;
+    const { rerender } = renderFileTransferHook({
+      detectedAgentId: "claude",
+      cwdProvider: () => "/somewhere/else",
+    });
+
+    rerender({ detectedAgentId: "claude", cwdProvider: () => CWD });
+    dropFiles([fileAt("App.tsx", absolute)]);
+
+    expect(lastWrittenPayload().trimEnd()).toBe(
+      await hybridInputBarToken("App.tsx", absolute, CWD)
+    );
+  });
+
+  it("leaves the shell form absolute even for a file inside the cwd", () => {
+    const absolute = `${CWD}/src/App.tsx`;
+    renderFileTransferHook({ cwdProvider: () => CWD });
+    dropFiles([fileAt("App.tsx", absolute)]);
+
+    // A shell resolves a relative path against its own cwd, which the pane only
+    // observes — it has no way to know the two still agree.
+    expect(lastWrittenPayload()).toBe(`${escapeShellArgOptional(absolute)} `);
+  });
+
+  it("relativizes a pasted image saved inside the worktree", async () => {
+    vi.mocked(window.electron.clipboard.saveImage).mockResolvedValue({
+      filePath: `${CWD}/.daintree/clipboard/shot.png`,
+      thumbnailDataUrl: "",
+    });
+
+    renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD });
+    await pasteImage();
+
+    expect(lastWrittenPayload()).toBe("@.daintree/clipboard/shot.png ");
   });
 
   it("switches format when the detected agent changes, without re-registering listeners", () => {

--- a/src/components/Terminal/__tests__/useTerminalFileTransfer.test.ts
+++ b/src/components/Terminal/__tests__/useTerminalFileTransfer.test.ts
@@ -5,7 +5,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act, cleanup } from "@testing-library/react";
 import { useRef } from "react";
 
-// Mock terminalClient and terminalInstanceService
+// Mutable terminal-instance state so each test can pick the delivery branch
+// (bracketed paste on/off, managed instance present/absent) without swapping
+// mock implementations, which would leak across tests.
+const instanceState = vi.hoisted(() => ({
+  bracketedPasteMode: false,
+  hasManagedInstance: true,
+}));
+
 vi.mock("@/clients", () => ({
   terminalClient: {
     write: vi.fn(),
@@ -15,13 +22,30 @@ vi.mock("@/clients", () => ({
 vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     notifyUserInput: vi.fn(),
+    get: vi.fn(() =>
+      instanceState.hasManagedInstance
+        ? { terminal: { modes: { bracketedPasteMode: instanceState.bracketedPasteMode } } }
+        : null
+    ),
   },
 }));
 
 import { IMAGE_EXTENSIONS, useTerminalFileTransfer } from "../useTerminalFileTransfer";
+import { formatAtFileToken } from "../hybridInputParsing";
 import { terminalClient } from "@/clients";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { escapeShellArgOptional } from "@shared/utils/shellEscape.js";
+import {
+  BRACKETED_PASTE_START,
+  BRACKETED_PASTE_END,
+  formatWithBracketedPaste,
+} from "@shared/utils/terminalInputProtocol.js";
+
+/** The payload handed to `terminalClient.write` for the most recent call. */
+function lastWrittenPayload(): string {
+  const calls = vi.mocked(terminalClient.write).mock.calls;
+  return calls[calls.length - 1]![1] as string;
+}
 
 describe("IMAGE_EXTENSIONS", () => {
   it("matches common image formats", () => {
@@ -56,6 +80,8 @@ describe("useTerminalFileTransfer hook", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    instanceState.bracketedPasteMode = false;
+    instanceState.hasManagedInstance = true;
     container = document.createElement("div");
     document.body.appendChild(container);
 
@@ -82,18 +108,29 @@ describe("useTerminalFileTransfer hook", () => {
     (window as unknown as Record<string, unknown>).electron = originalElectron;
   });
 
-  function renderFileTransferHook(options?: {
+  interface HookProps {
     isInputLocked?: boolean;
     onInput?: (data: string) => void;
-  }) {
-    return renderHook(() => {
-      const ref = useRef<HTMLDivElement>(container);
-      useTerminalFileTransfer(ref, {
-        terminalId: "term-1",
-        isInputLocked: options?.isInputLocked,
-        onInput: options?.onInput,
-      });
-    });
+    launchAgentId?: string;
+    detectedAgentId?: string;
+    agentState?: string;
+  }
+
+  function renderFileTransferHook(options: HookProps = {}) {
+    return renderHook(
+      (props: HookProps) => {
+        const ref = useRef<HTMLDivElement>(container);
+        return useTerminalFileTransfer(ref, {
+          terminalId: "term-1",
+          isInputLocked: props.isInputLocked,
+          onInput: props.onInput,
+          launchAgentId: props.launchAgentId,
+          detectedAgentId: props.detectedAgentId,
+          agentState: props.agentState as never,
+        });
+      },
+      { initialProps: options }
+    );
   }
 
   function makePasteEvent(hasImage: boolean): ClipboardEvent {
@@ -110,6 +147,12 @@ describe("useTerminalFileTransfer hook", () => {
       },
     });
     return event;
+  }
+
+  function fileAt(name: string, path?: string): File {
+    const file = new File([""], name);
+    if (path !== undefined) Object.defineProperty(file, "_testPath", { value: path });
+    return file;
   }
 
   function makeDropEvent(files: File[]): DragEvent {
@@ -135,23 +178,33 @@ describe("useTerminalFileTransfer hook", () => {
     return event;
   }
 
+  function dropFiles(files: File[]): DragEvent {
+    const event = makeDropEvent(files);
+    act(() => {
+      container.dispatchEvent(event);
+    });
+    return event;
+  }
+
+  async function pasteImage(): Promise<ClipboardEvent> {
+    const event = makePasteEvent(true);
+    await act(async () => {
+      container.dispatchEvent(event);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    return event;
+  }
+
   // --- Image paste tests ---
 
   it("image paste calls saveImage and writes escaped path to terminal", async () => {
     renderFileTransferHook();
-    const event = makePasteEvent(true);
-
-    await act(async () => {
-      container.dispatchEvent(event);
-      // Allow async saveImage to resolve
-      await vi.waitFor(() => {
-        expect(terminalClient.write).toHaveBeenCalled();
-      });
-    });
+    const event = await pasteImage();
 
     expect(terminalClient.write).toHaveBeenCalledWith(
       "term-1",
-      escapeShellArgOptional("/tmp/daintree-clipboard/clipboard-123-abc.png")
+      `${escapeShellArgOptional("/tmp/daintree-clipboard/clipboard-123-abc.png")} `
     );
     expect(terminalInstanceService.notifyUserInput).toHaveBeenCalledWith("term-1");
     expect(event.defaultPrevented).toBe(true);
@@ -160,17 +213,10 @@ describe("useTerminalFileTransfer hook", () => {
   it("image paste calls onInput with the escaped path", async () => {
     const onInput = vi.fn();
     renderFileTransferHook({ onInput });
-    const event = makePasteEvent(true);
-
-    await act(async () => {
-      container.dispatchEvent(event);
-      await vi.waitFor(() => {
-        expect(onInput).toHaveBeenCalled();
-      });
-    });
+    await pasteImage();
 
     expect(onInput).toHaveBeenCalledWith(
-      escapeShellArgOptional("/tmp/daintree-clipboard/clipboard-123-abc.png")
+      `${escapeShellArgOptional("/tmp/daintree-clipboard/clipboard-123-abc.png")} `
     );
   });
 
@@ -194,16 +240,11 @@ describe("useTerminalFileTransfer hook", () => {
     );
 
     renderFileTransferHook();
-    const event = makePasteEvent(true);
-
-    await act(async () => {
-      container.dispatchEvent(event);
-      // Wait a tick for the async handler to complete
-      await Promise.resolve();
-    });
+    const event = await pasteImage();
 
     expect(event.defaultPrevented).toBe(true);
     expect(terminalClient.write).not.toHaveBeenCalled();
+    expect(terminalInstanceService.notifyUserInput).not.toHaveBeenCalled();
   });
 
   it("image paste is blocked when isInputLocked is true", () => {
@@ -224,19 +265,73 @@ describe("useTerminalFileTransfer hook", () => {
     });
 
     renderFileTransferHook();
-    const event = makePasteEvent(true);
-
-    await act(async () => {
-      container.dispatchEvent(event);
-      await vi.waitFor(() => {
-        expect(terminalClient.write).toHaveBeenCalled();
-      });
-    });
+    await pasteImage();
 
     expect(terminalClient.write).toHaveBeenCalledWith(
       "term-1",
-      escapeShellArgOptional("/tmp/daintree clipboard/my screenshot.png")
+      `${escapeShellArgOptional("/tmp/daintree clipboard/my screenshot.png")} `
     );
+  });
+
+  it("image paste into an agent terminal writes an @ token, not a shell path", async () => {
+    renderFileTransferHook({ detectedAgentId: "claude" });
+    await pasteImage();
+
+    expect(terminalClient.write).toHaveBeenCalledWith(
+      "term-1",
+      `${formatAtFileToken("/tmp/daintree-clipboard/clipboard-123-abc.png")} `
+    );
+  });
+
+  it("locking while the image is still saving suppresses the write", async () => {
+    let releaseSave: (value: { filePath: string }) => void = () => {};
+    (window.electron.clipboard.saveImage as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise<{ filePath: string }>((resolve) => {
+        releaseSave = resolve;
+      })
+    );
+
+    const { rerender } = renderFileTransferHook({ isInputLocked: false });
+
+    act(() => {
+      container.dispatchEvent(makePasteEvent(true));
+    });
+
+    // Lock lands after the paste started but before saveImage settles.
+    rerender({ isInputLocked: true });
+
+    await act(async () => {
+      releaseSave({ filePath: "/tmp/late.png" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(terminalClient.write).not.toHaveBeenCalled();
+  });
+
+  it("unmounting while the image is still saving suppresses the write", async () => {
+    let releaseSave: (value: { filePath: string }) => void = () => {};
+    (window.electron.clipboard.saveImage as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise<{ filePath: string }>((resolve) => {
+        releaseSave = resolve;
+      })
+    );
+
+    const { unmount } = renderFileTransferHook();
+
+    act(() => {
+      container.dispatchEvent(makePasteEvent(true));
+    });
+
+    unmount();
+
+    await act(async () => {
+      releaseSave({ filePath: "/tmp/late.png" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(terminalClient.write).not.toHaveBeenCalled();
   });
 
   // --- File drop tests ---
@@ -244,18 +339,14 @@ describe("useTerminalFileTransfer hook", () => {
   it("file drop resolves paths and writes them to terminal", () => {
     renderFileTransferHook();
 
-    const file1 = new File([""], "document.pdf");
-    Object.defineProperty(file1, "_testPath", { value: "/Users/test/document.pdf" });
-
-    const file2 = new File([""], "script.sh");
-    Object.defineProperty(file2, "_testPath", { value: "/Users/test/script.sh" });
-
-    const event = makeDropEvent([file1, file2]);
-    container.dispatchEvent(event);
+    const event = dropFiles([
+      fileAt("document.pdf", "/Users/test/document.pdf"),
+      fileAt("script.sh", "/Users/test/script.sh"),
+    ]);
 
     expect(terminalClient.write).toHaveBeenCalledWith(
       "term-1",
-      `${escapeShellArgOptional("/Users/test/document.pdf")} ${escapeShellArgOptional("/Users/test/script.sh")}`
+      `${escapeShellArgOptional("/Users/test/document.pdf")} ${escapeShellArgOptional("/Users/test/script.sh")} `
     );
     expect(terminalInstanceService.notifyUserInput).toHaveBeenCalledWith("term-1");
     expect(event.defaultPrevented).toBe(true);
@@ -263,57 +354,34 @@ describe("useTerminalFileTransfer hook", () => {
 
   it("file drop escapes paths with spaces", () => {
     renderFileTransferHook();
-
-    const file = new File([""], "my file.pdf");
-    Object.defineProperty(file, "_testPath", { value: "/Users/test/my file.pdf" });
-
-    const event = makeDropEvent([file]);
-    container.dispatchEvent(event);
+    dropFiles([fileAt("my file.pdf", "/Users/test/my file.pdf")]);
 
     expect(terminalClient.write).toHaveBeenCalledWith(
       "term-1",
-      escapeShellArgOptional("/Users/test/my file.pdf")
+      `${escapeShellArgOptional("/Users/test/my file.pdf")} `
     );
   });
 
   it("file drop with unresolved path skips that file", () => {
     renderFileTransferHook();
-
-    const file1 = new File([""], "resolved.pdf");
-    Object.defineProperty(file1, "_testPath", { value: "/Users/test/resolved.pdf" });
-
-    const file2 = new File([""], "unresolved.pdf");
-    // No _testPath → getPathForFile returns ""
-
-    const event = makeDropEvent([file1, file2]);
-    container.dispatchEvent(event);
+    dropFiles([fileAt("resolved.pdf", "/Users/test/resolved.pdf"), fileAt("unresolved.pdf")]);
 
     expect(terminalClient.write).toHaveBeenCalledWith(
       "term-1",
-      escapeShellArgOptional("/Users/test/resolved.pdf")
+      `${escapeShellArgOptional("/Users/test/resolved.pdf")} `
     );
   });
 
   it("file drop with all unresolved paths does not write to terminal", () => {
     renderFileTransferHook();
-
-    const file = new File([""], "unresolved.pdf");
-    // No _testPath → returns ""
-
-    const event = makeDropEvent([file]);
-    container.dispatchEvent(event);
+    dropFiles([fileAt("unresolved.pdf")]);
 
     expect(terminalClient.write).not.toHaveBeenCalled();
   });
 
   it("file drop is blocked when isInputLocked is true", () => {
     renderFileTransferHook({ isInputLocked: true });
-
-    const file = new File([""], "file.pdf");
-    Object.defineProperty(file, "_testPath", { value: "/Users/test/file.pdf" });
-
-    const event = makeDropEvent([file]);
-    container.dispatchEvent(event);
+    dropFiles([fileAt("file.pdf", "/Users/test/file.pdf")]);
 
     expect(terminalClient.write).not.toHaveBeenCalled();
   });
@@ -321,14 +389,156 @@ describe("useTerminalFileTransfer hook", () => {
   it("file drop calls onInput with the joined paths", () => {
     const onInput = vi.fn();
     renderFileTransferHook({ onInput });
+    dropFiles([fileAt("file.ts", "/Users/test/file.ts")]);
 
-    const file = new File([""], "file.ts");
-    Object.defineProperty(file, "_testPath", { value: "/Users/test/file.ts" });
+    expect(onInput).toHaveBeenCalledWith(`${escapeShellArgOptional("/Users/test/file.ts")} `);
+  });
 
-    const event = makeDropEvent([file]);
-    container.dispatchEvent(event);
+  // --- Runtime identity decides the content format (#11574) ---
 
-    expect(onInput).toHaveBeenCalledWith(escapeShellArgOptional("/Users/test/file.ts"));
+  const AGENT_IDENTITIES: Array<[string, HookProps]> = [
+    ["a detected agent", { detectedAgentId: "claude" }],
+    ["a launched agent with no detection yet", { launchAgentId: "claude" }],
+    [
+      "a detected agent even while an exit signal is present",
+      { detectedAgentId: "claude", launchAgentId: "claude", agentState: "exited" },
+    ],
+  ];
+
+  it.each(AGENT_IDENTITIES)("formats dropped paths as @ tokens for %s", (_label, identity) => {
+    renderFileTransferHook(identity);
+    dropFiles([fileAt("App.tsx", "/Users/test/src/App.tsx")]);
+
+    expect(terminalClient.write).toHaveBeenCalledWith(
+      "term-1",
+      `${formatAtFileToken("/Users/test/src/App.tsx")} `
+    );
+  });
+
+  const SHELL_IDENTITIES: Array<[string, HookProps]> = [
+    ["a plain shell", {}],
+    ["a launched agent that has since exited", { launchAgentId: "claude", agentState: "exited" }],
+  ];
+
+  it.each(SHELL_IDENTITIES)("shell-escapes dropped paths for %s", (_label, identity) => {
+    renderFileTransferHook(identity);
+    dropFiles([fileAt("App.tsx", "/Users/test/src/App.tsx")]);
+
+    expect(terminalClient.write).toHaveBeenCalledWith(
+      "term-1",
+      `${escapeShellArgOptional("/Users/test/src/App.tsx")} `
+    );
+  });
+
+  it("quotes @ tokens for paths containing whitespace", () => {
+    renderFileTransferHook({ detectedAgentId: "claude" });
+    dropFiles([fileAt("my notes.md", "/Users/test/my notes.md")]);
+
+    const payload = lastWrittenPayload();
+    expect(payload).toBe(`${formatAtFileToken("/Users/test/my notes.md")} `);
+    // The quoting must survive into the payload — an unquoted space would split
+    // the reference into two arguments for the agent.
+    expect(payload).toContain('"');
+  });
+
+  it("switches format when the detected agent changes, without re-registering listeners", () => {
+    const addSpy = vi.spyOn(container, "addEventListener");
+    const { rerender } = renderFileTransferHook({});
+    const registrationsAfterMount = addSpy.mock.calls.length;
+
+    dropFiles([fileAt("a.ts", "/Users/test/a.ts")]);
+    expect(lastWrittenPayload()).toBe(`${escapeShellArgOptional("/Users/test/a.ts")} `);
+
+    rerender({ detectedAgentId: "claude" });
+
+    dropFiles([fileAt("a.ts", "/Users/test/a.ts")]);
+    expect(lastWrittenPayload()).toBe(`${formatAtFileToken("/Users/test/a.ts")} `);
+
+    expect(addSpy.mock.calls.length).toBe(registrationsAfterMount);
+    addSpy.mockRestore();
+  });
+
+  // --- Bracketed paste decides the delivery (#11574) ---
+
+  it("wraps the whole batch once when the program has bracketed paste on", () => {
+    instanceState.bracketedPasteMode = true;
+    renderFileTransferHook({ detectedAgentId: "claude" });
+
+    dropFiles([
+      fileAt("a.ts", "/Users/test/a.ts"),
+      fileAt("b.ts", "/Users/test/b.ts"),
+      fileAt("c.ts", "/Users/test/c.ts"),
+    ]);
+
+    const payload = lastWrittenPayload();
+    const logical = `${formatAtFileToken("/Users/test/a.ts")} ${formatAtFileToken("/Users/test/b.ts")} ${formatAtFileToken("/Users/test/c.ts")} `;
+
+    expect(payload).toBe(formatWithBracketedPaste(logical));
+    // One wrapper for the batch, not one per token.
+    expect(payload.split(BRACKETED_PASTE_START).length - 1).toBe(1);
+    expect(payload.split(BRACKETED_PASTE_END).length - 1).toBe(1);
+  });
+
+  it("does not wrap when the program has bracketed paste off", () => {
+    instanceState.bracketedPasteMode = false;
+    renderFileTransferHook({ detectedAgentId: "claude" });
+    dropFiles([fileAt("a.ts", "/Users/test/a.ts")]);
+
+    const payload = lastWrittenPayload();
+    expect(payload).toBe(`${formatAtFileToken("/Users/test/a.ts")} `);
+    expect(payload).not.toContain(BRACKETED_PASTE_START);
+  });
+
+  it("falls back to wrapping when no managed terminal instance exists", () => {
+    instanceState.hasManagedInstance = false;
+    renderFileTransferHook();
+    dropFiles([fileAt("a.ts", "/Users/test/a.ts")]);
+
+    expect(lastWrittenPayload()).toBe(
+      formatWithBracketedPaste(`${escapeShellArgOptional("/Users/test/a.ts")} `)
+    );
+  });
+
+  it("hands onInput the logical text, never the bracket markers", () => {
+    instanceState.bracketedPasteMode = true;
+    const onInput = vi.fn();
+    renderFileTransferHook({ onInput, detectedAgentId: "claude" });
+
+    dropFiles([fileAt("a.ts", "/Users/test/a.ts")]);
+
+    const forwarded = onInput.mock.calls[0]![0] as string;
+    expect(forwarded).toBe(`${formatAtFileToken("/Users/test/a.ts")} `);
+    expect(forwarded).not.toContain(BRACKETED_PASTE_START);
+    expect(forwarded).not.toContain(BRACKETED_PASTE_END);
+  });
+
+  it("never submits the insertion", () => {
+    instanceState.bracketedPasteMode = true;
+    renderFileTransferHook({ detectedAgentId: "claude" });
+    dropFiles([fileAt("a.ts", "/Users/test/a.ts")]);
+
+    const payload = lastWrittenPayload();
+    expect(payload).not.toContain("\r");
+    expect(payload).not.toContain("\n");
+  });
+
+  it("writes a mixed image/non-image drop as one ordered batch", () => {
+    renderFileTransferHook({ detectedAgentId: "claude" });
+
+    dropFiles([
+      fileAt("notes.md", "/Users/test/notes.md"),
+      fileAt("shot.png", "/Users/test/shot.png"),
+      fileAt("missing.txt"),
+      fileAt("my file.ts", "/Users/test/my file.ts"),
+    ]);
+
+    // Images take the same @ token as any other path — the terminal has no
+    // thumbnail-chip surface to justify the hybrid input's image branch.
+    expect(lastWrittenPayload()).toBe(
+      `${formatAtFileToken("/Users/test/notes.md")} ${formatAtFileToken("/Users/test/shot.png")} ${formatAtFileToken("/Users/test/my file.ts")} `
+    );
+    expect(terminalClient.write).toHaveBeenCalledTimes(1);
+    expect(terminalInstanceService.notifyUserInput).toHaveBeenCalledTimes(1);
   });
 
   // --- Drag event tests ---
@@ -339,6 +549,7 @@ describe("useTerminalFileTransfer hook", () => {
     container.dispatchEvent(event);
 
     expect(event.defaultPrevented).toBe(true);
+    expect(event.dataTransfer!.dropEffect).toBe("copy");
   });
 
   it("dragover without files does not prevent default", () => {
@@ -347,6 +558,94 @@ describe("useTerminalFileTransfer hook", () => {
     container.dispatchEvent(event);
 
     expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("dragover while locked does not advertise a copy target", () => {
+    renderFileTransferHook({ isInputLocked: true });
+    const event = makeDragEvent("dragover", true);
+    container.dispatchEvent(event);
+
+    expect(event.dataTransfer!.dropEffect).toBe("none");
+  });
+
+  // --- Drag-over state (#11574) ---
+
+  function dispatchDrag(type: string, hasFiles = true) {
+    act(() => {
+      container.dispatchEvent(makeDragEvent(type, hasFiles));
+    });
+  }
+
+  it("reports no drag-over state initially", () => {
+    const { result } = renderFileTransferHook();
+    expect(result.current).toBe(false);
+  });
+
+  it("reports drag-over state while files are over the terminal", () => {
+    const { result } = renderFileTransferHook();
+
+    dispatchDrag("dragenter");
+    expect(result.current).toBe(true);
+
+    dispatchDrag("dragleave");
+    expect(result.current).toBe(false);
+  });
+
+  it("survives nested dragenter/dragleave over child elements", () => {
+    const { result } = renderFileTransferHook();
+
+    dispatchDrag("dragenter");
+    dispatchDrag("dragenter");
+    expect(result.current).toBe(true);
+
+    // Leaving the inner element must not clear the state — the pointer is
+    // still inside the terminal.
+    dispatchDrag("dragleave");
+    expect(result.current).toBe(true);
+
+    dispatchDrag("dragleave");
+    expect(result.current).toBe(false);
+  });
+
+  it("clears drag-over state on drop even when nothing resolved", () => {
+    const { result } = renderFileTransferHook();
+
+    dispatchDrag("dragenter");
+    expect(result.current).toBe(true);
+
+    dropFiles([fileAt("unresolved.pdf")]);
+
+    expect(result.current).toBe(false);
+    expect(terminalClient.write).not.toHaveBeenCalled();
+  });
+
+  it("ignores drags that carry no files", () => {
+    const { result } = renderFileTransferHook();
+
+    dispatchDrag("dragenter", false);
+
+    expect(result.current).toBe(false);
+  });
+
+  it("does not advertise a drop target while input is locked", () => {
+    const { result } = renderFileTransferHook({ isInputLocked: true });
+
+    dispatchDrag("dragenter");
+
+    expect(result.current).toBe(false);
+  });
+
+  it("clears an active drag-over state when input becomes locked", () => {
+    const { result, rerender } = renderFileTransferHook({ isInputLocked: false });
+
+    dispatchDrag("dragenter");
+    expect(result.current).toBe(true);
+
+    act(() => {
+      rerender({ isInputLocked: true });
+    });
+
+    expect(result.current).toBe(false);
   });
 
   // --- Cleanup test ---

--- a/src/components/Terminal/__tests__/useTerminalFileTransfer.test.ts
+++ b/src/components/Terminal/__tests__/useTerminalFileTransfer.test.ts
@@ -15,7 +15,9 @@ const instanceState = vi.hoisted(() => ({
 
 vi.mock("@/clients", () => ({
   terminalClient: {
-    write: vi.fn(),
+    // Typed so call payloads read back as string without a cast — the lint
+    // ratchet counts `no-unsafe-type-assertion` per rule.
+    write: vi.fn<(terminalId: string, data: string) => void>(),
   },
 }));
 
@@ -44,7 +46,7 @@ import {
 /** The payload handed to `terminalClient.write` for the most recent call. */
 function lastWrittenPayload(): string {
   const calls = vi.mocked(terminalClient.write).mock.calls;
-  return calls[calls.length - 1]![1] as string;
+  return calls[calls.length - 1]![1];
 }
 
 describe("IMAGE_EXTENSIONS", () => {
@@ -221,7 +223,7 @@ describe("useTerminalFileTransfer hook", () => {
   });
 
   it("image paste with saveImage failure does not write to terminal", async () => {
-    (window.electron.clipboard.saveImage as ReturnType<typeof vi.fn>).mockRejectedValue(
+    vi.mocked(window.electron.clipboard.saveImage).mockRejectedValue(
       Object.assign(new Error("No image in clipboard"), {
         name: "AppError",
         code: "CLIPBOARD_EMPTY",
@@ -248,7 +250,7 @@ describe("useTerminalFileTransfer hook", () => {
   });
 
   it("image paste escapes paths with spaces", async () => {
-    (window.electron.clipboard.saveImage as ReturnType<typeof vi.fn>).mockResolvedValue({
+    vi.mocked(window.electron.clipboard.saveImage).mockResolvedValue({
       filePath: "/tmp/daintree clipboard/my screenshot.png",
       thumbnailDataUrl: "data:image/png;base64,abc",
     });
@@ -274,7 +276,7 @@ describe("useTerminalFileTransfer hook", () => {
 
   it("locking while the image is still saving suppresses the write", async () => {
     let releaseSave: (value: { filePath: string }) => void = () => {};
-    (window.electron.clipboard.saveImage as ReturnType<typeof vi.fn>).mockReturnValue(
+    vi.mocked(window.electron.clipboard.saveImage).mockReturnValue(
       new Promise<{ filePath: string }>((resolve) => {
         releaseSave = resolve;
       })
@@ -301,7 +303,7 @@ describe("useTerminalFileTransfer hook", () => {
 
   it("re-reads the agent identity across the save, not the one at paste time", async () => {
     let releaseSave: (value: { filePath: string }) => void = () => {};
-    (window.electron.clipboard.saveImage as ReturnType<typeof vi.fn>).mockReturnValue(
+    vi.mocked(window.electron.clipboard.saveImage).mockReturnValue(
       new Promise<{ filePath: string }>((resolve) => {
         releaseSave = resolve;
       })
@@ -328,7 +330,7 @@ describe("useTerminalFileTransfer hook", () => {
 
   it("unmounting while the image is still saving suppresses the write", async () => {
     let releaseSave: (value: { filePath: string }) => void = () => {};
-    (window.electron.clipboard.saveImage as ReturnType<typeof vi.fn>).mockReturnValue(
+    vi.mocked(window.electron.clipboard.saveImage).mockReturnValue(
       new Promise<{ filePath: string }>((resolve) => {
         releaseSave = resolve;
       })
@@ -561,12 +563,12 @@ describe("useTerminalFileTransfer hook", () => {
 
   it("hands onInput the logical text, never the bracket markers", () => {
     instanceState.bracketedPasteMode = true;
-    const onInput = vi.fn();
+    const onInput = vi.fn<(data: string) => void>();
     renderFileTransferHook({ onInput, detectedAgentId: "claude" });
 
     dropFiles([fileAt("a.ts", "/Users/test/a.ts")]);
 
-    const forwarded = onInput.mock.calls[0]![0] as string;
+    const forwarded = onInput.mock.calls[0]![0];
     expect(forwarded).toBe(`${formatAtFileToken("/Users/test/a.ts")} `);
     expect(forwarded).not.toContain(BRACKETED_PASTE_START);
     expect(forwarded).not.toContain(BRACKETED_PASTE_END);

--- a/src/components/Terminal/__tests__/useTerminalFileTransfer.test.ts
+++ b/src/components/Terminal/__tests__/useTerminalFileTransfer.test.ts
@@ -43,6 +43,9 @@ import {
   formatWithBracketedPaste,
 } from "@shared/utils/terminalInputProtocol.js";
 
+/** What `clipboard.saveImage` resolves to, taken from the IPC surface itself. */
+type SavedImage = Awaited<ReturnType<typeof window.electron.clipboard.saveImage>>;
+
 /** The payload handed to `terminalClient.write` for the most recent call. */
 function lastWrittenPayload(): string {
   const calls = vi.mocked(terminalClient.write).mock.calls;
@@ -275,9 +278,9 @@ describe("useTerminalFileTransfer hook", () => {
   });
 
   it("locking while the image is still saving suppresses the write", async () => {
-    let releaseSave: (value: { filePath: string }) => void = () => {};
+    let releaseSave: (value: SavedImage) => void = () => {};
     vi.mocked(window.electron.clipboard.saveImage).mockReturnValue(
-      new Promise<{ filePath: string }>((resolve) => {
+      new Promise<SavedImage>((resolve) => {
         releaseSave = resolve;
       })
     );
@@ -292,7 +295,7 @@ describe("useTerminalFileTransfer hook", () => {
     rerender({ isInputLocked: true });
 
     await act(async () => {
-      releaseSave({ filePath: "/tmp/late.png" });
+      releaseSave({ filePath: "/tmp/late.png", thumbnailDataUrl: "" });
       await Promise.resolve();
       await Promise.resolve();
     });
@@ -302,9 +305,9 @@ describe("useTerminalFileTransfer hook", () => {
   });
 
   it("re-reads the agent identity across the save, not the one at paste time", async () => {
-    let releaseSave: (value: { filePath: string }) => void = () => {};
+    let releaseSave: (value: SavedImage) => void = () => {};
     vi.mocked(window.electron.clipboard.saveImage).mockReturnValue(
-      new Promise<{ filePath: string }>((resolve) => {
+      new Promise<SavedImage>((resolve) => {
         releaseSave = resolve;
       })
     );
@@ -320,7 +323,7 @@ describe("useTerminalFileTransfer hook", () => {
     rerender({ detectedAgentId: "claude" });
 
     await act(async () => {
-      releaseSave({ filePath: "/tmp/shot.png" });
+      releaseSave({ filePath: "/tmp/shot.png", thumbnailDataUrl: "" });
       await Promise.resolve();
       await Promise.resolve();
     });
@@ -329,9 +332,9 @@ describe("useTerminalFileTransfer hook", () => {
   });
 
   it("unmounting while the image is still saving suppresses the write", async () => {
-    let releaseSave: (value: { filePath: string }) => void = () => {};
+    let releaseSave: (value: SavedImage) => void = () => {};
     vi.mocked(window.electron.clipboard.saveImage).mockReturnValue(
-      new Promise<{ filePath: string }>((resolve) => {
+      new Promise<SavedImage>((resolve) => {
         releaseSave = resolve;
       })
     );
@@ -345,7 +348,7 @@ describe("useTerminalFileTransfer hook", () => {
     unmount();
 
     await act(async () => {
-      releaseSave({ filePath: "/tmp/late.png" });
+      releaseSave({ filePath: "/tmp/late.png", thumbnailDataUrl: "" });
       await Promise.resolve();
       await Promise.resolve();
     });

--- a/src/components/Terminal/__tests__/useTerminalFileTransfer.test.ts
+++ b/src/components/Terminal/__tests__/useTerminalFileTransfer.test.ts
@@ -108,26 +108,15 @@ describe("useTerminalFileTransfer hook", () => {
     (window as unknown as Record<string, unknown>).electron = originalElectron;
   });
 
-  interface HookProps {
-    isInputLocked?: boolean;
-    onInput?: (data: string) => void;
-    launchAgentId?: string;
-    detectedAgentId?: string;
-    agentState?: string;
-  }
+  // Derived from the hook's own options type, so a tightened contract surfaces
+  // here as a type error instead of being papered over by a cast.
+  type HookProps = Omit<Parameters<typeof useTerminalFileTransfer>[1], "terminalId">;
 
   function renderFileTransferHook(options: HookProps = {}) {
     return renderHook(
       (props: HookProps) => {
         const ref = useRef<HTMLDivElement>(container);
-        return useTerminalFileTransfer(ref, {
-          terminalId: "term-1",
-          isInputLocked: props.isInputLocked,
-          onInput: props.onInput,
-          launchAgentId: props.launchAgentId,
-          detectedAgentId: props.detectedAgentId,
-          agentState: props.agentState as never,
-        });
+        return useTerminalFileTransfer(ref, { terminalId: "term-1", ...props });
       },
       { initialProps: options }
     );
@@ -307,6 +296,34 @@ describe("useTerminalFileTransfer hook", () => {
     });
 
     expect(terminalClient.write).not.toHaveBeenCalled();
+    expect(terminalInstanceService.notifyUserInput).not.toHaveBeenCalled();
+  });
+
+  it("re-reads the agent identity across the save, not the one at paste time", async () => {
+    let releaseSave: (value: { filePath: string }) => void = () => {};
+    (window.electron.clipboard.saveImage as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise<{ filePath: string }>((resolve) => {
+        releaseSave = resolve;
+      })
+    );
+
+    // Pasted while a shell owned the terminal…
+    const { rerender } = renderFileTransferHook({});
+
+    act(() => {
+      container.dispatchEvent(makePasteEvent(true));
+    });
+
+    // …but an agent is detected before the image finishes saving.
+    rerender({ detectedAgentId: "claude" });
+
+    await act(async () => {
+      releaseSave({ filePath: "/tmp/shot.png" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(lastWrittenPayload()).toBe(`${formatAtFileToken("/tmp/shot.png")} `);
   });
 
   it("unmounting while the image is still saving suppresses the write", async () => {
@@ -332,6 +349,7 @@ describe("useTerminalFileTransfer hook", () => {
     });
 
     expect(terminalClient.write).not.toHaveBeenCalled();
+    expect(terminalInstanceService.notifyUserInput).not.toHaveBeenCalled();
   });
 
   // --- File drop tests ---
@@ -434,11 +452,17 @@ describe("useTerminalFileTransfer hook", () => {
     renderFileTransferHook({ detectedAgentId: "claude" });
     dropFiles([fileAt("my notes.md", "/Users/test/my notes.md")]);
 
-    const payload = lastWrittenPayload();
-    expect(payload).toBe(`${formatAtFileToken("/Users/test/my notes.md")} `);
-    // The quoting must survive into the payload — an unquoted space would split
-    // the reference into two arguments for the agent.
-    expect(payload).toContain('"');
+    // Pinned to the literal wire format an agent CLI has to parse, rather than
+    // re-deriving it from the same formatter the hook calls — an unquoted space
+    // would split the reference into two arguments.
+    expect(lastWrittenPayload()).toBe('@"/Users/test/my notes.md" ');
+  });
+
+  it("writes the plain @ wire format for a path needing no quoting", () => {
+    renderFileTransferHook({ detectedAgentId: "claude" });
+    dropFiles([fileAt("App.tsx", "/Users/test/src/App.tsx")]);
+
+    expect(lastWrittenPayload()).toBe("@/Users/test/src/App.tsx ");
   });
 
   it("switches format when the detected agent changes, without re-registering listeners", () => {
@@ -489,14 +513,45 @@ describe("useTerminalFileTransfer hook", () => {
     expect(payload).not.toContain(BRACKETED_PASTE_START);
   });
 
-  it("falls back to wrapping when no managed terminal instance exists", () => {
+  // The renderer instance is created asynchronously, so a live PTY can exist
+  // while `get()` still returns null. "Unknown" must not be read as "on".
+  it("falls back to wrapping for an agent when no managed instance exists", () => {
+    instanceState.hasManagedInstance = false;
+    renderFileTransferHook({ detectedAgentId: "claude" });
+    dropFiles([fileAt("a.ts", "/Users/test/a.ts")]);
+
+    expect(lastWrittenPayload()).toBe(
+      formatWithBracketedPaste(`${formatAtFileToken("/Users/test/a.ts")} `)
+    );
+  });
+
+  it("falls back to raw text for a shell when no managed instance exists", () => {
     instanceState.hasManagedInstance = false;
     renderFileTransferHook();
     dropFiles([fileAt("a.ts", "/Users/test/a.ts")]);
 
-    expect(lastWrittenPayload()).toBe(
-      formatWithBracketedPaste(`${escapeShellArgOptional("/Users/test/a.ts")} `)
-    );
+    const payload = lastWrittenPayload();
+    expect(payload).toBe(`${escapeShellArgOptional("/Users/test/a.ts")} `);
+    // A shell that never enabled DECSET 2004 would echo these as literal input.
+    expect(payload).not.toContain(BRACKETED_PASTE_START);
+  });
+
+  it("strips ESC from a path so it cannot break out of the paste wrapper", () => {
+    instanceState.bracketedPasteMode = true;
+    renderFileTransferHook({ detectedAgentId: "claude" });
+
+    // A POSIX filename may legally contain ESC. Left verbatim, an embedded
+    // terminator would end the paste early and submit the remainder.
+    dropFiles([fileAt("evil", `/tmp/${BRACKETED_PASTE_END}evil.ts`)]);
+
+    const payload = lastWrittenPayload();
+    expect(payload.startsWith(BRACKETED_PASTE_START)).toBe(true);
+    expect(payload.endsWith(BRACKETED_PASTE_END)).toBe(true);
+    // Exactly one terminator: the real one, at the very end.
+    expect(payload.split(BRACKETED_PASTE_END).length - 1).toBe(1);
+    // Nothing between the delimiters can start an escape sequence of its own.
+    const body = payload.slice(BRACKETED_PASTE_START.length, -BRACKETED_PASTE_END.length);
+    expect(body).not.toContain(String.fromCharCode(27));
   });
 
   it("hands onInput the logical text, never the bracket markers", () => {
@@ -646,6 +701,22 @@ describe("useTerminalFileTransfer hook", () => {
     });
 
     expect(result.current).toBe(false);
+  });
+
+  it("restores the affordance when input unlocks mid-drag", () => {
+    const { result, rerender } = renderFileTransferHook({ isInputLocked: true });
+
+    // The pointer entered while locked, so no further dragenter will arrive.
+    // Depth is tracked physically, so unlocking alone must restore feedback —
+    // otherwise the drop is silently accepted with nothing on screen.
+    dispatchDrag("dragenter");
+    expect(result.current).toBe(false);
+
+    act(() => {
+      rerender({ isInputLocked: false });
+    });
+
+    expect(result.current).toBe(true);
   });
 
   // --- Cleanup test ---

--- a/src/components/Terminal/__tests__/useTerminalFileTransfer.test.ts
+++ b/src/components/Terminal/__tests__/useTerminalFileTransfer.test.ts
@@ -536,22 +536,27 @@ describe("useTerminalFileTransfer hook", () => {
     expect(payload).not.toContain(BRACKETED_PASTE_START);
   });
 
-  it("strips ESC from a path so it cannot break out of the paste wrapper", () => {
-    instanceState.bracketedPasteMode = true;
+  it.each([
+    ["carriage return", "\r"],
+    ["newline", "\n"],
+    ["escape", String.fromCharCode(27)],
+  ])("skips a path containing a %s rather than risk submitting it", (_label, char) => {
+    // Bracketed paste off is the dangerous case: the program reads CR as Enter.
+    instanceState.bracketedPasteMode = false;
     renderFileTransferHook({ detectedAgentId: "claude" });
 
-    // A POSIX filename may legally contain ESC. Left verbatim, an embedded
-    // terminator would end the paste early and submit the remainder.
-    dropFiles([fileAt("evil", `/tmp/${BRACKETED_PASTE_END}evil.ts`)]);
+    dropFiles([fileAt("bad", `/tmp/we${char}ird.ts`), fileAt("good", "/tmp/fine.ts")]);
 
-    const payload = lastWrittenPayload();
-    expect(payload.startsWith(BRACKETED_PASTE_START)).toBe(true);
-    expect(payload.endsWith(BRACKETED_PASTE_END)).toBe(true);
-    // Exactly one terminator: the real one, at the very end.
-    expect(payload.split(BRACKETED_PASTE_END).length - 1).toBe(1);
-    // Nothing between the delimiters can start an escape sequence of its own.
-    const body = payload.slice(BRACKETED_PASTE_START.length, -BRACKETED_PASTE_END.length);
-    expect(body).not.toContain(String.fromCharCode(27));
+    // The safe sibling still lands; the unsafe path is dropped like an
+    // unresolved one, and nothing that could submit reaches the PTY.
+    expect(lastWrittenPayload()).toBe(`${formatAtFileToken("/tmp/fine.ts")} `);
+  });
+
+  it("writes nothing when every dropped path carries a control character", () => {
+    renderFileTransferHook({ detectedAgentId: "claude" });
+    dropFiles([fileAt("bad", "/tmp/we\rird.ts")]);
+
+    expect(terminalClient.write).not.toHaveBeenCalled();
   });
 
   it("hands onInput the logical text, never the bracket markers", () => {

--- a/src/components/Terminal/useTerminalFileTransfer.ts
+++ b/src/components/Terminal/useTerminalFileTransfer.ts
@@ -37,6 +37,21 @@ function hasImageClipboardItem(event: ClipboardEvent): boolean {
   return false;
 }
 
+const ESC = String.fromCharCode(27);
+
+/**
+ * Control characters that cannot be delivered safely as terminal input.
+ *
+ * CR and LF read as Enter to a program that is not in bracketed-paste mode,
+ * which would submit rather than insert; ESC can open an escape sequence. All
+ * three are legal in a POSIX filename, so a dropped path really can carry them.
+ * Such a path is skipped exactly like one that failed to resolve — there is no
+ * sanitized form that still points at the same file.
+ */
+function isDeliverablePath(filePath: string): boolean {
+  return !filePath.includes("\r") && !filePath.includes("\n") && !filePath.includes(ESC);
+}
+
 interface UseTerminalFileTransferOptions extends TerminalFileTransferIdentity {
   terminalId: string;
   isInputLocked?: boolean;
@@ -161,7 +176,7 @@ export function useTerminalFileTransfer(
         // Re-check after the await: the pane may have unmounted or locked, and
         // the running agent may have changed, while the image was being saved.
         if (cancelled || !isMountedRef.current || isInputLockedRef.current) return;
-        if (!filePath) return;
+        if (!filePath || !isDeliverablePath(filePath)) return;
         const isAgent = isAgentTerminal();
         writeToTerminal(`${formatPath(filePath, isAgent)} `, isAgent);
       } catch {
@@ -206,7 +221,7 @@ export function useTerminalFileTransfer(
       const formatted: string[] = [];
       for (const file of Array.from(e.dataTransfer.files)) {
         const filePath = window.electron.webUtils.getPathForFile(file);
-        if (filePath) formatted.push(formatPath(filePath, isAgent));
+        if (filePath && isDeliverablePath(filePath)) formatted.push(formatPath(filePath, isAgent));
       }
 
       if (formatted.length === 0) return;

--- a/src/components/Terminal/useTerminalFileTransfer.ts
+++ b/src/components/Terminal/useTerminalFileTransfer.ts
@@ -1,13 +1,27 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { terminalClient } from "@/clients";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import { deriveTerminalChrome, type TerminalChromeInput } from "@/utils/terminalChrome";
 import { escapeShellArgOptional } from "@shared/utils/shellEscape.js";
+import { formatWithBracketedPaste } from "@shared/utils/terminalInputProtocol.js";
+import { formatAtFileToken } from "./hybridInputParsing";
 
 /**
  * Image file extension pattern shared with HybridInputBar.
  * Exported so both the input bar and terminal can use the same detection.
  */
 export const IMAGE_EXTENSIONS = /\.(png|jpe?g|bmp|tiff?|avif|heic)$/i;
+
+/**
+ * Runtime identity inputs used to decide whether an agent CLI — rather than a
+ * shell — owns this terminal. Passed straight to `deriveTerminalChrome`, which
+ * owns the precedence rules (`detectedAgentId` first, `launchAgentId` only
+ * while no explicit exit has been observed).
+ */
+export type TerminalFileTransferIdentity = Pick<
+  TerminalChromeInput,
+  "launchAgentId" | "detectedAgentId" | "agentState"
+>;
 
 /**
  * Checks whether a ClipboardEvent contains an image MIME type item.
@@ -21,7 +35,7 @@ function hasImageClipboardItem(event: ClipboardEvent): boolean {
   return false;
 }
 
-interface UseTerminalFileTransferOptions {
+interface UseTerminalFileTransferOptions extends TerminalFileTransferIdentity {
   terminalId: string;
   isInputLocked?: boolean;
   onInput?: (data: string) => void;
@@ -36,20 +50,96 @@ interface UseTerminalFileTransferOptions {
  * - **File drop:** Resolves file paths via `webUtils.getPathForFile()` and writes them
  *   into the terminal as text. Works for both image and non-image files.
  *
- * Paths are shell-escaped so filenames with spaces or metacharacters are safe.
+ * Two independent axes decide what reaches the PTY (#11574):
+ *
+ * - **Content** follows the terminal's runtime identity. An agent CLI gets the
+ *   same `@path` token every other attach surface produces (`@` autocomplete,
+ *   hybrid-input paste/drop, voice "link to"); a plain shell keeps a
+ *   shell-escaped path, which is what a shell can actually consume.
+ * - **Delivery** follows the live xterm bracketed-paste mode. Agent CLIs read
+ *   raw stdin and cannot distinguish an injected byte from a typed one, so an
+ *   unwrapped `@` would drive their own interactive file picker character by
+ *   character. Wrapping the batch marks it as a paste instead. This mirrors
+ *   `sendSelectionToTarget` in `useSendToAgentPalette`, including its fallback
+ *   to wrapping when no managed instance is available.
+ *
+ * Never appends a carriage return — a drop inserts text, it does not submit.
+ *
+ * @returns Whether files are currently dragged over the container, so the pane
+ *   can render drop feedback. Always `false` while input is locked: advertising
+ *   a drop target for a gesture that will be discarded is false feedback.
  */
 export function useTerminalFileTransfer(
   containerRef: React.RefObject<HTMLDivElement | null>,
-  { terminalId, isInputLocked, onInput }: UseTerminalFileTransferOptions
-) {
+  {
+    terminalId,
+    isInputLocked,
+    onInput,
+    launchAgentId,
+    detectedAgentId,
+    agentState,
+  }: UseTerminalFileTransferOptions
+): boolean {
   const dragDepthRef = useRef(0);
+  const [isDragOverFiles, setIsDragOverFiles] = useState(false);
+
+  // Runtime identity and lock state are read at gesture time, not captured in
+  // the listener closure: a detected-agent flip must change the next drop's
+  // format without tearing down and re-registering five DOM listeners, and the
+  // image-paste path has to re-read both across its `await saveImage()`.
+  const identityRef = useRef<TerminalFileTransferIdentity>({
+    launchAgentId,
+    detectedAgentId,
+    agentState,
+  });
+  const isInputLockedRef = useRef(isInputLocked);
+
+  useEffect(() => {
+    identityRef.current = { launchAgentId, detectedAgentId, agentState };
+  }, [launchAgentId, detectedAgentId, agentState]);
+
+  useEffect(() => {
+    isInputLockedRef.current = isInputLocked;
+  }, [isInputLocked]);
+
+  // Locking mid-drag strands the hover state on: the drop that would clear it
+  // is now a no-op, so clear it here instead.
+  useEffect(() => {
+    if (!isInputLocked) return;
+    dragDepthRef.current = 0;
+    setIsDragOverFiles(false);
+  }, [isInputLocked]);
 
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
 
+    let cancelled = false;
+
+    const formatPath = (filePath: string): string =>
+      deriveTerminalChrome(identityRef.current).isAgent
+        ? formatAtFileToken(filePath)
+        : escapeShellArgOptional(filePath);
+
+    /**
+     * Writes one already-formatted batch as a single insertion, wrapping it in
+     * bracketed paste when the foreground program has asked for it.
+     */
+    const writeToTerminal = (text: string) => {
+      const managed = terminalInstanceService.get(terminalId);
+      const payload =
+        !managed || managed.terminal.modes.bracketedPasteMode
+          ? formatWithBracketedPaste(text)
+          : text;
+
+      terminalClient.write(terminalId, payload);
+      terminalInstanceService.notifyUserInput(terminalId);
+      // The unwrapped text — bracket markers must not reach input tracking.
+      onInput?.(text);
+    };
+
     const handlePaste = async (event: ClipboardEvent) => {
-      if (isInputLocked) return;
+      if (isInputLockedRef.current) return;
       if (!hasImageClipboardItem(event)) return;
 
       // Prevent xterm from processing the image paste as text
@@ -58,10 +148,10 @@ export function useTerminalFileTransfer(
 
       try {
         const { filePath } = await window.electron.clipboard.saveImage();
-        const escaped = escapeShellArgOptional(filePath);
-        terminalClient.write(terminalId, escaped);
-        terminalInstanceService.notifyUserInput(terminalId);
-        onInput?.(escaped);
+        // Re-check after the await: the pane may have unmounted or locked, and
+        // the running agent may have changed, while the image was being saved.
+        if (cancelled || isInputLockedRef.current) return;
+        writeToTerminal(`${formatPath(filePath)} `);
       } catch {
         // Empty clipboard, IPC failure during window close, etc. — nothing to do.
       }
@@ -71,14 +161,16 @@ export function useTerminalFileTransfer(
       if (!e.dataTransfer?.types.includes("Files")) return;
       e.preventDefault();
       e.stopPropagation();
+      if (isInputLockedRef.current) return;
       dragDepthRef.current++;
+      if (dragDepthRef.current === 1) setIsDragOverFiles(true);
     };
 
     const handleDragOver = (e: DragEvent) => {
       if (!e.dataTransfer?.types.includes("Files")) return;
       e.preventDefault();
       e.stopPropagation();
-      e.dataTransfer.dropEffect = "copy";
+      e.dataTransfer.dropEffect = isInputLockedRef.current ? "none" : "copy";
     };
 
     const handleDragLeave = (e: DragEvent) => {
@@ -86,6 +178,7 @@ export function useTerminalFileTransfer(
       dragDepthRef.current--;
       if (dragDepthRef.current <= 0) {
         dragDepthRef.current = 0;
+        setIsDragOverFiles(false);
       }
     };
 
@@ -93,22 +186,22 @@ export function useTerminalFileTransfer(
       e.preventDefault();
       e.stopPropagation();
       dragDepthRef.current = 0;
+      setIsDragOverFiles(false);
 
-      if (isInputLocked) return;
+      if (isInputLockedRef.current) return;
       if (!e.dataTransfer?.files.length) return;
 
-      const escapedPaths: string[] = [];
+      const formatted: string[] = [];
       for (const file of Array.from(e.dataTransfer.files)) {
         const filePath = window.electron.webUtils.getPathForFile(file);
-        if (filePath) escapedPaths.push(escapeShellArgOptional(filePath));
+        if (filePath) formatted.push(formatPath(filePath));
       }
 
-      if (escapedPaths.length === 0) return;
+      if (formatted.length === 0) return;
 
-      const text = escapedPaths.join(" ");
-      terminalClient.write(terminalId, text);
-      terminalInstanceService.notifyUserInput(terminalId);
-      onInput?.(text);
+      // Trailing space terminates the last token and leaves the caret ready for
+      // the next argument or prompt word, matching the hybrid input's drop.
+      writeToTerminal(`${formatted.join(" ")} `);
     };
 
     // Use capture phase for paste so we intercept before xterm's own handler
@@ -119,11 +212,14 @@ export function useTerminalFileTransfer(
     container.addEventListener("drop", handleDrop);
 
     return () => {
+      cancelled = true;
       container.removeEventListener("paste", handlePaste, true);
       container.removeEventListener("dragenter", handleDragEnter);
       container.removeEventListener("dragover", handleDragOver);
       container.removeEventListener("dragleave", handleDragLeave);
       container.removeEventListener("drop", handleDrop);
     };
-  }, [containerRef, terminalId, isInputLocked, onInput]);
+  }, [containerRef, terminalId, onInput]);
+
+  return isDragOverFiles;
 }

--- a/src/components/Terminal/useTerminalFileTransfer.ts
+++ b/src/components/Terminal/useTerminalFileTransfer.ts
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import type { AgentState } from "@shared/types/agent";
 import { terminalClient } from "@/clients";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
-import { deriveTerminalChrome, type TerminalChromeInput } from "@/utils/terminalChrome";
+import { deriveTerminalChrome } from "@/utils/terminalChrome";
 import { escapeShellArgOptional } from "@shared/utils/shellEscape.js";
 import { formatWithBracketedPaste } from "@shared/utils/terminalInputProtocol.js";
 import { formatAtFileToken } from "./hybridInputParsing";
@@ -18,10 +19,11 @@ export const IMAGE_EXTENSIONS = /\.(png|jpe?g|bmp|tiff?|avif|heic)$/i;
  * owns the precedence rules (`detectedAgentId` first, `launchAgentId` only
  * while no explicit exit has been observed).
  */
-export type TerminalFileTransferIdentity = Pick<
-  TerminalChromeInput,
-  "launchAgentId" | "detectedAgentId" | "agentState"
->;
+export interface TerminalFileTransferIdentity {
+  launchAgentId?: string;
+  detectedAgentId?: string;
+  agentState?: AgentState;
+}
 
 /**
  * Checks whether a ClipboardEvent contains an image MIME type item.
@@ -81,34 +83,38 @@ export function useTerminalFileTransfer(
   }: UseTerminalFileTransferOptions
 ): boolean {
   const dragDepthRef = useRef(0);
+  // Physical presence of a file drag, independent of whether we would accept a
+  // drop. Masking happens on the way out, so unlocking mid-drag restores the
+  // affordance without waiting for the pointer to leave and re-enter.
   const [isDragOverFiles, setIsDragOverFiles] = useState(false);
 
   // Runtime identity and lock state are read at gesture time, not captured in
   // the listener closure: a detected-agent flip must change the next drop's
-  // format without tearing down and re-registering five DOM listeners, and the
+  // format without tearing down and re-registering the DOM listeners, and the
   // image-paste path has to re-read both across its `await saveImage()`.
+  //
+  // Layout phase, not passive: a promise continuation or a native drag event
+  // can run after a commit but before passive effects flush, and would then
+  // read a lock or identity the UI has already moved on from.
   const identityRef = useRef<TerminalFileTransferIdentity>({
     launchAgentId,
     detectedAgentId,
     agentState,
   });
   const isInputLockedRef = useRef(isInputLocked);
+  const isMountedRef = useRef(true);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     identityRef.current = { launchAgentId, detectedAgentId, agentState };
-  }, [launchAgentId, detectedAgentId, agentState]);
-
-  useEffect(() => {
     isInputLockedRef.current = isInputLocked;
-  }, [isInputLocked]);
+  });
 
-  // Locking mid-drag strands the hover state on: the drop that would clear it
-  // is now a no-op, so clear it here instead.
-  useEffect(() => {
-    if (!isInputLocked) return;
-    dragDepthRef.current = 0;
-    setIsDragOverFiles(false);
-  }, [isInputLocked]);
+  useLayoutEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -116,21 +122,25 @@ export function useTerminalFileTransfer(
 
     let cancelled = false;
 
-    const formatPath = (filePath: string): string =>
-      deriveTerminalChrome(identityRef.current).isAgent
-        ? formatAtFileToken(filePath)
-        : escapeShellArgOptional(filePath);
+    const isAgentTerminal = (): boolean => deriveTerminalChrome(identityRef.current).isAgent;
+
+    const formatPath = (filePath: string, isAgent: boolean): string =>
+      isAgent ? formatAtFileToken(filePath) : escapeShellArgOptional(filePath);
 
     /**
      * Writes one already-formatted batch as a single insertion, wrapping it in
      * bracketed paste when the foreground program has asked for it.
+     *
+     * The renderer instance is created asynchronously, so `get()` can return
+     * null while a live PTY is already attached. "Unknown" is not evidence of
+     * either mode, so fall back on identity: an agent almost certainly enabled
+     * bracketed paste and must not be fed raw `@` keystrokes, whereas a shell
+     * that never enabled it would render the delimiters as literal input.
      */
-    const writeToTerminal = (text: string) => {
+    const writeToTerminal = (text: string, isAgent: boolean) => {
       const managed = terminalInstanceService.get(terminalId);
-      const payload =
-        !managed || managed.terminal.modes.bracketedPasteMode
-          ? formatWithBracketedPaste(text)
-          : text;
+      const useBracketedPaste = managed ? managed.terminal.modes.bracketedPasteMode : isAgent;
+      const payload = useBracketedPaste ? formatWithBracketedPaste(text) : text;
 
       terminalClient.write(terminalId, payload);
       terminalInstanceService.notifyUserInput(terminalId);
@@ -150,8 +160,10 @@ export function useTerminalFileTransfer(
         const { filePath } = await window.electron.clipboard.saveImage();
         // Re-check after the await: the pane may have unmounted or locked, and
         // the running agent may have changed, while the image was being saved.
-        if (cancelled || isInputLockedRef.current) return;
-        writeToTerminal(`${formatPath(filePath)} `);
+        if (cancelled || !isMountedRef.current || isInputLockedRef.current) return;
+        if (!filePath) return;
+        const isAgent = isAgentTerminal();
+        writeToTerminal(`${formatPath(filePath, isAgent)} `, isAgent);
       } catch {
         // Empty clipboard, IPC failure during window close, etc. — nothing to do.
       }
@@ -161,7 +173,6 @@ export function useTerminalFileTransfer(
       if (!e.dataTransfer?.types.includes("Files")) return;
       e.preventDefault();
       e.stopPropagation();
-      if (isInputLockedRef.current) return;
       dragDepthRef.current++;
       if (dragDepthRef.current === 1) setIsDragOverFiles(true);
     };
@@ -191,17 +202,18 @@ export function useTerminalFileTransfer(
       if (isInputLockedRef.current) return;
       if (!e.dataTransfer?.files.length) return;
 
+      const isAgent = isAgentTerminal();
       const formatted: string[] = [];
       for (const file of Array.from(e.dataTransfer.files)) {
         const filePath = window.electron.webUtils.getPathForFile(file);
-        if (filePath) formatted.push(formatPath(filePath));
+        if (filePath) formatted.push(formatPath(filePath, isAgent));
       }
 
       if (formatted.length === 0) return;
 
       // Trailing space terminates the last token and leaves the caret ready for
       // the next argument or prompt word, matching the hybrid input's drop.
-      writeToTerminal(`${formatted.join(" ")} `);
+      writeToTerminal(`${formatted.join(" ")} `, isAgent);
     };
 
     // Use capture phase for paste so we intercept before xterm's own handler
@@ -221,5 +233,5 @@ export function useTerminalFileTransfer(
     };
   }, [containerRef, terminalId, onInput]);
 
-  return isDragOverFiles;
+  return isDragOverFiles && !isInputLocked;
 }

--- a/src/components/Terminal/useTerminalFileTransfer.ts
+++ b/src/components/Terminal/useTerminalFileTransfer.ts
@@ -5,7 +5,7 @@ import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
 import { escapeShellArgOptional } from "@shared/utils/shellEscape.js";
 import { formatWithBracketedPaste } from "@shared/utils/terminalInputProtocol.js";
-import { formatAtFileToken } from "./hybridInputParsing";
+import { formatAtFileTokenForCwd } from "./hybridInputParsing";
 
 /**
  * Image file extension pattern shared with HybridInputBar.
@@ -56,6 +56,13 @@ interface UseTerminalFileTransferOptions extends TerminalFileTransferIdentity {
   terminalId: string;
   isInputLocked?: boolean;
   onInput?: (data: string) => void;
+  /**
+   * Reads the terminal's live cwd, called at gesture time so a `cd` between
+   * mount and drop relativizes against where the terminal actually is.
+   * Omitted (or empty) leaves every path absolute, which is what
+   * `formatAtFileTokenForCwd` already does for an out-of-tree file.
+   */
+  cwdProvider?: () => string;
 }
 
 /**
@@ -71,8 +78,11 @@ interface UseTerminalFileTransferOptions extends TerminalFileTransferIdentity {
  *
  * - **Content** follows the terminal's runtime identity. An agent CLI gets the
  *   same `@path` token every other attach surface produces (`@` autocomplete,
- *   hybrid-input paste/drop, voice "link to"); a plain shell keeps a
- *   shell-escaped path, which is what a shell can actually consume.
+ *   hybrid-input paste/drop, voice "link to") — including its cwd-relative
+ *   spelling (#11575), so dropping a file on the terminal and dropping it on
+ *   the input bar cannot disagree about what the reference looks like. A plain
+ *   shell keeps an absolute shell-escaped path, which is what a shell can
+ *   actually consume.
  * - **Delivery** follows the live xterm bracketed-paste mode. Agent CLIs read
  *   raw stdin and cannot distinguish an injected byte from a typed one, so an
  *   unwrapped `@` would drive their own interactive file picker character by
@@ -92,6 +102,7 @@ export function useTerminalFileTransfer(
     terminalId,
     isInputLocked,
     onInput,
+    cwdProvider,
     launchAgentId,
     detectedAgentId,
     agentState,
@@ -117,11 +128,13 @@ export function useTerminalFileTransfer(
     agentState,
   });
   const isInputLockedRef = useRef(isInputLocked);
+  const cwdProviderRef = useRef(cwdProvider);
   const isMountedRef = useRef(true);
 
   useLayoutEffect(() => {
     identityRef.current = { launchAgentId, detectedAgentId, agentState };
     isInputLockedRef.current = isInputLocked;
+    cwdProviderRef.current = cwdProvider;
   });
 
   useLayoutEffect(() => {
@@ -139,8 +152,14 @@ export function useTerminalFileTransfer(
 
     const isAgentTerminal = (): boolean => deriveTerminalChrome(identityRef.current).isAgent;
 
+    // The OS hands drop and clipboard-save an absolute path, so the agent
+    // branch relativizes exactly like the hybrid input's drop and paste do —
+    // same helper, cwd read at gesture time. The shell branch stays absolute:
+    // a relative path only resolves if the shell's own cwd still matches.
     const formatPath = (filePath: string, isAgent: boolean): string =>
-      isAgent ? formatAtFileToken(filePath) : escapeShellArgOptional(filePath);
+      isAgent
+        ? formatAtFileTokenForCwd(filePath, cwdProviderRef.current?.() ?? "")
+        : escapeShellArgOptional(filePath);
 
     /**
      * Writes one already-formatted batch as a single insertion, wrapping it in


### PR DESCRIPTION
Summary of what changed and why:

The issue had two halves. First, dropping a file on a terminal always wrote a shell-escaped path regardless of what was running there, so an agent CLI got a bare `/Users/...` path while every other attach surface in the app (`@` autocomplete, hybrid-input paste and drop, voice "link to") hands it an `@path` token via `formatAtFileToken`. Second, `dragDepthRef` was incremented and decremented but never read, so dragging over a terminal produced no feedback at all.

Two independent axes now decide what reaches the PTY:
- CONTENT follows runtime identity — `deriveTerminalChrome({launchAgentId, detectedAgentId, agentState}).isAgent` picks `formatAtFileToken` for an agent and `escapeShellArgOptional` for a shell. `agentState` matters: `launchAgentId` is durable and outlives the process, so without it a terminal you had `/exit`ed back to a shell would still get `@path`.
- DELIVERY follows the live xterm bracketed-paste flag. This is load-bearing, not cosmetic: agent CLIs read raw stdin via `setRawMode(true)` and cannot tell an injected byte from a typed one, so an unwrapped `@` would drive their own interactive file picker character by character — shipping the new content format without this would have been worse than the original bug. Mirrors the existing `sendSelectionToTarget` precedent.

A drop inserts; it never submits. No trailing carriage return.

The issue asked to confirm `@path` doesn't trip an agent's own `@` picker. It does, if written raw — bracketed paste is what prevents it, and that is what VS Code, iTerm2 and Warp all do for dropped paths.

Also fixed, found during review:
- `formatWithBracketedPaste` didn't sanitize ESC. xterm's own `bracketTextForPaste` replaces `\x1b` with `␛` specifically so pasted content can't inject `ESC[201~` and escape the wrapper — ESC is legal in a POSIX filename, so this was reachable. All five callers of the shared util had the hole.
- Paths containing CR, LF or ESC are now skipped rather than delivered. With bracketed paste off, a CR in a filename reads as Enter and would submit.
- HelpPanel never forwarded `isInputLocked`, so `XtermAdapter`'s layout effect ran `setInputLocked(id, false)` and actively unlocked the assistant terminal on mount.
- Identity and lock state are read in the layout phase, so a promise continuation crossing `await saveImage()` can't observe values the UI has already moved past.
- When no managed xterm instance exists yet (it's created asynchronously, so this window is real), delivery falls back on identity rather than assuming bracketed paste is on — a shell would otherwise receive literal `ESC[200~`.
- Drag listeners moved to the padded wrapper: the 12px gutter reads as terminal, so listening only on the xterm host left a visible border that silently rejected drops.

The overlay is deliberately neutral — no accent tokens. Per the accent-restraint rule a transient drop hint is not a focus anchor or primary CTA, and `XtermAdapter.tsx` isn't in the accent allowlist. Opacity-only transition on the shared 200/120ms constants; reduced motion preserves opacity fades by design.

Rebased onto #11578, which centralised `@file` emission so drop and paste produce cwd-relative tokens through `formatAtFileTokenForCwd`. The xterm-surface drop is a fourth producer of those tokens, so it now calls the same helper, threading the terminal's live cwd through `XtermAdapter`'s existing `stableCwdProvider` — read at gesture time, not captured when the listeners registered, so a `cd` between mount and drop relativizes against where the terminal actually is. The two PRs touch disjoint files and rebase without conflict, so left alone this surface would have quietly kept emitting `@/Users/you/proj/src/App.tsx` while the input bar emitted `@src/App.tsx` for the identical gesture, with every existing test still green. A parity test now drops the same file on both surfaces and asserts they spell the reference identically, rather than pinning either one to its own literal.

That also retires the quote-character limitation this PR originally listed: #11578 quotes quote-bearing paths and escapes `"` as `\"` so they round-trip through `getAllAtFileTokens`, and because this change imports the shared formatter instead of reimplementing it, `/tmp/design "v2".md` is handled for free.

Still open and deliberately out of scope: `TerminalInputController.ts` and `src/lib/terminalInput.ts` build the bracketed-paste wrapper with inline template literals rather than the shared util, so the escape-the-wrapper hole survives on the main-process submit and stage paths. Filed separately.

Testing: the targeted suites pass (hook, adapter lifecycle, shared protocol util, hybrid-input parsing, hybrid drag-drop and paste extensions, terminal chrome, HelpPanel suite, send-to-agent palette, primary selection). Typecheck clean, eslint 0 errors, lint ratchet reports no new warnings. Reverting just the cwd threading fails six of the new assertions, including both parity tests. JSDOM can't verify computed opacity, hit-testing or containment geometry — those want a manual pass in Electron: drag across xterm content into the gutter in both normal and alt-buffer modes, and confirm a locked HelpPanel terminal shows no overlay and accepts no drop.

Resolves #11574
