### PR TITLE
fix(markdown): re-request local images when they change on disk

### DIFF
--- a/src/components/Markdown/MarkdownDocument.tsx
+++ b/src/components/Markdown/MarkdownDocument.tsx
@@ -141,10 +141,11 @@ export function MarkdownDocument({
         // as the file itself.
         if (HTTPish.test(url) || url.startsWith("data:")) return defaultUrlTransform(url);
         const local = buildDaintreeFileUrl(resolveAgainstFile(filePath, url), rootPath);
-        // Undefined-checked rather than truthy: "" is a token a host may hold
-        // before its first refresh, and dropping it there would make the very
-        // first rewrite invisible. The protocol handler reads only path/root,
-        // so `v` is inert to it.
+        // Undefined-checked rather than truthy, matching FileImagePreview and
+        // ZoomableImage: the token is opaque, so only "no host is tracking
+        // freshness" suppresses it — "" is a value like any other, and folding
+        // it in with absent would make a host that legitimately reached "" stop
+        // busting. The protocol handler reads only path/root, so `v` is inert.
         return cacheBust === undefined ? local : `${local}&v=${encodeURIComponent(cacheBust)}`;
       }
       return defaultUrlTransform(url);

--- a/src/components/Markdown/MarkdownDocument.tsx
+++ b/src/components/Markdown/MarkdownDocument.tsx
@@ -10,6 +10,7 @@ import {
   isLanguageRegistered,
 } from "@/components/Worktree/diffRefractor";
 import { dirname, isAbsolute, isPathInside, join, normalize } from "@shared/utils/path";
+import { buildDaintreeFileUrl } from "@/components/FileViewer/filePreviewKinds";
 import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
 import { cn } from "@/lib/utils";
@@ -22,6 +23,14 @@ export interface MarkdownDocumentProps {
   filePath: string;
   /** Containment root for daintree-file:// image loads */
   rootPath: string;
+  /**
+   * Cache-busting token appended to local image URLs. The daintree-file:// URL
+   * is otherwise a pure function of path + root, so a rewritten image keeps a
+   * byte-identical `src` and Chromium never refetches it (#11587). Hosts pass
+   * whatever token already tracks their refresh cycle; same `cacheBust` idiom
+   * as FileImagePreview and ZoomableImage.
+   */
+  cacheBust?: string;
   className?: string;
   /**
    * Fired once the document has committed. Hosts that pinned their height
@@ -97,10 +106,6 @@ function resolveAgainstFile(filePath: string, target: string): string {
   return isAbsolute(target) ? normalize(target) : normalize(join(dirname(filePath), target));
 }
 
-function buildDaintreeFileUrl(filePath: string, rootPath: string): string {
-  return `daintree-file://load?path=${encodeURIComponent(filePath)}&root=${encodeURIComponent(rootPath)}`;
-}
-
 const HTTPish = /^(https?|mailto):/i;
 
 /**
@@ -115,6 +120,7 @@ export function MarkdownDocument({
   content,
   filePath,
   rootPath,
+  cacheBust,
   className,
   onRendered,
 }: MarkdownDocumentProps) {
@@ -134,11 +140,16 @@ export function MarkdownDocument({
         // images referenced by specs render with the same containment checks
         // as the file itself.
         if (HTTPish.test(url) || url.startsWith("data:")) return defaultUrlTransform(url);
-        return buildDaintreeFileUrl(resolveAgainstFile(filePath, url), rootPath);
+        const local = buildDaintreeFileUrl(resolveAgainstFile(filePath, url), rootPath);
+        // Undefined-checked rather than truthy: "" is a token a host may hold
+        // before its first refresh, and dropping it there would make the very
+        // first rewrite invisible. The protocol handler reads only path/root,
+        // so `v` is inert to it.
+        return cacheBust === undefined ? local : `${local}&v=${encodeURIComponent(cacheBust)}`;
       }
       return defaultUrlTransform(url);
     };
-  }, [filePath, rootPath]);
+  }, [filePath, rootPath, cacheBust]);
 
   const handleLinkActivate = useMemo(() => {
     return (href: string | undefined) => {

--- a/src/components/Markdown/MarkdownViewer.tsx
+++ b/src/components/Markdown/MarkdownViewer.tsx
@@ -26,6 +26,13 @@ export interface MarkdownViewerProps {
   initialLine?: number;
   /** Source-mode only: soft-wrap long lines */
   wrapLines?: boolean;
+  /**
+   * Rendered-mode only: cache-busting token for local images. Without it a
+   * rewritten image keeps a byte-identical daintree-file:// src and Chromium
+   * never refetches it (#11587). Source mode renders raw text, so there is no
+   * image to bust — hosts only pass this where they render the document.
+   */
+  cacheBust?: string;
   className?: string;
   /**
    * Rendered-mode only: fired once the rendered document has committed. Hosts
@@ -42,7 +49,17 @@ export interface MarkdownViewerProps {
  */
 export const MarkdownViewer = forwardRef<MarkdownViewerHandle, MarkdownViewerProps>(
   function MarkdownViewer(
-    { content, filePath, rootPath, viewMode, initialLine, wrapLines, className, onRendered },
+    {
+      content,
+      filePath,
+      rootPath,
+      viewMode,
+      initialLine,
+      wrapLines,
+      cacheBust,
+      className,
+      onRendered,
+    },
     ref
   ) {
     const codeViewerRef = useRef<CodeViewerHandle>(null);
@@ -82,6 +99,7 @@ export const MarkdownViewer = forwardRef<MarkdownViewerHandle, MarkdownViewerPro
           content={content}
           filePath={filePath}
           rootPath={rootPath}
+          cacheBust={cacheBust}
           className={cn("px-6 py-5", className)}
           onRendered={onRendered}
         />

--- a/src/components/Markdown/__tests__/MarkdownDocument.test.tsx
+++ b/src/components/Markdown/__tests__/MarkdownDocument.test.tsx
@@ -133,6 +133,9 @@ describe("MarkdownDocument", () => {
     expect(src.startsWith("daintree-file://load?")).toBe(true);
     expect(decodeURIComponent(src)).toContain("/repo/docs/img/arch.png");
     expect(decodeURIComponent(src)).toContain("root=/repo");
+    // No host token supplied: the URL must stay clean rather than pick up an
+    // empty or "undefined" parameter.
+    expect(new URL(src).searchParams.has("v")).toBe(false);
   });
 
   it("keeps remote image sources untouched", () => {
@@ -142,6 +145,61 @@ describe("MarkdownDocument", () => {
     expect(container.querySelector("img")?.getAttribute("src")).toBe(
       "https://example.com/logo.png"
     );
+  });
+
+  it("carries the cache token on local images only, never on remote images or links", () => {
+    // A token with a space and an ampersand would corrupt the query string if it
+    // were interpolated raw; round-tripping it through searchParams proves it is
+    // encoded without restating how.
+    const token = "rev 1&2";
+    const { container } = render(
+      <MarkdownDocument
+        {...FIXTURE_PROPS}
+        cacheBust={token}
+        content={[
+          "![diagram](./img/arch.png)",
+          "",
+          "![logo](https://example.com/logo.png)",
+          "",
+          "[spec](./other.md)",
+        ].join("\n")}
+      />
+    );
+
+    const [local, remote] = Array.from(container.querySelectorAll("img"));
+    const localUrl = new URL(local!.getAttribute("src") ?? "");
+    expect(localUrl.searchParams.get("v")).toBe(token);
+    // The token rides alongside the routing params rather than displacing them.
+    expect(localUrl.searchParams.get("path")).toBe("/repo/docs/img/arch.png");
+    expect(localUrl.searchParams.get("root")).toBe("/repo");
+
+    // Remote images short-circuit before the daintree-file branch, and link
+    // hrefs never enter it at all — neither may leak the token.
+    expect(remote!.getAttribute("src")).toBe("https://example.com/logo.png");
+    expect(screen.getByRole("link", { name: "spec" }).getAttribute("href")).not.toContain("v=");
+  });
+
+  it("rebuilds local image sources when only the cache token changes", () => {
+    // The regression guard for #11587: a rewritten image keeps the same path and
+    // root, so the src is byte-identical and Chromium never refetches it. This
+    // fails if the token is dropped from the urlTransform memo's dependencies.
+    const content = "![diagram](./img/arch.png)";
+    const { container, rerender } = render(
+      <MarkdownDocument {...FIXTURE_PROPS} cacheBust="rev-1" content={content} />
+    );
+    const before = container.querySelector("img")!.getAttribute("src") ?? "";
+
+    rerender(<MarkdownDocument {...FIXTURE_PROPS} cacheBust="rev-2" content={content} />);
+    const after = container.querySelector("img")!.getAttribute("src") ?? "";
+
+    expect(after).not.toBe(before);
+    const afterUrl = new URL(after);
+    expect(afterUrl.searchParams.get("v")).toBe("rev-2");
+    // Only the token moved: still the same file under the same containment root.
+    expect(afterUrl.searchParams.get("path")).toBe(
+      new URL(before).searchParams.get("path")
+    );
+    expect(afterUrl.searchParams.get("root")).toBe(new URL(before).searchParams.get("root"));
   });
 
   it("opens external links through browser.openExternal instead of navigating", () => {

--- a/src/components/Markdown/__tests__/MarkdownDocument.test.tsx
+++ b/src/components/Markdown/__tests__/MarkdownDocument.test.tsx
@@ -179,27 +179,45 @@ describe("MarkdownDocument", () => {
     expect(screen.getByRole("link", { name: "spec" }).getAttribute("href")).not.toContain("v=");
   });
 
-  it("rebuilds local image sources when only the cache token changes", () => {
+  it("treats an empty token as a value to carry, not as an absent one", () => {
+    // The distinction the `=== undefined` check exists to make. A truthiness
+    // check would swallow "" and silently stop busting for a host that reached
+    // it — with only the undefined and non-empty cases covered, that swap would
+    // leave every other test in this file green.
+    const { container } = render(
+      <MarkdownDocument {...FIXTURE_PROPS} cacheBust="" content={"![diagram](./img/arch.png)"} />
+    );
+
+    const url = new URL(container.querySelector("img")!.getAttribute("src") ?? "");
+    expect(url.searchParams.has("v")).toBe(true);
+    expect(url.searchParams.get("v")).toBe("");
+  });
+
+  it("rebuilds local image sources in place when only the cache token changes", () => {
     // The regression guard for #11587: a rewritten image keeps the same path and
     // root, so the src is byte-identical and Chromium never refetches it. This
-    // fails if the token is dropped from the urlTransform memo's dependencies.
+    // fails if the token is dropped from the urlTransform memo's dependencies —
+    // the stale closure would keep emitting the first token.
     const content = "![diagram](./img/arch.png)";
     const { container, rerender } = render(
       <MarkdownDocument {...FIXTURE_PROPS} cacheBust="rev-1" content={content} />
     );
-    const before = container.querySelector("img")!.getAttribute("src") ?? "";
+    const imgBefore = container.querySelector("img")!;
+    const before = imgBefore.getAttribute("src") ?? "";
 
     rerender(<MarkdownDocument {...FIXTURE_PROPS} cacheBust="rev-2" content={content} />);
-    const after = container.querySelector("img")!.getAttribute("src") ?? "";
+    const imgAfter = container.querySelector("img")!;
+    const after = imgAfter.getAttribute("src") ?? "";
 
     expect(after).not.toBe(before);
     const afterUrl = new URL(after);
     expect(afterUrl.searchParams.get("v")).toBe("rev-2");
     // Only the token moved: still the same file under the same containment root.
-    expect(afterUrl.searchParams.get("path")).toBe(
-      new URL(before).searchParams.get("path")
-    );
+    expect(afterUrl.searchParams.get("path")).toBe(new URL(before).searchParams.get("path"));
     expect(afterUrl.searchParams.get("root")).toBe(new URL(before).searchParams.get("root"));
+    // The whole reason for busting the src rather than keying the document: the
+    // element is reused, so the reader's scroll position survives the swap.
+    expect(imgAfter).toBe(imgBefore);
   });
 
   it("opens external links through browser.openExternal instead of navigating", () => {

--- a/src/components/Markdown/__tests__/MarkdownViewer.test.tsx
+++ b/src/components/Markdown/__tests__/MarkdownViewer.test.tsx
@@ -38,6 +38,23 @@ describe("MarkdownViewer", () => {
     await waitFor(() => expect(onRendered).toHaveBeenCalledTimes(1));
   });
 
+  // #11587: the token has to survive the lazy() boundary. The document itself is
+  // covered in MarkdownDocument.test.tsx; what this pins is the forwarding, which
+  // could be deleted with every document-level test still green.
+  it("forwards the cache token across the lazy boundary to local images", async () => {
+    render(
+      <MarkdownViewer
+        {...FIXTURE_PROPS}
+        content={"![diagram](./img/arch.png)"}
+        viewMode="rendered"
+        cacheBust="rev-7"
+      />
+    );
+
+    const img = await screen.findByRole("img", { name: "diagram" });
+    expect(new URL(img.getAttribute("src") ?? "").searchParams.get("v")).toBe("rev-7");
+  });
+
   it("stays silent in source mode, which has no chunk to wait on", () => {
     const onRendered = vi.fn();
     render(<MarkdownViewer {...FIXTURE_PROPS} viewMode="source" onRendered={onRendered} />);

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -618,11 +618,17 @@ export function FileBrowserViewer({
             {/* min-h-full, never h-full: a floor lets a tall document grow past
                 the wrapper and scroll it, while a short one still fills the
                 preview. h-full would clamp it and silently restore the bug. */}
+            {/* `cacheBust` rather than a new `key`, for the same reason as the
+                image branch above: remounting would throw away the reader's
+                scroll position, while changing the image srcs reloads the
+                bytes in place. Unlike video/audio/pdf there is no playback to
+                interrupt (#11587). */}
             <MarkdownViewer
               content={state.content}
               filePath={filePath}
               rootPath={rootPath}
               viewMode={markdownMode}
+              cacheBust={revision}
               className="min-h-full"
             />
           </div>

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -191,20 +191,7 @@ describe("FileBrowserViewer rendered-markdown image freshness (#11587)", () => {
     await waitFor(() => expect(currentViewMode()).toBe("rendered"));
     expect(currentCacheBust()).toBe("r1");
 
-    rerender(
-      <TooltipProvider>
-        <FileBrowserViewer
-          filePath="/repo/docs/spec.md"
-          rootPath="/repo"
-          fileName="spec.md"
-          relativePath="spec.md"
-          revision="r2"
-          sidebarCollapsed={false}
-          onToggleSidebar={vi.fn()}
-          treeSidebarId="file-tree-column"
-        />
-      </TooltipProvider>
-    );
+    rerender(viewerJsx("/repo/docs/spec.md", { revision: "r2" }));
     await waitFor(() => expect(currentCacheBust()).toBe("r2"));
   });
 });

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -1,6 +1,9 @@
 // @vitest-environment jsdom
 import { render, act, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+// Type-only: erased before the vi.mock factory runs, so it cannot pull the real
+// module in ahead of its own mock.
+import type { MarkdownViewerProps } from "@/components/Markdown/MarkdownViewer";
 
 // FileBrowserViewer is the read-only preview beside the tree. #11319 adds a
 // Source/Rendered toggle for markdown, mirroring FilePane. Mock the heavy leaf
@@ -23,7 +26,7 @@ vi.mock("@/services/ActionService", () => ({
 // observable — without it the mode plumbing could be deleted and stay green.
 // cacheBust rides along for the same reason (#11587).
 vi.mock("@/components/Markdown/MarkdownViewer", () => ({
-  MarkdownViewer: (props: { viewMode: string; cacheBust?: string }) => (
+  MarkdownViewer: (props: Pick<MarkdownViewerProps, "viewMode" | "cacheBust">) => (
     <div
       data-testid="markdown-viewer-mock"
       data-view-mode={props.viewMode}

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -18,12 +18,17 @@ vi.mock("@/services/ActionService", () => ({
   actionService: { dispatch: dispatchMock },
 }));
 
-// A real MarkdownViewer lazy-loads its renderer, hiding the prop under test.
+// A real MarkdownViewer lazy-loads its renderer, hiding the props under test.
 // The mock surfaces viewMode as a data attribute so the toggle wiring is
 // observable — without it the mode plumbing could be deleted and stay green.
+// cacheBust rides along for the same reason (#11587).
 vi.mock("@/components/Markdown/MarkdownViewer", () => ({
-  MarkdownViewer: (props: { viewMode: string }) => (
-    <div data-testid="markdown-viewer-mock" data-view-mode={props.viewMode} />
+  MarkdownViewer: (props: { viewMode: string; cacheBust?: string }) => (
+    <div
+      data-testid="markdown-viewer-mock"
+      data-view-mode={props.viewMode}
+      data-cache-bust={props.cacheBust ?? ""}
+    />
   ),
 }));
 vi.mock("@/components/FileViewer/CodeViewer", () => ({
@@ -94,6 +99,10 @@ async function clickMode(label: "Source" | "Rendered") {
 
 function currentViewMode(): string | null {
   return screen.getByTestId("markdown-viewer-mock").getAttribute("data-view-mode");
+}
+
+function currentCacheBust(): string | null {
+  return screen.getByTestId("markdown-viewer-mock").getAttribute("data-cache-bust");
 }
 
 beforeEach(() => {
@@ -167,6 +176,33 @@ describe("FileBrowserViewer markdown Source/Rendered toggle (#11319)", () => {
     expect(screen.queryByRole("button", { name: "Source" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Rendered" })).toBeNull();
     expect(screen.queryByTestId("markdown-viewer-mock")).toBeNull();
+  });
+});
+
+describe("FileBrowserViewer rendered-markdown image freshness (#11587)", () => {
+  it("hands the refresh revision to the rendered document as its cache token", async () => {
+    // Embedded images resolve to daintree-file:// URLs built from path + root, so
+    // a rewritten image is invisible unless something in the URL moves. This is
+    // the same freshness choice the image branch already makes with ZoomableImage.
+    const { rerender } = renderViewer("/repo/docs/spec.md", { revision: "r1" });
+    await waitFor(() => expect(currentViewMode()).toBe("rendered"));
+    expect(currentCacheBust()).toBe("r1");
+
+    rerender(
+      <TooltipProvider>
+        <FileBrowserViewer
+          filePath="/repo/docs/spec.md"
+          rootPath="/repo"
+          fileName="spec.md"
+          relativePath="spec.md"
+          revision="r2"
+          sidebarCollapsed={false}
+          onToggleSidebar={vi.fn()}
+          treeSidebarId="file-tree-column"
+        />
+      </TooltipProvider>
+    );
+    await waitFor(() => expect(currentCacheBust()).toBe("r2"));
   });
 });
 

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -1226,6 +1226,7 @@ export function FilePane({
               rootPath={effectiveRootPath}
               viewMode="rendered"
               wrapLines={markdownWrapLines}
+              cacheBust={String(reloadNonce)}
               onRendered={heightHold.handleRendered}
             />
           ) : viewMode === "rendered" && isHtml ? (

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -663,7 +663,18 @@ export function FilePane({
           // toolbar Refresh) stay unconditional, keeping a manual path for an
           // asset-only change. reloadNonce isn't a loadFile dep, so neither can
           // re-trigger the load.
-          if (!silent || bytesChanged) setReloadNonce((nonce) => nonce + 1);
+          //
+          // Markdown opts out of the bytes-changed gate: an image embedded in the
+          // document is precisely the "unchanged file whose asset changed" case,
+          // and bytesChanged only ever sees the markdown text (#11587). Bumping
+          // freely is safe here because for a markdown file the nonce reaches
+          // nothing but MarkdownViewer's cacheBust — the frame this rule protects
+          // needs isHtml, and the media previews need their own loadStates — and
+          // a changed image src reloads in place rather than remounting, so there
+          // is no scroll or playback position to lose.
+          if (!silent || bytesChanged || isMarkdownFilePath(filePath)) {
+            setReloadNonce((nonce) => nonce + 1);
+          }
           setLoadState("loaded");
           setErrorCode(null);
           setErrorMessage(null);

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -121,11 +121,13 @@ vi.mock("@/lib/notify", () => ({ notify: notifyMock }));
 // Captures the props FilePane hands the rendered viewer so the #11255 release
 // chain (FilePane → MarkdownViewer.onRendered → the height pin) is observable;
 // without this the wiring could be deleted with every test still green.
+// cacheBust rides along for #11587: without it a rewritten embedded image keeps
+// a byte-identical daintree-file:// src and never refetches.
 const markdownViewerProps = vi.hoisted(() => ({
-  current: null as { onRendered?: () => void } | null,
+  current: null as { onRendered?: () => void; cacheBust?: string } | null,
 }));
 vi.mock("@/components/Markdown/MarkdownViewer", () => ({
-  MarkdownViewer: (props: { onRendered?: () => void }) => {
+  MarkdownViewer: (props: { onRendered?: () => void; cacheBust?: string }) => {
     markdownViewerProps.current = props;
     return <div data-testid="markdown-viewer-mock" />;
   },
@@ -941,6 +943,26 @@ describe("FilePane HTML Source/Rendered (#11191)", () => {
     renderPane("/repo/docs/spec.md", "rendered");
     expect(await screen.findByTestId("markdown-viewer-mock")).toBeTruthy();
     expect(screen.queryByTestId("html-viewer-mock")).toBeNull();
+  });
+
+  // #11587: images embedded in the document resolve to daintree-file:// URLs
+  // built from path + root alone, so a rewritten image stays invisible unless the
+  // pane advances a token. Refresh is the user-facing path that has to move it.
+  it("advances the rendered document's cache token when the pane re-reads the file", async () => {
+    renderPane("/repo/docs/spec.md", "rendered");
+    await screen.findByTestId("markdown-viewer-mock");
+    const before = markdownViewerProps.current?.cacheBust;
+    // The token must exist before it can be meaningfully compared — an
+    // unthreaded prop would leave both sides undefined and pass a bare !==.
+    expect(before).toBeDefined();
+
+    await act(async () => {
+      screen
+        .getByRole("button", { name: "Refresh" })
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    await waitFor(() => expect(markdownViewerProps.current?.cacheBust).not.toBe(before));
   });
 
   // The toolbar's open button follows the view: rendered HTML opens in the

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -3,6 +3,9 @@ import type { ReactNode } from "react";
 import { render, act, screen, waitFor, fireEvent } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GitStatus } from "@shared/types/git";
+// Type-only: erased before the vi.mock factory runs, so it cannot pull the real
+// module in ahead of its own mock.
+import type { MarkdownViewerProps } from "@/components/Markdown/MarkdownViewer";
 
 // FilePane forwards a fixed prop list to ContentPanel; #10991 was a dropped
 // `showRestoreControl`, which hid the inline "Move to grid" button on a docked
@@ -122,12 +125,15 @@ vi.mock("@/lib/notify", () => ({ notify: notifyMock }));
 // chain (FilePane → MarkdownViewer.onRendered → the height pin) is observable;
 // without this the wiring could be deleted with every test still green.
 // cacheBust rides along for #11587: without it a rewritten embedded image keeps
-// a byte-identical daintree-file:// src and never refetches.
+// a byte-identical daintree-file:// src and never refetches. Picked off the real
+// prop type rather than hand-written, so renaming either prop fails here instead
+// of silently capturing undefined forever.
+type CapturedMarkdownProps = Pick<MarkdownViewerProps, "onRendered" | "cacheBust">;
 const markdownViewerProps = vi.hoisted(() => ({
   current: null as { onRendered?: () => void; cacheBust?: string } | null,
 }));
 vi.mock("@/components/Markdown/MarkdownViewer", () => ({
-  MarkdownViewer: (props: { onRendered?: () => void; cacheBust?: string }) => {
+  MarkdownViewer: (props: CapturedMarkdownProps) => {
     markdownViewerProps.current = props;
     return <div data-testid="markdown-viewer-mock" />;
   },
@@ -947,13 +953,13 @@ describe("FilePane HTML Source/Rendered (#11191)", () => {
 
   // #11587: images embedded in the document resolve to daintree-file:// URLs
   // built from path + root alone, so a rewritten image stays invisible unless the
-  // pane advances a token. Refresh is the user-facing path that has to move it.
-  it("advances the rendered document's cache token when the pane re-reads the file", async () => {
+  // pane advances a token. Refresh is the explicit path that has to move it.
+  it("advances the rendered document's cache token on an explicit Refresh", async () => {
     renderPane("/repo/docs/spec.md", "rendered");
     await screen.findByTestId("markdown-viewer-mock");
     const before = markdownViewerProps.current?.cacheBust;
-    // The token must exist before it can be meaningfully compared — an
-    // unthreaded prop would leave both sides undefined and pass a bare !==.
+    // Both sides must be real values: an unthreaded prop would leave them
+    // undefined, and a bare inequality would never notice.
     expect(before).toBeDefined();
 
     await act(async () => {
@@ -963,6 +969,30 @@ describe("FilePane HTML Source/Rendered (#11191)", () => {
     });
 
     await waitFor(() => expect(markdownViewerProps.current?.cacheBust).not.toBe(before));
+    expect(markdownViewerProps.current?.cacheBust).toBeDefined();
+  });
+
+  // The failure #11587 actually reports: an agent rewrites ./img/arch.png while
+  // spec.md itself is untouched. The silent re-read sees identical markdown, so a
+  // bytes-changed gate would hold the token still and the stale image would stay
+  // on screen. Only markdown opts out of that gate — this is what pins it.
+  it("advances the token on a silent re-read even when the markdown bytes are unchanged", async () => {
+    renderPane("/repo/docs/spec.md", "rendered");
+    await screen.findByTestId("markdown-viewer-mock");
+    const before = markdownViewerProps.current?.cacheBust;
+    expect(before).toBeDefined();
+    const readsBefore = readMock.mock.calls.length;
+
+    // A loaded file reloads silently, so window focus regain re-reads it. The
+    // mocked read returns the same content both times — exactly the asset-only
+    // rewrite this has to survive.
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    await waitFor(() => expect(readMock.mock.calls.length).toBeGreaterThan(readsBefore));
+    await waitFor(() => expect(markdownViewerProps.current?.cacheBust).not.toBe(before));
+    expect(markdownViewerProps.current?.cacheBust).toBeDefined();
   });
 
   // The toolbar's open button follows the view: rendered HTML opens in the


### PR DESCRIPTION
## Summary

- `MarkdownDocument` built its `daintree-file://` image URLs purely from `filePath` plus `rootPath`, so a rewritten local image kept a byte-identical `<img src>` and Chromium never re-issued the request. The `no-store` `Cache-Control` header doesn't help here since it only governs a request that never happens.
- Every other local-media path in the app (`FileImagePreview`, `ZoomableImage`, `useMediaBlobUrl`) already carries a cache-bust token. Rendered markdown was the one gap.
- Also fixed a second bug found in review: `FilePane`'s reload nonce only advanced on a silent re-read when the markdown bytes themselves changed, so rewriting a referenced image while the markdown file stayed untouched (the scenario in the issue) still showed the stale image.

Resolves #11587

## Changes

- Added an optional `cacheBust?: string` prop to `MarkdownDocument` and `MarkdownViewer`, appended to local image URLs as an encoded `v` query param and included in the `urlTransform` memo's dependencies.
- Threaded it from the two rendered-mode hosts: `FilePane` (`String(reloadNonce)`) and `FileBrowserViewer` (`revision`). Source-mode call sites deliberately omit it, since `MarkdownViewer` returns `CodeViewer` before the `Suspense` branch and `MarkdownDocument` never mounts there.
- `FilePane` now opts markdown out of the bytes-changed gate on silent re-reads, so the nonce advances even when only a referenced image changed and the markdown bytes didn't. This is safe because for a markdown file the nonce only reaches `MarkdownViewer`'s `cacheBust` prop: the sandboxed HTML frame that gate protects requires `isHtml`, and media previews use their own `loadStates`. A changed image `src` reloads in place rather than remounting, so there's no scroll or playback position lost.
- Removed `MarkdownDocument`'s duplicate `buildDaintreeFileUrl` in favour of the shared helper in `filePreviewKinds.ts`. That drift is where the bug originated.

## Testing

413 tests across 11 covering files pass. New coverage includes:

- No token passed means no `v` param.
- Token present only on local images, never on remote images or link hrefs.
- Token change rebuilds the `src` while path and root stay stable, and the `<img>` element is reused rather than remounted.
- The empty-token branch, which a truthiness check would have silently swallowed.
- Forwarding across the `lazy()` boundary.
- The silent-re-read path, mutation-verified: reverting the production condition makes the test fail, restoring it makes it pass.

## Known limitations

- `FileBrowserViewer`'s `revision` ticks on every worktree write, so an N-image document re-requests all N images per tick. Chromium holds the old frame while the new one decodes, so there's no visible flicker, but path-scoped invalidation would be the proper fix and needs changed-path plumbing beyond this bugfix. `ZoomableImage` already accepts the same tradeoff.
- jsdom proves the `src` changes but can't prove Chromium actually re-issues the request. An Electron E2E test that rewrites an image under the same path would close that gap.
