### PR TITLE
feat(pty): log per-terminal session capture outcomes at graceful shutdown

### DIFF
--- a/electron/services/pty/TerminalGracefulShutdown.ts
+++ b/electron/services/pty/TerminalGracefulShutdown.ts
@@ -27,10 +27,12 @@ export interface TerminalGracefulShutdownHost {
  *
  * Success collapses into a single `captured` — whether the id arrived
  * mid-stream or on the last-chance match at exit doesn't explain anything,
- * because nothing went wrong. Failure stays granular for the opposite reason.
+ * because nothing went wrong. Failure stays granular for the opposite reason:
+ * each bucket points at a different suspect.
  */
 export type GracefulShutdownOutcome =
   | "already-exited"
+  | "already-killed"
   | "agent-not-live"
   | "no-resume-config"
   | "no-quit-signal"
@@ -85,8 +87,16 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
     });
   };
 
-  if (terminal.isExited || terminal.wasKilled) {
+  // Split rather than folded into one bucket: `wasKilled` is set when a kill
+  // is *requested*, while `isExited` means the process is actually gone. A
+  // terminal that is only `wasKilled` has something else tearing it down
+  // concurrently — a different suspect from one that had already exited.
+  if (terminal.isExited) {
     logOutcome("already-exited", false);
+    return null;
+  }
+  if (terminal.wasKilled) {
+    logOutcome("already-killed", false);
     return null;
   }
 

--- a/electron/services/pty/TerminalGracefulShutdown.ts
+++ b/electron/services/pty/TerminalGracefulShutdown.ts
@@ -8,6 +8,9 @@ import {
 } from "./types.js";
 import { getLiveAgentId } from "./terminalTitle.js";
 import { normalizeSubmitEnterDelay } from "./terminalInput.js";
+import { createLogger } from "../../utils/logger.js";
+
+const logger = createLogger("pty:TerminalGracefulShutdown");
 
 export interface TerminalGracefulShutdownHost {
   readonly terminalInfo: TerminalInfo;
@@ -16,17 +19,74 @@ export interface TerminalGracefulShutdownHost {
 }
 
 /**
+ * Which branch of `gracefulShutdown()` resolved this terminal. Logged so a
+ * restore that falls through to a fresh launch can be traced back to a cause:
+ * `timeout` points at the 2.5s budget, `agent-not-live` at state detection,
+ * `exited-no-match` at the agent's `sessionIdPattern`, and the write/demotion
+ * outcomes at the quit signal never landing (#11591).
+ *
+ * Success collapses into a single `captured` — whether the id arrived
+ * mid-stream or on the last-chance match at exit doesn't explain anything,
+ * because nothing went wrong. Failure stays granular for the opposite reason.
+ */
+export type GracefulShutdownOutcome =
+  | "already-exited"
+  | "agent-not-live"
+  | "no-resume-config"
+  | "no-quit-signal"
+  | "captured"
+  | "timeout"
+  | "exited-no-pattern"
+  | "exited-no-match"
+  | "prelude-write-failed"
+  | "demoted-during-clear-delay"
+  | "demoted-during-submit-delay"
+  | "quit-signal-write-failed";
+
+/**
  * Issue the agent's `quitCommand` / `shutdownKeySequence`, optionally wait
  * for a `session-id` echo to land, then `kill("graceful-shutdown")`. Used
  * by Daintree's resume flow to capture a chat session ID before tearing
  * down the PTY. Returns the captured session id, or `null` if the agent
  * has no resume config, has already exited, demoted before shutdown, or
  * the timeout fires before a match.
+ *
+ * Every agent terminal emits exactly one `info` line naming its
+ * {@link GracefulShutdownOutcome}; terminals with no agent identity stay
+ * silent. Callers get the bare id back — the outcome rides the log rather
+ * than the return type, so no caller signature has to widen for it.
  */
 export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Promise<string | null> {
+  const startedAt = Date.now();
   const terminal = host.terminalInfo;
 
+  // Scope gate: only agent terminals get an outcome line. A plain shell has
+  // neither agent id, so `host.isAgentLive` is already false for it — without
+  // this gate every non-agent pane would log `agent-not-live` on each quit.
+  // Deliberately hoisted above the liveness gate: `getLiveAgentId` and
+  // `isAgentLive` are both pure field reads, so the ordering swap is invisible
+  // and both paths still return null. Don't "restore" the original order.
+  const liveAgentId = getLiveAgentId(terminal);
+  if (!liveAgentId) {
+    return null;
+  }
+
+  // Never log the captured session id itself — it's a resume credential
+  // (`--resume <id>`) and `logs.getAll` serves this buffer to agents verbatim.
+  // `captured` carries everything the issue asked for.
+  const logOutcome = (outcome: GracefulShutdownOutcome, captured: boolean): void => {
+    logger.info("Graceful shutdown capture outcome", {
+      terminalId: terminal.id,
+      projectId: terminal.projectId ?? null,
+      agentId: liveAgentId,
+      outcome,
+      captured,
+      elapsedMs: Date.now() - startedAt,
+    });
+  };
+
   if (terminal.isExited || terminal.wasKilled) {
+    logOutcome("already-exited", false);
     return null;
   }
 
@@ -34,21 +94,23 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
   // user typed /quit and the terminal demoted to a plain shell. The
   // launchAgentId persists for identity, but the agent is gone.
   if (!host.isAgentLive) {
+    logOutcome("agent-not-live", false);
     return null;
   }
 
-  const liveAgentId = getLiveAgentId(terminal);
-  const agentConfig = liveAgentId ? getEffectiveAgentConfig(liveAgentId) : undefined;
+  const agentConfig = getEffectiveAgentConfig(liveAgentId);
   const resume = agentConfig?.resume;
 
   // Nothing to send — agent has no resume config or the config supplies
   // neither a quit command nor a key sequence we can emit on shutdown.
   if (!resume) {
+    logOutcome("no-resume-config", false);
     return null;
   }
   const quitCommand = resume.quitCommand;
   const shutdownKeySequence = resume.shutdownKeySequence;
   if (!quitCommand && !shutdownKeySequence) {
+    logOutcome("no-quit-signal", false);
     return null;
   }
   const quitSubmitEnterDelayMs = normalizeSubmitEnterDelay(
@@ -75,7 +137,7 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
     let origOnData: { dispose(): void } = { dispose() {} };
     let origOnExit: { dispose(): void } = { dispose() {} };
 
-    const finish = (sessionId: string | null) => {
+    const finish = (sessionId: string | null, outcome: GracefulShutdownOutcome) => {
       if (resolved) return;
       resolved = true;
       clearTimeout(timer);
@@ -89,11 +151,15 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
         terminal.agentSessionId = sessionId;
       }
 
+      // Logged before kill() so a throwing kill can't erase the diagnostic, and
+      // after the `resolved` guard so a losing racer never double-logs.
+      logOutcome(outcome, sessionId !== null);
+
       host.kill("graceful-shutdown");
       resolve(sessionId);
     };
 
-    const timer = setTimeout(() => finish(null), GRACEFUL_SHUTDOWN_TIMEOUT_MS);
+    const timer = setTimeout(() => finish(null, "timeout"), GRACEFUL_SHUTDOWN_TIMEOUT_MS);
 
     origOnData = terminal.ptyProcess.onData((data: string) => {
       if (resolved) return;
@@ -118,19 +184,20 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
         // restore-on-restart to hand the agent an invalid identifier.
         const captureEnd = match.index + match[0].length;
         if (captureEnd < stripped.length) {
-          finish(match[1]);
+          finish(match[1], "captured");
         }
       }
     });
 
     origOnExit = terminal.ptyProcess.onExit(() => {
       if (!pattern) {
-        finish(null);
+        finish(null, "exited-no-pattern");
         return;
       }
       const stripped = stripAnsiCodes(shutdownBuffer);
       const match = pattern.exec(stripped);
-      finish(match?.[1] ?? null);
+      const sessionId = match?.[1] ?? null;
+      finish(sessionId, sessionId ? "captured" : "exited-no-match");
     });
 
     // Clear any partial user input at the agent prompt before issuing the quit command.
@@ -145,7 +212,7 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
       } catch {
         origOnData.dispose();
         origOnExit.dispose();
-        finish(null);
+        finish(null, "prelude-write-failed");
         return;
       }
 
@@ -159,7 +226,7 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
       if (!host.isAgentLive) {
         origOnData.dispose();
         origOnExit.dispose();
-        finish(null);
+        finish(null, "demoted-during-clear-delay");
         return;
       }
 
@@ -184,7 +251,7 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
             if (!host.isAgentLive) {
               origOnData.dispose();
               origOnExit.dispose();
-              finish(null);
+              finish(null, "demoted-during-submit-delay");
               return;
             }
 
@@ -194,7 +261,7 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
       } catch {
         origOnData.dispose();
         origOnExit.dispose();
-        finish(null);
+        finish(null, "quit-signal-write-failed");
       }
     })();
   });

--- a/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
@@ -523,11 +523,33 @@ describe("TerminalProcess.gracefulShutdown — outcome logging", () => {
     return logBuffer.getFiltered({ sources: [SOURCE] });
   }
 
-  /** The outcome of the single entry logged so far, asserting there is only one. */
-  function soleOutcome(): string | undefined {
+  function contextOf(entry: { context?: unknown } | undefined) {
+    return entry?.context as
+      | {
+          terminalId?: string;
+          projectId?: string | null;
+          agentId?: string;
+          outcome?: string;
+          captured?: boolean;
+          elapsedMs?: number;
+        }
+      | undefined;
+  }
+
+  /**
+   * The outcome of the single entry logged so far, asserting there is exactly
+   * one and that it actually names something. Returning `undefined` on a
+   * missing outcome would let a branch that logs nothing useful slip past the
+   * distinctness checks below.
+   */
+  function soleOutcome(): string {
     const entries = shutdownEntries();
     expect(entries).toHaveLength(1);
-    return (entries[0]?.context as { outcome?: string } | undefined)?.outcome;
+    const outcome = contextOf(entries[0])?.outcome;
+    expect(typeof outcome).toBe("string");
+    expect(outcome).not.toBe("");
+    logBuffer.clear();
+    return outcome as string;
   }
 
   function createPlainTerminal(handles: MockPtyHandles): TerminalProcess {
@@ -561,84 +583,192 @@ describe("TerminalProcess.gracefulShutdown — outcome logging", () => {
     expect(shutdownEntries()).toHaveLength(0);
   });
 
-  it("reports a distinct outcome for each pre-quit early return", async () => {
-    // `no-quit-signal` is deliberately absent: no agent in the roster ships a
-    // resume config without a quitCommand or shutdownKeySequence, so that
-    // branch is defensive-only and unreachable without mocking the registry.
-    const collected: (string | undefined)[] = [];
+  // Every branch that is reachable without mocking the agent registry, each
+  // driven to completion and reduced to the outcome it logged. `no-quit-signal`
+  // is absent on purpose: no agent in the roster ships a resume config lacking
+  // both a quitCommand and a shutdownKeySequence, so it is defensive-only.
+  const BRANCHES: Record<string, () => Promise<string>> = {
+    async alreadyExited() {
+      const handles = createMockPty();
+      const terminal = createAgentTerminal(handles);
+      terminal.getInfo().isExited = true;
+      await expect(terminal.gracefulShutdown()).resolves.toBeNull();
+      return soleOutcome();
+    },
 
-    const exitedHandles = createMockPty();
-    const exited = createAgentTerminal(exitedHandles);
-    exited.getInfo().isExited = true;
-    await expect(exited.gracefulShutdown()).resolves.toBeNull();
-    collected.push(soleOutcome());
-    logBuffer.clear();
+    // `wasKilled` is set when a kill is *requested*; the process may still be
+    // running. Distinct from having already exited.
+    async alreadyKilled() {
+      const handles = createMockPty();
+      const terminal = createAgentTerminal(handles);
+      terminal.getInfo().wasKilled = true;
+      await expect(terminal.gracefulShutdown()).resolves.toBeNull();
+      return soleOutcome();
+    },
 
     // Demoted to a plain shell via /quit — launchAgentId persists for
     // identity, so this still counts as an agent terminal (issue #6605).
-    const demotedHandles = createMockPty();
-    const demoted = createAgentTerminal(demotedHandles);
-    demoted.getInfo().agentState = "exited";
-    demoted.getInfo().detectedAgentId = undefined;
-    await expect(demoted.gracefulShutdown()).resolves.toBeNull();
-    collected.push(soleOutcome());
-    logBuffer.clear();
+    async agentNotLive() {
+      const handles = createMockPty();
+      const terminal = createAgentTerminal(handles);
+      terminal.getInfo().agentState = "exited";
+      terminal.getInfo().detectedAgentId = undefined;
+      await expect(terminal.gracefulShutdown()).resolves.toBeNull();
+      return soleOutcome();
+    },
 
     // Cursor is registered but ships no resume config at all.
-    const noResumeHandles = createMockPty();
-    const noResume = createAgentTerminal(noResumeHandles, "cursor");
-    await expect(noResume.gracefulShutdown()).resolves.toBeNull();
-    collected.push(soleOutcome());
+    async noResumeConfig() {
+      const handles = createMockPty();
+      const terminal = createAgentTerminal(handles, "cursor");
+      await expect(terminal.gracefulShutdown()).resolves.toBeNull();
+      return soleOutcome();
+    },
 
-    expect(new Set(collected).size).toBe(collected.length);
-    expect(collected.every((o) => typeof o === "string" && o.length > 0)).toBe(true);
+    async capturedOnData() {
+      const handles = createMockPty();
+      const terminal = createAgentTerminal(handles);
+      const promise = terminal.gracefulShutdown();
+      await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+      handles.emitData("claude --resume mid-stream\n");
+      await expect(promise).resolves.toBe("mid-stream");
+      return soleOutcome();
+    },
+
+    // No trailing boundary, so onData must decline and only the last-chance
+    // match at exit can capture it.
+    async capturedAtExit() {
+      const handles = createMockPty();
+      const terminal = createAgentTerminal(handles);
+      const promise = terminal.gracefulShutdown();
+      await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+      handles.emitData("claude --resume at-exit");
+      // If onData wrongly accepted the buffer-tail capture it would resolve
+      // here, dispose the exit listener, and make the emitExit below a no-op —
+      // the outcome would still look right. Pin the interim state.
+      expect(shutdownEntries()).toHaveLength(0);
+      handles.emitExit(0);
+      await expect(promise).resolves.toBe("at-exit");
+      return soleOutcome();
+    },
+
+    async timeout() {
+      const handles = createMockPty();
+      const terminal = createAgentTerminal(handles);
+      const promise = terminal.gracefulShutdown();
+      await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_TIMEOUT_MS);
+      await expect(promise).resolves.toBeNull();
+      return soleOutcome();
+    },
+
+    // Kiro is project-scoped: null is the designed result, not a failure.
+    // Folding it into the pattern-miss bucket would send someone hunting a
+    // sessionIdPattern bug for an agent that has no pattern at all (#4781).
+    async exitedNoPattern() {
+      const handles = createMockPty();
+      const terminal = createAgentTerminal(handles, "kiro");
+      const promise = terminal.gracefulShutdown();
+      await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+      await vi.advanceTimersByTimeAsync(SUBMIT_ENTER_DELAY_MS);
+      handles.emitExit(0);
+      await expect(promise).resolves.toBeNull();
+      return soleOutcome();
+    },
+
+    async exitedNoMatch() {
+      const handles = createMockPty();
+      const terminal = createAgentTerminal(handles);
+      const promise = terminal.gracefulShutdown();
+      await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+      handles.emitData("goodbye, nothing resumable here\n");
+      handles.emitExit(0);
+      await expect(promise).resolves.toBeNull();
+      return soleOutcome();
+    },
+
+    async preludeWriteFailed() {
+      let pending = true;
+      const handles = createMockPty((data: string) => {
+        if (pending && data === "\x05\x15") {
+          pending = false;
+          throw new Error("pty dead");
+        }
+      });
+      const terminal = createAgentTerminal(handles);
+      await expect(terminal.gracefulShutdown()).resolves.toBeNull();
+      return soleOutcome();
+    },
+
+    async quitSignalWriteFailed() {
+      const handles = createMockPty((data: string) => {
+        if (data === "/quit\r") throw new Error("pty dead after prelude");
+      });
+      const terminal = createAgentTerminal(handles);
+      const promise = terminal.gracefulShutdown();
+      await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+      await expect(promise).resolves.toBeNull();
+      return soleOutcome();
+    },
+
+    // No quit signal has gone out yet at this point...
+    async demotedDuringClearDelay() {
+      const handles = createMockPty();
+      const terminal = createAgentTerminal(handles);
+      const promise = terminal.gracefulShutdown();
+      await Promise.resolve();
+      await Promise.resolve();
+      terminal.getInfo().agentState = "exited";
+      terminal.getInfo().detectedAgentId = undefined;
+      await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+      await expect(promise).resolves.toBeNull();
+      return soleOutcome();
+    },
+
+    // ...whereas here the split-write body landed and only Enter is missing.
+    // Codex splits body and Enter, so only it reaches this gate.
+    async demotedDuringSubmitDelay() {
+      const handles = createMockPty();
+      const terminal = createAgentTerminal(handles, "codex");
+      const promise = terminal.gracefulShutdown();
+      await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+      terminal.getInfo().agentState = "exited";
+      terminal.getInfo().detectedAgentId = undefined;
+      await vi.advanceTimersByTimeAsync(SUBMIT_ENTER_DELAY_MS);
+      await expect(promise).resolves.toBeNull();
+      return soleOutcome();
+    },
+  };
+
+  it("gives every branch its own outcome, and both capture paths the same one", async () => {
+    // The point of the whole feature: a reader of daintree.log can tell which
+    // branch fired. That only holds if no two branches share a label —
+    // checking pairs in isolation would miss a label reused across pairs.
+    // The two capture paths are the one deliberate collision: both succeeded,
+    // so neither explains a restore fallthrough.
+    const results: Record<string, string> = {};
+    for (const [name, run] of Object.entries(BRANCHES)) {
+      results[name] = await run();
+    }
+
+    expect(results.capturedAtExit).toBe(results.capturedOnData);
+
+    const distinct = Object.entries(results)
+      .filter(([name]) => name !== "capturedAtExit")
+      .map(([, outcome]) => outcome);
+    expect(new Set(distinct).size).toBe(distinct.length);
   });
 
-  it("reports one capture outcome whether the id lands mid-stream or at exit", async () => {
-    // Both are successes and neither explains a restore fallthrough, so they
-    // share a bucket. What must hold is that `captured` tracks the returned id.
-    const streamHandles = createMockPty();
-    const streamTerminal = createAgentTerminal(streamHandles);
-    const streamPromise = streamTerminal.gracefulShutdown();
+  it("reports captured only when an id actually came back", async () => {
+    // `captured` is the field the issue asked for — it must track the returned
+    // value, not the branch's optimism.
+    const hitHandles = createMockPty();
+    const hitTerminal = createAgentTerminal(hitHandles);
+    const hitPromise = hitTerminal.gracefulShutdown();
     await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
-    streamHandles.emitData("claude --resume mid-stream\n");
-    const streamResult = await streamPromise;
-    const streamEntry = shutdownEntries()[0];
-    const streamOutcome = soleOutcome();
-    logBuffer.clear();
-
-    // No trailing boundary, so onData declines and only the last-chance match
-    // at exit can capture it.
-    const exitHandles = createMockPty();
-    const exitTerminal = createAgentTerminal(exitHandles);
-    const exitPromise = exitTerminal.gracefulShutdown();
-    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
-    exitHandles.emitData("claude --resume at-exit");
-    exitHandles.emitExit(0);
-    const exitResult = await exitPromise;
-    const exitEntry = shutdownEntries()[0];
-    const exitOutcome = soleOutcome();
-
-    expect(streamResult).not.toBeNull();
-    expect(exitResult).not.toBeNull();
-    expect(exitOutcome).toBe(streamOutcome);
-    expect((streamEntry?.context as { captured?: boolean } | undefined)?.captured).toBe(
-      streamResult !== null
-    );
-    expect((exitEntry?.context as { captured?: boolean } | undefined)?.captured).toBe(
-      exitResult !== null
-    );
-  });
-
-  it("separates a capture at exit from a pattern that never matched", async () => {
-    const capturedHandles = createMockPty();
-    const capturedTerminal = createAgentTerminal(capturedHandles);
-    const capturedPromise = capturedTerminal.gracefulShutdown();
-    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
-    capturedHandles.emitData("claude --resume landed-late");
-    capturedHandles.emitExit(0);
-    await expect(capturedPromise).resolves.not.toBeNull();
-    const capturedOutcome = soleOutcome();
+    hitHandles.emitData("claude --resume landed\n");
+    const hitResult = await hitPromise;
+    expect(contextOf(shutdownEntries()[0])?.captured).toBe(hitResult !== null);
+    expect(hitResult).not.toBeNull();
     logBuffer.clear();
 
     const missHandles = createMockPty();
@@ -647,94 +777,9 @@ describe("TerminalProcess.gracefulShutdown — outcome logging", () => {
     await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
     missHandles.emitData("goodbye, nothing resumable here\n");
     missHandles.emitExit(0);
-    await expect(missPromise).resolves.toBeNull();
-    const missOutcome = soleOutcome();
-
-    // A miss points at the agent's sessionIdPattern; a capture points nowhere.
-    expect(missOutcome).not.toBe(capturedOutcome);
-  });
-
-  it("separates an agent with no session-id pattern from one whose pattern missed", async () => {
-    // Kiro is project-scoped: null is the designed result, not a failure.
-    // Collapsing it into the pattern-miss bucket would send someone hunting a
-    // sessionIdPattern bug for an agent that has no pattern at all (#4781).
-    const kiroHandles = createMockPty();
-    const kiroTerminal = createAgentTerminal(kiroHandles, "kiro");
-    const kiroPromise = kiroTerminal.gracefulShutdown();
-    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
-    await vi.advanceTimersByTimeAsync(SUBMIT_ENTER_DELAY_MS);
-    kiroHandles.emitExit(0);
-    await expect(kiroPromise).resolves.toBeNull();
-    const kiroOutcome = soleOutcome();
-    logBuffer.clear();
-
-    const missHandles = createMockPty();
-    const missTerminal = createAgentTerminal(missHandles);
-    const missPromise = missTerminal.gracefulShutdown();
-    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
-    missHandles.emitExit(0);
-    await expect(missPromise).resolves.toBeNull();
-    const missOutcome = soleOutcome();
-
-    expect(kiroOutcome).not.toBe(missOutcome);
-  });
-
-  it("separates the two demotion windows", async () => {
-    // They imply different amounts of submitted input: during the clear delay
-    // no quit signal has gone out at all, while during the submit delay the
-    // split-write body landed and only Enter is missing. Same cause
-    // ("agent went away"), different thing to go look at.
-    const clearHandles = createMockPty();
-    const clearTerminal = createAgentTerminal(clearHandles);
-    const clearPromise = clearTerminal.gracefulShutdown();
-    await Promise.resolve();
-    await Promise.resolve();
-    clearTerminal.getInfo().agentState = "exited";
-    clearTerminal.getInfo().detectedAgentId = undefined;
-    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
-    await expect(clearPromise).resolves.toBeNull();
-    const clearOutcome = soleOutcome();
-    logBuffer.clear();
-
-    // Codex splits body and Enter, so only it can reach the submit-delay gate.
-    const submitHandles = createMockPty();
-    const submitTerminal = createAgentTerminal(submitHandles, "codex");
-    const submitPromise = submitTerminal.gracefulShutdown();
-    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
-    submitTerminal.getInfo().agentState = "exited";
-    submitTerminal.getInfo().detectedAgentId = undefined;
-    await vi.advanceTimersByTimeAsync(SUBMIT_ENTER_DELAY_MS);
-    await expect(submitPromise).resolves.toBeNull();
-    const submitOutcome = soleOutcome();
-
-    expect(clearOutcome).not.toBe(submitOutcome);
-  });
-
-  it("separates a failed prelude write from a failed quit-signal write", async () => {
-    // The prelude failing means the PTY was already gone; the quit write
-    // failing means it died in the clear-delay window. Different suspects.
-    let preludePending = true;
-    const preludeHandles = createMockPty((data: string) => {
-      if (preludePending && data === "\x05\x15") {
-        preludePending = false;
-        throw new Error("pty dead");
-      }
-    });
-    const preludeTerminal = createAgentTerminal(preludeHandles);
-    await expect(preludeTerminal.gracefulShutdown()).resolves.toBeNull();
-    const preludeOutcome = soleOutcome();
-    logBuffer.clear();
-
-    const quitHandles = createMockPty((data: string) => {
-      if (data === "/quit\r") throw new Error("pty dead after prelude");
-    });
-    const quitTerminal = createAgentTerminal(quitHandles);
-    const quitPromise = quitTerminal.gracefulShutdown();
-    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
-    await expect(quitPromise).resolves.toBeNull();
-    const quitOutcome = soleOutcome();
-
-    expect(preludeOutcome).not.toBe(quitOutcome);
+    const missResult = await missPromise;
+    expect(contextOf(shutdownEntries()[0])?.captured).toBe(missResult !== null);
+    expect(missResult).toBeNull();
   });
 
   it("never lets the captured session id reach the log", async () => {
@@ -757,7 +802,38 @@ describe("TerminalProcess.gracefulShutdown — outcome logging", () => {
     await expect(shutdownPromise).resolves.toBe(sentinel);
     expect(terminal.getInfo().agentSessionId).toBe(sentinel);
 
-    expect(JSON.stringify(shutdownEntries())).not.toContain(sentinel);
+    // Positive control first: an empty buffer trivially "contains no secret",
+    // so without this the test would stay green if logging were deleted.
+    const entries = shutdownEntries();
+    expect(entries).toHaveLength(1);
+    expect(JSON.stringify(entries)).not.toContain(sentinel);
+
+    // Whitelist the context rather than just scanning for this one value: a
+    // leak under a brand-new key would slip a substring scan, and the logger's
+    // redaction only covers key names it already knows about.
+    expect(Object.keys(contextOf(entries[0]) ?? {}).sort()).toEqual([
+      "agentId",
+      "captured",
+      "elapsedMs",
+      "outcome",
+      "projectId",
+      "terminalId",
+    ]);
+  });
+
+  it("emits at info — loud enough for daintree.log, not louder", async () => {
+    // The info floor above proves it isn't debug, but warn would clear that bar
+    // too. Raising the floor to warn must silence it, which pins the level from
+    // both sides without asserting the literal "info" the implementation uses.
+    setLogLevelOverrides({ "*": "warn" });
+
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles);
+    const promise = terminal.gracefulShutdown();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_TIMEOUT_MS);
+    await expect(promise).resolves.toBeNull();
+
+    expect(shutdownEntries()).toHaveLength(0);
   });
 
   it("logs once when a late exit event races the capture that already won", async () => {
@@ -779,21 +855,42 @@ describe("TerminalProcess.gracefulShutdown — outcome logging", () => {
   });
 
   it("carries the terminal's identity and a real elapsed measurement", async () => {
+    // The issue's complaint was not being able to tell two panes of the same
+    // project apart, so every identity field has to survive the trip.
     const handles = createMockPty();
     const terminal = createAgentTerminal(handles);
+    terminal.getInfo().projectId = "proj-11591";
 
     const shutdownPromise = terminal.gracefulShutdown();
     await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_TIMEOUT_MS);
     await expect(shutdownPromise).resolves.toBeNull();
 
-    const context = shutdownEntries()[0]?.context as
-      { terminalId?: string; agentId?: string; captured?: boolean; elapsedMs?: number } | undefined;
+    const context = contextOf(shutdownEntries()[0]);
 
     expect(context?.terminalId).toBe(terminal.getInfo().id);
+    expect(context?.projectId).toBe(terminal.getInfo().projectId);
     expect(context?.agentId).toBe(terminal.getInfo().launchAgentId);
     expect(context?.captured).toBe(false);
-    // Elapsed has to be measured, not stamped: a shutdown that ran the full
-    // budget must report at least the budget, which a hardcoded 0 would not.
+    // Elapsed has to be measured, not stamped. Bounded on both sides: a
+    // hardcoded 0 fails the lower bound, and a sentinel like Infinity or a raw
+    // Date.now() stamp fails the upper one.
     expect(context?.elapsedMs).toBeGreaterThanOrEqual(GRACEFUL_SHUTDOWN_TIMEOUT_MS);
+    expect(context?.elapsedMs).toBeLessThan(GRACEFUL_SHUTDOWN_TIMEOUT_MS * 10);
+  });
+
+  it("measures elapsed from the start of the shutdown, not the whole session", async () => {
+    // A capture that lands early must report a small elapsed — that is what
+    // makes "timeout points at the 2.5s budget" actionable rather than noise.
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles);
+
+    const promise = terminal.gracefulShutdown();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+    handles.emitData("claude --resume quick\n");
+    await expect(promise).resolves.toBe("quick");
+
+    const elapsed = contextOf(shutdownEntries()[0])?.elapsedMs ?? -1;
+    expect(elapsed).toBeGreaterThanOrEqual(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+    expect(elapsed).toBeLessThan(GRACEFUL_SHUTDOWN_TIMEOUT_MS);
   });
 });

--- a/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
@@ -4,6 +4,8 @@ import { TerminalProcess } from "../TerminalProcess.js";
 import type { SpawnContext } from "../terminalSpawn.js";
 import { GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS, GRACEFUL_SHUTDOWN_TIMEOUT_MS } from "../types.js";
 import { SUBMIT_ENTER_DELAY_MS } from "../terminalInput.js";
+import { logBuffer } from "../../LogBuffer.js";
+import { getLogLevelOverrides, setLogLevelOverrides } from "../../../utils/logger.js";
 
 vi.mock("node-pty", () => {
   return { spawn: vi.fn() };
@@ -14,6 +16,13 @@ interface MockPtyHandles {
   writeMock: ReturnType<typeof vi.fn<(data: string) => void>>;
   emitData: (data: string) => void;
   emitExit: (exitCode: number, signal?: number) => void;
+  /**
+   * Deliver an exit event to the observer even after it was disposed —
+   * node-pty can hand over an already-queued exit during teardown, which is
+   * exactly the re-entry `finish()`'s `resolved` guard exists to absorb.
+   * `emitExit` can't reach it because dispose drops the callback first.
+   */
+  emitExitIgnoringDispose: (exitCode: number, signal?: number) => void;
   onDataDispose: ReturnType<typeof vi.fn>;
   onExitDispose: ReturnType<typeof vi.fn>;
 }
@@ -21,6 +30,8 @@ interface MockPtyHandles {
 function createMockPty(writeOverride?: (data: string) => void): MockPtyHandles {
   let dataCallback: ((data: string) => void) | null = null;
   let exitCallback: ((event: { exitCode: number; signal?: number }) => void) | null = null;
+  let undisposedExitCallback: ((event: { exitCode: number; signal?: number }) => void) | null =
+    null;
 
   const writeMock = vi.fn<(data: string) => void>();
   const onDataDispose = vi.fn(() => {
@@ -48,6 +59,7 @@ function createMockPty(writeOverride?: (data: string) => void): MockPtyHandles {
     },
     onExit: (cb: (e: { exitCode: number; signal?: number }) => void) => {
       exitCallback = cb;
+      undisposedExitCallback = cb;
       return { dispose: onExitDispose };
     },
   };
@@ -57,6 +69,8 @@ function createMockPty(writeOverride?: (data: string) => void): MockPtyHandles {
     writeMock,
     emitData: (data: string) => dataCallback?.(data),
     emitExit: (exitCode: number, signal?: number) => exitCallback?.({ exitCode, signal }),
+    emitExitIgnoringDispose: (exitCode: number, signal?: number) =>
+      undisposedExitCallback?.({ exitCode, signal }),
     onDataDispose,
     onExitDispose,
   };
@@ -480,5 +494,306 @@ describe("TerminalProcess.gracefulShutdown — listener disposal", () => {
 
     expect(handles.onDataDispose).toHaveBeenCalled();
     expect(handles.onExitDispose).toHaveBeenCalled();
+  });
+});
+
+describe("TerminalProcess.gracefulShutdown — outcome logging", () => {
+  const SOURCE = "pty:TerminalGracefulShutdown";
+  let savedOverrides: Record<string, string>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    savedOverrides = getLogLevelOverrides();
+    // Vitest runs with NODE_ENV=development, which floors the logger at
+    // "debug". Pin it to production's "info" floor: these lines only earn
+    // their keep if they reach daintree.log on a user's machine, so an
+    // implementation that emitted them at debug must fail here rather than
+    // pass on the looser dev floor.
+    setLogLevelOverrides({ "*": "info" });
+    logBuffer.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    setLogLevelOverrides(savedOverrides);
+    logBuffer.clear();
+  });
+
+  function shutdownEntries() {
+    return logBuffer.getFiltered({ sources: [SOURCE] });
+  }
+
+  /** The outcome of the single entry logged so far, asserting there is only one. */
+  function soleOutcome(): string | undefined {
+    const entries = shutdownEntries();
+    expect(entries).toHaveLength(1);
+    return (entries[0]?.context as { outcome?: string } | undefined)?.outcome;
+  }
+
+  function createPlainTerminal(handles: MockPtyHandles): TerminalProcess {
+    return new TerminalProcess(
+      "t-plain",
+      { cwd: process.cwd(), cols: 80, rows: 24, kind: "terminal" },
+      { emitData: () => {}, onExit: () => {} },
+      {
+        agentStateService: {
+          handleActivityState: () => {},
+          updateAgentState: () => {},
+          emitAgentKilled: () => {},
+        } as never,
+        ptyPool: null,
+        processTreeCache: null,
+      },
+      defaultSpawnContext(),
+      handles.pty
+    );
+  }
+
+  it("stays silent for a terminal that never had an agent", async () => {
+    // The scope gate. A plain shell fails `isAgentLive` for lack of any agent
+    // id, so without the gate every non-agent pane would report
+    // "agent-not-live" on each quit and bury the agent lines that matter.
+    const handles = createMockPty();
+    const terminal = createPlainTerminal(handles);
+
+    await expect(terminal.gracefulShutdown()).resolves.toBeNull();
+
+    expect(shutdownEntries()).toHaveLength(0);
+  });
+
+  it("reports a distinct outcome for each pre-quit early return", async () => {
+    // `no-quit-signal` is deliberately absent: no agent in the roster ships a
+    // resume config without a quitCommand or shutdownKeySequence, so that
+    // branch is defensive-only and unreachable without mocking the registry.
+    const collected: (string | undefined)[] = [];
+
+    const exitedHandles = createMockPty();
+    const exited = createAgentTerminal(exitedHandles);
+    exited.getInfo().isExited = true;
+    await expect(exited.gracefulShutdown()).resolves.toBeNull();
+    collected.push(soleOutcome());
+    logBuffer.clear();
+
+    // Demoted to a plain shell via /quit — launchAgentId persists for
+    // identity, so this still counts as an agent terminal (issue #6605).
+    const demotedHandles = createMockPty();
+    const demoted = createAgentTerminal(demotedHandles);
+    demoted.getInfo().agentState = "exited";
+    demoted.getInfo().detectedAgentId = undefined;
+    await expect(demoted.gracefulShutdown()).resolves.toBeNull();
+    collected.push(soleOutcome());
+    logBuffer.clear();
+
+    // Cursor is registered but ships no resume config at all.
+    const noResumeHandles = createMockPty();
+    const noResume = createAgentTerminal(noResumeHandles, "cursor");
+    await expect(noResume.gracefulShutdown()).resolves.toBeNull();
+    collected.push(soleOutcome());
+
+    expect(new Set(collected).size).toBe(collected.length);
+    expect(collected.every((o) => typeof o === "string" && o.length > 0)).toBe(true);
+  });
+
+  it("reports one capture outcome whether the id lands mid-stream or at exit", async () => {
+    // Both are successes and neither explains a restore fallthrough, so they
+    // share a bucket. What must hold is that `captured` tracks the returned id.
+    const streamHandles = createMockPty();
+    const streamTerminal = createAgentTerminal(streamHandles);
+    const streamPromise = streamTerminal.gracefulShutdown();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+    streamHandles.emitData("claude --resume mid-stream\n");
+    const streamResult = await streamPromise;
+    const streamEntry = shutdownEntries()[0];
+    const streamOutcome = soleOutcome();
+    logBuffer.clear();
+
+    // No trailing boundary, so onData declines and only the last-chance match
+    // at exit can capture it.
+    const exitHandles = createMockPty();
+    const exitTerminal = createAgentTerminal(exitHandles);
+    const exitPromise = exitTerminal.gracefulShutdown();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+    exitHandles.emitData("claude --resume at-exit");
+    exitHandles.emitExit(0);
+    const exitResult = await exitPromise;
+    const exitEntry = shutdownEntries()[0];
+    const exitOutcome = soleOutcome();
+
+    expect(streamResult).not.toBeNull();
+    expect(exitResult).not.toBeNull();
+    expect(exitOutcome).toBe(streamOutcome);
+    expect((streamEntry?.context as { captured?: boolean } | undefined)?.captured).toBe(
+      streamResult !== null
+    );
+    expect((exitEntry?.context as { captured?: boolean } | undefined)?.captured).toBe(
+      exitResult !== null
+    );
+  });
+
+  it("separates a capture at exit from a pattern that never matched", async () => {
+    const capturedHandles = createMockPty();
+    const capturedTerminal = createAgentTerminal(capturedHandles);
+    const capturedPromise = capturedTerminal.gracefulShutdown();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+    capturedHandles.emitData("claude --resume landed-late");
+    capturedHandles.emitExit(0);
+    await expect(capturedPromise).resolves.not.toBeNull();
+    const capturedOutcome = soleOutcome();
+    logBuffer.clear();
+
+    const missHandles = createMockPty();
+    const missTerminal = createAgentTerminal(missHandles);
+    const missPromise = missTerminal.gracefulShutdown();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+    missHandles.emitData("goodbye, nothing resumable here\n");
+    missHandles.emitExit(0);
+    await expect(missPromise).resolves.toBeNull();
+    const missOutcome = soleOutcome();
+
+    // A miss points at the agent's sessionIdPattern; a capture points nowhere.
+    expect(missOutcome).not.toBe(capturedOutcome);
+  });
+
+  it("separates an agent with no session-id pattern from one whose pattern missed", async () => {
+    // Kiro is project-scoped: null is the designed result, not a failure.
+    // Collapsing it into the pattern-miss bucket would send someone hunting a
+    // sessionIdPattern bug for an agent that has no pattern at all (#4781).
+    const kiroHandles = createMockPty();
+    const kiroTerminal = createAgentTerminal(kiroHandles, "kiro");
+    const kiroPromise = kiroTerminal.gracefulShutdown();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+    await vi.advanceTimersByTimeAsync(SUBMIT_ENTER_DELAY_MS);
+    kiroHandles.emitExit(0);
+    await expect(kiroPromise).resolves.toBeNull();
+    const kiroOutcome = soleOutcome();
+    logBuffer.clear();
+
+    const missHandles = createMockPty();
+    const missTerminal = createAgentTerminal(missHandles);
+    const missPromise = missTerminal.gracefulShutdown();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+    missHandles.emitExit(0);
+    await expect(missPromise).resolves.toBeNull();
+    const missOutcome = soleOutcome();
+
+    expect(kiroOutcome).not.toBe(missOutcome);
+  });
+
+  it("separates the two demotion windows", async () => {
+    // They imply different amounts of submitted input: during the clear delay
+    // no quit signal has gone out at all, while during the submit delay the
+    // split-write body landed and only Enter is missing. Same cause
+    // ("agent went away"), different thing to go look at.
+    const clearHandles = createMockPty();
+    const clearTerminal = createAgentTerminal(clearHandles);
+    const clearPromise = clearTerminal.gracefulShutdown();
+    await Promise.resolve();
+    await Promise.resolve();
+    clearTerminal.getInfo().agentState = "exited";
+    clearTerminal.getInfo().detectedAgentId = undefined;
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+    await expect(clearPromise).resolves.toBeNull();
+    const clearOutcome = soleOutcome();
+    logBuffer.clear();
+
+    // Codex splits body and Enter, so only it can reach the submit-delay gate.
+    const submitHandles = createMockPty();
+    const submitTerminal = createAgentTerminal(submitHandles, "codex");
+    const submitPromise = submitTerminal.gracefulShutdown();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+    submitTerminal.getInfo().agentState = "exited";
+    submitTerminal.getInfo().detectedAgentId = undefined;
+    await vi.advanceTimersByTimeAsync(SUBMIT_ENTER_DELAY_MS);
+    await expect(submitPromise).resolves.toBeNull();
+    const submitOutcome = soleOutcome();
+
+    expect(clearOutcome).not.toBe(submitOutcome);
+  });
+
+  it("separates a failed prelude write from a failed quit-signal write", async () => {
+    // The prelude failing means the PTY was already gone; the quit write
+    // failing means it died in the clear-delay window. Different suspects.
+    let preludePending = true;
+    const preludeHandles = createMockPty((data: string) => {
+      if (preludePending && data === "\x05\x15") {
+        preludePending = false;
+        throw new Error("pty dead");
+      }
+    });
+    const preludeTerminal = createAgentTerminal(preludeHandles);
+    await expect(preludeTerminal.gracefulShutdown()).resolves.toBeNull();
+    const preludeOutcome = soleOutcome();
+    logBuffer.clear();
+
+    const quitHandles = createMockPty((data: string) => {
+      if (data === "/quit\r") throw new Error("pty dead after prelude");
+    });
+    const quitTerminal = createAgentTerminal(quitHandles);
+    const quitPromise = quitTerminal.gracefulShutdown();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+    await expect(quitPromise).resolves.toBeNull();
+    const quitOutcome = soleOutcome();
+
+    expect(preludeOutcome).not.toBe(quitOutcome);
+  });
+
+  it("never lets the captured session id reach the log", async () => {
+    // A captured id is a resume credential (`--resume <id>`) and logs.getAll
+    // serves this buffer to agents verbatim, so leaking one would let any
+    // agent with log access resume another terminal's session. `captured`
+    // answers the diagnostic question without carrying the secret.
+    //
+    // The sentinel is deliberately plain: the logger's redaction is keyed on
+    // field names, so a leak under a name like `capturedId` would sail
+    // through it. Absence here has to come from never passing the id at all.
+    const sentinel = "zzz-sentinel-zzz";
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles);
+
+    const shutdownPromise = terminal.gracefulShutdown();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+    handles.emitData(`claude --resume ${sentinel}\n`);
+
+    await expect(shutdownPromise).resolves.toBe(sentinel);
+    expect(terminal.getInfo().agentSessionId).toBe(sentinel);
+
+    expect(JSON.stringify(shutdownEntries())).not.toContain(sentinel);
+  });
+
+  it("logs once when a late exit event races the capture that already won", async () => {
+    // `finish()` is re-entrant by design — the timer, onData and onExit can
+    // all reach it. The log sits behind the same `resolved` guard as the
+    // resolve itself, so a losing racer must add nothing.
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles);
+
+    const shutdownPromise = terminal.gracefulShutdown();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+    handles.emitData("claude --resume winner\n");
+    await expect(shutdownPromise).resolves.toBe("winner");
+
+    // An exit already queued inside node-pty when the listeners were disposed.
+    handles.emitExitIgnoringDispose(0);
+
+    expect(shutdownEntries()).toHaveLength(1);
+  });
+
+  it("carries the terminal's identity and a real elapsed measurement", async () => {
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles);
+
+    const shutdownPromise = terminal.gracefulShutdown();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_TIMEOUT_MS);
+    await expect(shutdownPromise).resolves.toBeNull();
+
+    const context = shutdownEntries()[0]?.context as
+      { terminalId?: string; agentId?: string; captured?: boolean; elapsedMs?: number } | undefined;
+
+    expect(context?.terminalId).toBe(terminal.getInfo().id);
+    expect(context?.agentId).toBe(terminal.getInfo().launchAgentId);
+    expect(context?.captured).toBe(false);
+    // Elapsed has to be measured, not stamped: a shutdown that ran the full
+    // budget must report at least the budget, which a hardcoded 0 would not.
+    expect(context?.elapsedMs).toBeGreaterThanOrEqual(GRACEFUL_SHUTDOWN_TIMEOUT_MS);
   });
 });

--- a/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
@@ -748,6 +748,11 @@ describe("TerminalProcess.gracefulShutdown — outcome logging", () => {
     const results: Record<string, string> = {};
     for (const [name, run] of Object.entries(BRANCHES)) {
       results[name] = await run();
+      // Every resolved shutdown ends in TerminalProcess.kill(), which leaves a
+      // pending SIGKILL escalation (ProcessTreeKiller). Queued across runners,
+      // the next scenario's timer advance would fire the earlier ones and
+      // sigkillSweep the mock's pid — a real number — against the real OS.
+      vi.clearAllTimers();
     }
 
     expect(results.capturedAtExit).toBe(results.capturedOnData);
@@ -883,6 +888,12 @@ describe("TerminalProcess.gracefulShutdown — outcome logging", () => {
     // makes "timeout points at the 2.5s budget" actionable rather than noise.
     const handles = createMockPty();
     const terminal = createAgentTerminal(handles);
+
+    // Age the terminal well past the upper bound first. Without this the
+    // terminal is born at the same instant the shutdown starts, so an
+    // implementation measuring from spawn time instead of from the shutdown
+    // would report the same small number and pass.
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_TIMEOUT_MS * 20);
 
     const promise = terminal.gracefulShutdown();
     await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);


### PR DESCRIPTION
## Summary
- `gracefulShutdown()` writes each agent's quit command into its PTY and pattern-matches the output for a resume session id, racing a 2.5 second timeout. The per-terminal outcome was never logged, so when a restore fell through to a fresh launch there was nothing in the log file to say whether the capture timed out, the agent wasn't live, the pattern never matched, or the quit command was never submitted.
- The only trace was an aggregate `Gracefully killing N terminal(s) for project...` line. This adds one info-level log per terminal naming which of 13 outcomes fired.

Resolves #11591

## Changes
- `electron/services/pty/TerminalGracefulShutdown.ts`: added a `GracefulShutdownOutcome` string-literal union naming all 13 resolution branches, and one `logger.info` call per agent terminal carrying `terminalId`, `projectId`, `agentId`, `outcome`, a `captured` boolean, and `elapsedMs`.
- The outcome rides the log only, not the return type. `gracefulShutdown()` still returns the same type, so no caller signature widens. Logging lives inside this module because `TerminalProcess.gracefulShutdown()` is the single choke point for both the batch `gracefulKillByProject` and the direct single-terminal `gracefulKill` callers (`HelpSessionService`, `ipc/handlers/terminal/lifecycle`).
- Scope gate: checks `getLiveAgentId` first, so terminals with no agent identity stay silent instead of reporting `agent-not-live` on every quit.
- Split `already-exited` from `already-killed`: `wasKilled` marks a kill request, `isExited` means the process is actually gone. Folding them together mislabelled a terminal being torn down concurrently.
- Security: the captured session id itself is never logged, only a `captured: true|false` boolean. A session id functions as a `--resume` credential, and the agent-callable `logs.getAll` MCP action serves the log buffer verbatim to other agents. A test asserts the id never appears in an emitted log entry and that the log context carries only the six permitted keys.
- All outcomes log at `info` because production's default log level floor is `info`. `debug` would reach neither the in-memory log buffer nor `daintree.log`, recreating the exact gap the issue reports.
- No new `await` anywhere, since this runs inside the `CLEANUP_TIMEOUT_MS`-bounded shutdown chain.

## Testing
- 8 new tests in `TerminalProcess.gracefulShutdown.test.ts`. One drives all 13 reachable branch scenarios and asserts every branch produces a distinct outcome, while both capture-success paths share one outcome value.
- Other tests cover the scope gate, the correspondence between `captured` and the result, the credential-never-logged invariant, single-logging under a listener race, an identity round-trip check, and elapsed time measurement.
- Log level is tested from both sides: confirmed emitted under an `info` floor, confirmed suppressed under a `warn` floor, rather than asserting a literal log level string.
- One branch, `no-quit-signal`, has no test: no agent in the current roster ships a resume config lacking both a quit command and a shutdown key sequence, so it's defensive-only and unreachable without mocking the agent registry.
- Locally: 782 tests pass across 20 files covering the shutdown path; eslint and prettier clean on both changed files.
