### PR TITLE
feat(file-browser): insert a file reference into an agent without dragging

### DIFF
--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -10,6 +10,7 @@ export * from "./brands";
 export {
   Activity, // project pulse / live activity heartbeat
   ArrowDownAZ, // alphabetical sort order (A to Z)
+  AtSign, // @file reference handed to an agent's prompt
   BellDot, // watch alert / notify on completion
   ChartNoAxesColumn, // frecency sort order ("Most used" — decayed access score)
   Clock, // recency sort order (most recently opened first)

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -10,9 +10,11 @@ import {
   PanelRightOpen,
   RefreshCw,
 } from "lucide-react";
-import { FolderOpen, Folders } from "@/components/icons";
+import { AtSign, FolderOpen, Folders } from "@/components/icons";
 import { basename, join } from "@shared/utils/path";
 import { cn } from "@/lib/utils";
+import { isMac } from "@/lib/platform";
+import { comboToAriaKeyshortcuts } from "@/lib/kbdShortcut";
 import type { BasePanelProps } from "@/components/Panel/ContentPanel";
 import { ContentPanel } from "@/components/Panel/ContentPanel";
 import { EmptyState } from "@/components/ui/EmptyState";
@@ -20,7 +22,11 @@ import { SpinningIcon } from "@/components/ui/SpinningIcon";
 import { FileViewerToolbar } from "@/components/FileViewer/FileViewerToolbar";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { Skeleton, SkeletonText } from "@/components/ui/Skeleton";
-import { ContextMenuItem, ContextMenuSeparator } from "@/components/ui/context-menu";
+import {
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+} from "@/components/ui/context-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { revealCopy } from "@/components/FileViewer/revealCopy";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
@@ -35,6 +41,8 @@ import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { FileTreeView } from "./FileTreeView";
 import { FileBrowserViewer } from "./FileBrowserViewer";
 import { useFileBrowserTree } from "./useFileBrowserTree";
+import { useInsertFileReference } from "./useInsertFileReference";
+import { INSERT_FILE_REFERENCE_COMBO } from "./fileReference";
 import {
   FILE_BROWSER_SIDEBAR_DEFAULT_WIDTH,
   FILE_BROWSER_SIDEBAR_MAX_WIDTH,
@@ -660,6 +668,25 @@ export function FileBrowserPane({
     attempt();
   }, [rootAbsolutePath, copyRootPath]);
 
+  // Hand a row to the agent the user was last talking to, without a drag
+  // (#11577). `basePath` is what makes the token absolute, matching what a
+  // Finder drop into the hybrid input produces.
+  const { canInsert: canInsertFileReference, insert: insertFileReference } =
+    useInsertFileReference();
+  const handleInsertFileReference = useCallback(
+    (path: string) => {
+      // Same guard as the copy handlers: a relative token would name nothing
+      // the agent can open. Unreachable through the UI — the pane shows its
+      // placeholder rather than a tree when no base resolves — but the
+      // handlers are what own the invariant.
+      if (!basePath) return;
+      insertFileReference(join(basePath, path));
+    },
+    [basePath, insertFileReference]
+  );
+  const insertShortcutHint = isMac() ? "⌘I" : "Ctrl+I";
+  const insertAriaKeyshortcuts = comboToAriaKeyshortcuts(INSERT_FILE_REFERENCE_COMBO, isMac());
+
   const reveal = useMemo(() => revealCopy(), []);
   const handleReveal = useCallback(
     (path: string) => {
@@ -711,6 +738,20 @@ export function FileBrowserPane({
             <ContextMenuSeparator />
           </>
         )}
+        {/* Disabled rather than hidden when nothing resolves: the gesture is
+            the point of the menu entry, and a row that silently drops it would
+            read as broken. The agent is resolved from typing history, so this
+            is off until the user has actually talked to one. */}
+        <ContextMenuItem
+          onSelect={() => handleInsertFileReference(row.path)}
+          disabled={!canInsertFileReference}
+          {...(canInsertFileReference ? { "aria-keyshortcuts": insertAriaKeyshortcuts } : {})}
+        >
+          <AtSign className="w-3.5 h-3.5 mr-2" />
+          Insert file reference
+          <ContextMenuShortcut>{insertShortcutHint}</ContextMenuShortcut>
+        </ContextMenuItem>
+        <ContextMenuSeparator />
         <ContextMenuItem onSelect={() => handleCopyFullPath(row.path)}>
           <Copy className="w-3.5 h-3.5 mr-2" />
           Copy full path
@@ -734,6 +775,10 @@ export function FileBrowserPane({
       isWorktreeSource,
       handleSetRoot,
       handleCopyFolderContext,
+      handleInsertFileReference,
+      canInsertFileReference,
+      insertShortcutHint,
+      insertAriaKeyshortcuts,
       handleCopyFullPath,
       handleCopyRelativePath,
       handleCopyFileName,
@@ -1101,6 +1146,8 @@ export function FileBrowserPane({
           onActivate={handleActivate}
           onRootFolder={handleSetRoot}
           rowContextMenu={rowContextMenu}
+          onInsertFileReference={handleInsertFileReference}
+          canInsertFileReference={canInsertFileReference}
           label={`Files in ${title}`}
         />
         {/* Below the tree, never above: the strip unmounts the instant a

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -669,8 +669,9 @@ export function FileBrowserPane({
   }, [rootAbsolutePath, copyRootPath]);
 
   // Hand a row to the agent the user was last talking to, without a drag
-  // (#11577). `basePath` is what makes the token absolute, matching what a
-  // Finder drop into the hybrid input produces.
+  // (#11577). `basePath` turns the tree's relative row into the absolute path
+  // the hook needs; the hook then relativizes it against the destination
+  // agent's cwd, exactly as a Finder drop into that agent's input would.
   const { canInsert: canInsertFileReference, insert: insertFileReference } =
     useInsertFileReference();
   const handleInsertFileReference = useCallback(

--- a/src/panels/file-browser/FileTreeView.tsx
+++ b/src/panels/file-browser/FileTreeView.tsx
@@ -45,6 +45,18 @@ export interface FileTreeViewProps {
   label: string;
 }
 
+/**
+ * Did this key actually happen in the tree, rather than in a portalled
+ * descendant? React bubbles a portal's events through the component tree, so a
+ * Radix row menu's keystrokes reach the container's handler even though its DOM
+ * lives under `document.body`.
+ */
+function isEventInsideTree(event: React.KeyboardEvent, container: HTMLElement | null): boolean {
+  if (container === null) return false;
+  const target = event.target;
+  return target instanceof Node && container.contains(target);
+}
+
 const INDENT_PER_DEPTH_PX = 12;
 const BASE_PADDING_PX = 6;
 const ROW_HEIGHT_PX = 24;
@@ -81,6 +93,11 @@ export function FileTreeView({
   // mint `file-browser-row-src/index.ts` — duplicate DOM ids that make
   // `aria-activedescendant` ambiguous.
   const instanceId = useId();
+
+  const selectedIndex = useMemo(
+    () => (selectedPath === null ? -1 : rows.findIndex((row) => row.path === selectedPath)),
+    [rows, selectedPath]
+  );
 
   // The rows array changes identity on every listing update, so the handler is
   // rebuilt with it. Reading through a ref instead would let a keypress act on
@@ -122,10 +139,23 @@ export function FileTreeView({
       // ahead of `resolveTreeKey` only for ordering clarity — that resolver is
       // a bare switch over the navigation keys and never claims a letter, so
       // plain `I` (and any future typeahead) stays untouched.
+      //
+      // Gated on the selection resolving to a *rendered* row, not merely on a
+      // non-null path: re-rooting the tree leaves `browserSelectedPath` naming
+      // the old root, which no longer appears in `rows`. Firing then would
+      // reference a row the user cannot see and that `aria-activedescendant`
+      // has already disowned.
+      //
+      // A row menu portals outside the container but still bubbles its keys
+      // through the React tree, and the menu advertises this very shortcut —
+      // so without the containment check, pressing it there would insert the
+      // *selected* row rather than the right-clicked one.
       if (
         onInsertFileReference &&
         canInsertFileReference &&
         selectedPath !== null &&
+        selectedIndex >= 0 &&
+        isEventInsideTree(event, containerRef.current) &&
         matchesInsertFileReferenceCombo(event.nativeEvent, isMac())
       ) {
         event.preventDefault();
@@ -156,6 +186,7 @@ export function FileTreeView({
     [
       rows,
       selectedPath,
+      selectedIndex,
       onSelect,
       onToggleExpanded,
       onActivate,
@@ -164,11 +195,6 @@ export function FileTreeView({
       canInsertFileReference,
       instanceId,
     ]
-  );
-
-  const selectedIndex = useMemo(
-    () => (selectedPath === null ? -1 : rows.findIndex((row) => row.path === selectedPath)),
-    [rows, selectedPath]
   );
 
   // Keep the selection on screen when it moves by keyboard. Runs after commit,
@@ -224,10 +250,11 @@ export function FileTreeView({
   const activeDescendant =
     selectedPath !== null && selectedIndex >= 0 ? rowDomId(instanceId, selectedPath) : undefined;
 
-  // Only advertised while the shortcut would actually do something — a tree
-  // with no reachable agent announcing Cmd+I would be promising a no-op.
+  // Only advertised while the shortcut would actually do something — announcing
+  // Cmd+I with no reachable agent, or with a selection that no longer resolves
+  // to a row, would be promising a no-op. Matches the handler's own gate.
   const insertKeyshortcuts =
-    onInsertFileReference && canInsertFileReference
+    onInsertFileReference && canInsertFileReference && selectedIndex >= 0
       ? comboToAriaKeyshortcuts(INSERT_FILE_REFERENCE_COMBO, isMac())
       : undefined;
 

--- a/src/panels/file-browser/FileTreeView.tsx
+++ b/src/panels/file-browser/FileTreeView.tsx
@@ -104,6 +104,14 @@ export function FileTreeView({
   // a tree the user is no longer looking at.
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
+      // A row's context menu portals out of this container but still bubbles
+      // its keys through the React tree, so every branch below would otherwise
+      // act on the *selected* row while the user is driving a menu opened on a
+      // different one — Enter activating the wrong file, arrows moving the
+      // selection behind the open menu. Radix owns those keys while its menu
+      // is up; the tree only handles what actually happened inside it.
+      if (!isEventInsideTree(event, containerRef.current)) return;
+
       // Shift+F10 / the ContextMenu key open the selected row's menu — the
       // rows never take focus, so without this the row menu would be
       // mouse-only. Replayed as a synthetic contextmenu on the row's DOM node
@@ -146,16 +154,16 @@ export function FileTreeView({
       // reference a row the user cannot see and that `aria-activedescendant`
       // has already disowned.
       //
-      // A row menu portals outside the container but still bubbles its keys
-      // through the React tree, and the menu advertises this very shortcut —
-      // so without the containment check, pressing it there would insert the
-      // *selected* row rather than the right-clicked one.
+      // Auto-repeat is dropped: holding the combo would append the same token
+      // over and over. It also keeps a user-rebound global Cmd+I from turning
+      // into this command — the global handler ignores repeats, so every
+      // repeat after its first press would otherwise fall through to here.
       if (
         onInsertFileReference &&
         canInsertFileReference &&
         selectedPath !== null &&
         selectedIndex >= 0 &&
-        isEventInsideTree(event, containerRef.current) &&
+        !event.repeat &&
         matchesInsertFileReferenceCombo(event.nativeEvent, isMac())
       ) {
         event.preventDefault();

--- a/src/panels/file-browser/FileTreeView.tsx
+++ b/src/panels/file-browser/FileTreeView.tsx
@@ -6,7 +6,10 @@ import { UI_INLINE_LOADING_GATE_MS } from "@/lib/animationUtils";
 import { Spinner } from "@/components/ui/Spinner";
 import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
 import { useDeferredLoading } from "@/hooks/useDeferredLoading";
+import { comboToAriaKeyshortcuts } from "@/lib/kbdShortcut";
+import { isMac } from "@/lib/platform";
 import { resolveTreeKey, type FlatTreeRow } from "./fileBrowserTree";
+import { INSERT_FILE_REFERENCE_COMBO, matchesInsertFileReferenceCombo } from "./fileReference";
 
 export interface FileTreeViewProps {
   // Mutable rather than `readonly`: this is exactly what the tree hook returns,
@@ -30,6 +33,14 @@ export interface FileTreeViewProps {
    * what the items do.
    */
   rowContextMenu?: (row: FlatTreeRow) => React.ReactNode;
+  /**
+   * Send the selected row to the last agent the user typed to (#11577). Fired
+   * by the tree-local Cmd+I, which only exists while a row is selected and a
+   * target actually resolves — `canInsertFileReference` is what the tree knows
+   * about the latter.
+   */
+  onInsertFileReference?: (path: string) => void;
+  canInsertFileReference?: boolean;
   /** Accessible name for the tree, since the panel header isn't part of it. */
   label: string;
 }
@@ -60,6 +71,8 @@ export function FileTreeView({
   onActivate,
   onRootFolder,
   rowContextMenu,
+  onInsertFileReference,
+  canInsertFileReference = false,
   label,
 }: FileTreeViewProps) {
   const virtuosoRef = useRef<VirtuosoHandle>(null);
@@ -105,6 +118,22 @@ export function FileTreeView({
         }
       }
 
+      // Handed to the agent the user was last talking to, without a drag. Sits
+      // ahead of `resolveTreeKey` only for ordering clarity — that resolver is
+      // a bare switch over the navigation keys and never claims a letter, so
+      // plain `I` (and any future typeahead) stays untouched.
+      if (
+        onInsertFileReference &&
+        canInsertFileReference &&
+        selectedPath !== null &&
+        matchesInsertFileReferenceCombo(event.nativeEvent, isMac())
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        onInsertFileReference(selectedPath);
+        return;
+      }
+
       const intent = resolveTreeKey(event.key, rows, selectedPath);
       if (!intent) return;
       event.preventDefault();
@@ -124,7 +153,17 @@ export function FileTreeView({
           break;
       }
     },
-    [rows, selectedPath, onSelect, onToggleExpanded, onActivate, rowContextMenu, instanceId]
+    [
+      rows,
+      selectedPath,
+      onSelect,
+      onToggleExpanded,
+      onActivate,
+      rowContextMenu,
+      onInsertFileReference,
+      canInsertFileReference,
+      instanceId,
+    ]
   );
 
   const selectedIndex = useMemo(
@@ -185,12 +224,20 @@ export function FileTreeView({
   const activeDescendant =
     selectedPath !== null && selectedIndex >= 0 ? rowDomId(instanceId, selectedPath) : undefined;
 
+  // Only advertised while the shortcut would actually do something — a tree
+  // with no reachable agent announcing Cmd+I would be promising a no-op.
+  const insertKeyshortcuts =
+    onInsertFileReference && canInsertFileReference
+      ? comboToAriaKeyshortcuts(INSERT_FILE_REFERENCE_COMBO, isMac())
+      : undefined;
+
   return (
     <div
       ref={containerRef}
       role="tree"
       aria-label={label}
       aria-activedescendant={activeDescendant}
+      {...(insertKeyshortcuts ? { "aria-keyshortcuts": insertKeyshortcuts } : {})}
       tabIndex={0}
       // Tells the global Shift+F10/ContextMenu-key handler to stand down: this
       // surface routes those keys to the selected row's own menu.

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -130,17 +130,27 @@ const FOLDER_ROW = {
 // double-click both land on it, and the pane's own file-vs-directory guard is
 // what these tests are after.
 const { treeProps } = vi.hoisted(() => ({
-  treeProps: { onActivate: undefined as ((path: string) => void) | undefined },
+  treeProps: {
+    onActivate: undefined as ((path: string) => void) | undefined,
+    onInsertFileReference: undefined as ((path: string) => void) | undefined,
+    canInsertFileReference: undefined as boolean | undefined,
+  },
 }));
 vi.mock("../FileTreeView", () => ({
   FileTreeView: ({
     rowContextMenu,
     onActivate,
+    onInsertFileReference,
+    canInsertFileReference,
   }: {
     rowContextMenu?: (row: unknown) => React.ReactNode;
     onActivate?: (path: string) => void;
+    onInsertFileReference?: (path: string) => void;
+    canInsertFileReference?: boolean;
   }) => {
     treeProps.onActivate = onActivate;
+    treeProps.onInsertFileReference = onInsertFileReference;
+    treeProps.canInsertFileReference = canInsertFileReference;
     return (
       <div data-testid="file-tree-view" role="tree" tabIndex={-1}>
         {rowContextMenu?.(FOLDER_ROW)}
@@ -149,15 +159,35 @@ vi.mock("../FileTreeView", () => ({
   },
 }));
 
+// The real hook subscribes to the panel/terminal/fleet stores; the pane's
+// contract is only that it joins basePath and hands the result over.
+const { insertFileReferenceMock, canInsertRef } = vi.hoisted(() => ({
+  insertFileReferenceMock: vi.fn<(path: string) => boolean>(() => true),
+  canInsertRef: { current: true },
+}));
+vi.mock("../useInsertFileReference", () => ({
+  useInsertFileReference: () => ({
+    canInsert: canInsertRef.current,
+    insert: insertFileReferenceMock,
+  }),
+}));
+
 vi.mock("@/components/ui/context-menu", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/components/ui/context-menu")>()),
   ContextMenuItem: ({
     children,
     onSelect,
+    ...rest
   }: {
     children: React.ReactNode;
     onSelect?: () => void;
-  }) => <button onClick={onSelect}>{children}</button>,
+  } & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    // `rest` is forwarded so `disabled` and `aria-keyshortcuts` stay assertable
+    // — a stub that swallowed them would let a broken gate pass.
+    <button onClick={onSelect} {...rest}>
+      {children}
+    </button>
+  ),
   ContextMenuSeparator: () => null,
 }));
 
@@ -287,6 +317,10 @@ beforeEach(() => {
   mockPanel.browserWorkspaceRooted = undefined;
   treeArgs.changeTick = undefined;
   treeProps.onActivate = undefined;
+  treeProps.onInsertFileReference = undefined;
+  treeProps.canInsertFileReference = undefined;
+  insertFileReferenceMock.mockClear();
+  canInsertRef.current = true;
   dispatchMock.mockReset();
   dispatchMock.mockResolvedValue({ ok: true, result: { panelId: "file-1" } });
   worktreeTicks.git = undefined;
@@ -1089,6 +1123,65 @@ describe("folder context menu", () => {
       "context-menu",
       expect.anything()
     );
+  });
+});
+
+/** #11577: send a row to the last agent without dragging it there. */
+describe("insert file reference", () => {
+  const insertItem = () => screen.getByRole("button", { name: /Insert file reference/ });
+
+  it("hands the agent an absolute path built from the browser's base", () => {
+    renderPane();
+    fireEvent.click(insertItem());
+
+    // Absolute, matching what a Finder drop into the hybrid input produces —
+    // a bare row path would name nothing the agent can open.
+    expect(insertFileReferenceMock).toHaveBeenCalledWith(`/repo/${FOLDER_ROW.path}`);
+  });
+
+  it("joins against the workspace root for a worktree-less browser", () => {
+    workspaceRootPathMock.mockReturnValue("/scratches/one");
+    renderPane({});
+    fireEvent.click(insertItem());
+
+    expect(insertFileReferenceMock).toHaveBeenCalledWith(`/scratches/one/${FOLDER_ROW.path}`);
+  });
+
+  it("disables the item when no agent resolves", () => {
+    canInsertRef.current = false;
+    renderPane();
+
+    expect(insertItem().hasAttribute("disabled")).toBe(true);
+    // The hint would be a lie on a dead item.
+    expect(insertItem().hasAttribute("aria-keyshortcuts")).toBe(false);
+  });
+
+  it("offers no menu at all when nothing resolves a base path", () => {
+    // The pane shows its placeholder instead of a tree, so there is no row to
+    // right-click — the handler's own basePath guard is belt-and-braces, not
+    // the reachable gate.
+    renderPane({});
+    expect(screen.queryByRole("button", { name: /Insert file reference/ })).toBeNull();
+  });
+
+  it("advertises the shortcut on the live item", () => {
+    renderPane();
+    expect(insertItem().getAttribute("aria-keyshortcuts")).toBeTruthy();
+  });
+
+  it("gives the tree the same handler and gate as the menu", () => {
+    // Both gestures must resolve one target the same way; a tree wired to a
+    // different callback would drift from the menu silently.
+    renderPane();
+    expect(treeProps.canInsertFileReference).toBe(true);
+    treeProps.onInsertFileReference?.(FOLDER_ROW.path);
+    expect(insertFileReferenceMock).toHaveBeenCalledWith(`/repo/${FOLDER_ROW.path}`);
+  });
+
+  it("closes the tree's gate when the pane's is closed", () => {
+    canInsertRef.current = false;
+    renderPane();
+    expect(treeProps.canInsertFileReference).toBe(false);
   });
 });
 

--- a/src/panels/file-browser/__tests__/FileTreeView.test.tsx
+++ b/src/panels/file-browser/__tests__/FileTreeView.test.tsx
@@ -232,6 +232,49 @@ describe("FileTreeView context-menu interactions", () => {
     expect(onInsertFileReference).not.toHaveBeenCalled();
   });
 
+  it("ignores a selection that no longer resolves to a row", () => {
+    // Re-rooting the tree leaves browserSelectedPath naming the old root, which
+    // is no longer in `rows`. Firing then would reference a row the user can't
+    // see and that aria-activedescendant has already disowned.
+    const onInsertFileReference = vi.fn();
+    const { getByRole } = renderTree({
+      selectedPath: "some/pruned/path",
+      onInsertFileReference,
+      canInsertFileReference: true,
+    });
+
+    fireEvent.keyDown(getByRole("tree"), { key: "i", metaKey: true });
+
+    expect(onInsertFileReference).not.toHaveBeenCalled();
+    expect(getByRole("tree").hasAttribute("aria-keyshortcuts")).toBe(false);
+  });
+
+  it("does not fire for a key pressed inside an open row menu", async () => {
+    // The menu portals out of the container but still bubbles through the React
+    // tree, and it advertises this very shortcut — so an unguarded handler
+    // would insert the SELECTED row rather than the right-clicked one.
+    const onInsertFileReference = vi.fn();
+    const { getByRole, findByRole } = render(
+      <FileTreeView
+        rows={ROWS}
+        selectedPath="README.md"
+        onSelect={vi.fn()}
+        onToggleExpanded={vi.fn()}
+        rowContextMenu={(clicked) => <ContextMenuItem>Act on {clicked.name}</ContextMenuItem>}
+        onInsertFileReference={onInsertFileReference}
+        canInsertFileReference
+        label="Files"
+      />
+    );
+
+    fireEvent.contextMenu(getByRole("treeitem", { name: "src" }));
+    const item = await findByRole("menuitem", { name: "Act on src" });
+
+    fireEvent.keyDown(item, { key: "i", metaKey: true });
+
+    expect(onInsertFileReference).not.toHaveBeenCalled();
+  });
+
   it("advertises the shortcut only while it would do something", () => {
     const { getByRole, rerender } = render(
       <FileTreeView

--- a/src/panels/file-browser/__tests__/FileTreeView.test.tsx
+++ b/src/panels/file-browser/__tests__/FileTreeView.test.tsx
@@ -249,17 +249,40 @@ describe("FileTreeView context-menu interactions", () => {
     expect(getByRole("tree").hasAttribute("aria-keyshortcuts")).toBe(false);
   });
 
-  it("does not fire for a key pressed inside an open row menu", async () => {
-    // The menu portals out of the container but still bubbles through the React
-    // tree, and it advertises this very shortcut — so an unguarded handler
-    // would insert the SELECTED row rather than the right-clicked one.
+  it("ignores auto-repeat so a held combo inserts once", () => {
+    // Beyond the obvious spam: the global keybinding handler drops repeats, so
+    // a user-rebound global Cmd+I would run its own action on the first press
+    // and let every repeat fall through to here — a genuine wrong action.
     const onInsertFileReference = vi.fn();
+    const { getByRole } = renderTree({
+      selectedPath: "README.md",
+      onInsertFileReference,
+      canInsertFileReference: true,
+    });
+    const tree = getByRole("tree");
+
+    fireEvent.keyDown(tree, { key: "i", metaKey: true });
+    fireEvent.keyDown(tree, { key: "i", metaKey: true, repeat: true });
+    fireEvent.keyDown(tree, { key: "i", metaKey: true, repeat: true });
+
+    expect(onInsertFileReference).toHaveBeenCalledTimes(1);
+  });
+
+  it("acts on nothing for keys pressed inside an open row menu", async () => {
+    // The menu portals out of the container but still bubbles through the React
+    // tree. Every branch is affected, not just the new one: Enter would
+    // activate the SELECTED row while the user is driving a menu opened on a
+    // different one, and arrows would move the selection behind the open menu.
+    const onInsertFileReference = vi.fn();
+    const onActivate = vi.fn();
+    const onSelect = vi.fn();
     const { getByRole, findByRole } = render(
       <FileTreeView
         rows={ROWS}
         selectedPath="README.md"
-        onSelect={vi.fn()}
+        onSelect={onSelect}
         onToggleExpanded={vi.fn()}
+        onActivate={onActivate}
         rowContextMenu={(clicked) => <ContextMenuItem>Act on {clicked.name}</ContextMenuItem>}
         onInsertFileReference={onInsertFileReference}
         canInsertFileReference
@@ -271,8 +294,11 @@ describe("FileTreeView context-menu interactions", () => {
     const item = await findByRole("menuitem", { name: "Act on src" });
 
     fireEvent.keyDown(item, { key: "i", metaKey: true });
+    fireEvent.keyDown(item, { key: "ArrowDown" });
 
     expect(onInsertFileReference).not.toHaveBeenCalled();
+    expect(onActivate).not.toHaveBeenCalled();
+    expect(onSelect).not.toHaveBeenCalled();
   });
 
   it("advertises the shortcut only while it would do something", () => {

--- a/src/panels/file-browser/__tests__/FileTreeView.test.tsx
+++ b/src/panels/file-browser/__tests__/FileTreeView.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render } from "@testing-library/react";
 import { forwardRef } from "react";
 import type { ReactNode } from "react";
@@ -7,6 +7,14 @@ import { UI_INLINE_LOADING_GATE_MS } from "@/lib/animationUtils";
 import { ContextMenuItem } from "@/components/ui/context-menu";
 import { FileTreeView } from "../FileTreeView";
 import type { FlatTreeRow } from "../fileBrowserTree";
+
+// `isMac` reads navigator.platform, which jsdom reports as neither — drive it
+// explicitly so both modifier branches of the insert shortcut are covered.
+const { isMacMock } = vi.hoisted(() => ({ isMacMock: vi.fn<() => boolean>(() => true) }));
+vi.mock("@/lib/platform", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/platform")>()),
+  isMac: isMacMock,
+}));
 
 // Render every row: the virtualization itself is not under test, and the row
 // interactions below need real DOM nodes for every item.
@@ -41,6 +49,11 @@ function row(path: string, isDirectory = false): FlatTreeRow {
 }
 
 const ROWS = [row("src", true), row("README.md")];
+
+// One test flips to Ctrl; without this reset it would leak into the rest.
+beforeEach(() => {
+  isMacMock.mockReturnValue(true);
+});
 
 function renderTree(overrides: Partial<Parameters<typeof FileTreeView>[0]> = {}) {
   const onSelect = vi.fn();
@@ -122,6 +135,129 @@ describe("FileTreeView context-menu interactions", () => {
     fireEvent.keyDown(tree, { key: "F10" });
 
     expect(contextMenuSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("hands the selected row to the agent on the platform's insert shortcut", () => {
+    const onInsertFileReference = vi.fn();
+    const { getByRole } = renderTree({
+      selectedPath: "README.md",
+      onInsertFileReference,
+      canInsertFileReference: true,
+    });
+
+    const event = new KeyboardEvent("keydown", {
+      key: "i",
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    act(() => {
+      getByRole("tree").dispatchEvent(event);
+    });
+
+    expect(onInsertFileReference.mock.calls).toEqual([["README.md"]]);
+    // Consumed so the combo can't also reach a global handler.
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("uses Ctrl rather than Cmd off macOS", () => {
+    isMacMock.mockReturnValue(false);
+    const onInsertFileReference = vi.fn();
+    const { getByRole } = renderTree({
+      selectedPath: "README.md",
+      onInsertFileReference,
+      canInsertFileReference: true,
+    });
+    const tree = getByRole("tree");
+
+    fireEvent.keyDown(tree, { key: "i", ctrlKey: true });
+    expect(onInsertFileReference.mock.calls).toEqual([["README.md"]]);
+
+    // The mac modifier must not also fire it, or a Windows user's Cmd-mapped
+    // key would double-insert.
+    fireEvent.keyDown(tree, { key: "i", metaKey: true });
+    expect(onInsertFileReference).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the bare letter and the inject combo to their own handlers", () => {
+    const onInsertFileReference = vi.fn();
+    const { getByRole } = renderTree({
+      selectedPath: "README.md",
+      onInsertFileReference,
+      canInsertFileReference: true,
+    });
+    const tree = getByRole("tree");
+
+    fireEvent.keyDown(tree, { key: "i" });
+    // Cmd+Shift+I belongs to terminal.inject.
+    fireEvent.keyDown(tree, { key: "i", metaKey: true, shiftKey: true });
+
+    expect(onInsertFileReference).not.toHaveBeenCalled();
+  });
+
+  it("no-ops the shortcut with no selection or no reachable agent", () => {
+    const onInsertFileReference = vi.fn();
+    const { getByRole, rerender } = render(
+      <FileTreeView
+        rows={ROWS}
+        selectedPath={null}
+        onSelect={vi.fn()}
+        onToggleExpanded={vi.fn()}
+        rowContextMenu={() => <div />}
+        onInsertFileReference={onInsertFileReference}
+        canInsertFileReference
+        label="Files"
+      />
+    );
+
+    fireEvent.keyDown(getByRole("tree"), { key: "i", metaKey: true });
+    expect(onInsertFileReference).not.toHaveBeenCalled();
+
+    // A selected row but no resolvable agent must stay inert too — refusing is
+    // the contract, not routing into whatever happens to be open.
+    rerender(
+      <FileTreeView
+        rows={ROWS}
+        selectedPath="README.md"
+        onSelect={vi.fn()}
+        onToggleExpanded={vi.fn()}
+        rowContextMenu={() => <div />}
+        onInsertFileReference={onInsertFileReference}
+        canInsertFileReference={false}
+        label="Files"
+      />
+    );
+
+    fireEvent.keyDown(getByRole("tree"), { key: "i", metaKey: true });
+    expect(onInsertFileReference).not.toHaveBeenCalled();
+  });
+
+  it("advertises the shortcut only while it would do something", () => {
+    const { getByRole, rerender } = render(
+      <FileTreeView
+        rows={ROWS}
+        selectedPath="README.md"
+        onSelect={vi.fn()}
+        onToggleExpanded={vi.fn()}
+        onInsertFileReference={vi.fn()}
+        canInsertFileReference
+        label="Files"
+      />
+    );
+    expect(getByRole("tree").getAttribute("aria-keyshortcuts")).toBe("Meta+I");
+
+    rerender(
+      <FileTreeView
+        rows={ROWS}
+        selectedPath="README.md"
+        onSelect={vi.fn()}
+        onToggleExpanded={vi.fn()}
+        onInsertFileReference={vi.fn()}
+        canInsertFileReference={false}
+        label="Files"
+      />
+    );
+    expect(getByRole("tree").hasAttribute("aria-keyshortcuts")).toBe(false);
   });
 
   it("routes double-click by row kind: folders re-root, files activate", () => {

--- a/src/panels/file-browser/__tests__/fileReference.test.ts
+++ b/src/panels/file-browser/__tests__/fileReference.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import {
+  appendFileReference,
+  matchesInsertFileReferenceCombo,
+  INSERT_FILE_REFERENCE_COMBO,
+} from "../fileReference";
+import { getAllAtFileTokens } from "@/components/Terminal/hybridInputParsing";
+
+describe("appendFileReference", () => {
+  it("produces a token the hybrid input's own parser recognizes", () => {
+    // The whole point of reusing formatAtFileToken is that the draft the file
+    // browser writes chips exactly like a drag/drop would.
+    const draft = appendFileReference("", "/repo/src/index.ts");
+    const tokens = getAllAtFileTokens(draft);
+    expect(tokens).toHaveLength(1);
+    expect(draft.slice(tokens[0]!.start, tokens[0]!.end)).toBe("@/repo/src/index.ts");
+  });
+
+  it("round-trips a path containing spaces through the parser", () => {
+    const draft = appendFileReference("", "/repo/my notes/todo.md");
+    const tokens = getAllAtFileTokens(draft);
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]!.path).toBe("/repo/my notes/todo.md");
+  });
+
+  it("separates the token from a draft that ends mid-word", () => {
+    const draft = appendFileReference("review", "/repo/a.ts");
+    expect(draft).toBe("review @/repo/a.ts ");
+  });
+
+  it("leaves the user's own trailing whitespace alone", () => {
+    // Normalizing it would silently rewrite spacing the user typed.
+    const draft = appendFileReference("review  ", "/repo/a.ts");
+    expect(draft).toBe("review  @/repo/a.ts ");
+    expect(getAllAtFileTokens(draft)).toHaveLength(1);
+  });
+
+  it("adds no leading separator to an empty draft", () => {
+    expect(appendFileReference("", "/repo/a.ts").startsWith("@")).toBe(true);
+  });
+
+  it("ends with a space so the next reference cannot fuse onto it", () => {
+    const once = appendFileReference("", "/repo/a.ts");
+    const twice = appendFileReference(once, "/repo/b.ts");
+    expect(getAllAtFileTokens(twice).map((t) => t.path)).toEqual(["/repo/a.ts", "/repo/b.ts"]);
+  });
+
+  it("keeps a repeated path as two distinct references", () => {
+    // Deduping would diverge from drag/drop and make a second Cmd+I look broken.
+    const twice = appendFileReference(appendFileReference("", "/repo/a.ts"), "/repo/a.ts");
+    expect(getAllAtFileTokens(twice)).toHaveLength(2);
+  });
+});
+
+describe("matchesInsertFileReferenceCombo", () => {
+  // The matcher takes the modifier fields it reads, not a whole KeyboardEvent,
+  // so the fixture needs no cast.
+  type ComboEvent = Parameters<typeof matchesInsertFileReferenceCombo>[0];
+  const event = (over: Partial<ComboEvent>): ComboEvent => ({
+    key: "i",
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    ...over,
+  });
+
+  it("matches the platform's primary modifier and rejects the other one", () => {
+    expect(matchesInsertFileReferenceCombo(event({ metaKey: true }), true)).toBe(true);
+    expect(matchesInsertFileReferenceCombo(event({ ctrlKey: true }), true)).toBe(false);
+    expect(matchesInsertFileReferenceCombo(event({ ctrlKey: true }), false)).toBe(true);
+    expect(matchesInsertFileReferenceCombo(event({ metaKey: true }), false)).toBe(false);
+  });
+
+  it("rejects the bare letter, so tree typeahead stays available", () => {
+    expect(matchesInsertFileReferenceCombo(event({}), true)).toBe(false);
+    expect(matchesInsertFileReferenceCombo(event({}), false)).toBe(false);
+  });
+
+  it("rejects extra modifiers so Cmd+Shift+I still reaches terminal.inject", () => {
+    expect(matchesInsertFileReferenceCombo(event({ metaKey: true, shiftKey: true }), true)).toBe(
+      false
+    );
+    expect(matchesInsertFileReferenceCombo(event({ metaKey: true, altKey: true }), true)).toBe(
+      false
+    );
+    expect(matchesInsertFileReferenceCombo(event({ ctrlKey: true, shiftKey: true }), false)).toBe(
+      false
+    );
+  });
+
+  it("matches regardless of the key's reported case", () => {
+    expect(matchesInsertFileReferenceCombo(event({ key: "I", metaKey: true }), true)).toBe(true);
+  });
+
+  it("ignores unrelated keys", () => {
+    expect(matchesInsertFileReferenceCombo(event({ key: "k", metaKey: true }), true)).toBe(false);
+  });
+
+  it("advertises the same combo the matcher accepts", () => {
+    // A drifted constant would leave the menu hint and the aria attribute
+    // describing a shortcut the tree no longer honours.
+    const [modifier, key] = INSERT_FILE_REFERENCE_COMBO.split("+");
+    expect(modifier).toBe("Cmd");
+    expect(matchesInsertFileReferenceCombo(event({ key: key!, metaKey: true }), true)).toBe(true);
+  });
+});

--- a/src/panels/file-browser/__tests__/fileReference.test.ts
+++ b/src/panels/file-browser/__tests__/fileReference.test.ts
@@ -8,46 +8,65 @@ import { getAllAtFileTokens } from "@/components/Terminal/hybridInputParsing";
 
 describe("appendFileReference", () => {
   it("produces a token the hybrid input's own parser recognizes", () => {
-    // The whole point of reusing formatAtFileToken is that the draft the file
-    // browser writes chips exactly like a drag/drop would.
-    const draft = appendFileReference("", "/repo/src/index.ts");
+    // The whole point of reusing the drop path's formatter is that the draft
+    // the file browser writes chips exactly like a drag/drop would.
+    const draft = appendFileReference("", "/repo/src/index.ts", "/repo");
     const tokens = getAllAtFileTokens(draft);
     expect(tokens).toHaveLength(1);
-    expect(draft.slice(tokens[0]!.start, tokens[0]!.end)).toBe("@/repo/src/index.ts");
+    expect(draft.slice(tokens[0]!.start, tokens[0]!.end)).toBe("@src/index.ts");
   });
 
   it("round-trips a path containing spaces through the parser", () => {
-    const draft = appendFileReference("", "/repo/my notes/todo.md");
+    const draft = appendFileReference("", "/repo/my notes/todo.md", "/repo");
     const tokens = getAllAtFileTokens(draft);
     expect(tokens).toHaveLength(1);
-    expect(tokens[0]!.path).toBe("/repo/my notes/todo.md");
+    expect(tokens[0]!.path).toBe("my notes/todo.md");
+  });
+
+  it("keeps a path outside the target's cwd absolute", () => {
+    // toWorktreeRelative passes an out-of-tree path through untouched, and the
+    // absolute form is the only one that resolves from that agent's cwd.
+    const outside = appendFileReference("", "/elsewhere/a.ts", "/repo");
+    expect(getAllAtFileTokens(outside).map((t) => t.path)).toEqual(["/elsewhere/a.ts"]);
+
+    // A sibling whose name merely extends the root is outside too.
+    const sibling = appendFileReference("", "/repo-other/a.ts", "/repo");
+    expect(getAllAtFileTokens(sibling).map((t) => t.path)).toEqual(["/repo-other/a.ts"]);
+
+    // As is every path when the target reports no cwd at all.
+    const noCwd = appendFileReference("", "/repo/a.ts", "");
+    expect(getAllAtFileTokens(noCwd).map((t) => t.path)).toEqual(["/repo/a.ts"]);
   });
 
   it("separates the token from a draft that ends mid-word", () => {
-    const draft = appendFileReference("review", "/repo/a.ts");
-    expect(draft).toBe("review @/repo/a.ts ");
+    const draft = appendFileReference("review", "/repo/a.ts", "/repo");
+    expect(draft).toBe("review @a.ts ");
   });
 
   it("leaves the user's own trailing whitespace alone", () => {
     // Normalizing it would silently rewrite spacing the user typed.
-    const draft = appendFileReference("review  ", "/repo/a.ts");
-    expect(draft).toBe("review  @/repo/a.ts ");
+    const draft = appendFileReference("review  ", "/repo/a.ts", "/repo");
+    expect(draft).toBe("review  @a.ts ");
     expect(getAllAtFileTokens(draft)).toHaveLength(1);
   });
 
   it("adds no leading separator to an empty draft", () => {
-    expect(appendFileReference("", "/repo/a.ts").startsWith("@")).toBe(true);
+    expect(appendFileReference("", "/repo/a.ts", "/repo").startsWith("@")).toBe(true);
   });
 
   it("ends with a space so the next reference cannot fuse onto it", () => {
-    const once = appendFileReference("", "/repo/a.ts");
-    const twice = appendFileReference(once, "/repo/b.ts");
-    expect(getAllAtFileTokens(twice).map((t) => t.path)).toEqual(["/repo/a.ts", "/repo/b.ts"]);
+    const once = appendFileReference("", "/repo/a.ts", "/repo");
+    const twice = appendFileReference(once, "/repo/b.ts", "/repo");
+    expect(getAllAtFileTokens(twice).map((t) => t.path)).toEqual(["a.ts", "b.ts"]);
   });
 
   it("keeps a repeated path as two distinct references", () => {
     // Deduping would diverge from drag/drop and make a second Cmd+I look broken.
-    const twice = appendFileReference(appendFileReference("", "/repo/a.ts"), "/repo/a.ts");
+    const twice = appendFileReference(
+      appendFileReference("", "/repo/a.ts", "/repo"),
+      "/repo/a.ts",
+      "/repo"
+    );
     expect(getAllAtFileTokens(twice)).toHaveLength(2);
   });
 });

--- a/src/panels/file-browser/__tests__/useInsertFileReference.test.tsx
+++ b/src/panels/file-browser/__tests__/useInsertFileReference.test.tsx
@@ -108,7 +108,7 @@ describe("useInsertFileReference — target resolution", () => {
       result.current.insert("/repo/a.ts");
     });
 
-    expect(inputState.setDraftInput).toHaveBeenCalledWith("t-2", "@/repo/a.ts ", "proj-1");
+    expect(inputState.setDraftInput).toHaveBeenCalledWith("t-2", "@a.ts ", "proj-1");
   });
 
   it("falls back to the sole open agent when nothing was typed yet", () => {
@@ -116,7 +116,7 @@ describe("useInsertFileReference — target resolution", () => {
     act(() => {
       result.current.insert("/repo/a.ts");
     });
-    expect(inputState.setDraftInput).toHaveBeenCalledWith("t-1", "@/repo/a.ts ", "proj-1");
+    expect(inputState.setDraftInput).toHaveBeenCalledWith("t-1", "@a.ts ", "proj-1");
   });
 
   it("refuses rather than guessing between two agents with no history", () => {
@@ -205,7 +205,22 @@ describe("useInsertFileReference — writing", () => {
     act(() => {
       result.current.insert("/repo/a.ts");
     });
-    expect(inputState.setDraftInput).toHaveBeenCalledWith("t-1", "look at @/repo/a.ts ", "proj-1");
+    expect(inputState.setDraftInput).toHaveBeenCalledWith("t-1", "look at @a.ts ", "proj-1");
+  });
+
+  it("relativizes against the destination agent's cwd, not the browser's worktree", () => {
+    // Two agents in different worktrees: the token has to be readable from the
+    // one that receives it, which is the recorded target.
+    seedPanels(agentPanel("t-1"), agentPanel("t-2", { cwd: "/other" }));
+    inputState.lastTypedAgentTarget = { workspaceId: WORKSPACE_ID, terminalId: "t-2" };
+
+    const { result } = renderHook(() => useInsertFileReference());
+    act(() => {
+      result.current.insert("/repo/a.ts");
+    });
+    // Outside /other, so the absolute form survives — a relative token would
+    // name a file that agent cannot open.
+    expect(inputState.setDraftInput).toHaveBeenCalledWith("t-2", "@/repo/a.ts ", "proj-1");
   });
 
   it("bumps the external revision exactly once so the editor resyncs", () => {

--- a/src/panels/file-browser/__tests__/useInsertFileReference.test.tsx
+++ b/src/panels/file-browser/__tests__/useInsertFileReference.test.tsx
@@ -1,0 +1,273 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+const WORKSPACE_ID = "ws-1";
+
+const { getViewWorkspaceIdMock } = vi.hoisted(() => ({
+  getViewWorkspaceIdMock: vi.fn<() => string | null>(() => WORKSPACE_ID),
+}));
+vi.mock("@/store/viewWorkspaceId", () => ({ getViewWorkspaceId: getViewWorkspaceIdMock }));
+
+// The real store graph pulls the whole app in; these four are all the hook
+// reads, and driving them directly is what makes the refusal matrix legible.
+const { asStore, panelState, inputState, fleetState, projectState } = vi.hoisted(() => ({
+  // Stands in for a Zustand hook: callable with a selector and carrying
+  // `getState`, which is the only shape this hook uses.
+  asStore: <S,>(state: S) => {
+    const hook = (selector: (s: S) => unknown) => selector(state);
+    hook.getState = () => state;
+    return hook;
+  },
+  panelState: {
+    panelsById: {} as Record<string, unknown>,
+    panelIds: [] as string[],
+    backendStatus: "connected" as string,
+    pingTerminal: vi.fn<(id: string) => void>(),
+  },
+  inputState: {
+    hybridInputEnabled: true,
+    voiceSubmittingPanels: new Set<string>(),
+    lastTypedAgentTarget: null as { workspaceId: string; terminalId: string } | null,
+    getDraftInput: vi.fn<(id: string, projectId?: string) => string>(() => ""),
+    setDraftInput: vi.fn<(id: string, value: string, projectId?: string) => void>(),
+    bumpExternalDraftRevision: vi.fn(),
+    recordLastTypedAgentTarget: vi.fn(),
+  },
+  fleetState: { armedIds: new Set<string>() },
+  projectState: { currentProject: { id: "proj-1" } as { id: string } | undefined },
+}));
+
+vi.mock("@/store", () => ({ usePanelStore: asStore(panelState) }));
+vi.mock("@/store/terminalInputStore", () => ({ useTerminalInputStore: asStore(inputState) }));
+vi.mock("@/store/fleetArmingStore", () => ({ useFleetArmingStore: asStore(fleetState) }));
+vi.mock("@/store/projectStore", () => ({ useProjectStore: asStore(projectState) }));
+
+const { showLocatorMock, announceMock } = vi.hoisted(() => ({
+  showLocatorMock: vi.fn<(label: string) => void>(),
+  announceMock: vi.fn<(msg: string, priority?: string) => void>(),
+}));
+vi.mock("@/store/typingLocatorStore", () => ({
+  useTypingLocatorStore: asStore({ showLocator: showLocatorMock }),
+}));
+vi.mock("@/store/accessibilityAnnouncerStore", () => ({
+  useAnnouncerStore: asStore({ announce: announceMock }),
+}));
+
+import type { PtyPanelData } from "@shared/types/panel";
+import { useInsertFileReference } from "../useInsertFileReference";
+
+/**
+ * Mirrors the fixture `typeAnywhere.test.ts` uses: PTY panels are
+ * `kind: "terminal"` and agent identity is derived from `launchAgentId`, not a
+ * bare `agentId` field. A panel missing `hasPty`/`runtimeStatus` silently
+ * fails `isAgentFleetActionEligible` for the wrong reason.
+ */
+function agentPanel(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanelData {
+  return {
+    id,
+    kind: "terminal",
+    title: "Claude",
+    location: "grid",
+    cwd: "/repo",
+    cols: 80,
+    rows: 24,
+    hasPty: true,
+    runtimeStatus: "running",
+    launchAgentId: "claude",
+    ...overrides,
+  };
+}
+
+function seedPanels(...panels: PtyPanelData[]): void {
+  panelState.panelsById = Object.fromEntries(panels.map((p) => [p.id, p]));
+  panelState.panelIds = panels.map((p) => p.id);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getViewWorkspaceIdMock.mockReturnValue(WORKSPACE_ID);
+  panelState.backendStatus = "connected";
+  inputState.hybridInputEnabled = true;
+  inputState.voiceSubmittingPanels = new Set();
+  inputState.lastTypedAgentTarget = null;
+  inputState.getDraftInput.mockReturnValue("");
+  fleetState.armedIds = new Set();
+  projectState.currentProject = { id: "proj-1" };
+  seedPanels(agentPanel("t-1"));
+});
+
+describe("useInsertFileReference — target resolution", () => {
+  it("routes to the recorded agent even when other agents are open", () => {
+    seedPanels(agentPanel("t-1"), agentPanel("t-2"));
+    inputState.lastTypedAgentTarget = { workspaceId: WORKSPACE_ID, terminalId: "t-2" };
+
+    const { result } = renderHook(() => useInsertFileReference());
+    expect(result.current.canInsert).toBe(true);
+    act(() => {
+      result.current.insert("/repo/a.ts");
+    });
+
+    expect(inputState.setDraftInput).toHaveBeenCalledWith("t-2", "@/repo/a.ts ", "proj-1");
+  });
+
+  it("falls back to the sole open agent when nothing was typed yet", () => {
+    const { result } = renderHook(() => useInsertFileReference());
+    act(() => {
+      result.current.insert("/repo/a.ts");
+    });
+    expect(inputState.setDraftInput).toHaveBeenCalledWith("t-1", "@/repo/a.ts ", "proj-1");
+  });
+
+  it("refuses rather than guessing between two agents with no history", () => {
+    seedPanels(agentPanel("t-1"), agentPanel("t-2"));
+    const { result } = renderHook(() => useInsertFileReference());
+    expect(result.current.canInsert).toBe(false);
+    act(() => {
+      expect(result.current.insert("/repo/a.ts")).toBe(false);
+    });
+    expect(inputState.setDraftInput).not.toHaveBeenCalled();
+  });
+
+  it("refuses a target recorded by a sibling view", () => {
+    seedPanels(agentPanel("t-1"), agentPanel("t-2"));
+    inputState.lastTypedAgentTarget = { workspaceId: "ws-other", terminalId: "t-2" };
+
+    const { result } = renderHook(() => useInsertFileReference());
+    // Ambiguous once the foreign record is discarded — it must not fall
+    // through to a different agent's draft.
+    expect(result.current.canInsert).toBe(false);
+  });
+
+  it("refuses when the known target cannot take input, instead of falling through", () => {
+    seedPanels(agentPanel("t-1"), agentPanel("t-2", { isInputLocked: true }));
+    inputState.lastTypedAgentTarget = { workspaceId: WORKSPACE_ID, terminalId: "t-2" };
+
+    const { result } = renderHook(() => useInsertFileReference());
+    expect(result.current.canInsert).toBe(false);
+    act(() => {
+      result.current.insert("/repo/a.ts");
+    });
+    expect(inputState.setDraftInput).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["a restarting target", () => seedPanels(agentPanel("t-1", { isRestarting: true }))],
+    ["an exited target", () => seedPanels(agentPanel("t-1", { runtimeStatus: "exited" }))],
+    [
+      "a raw shell with no agent identity",
+      () => seedPanels(agentPanel("t-1", { launchAgentId: undefined })),
+    ],
+    ["a docked target", () => seedPanels(agentPanel("t-1", { location: "dock" }))],
+  ])("refuses %s", (_label, seed) => {
+    seed();
+    const { result } = renderHook(() => useInsertFileReference());
+    expect(result.current.canInsert).toBe(false);
+  });
+
+  it("refuses while hybrid input is switched off, since there is no draft bar to show", () => {
+    inputState.hybridInputEnabled = false;
+    const { result } = renderHook(() => useInsertFileReference());
+    expect(result.current.canInsert).toBe(false);
+  });
+
+  it("refuses while the pty backend is down", () => {
+    panelState.backendStatus = "disconnected";
+    const { result } = renderHook(() => useInsertFileReference());
+    expect(result.current.canInsert).toBe(false);
+  });
+
+  it("refuses while the target is mid-voice-submit", () => {
+    inputState.voiceSubmittingPanels = new Set(["t-1"]);
+    const { result } = renderHook(() => useInsertFileReference());
+    expect(result.current.canInsert).toBe(false);
+  });
+
+  it("refuses during a live fleet broadcast but allows a single-armed preview", () => {
+    fleetState.armedIds = new Set(["t-1", "t-2"]);
+    expect(renderHook(() => useInsertFileReference()).result.current.canInsert).toBe(false);
+
+    fleetState.armedIds = new Set(["t-1"]);
+    expect(renderHook(() => useInsertFileReference()).result.current.canInsert).toBe(true);
+  });
+
+  it("refuses when the view has no workspace identity", () => {
+    getViewWorkspaceIdMock.mockReturnValue(null);
+    const { result } = renderHook(() => useInsertFileReference());
+    expect(result.current.canInsert).toBe(false);
+  });
+});
+
+describe("useInsertFileReference — writing", () => {
+  it("appends to the existing draft rather than replacing it", () => {
+    inputState.getDraftInput.mockReturnValue("look at");
+    const { result } = renderHook(() => useInsertFileReference());
+    act(() => {
+      result.current.insert("/repo/a.ts");
+    });
+    expect(inputState.setDraftInput).toHaveBeenCalledWith("t-1", "look at @/repo/a.ts ", "proj-1");
+  });
+
+  it("bumps the external revision exactly once so the editor resyncs", () => {
+    const { result } = renderHook(() => useInsertFileReference());
+    act(() => {
+      result.current.insert("/repo/a.ts");
+    });
+    expect(inputState.bumpExternalDraftRevision).toHaveBeenCalledTimes(1);
+  });
+
+  it("commits the draft before any feedback runs", () => {
+    // A throwing reveal must not be able to lose the reference (#11147).
+    const order: string[] = [];
+    inputState.setDraftInput.mockImplementation(() => void order.push("write"));
+    panelState.pingTerminal.mockImplementation(() => void order.push("ping"));
+    showLocatorMock.mockImplementation(() => void order.push("locator"));
+    announceMock.mockImplementation(() => void order.push("announce"));
+
+    const { result } = renderHook(() => useInsertFileReference());
+    act(() => {
+      result.current.insert("/repo/a.ts");
+    });
+
+    expect(order[0]).toBe("write");
+    expect(order).toContain("ping");
+  });
+
+  it("does not claim the routing target for the file browser", () => {
+    const { result } = renderHook(() => useInsertFileReference());
+    act(() => {
+      result.current.insert("/repo/a.ts");
+    });
+    expect(inputState.recordLastTypedAgentTarget).not.toHaveBeenCalled();
+  });
+
+  it("names the destination in both the pill and the polite announcement", () => {
+    seedPanels(agentPanel("t-1", { title: "Claude" }));
+    const { result } = renderHook(() => useInsertFileReference());
+    act(() => {
+      result.current.insert("/repo/a.ts");
+    });
+    expect(showLocatorMock).toHaveBeenCalledWith(expect.stringContaining("Claude"));
+    expect(announceMock).toHaveBeenCalledWith(expect.stringContaining("Claude"), "polite");
+  });
+
+  it("re-resolves at click time, so a target that died while the menu was open is refused", () => {
+    const { result } = renderHook(() => useInsertFileReference());
+    expect(result.current.canInsert).toBe(true);
+
+    // The agent exits between render and the menu item being chosen.
+    seedPanels(agentPanel("t-1", { runtimeStatus: "exited" }));
+    act(() => {
+      expect(result.current.insert("/repo/a.ts")).toBe(false);
+    });
+    expect(inputState.setDraftInput).not.toHaveBeenCalled();
+  });
+
+  it("ignores an empty path rather than writing a bare @", () => {
+    const { result } = renderHook(() => useInsertFileReference());
+    act(() => {
+      expect(result.current.insert("")).toBe(false);
+    });
+    expect(inputState.setDraftInput).not.toHaveBeenCalled();
+  });
+});

--- a/src/panels/file-browser/__tests__/useInsertFileReference.test.tsx
+++ b/src/panels/file-browser/__tests__/useInsertFileReference.test.tsx
@@ -261,6 +261,9 @@ describe("useInsertFileReference — writing", () => {
       expect(result.current.insert("/repo/a.ts")).toBe(false);
     });
     expect(inputState.setDraftInput).not.toHaveBeenCalled();
+    // A dead click is unobservable — the refusal has to say something.
+    expect(showLocatorMock).toHaveBeenCalledWith(expect.stringContaining("No agent"));
+    expect(announceMock).toHaveBeenCalledWith(expect.stringContaining("No agent"), "polite");
   });
 
   it("ignores an empty path rather than writing a bare @", () => {

--- a/src/panels/file-browser/fileReference.ts
+++ b/src/panels/file-browser/fileReference.ts
@@ -1,0 +1,54 @@
+import { formatAtFileToken } from "@/components/Terminal/hybridInputParsing";
+
+/**
+ * The file browser's "insert a file reference into an agent" gesture (#11577).
+ *
+ * Deliberately not a registered keybinding. The command is only meaningful
+ * while a particular file tree owns focus and knows its active row, and the
+ * global registry dispatches in capture phase before any tree could supply
+ * one — an action would have to re-infer the focused browser, its worktree and
+ * its base path. `FileTreeView`'s local Shift+F10 row-menu case is the
+ * precedent for a gesture scoped to the tree itself.
+ *
+ * `Cmd+I` is free across the shipped bindings: `Cmd+Shift+I` is
+ * `terminal.inject` and the `Cmd+Alt+*` family is agent/panel navigation.
+ */
+export const INSERT_FILE_REFERENCE_COMBO = "Cmd+I";
+
+/**
+ * Does this keydown mean "insert a file reference"?
+ *
+ * Cmd on macOS, Ctrl elsewhere — the same fold `combosFieldsEqual` applies for
+ * conflict detection. Shift and Alt must be absent rather than ignored, so
+ * `Cmd+Shift+I` keeps reaching `terminal.inject` instead of firing both.
+ */
+export function matchesInsertFileReferenceCombo(
+  event: Pick<KeyboardEvent, "key" | "metaKey" | "ctrlKey" | "shiftKey" | "altKey">,
+  mac: boolean
+): boolean {
+  if (event.key.toLowerCase() !== "i") return false;
+  if (event.shiftKey || event.altKey) return false;
+  return mac ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey;
+}
+
+/**
+ * Append an `@file` reference to a hybrid-input draft.
+ *
+ * Appends rather than inserting at a cursor: the gesture fires from the file
+ * browser, which has no view of where the caret sits in a sibling panel's
+ * editor. Mirrors the hybrid drop path (`useDragDrop`) otherwise — the same
+ * `formatAtFileToken` token followed by a trailing space, so the next
+ * reference or typed word never fuses onto it.
+ *
+ * Duplicates are preserved. The chip extensions already handle a repeated
+ * path deliberately, and swallowing the second insert would make the gesture
+ * look broken when the user meant to reference a file twice.
+ */
+export function appendFileReference(draft: string, absolutePath: string): string {
+  const token = formatAtFileToken(absolutePath);
+  // Only add the separator the draft is missing: trailing whitespace the user
+  // typed is theirs, and normalizing it would move their caret's worth of
+  // spacing for no reason.
+  const separator = draft === "" || /\s$/.test(draft) ? "" : " ";
+  return `${draft}${separator}${token} `;
+}

--- a/src/panels/file-browser/fileReference.ts
+++ b/src/panels/file-browser/fileReference.ts
@@ -1,4 +1,4 @@
-import { formatAtFileToken } from "@/components/Terminal/hybridInputParsing";
+import { formatAtFileTokenForCwd } from "@/components/Terminal/hybridInputParsing";
 
 /**
  * The file browser's "insert a file reference into an agent" gesture (#11577).
@@ -37,15 +37,21 @@ export function matchesInsertFileReferenceCombo(
  * Appends rather than inserting at a cursor: the gesture fires from the file
  * browser, which has no view of where the caret sits in a sibling panel's
  * editor. Mirrors the hybrid drop path (`useDragDrop`) otherwise — the same
- * `formatAtFileToken` token followed by a trailing space, so the next
+ * `formatAtFileTokenForCwd` token followed by a trailing space, so the next
  * reference or typed word never fuses onto it.
+ *
+ * `cwd` is the DESTINATION agent's, not the file browser's: relativizing
+ * against the terminal that has to open the path is what makes a reference
+ * into its own worktree short and a cross-worktree one fall back to absolute.
+ * `toWorktreeRelative` owns that fallback — a path outside `cwd`, or an empty
+ * `cwd`, passes through untouched.
  *
  * Duplicates are preserved. The chip extensions already handle a repeated
  * path deliberately, and swallowing the second insert would make the gesture
  * look broken when the user meant to reference a file twice.
  */
-export function appendFileReference(draft: string, absolutePath: string): string {
-  const token = formatAtFileToken(absolutePath);
+export function appendFileReference(draft: string, absolutePath: string, cwd: string): string {
+  const token = formatAtFileTokenForCwd(absolutePath, cwd);
   // Only add the separator the draft is missing: trailing whitespace the user
   // typed is theirs, and normalizing it would move their caret's worth of
   // spacing for no reason.

--- a/src/panels/file-browser/useInsertFileReference.ts
+++ b/src/panels/file-browser/useInsertFileReference.ts
@@ -1,0 +1,154 @@
+import { useCallback } from "react";
+import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
+import { usePanelStore } from "@/store";
+import type { BackendStatus } from "@/store/panelStore";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { useProjectStore } from "@/store/projectStore";
+import { useTerminalInputStore, type LastTypedAgentTarget } from "@/store/terminalInputStore";
+import { useTypingLocatorStore } from "@/store/typingLocatorStore";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+import { getViewWorkspaceId } from "@/store/viewWorkspaceId";
+import { getTerminalDisplayTitle } from "@/utils/terminalTitleDisplay";
+import { resolveRescueTarget } from "@/lib/typeAnywhere";
+import { appendFileReference } from "./fileReference";
+
+interface TargetInputs {
+  panelsById: Record<string, PanelInstance>;
+  panelIds: string[];
+  backendStatus: BackendStatus;
+  hybridInputEnabled: boolean;
+  voiceSubmittingIds: ReadonlySet<string>;
+  lastTypedAgentTarget: LastTypedAgentTarget | null;
+  armedCount: number;
+}
+
+/**
+ * The agent this view may insert a reference into, or `null` to refuse.
+ *
+ * Reuses `resolveRescueTarget` verbatim rather than deriving a second, weaker
+ * heuristic: the "recorded target wins, otherwise the sole eligible agent,
+ * otherwise refuse" contract (#11147) is exactly right here, and its
+ * hybrid-only gate is a feature — this feature writes a hybrid draft and
+ * nothing else, so a disabled hybrid bar genuinely has nowhere to put the
+ * token.
+ *
+ * The two guards `useTypeAnywhere` keeps outside the resolver are repeated for
+ * the same reasons: a target recorded by a sibling view belongs to that view,
+ * and a live fleet broadcast would fan one reference out to every armed agent.
+ */
+export function resolveInsertTargetId(inputs: TargetInputs): string | null {
+  const workspaceId = getViewWorkspaceId();
+  if (workspaceId === null) return null;
+
+  // Two armed ids means a real broadcast rather than a preview — the same
+  // threshold `tryFleetBroadcastFromEditor` uses.
+  if (inputs.armedCount >= 2) return null;
+
+  const recorded = inputs.lastTypedAgentTarget;
+  const lastTypedTerminalId =
+    recorded !== null && recorded.workspaceId === workspaceId ? recorded.terminalId : null;
+
+  const targetId = resolveRescueTarget({
+    panelsById: inputs.panelsById,
+    panelIds: inputs.panelIds,
+    lastTypedTerminalId,
+    voiceSubmittingIds: inputs.voiceSubmittingIds,
+    hybridInputEnabled: inputs.hybridInputEnabled,
+    isBackendReady: inputs.backendStatus === "connected",
+  });
+  if (targetId === null) return null;
+
+  const target = inputs.panelsById[targetId];
+  return target !== undefined && isPtyPanel(target) ? targetId : null;
+}
+
+export interface InsertFileReference {
+  /** False when nothing resolves — the menu item disables and the shortcut no-ops. */
+  canInsert: boolean;
+  /** Returns whether the reference was actually written. */
+  insert: (absolutePath: string) => boolean;
+}
+
+/**
+ * Send an `@file` reference to the agent the user was last talking to (#11577).
+ *
+ * The file browser is a sibling panel with no handle on any terminal's
+ * editor, so the token goes through the draft store — the sanctioned
+ * outside-write path that voice transcription and the type-anywhere rescue
+ * already use — and `HybridInputBar`'s `externalDraftRevision` effect syncs the
+ * mounted document.
+ *
+ * Deliberately does NOT move focus. The user is mid-flow in the tree and
+ * likely to reference several files; pulling focus (or the grid viewport) to
+ * the agent would break the run they are in the middle of. The locator pill
+ * names the destination instead, which is what makes the write observable.
+ */
+export function useInsertFileReference(): InsertFileReference {
+  const hybridInputEnabled = useTerminalInputStore((s) => s.hybridInputEnabled);
+  const voiceSubmittingPanels = useTerminalInputStore((s) => s.voiceSubmittingPanels);
+  const lastTypedAgentTarget = useTerminalInputStore((s) => s.lastTypedAgentTarget);
+  const armedCount = useFleetArmingStore((s) => s.armedIds.size);
+
+  // Derived inside the selector so the pane subscribes to one string, not the
+  // whole panel map: a live `panelsById` selector here would re-render the file
+  // browser on every agent-state flip and status flush.
+  const targetId = usePanelStore(
+    useCallback(
+      (state) =>
+        resolveInsertTargetId({
+          panelsById: state.panelsById,
+          panelIds: state.panelIds,
+          backendStatus: state.backendStatus,
+          hybridInputEnabled,
+          voiceSubmittingIds: voiceSubmittingPanels,
+          lastTypedAgentTarget,
+          armedCount,
+        }),
+      [hybridInputEnabled, voiceSubmittingPanels, lastTypedAgentTarget, armedCount]
+    )
+  );
+
+  const insert = useCallback((absolutePath: string): boolean => {
+    if (absolutePath === "") return false;
+
+    // Re-resolved from live state rather than trusting the rendered `targetId`:
+    // the menu can sit open while the agent it named exits or locks.
+    const panelState = usePanelStore.getState();
+    const inputStore = useTerminalInputStore.getState();
+    const resolvedId = resolveInsertTargetId({
+      panelsById: panelState.panelsById,
+      panelIds: panelState.panelIds,
+      backendStatus: panelState.backendStatus,
+      hybridInputEnabled: inputStore.hybridInputEnabled,
+      voiceSubmittingIds: inputStore.voiceSubmittingPanels,
+      lastTypedAgentTarget: inputStore.lastTypedAgentTarget,
+      armedCount: useFleetArmingStore.getState().armedIds.size,
+    });
+    if (resolvedId === null) return false;
+
+    const target = panelState.panelsById[resolvedId];
+    if (target === undefined) return false;
+
+    // Commit the reference BEFORE any feedback. Everything below is polish —
+    // if it throws, the token is already durably in the draft rather than lost
+    // (#11147).
+    const projectId = useProjectStore.getState().currentProject?.id;
+    const draft = inputStore.getDraftInput(resolvedId, projectId);
+    inputStore.setDraftInput(resolvedId, appendFileReference(draft, absolutePath), projectId);
+    inputStore.bumpExternalDraftRevision();
+    // Deliberately not `recordLastTypedAgentTarget`: this is not the user
+    // typing into that agent, and recording it would let the file browser
+    // silently claim the routing target on the sole-agent fallback path.
+
+    const title = getTerminalDisplayTitle(target, "compact");
+    const message = `File reference added to ${title}`;
+    panelState.pingTerminal(resolvedId);
+    useTypingLocatorStore.getState().showLocator(message);
+    // The pill is `aria-hidden` (it only restates where focus already is for
+    // the rescue it was built for), so assistive tech needs its own copy.
+    useAnnouncerStore.getState().announce(message, "polite");
+    return true;
+  }, []);
+
+  return { canInsert: targetId !== null, insert };
+}

--- a/src/panels/file-browser/useInsertFileReference.ts
+++ b/src/panels/file-browser/useInsertFileReference.ts
@@ -151,7 +151,16 @@ export function useInsertFileReference(): InsertFileReference {
     // (#11147).
     const projectId = useProjectStore.getState().currentProject?.id;
     const draft = inputStore.getDraftInput(resolvedId, projectId);
-    inputStore.setDraftInput(resolvedId, appendFileReference(draft, absolutePath), projectId);
+    // The token is relativized against the TARGET's cwd, not the browser's
+    // base path: that is what a drop into this agent would produce, and it is
+    // what makes a reference to another worktree stay absolute. `resolveInsertTargetId`
+    // already guarantees a pty panel; the narrow is for the type, not a case.
+    const targetCwd = isPtyPanel(target) ? (target.cwd ?? "") : "";
+    inputStore.setDraftInput(
+      resolvedId,
+      appendFileReference(draft, absolutePath, targetCwd),
+      projectId
+    );
     inputStore.bumpExternalDraftRevision();
     // Deliberately not `recordLastTypedAgentTarget`: this is not the user
     // typing into that agent, and recording it would let the file browser

--- a/src/panels/file-browser/useInsertFileReference.ts
+++ b/src/panels/file-browser/useInsertFileReference.ts
@@ -62,6 +62,19 @@ export function resolveInsertTargetId(inputs: TargetInputs): string | null {
   return target !== undefined && isPtyPanel(target) ? targetId : null;
 }
 
+/**
+ * Both receipts go through the same pair: the pill for sighted users, a polite
+ * announcement because the pill is `aria-hidden`.
+ */
+function report(message: string): void {
+  useTypingLocatorStore.getState().showLocator(message);
+  useAnnouncerStore.getState().announce(message, "polite");
+}
+
+function reportRefused(): void {
+  report("No agent is available for a file reference");
+}
+
 export interface InsertFileReference {
   /** False when nothing resolves — the menu item disables and the shortcut no-ops. */
   canInsert: boolean;
@@ -124,10 +137,14 @@ export function useInsertFileReference(): InsertFileReference {
       lastTypedAgentTarget: inputStore.lastTypedAgentTarget,
       armedCount: useFleetArmingStore.getState().armedIds.size,
     });
-    if (resolvedId === null) return false;
-
-    const target = panelState.panelsById[resolvedId];
-    if (target === undefined) return false;
+    const target = resolvedId === null ? undefined : panelState.panelsById[resolvedId];
+    if (resolvedId === null || target === undefined) {
+      // Only reachable in the race the re-resolve exists for — the rendered
+      // gate disables the affordance otherwise. Announcing it beats a dead
+      // click, which is by definition something the user cannot observe.
+      reportRefused();
+      return false;
+    }
 
     // Commit the reference BEFORE any feedback. Everything below is polish —
     // if it throws, the token is already durably in the draft rather than lost
@@ -140,13 +157,8 @@ export function useInsertFileReference(): InsertFileReference {
     // typing into that agent, and recording it would let the file browser
     // silently claim the routing target on the sole-agent fallback path.
 
-    const title = getTerminalDisplayTitle(target, "compact");
-    const message = `File reference added to ${title}`;
     panelState.pingTerminal(resolvedId);
-    useTypingLocatorStore.getState().showLocator(message);
-    // The pill is `aria-hidden` (it only restates where focus already is for
-    // the rescue it was built for), so assistive tech needs its own copy.
-    useAnnouncerStore.getState().announce(message, "polite");
+    report(`File reference added to ${getTerminalDisplayTitle(target, "compact")}`);
     return true;
   }, []);
 


### PR DESCRIPTION
## Summary

- Adds a non-drag way to send an `@file` reference from the file browser to an agent: an "Insert file reference" row context-menu entry (with a ⌘I / Ctrl+I hint) and a tree-local Cmd+I / Ctrl+I shortcut.
- Both append the same `@path` token a hybrid-input drag/drop already produces — relativized against the destination agent's cwd — to the draft of the agent the user last typed into.
- Drag can't be the only path here: it's pointer-only in a tree that's otherwise fully keyboard-driven, and it can't cross a project view or window boundary.

Resolves #11577

## Implementation

- New `src/panels/file-browser/fileReference.ts`: a pure `appendFileReference(draft, absolutePath, cwd)` (reuses the shared `formatAtFileTokenForCwd`, the same formatter the drop and paste paths use), `matchesInsertFileReferenceCombo(event, mac)`, and the `INSERT_FILE_REFERENCE_COMBO` constant.
- New `src/panels/file-browser/useInsertFileReference.ts`: resolves the destination through the existing `resolveRescueTarget` (#11147), so an ambiguous or unroutable target refuses rather than guesses. Writes via `setDraftInput` + `bumpExternalDraftRevision`, the same sanctioned outside-write path the type-anywhere rescue already uses. The token is relativized against the resolved *target's* cwd rather than the browser's base path, so a cross-worktree insert falls back to the absolute form that agent can actually open.
- `FileBrowserPane.tsx` joins the row against the browser's base path to hand the hook an absolute path, and disables the menu entry when nothing resolves.
- `FileTreeView.tsx` gets a local keydown case for the shortcut. It's deliberately not a registered action or global keybinding: a global binding dispatches in capture phase before the tree can supply its active row. The menu-local Shift+F10 handling is the existing precedent for this pattern.

## Design choices worth a look

- Diverges from `useTypeAnywhere` on purpose: it does not steal focus, does not scroll the grid, and does not call `recordLastTypedAgentTarget`. The user is mid-flow in the tree and likely inserting several references in a row, so the locator pill, a pane ping, and a polite announcement carry the receipt instead.
- Refuses rather than guesses when zero or two-or-more agents are plausible, matching the #11147 behavior.
- Hybrid-input only. Raw-xterm targeting is excluded because raw typing never updates `lastTypedAgentTarget`, and supporting it would mean routing on stale history.

## Also fixes

Found while working on this: the file tree was acting on keys bubbling up from its own portalled row context menu. Enter would activate the *selected* row while the user was operating a menu opened on a different one, and arrow keys moved the selection behind the open menu.

## Not covered

- Quote-containing paths, and Windows paths that land *outside* the target's cwd, still don't round-trip through `getAllAtFileTokens`: the unquoted branch terminates on `:`, so an absolute `@C:/repo/a.ts` chips as `@C`. Relativizing drops the drive letter for the in-tree case, which is the common one. What's left is a limitation of the shared `formatAtFileToken` and it affects drag/drop, paste, and autocomplete equally. The text actually delivered to the agent is still correct. Issue #11575 owns unifying this.
- A dialog-hosted file browser gets no sighted receipt: the shared TypingLocator sits at z-30 and the modal at z-60. The polite announcement still fires.
- A user-rebound global Cmd+I shadows the local shortcut. It fails closed: the shortcut just doesn't fire, and auto-repeat is dropped, so it can never turn into the wrong action.

## Testing

508 targeted tests pass locally: the whole `src/panels/file-browser/__tests__/` directory, plus `typeAnywhere`, `useTypeAnywhere`, `terminalInputStore`, `hybridInputParsing`, and `context-menu.shortcuts`.

New: `__tests__/fileReference.test.ts` and `__tests__/useInsertFileReference.test.tsx`, covering the full refusal matrix (sibling-view workspace, locked/restarting/exited target, hybrid off, backend down, voice-submitting, two-or-more armed fleet ids, ambiguous candidates), write-before-feedback ordering, and the relativization contract — in-cwd paths shorten, while an out-of-cwd path (including a sibling root whose name merely extends the cwd) and a target with no cwd keep the absolute form. Extended `FileBrowserPane.test.tsx` and `FileTreeView.test.tsx`.

Own-file eslint is clean: 0 errors, prettier clean. The 5 remaining eslint warnings on these files are all pre-existing.
