### PR TITLE
feat(file-browser): drag files from the file browser into an agent

### DIFF
--- a/src/__tests__/App.fileDropGuard.test.tsx
+++ b/src/__tests__/App.fileDropGuard.test.tsx
@@ -84,9 +84,9 @@ describe("useFileDropGuard", () => {
     expect(event.defaultPrevented).toBe(true);
   });
 
-  // The two real destinations stop propagation, so their drops never reach
-  // this listener and the guard cannot cancel a drop that was accepted.
-  it("leaves a drop a destination already claimed alone", () => {
+  // The two real destinations stop propagation, so their events never reach
+  // this listener and the guard cannot countermand a drag they accepted.
+  it("leaves an in-app drag a destination already claimed alone", () => {
     renderHook(() => useFileDropGuard());
 
     const { event, dataTransfer } = createDragEvent("dragover", [FILE_DRAG_MIME]);

--- a/src/__tests__/App.fileDropGuard.test.tsx
+++ b/src/__tests__/App.fileDropGuard.test.tsx
@@ -4,6 +4,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { renderHook, cleanup } from "@testing-library/react";
 import { useFileDropGuard } from "@/hooks/useFileDropGuard";
+import { FILE_DRAG_MIME } from "@/lib/fileDragPayload";
 
 function createDragEvent(
   type: string,
@@ -59,6 +60,40 @@ describe("useFileDropGuard", () => {
     document.dispatchEvent(event);
 
     expect(event.defaultPrevented).toBe(false);
+  });
+
+  // An in-app file drag (#11576) has to be refused on the same terms as an OS
+  // one. Nothing else would claim it, so without this the cursor would keep
+  // promising a copy over every surface that cannot take one.
+  it("refuses an in-app file drag on dragover", () => {
+    renderHook(() => useFileDropGuard());
+
+    const { event, dataTransfer } = createDragEvent("dragover", [FILE_DRAG_MIME]);
+    document.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(dataTransfer.dropEffect).toBe("none");
+  });
+
+  it("prevents default on an in-app file drop", () => {
+    renderHook(() => useFileDropGuard());
+
+    const { event } = createDragEvent("drop", [FILE_DRAG_MIME]);
+    document.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  // The two real destinations stop propagation, so their drops never reach
+  // this listener and the guard cannot cancel a drop that was accepted.
+  it("leaves a drop a destination already claimed alone", () => {
+    renderHook(() => useFileDropGuard());
+
+    const { event, dataTransfer } = createDragEvent("dragover", [FILE_DRAG_MIME]);
+    event.preventDefault();
+    document.dispatchEvent(event);
+
+    expect(dataTransfer.dropEffect).toBe("copy");
   });
 
   it("skips events already handled by a child (defaultPrevented)", () => {

--- a/src/components/Terminal/__tests__/useTerminalFileTransfer.test.ts
+++ b/src/components/Terminal/__tests__/useTerminalFileTransfer.test.ts
@@ -44,6 +44,7 @@ import {
   BRACKETED_PASTE_END,
   formatWithBracketedPaste,
 } from "@shared/utils/terminalInputProtocol.js";
+import { FILE_DRAG_MIME, encodeFileDragPaths } from "@/lib/fileDragPayload";
 
 /** What `clipboard.saveImage` resolves to, taken from the IPC surface itself. */
 type SavedImage = Awaited<ReturnType<typeof window.electron.clipboard.saveImage>>;
@@ -177,8 +178,53 @@ describe("useTerminalFileTransfer hook", () => {
     return event;
   }
 
+  /**
+   * A hover from an in-app file drag. Returns the transfer alongside the event
+   * so `dropEffect` reads back without narrowing the event to a `DragEvent`.
+   */
+  function makeInternalDragEvent(type: string): {
+    event: Event;
+    dataTransfer: { dropEffect: string };
+  } {
+    const event = new Event(type, { bubbles: true, cancelable: true });
+    const dataTransfer = {
+      types: [FILE_DRAG_MIME],
+      dropEffect: "none",
+      // Present so a gate that wrongly reached for the payload would still
+      // run — Chromium blanks it until the drop, which is what this returns.
+      getData: () => "",
+    };
+    Object.defineProperty(event, "dataTransfer", { value: dataTransfer });
+    return { event, dataTransfer };
+  }
+
   function dropFiles(files: File[]): DragEvent {
     const event = makeDropEvent(files);
+    act(() => {
+      container.dispatchEvent(event);
+    });
+    return event;
+  }
+
+  /**
+   * A drop from the file browser (#11576): the paths arrive on a custom type
+   * and there is no `File` behind any of them.
+   */
+  function makeInternalDropEvent(serialized: string): Event {
+    const event = new Event("drop", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "dataTransfer", {
+      value: {
+        files: [],
+        types: [FILE_DRAG_MIME],
+        dropEffect: "none",
+        getData: (type: string) => (type === FILE_DRAG_MIME ? serialized : ""),
+      },
+    });
+    return event;
+  }
+
+  function dropInternalPaths(paths: string[]): Event {
+    const event = makeInternalDropEvent(encodeFileDragPaths(paths));
     act(() => {
       container.dispatchEvent(event);
     });
@@ -841,6 +887,169 @@ describe("useTerminalFileTransfer hook", () => {
     });
 
     expect(result.current).toBe(true);
+  });
+
+  // --- In-app file drag (#11576) ---
+  //
+  // Only where the paths come from changes. Both axes the OS drop established
+  // — content (agent `@token` vs shell-escaped absolute) and delivery
+  // (bracketed paste per the live xterm mode) — have to keep deciding
+  // independently, so the matrix below is the point of this block.
+
+  describe("in-app file drag", () => {
+    it("writes the agent's @token for a dragged file", () => {
+      renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD });
+      dropInternalPaths([`${CWD}/src/App.tsx`]);
+
+      expect(lastWrittenPayload().trimEnd()).toBe("@src/App.tsx");
+    });
+
+    // The invariant the whole feature is measured against: a dragged row and
+    // an OS drop of the same file cannot disagree about what reaches the PTY.
+    it("writes exactly what an OS drop of the same file writes", () => {
+      const absolute = `${CWD}/src/App.tsx`;
+      const { unmount } = renderFileTransferHook({
+        detectedAgentId: "claude",
+        cwdProvider: () => CWD,
+      });
+      dropFiles([fileAt("App.tsx", absolute)]);
+      const fromOs = lastWrittenPayload();
+      unmount();
+
+      vi.mocked(terminalClient.write).mockClear();
+      renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD });
+      dropInternalPaths([absolute]);
+
+      expect(lastWrittenPayload()).toBe(fromOs);
+    });
+
+    // Content follows identity, not provenance: a shell cannot consume an
+    // `@token`, and a relative path only resolves if its cwd still matches.
+    it("keeps a shell's absolute escaped path", () => {
+      renderFileTransferHook({ cwdProvider: () => CWD });
+      dropInternalPaths([`${CWD}/src/my notes.md`]);
+
+      expect(lastWrittenPayload().trimEnd()).toBe(escapeShellArgOptional(`${CWD}/src/my notes.md`));
+    });
+
+    it("relativizes against the cwd read at drop time", () => {
+      const { rerender } = renderFileTransferHook({
+        detectedAgentId: "claude",
+        cwdProvider: () => "/somewhere/else",
+      });
+      act(() => {
+        rerender({ detectedAgentId: "claude", cwdProvider: () => CWD });
+      });
+      dropInternalPaths([`${CWD}/src/App.tsx`]);
+
+      expect(lastWrittenPayload().trimEnd()).toBe("@src/App.tsx");
+    });
+
+    // Delivery is the other axis and answers to the live xterm mode alone.
+    it("wraps in bracketed paste when the foreground program asked for it", () => {
+      instanceState.bracketedPasteMode = true;
+      renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD });
+      dropInternalPaths([`${CWD}/src/App.tsx`]);
+
+      expect(lastWrittenPayload()).toBe(formatWithBracketedPaste("@src/App.tsx "));
+    });
+
+    it("leaves the write unwrapped when it did not", () => {
+      instanceState.bracketedPasteMode = false;
+      renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD });
+      dropInternalPaths([`${CWD}/src/App.tsx`]);
+
+      expect(lastWrittenPayload()).toBe("@src/App.tsx ");
+    });
+
+    it("references a dragged folder", () => {
+      renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD });
+      dropInternalPaths([`${CWD}/src/components`]);
+
+      expect(lastWrittenPayload().trimEnd()).toBe("@src/components");
+    });
+
+    it("writes several dragged paths as one insertion", () => {
+      renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD });
+      dropInternalPaths([`${CWD}/a.ts`, `${CWD}/b.ts`]);
+
+      expect(vi.mocked(terminalClient.write)).toHaveBeenCalledTimes(1);
+      expect(lastWrittenPayload().trimEnd()).toBe("@a.ts @b.ts");
+    });
+
+    it("reports the unwrapped text to input tracking", () => {
+      instanceState.bracketedPasteMode = true;
+      const onInput = vi.fn();
+      renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD, onInput });
+      dropInternalPaths([`${CWD}/src/App.tsx`]);
+
+      expect(onInput).toHaveBeenCalledWith("@src/App.tsx ");
+    });
+
+    // A path carrying CR, LF or ESC has no sanitized form that still points at
+    // the same file, so it is skipped exactly as an OS-dropped one is.
+    it("skips a path that cannot be delivered as terminal input", () => {
+      renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD });
+      dropInternalPaths([`${CWD}/we${String.fromCharCode(10)}ird.ts`, `${CWD}/fine.ts`]);
+
+      expect(lastWrittenPayload().trimEnd()).toBe("@fine.ts");
+    });
+
+    it("writes nothing while input is locked", () => {
+      renderFileTransferHook({ isInputLocked: true, detectedAgentId: "claude" });
+      dropInternalPaths([`${CWD}/src/App.tsx`]);
+
+      expect(terminalClient.write).not.toHaveBeenCalled();
+    });
+
+    it("writes nothing for a malformed payload", () => {
+      renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD });
+      act(() => {
+        container.dispatchEvent(makeInternalDropEvent("not json"));
+      });
+
+      expect(terminalClient.write).not.toHaveBeenCalled();
+    });
+
+    it("never asks the OS to resolve a path it was handed", () => {
+      renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD });
+      dropInternalPaths([`${CWD}/src/App.tsx`]);
+
+      expect(window.electron.webUtils.getPathForFile).not.toHaveBeenCalled();
+    });
+
+    it("shows the drop affordance for the in-app type", () => {
+      const { result } = renderFileTransferHook();
+      const { event } = makeInternalDragEvent("dragenter");
+      act(() => {
+        container.dispatchEvent(event);
+      });
+
+      expect(result.current).toBe(true);
+    });
+
+    it("advertises a copy over an unlocked terminal", () => {
+      renderFileTransferHook();
+      const { event, dataTransfer } = makeInternalDragEvent("dragover");
+      act(() => {
+        container.dispatchEvent(event);
+      });
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(dataTransfer.dropEffect).toBe("copy");
+    });
+
+    // Advertising a drop the terminal will discard is false feedback, and the
+    // cursor is the only thing that says so before the gesture completes.
+    it("refuses the drop with the cursor while input is locked", () => {
+      renderFileTransferHook({ isInputLocked: true });
+      const { event, dataTransfer } = makeInternalDragEvent("dragover");
+      act(() => {
+        container.dispatchEvent(event);
+      });
+
+      expect(dataTransfer.dropEffect).toBe("none");
+    });
   });
 
   // --- Cleanup test ---

--- a/src/components/Terminal/__tests__/useTerminalFileTransfer.test.ts
+++ b/src/components/Terminal/__tests__/useTerminalFileTransfer.test.ts
@@ -962,6 +962,46 @@ describe("useTerminalFileTransfer hook", () => {
       expect(lastWrittenPayload()).toBe("@src/App.tsx ");
     });
 
+    // The mode is read at drop time, not captured when the listeners were
+    // registered: a program that enables bracketed paste after the pane
+    // mounted must still get a wrapped batch.
+    it("reads the bracketed-paste mode live, not at mount", () => {
+      instanceState.bracketedPasteMode = false;
+      renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD });
+      instanceState.bracketedPasteMode = true;
+      dropInternalPaths([`${CWD}/src/App.tsx`]);
+
+      expect(lastWrittenPayload()).toBe(formatWithBracketedPaste("@src/App.tsx "));
+    });
+
+    // Content and delivery are independent. A shell in bracketed-paste mode —
+    // readline enables it — must get a wrapped ABSOLUTE path, so an
+    // implementation that folded the two axes into one flag fails here.
+    it("wraps a shell's absolute path when the shell asked for bracketed paste", () => {
+      instanceState.bracketedPasteMode = true;
+      renderFileTransferHook({ cwdProvider: () => CWD });
+      dropInternalPaths([`${CWD}/src/App.tsx`]);
+
+      expect(lastWrittenPayload()).toBe(
+        formatWithBracketedPaste(`${escapeShellArgOptional(`${CWD}/src/App.tsx`)} `)
+      );
+    });
+
+    // With no managed instance the mode is unknown, so identity decides: an
+    // agent must never be fed raw `@` keystrokes, a shell must never see the
+    // delimiters as literal input.
+    it("falls back to identity when no managed instance answers", () => {
+      instanceState.hasManagedInstance = false;
+      renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD });
+      dropInternalPaths([`${CWD}/src/App.tsx`]);
+      expect(lastWrittenPayload()).toBe(formatWithBracketedPaste("@src/App.tsx "));
+
+      vi.mocked(terminalClient.write).mockClear();
+      renderFileTransferHook({ cwdProvider: () => CWD });
+      dropInternalPaths([`${CWD}/src/App.tsx`]);
+      expect(lastWrittenPayload()).toBe(`${escapeShellArgOptional(`${CWD}/src/App.tsx`)} `);
+    });
+
     it("references a dragged folder", () => {
       renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD });
       dropInternalPaths([`${CWD}/src/components`]);
@@ -986,13 +1026,25 @@ describe("useTerminalFileTransfer hook", () => {
       expect(onInput).toHaveBeenCalledWith("@src/App.tsx ");
     });
 
-    // A path carrying CR, LF or ESC has no sanitized form that still points at
-    // the same file, so it is skipped exactly as an OS-dropped one is.
-    it("skips a path that cannot be delivered as terminal input", () => {
+    // An OS drop skips only the undeliverable path and writes the rest,
+    // because its paths came from real files the user picked. This channel is
+    // writable by anything that can start a drag, so a control character is
+    // evidence the payload is not ours and the whole batch is refused — the
+    // terminal never gets the chance to write the "good" half of a forgery.
+    it("writes nothing when any path carries a terminal control character", () => {
       renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD });
       dropInternalPaths([`${CWD}/we${String.fromCharCode(10)}ird.ts`, `${CWD}/fine.ts`]);
 
-      expect(lastWrittenPayload().trimEnd()).toBe("@fine.ts");
+      expect(terminalClient.write).not.toHaveBeenCalled();
+    });
+
+    // ETX is the one that matters most: the line discipline raises SIGINT
+    // before any shell parses the argument, so shell-escaping cannot defuse it.
+    it("writes nothing for a path carrying ETX", () => {
+      renderFileTransferHook({ cwdProvider: () => CWD });
+      dropInternalPaths([`${CWD}/a${String.fromCharCode(3)}b.ts`]);
+
+      expect(terminalClient.write).not.toHaveBeenCalled();
     });
 
     it("writes nothing while input is locked", () => {
@@ -1016,6 +1068,26 @@ describe("useTerminalFileTransfer hook", () => {
       dropInternalPaths([`${CWD}/src/App.tsx`]);
 
       expect(window.electron.webUtils.getPathForFile).not.toHaveBeenCalled();
+    });
+
+    // Draining both sources would write every reference twice.
+    it("prefers the in-app payload when files ride along too", () => {
+      renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD });
+      const event = new Event("drop", { bubbles: true, cancelable: true });
+      Object.defineProperty(event, "dataTransfer", {
+        value: {
+          files: [fileAt("from-os.ts", `${CWD}/from-os.ts`)],
+          types: ["Files", FILE_DRAG_MIME],
+          dropEffect: "none",
+          getData: () => encodeFileDragPaths([`${CWD}/src/App.tsx`]),
+        },
+      });
+      act(() => {
+        container.dispatchEvent(event);
+      });
+
+      expect(vi.mocked(terminalClient.write)).toHaveBeenCalledTimes(1);
+      expect(lastWrittenPayload().trimEnd()).toBe("@src/App.tsx");
     });
 
     it("shows the drop affordance for the in-app type", () => {
@@ -1044,10 +1116,14 @@ describe("useTerminalFileTransfer hook", () => {
     it("refuses the drop with the cursor while input is locked", () => {
       renderFileTransferHook({ isInputLocked: true });
       const { event, dataTransfer } = makeInternalDragEvent("dragover");
+      // Starts at "copy" so a handler that ignored the drag entirely would
+      // leave it there rather than passing by accident.
+      dataTransfer.dropEffect = "copy";
       act(() => {
         container.dispatchEvent(event);
       });
 
+      expect(event.defaultPrevented).toBe(true);
       expect(dataTransfer.dropEffect).toBe("none");
     });
   });
@@ -1063,6 +1139,22 @@ describe("useTerminalFileTransfer hook", () => {
     container.dispatchEvent(event);
 
     expect(window.electron.clipboard.saveImage).not.toHaveBeenCalled();
+    expect(terminalClient.write).not.toHaveBeenCalled();
+  });
+
+  // The paste case above cannot see the four drag listeners, so dropping every
+  // drag cleanup would still pass it.
+  it("removes the drag listeners on unmount", () => {
+    const { unmount } = renderFileTransferHook({ detectedAgentId: "claude" });
+    unmount();
+
+    const { event: over, dataTransfer } = makeInternalDragEvent("dragover");
+    dataTransfer.dropEffect = "copy";
+    container.dispatchEvent(over);
+    container.dispatchEvent(makeInternalDropEvent(encodeFileDragPaths([`${CWD}/src/App.tsx`])));
+
+    expect(over.defaultPrevented).toBe(false);
+    expect(dataTransfer.dropEffect).toBe("copy");
     expect(terminalClient.write).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Terminal/hooks/__tests__/useDragDrop.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useDragDrop.test.ts
@@ -298,6 +298,23 @@ describe("useDragDrop", () => {
     expect(insertedToken(dispatch)).toBe("@shot.png");
   });
 
+  // `IMAGE_EXTENSIONS` is anchored, so a real file called `shot.png ` is not an
+  // image. Classifying on the trimmed display name instead would promote it to
+  // a thumbnail chip — and would disagree with the same file dragged in-app,
+  // which has no OS-supplied name to trim.
+  it("does not treat a trailing-space name as an image", async () => {
+    pathForFile.mockReturnValue(`${CWD}/shot.png `);
+    const { dispatch, ref } = fakeView();
+    const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+    await act(async () => {
+      await result.current.handleDrop(dropEvent([fakeFile("shot.png ")]));
+    });
+
+    expect(thumbnailFromPath).not.toHaveBeenCalled();
+    expect(effectValues(dispatch)[0]?.fileName).toBe("shot.png");
+  });
+
   it("does not dispatch when every dropped file resolves to no path", async () => {
     pathForFile.mockReturnValue("");
     const { view, ref } = fakeView();
@@ -544,8 +561,73 @@ describe("useDragDrop", () => {
         await result.current.handleDrop(event);
       });
 
+      // One dispatch, not two: a handler that decoded the payload and then fell
+      // through to the files would satisfy a first-call-only assertion while
+      // inserting everything twice.
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(pathForFile).not.toHaveBeenCalled();
       expect(effectValues(dispatch)).toHaveLength(1);
       expect(insertedToken(dispatch)).toBe("@src/App.tsx");
+    });
+
+    // Crossing CodeMirror's child elements fires nested enter/leave pairs, so
+    // the overlay has to survive the inner leave and clear only on the outer.
+    it("keeps the overlay up across nested enters and clears it on the last leave", () => {
+      const { ref } = fakeView();
+      const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+      act(() => {
+        result.current.handleDragEnter(dragEvent([FILE_DRAG_MIME]));
+        result.current.handleDragEnter(dragEvent([FILE_DRAG_MIME]));
+      });
+      expect(result.current.isDragOverFiles).toBe(true);
+
+      act(() => {
+        result.current.handleDragLeave(dragEvent([FILE_DRAG_MIME]));
+      });
+      expect(result.current.isDragOverFiles).toBe(true);
+
+      act(() => {
+        result.current.handleDragLeave(dragEvent([FILE_DRAG_MIME]));
+      });
+      expect(result.current.isDragOverFiles).toBe(false);
+    });
+
+    // Ranges are accumulated against the emitted spelling, and images emit a
+    // bare absolute path while files emit a shortened token. Interleaving them
+    // on this provenance is where an accumulator could drift independently of
+    // the OS branch's own coverage.
+    it("keeps ranges aligned when a dragged image sits between two files", async () => {
+      const { dispatch, ref, head } = fakeView(6);
+      const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+      await act(async () => {
+        await result.current.handleDrop(
+          internalDrop([`${CWD}/a.ts`, `${CWD}/shot.png`, `${CWD}/b.ts`])
+        );
+      });
+
+      expect(chipSpellings(dispatch, head).sort()).toEqual(
+        [`${CWD}/shot.png`, "@a.ts", "@b.ts"].sort()
+      );
+    });
+
+    // The pane can be torn down between the drag starting and the drop landing.
+    it("does nothing when the editor is already gone", async () => {
+      const ref = { current: null } as React.RefObject<EditorView | null>;
+      const { result } = renderHook(() => useDragDrop(ref, CWD));
+      const event = internalDrop([`${CWD}/src/App.tsx`]);
+
+      act(() => {
+        result.current.handleDragEnter(dragEvent([FILE_DRAG_MIME]));
+      });
+      await act(async () => {
+        await result.current.handleDrop(event);
+      });
+
+      expect(event.dataTransfer.getData).not.toHaveBeenCalled();
+      expect(thumbnailFromPath).not.toHaveBeenCalled();
+      expect(result.current.isDragOverFiles).toBe(false);
     });
   });
 });

--- a/src/components/Terminal/hooks/__tests__/useDragDrop.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useDragDrop.test.ts
@@ -12,6 +12,7 @@ vi.mock("../../useTerminalFileTransfer", () => ({
 }));
 
 const { useDragDrop } = await import("../useDragDrop");
+const { FILE_DRAG_MIME, encodeFileDragPaths } = await import("@/lib/fileDragPayload");
 
 const CWD = "/Users/greg/Projects/daintree";
 
@@ -24,12 +25,45 @@ function fakeView(head = 0) {
   return { view, dispatch, head, ref: { current: view } as React.RefObject<EditorView | null> };
 }
 
-function dropEvent(files: File[]): React.DragEvent {
+/**
+ * The one place a synthetic transfer becomes a `DragEvent`. Every builder
+ * below routes through it so the suite keeps a single assertion rather than
+ * one per drag shape.
+ */
+function dragEventWith(dataTransfer: object): React.DragEvent {
   return {
     preventDefault: vi.fn(),
     stopPropagation: vi.fn(),
-    dataTransfer: { files, types: ["Files"] },
+    dataTransfer,
   } as unknown as React.DragEvent;
+}
+
+function dropEvent(files: File[]): React.DragEvent {
+  return dragEventWith({ files, types: ["Files"] });
+}
+
+/**
+ * A drop from the file browser (#11576): paths, no `File` objects. `getData`
+ * only answers for the type the source actually wrote, which is what proves
+ * the handler asks for the right one.
+ */
+function internalDropEvent(
+  serialized: string,
+  getData: (type: string) => string = vi.fn((type: string) =>
+    type === FILE_DRAG_MIME ? serialized : ""
+  )
+): React.DragEvent {
+  return dragEventWith({ files: [], types: [FILE_DRAG_MIME], getData });
+}
+
+/** The same, carrying paths the source would really have encoded. */
+function internalDrop(paths: string[]): React.DragEvent {
+  return internalDropEvent(encodeFileDragPaths(paths));
+}
+
+/** A hover, with no payload readable yet — what protected mode really hands us. */
+function dragEvent(types: string[]): React.DragEvent {
+  return dragEventWith({ types, dropEffect: "none", getData: vi.fn(() => "") });
 }
 
 function fakeFile(name: string, size = 10): File {
@@ -274,5 +308,244 @@ describe("useDragDrop", () => {
     });
 
     expect(view.dispatch).not.toHaveBeenCalled();
+  });
+
+  // A drag out of the file browser (#11576). It carries paths instead of
+  // `File` objects, so the gate and the payload both have a second source —
+  // everything downstream has to stay the OS drop's.
+  describe("in-app file drag", () => {
+    it("lights the drop affordance up for the in-app type", () => {
+      const { ref } = fakeView();
+      const { result } = renderHook(() => useDragDrop(ref, CWD));
+      const enter = dragEvent([FILE_DRAG_MIME]);
+
+      act(() => {
+        result.current.handleDragEnter(enter);
+      });
+
+      expect(enter.preventDefault).toHaveBeenCalled();
+      expect(result.current.isDragOverFiles).toBe(true);
+    });
+
+    it("accepts the in-app type as a copy", () => {
+      const { ref } = fakeView();
+      const { result } = renderHook(() => useDragDrop(ref, CWD));
+      const over = dragEvent([FILE_DRAG_MIME]);
+
+      act(() => {
+        result.current.handleDragOver(over);
+      });
+
+      expect(over.preventDefault).toHaveBeenCalled();
+      expect(over.dataTransfer.dropEffect).toBe("copy");
+    });
+
+    // Chromium blanks `getData` until the drop, so a gate that reached for the
+    // payload would refuse every in-app drag it is supposed to advertise.
+    it("gates on the type alone, never on the payload", () => {
+      const { ref } = fakeView();
+      const { result } = renderHook(() => useDragDrop(ref, CWD));
+      const enter = dragEvent([FILE_DRAG_MIME]);
+      const over = dragEvent([FILE_DRAG_MIME]);
+
+      act(() => {
+        result.current.handleDragEnter(enter);
+        result.current.handleDragOver(over);
+      });
+
+      expect(enter.dataTransfer.getData).not.toHaveBeenCalled();
+      expect(over.dataTransfer.getData).not.toHaveBeenCalled();
+    });
+
+    it("ignores a drag carrying neither files nor the in-app type", () => {
+      const { ref } = fakeView();
+      const { result } = renderHook(() => useDragDrop(ref, CWD));
+      const enter = dragEvent(["text/plain"]);
+
+      act(() => {
+        result.current.handleDragEnter(enter);
+      });
+
+      expect(enter.preventDefault).not.toHaveBeenCalled();
+      expect(result.current.isDragOverFiles).toBe(false);
+    });
+
+    // The bar the whole feature is measured against: dragging a row must
+    // produce what dropping the same file from Finder produces.
+    it("inserts the same cwd-relative token an OS drop of the file produces", async () => {
+      const { dispatch, ref } = fakeView();
+      const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+      await act(async () => {
+        await result.current.handleDrop(internalDrop([`${CWD}/src/App.tsx`]));
+      });
+
+      expect(insertedToken(dispatch)).toBe("@src/App.tsx");
+    });
+
+    it("stores the absolute path on the chip and names it from the path", async () => {
+      const absolute = `${CWD}/src/App.tsx`;
+      const { dispatch, ref } = fakeView();
+      const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+      await act(async () => {
+        await result.current.handleDrop(internalDrop([absolute]));
+      });
+
+      const [chip] = effectValues(dispatch);
+      expect(chip?.filePath).toBe(absolute);
+      expect(chip?.fileName).toBe("App.tsx");
+      // No `File` behind an in-app drag, so no size — the chip already treats
+      // it as optional rather than this reaching for a stat over IPC.
+      expect(chip?.fileSize).toBeUndefined();
+    });
+
+    it("keeps a reserved-name collision a path", async () => {
+      const { dispatch, ref } = fakeView();
+      const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+      await act(async () => {
+        await result.current.handleDrop(internalDrop([`${CWD}/terminal`]));
+      });
+
+      expect(insertedToken(dispatch)).toBe("@./terminal");
+    });
+
+    it("quotes a dragged path that needs it", async () => {
+      const { dispatch, ref } = fakeView();
+      const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+      await act(async () => {
+        await result.current.handleDrop(internalDrop([`${CWD}/my notes.md`]));
+      });
+
+      expect(insertedToken(dispatch)).toBe('@"my notes.md"');
+    });
+
+    // A folder is a meaningful reference for an agent and drags like any file.
+    it("references a dragged folder", async () => {
+      const { dispatch, ref } = fakeView();
+      const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+      await act(async () => {
+        await result.current.handleDrop(internalDrop([`${CWD}/src/components`]));
+      });
+
+      expect(insertedToken(dispatch)).toBe("@src/components");
+    });
+
+    it("keeps chip ranges aligned across several dragged paths", async () => {
+      const { dispatch, ref, head } = fakeView(11);
+      const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+      await act(async () => {
+        await result.current.handleDrop(internalDrop([`${CWD}/src/a.ts`, `${CWD}/src/b.ts`]));
+      });
+
+      expect(chipSpellings(dispatch, head)).toEqual(["@src/a.ts", "@src/b.ts"]);
+    });
+
+    // Matching the OS drop means matching it for images too: Finder's drop of
+    // a PNG yields a thumbnail chip, so dragging that row must as well.
+    it("thumbnails a dragged image exactly as an OS drop does", async () => {
+      const absolute = `${CWD}/shot.png`;
+      const { dispatch, ref } = fakeView();
+      const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+      await act(async () => {
+        await result.current.handleDrop(internalDrop([absolute]));
+      });
+
+      expect(thumbnailFromPath).toHaveBeenCalledWith(absolute);
+      const insert = dispatch.mock.calls[0]?.[0]?.changes?.insert as string;
+      expect(insert.trimEnd()).toBe(absolute);
+    });
+
+    // A folder whose name ends in an image extension takes the same recovery a
+    // corrupt image already takes, rather than needing its own payload field.
+    it("falls back to a file chip when the thumbnail fails", async () => {
+      thumbnailFromPath.mockRejectedValue(new Error("not an image"));
+      const { dispatch, ref } = fakeView();
+      const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+      await act(async () => {
+        await result.current.handleDrop(internalDrop([`${CWD}/assets.png`]));
+      });
+
+      expect(insertedToken(dispatch)).toBe("@assets.png");
+    });
+
+    // The OS path would resolve nothing for a drag that has no `File` at all.
+    it("never asks the OS to resolve a path it was handed", async () => {
+      const { ref } = fakeView();
+      const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+      await act(async () => {
+        await result.current.handleDrop(internalDrop([`${CWD}/src/App.tsx`]));
+      });
+
+      expect(pathForFile).not.toHaveBeenCalled();
+    });
+
+    it("reads the payload from the in-app type", async () => {
+      const getData = vi.fn(() => encodeFileDragPaths([`${CWD}/src/App.tsx`]));
+      const { ref } = fakeView();
+      const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+      await act(async () => {
+        await result.current.handleDrop(internalDropEvent("", getData));
+      });
+
+      expect(getData).toHaveBeenCalledWith(FILE_DRAG_MIME);
+    });
+
+    // The payload is only readable once the drop has already been advertised,
+    // so a malformed one has to fail quietly rather than insert something.
+    it("dispatches nothing for a malformed payload but still clears the overlay", async () => {
+      const { view, ref } = fakeView();
+      const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+      act(() => {
+        result.current.handleDragEnter(dragEvent([FILE_DRAG_MIME]));
+      });
+      expect(result.current.isDragOverFiles).toBe(true);
+
+      await act(async () => {
+        await result.current.handleDrop(internalDropEvent("not json"));
+      });
+
+      expect(view.dispatch).not.toHaveBeenCalled();
+      expect(result.current.isDragOverFiles).toBe(false);
+    });
+
+    it("dispatches nothing for a payload carrying a relative path", async () => {
+      const { view, ref } = fakeView();
+      const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+      await act(async () => {
+        await result.current.handleDrop(internalDropEvent(encodeFileDragPaths(["src/App.tsx"])));
+      });
+
+      expect(view.dispatch).not.toHaveBeenCalled();
+    });
+
+    // Draining both would insert every reference twice.
+    it("prefers the in-app payload when files ride along too", async () => {
+      pathForFile.mockReturnValue(`${CWD}/from-os.ts`);
+      const { dispatch, ref } = fakeView();
+      const { result } = renderHook(() => useDragDrop(ref, CWD));
+      const event = dragEventWith({
+        files: [fakeFile("from-os.ts")],
+        types: ["Files", FILE_DRAG_MIME],
+        getData: () => encodeFileDragPaths([`${CWD}/src/App.tsx`]),
+      });
+
+      await act(async () => {
+        await result.current.handleDrop(event);
+      });
+
+      expect(effectValues(dispatch)).toHaveLength(1);
+      expect(insertedToken(dispatch)).toBe("@src/App.tsx");
+    });
   });
 });

--- a/src/components/Terminal/hooks/useDragDrop.ts
+++ b/src/components/Terminal/hooks/useDragDrop.ts
@@ -1,5 +1,12 @@
 import { useCallback, useRef, useState } from "react";
 import type { EditorView } from "@codemirror/view";
+import { basename } from "@shared/utils/path";
+import {
+  FILE_DRAG_MIME,
+  decodeFileDragPaths,
+  hasFileDrag,
+  hasInternalFileDrag,
+} from "@/lib/fileDragPayload";
 import { IMAGE_EXTENSIONS } from "../useTerminalFileTransfer";
 import { formatAtFileTokenForCwd } from "../hybridInputParsing";
 import { addImageChip, addFileDropChip } from "../inputEditorExtensions";
@@ -9,7 +16,7 @@ export function useDragDrop(editorViewRef: React.RefObject<EditorView | null>, c
   const [isDragOverFiles, setIsDragOverFiles] = useState(false);
 
   const handleDragEnter = useCallback((e: React.DragEvent) => {
-    if (!e.dataTransfer.types.includes("Files")) return;
+    if (!hasFileDrag(e.dataTransfer.types)) return;
     e.preventDefault();
     e.stopPropagation();
     dragDepthRef.current++;
@@ -17,7 +24,7 @@ export function useDragDrop(editorViewRef: React.RefObject<EditorView | null>, c
   }, []);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
-    if (!e.dataTransfer.types.includes("Files")) return;
+    if (!hasFileDrag(e.dataTransfer.types)) return;
     e.preventDefault();
     e.stopPropagation();
     e.dataTransfer.dropEffect = "copy";
@@ -40,29 +47,66 @@ export function useDragDrop(editorViewRef: React.RefObject<EditorView | null>, c
       setIsDragOverFiles(false);
 
       const view = editorViewRef.current;
-      if (!view || !e.dataTransfer.files.length) return;
+      if (!view) return;
+
+      // Both provenances reduce to the same three fields before anything is
+      // resolved, so an in-app drag (#11576) and an OS drop cannot disagree
+      // about what they insert. An in-app drag has no `File` behind it: the
+      // name comes from the path and there is no size, which the chip already
+      // treats as optional — the tooltip just omits the size line rather than
+      // this reaching for a stat over IPC.
+      //
+      // The internal type wins when both are somehow present; decoding it and
+      // then also draining `files` would insert every reference twice.
+      const dropped: { filePath: string; fileName: string; fileSize: number | undefined }[] =
+        hasInternalFileDrag(e.dataTransfer.types)
+          ? (decodeFileDragPaths(e.dataTransfer.getData(FILE_DRAG_MIME)) ?? []).map((filePath) => ({
+              filePath,
+              fileName: basename(filePath) || filePath,
+              fileSize: undefined,
+            }))
+          : Array.from(e.dataTransfer.files)
+              .map((file) => ({
+                filePath: window.electron.webUtils.getPathForFile(file),
+                osName: file.name,
+                fileSize: file.size,
+              }))
+              // A file the OS declines to resolve to a path is not referenceable.
+              .filter((entry) => entry.filePath !== "")
+              .map(({ filePath, osName, fileSize }) => ({
+                filePath,
+                fileName:
+                  osName.trim() || filePath.split(/[/\\]/).filter(Boolean).pop() || filePath,
+                fileSize,
+              }));
+
+      if (dropped.length === 0) return;
 
       type ResolvedFile =
         | { type: "image"; filePath: string; thumbnailDataUrl: string }
-        | { type: "file"; filePath: string; fileName: string; fileSize: number };
+        | {
+            type: "file";
+            filePath: string;
+            fileName: string;
+            fileSize: number | undefined;
+          };
 
       const resolved: ResolvedFile[] = [];
 
-      for (const file of Array.from(e.dataTransfer.files)) {
-        const filePath = window.electron.webUtils.getPathForFile(file);
-        if (!filePath) continue;
-        const name = file.name.trim() || filePath.split(/[/\\]/).filter(Boolean).pop() || filePath;
-
-        if (IMAGE_EXTENSIONS.test(file.name)) {
+      for (const { filePath, fileName, fileSize } of dropped) {
+        // A dragged folder reaches this too. One whose name ends in an image
+        // extension fails the thumbnail and falls back to the file chip, which
+        // is the same recovery a corrupt image already takes.
+        if (IMAGE_EXTENSIONS.test(fileName)) {
           try {
             const { thumbnailDataUrl } =
               await window.electron.clipboard.thumbnailFromPath(filePath);
             resolved.push({ type: "image", filePath, thumbnailDataUrl });
           } catch {
-            resolved.push({ type: "file", filePath, fileName: name, fileSize: file.size });
+            resolved.push({ type: "file", filePath, fileName, fileSize });
           }
         } else {
-          resolved.push({ type: "file", filePath, fileName: name, fileSize: file.size });
+          resolved.push({ type: "file", filePath, fileName, fileSize });
         }
       }
 

--- a/src/components/Terminal/hooks/useDragDrop.ts
+++ b/src/components/Terminal/hooks/useDragDrop.ts
@@ -11,6 +11,18 @@ import { IMAGE_EXTENSIONS } from "../useTerminalFileTransfer";
 import { formatAtFileTokenForCwd } from "../hybridInputParsing";
 import { addImageChip, addFileDropChip } from "../inputEditorExtensions";
 
+/**
+ * A dropped entry, normalized across the two provenances before anything is
+ * resolved. `rawName` is the untrimmed name used to classify images; `fileName`
+ * is what the chip displays and can differ from it.
+ */
+interface DroppedEntry {
+  filePath: string;
+  rawName: string;
+  fileName: string;
+  fileSize: number | undefined;
+}
+
 export function useDragDrop(editorViewRef: React.RefObject<EditorView | null>, cwd: string) {
   const dragDepthRef = useRef(0);
   const [isDragOverFiles, setIsDragOverFiles] = useState(false);
@@ -58,27 +70,30 @@ export function useDragDrop(editorViewRef: React.RefObject<EditorView | null>, c
       //
       // The internal type wins when both are somehow present; decoding it and
       // then also draining `files` would insert every reference twice.
-      const dropped: { filePath: string; fileName: string; fileSize: number | undefined }[] =
-        hasInternalFileDrag(e.dataTransfer.types)
-          ? (decodeFileDragPaths(e.dataTransfer.getData(FILE_DRAG_MIME)) ?? []).map((filePath) => ({
+      const dropped: DroppedEntry[] = hasInternalFileDrag(e.dataTransfer.types)
+        ? (decodeFileDragPaths(e.dataTransfer.getData(FILE_DRAG_MIME)) ?? []).map((filePath) => {
+            const rawName = basename(filePath);
+            return {
               filePath,
-              fileName: basename(filePath) || filePath,
+              rawName,
+              fileName: rawName || filePath,
               fileSize: undefined,
+            };
+          })
+        : Array.from(e.dataTransfer.files)
+            .map((file) => ({
+              filePath: window.electron.webUtils.getPathForFile(file),
+              rawName: file.name,
+              fileSize: file.size,
             }))
-          : Array.from(e.dataTransfer.files)
-              .map((file) => ({
-                filePath: window.electron.webUtils.getPathForFile(file),
-                osName: file.name,
-                fileSize: file.size,
-              }))
-              // A file the OS declines to resolve to a path is not referenceable.
-              .filter((entry) => entry.filePath !== "")
-              .map(({ filePath, osName, fileSize }) => ({
-                filePath,
-                fileName:
-                  osName.trim() || filePath.split(/[/\\]/).filter(Boolean).pop() || filePath,
-                fileSize,
-              }));
+            // A file the OS declines to resolve to a path is not referenceable.
+            .filter((entry) => entry.filePath !== "")
+            .map(({ filePath, rawName, fileSize }) => ({
+              filePath,
+              rawName,
+              fileName: rawName.trim() || filePath.split(/[/\\]/).filter(Boolean).pop() || filePath,
+              fileSize,
+            }));
 
       if (dropped.length === 0) return;
 
@@ -93,11 +108,16 @@ export function useDragDrop(editorViewRef: React.RefObject<EditorView | null>, c
 
       const resolved: ResolvedFile[] = [];
 
-      for (const { filePath, fileName, fileSize } of dropped) {
+      for (const { filePath, rawName, fileName, fileSize } of dropped) {
+        // Classified on the untrimmed name both provenances agree on, never on
+        // the display name: a real file called `shot.png ` is not an image, and
+        // trimming first would make the same file classify one way from Finder
+        // and the other way from the tree.
+        //
         // A dragged folder reaches this too. One whose name ends in an image
         // extension fails the thumbnail and falls back to the file chip, which
         // is the same recovery a corrupt image already takes.
-        if (IMAGE_EXTENSIONS.test(fileName)) {
+        if (IMAGE_EXTENSIONS.test(rawName)) {
           try {
             const { thumbnailDataUrl } =
               await window.electron.clipboard.thumbnailFromPath(filePath);

--- a/src/components/Terminal/useTerminalFileTransfer.ts
+++ b/src/components/Terminal/useTerminalFileTransfer.ts
@@ -5,6 +5,12 @@ import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
 import { escapeShellArgOptional } from "@shared/utils/shellEscape.js";
 import { formatWithBracketedPaste } from "@shared/utils/terminalInputProtocol.js";
+import {
+  FILE_DRAG_MIME,
+  decodeFileDragPaths,
+  hasFileDrag,
+  hasInternalFileDrag,
+} from "@/lib/fileDragPayload";
 import { formatAtFileTokenForCwd } from "./hybridInputParsing";
 
 /**
@@ -204,7 +210,7 @@ export function useTerminalFileTransfer(
     };
 
     const handleDragEnter = (e: DragEvent) => {
-      if (!e.dataTransfer?.types.includes("Files")) return;
+      if (!e.dataTransfer || !hasFileDrag(e.dataTransfer.types)) return;
       e.preventDefault();
       e.stopPropagation();
       dragDepthRef.current++;
@@ -212,7 +218,7 @@ export function useTerminalFileTransfer(
     };
 
     const handleDragOver = (e: DragEvent) => {
-      if (!e.dataTransfer?.types.includes("Files")) return;
+      if (!e.dataTransfer || !hasFileDrag(e.dataTransfer.types)) return;
       e.preventDefault();
       e.stopPropagation();
       e.dataTransfer.dropEffect = isInputLockedRef.current ? "none" : "copy";
@@ -234,12 +240,21 @@ export function useTerminalFileTransfer(
       setIsDragOverFiles(false);
 
       if (isInputLockedRef.current) return;
-      if (!e.dataTransfer?.files.length) return;
+      const transfer = e.dataTransfer;
+      if (!transfer) return;
+
+      // A drag out of the file browser (#11576) carries paths where the OS
+      // hands over `File` objects. Only the source of the paths differs —
+      // both axes below stay exactly as an OS drop drives them, so the two
+      // gestures cannot produce different bytes for the same file. The
+      // internal type wins when both are present, so nothing is written twice.
+      const paths = hasInternalFileDrag(transfer.types)
+        ? (decodeFileDragPaths(transfer.getData(FILE_DRAG_MIME)) ?? [])
+        : Array.from(transfer.files).map((file) => window.electron.webUtils.getPathForFile(file));
 
       const isAgent = isAgentTerminal();
       const formatted: string[] = [];
-      for (const file of Array.from(e.dataTransfer.files)) {
-        const filePath = window.electron.webUtils.getPathForFile(file);
+      for (const filePath of paths) {
         if (filePath && isDeliverablePath(filePath)) formatted.push(formatPath(filePath, isAgent));
       }
 

--- a/src/hooks/useFileDropGuard.ts
+++ b/src/hooks/useFileDropGuard.ts
@@ -1,23 +1,29 @@
 import { useEffect } from "react";
+import { hasFileDrag } from "@/lib/fileDragPayload";
 
 /**
  * Prevents browser-default file navigation when files are dropped on
  * non-terminal areas. Uses bubble phase so components that call
  * stopPropagation (terminal, HybridInputBar) handle their own drops.
  * Skips events already handled by a child (defaultPrevented check).
+ *
+ * Covers in-app file drags (#11576) on the same terms as OS ones. That is what
+ * makes an invalid target say so: with no handler claiming the drag, Chromium
+ * has no reason to show anything but the copy cursor, and the drop would read
+ * as accepted right up until nothing happened.
  */
 export function useFileDropGuard() {
   useEffect(() => {
     const handleDragOver = (e: DragEvent) => {
       if (e.defaultPrevented) return;
-      if (!e.dataTransfer?.types.includes("Files")) return;
+      if (!e.dataTransfer || !hasFileDrag(e.dataTransfer.types)) return;
       e.preventDefault();
       e.dataTransfer.dropEffect = "none";
     };
 
     const handleDrop = (e: DragEvent) => {
       if (e.defaultPrevented) return;
-      if (!e.dataTransfer?.types.includes("Files")) return;
+      if (!e.dataTransfer || !hasFileDrag(e.dataTransfer.types)) return;
       e.preventDefault();
     };
 

--- a/src/lib/__tests__/fileDragPayload.test.ts
+++ b/src/lib/__tests__/fileDragPayload.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import {
+  FILE_DRAG_MIME,
+  decodeFileDragPaths,
+  encodeFileDragPaths,
+  hasFileDrag,
+  hasInternalFileDrag,
+} from "../fileDragPayload";
+
+/** What a drop handler actually receives: whatever survived the round trip. */
+function roundTrip(paths: readonly string[]): string[] | null {
+  return decodeFileDragPaths(encodeFileDragPaths(paths));
+}
+
+describe("fileDragPayload", () => {
+  // Chromium lowercases custom `dataTransfer` types on the way in, so a
+  // constant carrying any uppercase letter would never match what `types`
+  // reports back at the drop site.
+  it("uses a type string Chromium will hand back unchanged", () => {
+    expect(FILE_DRAG_MIME).toBe(FILE_DRAG_MIME.toLowerCase());
+  });
+
+  it("round-trips a single path", () => {
+    expect(roundTrip(["/repo/src/App.tsx"])).toEqual(["/repo/src/App.tsx"]);
+  });
+
+  // The tree is single-select today, so nothing exercises this yet — the
+  // transport is shaped for the multi-select follow-up, and order is what
+  // decides the order the references are inserted in.
+  it("preserves order and duplicates across several paths", () => {
+    const paths = ["/repo/b.ts", "/repo/a.ts", "/repo/b.ts"];
+    expect(roundTrip(paths)).toEqual(paths);
+  });
+
+  it("round-trips paths whose spelling the token formatter has to quote", () => {
+    const paths = ["/repo/my notes.md", "/repo/it's here.txt", "/repo/diff:staged"];
+    expect(roundTrip(paths)).toEqual(paths);
+  });
+
+  it("round-trips Windows drive and UNC paths", () => {
+    expect(roundTrip(["C:/repo/src/App.tsx"])).toEqual(["C:/repo/src/App.tsx"]);
+    expect(roundTrip(["//server/share/App.tsx"])).toEqual(["//server/share/App.tsx"]);
+  });
+
+  // Everything below reaches a drop handler as an attacker-shaped or
+  // simply-not-ours string: `getData` returns whatever the drag source wrote,
+  // and the type check that got us here only proves the type is present.
+  it("rejects malformed JSON", () => {
+    expect(decodeFileDragPaths("")).toBeNull();
+    expect(decodeFileDragPaths("{")).toBeNull();
+    expect(decodeFileDragPaths("/repo/App.tsx")).toBeNull();
+  });
+
+  it("rejects JSON that is not an array of paths", () => {
+    expect(decodeFileDragPaths(JSON.stringify({ paths: ["/repo/App.tsx"] }))).toBeNull();
+    expect(decodeFileDragPaths(JSON.stringify("/repo/App.tsx"))).toBeNull();
+    expect(decodeFileDragPaths(JSON.stringify(null))).toBeNull();
+    expect(decodeFileDragPaths(JSON.stringify([1, 2]))).toBeNull();
+    expect(decodeFileDragPaths(JSON.stringify(["/repo/App.tsx", null]))).toBeNull();
+  });
+
+  it("rejects an empty payload rather than reporting an empty drop", () => {
+    expect(roundTrip([])).toBeNull();
+  });
+
+  // A relative path names nothing the receiving agent could open: its cwd is
+  // its own worktree, not the file browser's base path.
+  it("rejects relative and empty paths", () => {
+    expect(roundTrip(["src/App.tsx"])).toBeNull();
+    expect(roundTrip([""])).toBeNull();
+    expect(roundTrip(["/repo/App.tsx", "src/App.tsx"])).toBeNull();
+  });
+
+  describe("type gates", () => {
+    it("recognizes an in-app drag", () => {
+      expect(hasInternalFileDrag([FILE_DRAG_MIME])).toBe(true);
+      expect(hasInternalFileDrag(["Files"])).toBe(false);
+      expect(hasInternalFileDrag([])).toBe(false);
+    });
+
+    // The gate every dragenter/dragover handler shares, so the hybrid input
+    // and the terminal cannot drift on which drags light up their affordance.
+    it("accepts either an OS file drag or an in-app one", () => {
+      expect(hasFileDrag(["Files"])).toBe(true);
+      expect(hasFileDrag([FILE_DRAG_MIME])).toBe(true);
+      expect(hasFileDrag([FILE_DRAG_MIME, "Files"])).toBe(true);
+    });
+
+    // Text is the drag every editable surface in the app already accepts on
+    // its own terms; claiming it here would hijack ordinary text drops.
+    it("ignores a text-only drag", () => {
+      expect(hasFileDrag(["text/plain"])).toBe(false);
+      expect(hasFileDrag(["text/plain", "text/uri-list"])).toBe(false);
+      expect(hasFileDrag([])).toBe(false);
+    });
+  });
+});

--- a/src/lib/__tests__/fileDragPayload.test.ts
+++ b/src/lib/__tests__/fileDragPayload.test.ts
@@ -71,6 +71,37 @@ describe("fileDragPayload", () => {
     expect(roundTrip(["/repo/App.tsx", "src/App.tsx"])).toBeNull();
   });
 
+  // Nothing stops a page in a Browser panel from writing this type, and the
+  // terminal writes what it decodes straight to a PTY. A line discipline acts
+  // on these before any shell parses the command, so quoting cannot defuse
+  // them — ETX would raise SIGINT from inside a quoted argument.
+  it("rejects paths carrying terminal control characters", () => {
+    const control = (code: number) => `/repo/a${String.fromCharCode(code)}b.ts`;
+    // ETX (Ctrl-C), EOT (Ctrl-D), SUB (Ctrl-Z), BS, TAB, DEL.
+    for (const code of [0x03, 0x04, 0x1a, 0x08, 0x09, 0x7f]) {
+      expect(decodeFileDragPaths(encodeFileDragPaths([control(code)]))).toBeNull();
+    }
+  });
+
+  it("rejects the control characters the terminal already refused", () => {
+    for (const code of [0x0d, 0x0a, 0x1b]) {
+      const path = `/repo/a${String.fromCharCode(code)}b.ts`;
+      expect(decodeFileDragPaths(encodeFileDragPaths([path]))).toBeNull();
+    }
+  });
+
+  // One bad entry takes the whole list with it: a partial drop is the one
+  // outcome the user cannot tell apart from a complete one.
+  it("rejects the whole payload when only one entry is hostile", () => {
+    const hostile = `/repo/a${String.fromCharCode(0x03)}b.ts`;
+    expect(decodeFileDragPaths(encodeFileDragPaths(["/repo/fine.ts", hostile]))).toBeNull();
+  });
+
+  it("keeps ordinary punctuation and unicode in a path", () => {
+    const paths = ["/repo/naïve—file (v2).ts", "/repo/日本語.md"];
+    expect(roundTrip(paths)).toEqual(paths);
+  });
+
   describe("type gates", () => {
     it("recognizes an in-app drag", () => {
       expect(hasInternalFileDrag([FILE_DRAG_MIME])).toBe(true);

--- a/src/lib/fileDragPayload.ts
+++ b/src/lib/fileDragPayload.ts
@@ -34,6 +34,28 @@ export function encodeFileDragPaths(paths: readonly string[]): string {
 }
 
 /**
+ * Does this path carry a C0 or C1 control character?
+ *
+ * A terminal's line discipline acts on these before any shell parses the
+ * command, so shell-escaping the argument does not defuse them: ETX reads as
+ * SIGINT whether or not it sits inside quotes. The terminal's own
+ * `isDeliverablePath` already refuses CR, LF and ESC, but the drop handlers are
+ * not the right place to hold this line — this type is settable by anything
+ * that can start a drag, including a page loaded in a Browser panel, so the
+ * payload is untrusted input and must not reach a formatter carrying one.
+ *
+ * A codepoint scan rather than a regex: a control-character class needs literal
+ * control bytes in the source, which `no-control-regex` rejects outright.
+ */
+function hasControlCharacter(path: string): boolean {
+  for (let i = 0; i < path.length; i++) {
+    const code = path.charCodeAt(i);
+    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) return true;
+  }
+  return false;
+}
+
+/**
  * Reads the payload back at drop time, or `null` if it is not one we wrote.
  *
  * Nothing about a `DataTransfer` is trustworthy enough to skip this: the string
@@ -46,6 +68,11 @@ export function encodeFileDragPaths(paths: readonly string[]): string {
  * could open, since its cwd is not the file browser's base path. Order and
  * duplicates are preserved: dropping the same file twice is a thing a user can
  * mean, exactly as it is for the chip extensions.
+ *
+ * One bad entry rejects the whole list rather than filtering it. A partial drop
+ * is the one outcome a user cannot tell apart from a complete one, and every
+ * payload comes from a single gesture that either means all of its paths or is
+ * not ours at all.
  */
 export function decodeFileDragPaths(serialized: string): string[] | null {
   let parsed: unknown;
@@ -58,6 +85,7 @@ export function decodeFileDragPaths(serialized: string): string[] | null {
   const paths: string[] = [];
   for (const entry of parsed) {
     if (typeof entry !== "string" || entry === "" || !isAbsolute(entry)) return null;
+    if (hasControlCharacter(entry)) return null;
     paths.push(entry);
   }
   return paths;

--- a/src/lib/fileDragPayload.ts
+++ b/src/lib/fileDragPayload.ts
@@ -1,0 +1,79 @@
+import { isAbsolute } from "@shared/utils/path";
+
+/**
+ * The `dataTransfer` type an in-app file drag carries (#11576).
+ *
+ * A drag started inside the renderer has no OS file handle, so it cannot
+ * populate `dataTransfer.files` — the only thing it has is a path string. Every
+ * drop handler that accepts OS files therefore learns a second type, and this
+ * constant is the whole contract between them: the file browser writes it, the
+ * hybrid input and the terminal read it.
+ *
+ * Lowercase because Chromium lowercases custom types on the way in, so a
+ * mixed-case constant would never match what `types` reports back.
+ *
+ * Deliberately the ONLY type the drag carries. A `text/plain` fallback would
+ * look harmless and double-insert: CodeMirror's own `drop` handler reads
+ * `getData("Text")` and dispatches its own insertion, and it sits on the
+ * content DOM *inside* the element carrying the hybrid input's drop handler —
+ * so the raw path would land in the document alongside the `@file` chip. It
+ * would also put the drag beyond `useFileDropGuard`'s reach, since a text drag
+ * is one every editable surface in the app legitimately accepts.
+ */
+export const FILE_DRAG_MIME = "application/x-daintree-file-paths";
+
+/**
+ * Serializes the dragged paths for `dataTransfer.setData`.
+ *
+ * A list from the start even though the tree is single-select today (#11576):
+ * multi-select is the obvious follow-up, and widening the payload later would
+ * mean a second format both drop sites have to understand.
+ */
+export function encodeFileDragPaths(paths: readonly string[]): string {
+  return JSON.stringify(paths);
+}
+
+/**
+ * Reads the payload back at drop time, or `null` if it is not one we wrote.
+ *
+ * Nothing about a `DataTransfer` is trustworthy enough to skip this: the string
+ * only becomes readable at `drop` (Chromium's protected mode blanks `getData`
+ * during `dragover`), so the affordance has already been shown by the time the
+ * contents can be checked. A payload that fails here is a no-op drop rather
+ * than a fallback to some other type.
+ *
+ * Paths must be absolute — a relative one names nothing the receiving agent
+ * could open, since its cwd is not the file browser's base path. Order and
+ * duplicates are preserved: dropping the same file twice is a thing a user can
+ * mean, exactly as it is for the chip extensions.
+ */
+export function decodeFileDragPaths(serialized: string): string[] | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(serialized);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed) || parsed.length === 0) return null;
+  const paths: string[] = [];
+  for (const entry of parsed) {
+    if (typeof entry !== "string" || entry === "" || !isAbsolute(entry)) return null;
+    paths.push(entry);
+  }
+  return paths;
+}
+
+/** Is this an in-app file drag? Safe during `dragover` — reads types only. */
+export function hasInternalFileDrag(types: readonly string[]): boolean {
+  return types.includes(FILE_DRAG_MIME);
+}
+
+/**
+ * Is this a drag a file-drop surface should accept — OS files or our own?
+ *
+ * The gate every `dragenter`/`dragover` handler uses, so the two never drift on
+ * which drags light up the drop affordance.
+ */
+export function hasFileDrag(types: readonly string[]): boolean {
+  return types.includes("Files") || hasInternalFileDrag(types);
+}

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -1149,6 +1149,9 @@ export function FileBrowserPane({
           rowContextMenu={rowContextMenu}
           onInsertFileReference={handleInsertFileReference}
           canInsertFileReference={canInsertFileReference}
+          // Turns a dragged row's relative path absolute (#11576), the same
+          // join the insert-reference and copy-path handlers above use.
+          basePath={basePath}
           label={`Files in ${title}`}
         />
         {/* Below the tree, never above: the strip unmounts the instant a

--- a/src/panels/file-browser/FileTreeView.tsx
+++ b/src/panels/file-browser/FileTreeView.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useId, useMemo, useRef } from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { ChevronDown, ChevronRight, File, Folder, FolderOpen } from "lucide-react";
+import { join } from "@shared/utils/path";
 import { cn } from "@/lib/utils";
 import { UI_INLINE_LOADING_GATE_MS } from "@/lib/animationUtils";
+import { FILE_DRAG_MIME, encodeFileDragPaths } from "@/lib/fileDragPayload";
 import { Spinner } from "@/components/ui/Spinner";
 import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
 import { useDeferredLoading } from "@/hooks/useDeferredLoading";
@@ -41,6 +43,14 @@ export interface FileTreeViewProps {
    */
   onInsertFileReference?: (path: string) => void;
   canInsertFileReference?: boolean;
+  /**
+   * Absolute path the rows are relative to — the worktree or workspace root,
+   * NOT the folder the tree is currently rooted at. `row.path` stays relative
+   * to this even after a re-root, which is what lets a dragged row name an
+   * absolute file (#11576). Empty when no source resolves, which is the tree's
+   * signal that rows cannot be dragged anywhere useful.
+   */
+  basePath: string;
   /** Accessible name for the tree, since the panel header isn't part of it. */
   label: string;
 }
@@ -85,6 +95,7 @@ export function FileTreeView({
   rowContextMenu,
   onInsertFileReference,
   canInsertFileReference = false,
+  basePath,
   label,
 }: FileTreeViewProps) {
   const virtuosoRef = useRef<VirtuosoHandle>(null);
@@ -239,6 +250,7 @@ export function FileTreeView({
       rowContextMenu,
       hasDirectories,
       instanceId,
+      basePath,
     }),
     [
       selectedPath,
@@ -249,6 +261,7 @@ export function FileTreeView({
       rowContextMenu,
       hasDirectories,
       instanceId,
+      basePath,
     ]
   );
 
@@ -308,6 +321,7 @@ interface TreeContext {
   rowContextMenu?: ((row: FlatTreeRow) => React.ReactNode) | undefined;
   hasDirectories: boolean;
   instanceId: string;
+  basePath: string;
 }
 
 /**
@@ -383,6 +397,36 @@ function FileTreeRow({ row, isSelected, context }: FileTreeRowProps) {
     event.stopPropagation();
   };
 
+  // Hand this row to an agent by dragging it (#11576). Folders drag exactly
+  // like files: a directory reference is meaningful to every agent that takes
+  // `@path`, and the destination decides what to do with it.
+  //
+  // Everything the drop needs is written here, synchronously. Virtuoso unmounts
+  // this row the moment it scrolls out of the window, but the browser owns the
+  // drag session once `dragstart` returns — it has already snapshotted both the
+  // payload and the drag image, and neither destination looks at the source
+  // node again.
+  //
+  // Carries one type and no `text/plain`: see `FILE_DRAG_MIME`.
+  const handleDragStart = (event: React.DragEvent<HTMLDivElement>) => {
+    const { dataTransfer } = event;
+    // A drag with no data is a drag Chromium starts and no target can accept,
+    // which reads as a broken affordance rather than an absent one.
+    if (context.basePath === "") {
+      event.preventDefault();
+      return;
+    }
+    // A list of one: the tree is single-select today, but the transport is
+    // already shaped for the multi-select follow-up.
+    dataTransfer.setData(FILE_DRAG_MIME, encodeFileDragPaths([join(context.basePath, row.path)]));
+    // Referencing a file never moves or removes it.
+    dataTransfer.effectAllowed = "copy";
+    // The row itself is the preview — it already reads as this file (icon,
+    // name, indentation) and costs no throwaway DOM node to build or clean up.
+    // Grabbed near the icon so the cursor sits on the thing being dragged.
+    dataTransfer.setDragImage(event.currentTarget, 12, ROW_HEIGHT_PX / 2);
+  };
+
   const Chevron = row.isExpanded ? ChevronDown : ChevronRight;
   const FolderIcon = row.isExpanded ? FolderOpen : Folder;
 
@@ -397,6 +441,12 @@ function FileTreeRow({ row, isSelected, context }: FileTreeRowProps) {
       aria-level={row.depth + 1}
       aria-selected={isSelected}
       {...(row.isDirectory && { "aria-expanded": row.isExpanded })}
+      // Deliberately no `cursor-grab`: clicking to select or expand is what
+      // nearly every row interaction is, and advertising the drag on all of
+      // them would misdescribe the surface. Chromium supplies its own cursor
+      // once the gesture actually starts.
+      draggable={context.basePath !== ""}
+      onDragStart={handleDragStart}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
       style={{ paddingLeft: BASE_PADDING_PX + row.depth * INDENT_PER_DEPTH_PX }}

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -134,6 +134,7 @@ const { treeProps } = vi.hoisted(() => ({
     onActivate: undefined as ((path: string) => void) | undefined,
     onInsertFileReference: undefined as ((path: string) => void) | undefined,
     canInsertFileReference: undefined as boolean | undefined,
+    basePath: undefined as string | undefined,
   },
 }));
 vi.mock("../FileTreeView", () => ({
@@ -142,15 +143,18 @@ vi.mock("../FileTreeView", () => ({
     onActivate,
     onInsertFileReference,
     canInsertFileReference,
+    basePath,
   }: {
     rowContextMenu?: (row: unknown) => React.ReactNode;
     onActivate?: (path: string) => void;
     onInsertFileReference?: (path: string) => void;
     canInsertFileReference?: boolean;
+    basePath?: string;
   }) => {
     treeProps.onActivate = onActivate;
     treeProps.onInsertFileReference = onInsertFileReference;
     treeProps.canInsertFileReference = canInsertFileReference;
+    treeProps.basePath = basePath;
     return (
       <div data-testid="file-tree-view" role="tree" tabIndex={-1}>
         {rowContextMenu?.(FOLDER_ROW)}
@@ -319,6 +323,7 @@ beforeEach(() => {
   treeProps.onActivate = undefined;
   treeProps.onInsertFileReference = undefined;
   treeProps.canInsertFileReference = undefined;
+  treeProps.basePath = undefined;
   insertFileReferenceMock.mockClear();
   canInsertRef.current = true;
   dispatchMock.mockReset();
@@ -1182,6 +1187,14 @@ describe("insert file reference", () => {
     canInsertRef.current = false;
     renderPane();
     expect(treeProps.canInsertFileReference).toBe(false);
+  });
+
+  // The tree's rows are relative, so the drag source (#11576) needs the same
+  // absolute base the menu's own join uses. Passing the re-rooted folder here
+  // instead would double-prefix every dragged path.
+  it("hands the tree the base path its rows are relative to", () => {
+    renderPane();
+    expect(treeProps.basePath).toBe("/repo");
   });
 });
 

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -1190,9 +1190,17 @@ describe("insert file reference", () => {
   });
 
   // The tree's rows are relative, so the drag source (#11576) needs the same
-  // absolute base the menu's own join uses. Passing the re-rooted folder here
-  // instead would double-prefix every dragged path.
+  // absolute base the menu's own join uses.
   it("hands the tree the base path its rows are relative to", () => {
+    renderPane();
+    expect(treeProps.basePath).toBe("/repo");
+  });
+
+  // `row.path` stays relative to the true source root after a re-root, so the
+  // base must not follow the tree down. Joining the two would spell
+  // `/repo/src/src/App.tsx` for every dragged row.
+  it("keeps the base at the source root when the tree is re-rooted", () => {
+    mockPanel.browserRootPath = "src";
     renderPane();
     expect(treeProps.basePath).toBe("/repo");
   });

--- a/src/panels/file-browser/__tests__/FileTreeView.test.tsx
+++ b/src/panels/file-browser/__tests__/FileTreeView.test.tsx
@@ -5,6 +5,7 @@ import { forwardRef } from "react";
 import type { ReactNode } from "react";
 import { UI_INLINE_LOADING_GATE_MS } from "@/lib/animationUtils";
 import { ContextMenuItem } from "@/components/ui/context-menu";
+import { FILE_DRAG_MIME, decodeFileDragPaths } from "@/lib/fileDragPayload";
 import { FileTreeView } from "../FileTreeView";
 import type { FlatTreeRow } from "../fileBrowserTree";
 
@@ -50,6 +51,9 @@ function row(path: string, isDirectory = false): FlatTreeRow {
 
 const ROWS = [row("src", true), row("README.md")];
 
+/** Absolute root the rows hang off, so a drag can name a real file. */
+const BASE_PATH = "/repo";
+
 // One test flips to Ctrl; without this reset it would leak into the rest.
 beforeEach(() => {
   isMacMock.mockReturnValue(true);
@@ -64,6 +68,7 @@ function renderTree(overrides: Partial<Parameters<typeof FileTreeView>[0]> = {})
       onSelect={onSelect}
       onToggleExpanded={vi.fn()}
       rowContextMenu={() => <div />}
+      basePath={BASE_PATH}
       label="Files"
       {...overrides}
     />
@@ -86,6 +91,7 @@ describe("FileTreeView context-menu interactions", () => {
         onSelect={onSelect}
         onToggleExpanded={vi.fn()}
         rowContextMenu={(clicked) => <ContextMenuItem>Act on {clicked.name}</ContextMenuItem>}
+        basePath={BASE_PATH}
         label="Files"
       />
     );
@@ -206,6 +212,7 @@ describe("FileTreeView context-menu interactions", () => {
         rowContextMenu={() => <div />}
         onInsertFileReference={onInsertFileReference}
         canInsertFileReference
+        basePath={BASE_PATH}
         label="Files"
       />
     );
@@ -224,6 +231,7 @@ describe("FileTreeView context-menu interactions", () => {
         rowContextMenu={() => <div />}
         onInsertFileReference={onInsertFileReference}
         canInsertFileReference={false}
+        basePath={BASE_PATH}
         label="Files"
       />
     );
@@ -286,6 +294,7 @@ describe("FileTreeView context-menu interactions", () => {
         rowContextMenu={(clicked) => <ContextMenuItem>Act on {clicked.name}</ContextMenuItem>}
         onInsertFileReference={onInsertFileReference}
         canInsertFileReference
+        basePath={BASE_PATH}
         label="Files"
       />
     );
@@ -310,6 +319,7 @@ describe("FileTreeView context-menu interactions", () => {
         onToggleExpanded={vi.fn()}
         onInsertFileReference={vi.fn()}
         canInsertFileReference
+        basePath={BASE_PATH}
         label="Files"
       />
     );
@@ -323,6 +333,7 @@ describe("FileTreeView context-menu interactions", () => {
         onToggleExpanded={vi.fn()}
         onInsertFileReference={vi.fn()}
         canInsertFileReference={false}
+        basePath={BASE_PATH}
         label="Files"
       />
     );
@@ -451,6 +462,7 @@ describe("FileTreeView folder-load spinner", () => {
         selectedPath={null}
         onSelect={vi.fn()}
         onToggleExpanded={vi.fn()}
+        basePath={BASE_PATH}
         label="Files"
       />
     );
@@ -459,6 +471,110 @@ describe("FileTreeView folder-load spinner", () => {
     });
 
     expect(queryByRole("status")).toBeNull();
+  });
+});
+
+describe("FileTreeView drag source", () => {
+  /**
+   * jsdom ships no `DataTransfer`, and the real one has a read-only `types`
+   * anyway. A Map-backed stand-in records exactly what the source wrote, which
+   * is the contract the two drop handlers read back.
+   */
+  function dragStart(element: Element) {
+    const data = new Map<string, string>();
+    const dataTransfer = {
+      setData: (type: string, value: string) => {
+        data.set(type, value);
+      },
+      setDragImage: vi.fn(),
+      effectAllowed: "uninitialized",
+    };
+    const event = new Event("dragstart", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "dataTransfer", { value: dataTransfer });
+    fireEvent(element, event);
+    return { data, dataTransfer, event };
+  }
+
+  it("carries the row's absolute path as a list", () => {
+    const { getByRole } = renderTree();
+
+    const { data } = dragStart(getByRole("treeitem", { name: "README.md" }));
+
+    expect(decodeFileDragPaths(data.get(FILE_DRAG_MIME)!)).toEqual(["/repo/README.md"]);
+  });
+
+  // Rows are relative to the base path, so a drag that skipped the join would
+  // hand the agent a path resolving against its own cwd instead of the file's.
+  it("joins nested rows onto the base path", () => {
+    const { getByRole } = renderTree({ rows: [row("src/components/App.tsx")] });
+
+    const { data } = dragStart(getByRole("treeitem", { name: "App.tsx" }));
+
+    expect(decodeFileDragPaths(data.get(FILE_DRAG_MIME)!)).toEqual([
+      "/repo/src/components/App.tsx",
+    ]);
+  });
+
+  // Directory references are meaningful to the agents, so folders drag on
+  // exactly the same terms as files.
+  it("drags folders too", () => {
+    const { getByRole } = renderTree();
+    const folder = getByRole("treeitem", { name: "src" });
+
+    expect(folder.getAttribute("draggable")).toBe("true");
+    const { data } = dragStart(folder);
+
+    expect(decodeFileDragPaths(data.get(FILE_DRAG_MIME)!)).toEqual(["/repo/src"]);
+  });
+
+  // A `text/plain` twin would be inserted a second time by CodeMirror's own
+  // drop handler, which sits inside the element carrying the hybrid input's,
+  // and would put the drag beyond the app-wide invalid-target guard.
+  it("carries no other type alongside the payload", () => {
+    const { getByRole } = renderTree();
+
+    const { data } = dragStart(getByRole("treeitem", { name: "README.md" }));
+
+    expect([...data.keys()]).toEqual([FILE_DRAG_MIME]);
+  });
+
+  it("advertises a copy and previews the row itself", () => {
+    const { getByRole } = renderTree();
+    const rowElement = getByRole("treeitem", { name: "README.md" });
+
+    const { dataTransfer } = dragStart(rowElement);
+
+    // Referencing a file never moves or removes it.
+    expect(dataTransfer.effectAllowed).toBe("copy");
+    expect(dataTransfer.setDragImage).toHaveBeenCalledWith(
+      rowElement,
+      expect.any(Number),
+      expect.any(Number)
+    );
+  });
+
+  // With no base path the row cannot name an absolute file, so there is
+  // nothing to drag — and a drag carrying no data is one no target can accept,
+  // which reads as broken rather than absent.
+  it("does not drag when no base path resolves", () => {
+    const { getByRole } = renderTree({ basePath: "" });
+    const rowElement = getByRole("treeitem", { name: "README.md" });
+
+    expect(rowElement.getAttribute("draggable")).toBe("false");
+
+    const { data, event } = dragStart(rowElement);
+    expect(data.size).toBe(0);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  // Picking a row up is not the same gesture as choosing it: the viewer must
+  // not swap files under the user mid-drag.
+  it("does not move the selection", () => {
+    const { getByRole, onSelect } = renderTree();
+
+    dragStart(getByRole("treeitem", { name: "README.md" }));
+
+    expect(onSelect).not.toHaveBeenCalled();
   });
 });
 
@@ -477,6 +593,7 @@ describe("FileTreeView menu contract", () => {
         selectedPath={null}
         onSelect={vi.fn()}
         onToggleExpanded={vi.fn()}
+        basePath={BASE_PATH}
         label="Files"
       />
     );

--- a/src/panels/file-browser/__tests__/FileTreeView.test.tsx
+++ b/src/panels/file-browser/__tests__/FileTreeView.test.tsx
@@ -566,16 +566,6 @@ describe("FileTreeView drag source", () => {
     expect(data.size).toBe(0);
     expect(event.defaultPrevented).toBe(true);
   });
-
-  // Picking a row up is not the same gesture as choosing it: the viewer must
-  // not swap files under the user mid-drag.
-  it("does not move the selection", () => {
-    const { getByRole, onSelect } = renderTree();
-
-    dragStart(getByRole("treeitem", { name: "README.md" }));
-
-    expect(onSelect).not.toHaveBeenCalled();
-  });
 });
 
 describe("FileTreeView menu contract", () => {


### PR DESCRIPTION
## Summary

File browser tree rows had no drag source, so they could only receive drops, not send them. Both places you can drop a file (the hybrid input via `useDragDrop.ts`, and an agent terminal via `useTerminalFileTransfer.ts`) already accept files dropped from Finder or the OS. Both gate on `dataTransfer.types.includes("Files")` and then read `dataTransfer.files`, which an in-app drag can never populate: there's no OS file handle to hand over, only a path string. A drag source alone would have looked correct and done nothing.

The fix adds a second data channel to the drag: a custom lowercase MIME type, `application/x-daintree-file-paths`, carrying a JSON list of absolute paths. `types.includes(customType)` is readable during `dragover` (Chromium's protected mode only blanks `getData()` until drop), so it slots into the existing `Files` gate instead of needing a parallel architecture. At drop, both handlers decode it and run the result through the same downstream logic an OS drop takes: `formatAtFileTokenForCwd` for the token, `addFileDropChip` for the chip, and the terminal's two independent axes (content: agent `@token` vs. shell-escaped absolute path; delivery: bracketed-paste per the live xterm mode). A dragged row and a Finder drop of the same file now produce identical output.

Resolves #11576

## Changes

- `src/lib/fileDragPayload.ts` (new): the custom MIME type constant, encode/decode, and the shared type gates used on both the drag source and the drop handlers, plus its test.
- `src/panels/file-browser/FileTreeView.tsx`: makes tree rows natively draggable, sets the drag image to the row itself, and takes a new required `basePath` prop.
- `src/panels/file-browser/FileBrowserPane.tsx`: passes `basePath` through to the tree.
- `src/components/Terminal/hooks/useDragDrop.ts` and `src/components/Terminal/useTerminalFileTransfer.ts`: gate on the custom type alongside `Files`, decode it, and feed it through the existing drop logic.
- `src/hooks/useFileDropGuard.ts`: refuses in-app drags over invalid drop surfaces so the cursor reflects it.
- Five accompanying test files covering the above.

## Design decisions

- The drag payload carries only the custom MIME type, no `text/plain` twin. CodeMirror 6's own drop handler reads `getData("Text")` and dispatches its own insertion, which would double-insert the file reference since it sits on the content DOM inside the same element that owns the hybrid input's drop handler. A `text/plain` twin would also put the drag beyond `useFileDropGuard`'s reach.
- The payload is a list of paths from day one, even though the file tree is currently single-select. The issue asked for that so multi-file drag has somewhere to land later.
- Folders drag on the same terms as files.
- Malformed or forged payloads are rejected as a whole rather than filtered down. A partial drop is the one outcome a user can't visually distinguish from a complete one.
- The payload rejects C0/C1 control characters. The custom MIME type is settable by anything that can start a drag, including a page inside a Browser panel, and a terminal's line discipline can act on an ETX character before the shell even parses the argument it's quoted inside.

## Follow-up

An Electron `<webview>` guest (Browser and DevPreview panels) can still accept the drag, since the document-level drop guard can't see events inside an out-of-process frame. The existing shield that sets `pointer-events: none` on webviews while dragging is driven by dnd-kit's `useDragRecovery` hook, which relies on `mousemove`/`mouseup`, and Chromium suppresses both during a native drag, so it can't be reused as-is. Leaving this for a follow-up rather than hand-rolling global drag state, since tearing that down depends on a `dragend` event reaching the document, which is exactly what fails when Virtuoso unmounts the source row mid-drag.

## Testing

- 615 tests pass across the 14 suites covering every changed module.
- `eslint` clean, no per-rule ratchet regression.
- `tsc --noEmit` clean.
- Unit-tested at the jsdom level with synthetic `DataTransfer` objects, matching how the sibling OS-drop features (#11578/#11579) are tested. The repo has no Playwright coverage for native drag.
