### PR TITLE
fix(file-browser): refresh media previews and reach Refresh when collapsed

### DIFF
--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -387,8 +387,13 @@ export function FileBrowserPane({
     [location, onClose, basePath, rows]
   );
 
-  // Counted separately from the change tick so the toolbar's Refresh also
-  // re-reads the open file, not just the tree.
+  // The explicit half of the refresh signal, counted apart from the ambient
+  // change tick so Refresh also re-reads the open file, not just the tree. It
+  // then travels to the viewer BOTH ways, and both are load-bearing: merged
+  // into `viewerRevision` below, and handed over on its own as the media
+  // previews' reload key (#11586). Dropping the direct handoff makes Refresh
+  // inert for media again; substituting the merged value there restarts
+  // playback on every ambient write. Keep both.
   const [manualRefreshNonce, setManualRefreshNonce] = useState(0);
   const handleRefresh = useCallback(() => {
     setManualRefreshNonce((nonce) => nonce + 1);
@@ -397,7 +402,9 @@ export function FileBrowserPane({
 
   // One value per refresh *cycle*, not per directory listed. Deriving it from
   // the tree's per-listing commits would make a 500-directory refresh re-read
-  // the open file 500 times.
+  // the open file 500 times. Carrying the nonce here as well as separately is
+  // what re-runs the viewer's classification effect, so a media file stuck in
+  // `status: "error"` remounts its preview on Refresh instead of staying dead.
   const viewerRevision = `${changeTick ?? 0}:${manualRefreshNonce}`;
 
   const handleToggleDotfiles = useCallback(() => {

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -1018,6 +1018,13 @@ export function FileBrowserPane({
               fileName={selectedFileName}
               relativePath={selectedNode?.isDirectory === false ? (selectedPath ?? null) : null}
               revision={viewerRevision}
+              // Handed over separately from `revision` rather than pulled back
+              // out of it: the media previews may only re-fetch on the explicit
+              // half of that pair, and a merged string can't say which half
+              // moved (#11586).
+              manualRefreshNonce={manualRefreshNonce}
+              onRefresh={handleRefresh}
+              isRefreshing={isRefreshing}
               sidebarCollapsed={sidebarCollapsed}
               onToggleSidebar={handleToggleSidebar}
               treeSidebarId={treeSidebarId}

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -38,6 +38,7 @@ import {
   toFileReadErrorCode,
 } from "@/components/FileViewer/fileReadErrors";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { SpinningIcon } from "@/components/ui/SpinningIcon";
 import { Skeleton, SkeletonBone, SkeletonText } from "@/components/ui/Skeleton";
 import { SegmentedToggle } from "@/components/ui/SegmentedToggle";
 import { useDohertyGate } from "@/hooks/useDeferredLoading";
@@ -62,6 +63,18 @@ export interface FileBrowserViewerProps {
    * reflected instead of leaving stale bytes on screen.
    */
   revision: string;
+  /**
+   * Changes only when the user presses Refresh, never on an ambient worktree
+   * tick — the half of `revision` the media branches can safely honour. Typed
+   * `number` rather than `string | number` so handing it the merged `revision`
+   * (which also carries the change tick) is a compile error, not a silent
+   * regression to restarting playback on every background write.
+   */
+  manualRefreshNonce: number;
+  /** Runs the pane's manual refresh — re-reads the tree and the open file. */
+  onRefresh: () => void;
+  /** Whether that refresh is still draining; spins the Refresh icon. */
+  isRefreshing: boolean;
   /** Whether the tree sidebar is collapsed; drives the disclosure toggle's icon and state. */
   sidebarCollapsed: boolean;
   /** Opens/closes the tree sidebar. Owned by the pane, which persists the state. */
@@ -111,6 +124,9 @@ export function FileBrowserViewer({
   fileName,
   relativePath,
   revision,
+  manualRefreshNonce,
+  onRefresh,
+  isRefreshing,
   sidebarCollapsed,
   onToggleSidebar,
   treeSidebarId,
@@ -363,7 +379,26 @@ export function FileBrowserViewer({
               copied={pathCopied}
               onCopy={handleCopyPath}
             />
-            <FileViewerToolbar.Actions>
+          </>
+        )}
+        {/* Outside the `filePath` gate, unlike the actions below it: Refresh
+            re-reads the tree as well as the open file, and a workspace-rooted
+            browser has no change tick at all (#11482), so a collapsed sidebar
+            with nothing selected would otherwise offer no way to refresh
+            anything. */}
+        <FileViewerToolbar.Actions>
+          {/* Only while the tree column is collapsed away. Its header owns the
+              Refresh the rest of the time, and two identical buttons in one
+              panel would read as two different actions — the same
+              one-home-per-control rule that keeps the two disclosure toggles in
+              each other's columns (#11496). */}
+          {sidebarCollapsed && (
+            <FileViewerToolbar.IconButton label="Refresh" onClick={onRefresh}>
+              <SpinningIcon icon={RefreshCw} active={isRefreshing} className="h-4 w-4" />
+            </FileViewerToolbar.IconButton>
+          )}
+          {filePath && (
+            <>
               <FileViewerToolbar.IconButton
                 label={reveal.label}
                 onClick={() => void handleExternalAction("reveal")}
@@ -376,9 +411,9 @@ export function FileBrowserViewer({
               >
                 <ExternalLink className="h-4 w-4" />
               </FileViewerToolbar.IconButton>
-            </FileViewerToolbar.Actions>
-          </>
-        )}
+            </>
+          )}
+        </FileViewerToolbar.Actions>
       </FileViewerToolbar.Root>
       {filePath && externalError && (
         <InlineStatusBanner
@@ -491,14 +526,16 @@ export function FileBrowserViewer({
       case "video":
         return (
           <div className="h-full w-full overflow-auto">
-            {/* Deliberately NOT keyed on `revision`: it ticks on every worktree
-                write, and remounting the player would reset playback whenever
-                an agent touches any file. A rewritten video shows its new bytes
-                on re-selection — continuity beats freshness mid-playback. */}
+            {/* Reloaded on `manualRefreshNonce`, never on `revision`: that
+                ticks on every worktree write, and re-fetching would reset
+                playback whenever an agent touches any file. Pressing Refresh
+                is the one gesture that outranks continuity, so it — and only
+                it — pulls the rewritten bytes (#11586). */}
             <FileVideoPreview
               filePath={filePath}
               rootPath={rootPath}
               label={fileName}
+              reloadKey={manualRefreshNonce}
               onError={(error) =>
                 setState({
                   status: "error",
@@ -513,13 +550,14 @@ export function FileBrowserViewer({
       case "audio":
         return (
           <div className="h-full w-full overflow-auto">
-            {/* Deliberately NOT keyed on `revision`, for the same reason as
-                video above: a worktree write elsewhere must not restart the
-                track someone is listening to. */}
+            {/* Same split as video above: a worktree write elsewhere must not
+                restart the track someone is listening to, while Refresh
+                still re-fetches it on demand. */}
             <FileAudioPreview
               filePath={filePath}
               rootPath={rootPath}
               label={fileName}
+              reloadKey={manualRefreshNonce}
               onError={(error) =>
                 setState({
                   status: "error",
@@ -532,10 +570,15 @@ export function FileBrowserViewer({
 
       case "pdf":
         return (
-          // Same reasoning as the video case: no `revision` key. Remounting the
-          // frame on every worktree write would throw away the reader's page
-          // and zoom; a rewritten PDF shows new bytes on re-selection.
-          <FilePdfPreview filePath={filePath} rootPath={rootPath} label={fileName} />
+          // Same split as the video case: re-navigating the frame on every
+          // worktree write would throw away the reader's page and zoom, so only
+          // an explicit Refresh moves the key.
+          <FilePdfPreview
+            filePath={filePath}
+            rootPath={rootPath}
+            label={fileName}
+            reloadKey={manualRefreshNonce}
+          />
         );
 
       case "html":

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -1832,15 +1832,16 @@ describe("FileBrowserPane Refresh reachability and media wiring (#11586)", () =>
   });
 
   it("runs the pane's manual refresh from the viewer with nothing selected", () => {
-    // A workspace-rooted browser has no change tick (#11482), so with the tree
-    // hidden and no file selected this button is the only freshness signal
-    // there is.
+    // Nothing selected is not a dead layout: Refresh re-reads the tree, and a
+    // browser whose source reports no change tick (a workspace root, #11482)
+    // has no other freshness signal at all.
     mockPanel.browserSidebarCollapsed = true;
     renderPane();
-    expect(treeArgs.changeTick).toBeUndefined();
 
+    // getByRole, not the plural helper: this must be the one and only Refresh,
+    // and a missing button should fail here rather than inside fireEvent.
     act(() => {
-      fireEvent.click(refreshButtons()[0]!);
+      fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
     });
 
     expect(treeState.refresh).toHaveBeenCalledTimes(1);
@@ -1861,6 +1862,11 @@ describe("FileBrowserPane Refresh reachability and media wiring (#11586)", () =>
       blob: () => Promise.resolve(new Blob(["x"])),
     });
     vi.stubGlobal("fetch", fetchMock);
+    // Saved by hand: these are methods on URL, not globals, so
+    // `unstubAllGlobals` can't put them back and a later test would inherit
+    // this suite's sequence counter.
+    const realCreateObjectURL = URL.createObjectURL;
+    const realRevokeObjectURL = URL.revokeObjectURL;
     URL.createObjectURL = vi.fn(() => `blob:app://daintree/pane-audio-${objectUrlSequence++}`);
     URL.revokeObjectURL = vi.fn();
 
@@ -1876,21 +1882,32 @@ describe("FileBrowserPane Refresh reachability and media wiring (#11586)", () =>
       expect(String(fetchMock.mock.calls[0]?.[0])).toContain("v=0");
 
       act(() => {
-        fireEvent.click(refreshButtons()[0]!);
+        fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
       });
 
       // The tree refreshes and the preview re-requests — one gesture, both
       // halves, no rerender needed because the nonce is the pane's own state.
       expect(treeState.refresh).toHaveBeenCalledWith({ manual: true });
       await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+      // The one place the `v=` spelling is worth pinning: this is the whole
+      // thesis of the fix, that the pane's nonce survives the trip through the
+      // viewer into the leaf's request URL. A fetch count alone wouldn't say
+      // the nonce is what drove it.
       expect(String(fetchMock.mock.calls[1]?.[0])).toContain("v=1");
-      await waitFor(() =>
-        expect(container.querySelector("audio")?.getAttribute("src")).not.toBe(firstSrc)
-      );
+      // One waitFor for the whole claim: the hook nulls its object URL while
+      // refetching, so a bare src comparison would go green on the empty gap
+      // without the replacement player ever arriving.
+      await waitFor(() => {
+        const refreshed = container.querySelector("audio");
+        expect(refreshed).not.toBeNull();
+        expect(refreshed?.getAttribute("src")).not.toBe(firstSrc);
+      });
       // Media never round-trips through the text-read IPC path.
       expect(readMock).not.toHaveBeenCalled();
     } finally {
       vi.unstubAllGlobals();
+      URL.createObjectURL = realCreateObjectURL;
+      URL.revokeObjectURL = realRevokeObjectURL;
     }
   });
 });

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -1911,3 +1911,78 @@ describe("FileBrowserPane Refresh reachability and media wiring (#11586)", () =>
     }
   });
 });
+
+describe("FileBrowserPane refresh signal reaches both viewer paths (#11586)", () => {
+  // The nonce travels to the viewer twice over: merged into `viewerRevision`
+  // and handed across on its own. These drive the pane's REAL Refresh button so
+  // they exercise that formula — the viewer-level suite manufactures the
+  // revision string itself and would stay green if the merge were dropped,
+  // which is exactly the "simplification" the comment there warns against.
+  it("re-reads the open text file when Refresh is pressed", async () => {
+    mockPanel.browserSelectedPath = "src/app.ts";
+    mockPanel.browserSidebarCollapsed = true;
+    renderPane();
+
+    await waitFor(() => expect(readMock).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    });
+
+    // Drop the nonce from `viewerRevision` and this never moves: the tree
+    // refreshes, the file on screen silently keeps its stale bytes.
+    await waitFor(() => expect(readMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("recovers a media preview stuck in its error state when Refresh is pressed", async () => {
+    // The media half of the same invariant. A failed fetch unmounts the player,
+    // so the direct `reloadKey` handoff has nothing to reach — only the
+    // revision-driven reclassification can bring it back.
+    let objectUrlSequence = 0;
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("protocol unavailable"))
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        blob: () => Promise.resolve(new Blob(["x"])),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+    const realCreateObjectURL = URL.createObjectURL;
+    const realRevokeObjectURL = URL.revokeObjectURL;
+    URL.createObjectURL = vi.fn(() => `blob:app://daintree/pane-retry-${objectUrlSequence++}`);
+    URL.revokeObjectURL = vi.fn();
+
+    try {
+      treeState.rows = [
+        ...defaultRows,
+        {
+          path: "media/track.mp3",
+          name: "track.mp3",
+          isDirectory: false,
+          depth: 1,
+          isExpanded: false,
+          isLoading: false,
+        },
+      ];
+      mockPanel.browserSelectedPath = "media/track.mp3";
+      mockPanel.browserSidebarCollapsed = true;
+      const { container } = renderPane();
+
+      await screen.findByText("This audio file couldn't be played");
+      expect(container.querySelector("audio")).toBeNull();
+
+      act(() => {
+        fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+      });
+
+      await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+      expect(screen.queryByText("This audio file couldn't be played")).toBeNull();
+    } finally {
+      vi.unstubAllGlobals();
+      URL.createObjectURL = realCreateObjectURL;
+      URL.revokeObjectURL = realRevokeObjectURL;
+    }
+  });
+});

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -267,8 +267,8 @@ import {
 } from "../sidebarWidth";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
-function renderPane(props: { worktreeId?: string } = { worktreeId: "wt-1" }) {
-  return render(
+function paneJsx(props: { worktreeId?: string } = { worktreeId: "wt-1" }) {
+  return (
     <TooltipProvider>
       <FileBrowserPane
         id="fb-1"
@@ -281,6 +281,10 @@ function renderPane(props: { worktreeId?: string } = { worktreeId: "wt-1" }) {
       />
     </TooltipProvider>
   );
+}
+
+function renderPane(props: { worktreeId?: string } = { worktreeId: "wt-1" }) {
+  return render(paneJsx(props));
 }
 
 function classToken(el: Element, predicate: (cls: string) => boolean): string | undefined {
@@ -312,6 +316,10 @@ beforeEach(() => {
   treeState.rootError = null;
   treeState.isInitialLoading = false;
   treeState.captureSnapshot = () => null;
+  // Created once in `vi.hoisted`, so without these the manual-refresh call
+  // counts and the spinner state would leak between tests.
+  treeState.refresh.mockClear();
+  treeState.isRefreshing = false;
   mockPanel.browserSidebarCollapsed = undefined;
   mockPanel.browserViewerCollapsed = undefined;
   mockPanel.browserSelectedPath = undefined;
@@ -1778,5 +1786,111 @@ describe("FileBrowserPane row activation (#11496)", () => {
     await activate("src/app.ts");
 
     expect(notifyMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("FileBrowserPane Refresh reachability and media wiring (#11586)", () => {
+  // Refresh used to live only in the tree header, which unmounts with the tree
+  // column — so the viewer-only layout had no way to refresh at all. The viewer
+  // now grows its own, gated so exactly one is reachable in every layout.
+  const AUDIO_ROW = {
+    path: "media/track.mp3",
+    name: "track.mp3",
+    isDirectory: false,
+    depth: 1,
+    isExpanded: false,
+    isLoading: false,
+  };
+
+  function refreshButtons(): HTMLElement[] {
+    return screen.queryAllByRole("button", { name: "Refresh" });
+  }
+
+  it("keeps exactly one Refresh reachable in each of the three layouts", () => {
+    const { rerender } = renderPane();
+
+    // Both columns: the tree header owns it, and the viewer must not add a
+    // second identical control beside it.
+    expect(refreshButtons()).toHaveLength(1);
+    const treeColumn = document.getElementById(
+      screen.getByTestId("file-browser-sidebar-toggle").getAttribute("aria-controls")!
+    )!;
+    expect(treeColumn.contains(refreshButtons()[0]!)).toBe(true);
+
+    // Viewer collapsed: the tree header is still mounted and still owns it.
+    mockPanel.browserViewerCollapsed = true;
+    rerender(paneJsx());
+    expect(refreshButtons()).toHaveLength(1);
+
+    // Sidebar collapsed: the tree header is gone, so the viewer's takes over —
+    // this is the layout that had no Refresh at all.
+    mockPanel.browserViewerCollapsed = undefined;
+    mockPanel.browserSidebarCollapsed = true;
+    rerender(paneJsx());
+    expect(screen.queryByTestId("file-tree-view")).toBeNull();
+    expect(refreshButtons()).toHaveLength(1);
+  });
+
+  it("runs the pane's manual refresh from the viewer with nothing selected", () => {
+    // A workspace-rooted browser has no change tick (#11482), so with the tree
+    // hidden and no file selected this button is the only freshness signal
+    // there is.
+    mockPanel.browserSidebarCollapsed = true;
+    renderPane();
+    expect(treeArgs.changeTick).toBeUndefined();
+
+    act(() => {
+      fireEvent.click(refreshButtons()[0]!);
+    });
+
+    expect(treeState.refresh).toHaveBeenCalledTimes(1);
+    expect(treeState.refresh).toHaveBeenCalledWith({ manual: true });
+  });
+
+  it("refetches the open media preview when the viewer's Refresh is pressed", async () => {
+    // The end-to-end shape of the bug: the pane merges its change tick and its
+    // manual nonce into one `revision` string, and the media branches ignore
+    // that string wholesale. Handing the nonce over separately is what makes
+    // this pass — passing `revision` through instead would refetch on every
+    // ambient worktree write, which is the thing the merge was avoiding.
+    let objectUrlSequence = 0;
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      blob: () => Promise.resolve(new Blob(["x"])),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    URL.createObjectURL = vi.fn(() => `blob:app://daintree/pane-audio-${objectUrlSequence++}`);
+    URL.revokeObjectURL = vi.fn();
+
+    try {
+      treeState.rows = [...defaultRows, AUDIO_ROW];
+      mockPanel.browserSelectedPath = AUDIO_ROW.path;
+      mockPanel.browserSidebarCollapsed = true;
+      const { container } = renderPane();
+
+      await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+      const firstSrc = container.querySelector("audio")?.getAttribute("src");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(String(fetchMock.mock.calls[0]?.[0])).toContain("v=0");
+
+      act(() => {
+        fireEvent.click(refreshButtons()[0]!);
+      });
+
+      // The tree refreshes and the preview re-requests — one gesture, both
+      // halves, no rerender needed because the nonce is the pane's own state.
+      expect(treeState.refresh).toHaveBeenCalledWith({ manual: true });
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+      expect(String(fetchMock.mock.calls[1]?.[0])).toContain("v=1");
+      await waitFor(() =>
+        expect(container.querySelector("audio")?.getAttribute("src")).not.toBe(firstSrc)
+      );
+      // Media never round-trips through the text-read IPC path.
+      expect(readMock).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -36,12 +36,21 @@ vi.mock("@/components/Html/HtmlViewer", () => ({
 import { FileBrowserViewer } from "../FileBrowserViewer";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
-function renderViewer(
-  filePath: string | null,
-  opts: { sidebarCollapsed?: boolean; onToggleSidebar?: () => void; revision?: string } = {}
-) {
+interface ViewerOpts {
+  sidebarCollapsed?: boolean;
+  onToggleSidebar?: () => void;
+  revision?: string;
+  manualRefreshNonce?: number;
+  onRefresh?: () => void;
+  isRefreshing?: boolean;
+}
+
+// Defaults live here, never on the component: the props are required there so a
+// pane that forgets to wire one fails typecheck rather than silently losing
+// media refresh (#11586).
+function viewerJsx(filePath: string | null, opts: ViewerOpts = {}) {
   const fileName = filePath ? (filePath.split("/").pop() ?? filePath) : "";
-  return render(
+  return (
     <TooltipProvider>
       <FileBrowserViewer
         filePath={filePath}
@@ -49,12 +58,19 @@ function renderViewer(
         fileName={fileName}
         relativePath={filePath ? fileName : null}
         revision={opts.revision ?? "r1"}
+        manualRefreshNonce={opts.manualRefreshNonce ?? 0}
+        onRefresh={opts.onRefresh ?? vi.fn()}
+        isRefreshing={opts.isRefreshing ?? false}
         sidebarCollapsed={opts.sidebarCollapsed ?? false}
         onToggleSidebar={opts.onToggleSidebar ?? vi.fn()}
         treeSidebarId="file-tree-column"
       />
     </TooltipProvider>
   );
+}
+
+function renderViewer(filePath: string | null, opts: ViewerOpts = {}) {
+  return render(viewerJsx(filePath, opts));
 }
 
 // SegmentedToggle renders literal-text buttons; its accessible name is the
@@ -123,20 +139,7 @@ describe("FileBrowserViewer markdown Source/Rendered toggle (#11319)", () => {
 
     // Selecting another markdown file in the tree must not silently revert the
     // reader's choice back to rendered — the mode is sticky, mirroring FilePane.
-    rerender(
-      <TooltipProvider>
-        <FileBrowserViewer
-          filePath="/repo/docs/b.md"
-          rootPath="/repo"
-          fileName="b.md"
-          relativePath="b.md"
-          revision="r1"
-          sidebarCollapsed={false}
-          onToggleSidebar={vi.fn()}
-          treeSidebarId="file-tree-column"
-        />
-      </TooltipProvider>
-    );
+    rerender(viewerJsx("/repo/docs/b.md"));
     await waitFor(() => expect(currentViewMode()).toBe("source"));
   });
 
@@ -149,20 +152,7 @@ describe("FileBrowserViewer markdown Source/Rendered toggle (#11319)", () => {
     await clickMode("Source");
     await waitFor(() => expect(currentViewMode()).toBe("source"));
 
-    rerender(
-      <TooltipProvider>
-        <FileBrowserViewer
-          filePath="/repo/src/notes.txt"
-          rootPath="/repo"
-          fileName="notes.txt"
-          relativePath="notes.txt"
-          revision="r1"
-          sidebarCollapsed={false}
-          onToggleSidebar={vi.fn()}
-          treeSidebarId="file-tree-column"
-        />
-      </TooltipProvider>
-    );
+    rerender(viewerJsx("/repo/src/notes.txt"));
     await screen.findByTestId("code-viewer-mock");
     expect(screen.queryByRole("button", { name: "Source" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Rendered" })).toBeNull();
@@ -186,20 +176,7 @@ describe("FileBrowserViewer tree-sidebar toggle (#11328)", () => {
     const firstEmpty = screen.getAllByRole("button")[0];
     expect(firstEmpty?.getAttribute("data-testid")).toBe("file-browser-sidebar-toggle");
 
-    rerender(
-      <TooltipProvider>
-        <FileBrowserViewer
-          filePath="/repo/src/notes.txt"
-          rootPath="/repo"
-          fileName="notes.txt"
-          relativePath="notes.txt"
-          revision="r1"
-          sidebarCollapsed={false}
-          onToggleSidebar={vi.fn()}
-          treeSidebarId="file-tree-column"
-        />
-      </TooltipProvider>
-    );
+    rerender(viewerJsx("/repo/src/notes.txt"));
     await screen.findByTestId("code-viewer-mock");
     // Still first, ahead of the reveal/open-in-editor actions — the toggle
     // stays flush at the far left of the header per the issue.
@@ -215,20 +192,7 @@ describe("FileBrowserViewer tree-sidebar toggle (#11328)", () => {
     expect(expanded.getAttribute("aria-pressed")).toBeNull();
     expect(expanded.getAttribute("aria-controls")).toBe("file-tree-column");
 
-    rerender(
-      <TooltipProvider>
-        <FileBrowserViewer
-          filePath={null}
-          rootPath="/repo"
-          fileName=""
-          relativePath={null}
-          revision="r1"
-          sidebarCollapsed={true}
-          onToggleSidebar={vi.fn()}
-          treeSidebarId="file-tree-column"
-        />
-      </TooltipProvider>
-    );
+    rerender(viewerJsx(null, { sidebarCollapsed: true }));
     const collapsed = screen.getByTestId("file-browser-sidebar-toggle");
     expect(collapsed.getAttribute("aria-expanded")).toBe("false");
     // The tree column is unmounted while collapsed, so aria-controls must not
@@ -287,6 +251,38 @@ describe("FileBrowserViewer video preview (#11382)", () => {
     expect(readMock).not.toHaveBeenCalled();
     expect(screen.getByText(/Can't play this video format/)).toBeTruthy();
   });
+
+  it("refetches on an explicit refresh but rides out an ambient revision tick (#11586)", async () => {
+    // Both directions in one test: the ambient half must not disturb playback,
+    // and the explicit half must not be swallowed along with it. Unique object
+    // URLs so a silent remount can't pass as continuity.
+    let objectUrlSequence = 0;
+    URL.createObjectURL = vi.fn(() => `blob:app://daintree/video-${objectUrlSequence++}`);
+
+    const { container, rerender } = renderViewer("/repo/media/demo.webm", {
+      revision: "r1",
+      manualRefreshNonce: 0,
+    });
+    await waitFor(() => expect(container.querySelector("video")).not.toBeNull());
+    const firstNode = container.querySelector("video");
+    const firstSrc = firstNode?.getAttribute("src");
+    expect(videoFetchMock).toHaveBeenCalledTimes(1);
+
+    // A worktree write elsewhere: the player must be left completely alone.
+    rerender(viewerJsx("/repo/media/demo.webm", { revision: "r2", manualRefreshNonce: 0 }));
+    await act(async () => {});
+    expect(container.querySelector("video")).toBe(firstNode);
+    expect(container.querySelector("video")?.getAttribute("src")).toBe(firstSrc);
+    expect(videoFetchMock).toHaveBeenCalledTimes(1);
+
+    // Refresh pressed: exactly one more request, carrying the new nonce.
+    rerender(viewerJsx("/repo/media/demo.webm", { revision: "r2", manualRefreshNonce: 1 }));
+    await waitFor(() => expect(videoFetchMock).toHaveBeenCalledTimes(2));
+    expect(String(videoFetchMock.mock.calls[1]?.[0])).toContain("v=1");
+    await waitFor(() =>
+      expect(container.querySelector("video")?.getAttribute("src")).not.toBe(firstSrc)
+    );
+  });
 });
 
 describe("FileBrowserViewer audio preview (#11425)", () => {
@@ -339,20 +335,7 @@ describe("FileBrowserViewer audio preview (#11425)", () => {
     const firstSrc = firstNode?.getAttribute("src");
     expect(audioFetchMock).toHaveBeenCalledTimes(1);
 
-    rerender(
-      <TooltipProvider>
-        <FileBrowserViewer
-          filePath="/repo/media/track.mp3"
-          rootPath="/repo"
-          fileName="track.mp3"
-          relativePath="track.mp3"
-          revision="r2"
-          sidebarCollapsed={false}
-          onToggleSidebar={vi.fn()}
-          treeSidebarId="file-tree-column"
-        />
-      </TooltipProvider>
-    );
+    rerender(viewerJsx("/repo/media/track.mp3", { revision: "r2" }));
     await act(async () => {});
 
     // The very same element, still on its original blob — not a fresh one that
@@ -360,6 +343,33 @@ describe("FileBrowserViewer audio preview (#11425)", () => {
     expect(container.querySelector("audio")).toBe(firstNode);
     expect(container.querySelector("audio")?.getAttribute("src")).toBe(firstSrc);
     expect(audioFetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches the track when an explicit refresh moves the nonce (#11586)", async () => {
+    // The other half of the test above: the ambient tick is ignored, but
+    // pressing Refresh is the one gesture that must pull rewritten bytes.
+    let objectUrlSequence = 0;
+    URL.createObjectURL = vi.fn(() => `blob:app://daintree/audio-${objectUrlSequence++}`);
+
+    const { container, rerender } = renderViewer("/repo/media/track.mp3", {
+      manualRefreshNonce: 0,
+    });
+    await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+    const firstNode = container.querySelector("audio");
+    const firstSrc = firstNode?.getAttribute("src");
+    expect(audioFetchMock).toHaveBeenCalledTimes(1);
+
+    rerender(viewerJsx("/repo/media/track.mp3", { manualRefreshNonce: 1 }));
+    await waitFor(() => expect(audioFetchMock).toHaveBeenCalledTimes(2));
+
+    // The nonce reaches the protocol URL, so the fetch is a genuinely new
+    // request rather than a re-render of the cached blob.
+    expect(String(audioFetchMock.mock.calls[1]?.[0])).toContain("v=1");
+    await waitFor(() =>
+      expect(container.querySelector("audio")?.getAttribute("src")).not.toBe(firstSrc)
+    );
+    // Keyed by object URL, so fresh bytes mean a fresh element.
+    expect(container.querySelector("audio")).not.toBe(firstNode);
   });
 });
 
@@ -385,5 +395,75 @@ describe("FileBrowserViewer PDF preview (#11427)", () => {
     // attribute PDFium refuses to install its viewer frame.
     expect(frame?.hasAttribute("credentialless")).toBe(true);
     expect(frame?.hasAttribute("sandbox")).toBe(false);
+  });
+
+  it("re-navigates only on an explicit refresh, never on a revision tick (#11586)", async () => {
+    const { container, rerender } = renderViewer("/repo/docs/spec.pdf", {
+      revision: "r1",
+      manualRefreshNonce: 0,
+    });
+    await act(async () => {});
+    const frame = container.querySelector("iframe");
+    const firstSrc = frame?.getAttribute("src");
+
+    // An ambient write must not throw away the reader's page and zoom, which a
+    // changed src would.
+    rerender(viewerJsx("/repo/docs/spec.pdf", { revision: "r2", manualRefreshNonce: 0 }));
+    await act(async () => {});
+    expect(container.querySelector("iframe")?.getAttribute("src")).toBe(firstSrc);
+
+    rerender(viewerJsx("/repo/docs/spec.pdf", { revision: "r2", manualRefreshNonce: 1 }));
+    await act(async () => {});
+    const refreshed = container.querySelector("iframe");
+    expect(refreshed?.getAttribute("src")).not.toBe(firstSrc);
+    expect(new URL(refreshed?.getAttribute("src") ?? "").searchParams.get("v")).toBe("1");
+    // The reload rides the same frame, so the COEP contract must survive it.
+    expect(refreshed?.hasAttribute("credentialless")).toBe(true);
+    expect(refreshed?.hasAttribute("sandbox")).toBe(false);
+  });
+});
+
+describe("FileBrowserViewer Refresh control (#11586)", () => {
+  it("leaves Refresh to the tree header while the tree column is mounted", async () => {
+    renderViewer("/repo/src/notes.txt", { sidebarCollapsed: false });
+    await screen.findByTestId("code-viewer-mock");
+    // Two identical Refresh buttons in one panel would read as two different
+    // actions; the tree header owns the only one while it is on screen.
+    expect(screen.queryByRole("button", { name: "Refresh" })).toBeNull();
+  });
+
+  it("offers Refresh once the tree column is collapsed away, even with nothing selected", async () => {
+    const onRefresh = vi.fn();
+    renderViewer(null, { sidebarCollapsed: true, onRefresh });
+
+    // Nothing selected still needs it: Refresh re-reads the tree too, and a
+    // workspace-rooted browser has no change tick to fall back on (#11482).
+    expect(screen.getByText("Nothing selected")).toBeTruthy();
+    const button = screen.getByRole("button", { name: "Refresh" });
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("spins the icon only while the refresh is draining", () => {
+    const { rerender } = renderViewer(null, { sidebarCollapsed: true, isRefreshing: false });
+    const idleIcon = screen.getByRole("button", { name: "Refresh" }).querySelector("svg");
+    expect(idleIcon?.classList.contains("animate-spin")).toBe(false);
+
+    rerender(viewerJsx(null, { sidebarCollapsed: true, isRefreshing: true }));
+    const busyIcon = screen.getByRole("button", { name: "Refresh" }).querySelector("svg");
+    expect(busyIcon?.classList.contains("animate-spin")).toBe(true);
+  });
+
+  it("keeps re-reading text on an ambient revision tick", async () => {
+    // The half that already worked: `revision` must keep its job, or fixing the
+    // media path would quietly cost text its live updates.
+    const { rerender } = renderViewer("/repo/src/notes.txt", { revision: "r1" });
+    await screen.findByTestId("code-viewer-mock");
+    expect(readMock).toHaveBeenCalledTimes(1);
+
+    rerender(viewerJsx("/repo/src/notes.txt", { revision: "r2" }));
+    await waitFor(() => expect(readMock).toHaveBeenCalledTimes(2));
   });
 });

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -33,6 +33,16 @@ vi.mock("@/components/Html/HtmlViewer", () => ({
   HtmlViewer: () => <div data-testid="html-viewer-mock" />,
 }));
 
+// Surfaces the `active` prop instead of letting the real component apply its
+// spin class. What this suite owns is the wiring — `isRefreshing` reaching the
+// icon — while how a spin is rendered belongs to SpinningIcon's own suite; an
+// assertion on its class name here would break on a harmless refactor there.
+vi.mock("@/components/ui/SpinningIcon", () => ({
+  SpinningIcon: ({ active }: { active: boolean }) => (
+    <svg data-testid="spinning-icon-mock" data-active={String(active)} />
+  ),
+}));
+
 import { FileBrowserViewer } from "../FileBrowserViewer";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
@@ -275,13 +285,21 @@ describe("FileBrowserViewer video preview (#11382)", () => {
     expect(container.querySelector("video")?.getAttribute("src")).toBe(firstSrc);
     expect(videoFetchMock).toHaveBeenCalledTimes(1);
 
-    // Refresh pressed: exactly one more request, carrying the new nonce.
+    // Refresh pressed: exactly one more request, aimed at a different URL —
+    // proof the nonce reached it, without pinning the leaf's `v=` spelling.
     rerender(viewerJsx("/repo/media/demo.webm", { revision: "r2", manualRefreshNonce: 1 }));
     await waitFor(() => expect(videoFetchMock).toHaveBeenCalledTimes(2));
-    expect(String(videoFetchMock.mock.calls[1]?.[0])).toContain("v=1");
-    await waitFor(() =>
-      expect(container.querySelector("video")?.getAttribute("src")).not.toBe(firstSrc)
+    expect(String(videoFetchMock.mock.calls[1]?.[0])).not.toBe(
+      String(videoFetchMock.mock.calls[0]?.[0])
     );
+    // Both halves in ONE waitFor: the hook nulls its object URL while refetching,
+    // so a bare `.not.toBe(firstSrc)` would go green on the empty gap and never
+    // prove the replacement player arrived.
+    await waitFor(() => {
+      const refreshed = container.querySelector("video");
+      expect(refreshed).not.toBeNull();
+      expect(refreshed?.getAttribute("src")).not.toBe(firstSrc);
+    });
   });
 });
 
@@ -362,14 +380,46 @@ describe("FileBrowserViewer audio preview (#11425)", () => {
     rerender(viewerJsx("/repo/media/track.mp3", { manualRefreshNonce: 1 }));
     await waitFor(() => expect(audioFetchMock).toHaveBeenCalledTimes(2));
 
-    // The nonce reaches the protocol URL, so the fetch is a genuinely new
-    // request rather than a re-render of the cached blob.
-    expect(String(audioFetchMock.mock.calls[1]?.[0])).toContain("v=1");
-    await waitFor(() =>
-      expect(container.querySelector("audio")?.getAttribute("src")).not.toBe(firstSrc)
+    // A different URL, so the nonce genuinely reached the request rather than
+    // the blob being re-rendered from cache.
+    expect(String(audioFetchMock.mock.calls[1]?.[0])).not.toBe(
+      String(audioFetchMock.mock.calls[0]?.[0])
     );
-    // Keyed by object URL, so fresh bytes mean a fresh element.
-    expect(container.querySelector("audio")).not.toBe(firstNode);
+    // One waitFor for the whole claim: the hook nulls its object URL while
+    // refetching, so asserting the src alone would pass on the empty gap
+    // between the two players.
+    await waitFor(() => {
+      const refreshed = container.querySelector("audio");
+      expect(refreshed).not.toBeNull();
+      expect(refreshed?.getAttribute("src")).not.toBe(firstSrc);
+      // Keyed by object URL, so fresh bytes mean a fresh element.
+      expect(refreshed).not.toBe(firstNode);
+    });
+  });
+
+  it("recovers a failed track on refresh, which takes both halves of the signal", async () => {
+    // A failed fetch unmounts the preview entirely (`status: "error"`), so
+    // `reloadKey` alone can't bring it back — nothing is mounted to receive it.
+    // Recovery rides `revision`, whose re-run reclassifies the file and
+    // remounts the player. That is why the nonce must stay folded into
+    // `revision` as well as being passed separately.
+    let objectUrlSequence = 0;
+    URL.createObjectURL = vi.fn(() => `blob:app://daintree/audio-retry-${objectUrlSequence++}`);
+    audioFetchMock.mockRejectedValueOnce(new Error("protocol unavailable"));
+
+    const { container, rerender } = renderViewer("/repo/media/track.mp3", {
+      revision: "0:0",
+      manualRefreshNonce: 0,
+    });
+    await screen.findByText("This audio file couldn't be played");
+    expect(container.querySelector("audio")).toBeNull();
+
+    // Exactly what the pane emits for one Refresh press: both values move.
+    rerender(viewerJsx("/repo/media/track.mp3", { revision: "0:1", manualRefreshNonce: 1 }));
+
+    await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+    expect(screen.queryByText("This audio file couldn't be played")).toBeNull();
+    expect(audioFetchMock).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -403,20 +453,24 @@ describe("FileBrowserViewer PDF preview (#11427)", () => {
       manualRefreshNonce: 0,
     });
     await act(async () => {});
-    const frame = container.querySelector("iframe");
-    const firstSrc = frame?.getAttribute("src");
+    const firstFrame = container.querySelector("iframe");
+    const firstSrc = firstFrame?.getAttribute("src");
 
-    // An ambient write must not throw away the reader's page and zoom, which a
-    // changed src would.
+    // An ambient write must not throw away the reader's page and zoom. Both a
+    // changed src AND a remounted frame would do that, so pin the node too —
+    // a remount carrying an identical src resets the reader just the same.
     rerender(viewerJsx("/repo/docs/spec.pdf", { revision: "r2", manualRefreshNonce: 0 }));
     await act(async () => {});
+    expect(container.querySelector("iframe")).toBe(firstFrame);
     expect(container.querySelector("iframe")?.getAttribute("src")).toBe(firstSrc);
 
     rerender(viewerJsx("/repo/docs/spec.pdf", { revision: "r2", manualRefreshNonce: 1 }));
     await act(async () => {});
     const refreshed = container.querySelector("iframe");
+    // Re-navigated in place rather than remounted: the same element takes a new
+    // src, which is what makes the reload deliberate instead of incidental.
+    expect(refreshed).toBe(firstFrame);
     expect(refreshed?.getAttribute("src")).not.toBe(firstSrc);
-    expect(new URL(refreshed?.getAttribute("src") ?? "").searchParams.get("v")).toBe("1");
     // The reload rides the same frame, so the COEP contract must survive it.
     expect(refreshed?.hasAttribute("credentialless")).toBe(true);
     expect(refreshed?.hasAttribute("sandbox")).toBe(false);
@@ -446,14 +500,12 @@ describe("FileBrowserViewer Refresh control (#11586)", () => {
     expect(onRefresh).toHaveBeenCalledTimes(1);
   });
 
-  it("spins the icon only while the refresh is draining", () => {
+  it("hands the in-flight refresh state to the icon", () => {
     const { rerender } = renderViewer(null, { sidebarCollapsed: true, isRefreshing: false });
-    const idleIcon = screen.getByRole("button", { name: "Refresh" }).querySelector("svg");
-    expect(idleIcon?.classList.contains("animate-spin")).toBe(false);
+    expect(screen.getByTestId("spinning-icon-mock").getAttribute("data-active")).toBe("false");
 
     rerender(viewerJsx(null, { sidebarCollapsed: true, isRefreshing: true }));
-    const busyIcon = screen.getByRole("button", { name: "Refresh" }).querySelector("svg");
-    expect(busyIcon?.classList.contains("animate-spin")).toBe(true);
+    expect(screen.getByTestId("spinning-icon-mock").getAttribute("data-active")).toBe("true");
   });
 
   it("keeps re-reading text on an ambient revision tick", async () => {
@@ -464,6 +516,23 @@ describe("FileBrowserViewer Refresh control (#11586)", () => {
     expect(readMock).toHaveBeenCalledTimes(1);
 
     rerender(viewerJsx("/repo/src/notes.txt", { revision: "r2" }));
+    await waitFor(() => expect(readMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("re-reads text on an explicit refresh too, not just an ambient tick", async () => {
+    // Guards the other direction of the pane's dual handoff: the nonce is fed
+    // to the media previews directly AND folded into `revision`. Drop the
+    // second and text, html and svg go stale on Refresh with nothing to catch
+    // it — the media tests above would all still pass.
+    const { rerender } = renderViewer("/repo/src/notes.txt", {
+      revision: "0:0",
+      manualRefreshNonce: 0,
+    });
+    await screen.findByTestId("code-viewer-mock");
+    expect(readMock).toHaveBeenCalledTimes(1);
+
+    // What the pane produces for a Refresh press on a worktree with no tick.
+    rerender(viewerJsx("/repo/src/notes.txt", { revision: "0:1", manualRefreshNonce: 1 }));
     await waitFor(() => expect(readMock).toHaveBeenCalledTimes(2));
   });
 });


### PR DESCRIPTION
## Summary

- The file browser's Refresh only ever re-read text and image previews. Video, audio and PDF previews now get refreshed too, without disturbing playback or reader position on ambient background writes.
- Refresh now has a home in the viewer toolbar as well as the tree header, so it's reachable when the sidebar is collapsed and the file view is at full width.

Resolves #11586

## Changes

The pane merges its ambient worktree change tick and its explicit refresh counter into one string, `viewerRevision = ${changeTick}:${manualRefreshNonce}`, and hands that to the viewer as `revision`. That string also moves on every background write, so the video, audio and PDF branches deliberately ignored it, otherwise an agent touching an unrelated file would restart playback or reset the PDF reader's page. That opt-out also swallowed the one gesture that should always re-fetch: an explicit Refresh press.

The fix hands `manualRefreshNonce` to the viewer as its own prop alongside the unchanged `revision`, and forwards it as `reloadKey` to the three media previews, which already accepted one, they just never received it. Ambient ticks stay off that path, so background writes still leave playback and reader position alone. It's typed `number` rather than `string | number` specifically so passing the merged `revision` string back in is a compile error rather than a silent regression.

For reachability, the viewer's toolbar gets a Refresh gated on `sidebarCollapsed`, so exactly one is reachable in each of the three layouts (both columns, tree only, viewer only). Gating rather than always rendering is deliberate: two identical Refresh buttons ~300px apart in the default layout would read as two different actions, people would reasonably assume one refreshes the tree and the other the file, when both call the same handler. It also matches the panel's existing rule that each control has one home. The toolbar's `Actions` group moved outside the `filePath` gate, because Refresh also re-reads the tree, and a workspace-rooted browser has no change tick at all (#11482), so a collapsed sidebar with nothing selected would otherwise have offered no way to refresh anything.

One subtlety worth flagging for review: the nonce is now load-bearing in both paths. It stays folded into `viewerRevision` because that's what re-runs the viewer's classification effect, which is how a media file stuck in `status: "error"` gets its preview remounted on Refresh. Passing it separately is what refreshes a preview that's still mounted. Drop either one and something breaks quietly, so both are documented at the declaration.

No changes were needed in `FilePane`, `FileViewerToolbar`, `useMediaBlobUrl` or the media leaf components, their existing contracts already supported this.

## Testing

771 tests green across the file-browser, FileViewer, panel-registry and accent-guard suites. New coverage pins both directions per media kind (an ambient tick must not disturb the player, an explicit refresh must re-fetch it), the one-Refresh-per-layout invariant, and the dual-handoff invariant above. That last pair was verified by mutation: dropping the nonce from `viewerRevision` fails exactly those two tests and nothing else.