### PR TITLE
fix(terminal): keep the session-lost dismissal across worktree switches

### DIFF
--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -148,8 +148,10 @@ export interface AddPanelOptionsBase {
    * available (neither exact-session nor resume-latest), or resume-latest was
    * suppressed because a sibling pane owns this agent+cwd's single slot
    * (#11461) — so the prior conversation is unreachable for this pane.
-   * Drives the "Session no longer reachable" restart banner. Never persisted;
-   * cleared on the next restart. See `serializePtyPanel` (intentionally omitted).
+   * Drives the "Session no longer reachable" restart banner, and doubles as the
+   * "not yet acknowledged" gate: dismissing the banner consumes this flag
+   * (#11589), as does the next restart. Never persisted — see
+   * `serializePtyPanel` (intentionally omitted).
    */
   sessionLostOnRestore?: boolean;
   /**

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -517,8 +517,11 @@ export interface PtyPanelData extends BasePanelData {
    * could not be safely resumed — unreachable, or resume-latest suppressed
    * because a sibling pane owns the slot (#11461) — and a fresh session was
    * launched instead. Drives the
-   * "Session no longer reachable" restart banner. Cleared on restart; never
-   * serialized — see `serializePtyPanel`.
+   * "Session no longer reachable" restart banner. Cleared on restart, and when
+   * the user dismisses the banner (#11589) — dismissal consumes this signal
+   * rather than shadowing it with a second flag, so the acknowledgement
+   * survives the unmount a worktree switch causes. Never serialized — see
+   * `serializePtyPanel`.
    */
   sessionLostOnRestore?: boolean;
 }

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -93,6 +93,7 @@ import { decideChromeAction } from "./multiSelectGestures";
 import { registerPanelFocusHandler } from "@/components/Panel/panelFocusRegistry";
 import { deriveTerminalChrome, type TerminalChromeDescriptor } from "@/utils/terminalChrome";
 import { isPtyPanel } from "@shared/types/panel";
+import { selectHasMultipleSessionLost } from "@/store/slices/panelRegistry/selectors";
 import type { TerminalRuntimeIdentity } from "@shared/types/panel";
 
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
@@ -364,9 +365,12 @@ function TerminalPaneComponent({
   const [justFocusedUntil, setJustFocusedUntil] = useState(0);
   const inputBarRef = useRef<HybridInputBarHandle>(null);
   const [dismissedRestartPrompt, setDismissedRestartPrompt] = useState(false);
-  // Separate from dismissedRestartPrompt so dismissing the lost-session
-  // acknowledgement (issue #10823) never suppresses a later exit-error banner.
-  const [dismissedSessionLost, setDismissedSessionLost] = useState(false);
+  // Note: the lost-session acknowledgement is deliberately NOT component state.
+  // A worktree switch drops this pane from the grid entirely, so local state
+  // couldn't survive it — dismissal clears `sessionLostOnRestore` in the panel
+  // store instead (issue #11589). It stays independent of
+  // `dismissedRestartPrompt` either way, so acknowledging a lost session still
+  // never suppresses a later exit-error banner (issue #10823).
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [isUpdateCwdOpen, setIsUpdateCwdOpen] = useState(false);
   const [isAutoRestarting, setIsAutoRestarting] = useState(false);
@@ -395,7 +399,6 @@ function TerminalPaneComponent({
 
   useEffect(() => {
     setDismissedRestartPrompt(false);
-    setDismissedSessionLost(false);
     inputTracker.reset();
     // Track process start time on each restart for backoff stability window
     processStartTimeRef.current = Date.now();
@@ -412,6 +415,8 @@ function TerminalPaneComponent({
   const backendStatus = usePanelStore((state) => state.backendStatus);
   const clearReconnectError = usePanelStore((state) => state.clearReconnectError);
   const clearScrollbackRestoreError = usePanelStore((state) => state.clearScrollbackRestoreError);
+  const dismissSessionLost = usePanelStore((state) => state.dismissSessionLost);
+  const dismissAllSessionLost = usePanelStore((state) => state.dismissAllSessionLost);
 
   const cliDetails = useCliAvailabilityStore((state) => state.details);
   const getPanelCliDetail = (): AgentCliDetail | undefined => {
@@ -469,6 +474,7 @@ function TerminalPaneComponent({
     useShallow((state) => {
       const terminal = state.panelsById[id];
       const pty = terminal && isPtyPanel(terminal) ? terminal : undefined;
+      const sessionLostOnRestore = pty?.sessionLostOnRestore ?? false;
       return {
         isInputLocked: pty?.isInputLocked ?? false,
         stateChangeTrigger: pty?.stateChangeTrigger,
@@ -477,7 +483,14 @@ function TerminalPaneComponent({
         isTrashedOrRemoved: terminal?.location === "trash" || terminal === undefined,
         spawnStatus: pty?.spawnStatus,
         eagerAttach: pty?.eagerAttach ?? false,
-        sessionLostOnRestore: pty?.sessionLostOnRestore ?? false,
+        sessionLostOnRestore,
+        // Gate the cross-panel scan on this pane's own flag: with no banner to
+        // show there's nothing to offer a bulk dismissal for, so the common
+        // case costs nothing. Flagged panes share one memoized scan per store
+        // snapshot (see `selectHasMultipleSessionLost`).
+        hasOtherSessionLost: sessionLostOnRestore
+          ? selectHasMultipleSessionLost(state.panelsById)
+          : false,
       };
     })
   );
@@ -491,6 +504,7 @@ function TerminalPaneComponent({
     spawnStatus,
     eagerAttach,
     sessionLostOnRestore,
+    hasOtherSessionLost,
   } = terminalState;
   // Fleet-scope mounts pass `isInputLocked: true` to render the panel as a
   // read-only broadcast view. Prop takes precedence over the stored flag so
@@ -1167,7 +1181,6 @@ function TerminalPaneComponent({
     spawnError,
     backendStatus,
     sessionLostOnRestore,
-    dismissedSessionLost,
   });
   // Backend-dependent banners (restart / spawn / reconnect) describe failures
   // whose only recovery path runs through the host, so they're hidden while
@@ -1335,8 +1348,13 @@ function TerminalPaneComponent({
           onRestart={handleRestart}
           onDismiss={() =>
             restartBannerVariant.type === "session-resume-unavailable"
-              ? setDismissedSessionLost(true)
+              ? dismissSessionLost(id)
               : setDismissedRestartPrompt(true)
+          }
+          onDismissAll={
+            restartBannerVariant.type === "session-resume-unavailable" && hasOtherSessionLost
+              ? dismissAllSessionLost
+              : undefined
           }
         />
       </BannerSlot>

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -93,7 +93,7 @@ import { decideChromeAction } from "./multiSelectGestures";
 import { registerPanelFocusHandler } from "@/components/Panel/panelFocusRegistry";
 import { deriveTerminalChrome, type TerminalChromeDescriptor } from "@/utils/terminalChrome";
 import { isPtyPanel } from "@shared/types/panel";
-import { selectHasMultipleSessionLost } from "@/store/slices/panelRegistry/selectors";
+import { useSessionLostBanner } from "./useSessionLostBanner";
 import type { TerminalRuntimeIdentity } from "@shared/types/panel";
 
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
@@ -415,8 +415,7 @@ function TerminalPaneComponent({
   const backendStatus = usePanelStore((state) => state.backendStatus);
   const clearReconnectError = usePanelStore((state) => state.clearReconnectError);
   const clearScrollbackRestoreError = usePanelStore((state) => state.clearScrollbackRestoreError);
-  const dismissSessionLost = usePanelStore((state) => state.dismissSessionLost);
-  const dismissAllSessionLost = usePanelStore((state) => state.dismissAllSessionLost);
+  const sessionLostBanner = useSessionLostBanner(id);
 
   const cliDetails = useCliAvailabilityStore((state) => state.details);
   const getPanelCliDetail = (): AgentCliDetail | undefined => {
@@ -474,7 +473,6 @@ function TerminalPaneComponent({
     useShallow((state) => {
       const terminal = state.panelsById[id];
       const pty = terminal && isPtyPanel(terminal) ? terminal : undefined;
-      const sessionLostOnRestore = pty?.sessionLostOnRestore ?? false;
       return {
         isInputLocked: pty?.isInputLocked ?? false,
         stateChangeTrigger: pty?.stateChangeTrigger,
@@ -483,14 +481,6 @@ function TerminalPaneComponent({
         isTrashedOrRemoved: terminal?.location === "trash" || terminal === undefined,
         spawnStatus: pty?.spawnStatus,
         eagerAttach: pty?.eagerAttach ?? false,
-        sessionLostOnRestore,
-        // Gate the cross-panel scan on this pane's own flag: with no banner to
-        // show there's nothing to offer a bulk dismissal for, so the common
-        // case costs nothing. Flagged panes share one memoized scan per store
-        // snapshot (see `selectHasMultipleSessionLost`).
-        hasOtherSessionLost: sessionLostOnRestore
-          ? selectHasMultipleSessionLost(state.panelsById)
-          : false,
       };
     })
   );
@@ -503,8 +493,6 @@ function TerminalPaneComponent({
     isTrashedOrRemoved,
     spawnStatus,
     eagerAttach,
-    sessionLostOnRestore,
-    hasOtherSessionLost,
   } = terminalState;
   // Fleet-scope mounts pass `isInputLocked: true` to render the panel as a
   // read-only broadcast view. Prop takes precedence over the stored flag so
@@ -1180,7 +1168,7 @@ function TerminalPaneComponent({
     reconnectError,
     spawnError,
     backendStatus,
-    sessionLostOnRestore,
+    sessionLostOnRestore: sessionLostBanner.sessionLostOnRestore,
   });
   // Backend-dependent banners (restart / spawn / reconnect) describe failures
   // whose only recovery path runs through the host, so they're hidden while
@@ -1348,12 +1336,12 @@ function TerminalPaneComponent({
           onRestart={handleRestart}
           onDismiss={() =>
             restartBannerVariant.type === "session-resume-unavailable"
-              ? dismissSessionLost(id)
+              ? sessionLostBanner.dismiss()
               : setDismissedRestartPrompt(true)
           }
           onDismissAll={
-            restartBannerVariant.type === "session-resume-unavailable" && hasOtherSessionLost
-              ? dismissAllSessionLost
+            restartBannerVariant.type === "session-resume-unavailable"
+              ? sessionLostBanner.dismissAll
               : undefined
           }
         />

--- a/src/components/Terminal/TerminalRestartStatusBanner.tsx
+++ b/src/components/Terminal/TerminalRestartStatusBanner.tsx
@@ -9,6 +9,13 @@ export interface TerminalRestartStatusBannerProps {
   variant: RestartBannerVariant;
   onRestart: () => void;
   onDismiss: () => void;
+  /**
+   * Acknowledge the session-lost signal on every flagged pane at once (issue
+   * #11589). Only supplied when more than one pane is flagged — a single
+   * banner's own close control already clears the whole set — so leaving it
+   * undefined keeps the banner at exactly one control.
+   */
+  onDismissAll?: () => void;
 }
 
 function SpinnerIcon({ className, style }: { className?: string; style?: CSSProperties }) {
@@ -25,6 +32,7 @@ export function TerminalRestartStatusBanner({
   variant,
   onRestart,
   onDismiss,
+  onDismissAll,
 }: TerminalRestartStatusBannerProps) {
   switch (variant.type) {
     case "none":
@@ -63,6 +71,14 @@ export function TerminalRestartStatusBanner({
       // control; no restart action (a restart would be a redundant third
       // session). The banner still surfaces the lost session so it isn't
       // dropped silently (issue #9802).
+      //
+      // A restart can strand this banner on a dozen panes at once, so when more
+      // than one is flagged the caller supplies `onDismissAll` and we offer a
+      // second, neutral control (issue #11589). Warning severity is not bound by
+      // the single-action rule, so `actions` is legal here — and with a
+      // description present `InlineStatusBanner` keeps the close X in the title
+      // row and drops actions into their own controls row, which reads as the
+      // per-pane vs. project-wide split it is.
       return (
         <InlineStatusBanner
           icon={AlertTriangle}
@@ -73,6 +89,20 @@ export function TerminalRestartStatusBanner({
           role="status"
           ariaLive="polite"
           onClose={onDismiss}
+          actions={
+            onDismissAll
+              ? [
+                  {
+                    id: "dismiss-all-session-lost",
+                    label: RESTART_BANNER_COPY["session-resume-unavailable"].dismissAllLabel,
+                    variant: "dismiss",
+                    onClick: onDismissAll,
+                    ariaLabel:
+                      RESTART_BANNER_COPY["session-resume-unavailable"].dismissAllAriaLabel,
+                  },
+                ]
+              : undefined
+          }
         />
       );
 

--- a/src/components/Terminal/__tests__/TerminalRestartStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalRestartStatusBanner.test.tsx
@@ -173,5 +173,77 @@ describe("TerminalRestartStatusBanner", () => {
       fireEvent.click(button);
       expect(onDismiss).toHaveBeenCalledOnce();
     });
+
+    // A restart can strand this banner on many panes at once, so the bulk
+    // control appears only when the caller says more than one is flagged
+    // (#11589) — otherwise the per-pane X already covers the whole set.
+    describe("bulk dismissal (issue #11589)", () => {
+      it("offers a second control when onDismissAll is supplied", () => {
+        render(
+          <TerminalRestartStatusBanner
+            variant={{ type: "session-resume-unavailable" }}
+            onRestart={vi.fn()}
+            onDismiss={vi.fn()}
+            onDismissAll={vi.fn()}
+          />
+        );
+        expect(screen.getAllByRole("button")).toHaveLength(2);
+        expect(
+          screen.getByRole("button", { name: "Dismiss all session-lost warnings" })
+        ).toBeTruthy();
+      });
+
+      it("routes each control to its own callback", () => {
+        const onDismiss = vi.fn();
+        const onDismissAll = vi.fn();
+        render(
+          <TerminalRestartStatusBanner
+            variant={{ type: "session-resume-unavailable" }}
+            onRestart={vi.fn()}
+            onDismiss={onDismiss}
+            onDismissAll={onDismissAll}
+          />
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Dismiss all session-lost warnings" }));
+        expect(onDismissAll).toHaveBeenCalledOnce();
+        expect(onDismiss).not.toHaveBeenCalled();
+
+        fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+        expect(onDismiss).toHaveBeenCalledOnce();
+        expect(onDismissAll).toHaveBeenCalledOnce();
+      });
+
+      it("still offers no restart action alongside the bulk control", () => {
+        render(
+          <TerminalRestartStatusBanner
+            variant={{ type: "session-resume-unavailable" }}
+            onRestart={vi.fn()}
+            onDismiss={vi.fn()}
+            onDismissAll={vi.fn()}
+          />
+        );
+        expect(screen.queryByRole("button", { name: /restart session/i })).toBeNull();
+      });
+
+      it("does not leak the bulk control onto other variants", () => {
+        for (const variant of [
+          { type: "auto-restarting" },
+          { type: "restarting" },
+          { type: "exit-error", exitCode: 1 },
+        ] as const) {
+          const { unmount } = render(
+            <TerminalRestartStatusBanner
+              variant={variant}
+              onRestart={vi.fn()}
+              onDismiss={vi.fn()}
+              onDismissAll={vi.fn()}
+            />
+          );
+          expect(screen.queryByRole("button", { name: /dismiss all/i })).toBeNull();
+          unmount();
+        }
+      });
+    });
   });
 });

--- a/src/components/Terminal/__tests__/TerminalRestartStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalRestartStatusBanner.test.tsx
@@ -188,9 +188,29 @@ describe("TerminalRestartStatusBanner", () => {
           />
         );
         expect(screen.getAllByRole("button")).toHaveLength(2);
-        expect(
-          screen.getByRole("button", { name: "Dismiss all session-lost warnings" })
-        ).toBeTruthy();
+        expect(screen.getByRole("button", { name: /\bdismiss all\b/i })).toBeTruthy();
+      });
+
+      // WCAG "Label in Name": the accessible name must start with the visible
+      // label so speech-input users can say what they read, and must add the
+      // scope the short label leaves out.
+      it("names the bulk control with its visible label plus the missing scope", () => {
+        render(
+          <TerminalRestartStatusBanner
+            variant={{ type: "session-resume-unavailable" }}
+            onRestart={vi.fn()}
+            onDismiss={vi.fn()}
+            onDismissAll={vi.fn()}
+          />
+        );
+
+        const bulk = screen.getByRole("button", { name: /\bdismiss all\b/i });
+        const visible = (bulk.textContent ?? "").trim();
+        const accessible = (bulk.getAttribute("aria-label") ?? "").trim();
+
+        expect(visible.length).toBeGreaterThan(0);
+        expect(accessible.toLowerCase().startsWith(visible.toLowerCase())).toBe(true);
+        expect(accessible.length).toBeGreaterThan(visible.length);
       });
 
       it("routes each control to its own callback", () => {
@@ -205,7 +225,7 @@ describe("TerminalRestartStatusBanner", () => {
           />
         );
 
-        fireEvent.click(screen.getByRole("button", { name: "Dismiss all session-lost warnings" }));
+        fireEvent.click(screen.getByRole("button", { name: /\bdismiss all\b/i }));
         expect(onDismissAll).toHaveBeenCalledOnce();
         expect(onDismiss).not.toHaveBeenCalled();
 

--- a/src/components/Terminal/__tests__/restartBannerCopy.test.ts
+++ b/src/components/Terminal/__tests__/restartBannerCopy.test.ts
@@ -37,5 +37,19 @@ describe("RESTART_BANNER_COPY", () => {
       const text = `${copy.title} ${copy.description}`.toLowerCase();
       expect(text).not.toMatch(/expired|you lost|your fault|agent closed|killed/);
     });
+
+    // issue #11589 — the bulk control keeps a short visible label and carries
+    // the full scope in its accessible name.
+    it("keeps the bulk label period-free and shorter than its accessible name", () => {
+      expect(copy.dismissAllLabel.endsWith(".")).toBe(false);
+      expect(copy.dismissAllAriaLabel.endsWith(".")).toBe(false);
+      expect(copy.dismissAllAriaLabel.length).toBeGreaterThan(copy.dismissAllLabel.length);
+    });
+
+    it("keeps the bulk label in sentence case", () => {
+      const [firstWord = "", ...restWords] = copy.dismissAllLabel.split(" ");
+      expect(firstWord).toMatch(/^[A-Z]/);
+      expect(restWords.every((word) => /^[a-z]/.test(word))).toBe(true);
+    });
   });
 });

--- a/src/components/Terminal/__tests__/restartStatus.test.ts
+++ b/src/components/Terminal/__tests__/restartStatus.test.ts
@@ -262,16 +262,13 @@ describe("getRestartBannerVariant — session-resume-unavailable (issue #9802)",
   });
 
   it("returns none when sessionLostOnRestore is absent (resumed normally)", () => {
-    const result = getRestartBannerVariant({ ...restored, sessionLostOnRestore: false });
-    expect(result).toEqual({ type: "none" });
-  });
-
-  it("returns none once dismissal consumed the signal (issues #10823, #11589)", () => {
-    // The banner is dismissable, and dismissing it clears `sessionLostOnRestore`
-    // in the panel store rather than setting a second flag — so a cleared signal
-    // is exactly what an acknowledged banner looks like to this policy.
-    const result = getRestartBannerVariant({ ...restored, sessionLostOnRestore: undefined });
-    expect(result).toEqual({ type: "none" });
+    // Both falsey shapes: never set, and consumed by a dismissal (#11589).
+    expect(getRestartBannerVariant({ ...restored, sessionLostOnRestore: false })).toEqual({
+      type: "none",
+    });
+    expect(getRestartBannerVariant({ ...restored, sessionLostOnRestore: undefined })).toEqual({
+      type: "none",
+    });
   });
 
   it("stays visible when only dismissedRestartPrompt is set — independent flags (#10823)", () => {
@@ -284,18 +281,21 @@ describe("getRestartBannerVariant — session-resume-unavailable (issue #9802)",
     expect(result).toEqual({ type: "session-resume-unavailable" });
   });
 
-  it("surfaces exit-error after the lost-session banner is dismissed (#10823)", () => {
-    // Acknowledging the lost session clears only `sessionLostOnRestore` and
-    // never touches `dismissedRestartPrompt`, so a crash of the fresh session
-    // that followed must still get its own banner.
-    const result = getRestartBannerVariant({
-      ...restored,
-      isExited: true,
-      exitCode: 1,
-      sessionLostOnRestore: undefined,
-      dismissedRestartPrompt: false,
-    });
-    expect(result).toEqual({ type: "exit-error", exitCode: 1 });
+  it("hands off to exit-error when the lost-session banner is dismissed (#10823)", () => {
+    // The whole transition on one input, which is what makes it a guarantee
+    // rather than two unrelated assertions: the fresh session has already
+    // crashed, so both signals are live and session-lost wins. Acknowledging it
+    // consumes ONLY `sessionLostOnRestore` (#11589) — `dismissedRestartPrompt`
+    // is untouched — so the crash banner underneath must now surface.
+    const crashedAfterLostSession = { ...restored, isExited: true, exitCode: 1 };
+
+    expect(
+      getRestartBannerVariant({ ...crashedAfterLostSession, sessionLostOnRestore: true })
+    ).toEqual({ type: "session-resume-unavailable" });
+
+    expect(
+      getRestartBannerVariant({ ...crashedAfterLostSession, sessionLostOnRestore: undefined })
+    ).toEqual({ type: "exit-error", exitCode: 1 });
   });
 
   it("ignores backendStatus — the lost session is independent of host connectivity", () => {

--- a/src/components/Terminal/__tests__/restartStatus.test.ts
+++ b/src/components/Terminal/__tests__/restartStatus.test.ts
@@ -266,12 +266,11 @@ describe("getRestartBannerVariant — session-resume-unavailable (issue #9802)",
     expect(result).toEqual({ type: "none" });
   });
 
-  it("returns none once dismissed — the banner is dismissable (issue #10823)", () => {
-    const result = getRestartBannerVariant({
-      ...restored,
-      sessionLostOnRestore: true,
-      dismissedSessionLost: true,
-    });
+  it("returns none once dismissal consumed the signal (issues #10823, #11589)", () => {
+    // The banner is dismissable, and dismissing it clears `sessionLostOnRestore`
+    // in the panel store rather than setting a second flag — so a cleared signal
+    // is exactly what an acknowledged banner looks like to this policy.
+    const result = getRestartBannerVariant({ ...restored, sessionLostOnRestore: undefined });
     expect(result).toEqual({ type: "none" });
   });
 
@@ -286,14 +285,15 @@ describe("getRestartBannerVariant — session-resume-unavailable (issue #9802)",
   });
 
   it("surfaces exit-error after the lost-session banner is dismissed (#10823)", () => {
-    // The dedicated dismiss flag means acknowledging the lost session must not
-    // silently suppress a crash banner for the fresh session that followed.
+    // Acknowledging the lost session clears only `sessionLostOnRestore` and
+    // never touches `dismissedRestartPrompt`, so a crash of the fresh session
+    // that followed must still get its own banner.
     const result = getRestartBannerVariant({
       ...restored,
       isExited: true,
       exitCode: 1,
-      sessionLostOnRestore: true,
-      dismissedSessionLost: true,
+      sessionLostOnRestore: undefined,
+      dismissedRestartPrompt: false,
     });
     expect(result).toEqual({ type: "exit-error", exitCode: 1 });
   });

--- a/src/components/Terminal/__tests__/useSessionLostBanner.test.tsx
+++ b/src/components/Terminal/__tests__/useSessionLostBanner.test.tsx
@@ -9,7 +9,7 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
-import type { PanelInstance, PtyPanelData } from "@shared/types/panel";
+import { isPtyPanel, type PanelInstance, type PtyPanelData } from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -75,8 +75,8 @@ function seed(...panels: PanelInstance[]) {
 }
 
 function flagOf(id: string): boolean | undefined {
-  return (usePanelStore.getState().panelsById[id] as PtyPanelData | undefined)
-    ?.sessionLostOnRestore;
+  const panel = usePanelStore.getState().panelsById[id];
+  return panel && isPtyPanel(panel) ? panel.sessionLostOnRestore : undefined;
 }
 
 beforeEach(() => {

--- a/src/components/Terminal/__tests__/useSessionLostBanner.test.tsx
+++ b/src/components/Terminal/__tests__/useSessionLostBanner.test.tsx
@@ -1,0 +1,236 @@
+// @vitest-environment jsdom
+/**
+ * Regression guard for #11589. The grid renders only the active worktree's
+ * panels, so switching worktrees unmounts a pane outright. These tests drive
+ * the acknowledgement through a real store-connected render and then unmount
+ * and remount it — the sequence that used to resurrect the banner when the
+ * dismissal lived in `TerminalPane` component state.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import type { PanelInstance, PtyPanelData } from "@shared/types/panel";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn().mockResolvedValue(undefined),
+    trash: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+  },
+  appClient: { setState: vi.fn().mockResolvedValue(undefined) },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+    setTabGroups: vi.fn().mockResolvedValue(undefined),
+    getSettings: vi.fn().mockResolvedValue({}),
+  },
+  agentSettingsClient: { get: vi.fn().mockResolvedValue({}) },
+  systemClient: { getAppMetrics: vi.fn().mockResolvedValue({ totalMemoryMB: 512 }) },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    cleanup: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
+    destroy: vi.fn(),
+  },
+}));
+
+vi.mock("../../../store/slices/panelRegistry/persistence", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../store/slices/panelRegistry/persistence")
+  >("../../../store/slices/panelRegistry/persistence");
+  return { ...actual, saveNormalized: vi.fn() };
+});
+
+const { usePanelStore } = await import("@/store/panelStore");
+const { useSessionLostBanner } = await import("../useSessionLostBanner");
+const { _resetSelectorCacheForTests } = await import("@/store/slices/panelRegistry/selectors");
+
+function panel(id: string, overrides: Partial<PtyPanelData> = {}): PanelInstance {
+  return {
+    id,
+    kind: "terminal",
+    title: id,
+    cwd: "/repo",
+    cols: 80,
+    rows: 24,
+    location: "grid",
+    ...overrides,
+  } as PanelInstance;
+}
+
+function seed(...panels: PanelInstance[]) {
+  usePanelStore.setState({
+    panelsById: Object.fromEntries(panels.map((p) => [p.id, p])),
+    panelIds: panels.map((p) => p.id),
+  });
+}
+
+function flagOf(id: string): boolean | undefined {
+  return (usePanelStore.getState().panelsById[id] as PtyPanelData | undefined)
+    ?.sessionLostOnRestore;
+}
+
+beforeEach(() => {
+  _resetSelectorCacheForTests();
+  usePanelStore.setState({ panelsById: {}, panelIds: [] });
+});
+
+describe("useSessionLostBanner", () => {
+  it("reports the pane's unacknowledged signal", () => {
+    seed(panel("t-1", { sessionLostOnRestore: true }));
+    const { result } = renderHook(() => useSessionLostBanner("t-1"));
+    expect(result.current.sessionLostOnRestore).toBe(true);
+  });
+
+  it("reports no signal for a pane that resumed cleanly", () => {
+    seed(panel("t-1"));
+    const { result } = renderHook(() => useSessionLostBanner("t-1"));
+    expect(result.current.sessionLostOnRestore).toBe(false);
+  });
+
+  it("reports no signal for an unknown or non-PTY pane", () => {
+    const browserPanel: PanelInstance = {
+      id: "b-1",
+      kind: "browser",
+      title: "b-1",
+      location: "grid",
+    };
+    seed(browserPanel);
+    const { result: unknown } = renderHook(() => useSessionLostBanner("missing"));
+    const { result: browser } = renderHook(() => useSessionLostBanner("b-1"));
+    expect(unknown.current.sessionLostOnRestore).toBe(false);
+    expect(browser.current.sessionLostOnRestore).toBe(false);
+  });
+
+  // The bug: this sequence is exactly what a worktree switch does to a pane.
+  it("keeps the acknowledgement across an unmount and remount (#11589)", () => {
+    seed(panel("t-1", { sessionLostOnRestore: true }));
+
+    const first = renderHook(() => useSessionLostBanner("t-1"));
+    expect(first.result.current.sessionLostOnRestore).toBe(true);
+    act(() => first.result.current.dismiss());
+    expect(first.result.current.sessionLostOnRestore).toBe(false);
+
+    // Switch away: the pane leaves the grid entirely.
+    first.unmount();
+
+    // Switch back: a brand-new hook instance with no memory of the dismissal.
+    const second = renderHook(() => useSessionLostBanner("t-1"));
+    expect(second.result.current.sessionLostOnRestore).toBe(false);
+  });
+
+  it("still reports the signal on remount when it was never acknowledged", () => {
+    seed(panel("t-1", { sessionLostOnRestore: true }));
+
+    const first = renderHook(() => useSessionLostBanner("t-1"));
+    first.unmount();
+
+    const second = renderHook(() => useSessionLostBanner("t-1"));
+    expect(second.result.current.sessionLostOnRestore).toBe(true);
+  });
+
+  it("acknowledges only its own pane", () => {
+    seed(
+      panel("t-1", { sessionLostOnRestore: true }),
+      panel("t-2", { sessionLostOnRestore: true })
+    );
+
+    const { result } = renderHook(() => useSessionLostBanner("t-1"));
+    act(() => result.current.dismiss());
+
+    expect(flagOf("t-1")).toBeUndefined();
+    expect(flagOf("t-2")).toBe(true);
+  });
+
+  describe("bulk dismissal gate", () => {
+    it("withholds the bulk action when this is the only flagged pane", () => {
+      seed(panel("t-1", { sessionLostOnRestore: true }), panel("t-2"));
+      const { result } = renderHook(() => useSessionLostBanner("t-1"));
+      expect(result.current.dismissAll).toBeUndefined();
+    });
+
+    it("withholds the bulk action from an unflagged pane even when others are flagged", () => {
+      seed(
+        panel("t-1"),
+        panel("t-2", { sessionLostOnRestore: true }),
+        panel("t-3", { sessionLostOnRestore: true })
+      );
+      const { result } = renderHook(() => useSessionLostBanner("t-1"));
+      expect(result.current.dismissAll).toBeUndefined();
+    });
+
+    it("offers the bulk action once a second pane is flagged", () => {
+      seed(
+        panel("t-1", { sessionLostOnRestore: true }),
+        panel("t-2", { sessionLostOnRestore: true })
+      );
+      const { result } = renderHook(() => useSessionLostBanner("t-1"));
+      expect(result.current.dismissAll).toBeInstanceOf(Function);
+    });
+
+    // Panels of other worktrees aren't rendered, so a worktree-scoped bulk
+    // dismissal would leave banners waiting behind a switch — the bug itself.
+    it("counts flagged panes in other worktrees", () => {
+      seed(
+        panel("t-1", { sessionLostOnRestore: true, worktreeId: "wt-a" }),
+        panel("t-2", { sessionLostOnRestore: true, worktreeId: "wt-b" })
+      );
+      const { result } = renderHook(() => useSessionLostBanner("t-1"));
+      expect(result.current.dismissAll).toBeInstanceOf(Function);
+    });
+
+    it("clears every flagged pane and then withdraws the bulk action", () => {
+      seed(
+        panel("t-1", { sessionLostOnRestore: true, worktreeId: "wt-a" }),
+        panel("t-2", { sessionLostOnRestore: true, worktreeId: "wt-b" }),
+        panel("t-3")
+      );
+
+      const { result } = renderHook(() => useSessionLostBanner("t-1"));
+      act(() => result.current.dismissAll?.());
+
+      expect(flagOf("t-1")).toBeUndefined();
+      expect(flagOf("t-2")).toBeUndefined();
+      expect(result.current.sessionLostOnRestore).toBe(false);
+      expect(result.current.dismissAll).toBeUndefined();
+    });
+
+    it("withdraws the bulk action when the other flagged pane is dismissed elsewhere", () => {
+      seed(
+        panel("t-1", { sessionLostOnRestore: true }),
+        panel("t-2", { sessionLostOnRestore: true })
+      );
+
+      const { result } = renderHook(() => useSessionLostBanner("t-1"));
+      expect(result.current.dismissAll).toBeInstanceOf(Function);
+
+      act(() => usePanelStore.getState().dismissSessionLost("t-2"));
+
+      expect(result.current.sessionLostOnRestore).toBe(true);
+      expect(result.current.dismissAll).toBeUndefined();
+    });
+  });
+
+  it("re-renders when the signal arrives after mount", () => {
+    seed(panel("t-1"));
+    const { result } = renderHook(() => useSessionLostBanner("t-1"));
+    expect(result.current.sessionLostOnRestore).toBe(false);
+
+    act(() => {
+      usePanelStore.setState({
+        panelsById: { "t-1": panel("t-1", { sessionLostOnRestore: true }) },
+      });
+    });
+
+    expect(result.current.sessionLostOnRestore).toBe(true);
+  });
+});

--- a/src/components/Terminal/restartBannerCopy.ts
+++ b/src/components/Terminal/restartBannerCopy.ts
@@ -1,7 +1,12 @@
 export interface RestartBannerCopyMap {
   "auto-restarting": { title: string };
   restarting: { title: string };
-  "session-resume-unavailable": { title: string; description: string };
+  "session-resume-unavailable": {
+    title: string;
+    description: string;
+    dismissAllLabel: string;
+    dismissAllAriaLabel: string;
+  };
   "exit-error": (args: { exitCode: number }) => { title: string };
 }
 
@@ -12,9 +17,14 @@ export const RESTART_BANNER_COPY: RestartBannerCopyMap = {
   // rule. Title is a period-free noun phrase. The description reassures rather
   // than prompts an action (issue #10823) — the terminal already relaunched
   // into a fresh, usable session, so the banner is a dismissable acknowledgement.
+  // The bulk control keeps a short visible label — it sits inline next to the
+  // per-pane close X, where the banner's own title supplies the context — and
+  // carries the full scope in its accessible name (issue #11589).
   "session-resume-unavailable": {
     title: "Session no longer reachable",
     description: "The previous session couldn't be restored. A fresh session was started.",
+    dismissAllLabel: "Dismiss all",
+    dismissAllAriaLabel: "Dismiss all session-lost warnings",
   },
   "exit-error": ({ exitCode }) => ({ title: `Session exited with code ${exitCode}` }),
 };

--- a/src/components/Terminal/restartStatus.ts
+++ b/src/components/Terminal/restartStatus.ts
@@ -20,15 +20,16 @@ export interface RestartBannerInput {
   reconnectError?: TerminalReconnectError;
   spawnError?: SpawnError;
   backendStatus: BackendStatus;
-  /** True when restore fell through to a fresh agent launch (issue #9802). */
-  sessionLostOnRestore?: boolean;
   /**
-   * True once the user dismissed the session-resume-unavailable banner
-   * (issue #10823). Tracked separately from `dismissedRestartPrompt` so
-   * acknowledging a lost session never suppresses a later exit-error banner
-   * for a crash of the fresh session.
+   * True when restore fell through to a fresh agent launch and the user hasn't
+   * acknowledged it yet (issue #9802). Dismissing the banner clears the flag in
+   * the panel store (issue #11589), so this doubles as the "not yet dismissed"
+   * gate — there is deliberately no separate dismissal flag to fall out of sync
+   * with it. Kept independent of `dismissedRestartPrompt` so acknowledging a
+   * lost session never suppresses a later exit-error banner for a crash of the
+   * fresh session (issue #10823).
    */
-  dismissedSessionLost?: boolean;
+  sessionLostOnRestore?: boolean;
 }
 
 export function getRestartBannerVariant(input: RestartBannerInput): RestartBannerVariant {
@@ -52,13 +53,12 @@ export function getRestartBannerVariant(input: RestartBannerInput): RestartBanne
   // restart takes precedence) and above exit-error so a lost session is
   // acknowledged before any prior exit prompt. Dismissable (issue #10823): the
   // user recovers just by carrying on in the fresh session, so once they
-  // acknowledge it the banner stays gone for this session. Uses a dedicated
-  // `dismissedSessionLost` flag — not `dismissedRestartPrompt` — so dismissing
-  // this acknowledgement never suppresses a later exit-error for the fresh
-  // session crashing.
+  // acknowledge it the banner stays gone for this session. Dismissal clears
+  // `sessionLostOnRestore` itself in the panel store (issue #11589) — it never
+  // touches `dismissedRestartPrompt`, so acknowledging a lost session still
+  // can't suppress a later exit-error for the fresh session crashing.
   if (
     input.sessionLostOnRestore &&
-    !input.dismissedSessionLost &&
     !input.isRestarting &&
     !input.isAutoRestarting &&
     !input.restartError &&

--- a/src/components/Terminal/useSessionLostBanner.ts
+++ b/src/components/Terminal/useSessionLostBanner.ts
@@ -1,0 +1,66 @@
+import { useCallback } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { isPtyPanel } from "@shared/types/panel";
+import { usePanelStore } from "@/store/panelStore";
+import { selectHasMultipleSessionLost } from "@/store/slices/panelRegistry/selectors";
+
+export interface SessionLostBanner {
+  /**
+   * True while this pane has an unacknowledged lost-session signal. Feeds
+   * `getRestartBannerVariant`, which gates the banner below the in-flight
+   * restart states.
+   */
+  sessionLostOnRestore: boolean;
+  /** Acknowledge this pane's signal. */
+  dismiss: () => void;
+  /**
+   * Acknowledge every flagged pane's signal, or `undefined` when this is the
+   * only flagged pane — then the per-pane control already covers the whole set
+   * and a second button would be noise.
+   */
+  dismissAll: (() => void) | undefined;
+}
+
+/**
+ * Owns the "Session no longer reachable" banner's acknowledgement state for one
+ * pane (issue #11589).
+ *
+ * Deliberately reads and writes the panel store rather than component state:
+ * the grid renders only the active worktree's panels, so switching worktrees
+ * unmounts this pane outright and any local dismissal would be lost on the way
+ * back. Acknowledgement consumes `sessionLostOnRestore` itself — there is no
+ * second "was it dismissed" flag to drift out of sync with the signal.
+ *
+ * Keeping this path in its own hook also makes the issue #10823 guarantee
+ * structural rather than incidental: nothing here can reach
+ * `dismissedRestartPrompt`, so acknowledging a lost session cannot suppress a
+ * later exit-error banner for the fresh session.
+ */
+export function useSessionLostBanner(panelId: string): SessionLostBanner {
+  const { sessionLostOnRestore, hasOtherSessionLost } = usePanelStore(
+    useShallow((state) => {
+      const panel = state.panelsById[panelId];
+      const pty = panel && isPtyPanel(panel) ? panel : undefined;
+      const flagged = pty?.sessionLostOnRestore ?? false;
+      return {
+        sessionLostOnRestore: flagged,
+        // Gate the cross-panel scan on this pane's own flag: with no banner to
+        // show there is nothing to offer a bulk dismissal for, so the common
+        // case costs nothing. Flagged panes share one memoized scan per store
+        // snapshot (see `selectHasMultipleSessionLost`).
+        hasOtherSessionLost: flagged ? selectHasMultipleSessionLost(state.panelsById) : false,
+      };
+    })
+  );
+
+  const dismissSessionLost = usePanelStore((state) => state.dismissSessionLost);
+  const dismissAllSessionLost = usePanelStore((state) => state.dismissAllSessionLost);
+
+  const dismiss = useCallback(() => dismissSessionLost(panelId), [dismissSessionLost, panelId]);
+
+  return {
+    sessionLostOnRestore,
+    dismiss,
+    dismissAll: hasOtherSessionLost ? dismissAllSessionLost : undefined,
+  };
+}

--- a/src/store/slices/panelRegistry/__tests__/dismissSessionLost.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dismissSessionLost.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Durable dismissal of the "Session no longer reachable" banner (#11589).
+ *
+ * The banner is driven by `sessionLostOnRestore` on the panel. Dismissal used
+ * to live in `TerminalPane` component state, which a worktree switch destroys
+ * (the grid renders only the active worktree's panels), so the banner came
+ * back. Dismissal now consumes the signal in the store instead.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PanelInstance, PtyPanelData } from "@shared/types/panel";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn().mockResolvedValue(undefined),
+    trash: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+  },
+  appClient: {
+    setState: vi.fn().mockResolvedValue(undefined),
+  },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+    setTabGroups: vi.fn().mockResolvedValue(undefined),
+    getSettings: vi.fn().mockResolvedValue({}),
+  },
+  agentSettingsClient: {
+    get: vi.fn().mockResolvedValue({}),
+  },
+  systemClient: {
+    getAppMetrics: vi.fn().mockResolvedValue({ totalMemoryMB: 512 }),
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    cleanup: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
+    destroy: vi.fn(),
+  },
+}));
+
+vi.mock("../persistence", async () => {
+  const actual = await vi.importActual<typeof import("../persistence")>("../persistence");
+  return {
+    ...actual,
+    saveNormalized: vi.fn(),
+  };
+});
+
+const { usePanelStore } = await import("../../../panelStore");
+const { saveNormalized } = await import("../persistence");
+
+function ptyPanel(id: string, overrides: Partial<PtyPanelData> = {}): PanelInstance {
+  return {
+    id,
+    kind: "terminal",
+    title: id,
+    cwd: "/repo",
+    cols: 80,
+    rows: 24,
+    location: "grid",
+    ...overrides,
+  } as PanelInstance;
+}
+
+/**
+ * A non-PTY panel. `sessionLostOnRestore` isn't part of the browser shape, so
+ * the overrides are intentionally untyped — the point of these fixtures is to
+ * prove the actions narrow on `isPtyPanel` rather than on the field's presence.
+ */
+function browserPanel(id: string, overrides: Record<string, unknown> = {}): PanelInstance {
+  return {
+    id,
+    kind: "browser",
+    title: id,
+    location: "grid",
+    ...overrides,
+  } as PanelInstance;
+}
+
+function seed(panels: PanelInstance[], panelIds?: string[]) {
+  usePanelStore.setState({
+    panelsById: Object.fromEntries(panels.map((p) => [p.id, p])),
+    panelIds: panelIds ?? panels.map((p) => p.id),
+  });
+}
+
+function signalOf(id: string): boolean | undefined {
+  return (usePanelStore.getState().panelsById[id] as PtyPanelData | undefined)
+    ?.sessionLostOnRestore;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  usePanelStore.setState({ panelsById: {}, panelIds: [] });
+});
+
+describe("dismissSessionLost", () => {
+  it("consumes the signal so a remount can't resurface the banner", () => {
+    seed([ptyPanel("t-1", { sessionLostOnRestore: true })]);
+
+    usePanelStore.getState().dismissSessionLost("t-1");
+
+    expect(signalOf("t-1")).toBeUndefined();
+  });
+
+  it("leaves other flagged panels alone", () => {
+    seed([
+      ptyPanel("t-1", { sessionLostOnRestore: true }),
+      ptyPanel("t-2", { sessionLostOnRestore: true }),
+    ]);
+
+    usePanelStore.getState().dismissSessionLost("t-1");
+
+    expect(signalOf("t-1")).toBeUndefined();
+    expect(signalOf("t-2")).toBe(true);
+  });
+
+  it("preserves the rest of the panel's runtime state", () => {
+    seed([
+      ptyPanel("t-1", {
+        sessionLostOnRestore: true,
+        agentState: "working",
+        exitCode: 3,
+        isRestarting: true,
+      }),
+    ]);
+
+    usePanelStore.getState().dismissSessionLost("t-1");
+
+    const panel = usePanelStore.getState().panelsById["t-1"] as PtyPanelData;
+    expect(panel.agentState).toBe("working");
+    expect(panel.exitCode).toBe(3);
+    expect(panel.isRestarting).toBe(true);
+  });
+
+  it("is a no-op for an unknown id", () => {
+    seed([ptyPanel("t-1", { sessionLostOnRestore: true })]);
+    const before = usePanelStore.getState().panelsById;
+
+    usePanelStore.getState().dismissSessionLost("nope");
+
+    expect(usePanelStore.getState().panelsById).toBe(before);
+  });
+
+  it("keeps the same carrier identity when the panel was never flagged", () => {
+    seed([ptyPanel("t-1")]);
+    const before = usePanelStore.getState().panelsById;
+
+    usePanelStore.getState().dismissSessionLost("t-1");
+
+    expect(usePanelStore.getState().panelsById).toBe(before);
+  });
+
+  it("keeps the same carrier identity on a repeat dismissal", () => {
+    seed([ptyPanel("t-1", { sessionLostOnRestore: true })]);
+    usePanelStore.getState().dismissSessionLost("t-1");
+    const afterFirst = usePanelStore.getState().panelsById;
+
+    usePanelStore.getState().dismissSessionLost("t-1");
+
+    expect(usePanelStore.getState().panelsById).toBe(afterFirst);
+  });
+
+  it("ignores a non-PTY panel", () => {
+    seed([browserPanel("b-1", { sessionLostOnRestore: true })]);
+    const before = usePanelStore.getState().panelsById;
+
+    usePanelStore.getState().dismissSessionLost("b-1");
+
+    expect(usePanelStore.getState().panelsById).toBe(before);
+  });
+
+  // The signal is deliberately excluded from the persisted snapshot, so
+  // consuming it must not schedule a write.
+  it("does not persist", () => {
+    seed([ptyPanel("t-1", { sessionLostOnRestore: true })]);
+
+    usePanelStore.getState().dismissSessionLost("t-1");
+
+    expect(saveNormalized).not.toHaveBeenCalled();
+  });
+});
+
+describe("dismissAllSessionLost", () => {
+  it("clears every flagged panel regardless of worktree", () => {
+    seed([
+      ptyPanel("t-1", { sessionLostOnRestore: true, worktreeId: "wt-a" }),
+      ptyPanel("t-2", { sessionLostOnRestore: true, worktreeId: "wt-b" }),
+      ptyPanel("t-3", { sessionLostOnRestore: true, worktreeId: undefined }),
+    ]);
+
+    usePanelStore.getState().dismissAllSessionLost();
+
+    expect(signalOf("t-1")).toBeUndefined();
+    expect(signalOf("t-2")).toBeUndefined();
+    expect(signalOf("t-3")).toBeUndefined();
+  });
+
+  // A hydration/spawn batch publishes `panelsById` before appending ids
+  // (#9655), and a post-restart burst is exactly when this action gets used —
+  // so it must scan the carrier, not the ordered id list.
+  it("clears a panel that is not in panelIds yet", () => {
+    seed(
+      [
+        ptyPanel("t-1", { sessionLostOnRestore: true }),
+        ptyPanel("t-batched", { sessionLostOnRestore: true }),
+      ],
+      ["t-1"]
+    );
+
+    usePanelStore.getState().dismissAllSessionLost();
+
+    expect(signalOf("t-batched")).toBeUndefined();
+  });
+
+  it("clears panels parked outside the grid", () => {
+    seed([
+      ptyPanel("t-dock", { sessionLostOnRestore: true, location: "dock" }),
+      ptyPanel("t-trash", { sessionLostOnRestore: true, location: "trash" }),
+    ]);
+
+    usePanelStore.getState().dismissAllSessionLost();
+
+    expect(signalOf("t-dock")).toBeUndefined();
+    expect(signalOf("t-trash")).toBeUndefined();
+  });
+
+  it("leaves unflagged panels untouched by identity", () => {
+    const untouched = ptyPanel("t-2");
+    seed([ptyPanel("t-1", { sessionLostOnRestore: true }), untouched]);
+
+    usePanelStore.getState().dismissAllSessionLost();
+
+    expect(usePanelStore.getState().panelsById["t-2"]).toBe(untouched);
+  });
+
+  it("keeps the same carrier identity when nothing is flagged", () => {
+    seed([ptyPanel("t-1"), ptyPanel("t-2")]);
+    const before = usePanelStore.getState().panelsById;
+
+    usePanelStore.getState().dismissAllSessionLost();
+
+    expect(usePanelStore.getState().panelsById).toBe(before);
+  });
+
+  it("is idempotent", () => {
+    seed([
+      ptyPanel("t-1", { sessionLostOnRestore: true }),
+      ptyPanel("t-2", { sessionLostOnRestore: true }),
+    ]);
+    usePanelStore.getState().dismissAllSessionLost();
+    const afterFirst = usePanelStore.getState().panelsById;
+
+    usePanelStore.getState().dismissAllSessionLost();
+
+    expect(usePanelStore.getState().panelsById).toBe(afterFirst);
+  });
+
+  it("skips non-PTY panels", () => {
+    const browser = browserPanel("b-1", { sessionLostOnRestore: true });
+    seed([ptyPanel("t-1", { sessionLostOnRestore: true }), browser]);
+
+    usePanelStore.getState().dismissAllSessionLost();
+
+    expect(signalOf("t-1")).toBeUndefined();
+    expect(usePanelStore.getState().panelsById["b-1"]).toBe(browser);
+  });
+
+  it("does not persist", () => {
+    seed([ptyPanel("t-1", { sessionLostOnRestore: true })]);
+
+    usePanelStore.getState().dismissAllSessionLost();
+
+    expect(saveNormalized).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/slices/panelRegistry/__tests__/dismissSessionLost.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dismissSessionLost.test.ts
@@ -230,12 +230,17 @@ describe("dismissAllSessionLost", () => {
     expect(Object.keys(usePanelStore.getState().panelsById).sort()).toEqual(["t-1", "t-2", "t-3"]);
   });
 
-  it("notifies subscribers exactly once for the whole sweep", () => {
-    seed([
+  // One notification for the whole sweep, and every flagged panel replaced
+  // rather than edited: a single notification alone would still be emitted by
+  // an implementation that mutated each panel in place and then handed back a
+  // fresh carrier, which React memo boundaries reading a panel would miss.
+  it("notifies once and replaces each flagged panel object", () => {
+    const before = [
       ptyPanel("t-1", { sessionLostOnRestore: true }),
       ptyPanel("t-2", { sessionLostOnRestore: true }),
       ptyPanel("t-3", { sessionLostOnRestore: true }),
-    ]);
+    ];
+    seed(before);
 
     const notified = vi.fn();
     const unsubscribe = usePanelStore.subscribe(notified);
@@ -243,6 +248,10 @@ describe("dismissAllSessionLost", () => {
     unsubscribe();
 
     expect(notified).toHaveBeenCalledTimes(1);
+    for (const panel of before) {
+      expect(usePanelStore.getState().panelsById[panel.id]).not.toBe(panel);
+      expect(panel.sessionLostOnRestore).toBe(true);
+    }
   });
 
   // A hydration/spawn batch publishes `panelsById` before appending ids

--- a/src/store/slices/panelRegistry/__tests__/dismissSessionLost.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dismissSessionLost.test.ts
@@ -59,7 +59,7 @@ vi.mock("../persistence", async () => {
 const { usePanelStore } = await import("../../../panelStore");
 const { saveNormalized } = await import("../persistence");
 
-function ptyPanel(id: string, overrides: Partial<PtyPanelData> = {}): PanelInstance {
+function ptyPanel(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id,
     kind: "terminal",
@@ -69,7 +69,7 @@ function ptyPanel(id: string, overrides: Partial<PtyPanelData> = {}): PanelInsta
     rows: 24,
     location: "grid",
     ...overrides,
-  } as PanelInstance;
+  } as PtyPanelData;
 }
 
 /**
@@ -125,22 +125,43 @@ describe("dismissSessionLost", () => {
     expect(signalOf("t-2")).toBe(true);
   });
 
-  it("preserves the rest of the panel's runtime state", () => {
-    seed([
-      ptyPanel("t-1", {
-        sessionLostOnRestore: true,
-        agentState: "working",
-        exitCode: 3,
-        isRestarting: true,
-      }),
-    ]);
+  // Whole-object equality, not a sampled field list: an implementation that
+  // rebuilt the panel and dropped unrelated fields would pass a spot check.
+  it("changes nothing on the panel but the consumed signal", () => {
+    const before = ptyPanel("t-1", {
+      sessionLostOnRestore: true,
+      agentState: "working",
+      exitCode: 3,
+      isRestarting: true,
+      worktreeId: "wt-a",
+      agentSessionId: "sess-9",
+    });
+    seed([before]);
 
     usePanelStore.getState().dismissSessionLost("t-1");
 
-    const panel = usePanelStore.getState().panelsById["t-1"] as PtyPanelData;
-    expect(panel.agentState).toBe("working");
-    expect(panel.exitCode).toBe(3);
-    expect(panel.isRestarting).toBe(true);
+    const after = usePanelStore.getState().panelsById["t-1"] as PtyPanelData;
+    const { sessionLostOnRestore: _dropped, ...expected } = before as PtyPanelData;
+    expect(after).toEqual({ ...expected, sessionLostOnRestore: undefined });
+  });
+
+  // Zustand 5 only notifies subscribers when the returned root fails Object.is
+  // against the previous state, so an in-place mutation would leave every value
+  // assertion above green while the banner stayed on screen.
+  it("writes immutably so subscribers are notified", () => {
+    const before = ptyPanel("t-1", { sessionLostOnRestore: true });
+    seed([before]);
+    const carrierBefore = usePanelStore.getState().panelsById;
+
+    const notified = vi.fn();
+    const unsubscribe = usePanelStore.subscribe(notified);
+    usePanelStore.getState().dismissSessionLost("t-1");
+    unsubscribe();
+
+    expect(notified).toHaveBeenCalledTimes(1);
+    expect(usePanelStore.getState().panelsById).not.toBe(carrierBefore);
+    expect(usePanelStore.getState().panelsById["t-1"]).not.toBe(before);
+    expect(before.sessionLostOnRestore).toBe(true);
   });
 
   it("is a no-op for an unknown id", () => {
@@ -192,7 +213,7 @@ describe("dismissSessionLost", () => {
 });
 
 describe("dismissAllSessionLost", () => {
-  it("clears every flagged panel regardless of worktree", () => {
+  it("clears every flagged panel regardless of worktree, keeping them all", () => {
     seed([
       ptyPanel("t-1", { sessionLostOnRestore: true, worktreeId: "wt-a" }),
       ptyPanel("t-2", { sessionLostOnRestore: true, worktreeId: "wt-b" }),
@@ -204,6 +225,24 @@ describe("dismissAllSessionLost", () => {
     expect(signalOf("t-1")).toBeUndefined();
     expect(signalOf("t-2")).toBeUndefined();
     expect(signalOf("t-3")).toBeUndefined();
+    // Consuming the signal must not consume the panels: deleting them outright
+    // would satisfy the assertions above.
+    expect(Object.keys(usePanelStore.getState().panelsById).sort()).toEqual(["t-1", "t-2", "t-3"]);
+  });
+
+  it("notifies subscribers exactly once for the whole sweep", () => {
+    seed([
+      ptyPanel("t-1", { sessionLostOnRestore: true }),
+      ptyPanel("t-2", { sessionLostOnRestore: true }),
+      ptyPanel("t-3", { sessionLostOnRestore: true }),
+    ]);
+
+    const notified = vi.fn();
+    const unsubscribe = usePanelStore.subscribe(notified);
+    usePanelStore.getState().dismissAllSessionLost();
+    unsubscribe();
+
+    expect(notified).toHaveBeenCalledTimes(1);
   });
 
   // A hydration/spawn batch publishes `panelsById` before appending ids
@@ -244,12 +283,16 @@ describe("dismissAllSessionLost", () => {
     expect(usePanelStore.getState().panelsById["t-2"]).toBe(untouched);
   });
 
-  it("keeps the same carrier identity when nothing is flagged", () => {
+  it("wakes no subscriber when nothing is flagged", () => {
     seed([ptyPanel("t-1"), ptyPanel("t-2")]);
     const before = usePanelStore.getState().panelsById;
 
+    const notified = vi.fn();
+    const unsubscribe = usePanelStore.subscribe(notified);
     usePanelStore.getState().dismissAllSessionLost();
+    unsubscribe();
 
+    expect(notified).not.toHaveBeenCalled();
     expect(usePanelStore.getState().panelsById).toBe(before);
   });
 

--- a/src/store/slices/panelRegistry/__tests__/dismissSessionLost.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dismissSessionLost.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { PanelInstance, PtyPanelData } from "@shared/types/panel";
+import { isPtyPanel, type PanelInstance, type PtyPanelData } from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -95,8 +95,8 @@ function seed(panels: PanelInstance[], panelIds?: string[]) {
 }
 
 function signalOf(id: string): boolean | undefined {
-  return (usePanelStore.getState().panelsById[id] as PtyPanelData | undefined)
-    ?.sessionLostOnRestore;
+  const panel = usePanelStore.getState().panelsById[id];
+  return panel && isPtyPanel(panel) ? panel.sessionLostOnRestore : undefined;
 }
 
 beforeEach(() => {
@@ -140,8 +140,8 @@ describe("dismissSessionLost", () => {
 
     usePanelStore.getState().dismissSessionLost("t-1");
 
-    const after = usePanelStore.getState().panelsById["t-1"] as PtyPanelData;
-    const { sessionLostOnRestore: _dropped, ...expected } = before as PtyPanelData;
+    const after = usePanelStore.getState().panelsById["t-1"];
+    const { sessionLostOnRestore: _dropped, ...expected } = before;
     expect(after).toEqual({ ...expected, sessionLostOnRestore: undefined });
   });
 

--- a/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
@@ -956,6 +956,9 @@ describe("restartTerminal stale flow state cleared (#9899)", () => {
     await usePanelStore.getState().restartTerminal("test-1");
 
     const after = usePanelStore.getState().panelsById["test-1"] as PtyPanelData | undefined;
+    // Assert survival first — `after?.x` would read undefined for a panel that
+    // vanished, which is not what this test is about.
+    expect(after).toBeDefined();
     expect(after?.sessionLostOnRestore).toBeUndefined();
   });
 });

--- a/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
@@ -939,6 +939,25 @@ describe("restartTerminal stale flow state cleared (#9899)", () => {
     // folding the now-cleared paused flow status.
     expect(after?.runtimeStatus).not.toBe("paused-backpressure");
   });
+
+  // Restarting is itself an acknowledgement of the lost session (#9802), and
+  // dismissal now consumes the same flag (#11589) — so this clear is the other
+  // half of that contract and must keep working.
+  it("consumes the session-lost signal on restart (#9802)", async () => {
+    const lost = {
+      ...agentPanelBase,
+      sessionLostOnRestore: true,
+    };
+    usePanelStore.setState({
+      panelsById: { [lost.id]: lost },
+      panelIds: [lost.id],
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    const after = usePanelStore.getState().panelsById["test-1"] as PtyPanelData | undefined;
+    expect(after?.sessionLostOnRestore).toBeUndefined();
+  });
 });
 
 describe("restartTerminal input lock + parallel IPC (#9164)", () => {

--- a/src/store/slices/panelRegistry/__tests__/selectors.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/selectors.test.ts
@@ -206,10 +206,4 @@ describe("selectHasMultipleSessionLost", () => {
     expect(selectHasMultipleSessionLost({ a: lost("a") })).toBe(false);
     expect(selectHasMultipleSessionLost({ a: lost("a"), b: lost("b"), c: lost("c") })).toBe(true);
   });
-
-  it("is stable across repeated calls on the same carrier", () => {
-    const byId = { a: lost("a"), b: lost("b") };
-    expect(selectHasMultipleSessionLost(byId)).toBe(true);
-    expect(selectHasMultipleSessionLost(byId)).toBe(true);
-  });
 });

--- a/src/store/slices/panelRegistry/__tests__/selectors.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/selectors.test.ts
@@ -6,6 +6,7 @@ import {
   getNarrowPanels,
   getRenderablePanel,
   isPanelRenderEligible,
+  selectHasMultipleSessionLost,
 } from "../selectors";
 
 // Adapter selectors that narrow the legacy `TerminalInstance` carrier to the
@@ -158,5 +159,57 @@ describe("getNarrowPanels", () => {
     const second = getNarrowPanels({ a: panel("a") }, ids);
     expect(second).not.toBe(first);
     expect(second.map((p) => p.id)).toEqual(["a"]);
+  });
+});
+
+// Gate for the banner's "Dismiss all" control (#11589). Scans the carrier
+// rather than an ordered id list so a hydration batch that hasn't appended its
+// ids yet still counts — the post-restart burst this control exists for.
+describe("selectHasMultipleSessionLost", () => {
+  const lost = (id: string, overrides: Partial<PanelInstance> = {}) =>
+    panel(id, { sessionLostOnRestore: true, ...overrides } as Partial<PanelInstance>);
+
+  it("is false with no flagged panels", () => {
+    expect(selectHasMultipleSessionLost({ a: panel("a"), b: panel("b") })).toBe(false);
+  });
+
+  it("is false with exactly one flagged panel", () => {
+    expect(selectHasMultipleSessionLost({ a: lost("a"), b: panel("b") })).toBe(false);
+  });
+
+  it("is true with two flagged panels", () => {
+    expect(selectHasMultipleSessionLost({ a: lost("a"), b: lost("b") })).toBe(true);
+  });
+
+  it("counts flagged panels across different worktrees", () => {
+    expect(
+      selectHasMultipleSessionLost({
+        a: lost("a", { worktreeId: "wt-1" }),
+        b: lost("b", { worktreeId: "wt-2" }),
+      })
+    ).toBe(true);
+  });
+
+  it("ignores non-PTY panels carrying the field", () => {
+    expect(
+      selectHasMultipleSessionLost({
+        a: lost("a"),
+        b: lost("b", { kind: "browser" }),
+      })
+    ).toBe(false);
+  });
+
+  it("recomputes when the carrier identity changes", () => {
+    expect(selectHasMultipleSessionLost({ a: lost("a"), b: lost("b") })).toBe(true);
+    expect(selectHasMultipleSessionLost({ a: lost("a") })).toBe(false);
+  });
+
+  it("returns the cached verdict for an identity-equal carrier", () => {
+    const byId = { a: lost("a"), b: lost("b") };
+    expect(selectHasMultipleSessionLost(byId)).toBe(true);
+    // Mutating in place is invisible to the memo — proves the cache was hit
+    // rather than the scan re-running.
+    delete (byId as Record<string, PanelInstance>).b;
+    expect(selectHasMultipleSessionLost(byId)).toBe(true);
   });
 });

--- a/src/store/slices/panelRegistry/__tests__/selectors.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/selectors.test.ts
@@ -199,17 +199,17 @@ describe("selectHasMultipleSessionLost", () => {
     ).toBe(false);
   });
 
+  // The store replaces `panelsById` on every write, so identity change is the
+  // only invalidation signal the memo needs.
   it("recomputes when the carrier identity changes", () => {
     expect(selectHasMultipleSessionLost({ a: lost("a"), b: lost("b") })).toBe(true);
     expect(selectHasMultipleSessionLost({ a: lost("a") })).toBe(false);
+    expect(selectHasMultipleSessionLost({ a: lost("a"), b: lost("b"), c: lost("c") })).toBe(true);
   });
 
-  it("returns the cached verdict for an identity-equal carrier", () => {
+  it("is stable across repeated calls on the same carrier", () => {
     const byId = { a: lost("a"), b: lost("b") };
     expect(selectHasMultipleSessionLost(byId)).toBe(true);
-    // Mutating in place is invisible to the memo — proves the cache was hit
-    // rather than the scan re-running.
-    delete (byId as Record<string, PanelInstance>).b;
     expect(selectHasMultipleSessionLost(byId)).toBe(true);
   });
 });

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -27,7 +27,7 @@ import { getAgentConfig } from "@/config/agents";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
-import { isPtyPanel } from "@shared/types/panel";
+import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
 import { agentLifecycleLedger } from "@/services/terminal/lifecycleLedger";
 import { computeEnvProvenance } from "@shared/utils/agentLifecycleLedger";
 import { markTerminalRestarting, unmarkTerminalRestarting } from "@/store/restartExitSuppression";
@@ -173,7 +173,51 @@ export const createRestartActions = (
   | "setInputLocked"
   | "toggleInputLocked"
   | "activateFallbackPreset"
+  | "dismissSessionLost"
+  | "dismissAllSessionLost"
 > => ({
+  // Dismissing the banner acknowledges the lost session, which is exactly what
+  // `sessionLostOnRestore` tracks — so consume the signal rather than shadowing
+  // it with a second "was it dismissed" flag. Keeping the acknowledgement in the
+  // store is the fix for #11589: a worktree switch unmounts the pane, so
+  // component state could never survive it. Same reasoning as the restart path
+  // below, which has always cleared this signal on acknowledgement (#9802).
+  dismissSessionLost: (id) => {
+    set((state) => {
+      const terminal = state.panelsById[id];
+      if (!terminal || !isPtyPanel(terminal)) return state;
+      // Already acknowledged (or never flagged) — keep the same state object so
+      // a repeat dismissal doesn't wake every subscriber.
+      if (!terminal.sessionLostOnRestore) return state;
+      return {
+        panelsById: {
+          ...state.panelsById,
+          [id]: { ...terminal, sessionLostOnRestore: undefined },
+        },
+      };
+    });
+  },
+
+  // One atomic pass over the carrier so N flagged panes produce a single store
+  // notification. Iterates `panelsById` directly, not `panelIds`: a hydration
+  // batch publishes the carrier before appending ids (#9655), and this action
+  // exists precisely for the post-restart moment when many panels are flagged.
+  // Deliberately unscoped by worktree — leaving flagged panels behind a
+  // worktree switch is the bug this issue is about.
+  dismissAllSessionLost: () => {
+    set((state) => {
+      let next: Record<string, PanelInstance> | undefined;
+      for (const [panelId, panel] of Object.entries(state.panelsById)) {
+        if (!isPtyPanel(panel) || !panel.sessionLostOnRestore) continue;
+        next ??= { ...state.panelsById };
+        next[panelId] = { ...panel, sessionLostOnRestore: undefined };
+      }
+      // Nothing flagged — return the same state object so no subscriber wakes.
+      if (!next) return state;
+      return { panelsById: next };
+    });
+  },
+
   restartTerminal: async (id, options) => {
     const allowResumeLatest = options?.allowResumeLatest !== false;
     const terminal = get().panelsById[id];

--- a/src/store/slices/panelRegistry/selectors.ts
+++ b/src/store/slices/panelRegistry/selectors.ts
@@ -133,6 +133,40 @@ export function getNarrowPanels(
   return _prevNarrowResult;
 }
 
+let _prevSessionLostById: Record<string, PanelInstance> | null = null;
+let _prevSessionLostResult = false;
+
+/**
+ * True when more than one PTY panel is still carrying an unacknowledged
+ * `sessionLostOnRestore` signal — the gate for offering "Dismiss all" on the
+ * session-lost banner (issue #11589). Below the threshold the per-pane close
+ * control already covers the whole set, so the extra button would be noise.
+ *
+ * Reads `panelsById` directly rather than an ordered id list: during a
+ * hydration/spawn batch the carrier is published before ids are appended, so
+ * an id-driven scan can miss freshly restored panels (#9655) — precisely the
+ * moment a restart leaves many panes flagged at once.
+ *
+ * Memoized on the `panelsById` identity (same pattern as
+ * `selectOrderedTerminals`) so many flagged panes share one scan per store
+ * snapshot, and short-circuits at the second hit.
+ */
+export function selectHasMultipleSessionLost(panelsById: Record<string, PanelInstance>): boolean {
+  if (panelsById === _prevSessionLostById) {
+    return _prevSessionLostResult;
+  }
+  let seen = 0;
+  for (const panel of Object.values(panelsById)) {
+    if (isPtyPanel(panel) && panel.sessionLostOnRestore) {
+      seen += 1;
+      if (seen > 1) break;
+    }
+  }
+  _prevSessionLostById = panelsById;
+  _prevSessionLostResult = seen > 1;
+  return _prevSessionLostResult;
+}
+
 export function _resetSelectorCacheForTests(): void {
   _prevById = null;
   _prevIds = null;
@@ -140,4 +174,6 @@ export function _resetSelectorCacheForTests(): void {
   _prevNarrowById = null;
   _prevNarrowIds = null;
   _prevNarrowResult = null;
+  _prevSessionLostById = null;
+  _prevSessionLostResult = false;
 }

--- a/src/store/slices/panelRegistry/types.ts
+++ b/src/store/slices/panelRegistry/types.ts
@@ -269,6 +269,20 @@ export interface PanelRegistrySlice {
   clearReconnectError: (id: string) => void;
   setScrollbackRestoreError: (id: string, error: TerminalScrollbackRestoreError) => void;
   clearScrollbackRestoreError: (id: string) => void;
+  /**
+   * Acknowledge the "Session no longer reachable" signal for one panel by
+   * clearing `sessionLostOnRestore` (issue #11589). Lives in the store rather
+   * than component state so the acknowledgement survives the unmount a
+   * worktree switch causes.
+   */
+  dismissSessionLost: (id: string) => void;
+  /**
+   * Acknowledge the session-lost signal on every PTY panel carrying it, across
+   * all worktrees in this project view (issue #11589). Scoping to the active
+   * worktree would leave banners waiting behind a worktree switch — the exact
+   * behaviour this fixes.
+   */
+  dismissAllSessionLost: () => void;
 
   // Tab grouping methods - TabGroup is the single source of truth
   /** Get all panels in a group, ordered by group's panelIds array. Location param is deprecated. */


### PR DESCRIPTION
## Summary

- Dismissing the "Session no longer reachable" banner was only tracked in local component state (`TerminalPane.tsx`). The content grid mounts only the active worktree's panels (`useContentGridContext.tsx` line 389 reads `panelIdsByWorktreeId[activeWorktreeId]`), so switching worktrees genuinely unmounts the pane. Switching back remounts it with fresh state, and the banner returns. Project switches never showed this because each project gets its own `WebContentsView`, so nothing unmounts.
- Dismissal now consumes the existing `sessionLostOnRestore` flag in the panel store instead of shadowing it with a second local flag. `restart.ts` line 246 already clears that flag on acknowledgement (from #9802), so this reuses the existing single source of truth rather than adding a new field, `PTY_FIELD_CLASSIFICATION` entry, or serializer change.
- Also adds the "Dismiss all" action the issue asked for.

Resolves #11589

## Changes

- Removed the now-unreachable `dismissedSessionLost` input from `RestartBannerInput`.
- Added a "Dismiss all" action on the banner, shown only when more than one pane has `sessionLostOnRestore` set. It's intentionally not scoped to the current worktree: scoping it would leave banners waiting behind a worktree switch, reproducing this exact bug for the panes just dismissed.
- The bulk action reads `panelsById` directly rather than `panelIds`, because a hydration or spawn batch publishes the panel record before appending its id to `panelIds` (#9655), and a post-restart burst of panels is exactly when this action gets used.
- Fixed a related bug along the way: the fallback-preset activation path in `restart.ts` line 1205 bumps `restartKey` without clearing the session-lost signal, so it was resurrecting a dismissed banner. Moving acknowledgement into the store fixes this too.
- Added `useSessionLostBanner`, a store-connected hook that owns the acknowledgement path. Keeping it separate also enforces a constraint from #10823: the hook has no access to `dismissedRestartPrompt`, so acknowledging a lost session can't suppress a later exit-error banner.

## Testing

- New `useSessionLostBanner.test.tsx` mounts, dismisses, unmounts, and remounts a component, pinning the exact regression (a worktree switch).
- Store tests assert immutable writes and correct subscriber notification counts, not just that a single notification fired, since an in-place mutation could still notify once.
- 194 targeted tests pass, project typecheck is clean.

Note: a bulk dismissal doesn't transfer focus if it removes the currently focused banner. That's pre-existing behavior shared with the single close button, and it's deliberately out of scope here.