### PR TITLE
fix(copytree): return a file handle from copyTree.generate instead of the whole bundle

### DIFF
--- a/e2e/full/terminal/core-context-injection.spec.ts
+++ b/e2e/full/terminal/core-context-injection.spec.ts
@@ -88,13 +88,16 @@ test.describe.serial("Core: Context Injection", () => {
 
     const wtId = await getActiveWorktreeId(window);
 
-    // Generate content via the preload API
+    // Generate via the preload API, opting in to the inline head — the default
+    // now writes the bundle to a file and returns only its path (#11528).
     const result: any = await window.evaluate(
-      async (id: string) => (window as any).electron.copyTree.generate(id),
+      async (id: string) => (window as any).electron.copyTree.generate(id, undefined, true),
       wtId
     );
 
     expect(result?.error).toBeFalsy();
+    expect(result?.filePath).toBeTruthy();
+    expect(result?.outputBytes).toBeGreaterThan(100);
     expect(result?.content?.length).toBeGreaterThan(100);
     expect(result?.fileCount).toBeGreaterThanOrEqual(4);
 

--- a/e2e/nightly/nightly-worker-governance-memory.spec.ts
+++ b/e2e/nightly/nightly-worker-governance-memory.spec.ts
@@ -92,7 +92,12 @@ async function generateContext(window: AppContext["window"], worktreeId: string)
     worktreeId
   );
   expect(result?.error).toBeFalsy();
-  expect(result?.content?.length).toBeGreaterThan(0);
+  // The default path streams the bundle to a file, so nothing but metadata
+  // crosses the worker → host → main → renderer boundaries — which is exactly
+  // the memory behaviour this churn loop measures (#11528).
+  expect(result?.content).toBe("");
+  expect(result?.filePath).toBeTruthy();
+  expect(result?.outputBytes).toBeGreaterThan(0);
 }
 
 async function waitForFileOpsRateLimitWindow(window: AppContext["window"]): Promise<void> {

--- a/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import nodeFs from "fs/promises";
+import nodeOs from "os";
+import nodePath from "path";
 
 const ipcMainMock = vi.hoisted(() => ({
   handle: vi.fn(),
@@ -54,6 +57,7 @@ vi.mock("../../../window/windowRef.js", () => ({
 
 import { CHANNELS } from "../../channels.js";
 import { _resetRateLimitQueuesForTest } from "../../utils.js";
+import { contextDir, _resetReservedPathsForTests } from "../../../services/copyTreeOutputFile.js";
 import {
   registerCopyTreeHandlers,
   mergeCopyTreeOptions,
@@ -634,6 +638,204 @@ describe("copyTree handlers", () => {
           expect(projectStoreMock.getProjectSettings).toHaveBeenCalledWith(GLOBAL_PROJECT);
         });
       }
+    );
+  });
+});
+
+const mockSender = { sender: { id: 1 } } as never;
+
+describe("file-backed generation", () => {
+  let tmpRoot: string;
+  /** The destination the handler reserved and handed to the workspace host. */
+  let lastOutputPath: string | undefined;
+
+  /**
+   * Stand in for the workspace host: write the bundle where the handler asked,
+   * exactly as the streaming service does, and report only the path back.
+   */
+  function makeService(body: string, overrides: Record<string, unknown> = {}) {
+    const generateContext = vi.fn(
+      async (_root: string, _options: unknown, _onProgress: unknown, outputPath?: string) => {
+        lastOutputPath = outputPath;
+        if (!outputPath) return { content: body, fileCount: 2 };
+        await nodeFs.writeFile(outputPath, body, { encoding: "utf8", mode: 0o600 });
+        return {
+          content: "",
+          fileCount: 2,
+          filePath: outputPath,
+          outputBytes: Buffer.byteLength(body, "utf8"),
+          stats: { totalSize: 10, duration: 3 },
+          ...overrides,
+        };
+      }
+    );
+
+    browserWindowMock.fromWebContents.mockReturnValue({ id: 7, isDestroyed: () => false });
+    ipcMainMock.handle.mockClear();
+    registerCopyTreeHandlers({
+      mainWindow: {
+        isDestroyed: () => false,
+        webContents: { isDestroyed: () => false, send: vi.fn() },
+      },
+      ptyClient: { hasTerminal: vi.fn(() => true), write: vi.fn() },
+      worktreeService: {
+        getAllStatesAsync: vi.fn(async () => [
+          { id: "wt-1", path: "/repos/daintree", branch: "main" },
+        ]),
+        generateContext,
+        testConfig: vi.fn(),
+        getContextFileTree: vi.fn(),
+      },
+    } as never);
+    return generateContext;
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    _resetRateLimitQueuesForTest();
+    _resetReservedPathsForTests();
+    lastOutputPath = undefined;
+    tmpRoot = await nodeFs.mkdtemp(nodePath.join(nodeOs.tmpdir(), "daintree-handlers-"));
+    // contextDir() reads os.tmpdir() per call, so redirecting the temp vars
+    // keeps every bundle this suite writes inside its own scratch directory.
+    vi.stubEnv("TMPDIR", tmpRoot);
+    vi.stubEnv("TEMP", tmpRoot);
+    vi.stubEnv("TMP", tmpRoot);
+    projectStoreMock.getCurrentProjectId.mockReturnValue(null);
+    projectStoreMock.getProjectById.mockReturnValue(null);
+    projectStoreMock.getProjectSettings.mockReset();
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await nodeFs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("returns a path instead of the bundle, and never asks the host for the string", async () => {
+    const body = "<files>a very large bundle</files>";
+    const generateContext = makeService(body);
+    const handler = getInvokeHandler(CHANNELS.COPYTREE_GENERATE);
+
+    const result = (await handler(mockSender, { worktreeId: "wt-1" })) as Record<string, unknown>;
+
+    expect(result.filePath).toBe(lastOutputPath);
+    expect(result.content).toBe("");
+    expect(result.outputBytes).toBe(Buffer.byteLength(body, "utf8"));
+    // The destination reached the host, which is what keeps the bundle off the
+    // worker → host → main crossings.
+    expect(generateContext.mock.calls[0][3]).toBe(lastOutputPath);
+    expect(await nodeFs.readFile(result.filePath as string, "utf8")).toBe(body);
+  });
+
+  it("writes the bundle into the shared context directory", async () => {
+    makeService("<files/>");
+    const handler = getInvokeHandler(CHANNELS.COPYTREE_GENERATE);
+
+    const result = (await handler(mockSender, { worktreeId: "wt-1" })) as Record<string, unknown>;
+
+    expect(nodePath.dirname(result.filePath as string)).toBe(contextDir());
+    expect(nodePath.basename(result.filePath as string)).toMatch(/^daintree-main-.*\.xml$/);
+  });
+
+  it("takes the extension from the merged format", async () => {
+    makeService("# context");
+    const handler = getInvokeHandler(CHANNELS.COPYTREE_GENERATE);
+
+    const result = (await handler(mockSender, {
+      worktreeId: "wt-1",
+      options: { format: "markdown" },
+    })) as Record<string, unknown>;
+
+    expect(result.filePath).toMatch(/\.md$/);
+  });
+
+  it("omits content unless it was asked for", async () => {
+    makeService("<files>body</files>");
+    const handler = getInvokeHandler(CHANNELS.COPYTREE_GENERATE);
+
+    const result = (await handler(mockSender, { worktreeId: "wt-1" })) as Record<string, unknown>;
+
+    expect(result.content).toBe("");
+    expect(result.contentTruncated).toBeUndefined();
+  });
+
+  it("reads a small bundle back whole when content was asked for", async () => {
+    makeService("<files>body</files>");
+    const handler = getInvokeHandler(CHANNELS.COPYTREE_GENERATE);
+
+    const result = (await handler(mockSender, {
+      worktreeId: "wt-1",
+      includeContent: true,
+    })) as Record<string, unknown>;
+
+    expect(result.content).toBe("<files>body</files>");
+    expect(result.contentTruncated).toBe(false);
+    expect(result.filePath).toBe(lastOutputPath);
+  });
+
+  it("keeps an opted-in result inside the tool-result budget for a huge bundle", async () => {
+    makeService("<file>".concat("x".repeat(400_000), "</file>"));
+    const handler = getInvokeHandler(CHANNELS.COPYTREE_GENERATE);
+
+    const result = (await handler(mockSender, {
+      worktreeId: "wt-1",
+      includeContent: true,
+    })) as Record<string, unknown>;
+
+    expect(result.contentTruncated).toBe(true);
+    // The transport drops structuredContent and flags isError past 50 KiB, so
+    // the opt-in is only useful if the whole serialized result stays under it.
+    expect(Buffer.byteLength(JSON.stringify(result), "utf8")).toBeLessThan(50 * 1024);
+    // The file still holds everything the head was cut from.
+    expect((await nodeFs.stat(result.filePath as string)).size).toBeGreaterThan(400_000);
+  });
+
+  it("ignores an output path supplied by the caller", async () => {
+    const generateContext = makeService("<files/>");
+    const handler = getInvokeHandler(CHANNELS.COPYTREE_GENERATE);
+    const hijack = nodePath.join(tmpRoot, "attacker-owned.xml");
+
+    const result = (await handler(mockSender, {
+      worktreeId: "wt-1",
+      outputPath: hijack,
+      options: { outputPath: hijack, output: hijack },
+    })) as Record<string, unknown>;
+
+    // The destination is main's alone. Honouring a caller's would turn a
+    // context dump into an arbitrary file write for any MCP consumer.
+    expect(generateContext.mock.calls[0][3]).not.toBe(hijack);
+    expect(result.filePath).not.toBe(hijack);
+    await expect(nodeFs.access(hijack)).rejects.toThrow();
+  });
+
+  it("refuses a result that names a file other than the one reserved", async () => {
+    makeService("<files/>", { filePath: "/tmp/somewhere-else.xml" });
+    const handler = getInvokeHandler(CHANNELS.COPYTREE_GENERATE);
+
+    const result = (await handler(mockSender, { worktreeId: "wt-1" })) as Record<string, unknown>;
+
+    expect(result.error).toBe("Failed to generate context");
+    expect(result.filePath).toBeUndefined();
+  });
+
+  it("puts the host-written file on the clipboard without rewriting it in main", async () => {
+    const generateContext = makeService("<files>clipboard me</files>");
+    const handler = getInvokeHandler(CHANNELS.COPYTREE_GENERATE_AND_COPY_FILE);
+
+    const result = (await handler(mockSender, { worktreeId: "wt-1" })) as Record<string, unknown>;
+
+    expect(result.filePath).toBe(lastOutputPath);
+    expect(result.content).toBe("");
+    expect(generateContext.mock.calls[0][3]).toBe(lastOutputPath);
+
+    const onClipboard = clipboardMock.writeText.mock.calls
+      .concat(clipboardMock.writeBuffer.mock.calls)
+      .flat()
+      .map((value) => (Buffer.isBuffer(value) ? value.toString("utf8") : String(value)))
+      .join("\n");
+    expect(onClipboard).toContain(result.filePath as string);
+    expect(await nodeFs.readFile(result.filePath as string, "utf8")).toBe(
+      "<files>clipboard me</files>"
     );
   });
 });

--- a/electron/ipc/handlers/copyTree.ts
+++ b/electron/ipc/handlers/copyTree.ts
@@ -272,13 +272,21 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
     options: CopyTreeOptions,
     onProgress: (progress: CopyTreeProgress) => void
   ): Promise<CopyTreeResult> => {
-    const filePath = await reserveContextFilePath({
-      worktreePath: worktree.path,
-      branch: worktree.branch,
-      // The merged options, not the caller's: project settings decide the
-      // format too, and the extension has to match what actually gets written.
-      extension: getExtensionForFormat(options.format),
-    });
+    let filePath: string;
+    try {
+      filePath = await reserveContextFilePath({
+        worktreePath: worktree.path,
+        branch: worktree.branch,
+        // The merged options, not the caller's: project settings decide the
+        // format too, and the extension has to match what actually gets written.
+        extension: getExtensionForFormat(options.format),
+      });
+    } catch (error) {
+      // A raw fs rejection carries absolute paths, and this result is published
+      // to MCP callers verbatim — so only the static message crosses.
+      console.error("[CopyTree] Failed to reserve a context file:", error);
+      return { content: "", fileCount: 0, error: "Can't write the context file" };
+    }
 
     try {
       const result = await deps.worktreeService!.generateContext(
@@ -288,10 +296,11 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
         filePath
       );
       if (result.error) return result;
-      if (result.filePath !== filePath) {
-        // A successful generation names the file we reserved. Anything else is
-        // a result that outlived its operation, and publishing its path would
-        // hand this caller another run's bundle.
+      // A successful generation names the file we reserved and reports its
+      // size. Anything else is a result that outlived its operation: publishing
+      // its path would hand this caller another run's bundle, and the missing
+      // size would break the shape the tool advertises.
+      if (result.filePath !== filePath || typeof result.outputBytes !== "number") {
         return { content: "", fileCount: 0, error: "Failed to generate context" };
       }
       return result;

--- a/electron/ipc/handlers/copyTree.ts
+++ b/electron/ipc/handlers/copyTree.ts
@@ -1,8 +1,6 @@
 import { clipboard } from "electron";
 import crypto from "crypto";
-import os from "os";
 import path from "path";
-import { chmod, mkdir, writeFile } from "fs/promises";
 import { pathToFileURL } from "url";
 import { z } from "zod";
 import { CHANNELS } from "../channels.js";
@@ -108,6 +106,12 @@ import type {
 } from "../../types/index.js";
 import { projectStore } from "../../services/ProjectStore.js";
 import { contextInjectionTracker } from "../../services/ContextInjectionTracker.js";
+import {
+  fitContentToResultBudget,
+  readContentPreview,
+  releaseContextFilePath,
+  reserveContextFilePath,
+} from "../../services/copyTreeOutputFile.js";
 
 function getStringField(payload: unknown, key: string): string | undefined {
   if (!payload || typeof payload !== "object") {
@@ -255,6 +259,47 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
   // copyTree progress is broadcast to all windows
   const handlers: Array<() => void> = [];
 
+  /**
+   * Generate a bundle straight into a freshly reserved temp file.
+   *
+   * Both file-backed callers come through here. The write happens in the
+   * workspace host, not in this process: that is the whole point of #11528 —
+   * the bundle used to be built as one multi-MB string and then cloned across
+   * the host → main → renderer boundaries before anything trimmed it.
+   */
+  const generateToFile = async (
+    worktree: { path: string; branch?: string },
+    options: CopyTreeOptions,
+    onProgress: (progress: CopyTreeProgress) => void
+  ): Promise<CopyTreeResult> => {
+    const filePath = await reserveContextFilePath({
+      worktreePath: worktree.path,
+      branch: worktree.branch,
+      // The merged options, not the caller's: project settings decide the
+      // format too, and the extension has to match what actually gets written.
+      extension: getExtensionForFormat(options.format),
+    });
+
+    try {
+      const result = await deps.worktreeService!.generateContext(
+        worktree.path,
+        options,
+        onProgress,
+        filePath
+      );
+      if (result.error) return result;
+      if (result.filePath !== filePath) {
+        // A successful generation names the file we reserved. Anything else is
+        // a result that outlived its operation, and publishing its path would
+        // hand this caller another run's bundle.
+        return { content: "", fileCount: 0, error: "Failed to generate context" };
+      }
+      return result;
+    } finally {
+      releaseContextFilePath(filePath);
+    }
+  };
+
   const handleCopyTreeGenerate = async (
     ctx: import("../types.js").IpcContext,
     payload: CopyTreeGeneratePayload
@@ -316,7 +361,27 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
     const projectSettings = await loadCopyTreeProjectSettings(settingsProjectId);
     const mergedOptions = mergeCopyTreeOptions(projectSettings, validated.options);
 
-    return deps.worktreeService.generateContext(worktree.path, mergedOptions, onProgress);
+    const result = await generateToFile(worktree, mergedOptions, onProgress);
+    if (result.error || !result.filePath || !validated.includeContent) {
+      return result;
+    }
+
+    // The opt-in reads a head back out of the file rather than asking for the
+    // string: the bundle stays on disk, and only what the caller can actually
+    // receive is loaded.
+    try {
+      const preview = await readContentPreview(result.filePath);
+      return fitContentToResultBudget(
+        preview.content,
+        (content, contentTruncated) => ({ ...result, content, contentTruncated }),
+        preview.truncated
+      ).result;
+    } catch (error) {
+      // The bundle itself is fine and its path is already usable, so a failed
+      // read-back downgrades to the default shape instead of failing the run.
+      console.warn(`[${traceId}] Failed to read back context preview:`, error);
+      return result;
+    }
   };
   handlers.push(typedHandleWithContext(CHANNELS.COPYTREE_GENERATE, handleCopyTreeGenerate));
 
@@ -383,52 +448,18 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
     const projectSettings = await loadCopyTreeProjectSettings(settingsProjectId);
     const mergedOptions = mergeCopyTreeOptions(projectSettings, validated.options);
 
-    const result = await deps.worktreeService.generateContext(
-      worktree.path,
-      mergedOptions,
-      onProgress
-    );
+    // Written by the workspace host straight to disk. This handler used to pull
+    // the whole bundle across two process boundaries only to write it out here
+    // (#11528); the file it needs is now already on disk when the call returns.
+    const result = await generateToFile(worktree, mergedOptions, onProgress);
 
-    if (result.error) {
+    if (result.error || !result.filePath) {
       return result;
     }
 
+    const filePath = result.filePath;
+
     try {
-      const tempDir = path.join(os.tmpdir(), "daintree-context");
-      await mkdir(tempDir, { recursive: true, mode: 0o700 });
-      // mkdir({ mode }) is ignored when the directory already exists, so
-      // chmod the directory explicitly each run to evict any stale, more
-      // permissive mode left behind by a previous build or another process.
-      // chmod is a no-op for permission bits on Windows.
-      if (process.platform !== "win32") {
-        try {
-          await chmod(tempDir, 0o700);
-        } catch {
-          // best effort — file mode below still protects the contents
-        }
-      }
-
-      const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-      const projectName =
-        path
-          .basename(worktree.path)
-          .replace(/[^a-zA-Z0-9-_]/g, "-")
-          .replace(/-+/g, "-")
-          .replace(/^-+|-+$/g, "")
-          .toLowerCase()
-          .slice(0, 50) || "project";
-      const safeBranch =
-        (worktree.branch || "head")
-          .replace(/[^a-zA-Z0-9-_]/g, "-")
-          .replace(/-+/g, "-")
-          .replace(/^-+|-+$/g, "")
-          .slice(0, 100) || "head";
-      const extension = getExtensionForFormat(validated.options?.format);
-      const filename = `${projectName}-${safeBranch}-${timestamp}.${extension}`;
-      const filePath = path.join(tempDir, filename);
-
-      await writeFile(filePath, result.content, { encoding: "utf8", mode: 0o600 });
-
       if (process.platform === "darwin") {
         // Electron's `clipboard.writeBuffer` maps to Chromium's
         // `WritePortableAndPlatformRepresentations`, which calls
@@ -456,20 +487,24 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
 
       console.log(`[${traceId}] Copied context file to clipboard: ${filePath}`);
 
-      // Content was written to the temp file; renderer callers read only
-      // fileCount/stats/error, so drop it to avoid cloning a second copy.
       return {
         content: "",
         fileCount: result.fileCount,
+        filePath,
+        outputBytes: result.outputBytes,
         stats: result.stats,
         outputFormatVersion: result.outputFormatVersion,
       };
     } catch (error) {
       const errorMessage = formatErrorMessage(error, "Failed to copy context file");
       console.error(`[${traceId}] Failed to save/copy context file:`, errorMessage);
+      // The bundle exists either way, so its path still rides back — only the
+      // clipboard step failed, and the caller can still reach the file.
       return {
         content: "",
         fileCount: result.fileCount,
+        filePath,
+        outputBytes: result.outputBytes,
         stats: result.stats,
         outputFormatVersion: result.outputFormatVersion,
         error: `Failed to copy file to clipboard: ${errorMessage}`,

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1398,8 +1398,8 @@ function buildElectronApi(): ElectronAPI {
 
     // CopyTree API
     copyTree: {
-      generate: (worktreeId: string, options?: CopyTreeOptions) =>
-        _unwrappingInvoke(CHANNELS.COPYTREE_GENERATE, { worktreeId, options }),
+      generate: (worktreeId: string, options?: CopyTreeOptions, includeContent?: boolean) =>
+        _unwrappingInvoke(CHANNELS.COPYTREE_GENERATE, { worktreeId, options, includeContent }),
 
       generateAndCopyFile: (worktreeId: string, options?: CopyTreeOptions) =>
         _unwrappingInvoke(CHANNELS.COPYTREE_GENERATE_AND_COPY_FILE, { worktreeId, options }),

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -494,6 +494,11 @@ export const CopyTreeOptionsSchema = z
 export const CopyTreeGeneratePayloadSchema = z.object({
   worktreeId: z.string().min(1),
   options: CopyTreeOptionsSchema,
+  // Response shape, not a generation setting — see CopyTreeGeneratePayload.
+  // Note there is deliberately no caller-supplied output path here or in
+  // CopyTreeOptionsSchema: the destination is chosen by the main process, so a
+  // tool call can never turn into an arbitrary file write.
+  includeContent: z.boolean().optional(),
 });
 
 export const CopyTreeGenerateAndCopyFilePayloadSchema = z.object({

--- a/electron/services/CopyTreeService.ts
+++ b/electron/services/CopyTreeService.ts
@@ -1,11 +1,15 @@
 import type {
   CopyResult,
   CopyOptions as SdkCopyOptions,
+  CopyStreamOptions as SdkCopyStreamOptions,
   ProgressEvent,
   ConfigManager as SdkConfigManager,
 } from "copytree";
 import * as path from "path";
 import * as fs from "fs/promises";
+import { Readable } from "stream";
+import { pipeline } from "stream/promises";
+import { MAX_OUTPUT_BYTES } from "./copyTreeOutputFile.js";
 import type { CopyTreeOptions, CopyTreeResult, CopyTreeProgress } from "../types/index.js";
 import type {
   CopyTreeBudgetStats,
@@ -34,6 +38,13 @@ const ERROR_CODE_MESSAGES: Record<string, string> = {
   ERR_ABORTED: "Context generation cancelled",
   ENOENT: "Project path is unavailable",
   EACCES: "Can't read the project files",
+  ERR_OUTPUT_TOO_LARGE:
+    "Context is too large to write — narrow the scope or lower the context size limits",
+  ERR_STREAM_INCOMPLETE: "Context generation ended before it finished",
+  // Distinct from ENOENT/EACCES above: those describe the project being read,
+  // and a failure writing our own output file would otherwise be reported as
+  // "Project path is unavailable" and send the user looking in the wrong place.
+  ERR_OUTPUT_WRITE_FAILED: "Can't write the context file",
 };
 
 /**
@@ -78,6 +89,9 @@ export type { CopyTreeOptions, CopyTreeResult, CopyTreeProgress };
 
 export type ProgressCallback = (progress: CopyTreeProgress) => void;
 
+/** What `copyStream`'s `onComplete` hands back — the stats and manifest `copy()` returns. */
+type StreamCompletion = Parameters<NonNullable<SdkCopyStreamOptions["onComplete"]>>[0];
+
 /**
  * CopyTreeService - Generates context trees for AI agents.
  *
@@ -97,11 +111,24 @@ export type ProgressCallback = (progress: CopyTreeProgress) => void;
 class CopyTreeService {
   private activeOperations = new Map<string, AbortController>();
 
+  /**
+   * Build a context bundle.
+   *
+   * With `outputPath` the bundle is streamed straight to that file and only its
+   * path and size come back (#11528). Without it the whole document is returned
+   * as one string, which is what `injectToTerminal` still needs — it writes the
+   * bundle into a PTY in chunks and has nowhere else to read it from.
+   *
+   * `outputPath` is an internal argument: it is chosen by the main process and
+   * is deliberately absent from `CopyTreeOptions`, which arrives from MCP
+   * callers and would otherwise make this an arbitrary file write.
+   */
   async generate(
     rootPath: string,
     options: CopyTreeOptions = {},
     onProgress?: ProgressCallback,
-    traceId?: string
+    traceId?: string,
+    outputPath?: string
   ): Promise<CopyTreeResult> {
     const opId = traceId || crypto.randomUUID();
     const effectiveTraceId = opId;
@@ -128,7 +155,10 @@ class CopyTreeService {
       const controller = new AbortController();
       this.activeOperations.set(opId, controller);
 
-      const { copy } = await getCopytree();
+      // Reached through the namespace rather than destructured: only one of the
+      // two entry points is used per call, and touching the other would make
+      // every caller (and every test double) have to provide it.
+      const copytree = await getCopytree();
       this.throwIfAborted(controller.signal);
 
       const config = await this.createConfig(controller.signal);
@@ -152,7 +182,17 @@ class CopyTreeService {
         progressThrottleMs: 100,
       };
 
-      const result: CopyResult = await copy(rootPath, sdkOptions);
+      if (outputPath) {
+        return await this.streamToFile(
+          copytree.copyStream,
+          rootPath,
+          sdkOptions,
+          outputPath,
+          controller
+        );
+      }
+
+      const result: CopyResult = await copytree.copy(rootPath, sdkOptions);
       this.logScanErrors(result);
 
       return {
@@ -162,13 +202,131 @@ class CopyTreeService {
         stats: {
           totalSize: result.stats.totalSize,
           duration: result.stats.duration,
-          ...this.mapBudgetStats(result),
+          ...this.mapBudgetStats(result.stats),
         },
       };
     } catch (error: unknown) {
       return this.handleError(error);
     } finally {
       this.activeOperations.delete(opId);
+    }
+  }
+
+  /**
+   * Stream the bundle to `outputPath` without ever holding it whole.
+   *
+   * `copy()` cannot do this job even when handed an output path: it assembles
+   * the entire document as one string and only then writes it, so the
+   * allocation this exists to avoid happens either way. `copyStream()` emits
+   * the formatted document in chunks instead, and `onComplete` still delivers
+   * the stats and manifest `copy()` would have returned.
+   *
+   * Chunks go through `pipeline()` rather than a hand-rolled write loop: it
+   * honours backpressure, propagates errors from either end, destroys both
+   * sides on abort, and resolves only once the file is actually flushed.
+   *
+   * The bundle is published by renaming a unique `.part` file over the final
+   * path. A caller that finds the final path finds a complete bundle — a
+   * cancelled or failed run never leaves one that merely looks finished.
+   */
+  private async streamToFile(
+    copyStream: (typeof import("copytree"))["copyStream"],
+    rootPath: string,
+    sdkOptions: SdkCopyOptions,
+    outputPath: string,
+    controller: AbortController
+  ): Promise<CopyTreeResult> {
+    const partialPath = `${outputPath}.${crypto.randomUUID()}.part`;
+    let completion: StreamCompletion | undefined;
+    let outputBytes = 0;
+    let published = false;
+
+    const streamOptions: SdkCopyStreamOptions = {
+      ...sdkOptions,
+      onComplete: (result) => {
+        completion = result;
+      },
+    };
+
+    async function* countedChunks(): AsyncGenerator<Buffer> {
+      for await (const chunk of copyStream(rootPath, streamOptions)) {
+        // Each chunk is independently valid UTF-8 — the SDK guarantees it never
+        // splits a surrogate pair — so encoding per chunk is safe and gives an
+        // exact byte count without re-measuring the whole document.
+        const buffer = Buffer.from(chunk, "utf8");
+        outputBytes += buffer.length;
+        if (outputBytes > MAX_OUTPUT_BYTES) {
+          // Pruning runs between operations and so cannot stop a single
+          // runaway run from filling the disk. This can.
+          throw Object.assign(new Error("Context output exceeded the size ceiling"), {
+            code: "ERR_OUTPUT_TOO_LARGE",
+          });
+        }
+        yield buffer;
+      }
+    }
+
+    // Opened before the stream starts so a destination we cannot create is
+    // reported as exactly that. Once both ends are running, `pipeline` tears
+    // the destination down whenever the SOURCE fails and the write stream emits
+    // the source's own error object — so after that point the two are
+    // indistinguishable, and guessing would mislabel a scan failure as a disk
+    // problem. `wx` rather than `w`: the file must be one this run created, not
+    // whatever a symlink in a shared temp directory happens to point at.
+    let handle: Awaited<ReturnType<typeof fs.open>>;
+    try {
+      handle = await fs.open(partialPath, "wx", 0o600);
+    } catch (error) {
+      throw Object.assign(new Error("Failed to create the context file"), {
+        code: "ERR_OUTPUT_WRITE_FAILED",
+        cause: error,
+      });
+    }
+
+    try {
+      await pipeline(Readable.from(countedChunks()), handle.createWriteStream(), {
+        signal: controller.signal,
+      });
+      this.throwIfAborted(controller.signal);
+
+      const finished = completion;
+      if (!finished) {
+        // `onComplete` fires only on normal completion, so a pipeline that
+        // resolved without it means the source stopped early — the file on disk
+        // is a prefix, not a bundle.
+        throw Object.assign(new Error("CopyTree stream produced no completion"), {
+          code: "ERR_STREAM_INCOMPLETE",
+        });
+      }
+
+      await fs.rename(partialPath, outputPath).catch((error: unknown) => {
+        throw Object.assign(new Error("Failed to publish the context bundle"), {
+          code: "ERR_OUTPUT_WRITE_FAILED",
+          cause: error,
+        });
+      });
+      published = true;
+
+      return {
+        content: "",
+        filePath: outputPath,
+        outputBytes,
+        fileCount: finished.stats.totalFiles,
+        outputFormatVersion: finished.outputFormatVersion,
+        stats: {
+          totalSize: finished.stats.totalSize,
+          duration: finished.stats.duration,
+          ...this.mapBudgetStats(finished.stats),
+        },
+      };
+    } catch (error) {
+      // Only unlink the destination when this run is the one that put it there:
+      // after a failed rename the path may still hold a previous bundle.
+      await Promise.allSettled([
+        fs.rm(partialPath, { force: true }),
+        ...(published ? [fs.rm(outputPath, { force: true })] : []),
+      ]);
+      throw error;
     }
   }
 
@@ -228,7 +386,7 @@ class CopyTreeService {
         includedFiles: included.length,
         includedSize: included.reduce((total, entry) => total + entry.size, 0),
         files: included,
-        ...this.mapBudgetStats(result),
+        ...this.mapBudgetStats(result.stats),
       };
     } catch (error: unknown) {
       return {
@@ -481,8 +639,7 @@ class CopyTreeService {
     };
   }
 
-  private mapBudgetStats(result: CopyResult): CopyTreeBudgetStats {
-    const stats = result.stats;
+  private mapBudgetStats(stats: CopyResult["stats"]): CopyTreeBudgetStats {
     return {
       estimatedOutputChars: stats.estimatedOutputChars,
       estimatedTokens: stats.estimatedTokens,

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -779,9 +779,10 @@ export class WorkspaceClient extends EventEmitter {
   async generateContext(
     rootPath: string,
     options?: CopyTreeOptions,
-    onProgress?: CopyTreeProgressCallback
+    onProgress?: CopyTreeProgressCallback,
+    outputPath?: string
   ): Promise<CopyTreeResult> {
-    return this.copyTree.generateContext(rootPath, options, onProgress);
+    return this.copyTree.generateContext(rootPath, options, onProgress, outputPath);
   }
 
   cancelContext(operationId: string): void {

--- a/electron/services/__tests__/CopyTreeService.stream.test.ts
+++ b/electron/services/__tests__/CopyTreeService.stream.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+const copyMock = vi.hoisted(() => vi.fn());
+const copyStreamMock = vi.hoisted(() => vi.fn());
+const configCreateMock = vi.hoisted(() => vi.fn());
+
+vi.mock("copytree", () => ({
+  copy: copyMock,
+  copyStream: copyStreamMock,
+  ConfigManager: {
+    create: configCreateMock,
+  },
+}));
+
+import { copyTreeService, _resetConfigCacheForTests } from "../CopyTreeService.js";
+
+const STATS = {
+  totalFiles: 3,
+  totalSize: 4096,
+  duration: 12,
+  estimatedOutputChars: 400,
+  estimatedTokens: 100,
+  noFilesMatched: false,
+  excluded: { total: 0, byReason: {} },
+};
+
+type StreamOptions = {
+  signal?: AbortSignal;
+  onComplete?: (result: {
+    outputFormatVersion: string | null;
+    manifest: unknown[];
+    stats: typeof STATS;
+  }) => void;
+};
+
+/**
+ * Stand in for the SDK generator: yield the given chunks, then report
+ * completion exactly as `copyStream` does — only on a run that finished.
+ */
+function streamYielding(chunks: string[], options: { complete?: boolean } = {}) {
+  return (_rootPath: string, streamOptions: StreamOptions) =>
+    (async function* () {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+      if (options.complete !== false) {
+        streamOptions.onComplete?.({
+          outputFormatVersion: "copytree-xml@1",
+          manifest: [],
+          stats: STATS,
+        });
+      }
+    })();
+}
+
+describe("CopyTreeService streaming to a file", () => {
+  let tempDir: string;
+  let outputPath: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-copytree-stream-"));
+    outputPath = path.join(tempDir, "bundle.xml");
+    vi.clearAllMocks();
+    _resetConfigCacheForTests();
+    configCreateMock.mockResolvedValue({ isDefaultsLoaded: true });
+  });
+
+  afterEach(async () => {
+    copyTreeService.cancelAll();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  /** Files this run left in the output directory, so leftovers are visible. */
+  async function residue(): Promise<string[]> {
+    return (await fs.readdir(tempDir)).sort();
+  }
+
+  it("streams the whole document to the file and keeps it out of the result", async () => {
+    copyStreamMock.mockImplementation(streamYielding(["<files>", "<file/>", "</files>"]));
+
+    const result = await copyTreeService.generate(tempDir, {}, undefined, "op-1", outputPath);
+
+    expect(result.error).toBeUndefined();
+    expect(result.filePath).toBe(outputPath);
+    // The point of the change: the bundle went to disk, not into the result.
+    expect(result.content).toBe("");
+    expect(await fs.readFile(outputPath, "utf8")).toBe("<files><file/></files>");
+    expect(copyMock).not.toHaveBeenCalled();
+  });
+
+  it("reports the byte size the file actually has", async () => {
+    // Multi-byte on purpose: a character count would disagree with the file.
+    copyStreamMock.mockImplementation(streamYielding(["héllo ", "☃", "😀"]));
+
+    const result = await copyTreeService.generate(tempDir, {}, undefined, "op-1", outputPath);
+
+    expect(result.outputBytes).toBe((await fs.stat(outputPath)).size);
+    expect(await fs.readFile(outputPath, "utf8")).toBe("héllo ☃😀");
+  });
+
+  it("carries the completion stats through unchanged", async () => {
+    copyStreamMock.mockImplementation(streamYielding(["<files/>"]));
+
+    const result = await copyTreeService.generate(tempDir, {}, undefined, "op-1", outputPath);
+
+    expect(result.fileCount).toBe(STATS.totalFiles);
+    expect(result.outputFormatVersion).toBe("copytree-xml@1");
+    expect(result.stats).toMatchObject({
+      totalSize: STATS.totalSize,
+      duration: STATS.duration,
+      estimatedTokens: STATS.estimatedTokens,
+    });
+  });
+
+  it("publishes atomically, leaving no partial behind", async () => {
+    copyStreamMock.mockImplementation(streamYielding(["<files/>"]));
+
+    await copyTreeService.generate(tempDir, {}, undefined, "op-1", outputPath);
+
+    expect(await residue()).toEqual(["bundle.xml"]);
+  });
+
+  it("writes the bundle owner-only", async () => {
+    if (process.platform === "win32") return;
+    copyStreamMock.mockImplementation(streamYielding(["<files/>"]));
+
+    await copyTreeService.generate(tempDir, {}, undefined, "op-1", outputPath);
+
+    expect((await fs.stat(outputPath)).mode & 0o777).toBe(0o600);
+  });
+
+  it("leaves nothing on disk when the source fails midway", async () => {
+    copyStreamMock.mockImplementation(() =>
+      (async function* () {
+        yield "<files>";
+        throw new Error("scan blew up");
+      })()
+    );
+
+    const result = await copyTreeService.generate(tempDir, {}, undefined, "op-1", outputPath);
+
+    expect(result.error).toBe("Failed to generate context");
+    // Neither the destination nor the partial survives — a caller that finds
+    // the final path must never find a prefix of a bundle.
+    expect(await residue()).toEqual([]);
+  });
+
+  it("refuses to publish a run that never reported completion", async () => {
+    // `onComplete` fires only on normal completion, so its absence means the
+    // source stopped early and the bytes on disk are a prefix.
+    copyStreamMock.mockImplementation(
+      streamYielding(["<files>", "truncated"], { complete: false })
+    );
+
+    const result = await copyTreeService.generate(tempDir, {}, undefined, "op-1", outputPath);
+
+    expect(result.error).toBe("Context generation ended before it finished");
+    expect(await residue()).toEqual([]);
+  });
+
+  it("cleans up both files when the run is cancelled mid-stream", async () => {
+    let releaseGate: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    let markStarted: () => void = () => {};
+    // Resolved from inside the generator: by then the operation is registered
+    // and the first chunk is on its way to the writer, which is the only point
+    // at which a cancel is actually testing mid-stream teardown.
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+
+    copyStreamMock.mockImplementation((_rootPath: string, streamOptions: StreamOptions) =>
+      (async function* () {
+        yield "<files>";
+        markStarted();
+        await gate;
+        if (streamOptions.signal?.aborted) {
+          throw Object.assign(new Error("aborted"), { name: "AbortError" });
+        }
+        yield "</files>";
+      })()
+    );
+
+    const pending = copyTreeService.generate(tempDir, {}, undefined, "op-cancel", outputPath);
+    await started;
+    expect(copyTreeService.cancel("op-cancel")).toBe(true);
+    releaseGate();
+
+    const result = await pending;
+
+    expect(result.error).toBe("Context generation cancelled");
+    expect(await residue()).toEqual([]);
+  });
+
+  it("does not touch the file when no output path is given", async () => {
+    copyMock.mockResolvedValue({
+      output: "<context />",
+      outputFormatVersion: "copytree-xml@1",
+      manifest: [],
+      stats: STATS,
+    });
+
+    const result = await copyTreeService.generate(tempDir);
+
+    expect(result.content).toBe("<context />");
+    expect(result.filePath).toBeUndefined();
+    expect(result.outputBytes).toBeUndefined();
+    expect(copyStreamMock).not.toHaveBeenCalled();
+  });
+
+  it("hands the streamed run the same options the copy() run would get", async () => {
+    copyStreamMock.mockImplementation(streamYielding(["<files/>"]));
+
+    await copyTreeService.generate(
+      tempDir,
+      { format: "markdown", charLimit: 1000, maxFileCount: 5 },
+      undefined,
+      "op-1",
+      outputPath
+    );
+
+    const streamOptions = copyStreamMock.mock.calls[0][1];
+    expect(streamOptions).toMatchObject({
+      format: "markdown",
+      charLimit: 1000,
+      maxFileCount: 5,
+      respectGitignore: true,
+      secretsGuard: false,
+    });
+    // Cancellation still has to reach the SDK, not just the pipeline.
+    expect(streamOptions.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("names the output file as the problem when the destination can't be created", async () => {
+    copyStreamMock.mockImplementation(streamYielding(["<files/>"]));
+
+    const result = await copyTreeService.generate(
+      tempDir,
+      {},
+      undefined,
+      "op-1",
+      path.join(tempDir, "missing-dir", "bundle.xml")
+    );
+
+    // The raw ENOENT would map to "Project path is unavailable", which points
+    // at the project being read rather than the file being written.
+    expect(result.error).toBe("Can't write the context file");
+    expect(result.filePath).toBeUndefined();
+    // Nothing was generated, so the SDK should never have been started.
+    expect(copyStreamMock).not.toHaveBeenCalled();
+  });
+});

--- a/electron/services/__tests__/copyTreeOutputFile.test.ts
+++ b/electron/services/__tests__/copyTreeOutputFile.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import crypto from "crypto";
 import fs from "fs/promises";
 import os from "os";
 import path from "path";
@@ -31,6 +32,20 @@ async function writeAged(filePath: string, contents: string, ageMs: number): Pro
   await fs.writeFile(filePath, contents, "utf8");
   const when = new Date(Date.now() - ageMs);
   await fs.utimes(filePath, when, when);
+}
+
+/**
+ * A name shaped like one this module hands out. Pruning only touches its own
+ * naming scheme, so a fixture named `stale.xml` would simply be ignored and the
+ * test would prove nothing.
+ */
+function bundleName(label: string, extension = "xml"): string {
+  return buildContextFileName({
+    projectName: label,
+    branch: "main",
+    extension,
+    timestamp: "2026-07-31T00-00-00-000Z",
+  });
 }
 
 describe("copyTreeOutputFile", () => {
@@ -110,6 +125,33 @@ describe("copyTreeOutputFile", () => {
       expect(stats.mode & 0o777).toBe(0o700);
     });
 
+    it("refuses a context directory that is a symlink", async () => {
+      if (process.platform === "win32") return;
+      // A symlink on this predictable name would redirect the write AND the
+      // prune sweep into whatever it points at — on a shared /tmp, someone
+      // else's choice.
+      const target = path.join(root, "victim");
+      await fs.mkdir(target);
+      const sentinel = path.join(target, "keepme.txt");
+      await fs.writeFile(sentinel, "private", "utf8");
+      await fs.symlink(target, contextDir());
+
+      await expect(
+        reserveContextFilePath({ worktreePath: "/repos/x", extension: "xml" })
+      ).rejects.toThrow();
+
+      await expect(fs.access(sentinel)).resolves.toBeUndefined();
+      expect(await fs.readdir(target)).toEqual(["keepme.txt"]);
+    });
+
+    it("refuses a context directory that is a plain file", async () => {
+      await fs.writeFile(contextDir(), "not a directory", "utf8");
+
+      await expect(
+        reserveContextFilePath({ worktreePath: "/repos/x", extension: "xml" })
+      ).rejects.toThrow();
+    });
+
     it("hands out a distinct path per call", async () => {
       const paths = await Promise.all(
         Array.from({ length: 5 }, () =>
@@ -123,8 +165,8 @@ describe("copyTreeOutputFile", () => {
   describe("pruneContextDir", () => {
     it("removes bundles past the age ceiling and keeps fresh ones", async () => {
       await fs.mkdir(contextDir(), { recursive: true });
-      const stale = path.join(contextDir(), "stale.xml");
-      const fresh = path.join(contextDir(), "fresh.xml");
+      const stale = path.join(contextDir(), bundleName("stale"));
+      const fresh = path.join(contextDir(), bundleName("fresh"));
       await writeAged(stale, "old", 48 * 60 * 60 * 1000);
       await writeAged(fresh, "new", 60 * 1000);
 
@@ -134,10 +176,25 @@ describe("copyTreeOutputFile", () => {
       await expect(fs.access(fresh)).resolves.toBeUndefined();
     });
 
+    it("never deletes a file it did not write, however old", async () => {
+      await fs.mkdir(contextDir(), { recursive: true });
+      // This directory sits at a predictable path under the temp dir. If it were
+      // ever redirected onto somewhere holding real files, the sweep must still
+      // only touch its own naming scheme.
+      const bystanders = ["notes.txt", "id_rsa", "budget.xlsx", "bundle.xml", "archive.xml.part"];
+      for (const name of bystanders) {
+        await writeAged(path.join(contextDir(), name), "not ours", 90 * 24 * 60 * 60 * 1000);
+      }
+
+      await pruneContextDir();
+
+      expect((await fs.readdir(contextDir())).sort()).toEqual([...bystanders].sort());
+    });
+
     it("expires a partial far sooner than a finished bundle of the same age", async () => {
       await fs.mkdir(contextDir(), { recursive: true });
-      const partial = path.join(contextDir(), "run.xml.abc.part");
-      const finished = path.join(contextDir(), "run.xml");
+      const finished = path.join(contextDir(), bundleName("run"));
+      const partial = `${finished}.${crypto.randomUUID()}.part`;
       const age = 3 * 60 * 60 * 1000;
       await writeAged(partial, "half", age);
       await writeAged(finished, "whole", age);
@@ -151,21 +208,22 @@ describe("copyTreeOutputFile", () => {
     it("trims to the retention count, dropping the oldest first", async () => {
       await fs.mkdir(contextDir(), { recursive: true });
       const total = MAX_RETAINED_FILES + 4;
+      const names: string[] = [];
       for (let i = 0; i < total; i += 1) {
+        const name = bundleName(`bundle${i}`);
+        names.push(name);
         // Age descends with the index, so the highest indices are the newest.
-        await writeAged(
-          path.join(contextDir(), `bundle-${i}.xml`),
-          `body-${i}`,
-          (total - i) * 1000
-        );
+        await writeAged(path.join(contextDir(), name), `body-${i}`, (total - i) * 1000);
       }
 
       await pruneContextDir();
 
-      const remaining = (await fs.readdir(contextDir())).sort();
-      expect(remaining).toHaveLength(MAX_RETAINED_FILES);
-      const survivorIndices = remaining.map((name) => Number(/bundle-(\d+)\.xml/.exec(name)![1]));
-      expect(Math.min(...survivorIndices)).toBe(total - MAX_RETAINED_FILES);
+      const remaining = new Set(await fs.readdir(contextDir()));
+      expect(remaining.size).toBe(MAX_RETAINED_FILES);
+      // The newest MAX_RETAINED_FILES survive; everything older is gone.
+      for (const [index, name] of names.entries()) {
+        expect(remaining.has(name)).toBe(index >= total - MAX_RETAINED_FILES);
+      }
     });
 
     it("spares a reserved bundle and its in-flight partial that age alone would sweep", async () => {
@@ -176,7 +234,7 @@ describe("copyTreeOutputFile", () => {
       });
       // Both are old enough for their own ceiling — 48h for a finished bundle,
       // 5h for a partial — so only the reservation keeps them.
-      const partial = `${reserved}.deadbeef.part`;
+      const partial = `${reserved}.${crypto.randomUUID()}.part`;
       await writeAged(reserved, "published", 48 * 60 * 60 * 1000);
       await writeAged(partial, "in flight", 5 * 60 * 60 * 1000);
 
@@ -191,7 +249,7 @@ describe("copyTreeOutputFile", () => {
         worktreePath: "/repos/x",
         extension: "xml",
       });
-      const partial = `${reserved}.deadbeef.part`;
+      const partial = `${reserved}.${crypto.randomUUID()}.part`;
       await writeAged(reserved, "done", 48 * 60 * 60 * 1000);
       await writeAged(partial, "half", 5 * 60 * 60 * 1000);
 
@@ -236,6 +294,30 @@ describe("copyTreeOutputFile", () => {
 
       expect(preview.truncated).toBe(true);
       expect(Buffer.byteLength(preview.content, "utf8")).toBeLessThanOrEqual(512);
+    });
+
+    it.each([
+      [511, false],
+      [512, false],
+      [513, true],
+    ])("reports a %i-byte file against a 512-byte cap as truncated=%s", async (size, truncated) => {
+      // The boundary case is the interesting one: a file of exactly the cap
+      // fills the window with nothing left over, and measuring only the window
+      // would report a complete read as cut.
+      const filePath = path.join(root, `exact-${size}.xml`);
+      await fs.writeFile(filePath, "a".repeat(size), "utf8");
+
+      const preview = await readContentPreview(filePath, 512);
+
+      expect(preview.truncated).toBe(truncated);
+      expect(preview.content).toHaveLength(Math.min(size, 512));
+    });
+
+    it("returns nothing for a zero-byte window without claiming the file was whole", async () => {
+      const filePath = path.join(root, "zero.xml");
+      await fs.writeFile(filePath, "abc", "utf8");
+
+      expect(await readContentPreview(filePath, 0)).toEqual({ content: "", truncated: true });
     });
 
     it("never decodes a partial code point at the cut", async () => {
@@ -319,11 +401,37 @@ describe("copyTreeOutputFile", () => {
       expect(serializedSize(fitted.result)).toBeLessThanOrEqual(1024);
     });
 
-    it("drops content entirely rather than exceed a budget the metadata alone fills", () => {
-      const fitted = fitContentToResultBudget("some content", build, false, 40);
+    it("drops content entirely when the budget only just clears the metadata", () => {
+      const metadataOnly = serializedSize(build("", true));
+
+      const fitted = fitContentToResultBudget("some content", build, false, metadataOnly);
 
       expect(fitted.content).toBe("");
       expect(fitted.truncated).toBe(true);
+      expect(serializedSize(fitted.result)).toBeLessThanOrEqual(metadataOnly);
+    });
+
+    it("returns the smallest result it can build when even the metadata overflows", () => {
+      // Nothing can be cut to make this fit, so the helper must still return the
+      // minimum rather than silently hand back an over-budget result.
+      const fitted = fitContentToResultBudget("some content", build, false, 10);
+
+      expect(fitted.content).toBe("");
+      expect(fitted.truncated).toBe(true);
+      expect(fitted.result.content).toBe("");
+    });
+
+    it("does not claim truncation when nothing was actually cut", () => {
+      // `"contentTruncated":true` serializes one byte shorter than `false`, so a
+      // budget that only the `true` rendering clears must not be met by
+      // relabelling the untouched string.
+      const content = "x";
+      const withFlagOff = serializedSize(build(content, false));
+
+      const fitted = fitContentToResultBudget(content, build, false, withFlagOff - 1);
+
+      expect(fitted.truncated === false || fitted.content.length < content.length).toBe(true);
+      expect(serializedSize(fitted.result)).toBeLessThanOrEqual(withFlagOff - 1);
     });
   });
 });

--- a/electron/services/__tests__/copyTreeOutputFile.test.ts
+++ b/electron/services/__tests__/copyTreeOutputFile.test.ts
@@ -1,0 +1,329 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+import {
+  MAX_RETAINED_FILES,
+  buildContextFileName,
+  contextDir,
+  fitContentToResultBudget,
+  pruneContextDir,
+  readContentPreview,
+  releaseContextFilePath,
+  reserveContextFilePath,
+  _resetReservedPathsForTests,
+} from "../copyTreeOutputFile.js";
+
+/**
+ * `contextDir()` resolves `os.tmpdir()` per call, and `os.tmpdir()` reads the
+ * environment, so pointing the temp vars at a scratch directory redirects the
+ * whole module without mocking it. Every platform's lookup order is covered:
+ * TMPDIR on POSIX, TEMP/TMP on Windows.
+ */
+function redirectTmpdir(root: string): void {
+  vi.stubEnv("TMPDIR", root);
+  vi.stubEnv("TEMP", root);
+  vi.stubEnv("TMP", root);
+}
+
+async function writeAged(filePath: string, contents: string, ageMs: number): Promise<void> {
+  await fs.writeFile(filePath, contents, "utf8");
+  const when = new Date(Date.now() - ageMs);
+  await fs.utimes(filePath, when, when);
+}
+
+describe("copyTreeOutputFile", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-ctxfile-"));
+    redirectTmpdir(root);
+    _resetReservedPathsForTests();
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  describe("buildContextFileName", () => {
+    it("keeps two names apart when project, branch and timestamp all match", () => {
+      const args = {
+        projectName: "daintree",
+        branch: "main",
+        extension: "xml",
+        timestamp: "2026-07-31T00-00-00-000Z",
+      };
+      expect(buildContextFileName(args)).not.toBe(buildContextFileName(args));
+    });
+
+    it("strips path separators and shell metacharacters out of both segments", () => {
+      const name = buildContextFileName({
+        projectName: "../../etc",
+        branch: "feature/x;rm -rf /",
+        extension: "xml",
+        timestamp: "t",
+      });
+      expect(path.basename(name)).toBe(name);
+      expect(name).not.toContain("..");
+      expect(name).not.toContain(";");
+      expect(name).not.toContain(" ");
+    });
+
+    it("falls back to placeholders when sanitizing empties a segment", () => {
+      const name = buildContextFileName({
+        projectName: "///",
+        branch: "!!!",
+        extension: "md",
+        timestamp: "t",
+      });
+      expect(name.startsWith("project-head-")).toBe(true);
+      expect(name.endsWith(".md")).toBe(true);
+    });
+  });
+
+  describe("reserveContextFilePath", () => {
+    it("creates an owner-only directory and returns a path inside it", async () => {
+      const filePath = await reserveContextFilePath({
+        worktreePath: "/repos/daintree",
+        branch: "main",
+        extension: "xml",
+      });
+
+      expect(path.dirname(filePath)).toBe(contextDir());
+      const stats = await fs.stat(contextDir());
+      expect(stats.isDirectory()).toBe(true);
+      if (process.platform !== "win32") {
+        expect(stats.mode & 0o777).toBe(0o700);
+      }
+    });
+
+    it("tightens a directory left behind with a wider mode", async () => {
+      if (process.platform === "win32") return;
+      await fs.mkdir(contextDir(), { recursive: true, mode: 0o777 });
+      await fs.chmod(contextDir(), 0o777);
+
+      await reserveContextFilePath({ worktreePath: "/repos/x", extension: "xml" });
+
+      const stats = await fs.stat(contextDir());
+      expect(stats.mode & 0o777).toBe(0o700);
+    });
+
+    it("hands out a distinct path per call", async () => {
+      const paths = await Promise.all(
+        Array.from({ length: 5 }, () =>
+          reserveContextFilePath({ worktreePath: "/repos/x", branch: "main", extension: "xml" })
+        )
+      );
+      expect(new Set(paths).size).toBe(paths.length);
+    });
+  });
+
+  describe("pruneContextDir", () => {
+    it("removes bundles past the age ceiling and keeps fresh ones", async () => {
+      await fs.mkdir(contextDir(), { recursive: true });
+      const stale = path.join(contextDir(), "stale.xml");
+      const fresh = path.join(contextDir(), "fresh.xml");
+      await writeAged(stale, "old", 48 * 60 * 60 * 1000);
+      await writeAged(fresh, "new", 60 * 1000);
+
+      await pruneContextDir();
+
+      await expect(fs.access(stale)).rejects.toThrow();
+      await expect(fs.access(fresh)).resolves.toBeUndefined();
+    });
+
+    it("expires a partial far sooner than a finished bundle of the same age", async () => {
+      await fs.mkdir(contextDir(), { recursive: true });
+      const partial = path.join(contextDir(), "run.xml.abc.part");
+      const finished = path.join(contextDir(), "run.xml");
+      const age = 3 * 60 * 60 * 1000;
+      await writeAged(partial, "half", age);
+      await writeAged(finished, "whole", age);
+
+      await pruneContextDir();
+
+      await expect(fs.access(partial)).rejects.toThrow();
+      await expect(fs.access(finished)).resolves.toBeUndefined();
+    });
+
+    it("trims to the retention count, dropping the oldest first", async () => {
+      await fs.mkdir(contextDir(), { recursive: true });
+      const total = MAX_RETAINED_FILES + 4;
+      for (let i = 0; i < total; i += 1) {
+        // Age descends with the index, so the highest indices are the newest.
+        await writeAged(
+          path.join(contextDir(), `bundle-${i}.xml`),
+          `body-${i}`,
+          (total - i) * 1000
+        );
+      }
+
+      await pruneContextDir();
+
+      const remaining = (await fs.readdir(contextDir())).sort();
+      expect(remaining).toHaveLength(MAX_RETAINED_FILES);
+      const survivorIndices = remaining.map((name) => Number(/bundle-(\d+)\.xml/.exec(name)![1]));
+      expect(Math.min(...survivorIndices)).toBe(total - MAX_RETAINED_FILES);
+    });
+
+    it("spares a reserved bundle and its in-flight partial that age alone would sweep", async () => {
+      const reserved = await reserveContextFilePath({
+        worktreePath: "/repos/x",
+        branch: "main",
+        extension: "xml",
+      });
+      // Both are old enough for their own ceiling — 48h for a finished bundle,
+      // 5h for a partial — so only the reservation keeps them.
+      const partial = `${reserved}.deadbeef.part`;
+      await writeAged(reserved, "published", 48 * 60 * 60 * 1000);
+      await writeAged(partial, "in flight", 5 * 60 * 60 * 1000);
+
+      await pruneContextDir();
+
+      await expect(fs.access(reserved)).resolves.toBeUndefined();
+      await expect(fs.access(partial)).resolves.toBeUndefined();
+    });
+
+    it("sweeps a path and its partial once the reservation is released", async () => {
+      const reserved = await reserveContextFilePath({
+        worktreePath: "/repos/x",
+        extension: "xml",
+      });
+      const partial = `${reserved}.deadbeef.part`;
+      await writeAged(reserved, "done", 48 * 60 * 60 * 1000);
+      await writeAged(partial, "half", 5 * 60 * 60 * 1000);
+
+      releaseContextFilePath(reserved);
+      await pruneContextDir();
+
+      await expect(fs.access(reserved)).rejects.toThrow();
+      await expect(fs.access(partial)).rejects.toThrow();
+    });
+
+    it("leaves subdirectories alone", async () => {
+      await fs.mkdir(path.join(contextDir(), "nested"), { recursive: true });
+      const nested = path.join(contextDir(), "nested", "deep.xml");
+      await writeAged(nested, "keep", 72 * 60 * 60 * 1000);
+
+      await pruneContextDir();
+
+      await expect(fs.access(nested)).resolves.toBeUndefined();
+    });
+
+    it("is a no-op when the directory does not exist", async () => {
+      await expect(pruneContextDir()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("readContentPreview", () => {
+    it("returns a short file whole and does not flag it truncated", async () => {
+      const filePath = path.join(root, "small.xml");
+      await fs.writeFile(filePath, "<files>hello</files>", "utf8");
+
+      expect(await readContentPreview(filePath, 1024)).toEqual({
+        content: "<files>hello</files>",
+        truncated: false,
+      });
+    });
+
+    it("stops at the cap and flags the cut", async () => {
+      const filePath = path.join(root, "big.xml");
+      await fs.writeFile(filePath, "a".repeat(5000), "utf8");
+
+      const preview = await readContentPreview(filePath, 512);
+
+      expect(preview.truncated).toBe(true);
+      expect(Buffer.byteLength(preview.content, "utf8")).toBeLessThanOrEqual(512);
+    });
+
+    it("never decodes a partial code point at the cut", async () => {
+      const filePath = path.join(root, "multibyte.xml");
+      // Each snowman is 3 UTF-8 bytes, so a 100-byte window lands mid-character.
+      await fs.writeFile(filePath, "☃".repeat(200), "utf8");
+
+      const preview = await readContentPreview(filePath, 100);
+
+      expect(preview.content).not.toContain("�");
+      expect(Buffer.byteLength(preview.content, "utf8") % 3).toBe(0);
+    });
+
+    it("reads a file larger than one read() call in full up to the cap", async () => {
+      const filePath = path.join(root, "large.xml");
+      await fs.writeFile(filePath, "z".repeat(300_000), "utf8");
+
+      const preview = await readContentPreview(filePath, 128 * 1024);
+
+      expect(preview.content).toHaveLength(128 * 1024);
+      expect(preview.truncated).toBe(true);
+    });
+  });
+
+  describe("fitContentToResultBudget", () => {
+    const build = (content: string, contentTruncated: boolean) => ({
+      filePath: "/tmp/daintree-context/bundle.xml",
+      fileCount: 12,
+      outputBytes: 999_999,
+      content,
+      contentTruncated,
+    });
+    const serializedSize = (value: unknown) => Buffer.byteLength(JSON.stringify(value), "utf8");
+
+    it("passes content through untouched when the whole result already fits", () => {
+      const fitted = fitContentToResultBudget("<files>tiny</files>", build, false, 4096);
+
+      expect(fitted.content).toBe("<files>tiny</files>");
+      expect(fitted.truncated).toBe(false);
+      expect(fitted.result.contentTruncated).toBe(false);
+    });
+
+    it("keeps the SERIALIZED result inside the budget, not the raw bytes", () => {
+      // Every character escapes to six JSON bytes, so raw length is a wildly
+      // optimistic estimate of what lands on the wire — the exact trap that
+      // makes a raw-byte cap unsafe.
+      const controlHeavy = String.fromCharCode(1).repeat(4000);
+
+      const fitted = fitContentToResultBudget(controlHeavy, build, true, 2048);
+
+      expect(serializedSize(fitted.result)).toBeLessThanOrEqual(2048);
+      expect(fitted.content.length).toBeLessThan(controlHeavy.length);
+      expect(fitted.result.contentTruncated).toBe(true);
+    });
+
+    it("marks a result truncated once the budget forced a cut", () => {
+      const fitted = fitContentToResultBudget("x".repeat(10_000), build, false, 1024);
+
+      expect(fitted.truncated).toBe(true);
+      expect(fitted.result.contentTruncated).toBe(true);
+      expect(serializedSize(fitted.result)).toBeLessThanOrEqual(1024);
+    });
+
+    it("keeps the already-truncated flag when the head still fits", () => {
+      const fitted = fitContentToResultBudget("short", build, true, 4096);
+
+      expect(fitted.content).toBe("short");
+      expect(fitted.truncated).toBe(true);
+    });
+
+    it("never leaves a lone surrogate half at the cut", () => {
+      // Astral characters are surrogate pairs in UTF-16; cutting between the
+      // halves would emit an unpaired one.
+      const fitted = fitContentToResultBudget("😀".repeat(2000), build, false, 1024);
+
+      expect(fitted.content).toBe(
+        // Whatever survived must round-trip through UTF-8 unchanged.
+        Buffer.from(fitted.content, "utf8").toString("utf8")
+      );
+      expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(fitted.content)).toBe(false);
+      expect(serializedSize(fitted.result)).toBeLessThanOrEqual(1024);
+    });
+
+    it("drops content entirely rather than exceed a budget the metadata alone fills", () => {
+      const fitted = fitContentToResultBudget("some content", build, false, 40);
+
+      expect(fitted.content).toBe("");
+      expect(fitted.truncated).toBe(true);
+    });
+  });
+});

--- a/electron/services/copyTreeOutputFile.ts
+++ b/electron/services/copyTreeOutputFile.ts
@@ -1,7 +1,7 @@
 import crypto from "crypto";
 import os from "os";
 import path from "path";
-import { chmod, mkdir, open, readdir, rm, stat } from "fs/promises";
+import { chmod, lstat, mkdir, open, readdir, rm, stat } from "fs/promises";
 import { logWarn } from "../utils/logger.js";
 
 /**
@@ -58,6 +58,23 @@ const MAX_PARTIAL_AGE_MS = 60 * 60 * 1000;
 const PARTIAL_SUFFIX = ".part";
 
 /**
+ * Names this module generates, and only those.
+ *
+ * Pruning deletes files, so it must never act on something it did not write.
+ * The directory sits at a predictable path under `os.tmpdir()`, and on a shared
+ * `/tmp` its name can be claimed by another user before Daintree gets there —
+ * `ensureContextDir` rejects a symlink sitting on the name, but a sweep
+ * restricted to this shape cannot delete a bystander's file even if that check
+ * were ever defeated.
+ *
+ * Matches `<project>-<branch>-<timestamp>-<uuid8>.<ext>` plus the
+ * `.<uuid>.part` suffix a partial carries. The `uuid8` group is optional so
+ * bundles written by the pre-#11528 clipboard path are still swept.
+ */
+const BUNDLE_NAME_PATTERN =
+  /-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z(-[0-9a-f]{8})?\.[a-z]+(\.[0-9a-f-]{36}\.part)?$/;
+
+/**
  * Paths handed out but not yet finished. Pruning runs while other generations
  * are in flight, and deleting the file one of them is about to publish (or is
  * writing right now) would fail that run for no reason.
@@ -100,6 +117,17 @@ export function buildContextFileName(options: {
  * on Windows.
  */
 async function ensureContextDir(dir: string): Promise<void> {
+  // `lstat` rather than `stat`, and before `mkdir`: a symlink sitting on this
+  // name would be followed by mkdir, by the writes, and by the prune sweep,
+  // redirecting all three into whatever it points at. On a shared `/tmp` that
+  // target is another user's choice. This cannot close the replace-after-check
+  // race on its own, which is why pruning is also restricted to names this
+  // module generates.
+  const existing = await lstat(dir).catch(() => null);
+  if (existing && !existing.isDirectory()) {
+    throw new Error("Context directory is not a directory");
+  }
+
   await mkdir(dir, { recursive: true, mode: 0o700 });
   if (process.platform !== "win32") {
     try {
@@ -170,6 +198,8 @@ export async function pruneContextDir(): Promise<void> {
     // it points at be deleted, and recursing would take the sweep somewhere it
     // has no business being.
     if (!entry.isFile()) continue;
+    // Anything this module did not write is none of the sweep's business.
+    if (!BUNDLE_NAME_PATTERN.test(entry.name)) continue;
     const filePath = path.join(dir, entry.name);
     if (isProtected(filePath)) continue;
 
@@ -255,17 +285,21 @@ export async function readContentPreview(
 ): Promise<{ content: string; truncated: boolean }> {
   const handle = await open(filePath, "r");
   try {
-    const buffer = Buffer.alloc(maxBytes);
+    // One byte past the window: a file of exactly `maxBytes` fills the window
+    // without anything being left over, and measuring only the window would
+    // report it truncated when nothing was dropped.
+    const buffer = Buffer.alloc(maxBytes + 1);
     let read = 0;
-    while (read < maxBytes) {
-      const { bytesRead } = await handle.read(buffer, read, maxBytes - read, read);
+    while (read <= maxBytes) {
+      const { bytesRead } = await handle.read(buffer, read, maxBytes + 1 - read, read);
       if (bytesRead === 0) break;
       read += bytesRead;
     }
 
-    // A short read means the file ended, so what was read is already complete.
-    const truncated = read === maxBytes;
-    const end = truncated ? trimToUtf8Boundary(buffer, read) : read;
+    const truncated = read > maxBytes;
+    const limit = Math.min(read, maxBytes);
+    // Only a cut can land mid-sequence; a file that ended on its own is whole.
+    const end = truncated ? trimToUtf8Boundary(buffer, limit) : limit;
     return { content: buffer.subarray(0, end).toString("utf8"), truncated };
   } finally {
     await handle.close();
@@ -314,26 +348,52 @@ export function fitContentToResultBudget<T>(
   alreadyTruncated: boolean,
   maxBytes: number = CONTENT_RESULT_MAX_BYTES
 ): { result: T; content: string; truncated: boolean } {
-  const fits = (candidate: string, truncated: boolean) =>
-    Buffer.byteLength(JSON.stringify(buildResult(candidate, truncated)), "utf8") <= maxBytes;
+  /**
+   * A candidate and the flag it would actually ship with.
+   *
+   * The flag has to be derived here rather than passed in: `contentTruncated`
+   * is itself part of the measured JSON (`true` renders one byte shorter than
+   * `false`), so measuring a candidate under a flag it would not be sent with
+   * lets the search accept the untouched string and then label it truncated.
+   */
+  const evaluate = (end: number) => {
+    const slice = content.slice(0, safeEnd(content, end));
+    const truncated = alreadyTruncated || slice.length < content.length;
+    const result = buildResult(slice, truncated);
+    return {
+      slice,
+      truncated,
+      result,
+      ok: Buffer.byteLength(JSON.stringify(result), "utf8") <= maxBytes,
+    };
+  };
 
-  if (fits(content, alreadyTruncated)) {
-    return { result: buildResult(content, alreadyTruncated), content, truncated: alreadyTruncated };
+  const whole = evaluate(content.length);
+  if (whole.ok) {
+    return { result: whole.result, content: whole.slice, truncated: whole.truncated };
+  }
+
+  // The metadata alone overflows, so no amount of cutting helps. Ship the
+  // smallest thing this helper can build and let the transport cap — which
+  // measures the real envelope — be the backstop.
+  const empty = evaluate(0);
+  if (!empty.ok) {
+    return { result: buildResult("", true), content: "", truncated: true };
   }
 
   let low = 0;
   let high = content.length;
   while (low < high) {
     const mid = Math.ceil((low + high) / 2);
-    if (fits(content.slice(0, safeEnd(content, mid)), true)) {
+    if (evaluate(mid).ok) {
       low = mid;
     } else {
       high = mid - 1;
     }
   }
 
-  const fitted = content.slice(0, safeEnd(content, low));
-  return { result: buildResult(fitted, true), content: fitted, truncated: true };
+  const best = evaluate(low);
+  return { result: best.result, content: best.slice, truncated: best.truncated };
 }
 
 /** Back off an index that would leave a high surrogate without its pair. */

--- a/electron/services/copyTreeOutputFile.ts
+++ b/electron/services/copyTreeOutputFile.ts
@@ -1,0 +1,349 @@
+import crypto from "crypto";
+import os from "os";
+import path from "path";
+import { chmod, mkdir, open, readdir, rm, stat } from "fs/promises";
+import { logWarn } from "../utils/logger.js";
+
+/**
+ * Temp-file plumbing for file-backed CopyTree generation (#11528).
+ *
+ * `copyTree.generate` used to hand its whole bundle back as a string — 31 MB on
+ * this repo — which crossed three structured-clone boundaries before the MCP
+ * transport cap trimmed it to 50 KiB. It now writes the bundle to a file here
+ * and returns the path, so the only thing that travels is a few hundred bytes
+ * of metadata.
+ *
+ * That makes retention this module's problem. The tool sits on the lowest MCP
+ * tier and is rate-limited to 5 calls per 10s, so an unattended agent can write
+ * a lot of context in a short time, and nothing else ever cleans this directory
+ * up.
+ */
+
+/**
+ * Shared temp directory for every generated bundle.
+ *
+ * Resolved per call rather than captured at import: `os.tmpdir()` reads the
+ * environment every time, and pinning it at module load would freeze whatever
+ * `TMPDIR` happened to be when this module was first touched.
+ */
+export function contextDir(): string {
+  return path.join(os.tmpdir(), "daintree-context");
+}
+
+/**
+ * Ceiling on a single bundle.
+ *
+ * Pruning is retrospective: it cannot stop one in-flight run from filling the
+ * disk, so the streamed writer stops itself. Well clear of the ~31 MB a large
+ * real repository produces, low enough that a runaway run fails instead of
+ * consuming everything.
+ */
+export const MAX_OUTPUT_BYTES = 256 * 1024 * 1024;
+
+/**
+ * Retention. Bundles are consumed immediately (an agent reads the path it was
+ * just handed, or the user pastes the one on their clipboard), so keeping the
+ * newest few is enough.
+ *
+ * Deliberately no aggregate-byte quota: `generateAndCopyFile` puts a path on
+ * the user's clipboard to paste elsewhere, and a size-pressure sweep could
+ * delete that file seconds after they copied it. The count and per-file
+ * ceilings bound the directory without that hazard.
+ */
+export const MAX_RETAINED_FILES = 10;
+const MAX_AGE_MS = 24 * 60 * 60 * 1000;
+/** Partials only outlive their run when the process died mid-write. */
+const MAX_PARTIAL_AGE_MS = 60 * 60 * 1000;
+
+const PARTIAL_SUFFIX = ".part";
+
+/**
+ * Paths handed out but not yet finished. Pruning runs while other generations
+ * are in flight, and deleting the file one of them is about to publish (or is
+ * writing right now) would fail that run for no reason.
+ */
+const reservedPaths = new Set<string>();
+
+function sanitizeSegment(value: string, maxLength: number): string {
+  return value
+    .replace(/[^a-zA-Z0-9-_]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, maxLength);
+}
+
+/**
+ * Build the bundle's filename.
+ *
+ * The UUID is load-bearing, not decorative: two generations of the same
+ * worktree started inside the same millisecond would otherwise collide on the
+ * timestamp and one would overwrite the other's output.
+ */
+export function buildContextFileName(options: {
+  projectName: string;
+  branch: string;
+  extension: string;
+  timestamp: string;
+}): string {
+  const project = sanitizeSegment(options.projectName, 50) || "project";
+  const branch = sanitizeSegment(options.branch || "head", 100) || "head";
+  const unique = crypto.randomUUID().slice(0, 8);
+  return `${project}-${branch}-${options.timestamp}-${unique}.${options.extension}`;
+}
+
+/**
+ * Create the context directory with owner-only access.
+ *
+ * `mkdir({ mode })` is ignored when the directory already exists, so the mode
+ * is reapplied explicitly each run to evict a stale, more permissive mode left
+ * by a previous build or another process. chmod is a no-op for permission bits
+ * on Windows.
+ */
+async function ensureContextDir(dir: string): Promise<void> {
+  await mkdir(dir, { recursive: true, mode: 0o700 });
+  if (process.platform !== "win32") {
+    try {
+      await chmod(dir, 0o700);
+    } catch {
+      // Best effort — the 0o600 file mode still protects the contents.
+    }
+  }
+}
+
+/**
+ * Reserve a path for a bundle about to be generated.
+ *
+ * Only the main process calls this. The path never comes from a payload or
+ * from `CopyTreeOptions`, both of which are caller-controlled over MCP —
+ * letting either name the destination would turn a context dump into an
+ * arbitrary file write.
+ */
+export async function reserveContextFilePath(options: {
+  worktreePath: string;
+  branch?: string;
+  extension: string;
+}): Promise<string> {
+  const dir = contextDir();
+  await ensureContextDir(dir);
+  // Before, not after: the new bundle is the one thing that must not be swept,
+  // and pruning first keeps the directory bounded even if a run never finishes.
+  await pruneContextDir();
+
+  const filePath = path.join(
+    dir,
+    buildContextFileName({
+      projectName: path.basename(options.worktreePath),
+      branch: options.branch ?? "head",
+      extension: options.extension,
+      timestamp: new Date().toISOString().replace(/[:.]/g, "-"),
+    })
+  );
+  reservedPaths.add(filePath);
+  return filePath;
+}
+
+/** Release a reserved path once its run has settled, successfully or not. */
+export function releaseContextFilePath(filePath: string): void {
+  reservedPaths.delete(filePath);
+}
+
+/**
+ * Drop expired and surplus bundles, oldest first.
+ *
+ * Failures are logged and swallowed: a directory we cannot tidy is not a reason
+ * to fail the generation the caller actually asked for.
+ */
+export async function pruneContextDir(): Promise<void> {
+  const dir = contextDir();
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  const now = Date.now();
+  const candidates: { filePath: string; mtimeMs: number }[] = [];
+
+  for (const entry of entries) {
+    // Regular files in this directory only. A symlink here would let whatever
+    // it points at be deleted, and recursing would take the sweep somewhere it
+    // has no business being.
+    if (!entry.isFile()) continue;
+    const filePath = path.join(dir, entry.name);
+    if (isProtected(filePath)) continue;
+
+    let stats;
+    try {
+      stats = await stat(filePath);
+    } catch {
+      continue;
+    }
+
+    const age = now - stats.mtimeMs;
+    const maxAge = entry.name.endsWith(PARTIAL_SUFFIX) ? MAX_PARTIAL_AGE_MS : MAX_AGE_MS;
+    if (age > maxAge) {
+      await removeQuietly(filePath);
+      continue;
+    }
+    if (!entry.name.endsWith(PARTIAL_SUFFIX)) {
+      candidates.push({ filePath, mtimeMs: stats.mtimeMs });
+    }
+  }
+
+  if (candidates.length <= MAX_RETAINED_FILES) return;
+  candidates.sort((a, b) => a.mtimeMs - b.mtimeMs || a.filePath.localeCompare(b.filePath));
+  for (const { filePath } of candidates.slice(0, candidates.length - MAX_RETAINED_FILES)) {
+    await removeQuietly(filePath);
+  }
+}
+
+/**
+ * A reserved bundle is protected, and so is any partial named after it — the
+ * writer publishes `<path>.<uuid>.part` by renaming it onto `<path>`.
+ */
+function isProtected(filePath: string): boolean {
+  if (reservedPaths.has(filePath)) return true;
+  for (const reserved of reservedPaths) {
+    if (filePath.startsWith(`${reserved}.`)) return true;
+  }
+  return false;
+}
+
+async function removeQuietly(filePath: string): Promise<void> {
+  try {
+    await rm(filePath, { force: true });
+  } catch (error) {
+    logWarn("Failed to prune a CopyTree context file", { error });
+  }
+}
+
+/**
+ * Byte ceiling on the head read back from the bundle.
+ *
+ * Only an upper bound on the read — the serialized budget below is what
+ * actually decides how much survives.
+ */
+export const CONTENT_PREVIEW_MAX_BYTES = 32 * 1024;
+
+/**
+ * Byte ceiling on the whole serialized result.
+ *
+ * `buildToolCallTextResult` drops `structuredContent` and flags `isError` once
+ * a serialized tool result passes `TOOL_RESULT_TEXT_MAX_BYTES` (50 KiB), so a
+ * head sized against the raw file would defeat the opt-in it exists to serve.
+ * Raw bytes are the wrong unit for that budget: JSON escaping doubles a
+ * newline, a quote and a backslash, and expands most C0 controls to a six-byte
+ * `\u00xx` — a 32 KiB head of the wrong file serializes to 192 KiB. So the fit
+ * is measured on the serialized object, and this sits 2 KiB under the transport
+ * cap to leave room for the envelope around it.
+ */
+export const CONTENT_RESULT_MAX_BYTES = 48 * 1024;
+
+/**
+ * Read at most `CONTENT_PREVIEW_MAX_BYTES` from the head of `filePath`.
+ *
+ * Positional reads into one fixed buffer, never `readFile` — the file this
+ * bounds is the multi-megabyte bundle the whole change exists to keep out of
+ * memory. A cut inside a multi-byte sequence would decode to U+FFFD, so the
+ * tail is backed off to a UTF-8 boundary instead (a sequence is at most 4
+ * bytes, so at most 3 continuation bytes can precede the cut).
+ */
+export async function readContentPreview(
+  filePath: string,
+  maxBytes: number = CONTENT_PREVIEW_MAX_BYTES
+): Promise<{ content: string; truncated: boolean }> {
+  const handle = await open(filePath, "r");
+  try {
+    const buffer = Buffer.alloc(maxBytes);
+    let read = 0;
+    while (read < maxBytes) {
+      const { bytesRead } = await handle.read(buffer, read, maxBytes - read, read);
+      if (bytesRead === 0) break;
+      read += bytesRead;
+    }
+
+    // A short read means the file ended, so what was read is already complete.
+    const truncated = read === maxBytes;
+    const end = truncated ? trimToUtf8Boundary(buffer, read) : read;
+    return { content: buffer.subarray(0, end).toString("utf8"), truncated };
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * Largest cut at or below `end` that does not land inside a UTF-8 sequence.
+ *
+ * The buffer stops exactly at the window, so unlike a cut made inside a larger
+ * buffer there is no following byte to inspect — the last sequence has to be
+ * located by walking back to its lead byte and asking whether all of it made
+ * it in. A chopped tail would otherwise decode to U+FFFD.
+ */
+function trimToUtf8Boundary(buffer: Buffer, end: number): number {
+  // A sequence is at most 4 bytes, so at most 3 continuation bytes precede the
+  // lead. Anything longer is malformed input, not a boundary.
+  let start = end - 1;
+  for (let i = 0; i < 3 && start >= 0 && (buffer[start] & 0xc0) === 0x80; i += 1) {
+    start -= 1;
+  }
+  if (start < 0) return 0;
+
+  const lead = buffer[start];
+  let expected = 1;
+  if ((lead & 0xf8) === 0xf0) expected = 4;
+  else if ((lead & 0xf0) === 0xe0) expected = 3;
+  else if ((lead & 0xe0) === 0xc0) expected = 2;
+
+  return start + expected <= end ? end : start;
+}
+
+/**
+ * Shrink `content` until the whole result serializes within
+ * `CONTENT_RESULT_MAX_BYTES`.
+ *
+ * `buildResult` is called with a candidate head rather than the caller
+ * assembling one, because the sibling fields (`filePath`, stats) count against
+ * the same budget and their size isn't known here. The search runs on code-unit
+ * indices and then walks back off a lone high surrogate, so a cut never splits
+ * a surrogate pair into an unpaired half.
+ */
+export function fitContentToResultBudget<T>(
+  content: string,
+  buildResult: (content: string, truncated: boolean) => T,
+  alreadyTruncated: boolean,
+  maxBytes: number = CONTENT_RESULT_MAX_BYTES
+): { result: T; content: string; truncated: boolean } {
+  const fits = (candidate: string, truncated: boolean) =>
+    Buffer.byteLength(JSON.stringify(buildResult(candidate, truncated)), "utf8") <= maxBytes;
+
+  if (fits(content, alreadyTruncated)) {
+    return { result: buildResult(content, alreadyTruncated), content, truncated: alreadyTruncated };
+  }
+
+  let low = 0;
+  let high = content.length;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    if (fits(content.slice(0, safeEnd(content, mid)), true)) {
+      low = mid;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  const fitted = content.slice(0, safeEnd(content, low));
+  return { result: buildResult(fitted, true), content: fitted, truncated: true };
+}
+
+/** Back off an index that would leave a high surrogate without its pair. */
+function safeEnd(value: string, end: number): number {
+  if (end <= 0 || end >= value.length) return Math.max(0, Math.min(end, value.length));
+  const last = value.charCodeAt(end - 1);
+  return last >= 0xd800 && last <= 0xdbff ? end - 1 : end;
+}
+
+/** Reset module state between tests. */
+export function _resetReservedPathsForTests(): void {
+  reservedPaths.clear();
+}

--- a/electron/services/workspace-client/WorkspaceCopyTreeClient.ts
+++ b/electron/services/workspace-client/WorkspaceCopyTreeClient.ts
@@ -21,10 +21,16 @@ export class WorkspaceCopyTreeClient {
     this.iterateEntries = deps.iterateEntries;
   }
 
+  /**
+   * `outputPath` streams the bundle to that file in the host and returns only
+   * its path, keeping a multi-MB string off this structured-clone boundary
+   * (#11528). It is main-process-chosen — never a caller's.
+   */
   async generateContext(
     rootPath: string,
     options?: CopyTreeOptions,
-    onProgress?: CopyTreeProgressCallback
+    onProgress?: CopyTreeProgressCallback,
+    outputPath?: string
   ): Promise<CopyTreeResult> {
     const host = this.resolveHostForPath(rootPath);
     if (!host) throw new Error("No workspace host for path");
@@ -45,6 +51,7 @@ export class WorkspaceCopyTreeClient {
           operationId,
           rootPath,
           options,
+          outputPath,
         },
         120000
       );

--- a/electron/services/workspace-client/__tests__/WorkspaceCopyTreeClient.test.ts
+++ b/electron/services/workspace-client/__tests__/WorkspaceCopyTreeClient.test.ts
@@ -45,6 +45,54 @@ describe("WorkspaceCopyTreeClient", () => {
     });
   });
 
+  describe("generateContext", () => {
+    it("carries the destination to the host so the bundle is written there, not returned", async () => {
+      const sendWithResponse = vi
+        .fn()
+        .mockResolvedValue({ result: { content: "", fileCount: 2, filePath: "/tmp/ctx/a.xml" } });
+      hostA = makeHost({ sendWithResponse });
+      entries[0] = makeEntry(hostA, "/project/a");
+
+      const result = await client.generateContext(
+        "/project/a",
+        { exclude: ["docs/**"] },
+        undefined,
+        "/tmp/ctx/a.xml"
+      );
+
+      expect(sendWithResponse.mock.calls[0][0]).toMatchObject({
+        type: "copytree:generate",
+        rootPath: "/project/a",
+        options: { exclude: ["docs/**"] },
+        outputPath: "/tmp/ctx/a.xml",
+      });
+      expect(result.filePath).toBe("/tmp/ctx/a.xml");
+    });
+
+    it("omits the destination when the caller wants the string back", async () => {
+      const sendWithResponse = vi
+        .fn()
+        .mockResolvedValue({ result: { content: "x", fileCount: 1 } });
+      hostA = makeHost({ sendWithResponse });
+      entries[0] = makeEntry(hostA, "/project/a");
+
+      await client.generateContext("/project/a");
+
+      expect(sendWithResponse.mock.calls[0][0].outputPath).toBeUndefined();
+    });
+
+    it("releases the operation once the generation settles", async () => {
+      const sendWithResponse = vi.fn().mockRejectedValue(new Error("host died"));
+      hostA = makeHost({ sendWithResponse });
+      entries[0] = makeEntry(hostA, "/project/a");
+
+      await expect(client.generateContext("/project/a")).rejects.toThrow("host died");
+
+      expect(client.activeCopyTreeOperations.size).toBe(0);
+      expect(client.copyTreeProgressCallbacks.size).toBe(0);
+    });
+  });
+
   describe("cancelContext", () => {
     it("routes cancel to the host that owns the operation", () => {
       client.activeCopyTreeOperations.set("op-1", "/project/a");

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -652,7 +652,7 @@ port.on("message", async (rawMsg: any) => {
       }
 
       case "copytree:generate": {
-        const { requestId, operationId, rootPath, options } = request;
+        const { requestId, operationId, rootPath, options, outputPath } = request;
         console.log(`[WorkspaceHost] CopyTree generate started: ${operationId}`);
 
         const onProgress = (progress: CopyTreeProgress) => {
@@ -668,7 +668,8 @@ port.on("message", async (rawMsg: any) => {
             rootPath,
             options || {},
             onProgress,
-            operationId
+            operationId,
+            outputPath
           );
           sendEvent({
             type: "copytree:complete",

--- a/electron/workspace-host/CopytreeWorkerClient.ts
+++ b/electron/workspace-host/CopytreeWorkerClient.ts
@@ -89,13 +89,14 @@ export class CopytreeWorkerClient {
     rootPath: string,
     options: CopyTreeOptions = {},
     onProgress?: ProgressCallback,
-    operationId?: string
+    operationId?: string,
+    outputPath?: string
   ): Promise<CopyTreeResult> {
     const id = operationId || crypto.randomUUID();
     this.lastActivityAt = Date.now();
     const worker = this.getWorker();
     if (!worker) {
-      return copyTreeService.generate(rootPath, options, onProgress, id);
+      return copyTreeService.generate(rootPath, options, onProgress, id, outputPath);
     }
     const pending = new Promise<CopyTreeResult>((resolve, reject) => {
       this.pendingGenerate.set(id, {
@@ -111,13 +112,14 @@ export class CopytreeWorkerClient {
         id,
         rootPath,
         options,
+        outputPath,
       } satisfies CopytreeWorkerRequest);
     } catch (error) {
       this.takePendingGenerate(id);
       logWarn("copytree worker postMessage failed; running in-process", {
         error: formatErrorMessage(error, "postMessage failed"),
       });
-      return copyTreeService.generate(rootPath, options, onProgress, id);
+      return copyTreeService.generate(rootPath, options, onProgress, id, outputPath);
     }
     return pending;
   }

--- a/electron/workspace-host/__tests__/CopytreeWorkerClient.test.ts
+++ b/electron/workspace-host/__tests__/CopytreeWorkerClient.test.ts
@@ -63,6 +63,38 @@ describe("CopytreeWorkerClient", () => {
     expect(copyTreeService.generate).not.toHaveBeenCalled();
   });
 
+  it("carries the output destination to the worker", async () => {
+    const { client, worker } = makeClient();
+
+    void client.generate("/root", {}, undefined, "op-1", "/tmp/ctx/bundle.xml");
+
+    expect(worker.postMessage.mock.calls[0][0]).toMatchObject({
+      type: "generate",
+      outputPath: "/tmp/ctx/bundle.xml",
+    });
+  });
+
+  it("carries the output destination onto every in-thread fallback", async () => {
+    // The fallback runs the same service in the host thread. Dropping the
+    // destination here would silently restore the multi-MB string this
+    // parameter exists to avoid (#11528).
+    const worker = new FakeWorker();
+    worker.postMessage.mockImplementation(() => {
+      throw new Error("worker port closed");
+    });
+    const { client } = makeClient(worker);
+
+    await client.generate("/root", {}, undefined, "op-1", "/tmp/ctx/bundle.xml");
+
+    expect(copyTreeService.generate).toHaveBeenCalledWith(
+      "/root",
+      {},
+      undefined,
+      "op-1",
+      "/tmp/ctx/bundle.xml"
+    );
+  });
+
   it("relays worker progress to the caller's onProgress", async () => {
     const { client, worker } = makeClient();
     const onProgress = vi.fn();
@@ -102,7 +134,13 @@ describe("CopytreeWorkerClient", () => {
 
     await expect(client.generate("/root", {}, undefined, "op-1")).resolves.toEqual(inlineResult);
     expect(factory).not.toHaveBeenCalled();
-    expect(copyTreeService.generate).toHaveBeenCalledWith("/root", {}, undefined, "op-1");
+    expect(copyTreeService.generate).toHaveBeenCalledWith(
+      "/root",
+      {},
+      undefined,
+      "op-1",
+      undefined
+    );
   });
 
   it("falls back in-thread when the worker fails to spawn, and stays there", async () => {
@@ -317,7 +355,13 @@ describe("CopytreeWorkerClient", () => {
     const { client } = makeClient(worker);
 
     await expect(client.generate("/root", {}, undefined, "op-1")).resolves.toEqual(inlineResult);
-    expect(copyTreeService.generate).toHaveBeenCalledWith("/root", {}, undefined, "op-1");
+    expect(copyTreeService.generate).toHaveBeenCalledWith(
+      "/root",
+      {},
+      undefined,
+      "op-1",
+      undefined
+    );
 
     await expect(client.testConfig("/root", {}, "op-2")).resolves.toEqual(inlineTestResult);
     expect(copyTreeService.testConfig).toHaveBeenCalledWith("/root", {}, "op-2");

--- a/electron/workspace-host/copytreeWorker.ts
+++ b/electron/workspace-host/copytreeWorker.ts
@@ -27,9 +27,15 @@ function post(message: CopytreeWorkerResponse): void {
 port.on("message", (message: CopytreeWorkerRequest) => {
   switch (message.type) {
     case "generate": {
-      const { id, rootPath, options } = message;
+      const { id, rootPath, options, outputPath } = message;
       void copyTreeService
-        .generate(rootPath, options, (progress) => post({ type: "progress", id, progress }), id)
+        .generate(
+          rootPath,
+          options,
+          (progress) => post({ type: "progress", id, progress }),
+          id,
+          outputPath
+        )
         .then(
           (result) => post({ type: "generate-result", id, result }),
           (error: unknown) =>

--- a/electron/workspace-host/copytreeWorkerProtocol.ts
+++ b/electron/workspace-host/copytreeWorkerProtocol.ts
@@ -7,7 +7,16 @@ import type { CopyTreeTestConfigResult, FileTreeNode } from "../../shared/types/
  * it onto its own per-operation AbortController inside CopyTreeService.
  */
 export type CopytreeWorkerRequest =
-  | { type: "generate"; id: string; rootPath: string; options: CopyTreeOptions }
+  // `outputPath` is chosen by the main process, never by a caller: with it set
+  // the bundle is streamed to that file and only its path returns, so a
+  // multi-MB string never crosses this port (#11528).
+  | {
+      type: "generate";
+      id: string;
+      rootPath: string;
+      options: CopyTreeOptions;
+      outputPath?: string;
+    }
   | { type: "test-config"; id: string; rootPath: string; options: CopyTreeOptions }
   | {
       type: "get-file-tree";

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -361,7 +361,11 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     applyPatch(options: ApplyPatchOptions): Promise<ApplyPatchResult>;
   };
   copyTree: {
-    generate(worktreeId: string, options?: CopyTreeOptions): Promise<CopyTreeResult>;
+    generate(
+      worktreeId: string,
+      options?: CopyTreeOptions,
+      includeContent?: boolean
+    ): Promise<CopyTreeResult>;
     generateAndCopyFile(worktreeId: string, options?: CopyTreeOptions): Promise<CopyTreeResult>;
     injectToTerminal(
       terminalId: string,

--- a/shared/types/ipc/copyTree.ts
+++ b/shared/types/ipc/copyTree.ts
@@ -50,6 +50,20 @@ export interface CopyTreeOptions {
 export interface CopyTreeGeneratePayload {
   worktreeId: string;
   options?: CopyTreeOptions;
+  /**
+   * Return a bounded head of the bundle alongside the file path (#11528).
+   *
+   * Off by default: the bundle is written to a file and only its path comes
+   * back, so a multi-MB context never crosses a process boundary. Opting in
+   * never restores that — the file is still the source, and the head is read
+   * back from it under a hard serialized-size budget.
+   *
+   * Deliberately a payload field rather than a `CopyTreeOptions` one: the
+   * options object is caller-supplied over MCP and merged with persisted
+   * project settings, and this is a per-call response shape, not a
+   * context-generation setting.
+   */
+  includeContent?: boolean;
 }
 
 export interface CopyTreeGenerateAndCopyFilePayload {
@@ -182,10 +196,28 @@ export interface CopyTreeGetFileTreePayload {
 
 /** Result from CopyTree generation */
 export interface CopyTreeResult {
-  /** Generated content */
+  /**
+   * Generated content.
+   *
+   * Empty on every file-backed path — `generate` (which now writes a file by
+   * default), `generateAndCopyFile` and `injectToTerminal` all deliver the
+   * bundle somewhere other than this field and drop it rather than clone a
+   * second multi-MB copy across a process boundary.
+   */
   content: string;
   /** Number of files included */
   fileCount: number;
+  /**
+   * Absolute path of the written bundle, when generation was file-backed.
+   *
+   * Ephemeral: it lives in the OS temp directory and is pruned by age and by
+   * count, so a consumer must read it promptly rather than store it.
+   */
+  filePath?: string;
+  /** UTF-8 byte size of the written bundle. Present whenever `filePath` is. */
+  outputBytes?: number;
+  /** True when `content` holds only the head of a larger bundle. */
+  contentTruncated?: boolean;
   /** Error message if generation failed */
   error?: string;
   /**

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -447,6 +447,12 @@ export type WorkspaceHostRequest =
       operationId: string;
       rootPath: string;
       options?: CopyTreeOptions;
+      /**
+       * Where to stream the bundle. Main-process-chosen and internal to this
+       * protocol — with it set, only the path returns instead of a multi-MB
+       * string (#11528).
+       */
+      outputPath?: string;
     }
   | { type: "copytree:cancel"; operationId: string }
   | {

--- a/src/clients/copyTreeClient.ts
+++ b/src/clients/copyTreeClient.ts
@@ -8,8 +8,12 @@ import type {
 } from "@shared/types";
 
 export const copyTreeClient = {
-  generate: (worktreeId: string, options?: CopyTreeOptions): Promise<CopyTreeResult> => {
-    return window.electron.copyTree.generate(worktreeId, options);
+  generate: (
+    worktreeId: string,
+    options?: CopyTreeOptions,
+    includeContent?: boolean
+  ): Promise<CopyTreeResult> => {
+    return window.electron.copyTree.generate(worktreeId, options, includeContent);
   },
 
   generateAndCopyFile: (worktreeId: string, options?: CopyTreeOptions): Promise<CopyTreeResult> => {

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -935,7 +935,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "copyTree",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Generate a CopyTree context dump (file tree plus selected file contents) for a worktree and return it as a string. Args (all optional): \`worktreeId\` or \`worktreePath\` — the worktree, defaults to the active one; \`options\` — CopyTree include/exclude options. Returns { content, fileCount, optional stats:{ totalSize, duration } }. Throws when generation fails or when no worktree is given and none is active. Do NOT use this to inject context into a terminal — use \`copyTree.injectToTerminal\`.",
+    "description": "Generate a CopyTree context dump (file tree plus selected file contents) for a worktree and write it to a file, returning the path. Args (all optional): \`worktreeId\` or \`worktreePath\` — the worktree, defaults to the active one; \`options\` — CopyTree include/exclude options; \`includeContent\` — also return a bounded head of the bundle. Returns { filePath, fileCount, outputBytes, optional content, optional contentTruncated, optional stats:{ totalSize, duration } }. \`filePath\` is a temporary file that is pruned by age and count, so read it promptly. The bundle is NOT returned inline by default — it routinely runs to tens of megabytes, far past what any tool result can carry; \`includeContent\` returns only the first few KB. Throws when generation fails or when no worktree is given and none is active. Do NOT use this to inject context into a terminal — use \`copyTree.injectToTerminal\`.",
     "examples": undefined,
     "id": "copyTree.generate",
     "keywords": [
@@ -952,7 +952,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "copyTree",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Generate worktree context and copy to clipboard",
+    "description": "Generate worktree context, write it to a file and put that file on the clipboard. Args (all optional): \`worktreeId\` — the worktree, defaults to the active one; \`options\` — CopyTree include/exclude options. Returns { filePath, fileCount, outputBytes, optional stats:{ totalSize, duration } }. The bundle is never returned inline. Throws when generation or the clipboard write fails.",
     "examples": undefined,
     "id": "copyTree.generateAndCopyFile",
     "keywords": undefined,
@@ -976,7 +976,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "copyTree",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Inject worktree context into a terminal",
+    "description": "Write a worktree's CopyTree context straight into a terminal. Args: \`terminalId\` — required; \`worktreeId\` — defaults to the active worktree; \`options\` — CopyTree include/exclude options. Returns { fileCount, optional stats:{ totalSize, duration } } — the context goes to the terminal, never back through this result. Throws when generation or injection fails.",
     "examples": undefined,
     "id": "copyTree.injectToTerminal",
     "keywords": [

--- a/src/services/actions/__tests__/actionDefinitions.project-system-preferences.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.project-system-preferences.adversarial.test.ts
@@ -651,8 +651,13 @@ describe("system action hardening", () => {
     mocks.systemClient.checkCommand.mockResolvedValueOnce(true);
     mocks.filesClient.search.mockResolvedValueOnce(["src/main.ts"]);
     mocks.slashCommandsClient.list.mockResolvedValueOnce(["/review"]);
-    mocks.copyTreeClient.generate.mockResolvedValueOnce("tree");
-    mocks.copyTreeClient.injectToTerminal.mockResolvedValueOnce({ injected: true });
+    mocks.copyTreeClient.generate.mockResolvedValueOnce({
+      content: "",
+      fileCount: 2,
+      filePath: "/tmp/daintree-context/repo-main-x.xml",
+      outputBytes: 512,
+    });
+    mocks.copyTreeClient.injectToTerminal.mockResolvedValueOnce({ content: "", fileCount: 2 });
     mocks.copyTreeClient.getFileTree.mockResolvedValueOnce([{ path: "src", type: "directory" }]);
     const { service } = buildService(registerSystemActions);
 
@@ -671,21 +676,33 @@ describe("system action hardening", () => {
         worktreeId: "wt-1",
         options: { includeGitStatus: true },
       })
-    ).resolves.toEqual({ ok: true, result: "tree" });
+    ).resolves.toEqual({
+      ok: true,
+      result: {
+        filePath: "/tmp/daintree-context/repo-main-x.xml",
+        fileCount: 2,
+        outputBytes: 512,
+      },
+    });
     await expect(
       service.dispatch("copyTree.injectToTerminal", {
         terminalId: "term-1",
         worktreeId: "wt-1",
         options: { includeGitStatus: true },
       })
-    ).resolves.toEqual({ ok: true, result: { injected: true } });
+    ).resolves.toEqual({ ok: true, result: { fileCount: 2 } });
     await expect(
       service.dispatch("copyTree.getFileTree", { worktreeId: "wt-1", dirPath: "src" })
     ).resolves.toEqual({ ok: true, result: { nodes: [{ path: "src", type: "directory" }] } });
   });
 
   it("keeps scoped folder paths in copyTree options instead of validating them away", async () => {
-    mocks.copyTreeClient.generate.mockResolvedValueOnce("tree");
+    mocks.copyTreeClient.generate.mockResolvedValueOnce({
+      content: "",
+      fileCount: 1,
+      filePath: "/tmp/daintree-context/repo-main-x.xml",
+      outputBytes: 128,
+    });
     const { service } = buildService(registerSystemActions);
 
     await service.dispatch("copyTree.generate", {

--- a/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
@@ -74,11 +74,31 @@ function setupActions(): {
   };
 }
 
+/**
+ * A plausible file-backed CopyTreeResult, i.e. what the IPC layer actually
+ * answers with. The copyTree actions project their MCP result out of this, so a
+ * bare `undefined` mock would only prove they never look at it.
+ */
+const COPY_TREE_RESULT = {
+  content: "",
+  fileCount: 3,
+  filePath: "/tmp/daintree-context/repo-main-x.xml",
+  outputBytes: 2048,
+  outputFormatVersion: "copytree-xml@1",
+  stats: { totalSize: 4096, duration: 12 },
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   for (const fn of Object.values(filesClientMock)) fn.mockResolvedValue(undefined);
   for (const fn of Object.values(copyTreeClientMock)) fn.mockResolvedValue(undefined);
   for (const fn of Object.values(slashCommandsClientMock)) fn.mockResolvedValue(undefined);
+  copyTreeClientMock.generate.mockResolvedValue({ ...COPY_TREE_RESULT });
+  copyTreeClientMock.generateAndCopyFile.mockResolvedValue({ ...COPY_TREE_RESULT });
+  copyTreeClientMock.injectToTerminal.mockResolvedValue({
+    ...COPY_TREE_RESULT,
+    filePath: undefined,
+  });
 });
 
 describe("systemActions adversarial", () => {
@@ -161,14 +181,20 @@ describe("systemActions adversarial", () => {
     it("falls back to ctx.activeWorktreeId when worktreeId is omitted", async () => {
       const { run } = setupActions();
       await run("copyTree.generate", undefined, { activeWorktreeId: "wt-active" });
-      expect(copyTreeClientMock.generate).toHaveBeenCalledWith("wt-active", undefined);
+      expect(copyTreeClientMock.generate).toHaveBeenCalledWith("wt-active", undefined, undefined);
     });
 
     it("forwards options when provided", async () => {
       const { run } = setupActions();
       const options = { format: "xml" as const };
       await run("copyTree.generate", { options }, { activeWorktreeId: "wt-active" });
-      expect(copyTreeClientMock.generate).toHaveBeenCalledWith("wt-active", options);
+      expect(copyTreeClientMock.generate).toHaveBeenCalledWith("wt-active", options, undefined);
+    });
+
+    it("forwards the content opt-in so the head is only read when asked for", async () => {
+      const { run } = setupActions();
+      await run("copyTree.generate", { includeContent: true }, { activeWorktreeId: "wt-active" });
+      expect(copyTreeClientMock.generate).toHaveBeenCalledWith("wt-active", undefined, true);
     });
 
     it("throws when worktreeId is omitted and no active worktree", async () => {
@@ -191,12 +217,50 @@ describe("systemActions adversarial", () => {
       ).rejects.toThrow("copytree exited with code 1");
     });
 
-    it("passes a successful generation through untouched", async () => {
+    it("returns the file handle and keeps the bundle off the result", async () => {
       const { run } = setupActions();
-      copyTreeClientMock.generate.mockResolvedValueOnce({ content: "dump", fileCount: 3 });
+      // The IPC layer answers with the full CopyTreeResult shape. Anything the
+      // success schema doesn't name has to be dropped here: `resultSchema` is
+      // manifest documentation and strips nothing (#10870), so a field left in
+      // reaches the wire regardless of what the schema advertises.
+      copyTreeClientMock.generate.mockResolvedValueOnce({
+        content: "",
+        fileCount: 3,
+        filePath: "/tmp/daintree-context/repo-main-x.xml",
+        outputBytes: 31_457_280,
+        outputFormatVersion: "copytree-xml@1",
+        stats: { totalSize: 4096, duration: 12, estimatedTokens: 7_500_063 },
+      });
+
       await expect(
         run("copyTree.generate", undefined, { activeWorktreeId: "wt-active" })
-      ).resolves.toEqual({ content: "dump", fileCount: 3 });
+      ).resolves.toEqual({
+        filePath: "/tmp/daintree-context/repo-main-x.xml",
+        fileCount: 3,
+        outputBytes: 31_457_280,
+        stats: { totalSize: 4096, duration: 12 },
+      });
+    });
+
+    it("carries the head and its truncation flag only when one came back", async () => {
+      const { run } = setupActions();
+      copyTreeClientMock.generate.mockResolvedValueOnce({
+        content: "<files>head</files>",
+        contentTruncated: true,
+        fileCount: 3,
+        filePath: "/tmp/daintree-context/repo-main-x.xml",
+        outputBytes: 31_457_280,
+      });
+
+      await expect(
+        run("copyTree.generate", { includeContent: true }, { activeWorktreeId: "wt-active" })
+      ).resolves.toEqual({
+        filePath: "/tmp/daintree-context/repo-main-x.xml",
+        fileCount: 3,
+        outputBytes: 31_457_280,
+        content: "<files>head</files>",
+        contentTruncated: true,
+      });
     });
   });
 
@@ -205,6 +269,33 @@ describe("systemActions adversarial", () => {
       const { run } = setupActions();
       await run("copyTree.generateAndCopyFile", undefined, { activeWorktreeId: "wt-active" });
       expect(copyTreeClientMock.generateAndCopyFile).toHaveBeenCalledWith("wt-active", undefined);
+    });
+
+    it("returns the file handle without the bundle", async () => {
+      const { run } = setupActions();
+      await expect(
+        run("copyTree.generateAndCopyFile", undefined, { activeWorktreeId: "wt-active" })
+      ).resolves.toEqual({
+        filePath: "/tmp/daintree-context/repo-main-x.xml",
+        fileCount: 3,
+        outputBytes: 2048,
+        stats: { totalSize: 4096, duration: 12 },
+      });
+    });
+
+    it("throws on a failure instead of returning it as success data", async () => {
+      const { run } = setupActions();
+      // Same trap #11543 fixed for `generate`: a returned value is serialized as
+      // a SUCCESSFUL tool result, so an agent checking isError never sees an
+      // `error` field riding back beside an empty dump.
+      copyTreeClientMock.generateAndCopyFile.mockResolvedValueOnce({
+        content: "",
+        fileCount: 0,
+        error: "Failed to copy file to clipboard: EACCES",
+      });
+      await expect(
+        run("copyTree.generateAndCopyFile", undefined, { activeWorktreeId: "wt-active" })
+      ).rejects.toThrow("Failed to copy file to clipboard: EACCES");
     });
   });
 
@@ -242,6 +333,25 @@ describe("systemActions adversarial", () => {
       await expect(run("copyTree.injectToTerminal", { terminalId: "t-1" })).rejects.toThrow(
         "No active worktree"
       );
+    });
+
+    it("reports only the counts — the context went to the terminal, not the result", async () => {
+      const { run } = setupActions();
+      await expect(
+        run("copyTree.injectToTerminal", { terminalId: "t-1" }, { activeWorktreeId: "wt-active" })
+      ).resolves.toEqual({ fileCount: 3, stats: { totalSize: 4096, duration: 12 } });
+    });
+
+    it("throws on a failure instead of returning it as success data", async () => {
+      const { run } = setupActions();
+      copyTreeClientMock.injectToTerminal.mockResolvedValueOnce({
+        content: "",
+        fileCount: 0,
+        error: "Terminal closed during injection",
+      });
+      await expect(
+        run("copyTree.injectToTerminal", { terminalId: "t-1" }, { activeWorktreeId: "wt-active" })
+      ).rejects.toThrow("Terminal closed during injection");
     });
   });
 });

--- a/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
@@ -223,8 +223,10 @@ describe("systemActions adversarial", () => {
       // success schema doesn't name has to be dropped here: `resultSchema` is
       // manifest documentation and strips nothing (#10870), so a field left in
       // reaches the wire regardless of what the schema advertises.
+      // A non-empty sentinel: an empty string would let a projection that
+      // forwards `content` unconditionally pass this test anyway.
       copyTreeClientMock.generate.mockResolvedValueOnce({
-        content: "",
+        content: "LEAKED BUNDLE".repeat(1000),
         fileCount: 3,
         filePath: "/tmp/daintree-context/repo-main-x.xml",
         outputBytes: 31_457_280,
@@ -240,6 +242,21 @@ describe("systemActions adversarial", () => {
         outputBytes: 31_457_280,
         stats: { totalSize: 4096, duration: 12 },
       });
+    });
+
+    it("reports a head that was not truncated as such", async () => {
+      const { run } = setupActions();
+      copyTreeClientMock.generate.mockResolvedValueOnce({
+        content: "<files>whole</files>",
+        contentTruncated: false,
+        fileCount: 1,
+        filePath: "/tmp/daintree-context/repo-main-x.xml",
+        outputBytes: 20,
+      });
+
+      await expect(
+        run("copyTree.generate", { includeContent: true }, { activeWorktreeId: "wt-active" })
+      ).resolves.toMatchObject({ content: "<files>whole</files>", contentTruncated: false });
     });
 
     it("carries the head and its truncation flag only when one came back", async () => {

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -249,6 +249,12 @@ export const CopyTreeOptionsSchema = z.object({
   maxFileCount: z.number().int().positive().optional(),
   withLineNumbers: z.boolean().optional(),
   charLimit: z.number().int().positive().optional(),
+  // These actions validate against their own copy of the options schema, so a
+  // field only the IPC schema knows about is stripped before the request ever
+  // leaves the renderer. `sort` was missing here while `CopyTreeOptions` and the
+  // IPC schema both accepted it, so an MCP caller asking for a sort order
+  // silently got the default one.
+  sort: z.enum(["path", "size", "modified", "name", "extension", "depth"]).optional(),
 });
 
 export const AgentPresetSchema = z.object({

--- a/src/services/actions/definitions/systemActions.ts
+++ b/src/services/actions/definitions/systemActions.ts
@@ -399,8 +399,12 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
           filePath: result.filePath,
           fileCount: result.fileCount,
           outputBytes: result.outputBytes,
-          ...(result.content ? { content: result.content } : {}),
-          ...(result.contentTruncated ? { contentTruncated: true } : {}),
+          // Gated on what was ASKED for, not on what came back: keying off the
+          // response would forward a bundle to a caller who never opted in if
+          // the layer below ever returned one.
+          ...(args?.includeContent
+            ? { content: result.content, contentTruncated: result.contentTruncated === true }
+            : {}),
           ...(result.stats ? { stats: projectCopyTreeStats(result.stats) } : {}),
         };
       },

--- a/src/services/actions/definitions/systemActions.ts
+++ b/src/services/actions/definitions/systemActions.ts
@@ -19,6 +19,52 @@ import {
   systemClient,
 } from "@/clients";
 import { cancelContextInjection } from "@/hooks/useContextInjection";
+import type { CopyTreeResult } from "@shared/types";
+
+/**
+ * The generation numbers every CopyTree action reports. Kept separate from
+ * CopyTree's own richer budget stats so the advertised shape stays small — the
+ * whole point of #11528 is that these tools return metadata, not bulk.
+ */
+const CopyTreeStatsSchema = z
+  .object({
+    totalSize: z.number(),
+    duration: z.number(),
+  })
+  .optional();
+
+const CopyTreeGenerateResultSchema = z.object({
+  filePath: z
+    .string()
+    .describe("Absolute path of the written bundle. Temporary — read it promptly."),
+  fileCount: z.number(),
+  outputBytes: z.number().describe("UTF-8 size of the bundle on disk."),
+  content: z
+    .string()
+    .optional()
+    .describe("Head of the bundle, only when `includeContent` was set."),
+  contentTruncated: z.boolean().optional(),
+  stats: CopyTreeStatsSchema,
+});
+
+function projectCopyTreeStats(stats: NonNullable<CopyTreeResult["stats"]>) {
+  return { totalSize: stats.totalSize, duration: stats.duration };
+}
+
+/**
+ * Turn an error-shaped CopyTree result into a thrown error.
+ *
+ * A returned value is serialized by the MCP bridge as a SUCCESSFUL tool result,
+ * so a failure reported in an `error` field beside an empty dump is invisible to
+ * an agent checking `isError` (#11543). Throwing routes it through
+ * EXECUTION_ERROR, which the bridge reports as a tool error. `generate` already
+ * did this; the other two returned their failures as success data.
+ */
+function throwOnCopyTreeFailure(result: CopyTreeResult): void {
+  const failure =
+    result && typeof result === "object" ? (result as { error?: string }).error : undefined;
+  if (failure) throw new Error(failure);
+}
 
 export function registerSystemActions(actions: ActionRegistry, _callbacks: ActionCallbacks): void {
   actions.set("system.openExternal", () =>
@@ -314,36 +360,49 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
       id: "copyTree.generate",
       title: "Generate CopyTree Context",
       description:
-        "Generate a CopyTree context dump (file tree plus selected file contents) for a worktree and return it as a string. Args (all optional): `worktreeId` or `worktreePath` — the worktree, defaults to the active one; `options` — CopyTree include/exclude options. Returns { content, fileCount, optional stats:{ totalSize, duration } }. Throws when generation fails or when no worktree is given and none is active. Do NOT use this to inject context into a terminal — use `copyTree.injectToTerminal`.",
+        "Generate a CopyTree context dump (file tree plus selected file contents) for a worktree and write it to a file, returning the path. Args (all optional): `worktreeId` or `worktreePath` — the worktree, defaults to the active one; `options` — CopyTree include/exclude options; `includeContent` — also return a bounded head of the bundle. Returns { filePath, fileCount, outputBytes, optional content, optional contentTruncated, optional stats:{ totalSize, duration } }. `filePath` is a temporary file that is pruned by age and count, so read it promptly. The bundle is NOT returned inline by default — it routinely runs to tens of megabytes, far past what any tool result can carry; `includeContent` returns only the first few KB. Throws when generation fails or when no worktree is given and none is active. Do NOT use this to inject context into a terminal — use `copyTree.injectToTerminal`.",
       category: "copyTree",
       kind: "query",
       danger: "safe",
       scope: "renderer",
       keywords: ["context", "dump", "snapshot", "tree"],
+      // Kind stays `query` — this reads a worktree and the palette treats it as
+      // one — but the annotations it would imply are now false: every call
+      // writes a new temp file, so the result is neither read-only nor the same
+      // twice (#11528).
+      mcpAnnotations: { readOnlyHint: false, idempotentHint: false },
       argsSchema: withWorktreeLocation({
         options: CopyTreeOptionsSchema.optional(),
+        includeContent: z
+          .boolean()
+          .optional()
+          .describe(
+            "Also return a bounded head of the bundle in `content`. Capped well under the tool-result limit; `contentTruncated` reports when it was cut. The file at `filePath` always holds the whole bundle."
+          ),
       }).optional(),
-      resultSchema: z.object({
-        content: z.string(),
-        fileCount: z.number(),
-        stats: z
-          .object({
-            totalSize: z.number(),
-            duration: z.number(),
-          })
-          .optional(),
-      }),
+      resultSchema: CopyTreeGenerateResultSchema,
+      // A `resultSchema` alone advertises nothing — the manifest only publishes
+      // an MCP outputSchema when this flag is set too.
+      mcpOutputSchema: true,
       run: async (args, ctx: ActionContext) => {
-        const result = await copyTreeClient.generate(requireWorktreeId(args, ctx), args?.options);
-        // A generation failure used to ride back in an `error` field beside an
-        // empty dump. The MCP bridge serializes a returned value as a SUCCESSFUL
-        // tool result, so an agent checking `isError` never saw it (#11543).
-        // Throwing routes it through EXECUTION_ERROR, which the bridge reports
-        // as a tool error. Everything else passes through untouched.
-        const failure =
-          result && typeof result === "object" ? (result as { error?: string }).error : undefined;
-        if (failure) throw new Error(failure);
-        return result;
+        const result = await copyTreeClient.generate(
+          requireWorktreeId(args, ctx),
+          args?.options,
+          args?.includeContent
+        );
+        throwOnCopyTreeFailure(result);
+        // Projected explicitly rather than passed through: `resultSchema` is
+        // manifest documentation and strips nothing, so omitting `content` from
+        // the schema would not stop it reaching the wire. Building the result
+        // here is what actually keeps the bundle off it.
+        return {
+          filePath: result.filePath,
+          fileCount: result.fileCount,
+          outputBytes: result.outputBytes,
+          ...(result.content ? { content: result.content } : {}),
+          ...(result.contentTruncated ? { contentTruncated: true } : {}),
+          ...(result.stats ? { stats: projectCopyTreeStats(result.stats) } : {}),
+        };
       },
     })
   );
@@ -352,7 +411,8 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
     defineAction({
       id: "copyTree.generateAndCopyFile",
       title: "Generate And Copy Context",
-      description: "Generate worktree context and copy to clipboard",
+      description:
+        "Generate worktree context, write it to a file and put that file on the clipboard. Args (all optional): `worktreeId` — the worktree, defaults to the active one; `options` — CopyTree include/exclude options. Returns { filePath, fileCount, outputBytes, optional stats:{ totalSize, duration } }. The bundle is never returned inline. Throws when generation or the clipboard write fails.",
       category: "copyTree",
       kind: "command",
       danger: "safe",
@@ -374,10 +434,24 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
           options: CopyTreeOptionsSchema.optional(),
         })
         .optional(),
+      resultSchema: z.object({
+        filePath: z.string(),
+        fileCount: z.number(),
+        outputBytes: z.number(),
+        stats: CopyTreeStatsSchema,
+      }),
+      mcpOutputSchema: true,
       run: async (args, ctx: ActionContext) => {
         const worktreeId = args?.worktreeId ?? ctx.activeWorktreeId;
         if (!worktreeId) throw new Error("No active worktree");
-        return await copyTreeClient.generateAndCopyFile(worktreeId, args?.options);
+        const result = await copyTreeClient.generateAndCopyFile(worktreeId, args?.options);
+        throwOnCopyTreeFailure(result);
+        return {
+          filePath: result.filePath,
+          fileCount: result.fileCount,
+          outputBytes: result.outputBytes,
+          ...(result.stats ? { stats: projectCopyTreeStats(result.stats) } : {}),
+        };
       },
     })
   );
@@ -386,7 +460,8 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
     defineAction({
       id: "copyTree.injectToTerminal",
       title: "Inject Context To Terminal",
-      description: "Inject worktree context into a terminal",
+      description:
+        "Write a worktree's CopyTree context straight into a terminal. Args: `terminalId` — required; `worktreeId` — defaults to the active worktree; `options` — CopyTree include/exclude options. Returns { fileCount, optional stats:{ totalSize, duration } } — the context goes to the terminal, never back through this result. Throws when generation or injection fails.",
       category: "copyTree",
       kind: "command",
       danger: "safe",
@@ -397,10 +472,25 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
         worktreeId: z.string().optional().describe("Worktree ID. Defaults to the active worktree."),
         options: CopyTreeOptionsSchema.optional(),
       }),
+      // No path: this bundle is streamed into the PTY and never written to disk.
+      resultSchema: z.object({
+        fileCount: z.number(),
+        stats: CopyTreeStatsSchema,
+      }),
+      mcpOutputSchema: true,
       run: async ({ terminalId, worktreeId, options }, ctx: ActionContext) => {
         const resolvedWorktreeId = worktreeId ?? ctx.activeWorktreeId;
         if (!resolvedWorktreeId) throw new Error("No active worktree");
-        return await copyTreeClient.injectToTerminal(terminalId, resolvedWorktreeId, options);
+        const result = await copyTreeClient.injectToTerminal(
+          terminalId,
+          resolvedWorktreeId,
+          options
+        );
+        throwOnCopyTreeFailure(result);
+        return {
+          fileCount: result.fileCount,
+          ...(result.stats ? { stats: projectCopyTreeStats(result.stats) } : {}),
+        };
       },
     })
   );


### PR DESCRIPTION
## Summary

`copyTree.generate` was returning the entire generated context bundle as one inline string. On this repo with default args that's 31.2 MB, roughly 7.8 million tokens, 3,555 files, and it sits on the lowest MCP tier, so every consumer can reach it.

The wire size isn't even the real problem. The bundle was built as one contiguous string inside the copytree worker thread, then cloned across four process boundaries (worker to workspace-host, host to main, main to renderer, plus a renderer-scoped MCP dispatch bounce) before #11526's 50 KiB transport cap trimmed it down. That cap protects the wire. Nothing protected the heap.

Resolves #11528

## Changes

- `copyTree.generate` now streams the bundle straight to a temp file inside the worker via copytree's `copyStream()`, and returns `{ filePath, fileCount, outputBytes }`. Only metadata crosses a process boundary. `copy({ output })` would not have worked here, it materializes the whole document in memory first and only then writes it.
- An explicit `includeContent` opt-in reads a bounded head back from the file. It's fitted against a 48 KiB *serialized* budget, not a raw byte count: JSON escaping doubles newlines and quotes and expands C0 controls sixfold, so a raw 32 KiB head can serialize to 192 KiB and trip the transport's `isError` path, which is exactly the failure this is meant to avoid.
- Bundles publish atomically: a unique `.part` file gets renamed onto the destination, so a caller that finds the final path never finds a truncated prefix. Aborts and failures clean up both paths.
- New `copyTreeOutputFile` module owns the temp directory: owner-only mode, collision-proof naming, age/count pruning. Generation is now MCP-triggered at 5 calls per 10s, so nothing else was ever going to clean this up. Pruning only ever matches filenames it generates, and the directory is rejected outright if a symlink is sitting on the name.
- `generateAndCopyFile` routes through the same worker-side write. It already wrote this exact file, just from the main process, after paying for all three crossings.

Reviewed in the same pass, since the issue asked for the siblings to be checked too:

- All three copyTree actions now carry a `resultSchema` *and* `mcpOutputSchema: true`. A `resultSchema` alone advertises nothing, `ActionService.computeSchemas` requires both, so `copyTree.generate` had been publishing no MCP output schema at all despite having one defined.
- `generateAndCopyFile` and `injectToTerminal` still had the #11543 bug: they returned failures as `{ error }` beside an empty dump, which the MCP bridge serializes as a successful tool result. Both now throw.
- `sort` was missing from the action-side `CopyTreeOptionsSchema` while the IPC schema and shared type both accepted it, so an MCP caller's sort order was silently dropped.
- `generate` keeps `kind: "query"`, but now declares `readOnlyHint: false` and `idempotentHint: false`. It writes a new file per call, so the annotations `query` implies were untrue.

## Testing

447 tests across 17 suites pass locally, typecheck is clean. Two new suites, `copyTreeOutputFile.test.ts` and `CopyTreeService.stream.test.ts`, cover the cleanup matrix, UTF-8 boundary handling, the serialized-budget fit, and pruning. Two e2e specs were updated for the new default shape.
