### PR TITLE
feat(mcp): send server instructions at initialize

### DIFF
--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import { McpError, ErrorCode, LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/sdk/types.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { ActionManifestEntry, ActionId } from "../../../../shared/types/actions.js";
 
@@ -29,10 +29,18 @@ import {
   unwrapDispatchResult,
   RESOLVED_WORKSPACE_META_KEY,
   withResolvedWorkspace,
+  MCP_SERVER_INSTRUCTIONS,
+  MCP_SERVER_INSTRUCTIONS_MAX_BYTES,
+  TIER_ALLOWLISTS,
 } from "../shared.js";
 import type { DispatchedWorkspaceRef } from "../shared.js";
 import { TOOL_RESULT_TEXT_MAX_BYTES } from "../toolCallResult.js";
-import { isTierPermitted, shouldExposeTool } from "../tierAuth.js";
+import {
+  isTierPermitted,
+  shouldExposeTool,
+  ACTIONS_SEARCH_TOOL_ID,
+  ACTIONS_GET_SCHEMA_TOOL_ID,
+} from "../tierAuth.js";
 import { SessionBindingError, RendererBridgeUnavailableError } from "../rendererBridge.js";
 import { getAgentAvailabilityStore } from "../../AgentAvailabilityStore.js";
 import { events } from "../../events.js";
@@ -202,6 +210,40 @@ async function listTools(server: ReturnType<typeof createSessionServer>) {
   ) as Promise<{ tools: Array<{ name: string }> }>;
 }
 
+/**
+ * Drive the SDK's own `initialize` handler (#11541). The handler under test is
+ * registered by the base `Server` constructor rather than by us, so this proves
+ * the constructor option actually reaches the wire result — an assertion on the
+ * options object we passed in would pass even if the SDK stopped forwarding it.
+ */
+async function initializeServer(server: ReturnType<typeof createSessionServer>) {
+  const handlers = (
+    server as unknown as {
+      _requestHandlers: Map<string, (req: unknown, extra: unknown) => Promise<unknown>>;
+    }
+  )._requestHandlers;
+  const handler = handlers.get("initialize");
+  if (!handler) throw new Error("initialize handler not found");
+  return handler(
+    {
+      method: "initialize",
+      params: {
+        protocolVersion: LATEST_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: "test-client", version: "1.0.0" },
+      },
+      jsonrpc: "2.0",
+      id: 1,
+    },
+    {
+      signal: new AbortController().signal,
+      _meta: {},
+      sendNotification: vi.fn(),
+      requestId: 1,
+    }
+  ) as Promise<{ instructions?: string; serverInfo: { name: string; version: string } }>;
+}
+
 function makeManifestEntry(id: string): ActionManifestEntry {
   return {
     id: id as ActionId,
@@ -216,6 +258,71 @@ function makeManifestEntry(id: string): ActionManifestEntry {
     inputSchema: { type: "object", properties: {} },
   };
 }
+
+describe("sessionServer initialize instructions", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the instructions through the SDK's own initialize result", async () => {
+    const server = createSessionServer("session-instructions", fakeDeps());
+    const result = await initializeServer(server);
+
+    expect(result.instructions).toBe(MCP_SERVER_INSTRUCTIONS);
+    // Proves this is the SDK-generated initialize result rather than a handler
+    // of ours that happens to echo the constant back.
+    expect(result.serverInfo).toMatchObject({ name: "Daintree" });
+  });
+
+  it("sends the same instructions regardless of session tier", async () => {
+    // Instructions are sent once and have no update notification, so they must
+    // not encode a tier that can elevate or decay later in the same session.
+    const perTier = await Promise.all(
+      (Object.keys(TIER_ALLOWLISTS) as Array<keyof typeof TIER_ALLOWLISTS>).map(async (tier) => {
+        const server = createSessionServer(
+          `session-${tier}`,
+          fakeDeps({ sessionStore: fakeSessionStore(tier) })
+        );
+        return (await initializeServer(server)).instructions;
+      })
+    );
+
+    expect(new Set(perTier).size).toBe(1);
+  });
+
+  it("stays within the authored byte budget, itself under the 2 KiB client cap", () => {
+    // Claude Code truncates at 2 KiB and the authorization paragraph is last,
+    // so overflow silently drops the denial guidance rather than erroring.
+    expect(Buffer.byteLength(MCP_SERVER_INSTRUCTIONS, "utf8")).toBeLessThanOrEqual(
+      MCP_SERVER_INSTRUCTIONS_MAX_BYTES
+    );
+    expect(MCP_SERVER_INSTRUCTIONS_MAX_BYTES).toBeLessThan(2 * 1024);
+  });
+
+  it("names every tier a session can hold", () => {
+    // Adding a tier without describing it here leaves the model unable to
+    // reason about a denial it can now receive.
+    for (const tier of Object.keys(TIER_ALLOWLISTS)) {
+      expect(MCP_SERVER_INSTRUCTIONS).toContain(tier);
+    }
+    expect(MCP_SERVER_INSTRUCTIONS).toContain(TIER_NOT_PERMITTED_CODE);
+  });
+
+  it("points discovery at the live introspection tool ids", () => {
+    // The ids are literal prose, so a rename that skips this text fails here
+    // instead of silently telling every connecting model to call a dead name.
+    expect(MCP_SERVER_INSTRUCTIONS).toContain(ACTIONS_SEARCH_TOOL_ID);
+    expect(MCP_SERVER_INSTRUCTIONS).toContain(ACTIONS_GET_SCHEMA_TOOL_ID);
+  });
+
+  it("does not claim unlisted tools are callable", () => {
+    // #11582 tried a discoverable-but-unlisted surface and #11585 removed it:
+    // withholding a name is equivalent to revoking it. Instructions that
+    // promised otherwise would send models probing for names that cannot exist.
+    expect(MCP_SERVER_INSTRUCTIONS).toContain("do not invent tool names");
+    expect(MCP_SERVER_INSTRUCTIONS).toContain("does not reveal a deferred catalog");
+  });
+});
 
 describe("sessionServer tools/list handler", () => {
   // The external tier is gated by the curated MCP_TOOL_ALLOWLIST and nothing

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -298,9 +298,9 @@ describe("sessionServer initialize instructions", () => {
     // skips this prose fails here rather than telling every connecting model to
     // call a name that no longer resolves. New references are covered on
     // arrival, without interpolating constants into model-facing text.
-    const referenced = [...MCP_SERVER_INSTRUCTIONS.matchAll(/`([a-z][A-Za-z]*\.[A-Za-z]+)`/g)].map(
-      ([, id]) => id
-    );
+    const referenced = [
+      ...MCP_SERVER_INSTRUCTIONS.matchAll(/`([a-z][A-Za-z]*(?:\.[A-Za-z]+)+)`/g),
+    ].map(([, id]) => id);
 
     expect(referenced).toContain(ACTIONS_SEARCH_TOOL_ID);
     expect(referenced).toContain(ACTIONS_GET_SCHEMA_TOOL_ID);

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { McpError, ErrorCode, LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/sdk/types.js";
+import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { ActionManifestEntry, ActionId } from "../../../../shared/types/actions.js";
+import { BUILT_IN_ACTION_IDS } from "../../../../shared/config/actionIds.js";
 
 vi.mock("electron", () => ({
   app: {
@@ -211,37 +214,24 @@ async function listTools(server: ReturnType<typeof createSessionServer>) {
 }
 
 /**
- * Drive the SDK's own `initialize` handler (#11541). The handler under test is
- * registered by the base `Server` constructor rather than by us, so this proves
- * the constructor option actually reaches the wire result — an assertion on the
- * options object we passed in would pass even if the SDK stopped forwarding it.
+ * Complete a real MCP handshake against the session server and return what the
+ * client received (#11541).
+ *
+ * Deliberately the public path rather than this file's `_requestHandlers` idiom:
+ * `initialize` is the SDK's own handler, not one we register, so the question
+ * is whether the constructor option survives all the way to a client. Invoking
+ * the handler directly would stay green if the SDK stopped forwarding the field
+ * on the way to the transport, which is the failure actually worth catching.
  */
-async function initializeServer(server: ReturnType<typeof createSessionServer>) {
-  const handlers = (
-    server as unknown as {
-      _requestHandlers: Map<string, (req: unknown, extra: unknown) => Promise<unknown>>;
-    }
-  )._requestHandlers;
-  const handler = handlers.get("initialize");
-  if (!handler) throw new Error("initialize handler not found");
-  return handler(
-    {
-      method: "initialize",
-      params: {
-        protocolVersion: LATEST_PROTOCOL_VERSION,
-        capabilities: {},
-        clientInfo: { name: "test-client", version: "1.0.0" },
-      },
-      jsonrpc: "2.0",
-      id: 1,
-    },
-    {
-      signal: new AbortController().signal,
-      _meta: {},
-      sendNotification: vi.fn(),
-      requestId: 1,
-    }
-  ) as Promise<{ instructions?: string; serverInfo: { name: string; version: string } }>;
+async function initializeClient(server: ReturnType<typeof createSessionServer>) {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test-client", version: "1.0.0" }, { capabilities: {} });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  try {
+    return client.getInstructions();
+  } finally {
+    await client.close();
+  }
 }
 
 function makeManifestEntry(id: string): ActionManifestEntry {
@@ -264,63 +254,57 @@ describe("sessionServer initialize instructions", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns the instructions through the SDK's own initialize result", async () => {
+  it("delivers the instructions to a client that completes a real handshake", async () => {
     const server = createSessionServer("session-instructions", fakeDeps());
-    const result = await initializeServer(server);
 
-    expect(result.instructions).toBe(MCP_SERVER_INSTRUCTIONS);
-    // Proves this is the SDK-generated initialize result rather than a handler
-    // of ours that happens to echo the constant back.
-    expect(result.serverInfo).toMatchObject({ name: "Daintree" });
+    await expect(initializeClient(server)).resolves.toBe(MCP_SERVER_INSTRUCTIONS);
   });
 
   it("sends the same instructions regardless of session tier", async () => {
     // Instructions are sent once and have no update notification, so they must
     // not encode a tier that can elevate or decay later in the same session.
     const perTier = await Promise.all(
-      (Object.keys(TIER_ALLOWLISTS) as Array<keyof typeof TIER_ALLOWLISTS>).map(async (tier) => {
-        const server = createSessionServer(
-          `session-${tier}`,
-          fakeDeps({ sessionStore: fakeSessionStore(tier) })
-        );
-        return (await initializeServer(server)).instructions;
-      })
+      (Object.keys(TIER_ALLOWLISTS) as Array<keyof typeof TIER_ALLOWLISTS>).map((tier) =>
+        initializeClient(
+          createSessionServer(`session-${tier}`, fakeDeps({ sessionStore: fakeSessionStore(tier) }))
+        )
+      )
     );
 
-    expect(new Set(perTier).size).toBe(1);
+    expect(new Set(perTier)).toEqual(new Set([MCP_SERVER_INSTRUCTIONS]));
   });
 
-  it("stays within the authored byte budget, itself under the 2 KiB client cap", () => {
-    // Claude Code truncates at 2 KiB and the authorization paragraph is last,
-    // so overflow silently drops the denial guidance rather than erroring.
+  it("stays within the authored byte budget", () => {
+    // The budget is derived from the client truncation point minus a reserve,
+    // and the authorization paragraph is last — overflow silently drops the
+    // denial guidance in the field rather than failing anything here.
     expect(Buffer.byteLength(MCP_SERVER_INSTRUCTIONS, "utf8")).toBeLessThanOrEqual(
       MCP_SERVER_INSTRUCTIONS_MAX_BYTES
     );
-    expect(MCP_SERVER_INSTRUCTIONS_MAX_BYTES).toBeLessThan(2 * 1024);
   });
 
   it("names every tier a session can hold", () => {
     // Adding a tier without describing it here leaves the model unable to
-    // reason about a denial it can now receive.
+    // reason about a denial it can now receive. Matched with backticks because
+    // the bare word `action` also occurs inside `actions.search` and prose.
     for (const tier of Object.keys(TIER_ALLOWLISTS)) {
-      expect(MCP_SERVER_INSTRUCTIONS).toContain(tier);
+      expect(MCP_SERVER_INSTRUCTIONS).toContain(`\`${tier}\``);
     }
     expect(MCP_SERVER_INSTRUCTIONS).toContain(TIER_NOT_PERMITTED_CODE);
   });
 
-  it("points discovery at the live introspection tool ids", () => {
-    // The ids are literal prose, so a rename that skips this text fails here
-    // instead of silently telling every connecting model to call a dead name.
-    expect(MCP_SERVER_INSTRUCTIONS).toContain(ACTIONS_SEARCH_TOOL_ID);
-    expect(MCP_SERVER_INSTRUCTIONS).toContain(ACTIONS_GET_SCHEMA_TOOL_ID);
-  });
+  it("names only tools that actually exist", () => {
+    // Every dotted id in the text, not a hand-listed subset: a tool rename that
+    // skips this prose fails here rather than telling every connecting model to
+    // call a name that no longer resolves. New references are covered on
+    // arrival, without interpolating constants into model-facing text.
+    const referenced = [...MCP_SERVER_INSTRUCTIONS.matchAll(/`([a-z][A-Za-z]*\.[A-Za-z]+)`/g)].map(
+      ([, id]) => id
+    );
 
-  it("does not claim unlisted tools are callable", () => {
-    // #11582 tried a discoverable-but-unlisted surface and #11585 removed it:
-    // withholding a name is equivalent to revoking it. Instructions that
-    // promised otherwise would send models probing for names that cannot exist.
-    expect(MCP_SERVER_INSTRUCTIONS).toContain("do not invent tool names");
-    expect(MCP_SERVER_INSTRUCTIONS).toContain("does not reveal a deferred catalog");
+    expect(referenced).toContain(ACTIONS_SEARCH_TOOL_ID);
+    expect(referenced).toContain(ACTIONS_GET_SCHEMA_TOOL_ID);
+    expect(referenced.filter((id) => !BUILT_IN_ACTION_IDS.includes(id as never))).toEqual([]);
   });
 });
 

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -305,6 +305,14 @@ describe("sessionServer initialize instructions", () => {
     expect(referenced).toContain(ACTIONS_SEARCH_TOOL_ID);
     expect(referenced).toContain(ACTIONS_GET_SCHEMA_TOOL_ID);
     expect(referenced.filter((id) => !BUILT_IN_ACTION_IDS.includes(id as never))).toEqual([]);
+    // Existing as an action is the weaker guard. The instructions go to every
+    // session including `external`, whose surface is the hand-curated
+    // `mcpExternalTierAllowlist.ts` — `terminal.close` was cut from it in
+    // #11592 while staying a perfectly valid BuiltInActionId. Cutting a
+    // referenced id without editing the prose would leave the text telling
+    // external clients to call something that only ever returns
+    // TIER_NOT_PERMITTED.
+    expect(referenced.filter((id) => !TIER_ALLOWLISTS.external.has(id))).toEqual([]);
   });
 });
 

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -35,6 +35,7 @@ import {
   truncateText,
   readStringField,
   RESOURCE_BACKING_ACTIONS,
+  MCP_SERVER_INSTRUCTIONS,
   TIER_NOT_PERMITTED_CODE,
   CONFIRMATION_REQUIRED_CODE,
   MCP_DEDUP_ALLOWLIST,
@@ -367,6 +368,11 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
         resources: { subscribe: true, listChanged: false },
         prompts: {},
       },
+      // The SDK folds this into the `initialize` result on its own, so no
+      // handler of ours is involved (#11541). Passed at construction because
+      // that result is built once, at the handshake, and instructions have no
+      // update notification — there is no later seam to set them from.
+      instructions: MCP_SERVER_INSTRUCTIONS,
     }
   );
 

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -379,17 +379,32 @@ export const TIER_ALLOWLISTS: Readonly<Record<McpTier, ReadonlySet<string>>> = {
 export const TIER_NOT_PERMITTED_CODE = "TIER_NOT_PERMITTED";
 
 /**
- * Authoring budget for {@link MCP_SERVER_INSTRUCTIONS}, enforced by test rather
- * than by runtime truncation (#11541).
- *
- * Claude Code hard-truncates server instructions at 2 KiB, and the tail is the
- * authorization paragraph — the one sentence whose loss would leave a model
- * guessing at why a call was denied. Silently cutting controlled static text is
- * strictly worse than failing an author's edit, so this is a ceiling the suite
- * asserts, not a bound `truncateText` applies. The 512-byte gap under 2048 is
- * headroom for a future paragraph, not slack to spend on prose.
+ * Where the strictest known client cuts `instructions` off. Claude Code
+ * hard-truncates at 2 KiB, and our tail is the authorization paragraph — the
+ * one sentence whose loss would leave a model guessing at why a call was
+ * denied.
  */
-export const MCP_SERVER_INSTRUCTIONS_MAX_BYTES = 1_536;
+const MCP_INSTRUCTIONS_CLIENT_TRUNCATION_BYTES = 2_048;
+
+/**
+ * Headroom held back from the client cap so the next paragraph someone adds
+ * does not have to arrive in the same edit as a re-measurement of the whole
+ * string. Slack for a future author, not slack to spend on prose.
+ */
+const MCP_INSTRUCTIONS_RESERVE_BYTES = 512;
+
+/**
+ * Authoring budget for {@link MCP_SERVER_INSTRUCTIONS}, enforced by test rather
+ * than by runtime truncation (#11541) — silently cutting controlled static text
+ * is strictly worse than failing an author's edit, so this is a ceiling the
+ * suite asserts, not a bound `truncateText` applies.
+ *
+ * Derived rather than written as a literal so the reserve cannot be quietly
+ * spent by editing one number: raising this means raising the client cap or
+ * lowering the reserve, both of which read as the decisions they are.
+ */
+export const MCP_SERVER_INSTRUCTIONS_MAX_BYTES =
+  MCP_INSTRUCTIONS_CLIENT_TRUNCATION_BYTES - MCP_INSTRUCTIONS_RESERVE_BYTES;
 
 /**
  * The `instructions` string sent once in the MCP `initialize` result (#11541).
@@ -406,25 +421,30 @@ export const MCP_SERVER_INSTRUCTIONS_MAX_BYTES = 1_536;
  * tier-specific sentence would silently rot, whereas the generic tier-model
  * sentence stays true for the life of the session.
  *
- * Tool ids and `TIER_NOT_PERMITTED` appear as literal prose rather than
- * interpolated constants on purpose: the suite asserts they match the exported
- * source-of-truth ids, so renaming a tool fails a test that names this text as
- * newly-lying instead of silently rewriting what the model is told.
+ * Tool ids appear as literal prose rather than interpolated constants on
+ * purpose: the suite extracts every dotted id from this text and asserts it is
+ * a real action, so renaming a tool fails a test naming this text as newly
+ * lying instead of silently rewriting what the model is told.
  *
  * On the discovery paragraph: it must not imply a deferred catalog. #11582
  * tried withholding tools from `tools/list` while keeping them dispatchable and
  * it does not work — no shipped client sends `tools/call` for a name it never
  * received — so #11585 made the listing and the callable set the same boundary.
  * Telling a model otherwise would send it probing for names that cannot exist.
+ *
+ * The shell sentence is scoped to external clients deliberately. In-app tiers
+ * withhold writes on purpose (git/file mutations arrive only at `system`), so
+ * an unscoped "use your shell when a tool is missing" would read to an
+ * `action`-tier model as licence to route around its own authorization floor.
  */
 export const MCP_SERVER_INSTRUCTIONS = [
-  "Daintree orchestrates IDE-owned worktrees, recipes, and agent terminals. Use it for that coordination; when repository, file, git, or forge tools are not exposed, use your own shell.",
+  "Daintree orchestrates IDE-owned worktrees, recipes, and agent terminals — use it for that coordination. External clients should use their own shell and tooling for repository, file, git, and forge work omitted from `tools/list`; that is not licence to route around an in-app tier.",
 
-  "`tools/list` is the advertised baseline; do not invent tool names. When its full schemas are too large to reason over, use `actions.search` with task keywords for a lightweight ranked view of the current session's already-authorized actions, then `actions.getSchema` for one action's exact input and output schema. Discovery reduces context; it does not reveal a deferred catalog or widen access.",
+  "`tools/list` is the advertised baseline; do not invent tool names. When its schemas are too large to reason over, use `actions.search` for a compact ranked shortlist of what this session is already authorized to call, then `actions.getSchema` for one action's manifest entry and whatever schemas it publishes. This narrows attention; it does not reveal a deferred catalog or widen access.",
 
-  "Resolve the active worktree and terminal IDs before acting. `terminal.sendCommand` returns once the text is submitted, not when the command or agent turn finishes — wait with `terminal.waitUntilIdle` or `terminal.waitUntilIdleBatch` rather than polling in a tight loop, then check `agentState`, `waitingReason`, and `exitCode` before your next turn or any irreversible step.",
+  'Resolve the target worktree and terminal ids before scoped actions. `terminal.sendCommand` returns once the text is submitted, not when the work finishes — prefer `terminal.waitUntilIdle` or `terminal.waitUntilIdleBatch` over tight polling, then read `idleReason`, `waitingReason`, and `exitCode` before your next turn or any irreversible step. Those waits track agent panes: a terminal with no tracked agent returns `idleReason: "unknown"` at once, which is not proof a shell command finished.',
 
-  "Authorization is tiered: in-app `workbench`, `action`, and `system` tiers progressively widen access, while `external` has a separate curated surface; calls outside the current authorized surface return `TIER_NOT_PERMITTED`.",
+  "Authorization is tiered: in-app `workbench`, `action`, and `system` progressively widen access, while `external` is an independently curated allowlist; a call outside the current authorized surface returns `TIER_NOT_PERMITTED`. Honor `retriable` on errors — retry a `false` only once arguments, context, or authorization have changed.",
 ].join("\n\n");
 
 /**

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -379,6 +379,55 @@ export const TIER_ALLOWLISTS: Readonly<Record<McpTier, ReadonlySet<string>>> = {
 export const TIER_NOT_PERMITTED_CODE = "TIER_NOT_PERMITTED";
 
 /**
+ * Authoring budget for {@link MCP_SERVER_INSTRUCTIONS}, enforced by test rather
+ * than by runtime truncation (#11541).
+ *
+ * Claude Code hard-truncates server instructions at 2 KiB, and the tail is the
+ * authorization paragraph — the one sentence whose loss would leave a model
+ * guessing at why a call was denied. Silently cutting controlled static text is
+ * strictly worse than failing an author's edit, so this is a ceiling the suite
+ * asserts, not a bound `truncateText` applies. The 512-byte gap under 2048 is
+ * headroom for a future paragraph, not slack to spend on prose.
+ */
+export const MCP_SERVER_INSTRUCTIONS_MAX_BYTES = 1_536;
+
+/**
+ * The `instructions` string sent once in the MCP `initialize` result (#11541).
+ * Clients fold it into the model's system prompt at session start, so this is
+ * the only place to establish cross-cutting workflow rules before the model has
+ * picked a tool. Per the MCP spec, it deliberately does not restate tool
+ * descriptions — every line here is guidance no single tool's description
+ * carries.
+ *
+ * Deliberately static and tier-agnostic even though the tier is knowable at
+ * construction (`httpLifecycle.ts` resolves it before `createSessionServer`).
+ * `instructions` is sent once and has no update notification, while in-app tiers
+ * elevate and decay mid-session and grants widen the surface transiently — a
+ * tier-specific sentence would silently rot, whereas the generic tier-model
+ * sentence stays true for the life of the session.
+ *
+ * Tool ids and `TIER_NOT_PERMITTED` appear as literal prose rather than
+ * interpolated constants on purpose: the suite asserts they match the exported
+ * source-of-truth ids, so renaming a tool fails a test that names this text as
+ * newly-lying instead of silently rewriting what the model is told.
+ *
+ * On the discovery paragraph: it must not imply a deferred catalog. #11582
+ * tried withholding tools from `tools/list` while keeping them dispatchable and
+ * it does not work — no shipped client sends `tools/call` for a name it never
+ * received — so #11585 made the listing and the callable set the same boundary.
+ * Telling a model otherwise would send it probing for names that cannot exist.
+ */
+export const MCP_SERVER_INSTRUCTIONS = [
+  "Daintree orchestrates IDE-owned worktrees, recipes, and agent terminals. Use it for that coordination; when repository, file, git, or forge tools are not exposed, use your own shell.",
+
+  "`tools/list` is the advertised baseline; do not invent tool names. When its full schemas are too large to reason over, use `actions.search` with task keywords for a lightweight ranked view of the current session's already-authorized actions, then `actions.getSchema` for one action's exact input and output schema. Discovery reduces context; it does not reveal a deferred catalog or widen access.",
+
+  "Resolve the active worktree and terminal IDs before acting. `terminal.sendCommand` returns once the text is submitted, not when the command or agent turn finishes — wait with `terminal.waitUntilIdle` or `terminal.waitUntilIdleBatch` rather than polling in a tight loop, then check `agentState`, `waitingReason`, and `exitCode` before your next turn or any irreversible step.",
+
+  "Authorization is tiered: in-app `workbench`, `action`, and `system` tiers progressively widen access, while `external` has a separate curated surface; calls outside the current authorized surface return `TIER_NOT_PERMITTED`.",
+].join("\n\n");
+
+/**
  * Creation-tool allowlist for per-session idempotency dedup. LLMs replay
  * tool calls during multi-step planning, especially across reconnects.
  * Inside the TTL window a duplicate call returns the original result


### PR DESCRIPTION
## Summary

- The local MCP server sent no `instructions` field at `initialize`. Clients fold that text into the model's system prompt at session start, so it's the only place to set cross-cutting workflow rules before the model has picked a tool.
- Adds a static `MCP_SERVER_INSTRUCTIONS` string in `shared.ts` and passes it as `ServerOptions.instructions` in the existing `new Server(...)` call in `sessionServer.ts`. The SDK folds it into the initialize result on its own, no request handler of ours is involved.
- Text is static and tier-agnostic on purpose: the tier is knowable at construction time, but `instructions` is sent once with no update notification, while in-app tiers elevate and decay mid-session. A tier-specific sentence would go stale within the same session.

Resolves #11541

## A note on the issue's premise

Issue #11541 was written when #11540 (ship a small core tool set, defer the rest) was the plan, and asked for text stating "a tool is callable whether or not it is listed." #11582 and #11585 reversed that plan: `McpVisibility` is now `"core" | "hidden"` (no `"discoverable"`), and `mcpExternalTierAllowlist.ts` records that withholding a name is equivalent to revoking it, because no shipped client sends `tools/call` for a name it never received.

So the instructions state the inverse: `tools/list` is the advertised baseline, and discovery reveals no deferred catalog. Writing the issue's literal wording would have shipped a false claim to every connecting model. Calling it out here so a reviewer comparing against the issue text sees this was deliberate, not a misread.

## Changes

- `electron/services/mcp-server/shared.ts`: adds `MCP_SERVER_INSTRUCTIONS`, covering four things:
  1. **Orchestration boundary**: Daintree owns worktrees, recipes, and agent terminals; external clients use their own shell for repo, file, git, and forge work. Scoped explicitly to external so it doesn't read as permission for an in-app tier to bypass its authorization floor.
  2. **Discovery path**: `actions.search` for a ranked shortlist, `actions.getSchema` for one action's schemas.
  3. **Terminal sequencing**: `terminal.sendCommand` is fire-and-return, prefer the wait tools over tight polling. An untracked terminal returns `idleReason: "unknown"` immediately, which is no proof a shell command finished.
  4. **Tier model** plus the `retriable` error convention.
- `electron/services/mcp-server/sessionServer.ts`: passes `MCP_SERVER_INSTRUCTIONS` as `ServerOptions.instructions`.
- `electron/services/mcp-server/__tests__/sessionServer.test.ts`: new coverage (see Testing).

The byte budget is derived (`2048` client truncation limit minus a `512` reserve equals `1536`) rather than a literal, so the reserve can't be spent by editing one number. Current string is 1508 bytes.

## Testing

- 620 tests pass across every suite covering the changed modules: `sessionServer`, `tierAuth`, `httpLifecycle`, `readinessProbe`, `rendererBridge`, `sessionStore`, `toolCallResult`, `waitUntilIdle`, `McpServerService.auditLog`, `McpServerService.promptsAndResources`.
- `npm run typecheck` exits 0.
- `npx prettier --check` and `npx eslint` both exit 0 on all three changed files.
- Reviewed across three Codex passes, final pass returned ship with no blocking items.
- New tests drive a real MCP handshake through `Client` + `InMemoryTransport.createLinkedPair()` and assert `client.getInstructions()`, so the assertion fails if the field is dropped anywhere between the SDK handler and the client. Also covers the byte budget, tier-invariance across all four tiers, backtick-wrapped tier-name coverage derived from `TIER_ALLOWLISTS` keys, and every dotted tool id in the text checked against `BUILT_IN_ACTION_IDS` so a tool rename fails a test instead of silently telling models to call a dead name.

No docs changed. `docs/architecture/mcp-server.md` already describes the tier model and discovery contract, both unchanged by this.