### PR TITLE
feat(file-browser): add file-type icons to the tree

### DIFF
--- a/src/config/__tests__/fileTreeIcons.contract.test.ts
+++ b/src/config/__tests__/fileTreeIcons.contract.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(TEST_DIR, "../../..");
+const INDEX_CSS = path.join(REPO_ROOT, "src/index.css");
+
+// Issue #11596: the file-browser tree tints file icons with category-* hues so
+// types separate at a glance. Those hues are tuned for restrained chroma, not
+// for maximum contrast, so Increase Contrast repaints them monochrome — the
+// glyph shapes already carry the type, and the hue is the expendable half.
+// jsdom never evaluates media queries, so the rule is guarded here in source.
+
+/** Bodies of every `@media (<query>)` block in a stylesheet, brace-matched. */
+function readMediaBlocks(file: string, query: string): string {
+  const content = fs.readFileSync(file, "utf8");
+  const marker = `@media (${query})`;
+  const blocks: string[] = [];
+
+  let searchFrom = 0;
+  for (;;) {
+    const start = content.indexOf(marker, searchFrom);
+    if (start === -1) break;
+
+    const open = content.indexOf("{", start);
+    if (open === -1) break;
+    let depth = 0;
+    let end = open;
+    for (let i = open; i < content.length; i++) {
+      if (content[i] === "{") depth++;
+      else if (content[i] === "}") {
+        depth--;
+        if (depth === 0) {
+          end = i;
+          break;
+        }
+      }
+    }
+    blocks.push(content.slice(open, end + 1));
+    searchFrom = end + 1;
+  }
+
+  return blocks.join("\n");
+}
+
+describe("file-tree icon contrast contract (#11596)", () => {
+  it("repaints entry icons with the solid text token under Increase Contrast", () => {
+    const block = readMediaBlocks(INDEX_CSS, "prefers-contrast: more");
+    expect(block).toContain(".file-tree-entry-icon");
+    // !important is load-bearing: the Tailwind `text-category-*` utility has
+    // equal specificity (0,1,0) and would win on source order without it.
+    expect(block).toMatch(/\.file-tree-entry-icon\s*\{[^}]*color:[^;}]*!important/);
+  });
+
+  it("leaves the icons opted in to forced-colors", () => {
+    // These icons paint from `currentColor`, and forced-colors already forces
+    // `color` to a system keyword — so no rule is needed there, but opting out
+    // with `forced-color-adjust: none` would strand High Contrast users on the
+    // category hues. Guard the absence.
+    const block = readMediaBlocks(INDEX_CSS, "forced-colors: active");
+    expect(block).not.toMatch(/\.file-tree-entry-icon\s*\{[^}]*forced-color-adjust:\s*none/);
+  });
+
+  it("keeps the two contrast blocks separate", () => {
+    // macOS fires only prefers-contrast; Windows swaps in system colors via
+    // forced-colors. Consolidating them silently drops one platform.
+    const content = fs.readFileSync(INDEX_CSS, "utf8");
+    expect(content).toContain("@media (prefers-contrast: more)");
+    expect(content).toContain("@media (forced-colors: active)");
+    expect(content).not.toMatch(/@media\s*\([^)]*prefers-contrast[^)]*\)\s*and\s*\(forced-colors/);
+  });
+});

--- a/src/config/__tests__/fileTreeIcons.contract.test.ts
+++ b/src/config/__tests__/fileTreeIcons.contract.test.ts
@@ -14,7 +14,7 @@ const INDEX_CSS = path.join(REPO_ROOT, "src/index.css");
 // glyph shapes already carry the type, and the hue is the expendable half.
 // jsdom never evaluates media queries, so the rule is guarded here in source.
 
-/** CSS with every `/* … *​/` comment blanked, so a marker quoted in prose can't match. */
+/** CSS with every block comment blanked, so a marker quoted in prose can't match. */
 function stripComments(css: string): string {
   return css.replace(/\/\*[\s\S]*?\*\//g, "");
 }

--- a/src/config/__tests__/fileTreeIcons.contract.test.ts
+++ b/src/config/__tests__/fileTreeIcons.contract.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { FILE_TREE_ICON_CLASS } from "@/panels/file-browser/fileTypeIcons";
 
 const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(TEST_DIR, "../../..");
@@ -13,9 +14,14 @@ const INDEX_CSS = path.join(REPO_ROOT, "src/index.css");
 // glyph shapes already carry the type, and the hue is the expendable half.
 // jsdom never evaluates media queries, so the rule is guarded here in source.
 
+/** CSS with every `/* … *​/` comment blanked, so a marker quoted in prose can't match. */
+function stripComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
 /** Bodies of every `@media (<query>)` block in a stylesheet, brace-matched. */
 function readMediaBlocks(file: string, query: string): string {
-  const content = fs.readFileSync(file, "utf8");
+  const content = stripComments(fs.readFileSync(file, "utf8"));
   const marker = `@media (${query})`;
   const blocks: string[] = [];
 
@@ -45,30 +51,42 @@ function readMediaBlocks(file: string, query: string): string {
   return blocks.join("\n");
 }
 
+// The class name is imported, not spelled out, so the component and this test
+// can never drift onto two different selectors.
+const SELECTOR = new RegExp(`\\.${FILE_TREE_ICON_CLASS}\\s*\\{([^}]*)\\}`);
+
 describe("file-tree icon contrast contract (#11596)", () => {
   it("repaints entry icons with the solid text token under Increase Contrast", () => {
     const block = readMediaBlocks(INDEX_CSS, "prefers-contrast: more");
-    expect(block).toContain(".file-tree-entry-icon");
-    // !important is load-bearing: the Tailwind `text-category-*` utility has
-    // equal specificity (0,1,0) and would win on source order without it.
-    expect(block).toMatch(/\.file-tree-entry-icon\s*\{[^}]*color:[^;}]*!important/);
+    // Fail loudly rather than vacuously if the whole block ever disappears.
+    expect(block).not.toBe("");
+
+    const rule = block.match(SELECTOR);
+    expect(rule, `no .${FILE_TREE_ICON_CLASS} rule under prefers-contrast`).toBeTruthy();
+
+    const body = rule![1]!;
+    // Specifically the solid primary-text token: `transparent`, `inherit` or a
+    // category hue would all satisfy a bare "sets a color" assertion while
+    // leaving Increase Contrast users exactly where they started.
+    expect(body).toMatch(/color:\s*var\(--color-daintree-text\)/);
+    expect(body).not.toMatch(/category/);
   });
 
   it("leaves the icons opted in to forced-colors", () => {
     // These icons paint from `currentColor`, and forced-colors already forces
-    // `color` to a system keyword — so no rule is needed there, but opting out
-    // with `forced-color-adjust: none` would strand High Contrast users on the
-    // category hues. Guard the absence.
-    const block = readMediaBlocks(INDEX_CSS, "forced-colors: active");
-    expect(block).not.toMatch(/\.file-tree-entry-icon\s*\{[^}]*forced-color-adjust:\s*none/);
-  });
-
-  it("keeps the two contrast blocks separate", () => {
-    // macOS fires only prefers-contrast; Windows swaps in system colors via
-    // forced-colors. Consolidating them silently drops one platform.
-    const content = fs.readFileSync(INDEX_CSS, "utf8");
-    expect(content).toContain("@media (prefers-contrast: more)");
-    expect(content).toContain("@media (forced-colors: active)");
-    expect(content).not.toMatch(/@media\s*\([^)]*prefers-contrast[^)]*\)\s*and\s*\(forced-colors/);
+    // `color` to a system keyword — so no rule is needed there. But opting out
+    // with `forced-color-adjust: none` anywhere would strand High Contrast
+    // users on the category hues, so guard that absence repo-wide rather than
+    // only inside the media block (the property inherits, so an ancestor rule
+    // outside any media query would disable the repaint just as effectively).
+    const content = stripComments(fs.readFileSync(INDEX_CSS, "utf8"));
+    const rules = [
+      ...content.matchAll(new RegExp(`\\.${FILE_TREE_ICON_CLASS}[^{}]*\\{([^}]*)\\}`, "g")),
+    ];
+    // Non-vacuous: there is at least one such rule to inspect.
+    expect(rules.length).toBeGreaterThan(0);
+    for (const rule of rules) {
+      expect(rule[1]).not.toMatch(/forced-color-adjust:\s*none/);
+    }
   });
 });

--- a/src/config/__tests__/fileTreeIcons.contract.test.ts
+++ b/src/config/__tests__/fileTreeIcons.contract.test.ts
@@ -65,20 +65,25 @@ describe("file-tree icon contrast contract (#11596)", () => {
     expect(rule, `no .${FILE_TREE_ICON_CLASS} rule under prefers-contrast`).toBeTruthy();
 
     const body = rule![1]!;
-    // Specifically the solid primary-text token: `transparent`, `inherit` or a
-    // category hue would all satisfy a bare "sets a color" assertion while
-    // leaving Increase Contrast users exactly where they started.
-    expect(body).toMatch(/color:\s*var\(--color-daintree-text\)/);
+    // Specifically the `color` property set to the solid primary-text token.
+    // The leading boundary matters: without it `background-color` or
+    // `border-color` would satisfy this while the glyph itself stayed tinted.
+    // And `transparent`, `inherit` or a category hue would all satisfy a bare
+    // "sets a color" assertion while leaving Increase Contrast users exactly
+    // where they started.
+    expect(body).toMatch(/(^|[;{\s])color:\s*var\(--color-daintree-text\)/);
     expect(body).not.toMatch(/category/);
   });
 
   it("leaves the icons opted in to forced-colors", () => {
     // These icons paint from `currentColor`, and forced-colors already forces
     // `color` to a system keyword — so no rule is needed there. But opting out
-    // with `forced-color-adjust: none` anywhere would strand High Contrast
-    // users on the category hues, so guard that absence repo-wide rather than
-    // only inside the media block (the property inherits, so an ancestor rule
-    // outside any media query would disable the repaint just as effectively).
+    // with `forced-color-adjust: none` would strand High Contrast users on the
+    // category hues, so guard that no rule naming these icons ever does.
+    //
+    // Scoped to rules that name the icon class: the property inherits, so an
+    // ancestor opting out would defeat this too, but enumerating every possible
+    // ancestor selector is not something a source scan can do honestly.
     const content = stripComments(fs.readFileSync(INDEX_CSS, "utf8"));
     const rules = [
       ...content.matchAll(new RegExp(`\\.${FILE_TREE_ICON_CLASS}[^{}]*\\{([^}]*)\\}`, "g")),

--- a/src/index.css
+++ b/src/index.css
@@ -2775,10 +2775,12 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
    * carry the type — so repaint every entry icon with the solid text token.
    *
    * Unlike the rule above, !important is belt-and-braces here rather than
-   * load-bearing: this rule is unlayered and Tailwind's `text-category-*`
-   * utility lives in the `utilities` layer, so unlayered author CSS already
-   * outranks it whatever the specificity. It stays because moving this rule
-   * into a layer during some later refactor would silently reverse that.
+   * load-bearing: this rule is unlayered while the Tailwind category-hue text
+   * utilities live in the `utilities` layer, and unlayered author CSS already
+   * outranks any layered rule whatever the specificity. It stays because
+   * moving this rule into a layer later would silently reverse that.
+   * (Spelling those utility names out in full here would trip the
+   * colorSystem contract's scan for unexported color tokens.)
    *
    * There is deliberately no counterpart in the `forced-colors: active` block
    * earlier in this file: these icons paint from `currentColor`, and that mode

--- a/src/index.css
+++ b/src/index.css
@@ -2773,13 +2773,16 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
    * for restrained chroma, not for maximum contrast. Under Increase Contrast
    * the hue is the expendable half of the signal — the glyph shapes already
    * carry the type — so repaint every entry icon with the solid text token.
-   * !important for the same reason as the rule above: the Tailwind
-   * `text-category-*` utility has equal specificity (0,1,0) and wins on source
-   * order.
    *
-   * There is deliberately no `forced-colors: active` counterpart: these icons
-   * paint from `currentColor`, and that mode already forces `color` to a
-   * system keyword, so the same flattening happens with no rule at all. */
+   * Unlike the rule above, !important is belt-and-braces here rather than
+   * load-bearing: this rule is unlayered and Tailwind's `text-category-*`
+   * utility lives in the `utilities` layer, so unlayered author CSS already
+   * outranks it whatever the specificity. It stays because moving this rule
+   * into a layer during some later refactor would silently reverse that.
+   *
+   * There is deliberately no counterpart in the Windows High Contrast block
+   * below: these icons paint from `currentColor`, and that mode already forces
+   * `color` to a system keyword, so the flattening happens with no rule. */
   .file-tree-entry-icon {
     color: var(--color-daintree-text) !important;
   }

--- a/src/index.css
+++ b/src/index.css
@@ -2780,9 +2780,10 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
    * outranks it whatever the specificity. It stays because moving this rule
    * into a layer during some later refactor would silently reverse that.
    *
-   * There is deliberately no counterpart in the Windows High Contrast block
-   * below: these icons paint from `currentColor`, and that mode already forces
-   * `color` to a system keyword, so the flattening happens with no rule. */
+   * There is deliberately no counterpart in the `forced-colors: active` block
+   * earlier in this file: these icons paint from `currentColor`, and that mode
+   * already forces `color` to a system keyword, so the flattening happens on
+   * its own with no rule at all. */
   .file-tree-entry-icon {
     color: var(--color-daintree-text) !important;
   }

--- a/src/index.css
+++ b/src/index.css
@@ -2768,6 +2768,22 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
     border-color: var(--color-daintree-text);
   }
 
+  /* File-browser type icons (issue #11596). The tree tints file icons with the
+   * category-* hues so types separate at a glance, but those hues are chosen
+   * for restrained chroma, not for maximum contrast. Under Increase Contrast
+   * the hue is the expendable half of the signal — the glyph shapes already
+   * carry the type — so repaint every entry icon with the solid text token.
+   * !important for the same reason as the rule above: the Tailwind
+   * `text-category-*` utility has equal specificity (0,1,0) and wins on source
+   * order.
+   *
+   * There is deliberately no `forced-colors: active` counterpart: these icons
+   * paint from `currentColor`, and that mode already forces `color` to a
+   * system keyword, so the same flattening happens with no rule at all. */
+  .file-tree-entry-icon {
+    color: var(--color-daintree-text) !important;
+  }
+
   /* Diff-viewer increased-contrast rules live in src/components/Worktree/DiffViewer.css
      (component-owned: the stylesheet rides the lazy diff chunk). */
 }

--- a/src/panels/file-browser/FileTreeView.tsx
+++ b/src/panels/file-browser/FileTreeView.tsx
@@ -11,7 +11,7 @@ import { useDeferredLoading } from "@/hooks/useDeferredLoading";
 import { comboToAriaKeyshortcuts } from "@/lib/kbdShortcut";
 import { isMac } from "@/lib/platform";
 import { resolveTreeKey, type FlatTreeRow } from "./fileBrowserTree";
-import { UNKNOWN_FILE_COLOR_CLASS, getFileTypeIcon } from "./fileTypeIcons";
+import { FILE_TREE_ICON_CLASS, UNKNOWN_FILE_COLOR_CLASS, getFileTypeIcon } from "./fileTypeIcons";
 import { INSERT_FILE_REFERENCE_COMBO, matchesInsertFileReferenceCombo } from "./fileReference";
 
 export interface FileTreeViewProps {
@@ -501,7 +501,7 @@ function FileTreeRow({ row, isSelected, context }: FileTreeRowProps) {
         to monochrome; see `src/index.css`.
       */}
       <RowIcon
-        className={cn("file-tree-entry-icon h-3.5 w-3.5 shrink-0", rowIconColor)}
+        className={cn(FILE_TREE_ICON_CLASS, "h-3.5 w-3.5 shrink-0", rowIconColor)}
         aria-hidden="true"
       />
       <span className={cn("truncate", isSelected && "font-medium")}>{row.name}</span>

--- a/src/panels/file-browser/FileTreeView.tsx
+++ b/src/panels/file-browser/FileTreeView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useId, useMemo, useRef } from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
-import { ChevronDown, ChevronRight, File, Folder, FolderOpen } from "lucide-react";
+import { ChevronDown, ChevronRight, Folder, FolderOpen } from "lucide-react";
 import { join } from "@shared/utils/path";
 import { cn } from "@/lib/utils";
 import { UI_INLINE_LOADING_GATE_MS } from "@/lib/animationUtils";
@@ -11,6 +11,7 @@ import { useDeferredLoading } from "@/hooks/useDeferredLoading";
 import { comboToAriaKeyshortcuts } from "@/lib/kbdShortcut";
 import { isMac } from "@/lib/platform";
 import { resolveTreeKey, type FlatTreeRow } from "./fileBrowserTree";
+import { UNKNOWN_FILE_COLOR_CLASS, getFileTypeIcon } from "./fileTypeIcons";
 import { INSERT_FILE_REFERENCE_COMBO, matchesInsertFileReferenceCombo } from "./fileReference";
 
 export interface FileTreeViewProps {
@@ -429,6 +430,15 @@ function FileTreeRow({ row, isSelected, context }: FileTreeRowProps) {
 
   const Chevron = row.isExpanded ? ChevronDown : ChevronRight;
   const FolderIcon = row.isExpanded ? FolderOpen : Folder;
+  // Files carry their type; folders keep the folder shape (#11596). Resolved
+  // per render rather than memoized: it is an object lookup, and Virtuoso only
+  // ever renders the visible window.
+  //
+  // Folders stay neutral deliberately — they are one shape for the whole tree,
+  // so a hue on them would sort nothing.
+  const fileIcon = row.isDirectory ? null : getFileTypeIcon(row.name);
+  const RowIcon = fileIcon?.Icon ?? FolderIcon;
+  const rowIconColor = fileIcon?.colorClass ?? UNKNOWN_FILE_COLOR_CLASS;
 
   const menuItems = context.rowContextMenu?.(row);
   const rowSurface = (
@@ -480,11 +490,20 @@ function FileTreeRow({ row, isSelected, context }: FileTreeRowProps) {
       ) : (
         context.hasDirectories && <span className="h-4 w-4 shrink-0" />
       )}
-      {row.isDirectory ? (
-        <FolderIcon className="h-3.5 w-3.5 shrink-0 text-daintree-text/40" aria-hidden="true" />
-      ) : (
-        <File className="h-3.5 w-3.5 shrink-0 text-daintree-text/30" aria-hidden="true" />
-      )}
+      {/*
+        Rendered bare, never wrapped: the row's first element child is the
+        chevron gutter when folders are present and this icon when they are
+        not, and the tree's layout contract is asserted on exactly that.
+
+        Solid color rather than the old `/30`–`/40` alpha — at 14px an
+        alpha-reduced stroke is barely a shape cue, let alone a type cue. The
+        `file-tree-entry-icon` marker is what `prefers-contrast: more` repaints
+        to monochrome; see `src/index.css`.
+      */}
+      <RowIcon
+        className={cn("file-tree-entry-icon h-3.5 w-3.5 shrink-0", rowIconColor)}
+        aria-hidden="true"
+      />
       <span className={cn("truncate", isSelected && "font-medium")}>{row.name}</span>
       {showLoadingSpinner && (
         // Subdued via `text-daintree-text/40` (Spinner strokes currentColor) so

--- a/src/panels/file-browser/FileTreeView.tsx
+++ b/src/panels/file-browser/FileTreeView.tsx
@@ -497,7 +497,7 @@ function FileTreeRow({ row, isSelected, context }: FileTreeRowProps) {
 
         Solid color rather than the old `/30`–`/40` alpha — at 14px an
         alpha-reduced stroke is barely a shape cue, let alone a type cue. The
-        `file-tree-entry-icon` marker is what `prefers-contrast: more` repaints
+        FILE_TREE_ICON_CLASS marker is what `prefers-contrast: more` repaints
         to monochrome; see `src/index.css`.
       */}
       <RowIcon

--- a/src/panels/file-browser/__tests__/FileTreeView.test.tsx
+++ b/src/panels/file-browser/__tests__/FileTreeView.test.tsx
@@ -429,8 +429,10 @@ describe("FileTreeView row icons", () => {
   /** The row's icon: the direct <svg> child, past the chevron gutter if present. */
   function iconOf(element: Element): SVGElement {
     const svg = element.querySelector(":scope > svg");
-    expect(svg).toBeTruthy();
-    return svg as SVGElement;
+    if (!(svg instanceof SVGElement)) {
+      throw new Error(`no direct <svg> child on row ${element.getAttribute("aria-label")}`);
+    }
+    return svg;
   }
 
   it("gives each file kind its own glyph", () => {

--- a/src/panels/file-browser/__tests__/FileTreeView.test.tsx
+++ b/src/panels/file-browser/__tests__/FileTreeView.test.tsx
@@ -8,6 +8,7 @@ import { ContextMenuItem } from "@/components/ui/context-menu";
 import { FILE_DRAG_MIME, decodeFileDragPaths } from "@/lib/fileDragPayload";
 import { FileTreeView } from "../FileTreeView";
 import type { FlatTreeRow } from "../fileBrowserTree";
+import { FILE_TREE_ICON_CLASS, getFileTypeIcon } from "../fileTypeIcons";
 
 // `isMac` reads navigator.platform, which jsdom reports as neither — drive it
 // explicitly so both modifier branches of the insert shortcut are covered.
@@ -456,23 +457,40 @@ describe("FileTreeView row icons", () => {
     }
   });
 
-  it("tints classified files and leaves folders and unknowns neutral", () => {
+  it("paints each file with the color its own resolution asked for", () => {
     const { getByRole } = renderTree({ rows: MIXED, rowContextMenu: undefined });
 
-    // Lucide stamps its own `lucide-<name>` class on every icon, so compare the
-    // color utilities rather than the whole class attribute.
-    const colorsOf = (name: string) =>
-      iconOf(getByRole("treeitem", { name }))
-        .getAttribute("class")
-        ?.match(/\btext-[a-z][a-z0-9-]*\b/g) ?? [];
-
-    for (const name of ["clip.mp4", "index.json", "logo.png", "bundle.zip", "main.ts"]) {
-      expect(colorsOf(name).some((token) => token.startsWith("text-category-"))).toBe(true);
+    // Compared against the resolver rather than against a literal token, so a
+    // renderer that hardcoded one hue for every row would fail here.
+    for (const entry of MIXED.filter((candidate) => !candidate.isDirectory)) {
+      const className = iconOf(getByRole("treeitem", { name: entry.name })).getAttribute("class");
+      expect(className?.split(/\s+/)).toContain(getFileTypeIcon(entry.name).colorClass);
     }
-    // A folder is one shape for the whole tree, so a hue on it sorts nothing —
-    // it shares the unclassified file's neutral.
-    expect(colorsOf("src")).toEqual(colorsOf("mystery.qqq"));
-    expect(colorsOf("src").some((token) => token.startsWith("text-category-"))).toBe(false);
+  });
+
+  it("leaves folders on the unclassified file's neutral", () => {
+    const { getByRole } = renderTree({ rows: MIXED, rowContextMenu: undefined });
+    const classesOf = (name: string) =>
+      iconOf(getByRole("treeitem", { name })).getAttribute("class")?.split(/\s+/) ?? [];
+
+    // A folder is one shape for the whole tree, so a hue on it sorts nothing.
+    expect(classesOf("src")).toContain(getFileTypeIcon("mystery.qqq").colorClass);
+    expect(classesOf("src").some((token) => token.startsWith("text-category-"))).toBe(false);
+    // ...but it must still be a folder, not the generic file glyph.
+    expect(iconOf(getByRole("treeitem", { name: "src" })).innerHTML).not.toBe(
+      iconOf(getByRole("treeitem", { name: "mystery.qqq" })).innerHTML
+    );
+  });
+
+  it("marks every entry icon for the increased-contrast repaint", () => {
+    const { getByRole } = renderTree({ rows: MIXED, rowContextMenu: undefined });
+
+    // The stylesheet's `prefers-contrast: more` rule keys off this class; the
+    // contract test guards the other half.
+    for (const entry of MIXED) {
+      const className = iconOf(getByRole("treeitem", { name: entry.name })).getAttribute("class");
+      expect(className?.split(/\s+/)).toContain(FILE_TREE_ICON_CLASS);
+    }
   });
 
   it("never dims an entry icon into invisibility or reaches for the accent", () => {
@@ -482,6 +500,7 @@ describe("FileTreeView row icons", () => {
       const className = iconOf(getByRole("treeitem", { name: entry.name })).getAttribute("class");
       // The `/30`-`/40` alpha is exactly the "near invisible" complaint.
       expect(className).not.toMatch(/text-[a-z-]+\/\d/);
+      expect(className).not.toMatch(/\bopacity-/);
       // Accent restraint: never dozens of rows at once.
       expect(className).not.toMatch(/accent/);
     }

--- a/src/panels/file-browser/__tests__/FileTreeView.test.tsx
+++ b/src/panels/file-browser/__tests__/FileTreeView.test.tsx
@@ -412,6 +412,82 @@ describe("FileTreeView context-menu interactions", () => {
   });
 });
 
+describe("FileTreeView row icons", () => {
+  // One row per visibly different kind of file, plus a folder and an
+  // unclassifiable name.
+  const MIXED = [
+    row("src", true),
+    row("clip.mp4"),
+    row("index.json"),
+    row("logo.png"),
+    row("bundle.zip"),
+    row("main.ts"),
+    row("mystery.qqq"),
+  ];
+
+  /** The row's icon: the direct <svg> child, past the chevron gutter if present. */
+  function iconOf(element: Element): SVGElement {
+    const svg = element.querySelector(":scope > svg");
+    expect(svg).toBeTruthy();
+    return svg as SVGElement;
+  }
+
+  it("gives each file kind its own glyph", () => {
+    const { getByRole } = renderTree({ rows: MIXED, rowContextMenu: undefined });
+
+    const shapes = ["clip.mp4", "index.json", "logo.png", "bundle.zip", "main.ts"].map(
+      (name) => iconOf(getByRole("treeitem", { name })).innerHTML
+    );
+
+    // The bug this fixes was every row drawing the same glyph.
+    expect(new Set(shapes).size).toBe(shapes.length);
+  });
+
+  it("keeps every entry icon decorative and unwrapped", () => {
+    const { getByRole } = renderTree({ rows: MIXED, rowContextMenu: undefined });
+
+    for (const entry of MIXED) {
+      // Wrapping the icon would break the tree's first-child layout contract
+      // asserted above, so assert the direct-child relationship per row.
+      const icon = iconOf(getByRole("treeitem", { name: entry.name }));
+      // The row already announces the filename; a second spoken label would
+      // just repeat the extension on every arrow-key move.
+      expect(icon.getAttribute("aria-hidden")).toBe("true");
+    }
+  });
+
+  it("tints classified files and leaves folders and unknowns neutral", () => {
+    const { getByRole } = renderTree({ rows: MIXED, rowContextMenu: undefined });
+
+    // Lucide stamps its own `lucide-<name>` class on every icon, so compare the
+    // color utilities rather than the whole class attribute.
+    const colorsOf = (name: string) =>
+      iconOf(getByRole("treeitem", { name }))
+        .getAttribute("class")
+        ?.match(/\btext-[a-z][a-z0-9-]*\b/g) ?? [];
+
+    for (const name of ["clip.mp4", "index.json", "logo.png", "bundle.zip", "main.ts"]) {
+      expect(colorsOf(name).some((token) => token.startsWith("text-category-"))).toBe(true);
+    }
+    // A folder is one shape for the whole tree, so a hue on it sorts nothing —
+    // it shares the unclassified file's neutral.
+    expect(colorsOf("src")).toEqual(colorsOf("mystery.qqq"));
+    expect(colorsOf("src").some((token) => token.startsWith("text-category-"))).toBe(false);
+  });
+
+  it("never dims an entry icon into invisibility or reaches for the accent", () => {
+    const { getByRole } = renderTree({ rows: MIXED, rowContextMenu: undefined });
+
+    for (const entry of MIXED) {
+      const className = iconOf(getByRole("treeitem", { name: entry.name })).getAttribute("class");
+      // The `/30`-`/40` alpha is exactly the "near invisible" complaint.
+      expect(className).not.toMatch(/text-[a-z-]+\/\d/);
+      // Accent restraint: never dozens of rows at once.
+      expect(className).not.toMatch(/accent/);
+    }
+  });
+});
+
 describe("FileTreeView folder-load spinner", () => {
   afterEach(() => {
     vi.useRealTimers();

--- a/src/panels/file-browser/__tests__/fileTypeIcons.test.ts
+++ b/src/panels/file-browser/__tests__/fileTypeIcons.test.ts
@@ -10,24 +10,30 @@ import { UNKNOWN_FILE_COLOR_CLASS, getFileTypeIcon } from "../fileTypeIcons";
 // table back. Copying `png -> image` here would just restate the source and
 // would have to be edited in lockstep with it, which proves nothing.
 
-/** Members of each group must agree with each other and differ from the others. */
-const GROUPS = {
-  image: ["logo.png", "shot.JPEG", "icon.svg", "still.webp"],
-  video: ["clip.mp4", "reel.MOV", "capture.mkv"],
-  audio: ["track.mp3", "voice.wav", "sting.flac"],
-  archive: ["bundle.zip", "release.tar.gz", "lib.jar"],
-  source: ["main.ts", "app.tsx", "server.py", "lib.rs"],
-  script: ["deploy.sh", "setup.bash", "build.ps1"],
-  data: ["index.json", "records.jsonl", "shape.geojson"],
-  document: ["notes.md", "manual.pdf", "LICENSE"],
-  spreadsheet: ["rows.csv", "budget.xlsx"],
-  database: ["schema.sql", "cache.sqlite3"],
-  font: ["Inter.woff2", "mono.ttf"],
-  key: ["server.pem", "client.p12"],
-  binary: ["app.exe", "core.dylib", "mod.wasm"],
-  config: ["settings.toml", "values.yaml", "Makefile"],
-  lock: ["yarn.lock", "Cargo.lock", "poetry.lock"],
-} as const;
+/**
+ * Members of each group must agree with each other and differ from the others.
+ *
+ * A list rather than a keyed object so the group labels stay plain data — the
+ * labels are only there to name the test cases, and are deliberately NOT
+ * asserted against the resolver's own category names.
+ */
+const GROUPS = [
+  { label: "image", samples: ["logo.png", "shot.JPEG", "icon.svg", "still.webp"] },
+  { label: "video", samples: ["clip.mp4", "reel.MOV", "capture.mkv"] },
+  { label: "audio", samples: ["track.mp3", "voice.wav", "sting.flac"] },
+  { label: "archive", samples: ["bundle.zip", "release.tar.gz", "lib.jar"] },
+  { label: "source", samples: ["main.ts", "app.tsx", "server.py", "lib.rs"] },
+  { label: "script", samples: ["deploy.sh", "setup.bash", "build.ps1"] },
+  { label: "data", samples: ["index.json", "records.jsonl", "shape.geojson"] },
+  { label: "document", samples: ["notes.md", "manual.pdf", "LICENSE"] },
+  { label: "spreadsheet", samples: ["rows.csv", "budget.xlsx"] },
+  { label: "database", samples: ["schema.sql", "cache.sqlite3"] },
+  { label: "font", samples: ["Inter.woff2", "mono.ttf"] },
+  { label: "key", samples: ["server.pem", "client.p12"] },
+  { label: "binary", samples: ["app.exe", "core.dylib", "mod.wasm"] },
+  { label: "config", samples: ["settings.toml", "values.yaml", "Makefile"] },
+  { label: "lock", samples: ["yarn.lock", "Cargo.lock", "poetry.lock"] },
+] as const;
 
 /**
  * A name no table can claim, so its result IS the fallback. Comparing against
@@ -36,18 +42,16 @@ const GROUPS = {
  */
 const FALLBACK = getFileTypeIcon("mystery.qqq");
 
-const GROUP_NAMES = Object.keys(GROUPS) as Array<keyof typeof GROUPS>;
-
 /** The first name in each group, as the group's representative. */
-function representative(group: keyof typeof GROUPS) {
-  return getFileTypeIcon(GROUPS[group][0]);
+function representative(group: (typeof GROUPS)[number]) {
+  return getFileTypeIcon(group.samples[0]);
 }
 
 describe("getFileTypeIcon grouping", () => {
-  for (const group of GROUP_NAMES) {
-    it(`resolves every ${group} name to one identity`, () => {
+  for (const group of GROUPS) {
+    it(`resolves every ${group.label} name to one identity`, () => {
       const first = representative(group);
-      for (const name of GROUPS[group]) {
+      for (const name of group.samples) {
         const entry = getFileTypeIcon(name);
         expect(entry.category).toBe(first.category);
         expect(entry.Icon).toBe(first.Icon);
@@ -57,19 +61,19 @@ describe("getFileTypeIcon grouping", () => {
   }
 
   it("gives every group a distinct category and a distinct glyph", () => {
-    const categories = GROUP_NAMES.map((group) => representative(group).category);
-    const icons = GROUP_NAMES.map((group) => representative(group).Icon);
+    const categories = GROUPS.map((group) => representative(group).category);
+    const icons = GROUPS.map((group) => representative(group).Icon);
 
-    expect(new Set(categories).size).toBe(GROUP_NAMES.length);
+    expect(new Set(categories).size).toBe(GROUPS.length);
     // Shape is the primary signal, so no two categories may share a glyph —
     // hues are allowed to repeat, glyphs are not.
-    expect(new Set(icons).size).toBe(GROUP_NAMES.length);
+    expect(new Set(icons).size).toBe(GROUPS.length);
   });
 
   it("separates unrecognized files from every classified group", () => {
     expect(FALLBACK.colorClass).toBe(UNKNOWN_FILE_COLOR_CLASS);
 
-    for (const group of GROUP_NAMES) {
+    for (const group of GROUPS) {
       expect(representative(group).Icon).not.toBe(FALLBACK.Icon);
       expect(representative(group).category).not.toBe(FALLBACK.category);
     }
@@ -124,7 +128,7 @@ describe("getFileTypeIcon name normalization", () => {
 
   it("treats a leading dot as part of the name, not an extension", () => {
     // `.env` must not resolve as an `env` extension — it has none.
-    expect(getFileTypeIcon(".env").category).not.toBe("unknown");
+    expect(getFileTypeIcon(".env").category).not.toBe(FALLBACK.category);
     expect(getFileTypeIcon(".env")).toEqual(getFileTypeIcon(".env.production"));
   });
 });
@@ -202,7 +206,11 @@ describe("getFileTypeIcon coverage", () => {
 
 describe("getFileTypeIcon palette", () => {
   const ALLOWED = new Set(WORKTREE_COLOR_PALETTE.map((token) => `text-${token}`));
-  const ALL_NAMES = [...Object.values(GROUPS).flat(), "mystery.qqq", "yarn.lock", "vite.config.ts"];
+  const ALL_NAMES = [
+    ...GROUPS.flatMap((group) => [...group.samples]),
+    "mystery.qqq",
+    "vite.config.ts",
+  ];
 
   it("draws every classified hue from the CVD-proven palette", () => {
     for (const name of ALL_NAMES) {
@@ -230,7 +238,7 @@ describe("getFileTypeIcon palette", () => {
 });
 
 describe("getFileTypeIcon components", () => {
-  const REPRESENTATIVES = [...GROUP_NAMES.map((group) => GROUPS[group][0]), "mystery.qqq"];
+  const REPRESENTATIVES: string[] = [...GROUPS.map((group) => group.samples[0]), "mystery.qqq"];
 
   it("returns icons that paint from currentColor so one class can tint them", () => {
     for (const name of REPRESENTATIVES) {

--- a/src/panels/file-browser/__tests__/fileTypeIcons.test.ts
+++ b/src/panels/file-browser/__tests__/fileTypeIcons.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { WORKTREE_COLOR_PALETTE } from "@shared/theme/worktreeColors";
+import { LANGUAGE_MAP } from "@/components/FileViewer/languageUtils";
+import { UNKNOWN_FILE_COLOR_CLASS, getFileTypeIcon } from "../fileTypeIcons";
+
+// These tests assert relationships — "these names agree", "this name outranks
+// that one", "this hue comes from the proven palette" — rather than echoing the
+// table back. Copying `png -> image` here would just restate the source and
+// would have to be edited in lockstep with it, which proves nothing.
+
+/** Members of each group must agree with each other and differ from the others. */
+const GROUPS = {
+  image: ["logo.png", "shot.JPEG", "icon.svg", "still.webp"],
+  video: ["clip.mp4", "reel.MOV", "capture.mkv"],
+  audio: ["track.mp3", "voice.wav", "sting.flac"],
+  archive: ["bundle.zip", "release.tar.gz", "lib.jar"],
+  source: ["main.ts", "app.tsx", "server.py", "lib.rs"],
+  script: ["deploy.sh", "setup.bash", "build.ps1"],
+  data: ["index.json", "records.jsonl", "shape.geojson"],
+  document: ["notes.md", "manual.pdf", "LICENSE"],
+  spreadsheet: ["rows.csv", "budget.xlsx"],
+  database: ["schema.sql", "cache.sqlite3"],
+  font: ["Inter.woff2", "mono.ttf"],
+  key: ["server.pem", "client.p12"],
+  binary: ["app.exe", "core.dylib", "mod.wasm"],
+} as const;
+
+const GROUP_NAMES = Object.keys(GROUPS) as Array<keyof typeof GROUPS>;
+
+/** The first name in each group, as the group's representative. */
+function representative(group: keyof typeof GROUPS) {
+  return getFileTypeIcon(GROUPS[group][0]);
+}
+
+describe("getFileTypeIcon grouping", () => {
+  for (const group of GROUP_NAMES) {
+    it(`resolves every ${group} name to one identity`, () => {
+      const first = representative(group);
+      for (const name of GROUPS[group]) {
+        const entry = getFileTypeIcon(name);
+        expect(entry.category).toBe(first.category);
+        expect(entry.Icon).toBe(first.Icon);
+        expect(entry.colorClass).toBe(first.colorClass);
+      }
+    });
+  }
+
+  it("gives every group a distinct category and a distinct glyph", () => {
+    const categories = GROUP_NAMES.map((group) => representative(group).category);
+    const icons = GROUP_NAMES.map((group) => representative(group).Icon);
+
+    expect(new Set(categories).size).toBe(GROUP_NAMES.length);
+    // Shape is the primary signal, so no two categories may share a glyph —
+    // hues are allowed to repeat, glyphs are not.
+    expect(new Set(icons).size).toBe(GROUP_NAMES.length);
+  });
+
+  it("separates unrecognized files from every classified group", () => {
+    const unknown = getFileTypeIcon("mystery.qqq");
+    expect(unknown.category).toBe("unknown");
+    expect(unknown.colorClass).toBe(UNKNOWN_FILE_COLOR_CLASS);
+
+    for (const group of GROUP_NAMES) {
+      expect(representative(group).Icon).not.toBe(unknown.Icon);
+    }
+  });
+});
+
+describe("getFileTypeIcon name normalization", () => {
+  it("ignores case", () => {
+    expect(getFileTypeIcon("Photo.PNG")).toEqual(getFileTypeIcon("photo.png"));
+    expect(getFileTypeIcon("MAKEFILE")).toEqual(getFileTypeIcon("Makefile"));
+  });
+
+  it("classifies on the basename of a path, either separator", () => {
+    const bare = getFileTypeIcon("notes.md");
+    expect(getFileTypeIcon("docs/deep/notes.md")).toEqual(bare);
+    expect(getFileTypeIcon("docs\\deep\\notes.md")).toEqual(bare);
+    // A directory segment must never leak into the decision.
+    expect(getFileTypeIcon("images.png/readme.md")).toEqual(getFileTypeIcon("readme.md"));
+  });
+
+  it("reads a compound extension by its last segment", () => {
+    expect(getFileTypeIcon("release.tar.gz")).toEqual(getFileTypeIcon("release.gz"));
+  });
+
+  it("treats a leading dot as part of the name, not an extension", () => {
+    // `.env` must not resolve as an `env` extension — it has none.
+    expect(getFileTypeIcon(".env").category).not.toBe("unknown");
+    expect(getFileTypeIcon(".env")).toEqual(getFileTypeIcon(".env.production"));
+  });
+});
+
+describe("getFileTypeIcon precedence", () => {
+  it("reads a lockfile as a lock, not as its container format", () => {
+    const lock = getFileTypeIcon("yarn.lock");
+    expect(getFileTypeIcon("package-lock.json")).toEqual(lock);
+    expect(getFileTypeIcon("pnpm-lock.yaml")).toEqual(lock);
+    expect(getFileTypeIcon("Cargo.lock")).toEqual(lock);
+    expect(getFileTypeIcon("go.sum")).toEqual(lock);
+
+    expect(getFileTypeIcon("package-lock.json")).not.toEqual(getFileTypeIcon("data.json"));
+    expect(getFileTypeIcon("pnpm-lock.yaml")).not.toEqual(getFileTypeIcon("values.yaml"));
+  });
+
+  it("reads a tool config as config, not as its source language", () => {
+    const config = getFileTypeIcon("settings.toml");
+    expect(getFileTypeIcon("vite.config.ts")).toEqual(config);
+    expect(getFileTypeIcon("tsconfig.build.json")).toEqual(config);
+    expect(getFileTypeIcon(".prettierrc")).toEqual(config);
+    expect(getFileTypeIcon("Dockerfile.dev")).toEqual(config);
+    expect(getFileTypeIcon("docker-compose.yml")).toEqual(config);
+
+    expect(getFileTypeIcon("vite.config.ts")).not.toEqual(getFileTypeIcon("index.ts"));
+    expect(getFileTypeIcon("tsconfig.build.json")).not.toEqual(getFileTypeIcon("data.json"));
+  });
+
+  it("keeps `.ts` on TypeScript rather than MPEG transport stream", () => {
+    expect(getFileTypeIcon("player.ts")).toEqual(getFileTypeIcon("player.tsx"));
+    expect(getFileTypeIcon("player.ts")).not.toEqual(getFileTypeIcon("player.mp4"));
+  });
+});
+
+describe("getFileTypeIcon coverage", () => {
+  it("classifies every extension the file viewer knows a language for", () => {
+    // Sourced from LANGUAGE_MAP rather than restated, so a language added there
+    // and forgotten here fails instead of silently rendering a blank file icon.
+    // Its two extensionless keys are whole basenames; the rest are extensions.
+    const EXTENSIONLESS = new Set(["dockerfile", "makefile"]);
+    const unresolved = Object.keys(LANGUAGE_MAP).filter((key) => {
+      const name = EXTENSIONLESS.has(key) ? key : `sample.${key}`;
+      return getFileTypeIcon(name).category === "unknown";
+    });
+    expect(unresolved).toEqual([]);
+  });
+});
+
+describe("getFileTypeIcon palette", () => {
+  const ALLOWED = new Set(WORKTREE_COLOR_PALETTE.map((token) => `text-${token}`));
+  const ALL_NAMES = [...Object.values(GROUPS).flat(), "mystery.qqq", "yarn.lock", "vite.config.ts"];
+
+  it("draws every classified hue from the CVD-proven palette", () => {
+    for (const name of ALL_NAMES) {
+      const { category, colorClass } = getFileTypeIcon(name);
+      if (category === "unknown") continue;
+      expect(ALLOWED.has(colorClass), `${name} -> ${colorClass}`).toBe(true);
+    }
+  });
+
+  it("keeps the unknown fallback outside the categorical palette", () => {
+    expect(ALLOWED.has(getFileTypeIcon("mystery.qqq").colorClass)).toBe(false);
+  });
+
+  it("never reaches for the accent, a status hue, or an alpha suffix", () => {
+    for (const name of ALL_NAMES) {
+      const { colorClass } = getFileTypeIcon(name);
+      // Accent restraint: one load-bearing accent signal per focus region, and
+      // a tree tinting dozens of rows is not it.
+      expect(colorClass).not.toMatch(/accent/);
+      expect(colorClass).not.toMatch(/status-/);
+      // The `/30`-`/40` alpha is the "near invisible" bug this issue fixed.
+      expect(colorClass).not.toMatch(/\//);
+    }
+  });
+});
+
+describe("getFileTypeIcon components", () => {
+  it("returns icons that paint from currentColor so one class can tint them", () => {
+    for (const name of Object.values(GROUPS).flat()) {
+      const markup = renderToStaticMarkup(createElement(getFileTypeIcon(name).Icon));
+      expect(markup.startsWith("<svg")).toBe(true);
+      expect(markup).toContain("currentColor");
+    }
+  });
+});

--- a/src/panels/file-browser/__tests__/fileTypeIcons.test.ts
+++ b/src/panels/file-browser/__tests__/fileTypeIcons.test.ts
@@ -25,7 +25,16 @@ const GROUPS = {
   font: ["Inter.woff2", "mono.ttf"],
   key: ["server.pem", "client.p12"],
   binary: ["app.exe", "core.dylib", "mod.wasm"],
+  config: ["settings.toml", "values.yaml", "Makefile"],
+  lock: ["yarn.lock", "Cargo.lock", "poetry.lock"],
 } as const;
+
+/**
+ * A name no table can claim, so its result IS the fallback. Comparing against
+ * this rather than the string "unknown" keeps the tests from going quiet if the
+ * category is ever renamed.
+ */
+const FALLBACK = getFileTypeIcon("mystery.qqq");
 
 const GROUP_NAMES = Object.keys(GROUPS) as Array<keyof typeof GROUPS>;
 
@@ -58,12 +67,39 @@ describe("getFileTypeIcon grouping", () => {
   });
 
   it("separates unrecognized files from every classified group", () => {
-    const unknown = getFileTypeIcon("mystery.qqq");
-    expect(unknown.category).toBe("unknown");
-    expect(unknown.colorClass).toBe(UNKNOWN_FILE_COLOR_CLASS);
+    expect(FALLBACK.colorClass).toBe(UNKNOWN_FILE_COLOR_CLASS);
 
     for (const group of GROUP_NAMES) {
-      expect(representative(group).Icon).not.toBe(unknown.Icon);
+      expect(representative(group).Icon).not.toBe(FALLBACK.Icon);
+      expect(representative(group).category).not.toBe(FALLBACK.category);
+    }
+  });
+
+  it("falls back rather than throwing on degenerate names", () => {
+    // Nothing here can match a table, so every one must land on the fallback
+    // instead of resolving to a partial or undefined result.
+    for (const name of ["", ".", "...", "foo.", "  ", "a".repeat(300), `x.${"y".repeat(300)}`]) {
+      expect(getFileTypeIcon(name)).toEqual(FALLBACK);
+    }
+  });
+
+  it("does not mistake inherited object members for classifications", () => {
+    // The lookup tables are plain objects, so a file actually named
+    // `constructor` would read Object.prototype without an own-key guard and
+    // hand back undefined — which the tree then paints as a folder.
+    for (const name of [
+      "constructor",
+      "__proto__",
+      "toString",
+      "hasOwnProperty",
+      "valueOf",
+      "file.constructor",
+      "file.__proto__",
+      "file.toString",
+    ]) {
+      const resolved = getFileTypeIcon(name);
+      expect(resolved).toBeDefined();
+      expect(resolved).toEqual(FALLBACK);
     }
   });
 });
@@ -121,18 +157,45 @@ describe("getFileTypeIcon precedence", () => {
     expect(getFileTypeIcon("player.ts")).toEqual(getFileTypeIcon("player.tsx"));
     expect(getFileTypeIcon("player.ts")).not.toEqual(getFileTypeIcon("player.mp4"));
   });
+
+  it("lets a strong extension outrank a `.config.` infix", () => {
+    // `.config.` is common enough inside ordinary names that an open suffix
+    // would swallow media and executables whose own extension says more.
+    expect(getFileTypeIcon("photo.config.png")).toEqual(getFileTypeIcon("photo.png"));
+    expect(getFileTypeIcon("payload.config.exe")).toEqual(getFileTypeIcon("payload.exe"));
+    // ...while a real config carrier still wins over its own format.
+    expect(getFileTypeIcon("vite.config.ts")).not.toEqual(getFileTypeIcon("vite.ts"));
+  });
+
+  it("reads Terraform's dependency lock as a lock, not as HCL config", () => {
+    expect(getFileTypeIcon(".terraform.lock.hcl")).toEqual(getFileTypeIcon("yarn.lock"));
+    expect(getFileTypeIcon(".terraform.lock.hcl")).not.toEqual(getFileTypeIcon("main.hcl"));
+  });
+
+  it("reads the Gradle wrapper launchers as scripts", () => {
+    const script = getFileTypeIcon("deploy.sh");
+    expect(getFileTypeIcon("gradlew")).toEqual(script);
+    // `.bat` already resolves as a script, so this must not be overridden back
+    // to config the way an exact entry once did.
+    expect(getFileTypeIcon("gradlew.bat")).toEqual(script);
+  });
 });
 
 describe("getFileTypeIcon coverage", () => {
   it("classifies every extension the file viewer knows a language for", () => {
     // Sourced from LANGUAGE_MAP rather than restated, so a language added there
     // and forgotten here fails instead of silently rendering a blank file icon.
-    // Its two extensionless keys are whole basenames; the rest are extensions.
-    const EXTENSIONLESS = new Set(["dockerfile", "makefile"]);
-    const unresolved = Object.keys(LANGUAGE_MAP).filter((key) => {
-      const name = EXTENSIONLESS.has(key) ? key : `sample.${key}`;
-      return getFileTypeIcon(name).category === "unknown";
-    });
+    const keys = Object.keys(LANGUAGE_MAP);
+    // Without this the filter below would pass on an empty map.
+    expect(keys.length).toBeGreaterThan(0);
+
+    // Most keys are extensions, a couple (Dockerfile, Makefile) are whole
+    // basenames. Accept either reading rather than hardcoding which is which.
+    const unresolved = keys.filter(
+      (key) =>
+        getFileTypeIcon(`sample.${key}`).category === FALLBACK.category &&
+        getFileTypeIcon(key).category === FALLBACK.category
+    );
     expect(unresolved).toEqual([]);
   });
 });
@@ -144,13 +207,13 @@ describe("getFileTypeIcon palette", () => {
   it("draws every classified hue from the CVD-proven palette", () => {
     for (const name of ALL_NAMES) {
       const { category, colorClass } = getFileTypeIcon(name);
-      if (category === "unknown") continue;
+      if (category === FALLBACK.category) continue;
       expect(ALLOWED.has(colorClass), `${name} -> ${colorClass}`).toBe(true);
     }
   });
 
   it("keeps the unknown fallback outside the categorical palette", () => {
-    expect(ALLOWED.has(getFileTypeIcon("mystery.qqq").colorClass)).toBe(false);
+    expect(ALLOWED.has(FALLBACK.colorClass)).toBe(false);
   });
 
   it("never reaches for the accent, a status hue, or an alpha suffix", () => {
@@ -167,11 +230,22 @@ describe("getFileTypeIcon palette", () => {
 });
 
 describe("getFileTypeIcon components", () => {
+  const REPRESENTATIVES = [...GROUP_NAMES.map((group) => GROUPS[group][0]), "mystery.qqq"];
+
   it("returns icons that paint from currentColor so one class can tint them", () => {
-    for (const name of Object.values(GROUPS).flat()) {
+    for (const name of REPRESENTATIVES) {
       const markup = renderToStaticMarkup(createElement(getFileTypeIcon(name).Icon));
       expect(markup.startsWith("<svg")).toBe(true);
       expect(markup).toContain("currentColor");
     }
+  });
+
+  it("draws a visibly different glyph for every category", () => {
+    // Component identity is checked above; this compares what actually paints,
+    // so two distinct exports that happen to render the same art still fail.
+    const drawn = REPRESENTATIVES.map((name) =>
+      renderToStaticMarkup(createElement(getFileTypeIcon(name).Icon))
+    );
+    expect(new Set(drawn).size).toBe(REPRESENTATIVES.length);
   });
 });

--- a/src/panels/file-browser/fileTypeIcons.ts
+++ b/src/panels/file-browser/fileTypeIcons.ts
@@ -1,0 +1,518 @@
+import {
+  Binary,
+  Database,
+  File,
+  FileArchive,
+  FileBraces,
+  FileCode,
+  FileCog,
+  FileImage,
+  FileKey,
+  FileLock,
+  FileMusic,
+  FilePlay,
+  FileSpreadsheet,
+  FileTerminal,
+  FileText,
+  FileType,
+  type LucideIcon,
+} from "lucide-react";
+import type { WORKTREE_COLOR_PALETTE } from "@shared/theme/worktreeColors";
+
+/**
+ * File-type icons for the browser tree (#11596).
+ *
+ * Every row used to render the same generic `File`, so a folder of `.mp4`
+ * clips looked exactly like a folder of source files. Classification is
+ * filename-only — no MIME sniffing, no stat, no extra IPC — because the tree
+ * already has the basename and nothing else is worth a round trip per row.
+ *
+ * Colors come from the existing `category-*` theme tokens, never the accent:
+ * accent restraint allows one load-bearing accent signal per focus region, and
+ * a tree tinting dozens of rows at once is exactly what that forbids. The hues
+ * are limited to the eight-token CVD-safe subset `WORKTREE_COLOR_PALETTE`
+ * already proven distinguishable under all three dichromacies across every
+ * built-in theme, so this map inherits that proof instead of restating it.
+ *
+ * At `h-3.5` shape carries the signal and color only reinforces it — which is
+ * why hues repeat across categories whose glyphs look nothing alike (a gear
+ * and a play triangle both sit on violet), and why dropping to monochrome
+ * under `prefers-contrast: more` costs nothing but the reinforcement.
+ */
+
+/** Category identity. Exposed so callers can group rows without matching on icon identity. */
+export type FileTypeCategory =
+  | "source"
+  | "script"
+  | "data"
+  | "config"
+  | "lock"
+  | "image"
+  | "video"
+  | "audio"
+  | "archive"
+  | "document"
+  | "spreadsheet"
+  | "database"
+  | "font"
+  | "key"
+  | "binary"
+  | "unknown";
+
+type CategoryColor = `text-${(typeof WORKTREE_COLOR_PALETTE)[number]}`;
+
+/** The neutral every unrecognized file falls back to — deliberately outside the categorical palette. */
+export const UNKNOWN_FILE_COLOR_CLASS = "text-text-secondary";
+
+export interface FileTypeIcon {
+  category: FileTypeCategory;
+  Icon: LucideIcon;
+  /**
+   * A complete Tailwind literal, never composed at runtime: the v4 scanner
+   * only emits utilities it can find as whole strings in source.
+   */
+  colorClass: CategoryColor | typeof UNKNOWN_FILE_COLOR_CLASS;
+}
+
+const CATEGORIES: Record<FileTypeCategory, FileTypeIcon> = {
+  source: { category: "source", Icon: FileCode, colorClass: "text-category-blue" },
+  script: { category: "script", Icon: FileTerminal, colorClass: "text-category-cyan" },
+  data: { category: "data", Icon: FileBraces, colorClass: "text-category-amber" },
+  config: { category: "config", Icon: FileCog, colorClass: "text-category-violet" },
+  lock: { category: "lock", Icon: FileLock, colorClass: "text-category-indigo" },
+  image: { category: "image", Icon: FileImage, colorClass: "text-category-pink" },
+  video: { category: "video", Icon: FilePlay, colorClass: "text-category-violet" },
+  audio: { category: "audio", Icon: FileMusic, colorClass: "text-category-cyan" },
+  archive: { category: "archive", Icon: FileArchive, colorClass: "text-category-orange" },
+  document: { category: "document", Icon: FileText, colorClass: "text-category-teal" },
+  spreadsheet: { category: "spreadsheet", Icon: FileSpreadsheet, colorClass: "text-category-teal" },
+  database: { category: "database", Icon: Database, colorClass: "text-category-amber" },
+  font: { category: "font", Icon: FileType, colorClass: "text-category-pink" },
+  key: { category: "key", Icon: FileKey, colorClass: "text-category-indigo" },
+  binary: { category: "binary", Icon: Binary, colorClass: "text-category-orange" },
+  unknown: { category: "unknown", Icon: File, colorClass: UNKNOWN_FILE_COLOR_CLASS },
+};
+
+/**
+ * Extension → category. Keys are lowercase and carry no leading dot.
+ *
+ * `ts` is TypeScript, not MPEG transport stream: this is an IDE, and the cost
+ * of the two readings is wildly asymmetric.
+ */
+const EXTENSION_CATEGORIES: Record<string, FileTypeCategory> = {
+  // source
+  js: "source",
+  jsx: "source",
+  ts: "source",
+  tsx: "source",
+  mjs: "source",
+  cjs: "source",
+  mts: "source",
+  cts: "source",
+  html: "source",
+  htm: "source",
+  css: "source",
+  scss: "source",
+  sass: "source",
+  less: "source",
+  styl: "source",
+  xml: "source",
+  xsl: "source",
+  py: "source",
+  pyw: "source",
+  pyi: "source",
+  rb: "source",
+  go: "source",
+  rs: "source",
+  java: "source",
+  kt: "source",
+  kts: "source",
+  swift: "source",
+  m: "source",
+  mm: "source",
+  c: "source",
+  cc: "source",
+  cpp: "source",
+  cxx: "source",
+  h: "source",
+  hh: "source",
+  hpp: "source",
+  hxx: "source",
+  cs: "source",
+  php: "source",
+  ex: "source",
+  exs: "source",
+  erl: "source",
+  hrl: "source",
+  fs: "source",
+  fsx: "source",
+  vb: "source",
+  lua: "source",
+  pl: "source",
+  pm: "source",
+  r: "source",
+  scala: "source",
+  dart: "source",
+  sol: "source",
+  zig: "source",
+  nim: "source",
+  hs: "source",
+  clj: "source",
+  cljs: "source",
+  cljc: "source",
+  groovy: "source",
+  vue: "source",
+  svelte: "source",
+  astro: "source",
+  graphql: "source",
+  gql: "source",
+  proto: "source",
+  ipynb: "source",
+
+  // script
+  sh: "script",
+  bash: "script",
+  zsh: "script",
+  fish: "script",
+  ksh: "script",
+  ps1: "script",
+  psm1: "script",
+  bat: "script",
+  cmd: "script",
+  nu: "script",
+
+  // data
+  json: "data",
+  jsonc: "data",
+  json5: "data",
+  jsonl: "data",
+  ndjson: "data",
+  geojson: "data",
+  topojson: "data",
+  map: "data",
+
+  // config
+  yaml: "config",
+  yml: "config",
+  toml: "config",
+  ini: "config",
+  cfg: "config",
+  conf: "config",
+  config: "config",
+  properties: "config",
+  plist: "config",
+  tf: "config",
+  tfvars: "config",
+  hcl: "config",
+
+  // lock
+  lock: "lock",
+  lockb: "lock",
+
+  // image
+  png: "image",
+  jpg: "image",
+  jpeg: "image",
+  jpe: "image",
+  gif: "image",
+  webp: "image",
+  avif: "image",
+  svg: "image",
+  ico: "image",
+  icns: "image",
+  bmp: "image",
+  tif: "image",
+  tiff: "image",
+  heic: "image",
+  heif: "image",
+  psd: "image",
+  ai: "image",
+  sketch: "image",
+  fig: "image",
+
+  // video
+  mp4: "video",
+  m4v: "video",
+  mov: "video",
+  avi: "video",
+  mkv: "video",
+  webm: "video",
+  mpeg: "video",
+  mpg: "video",
+  mpe: "video",
+  wmv: "video",
+  flv: "video",
+  ogv: "video",
+  "3gp": "video",
+  "3g2": "video",
+
+  // audio
+  mp3: "audio",
+  wav: "audio",
+  flac: "audio",
+  aac: "audio",
+  m4a: "audio",
+  ogg: "audio",
+  oga: "audio",
+  opus: "audio",
+  wma: "audio",
+  aiff: "audio",
+  aif: "audio",
+  midi: "audio",
+  mid: "audio",
+
+  // archive — package artifacts live here too: a .jar, .whl or .deb is a
+  // container, and giving them their own glyph would split one idea in two.
+  zip: "archive",
+  "7z": "archive",
+  rar: "archive",
+  tar: "archive",
+  gz: "archive",
+  tgz: "archive",
+  bz2: "archive",
+  tbz: "archive",
+  tbz2: "archive",
+  xz: "archive",
+  txz: "archive",
+  zst: "archive",
+  tzst: "archive",
+  lz: "archive",
+  lz4: "archive",
+  cab: "archive",
+  iso: "archive",
+  dmg: "archive",
+  jar: "archive",
+  war: "archive",
+  ear: "archive",
+  apk: "archive",
+  ipa: "archive",
+  deb: "archive",
+  rpm: "archive",
+  pkg: "archive",
+  msi: "archive",
+  nupkg: "archive",
+  gem: "archive",
+  whl: "archive",
+  egg: "archive",
+  crate: "archive",
+
+  // document
+  txt: "document",
+  md: "document",
+  mdx: "document",
+  markdown: "document",
+  rst: "document",
+  adoc: "document",
+  asciidoc: "document",
+  org: "document",
+  rtf: "document",
+  pdf: "document",
+  tex: "document",
+  bib: "document",
+  log: "document",
+  doc: "document",
+  docx: "document",
+  odt: "document",
+  pages: "document",
+  ppt: "document",
+  pptx: "document",
+  odp: "document",
+
+  // spreadsheet
+  csv: "spreadsheet",
+  tsv: "spreadsheet",
+  xls: "spreadsheet",
+  xlsx: "spreadsheet",
+  xlsm: "spreadsheet",
+  ods: "spreadsheet",
+  ots: "spreadsheet",
+  numbers: "spreadsheet",
+
+  // database
+  sql: "database",
+  db: "database",
+  db3: "database",
+  sqlite: "database",
+  sqlite3: "database",
+  duckdb: "database",
+  parquet: "database",
+  avro: "database",
+  orc: "database",
+
+  // font
+  ttf: "font",
+  otf: "font",
+  woff: "font",
+  woff2: "font",
+  eot: "font",
+
+  // key / certificate
+  pem: "key",
+  crt: "key",
+  cer: "key",
+  der: "key",
+  p12: "key",
+  pfx: "key",
+  key: "key",
+  pub: "key",
+  jks: "key",
+  keystore: "key",
+  gpg: "key",
+  asc: "key",
+
+  // binary
+  bin: "binary",
+  exe: "binary",
+  dll: "binary",
+  so: "binary",
+  dylib: "binary",
+  o: "binary",
+  obj: "binary",
+  a: "binary",
+  lib: "binary",
+  class: "binary",
+  pyc: "binary",
+  pyo: "binary",
+  wasm: "binary",
+};
+
+/**
+ * Exact basenames, lowercase. Checked before extensions so a manifest wins
+ * over its own container format — `package-lock.json` is a lockfile first and
+ * JSON second, `Cargo.toml` is a manifest first and TOML second.
+ */
+const BASENAME_CATEGORIES: Record<string, FileTypeCategory> = {
+  // lockfiles
+  "package-lock.json": "lock",
+  "npm-shrinkwrap.json": "lock",
+  "packages.lock.json": "lock",
+  "pnpm-lock.yaml": "lock",
+  "yarn.lock": "lock",
+  "bun.lock": "lock",
+  "bun.lockb": "lock",
+  "deno.lock": "lock",
+  "cargo.lock": "lock",
+  "gemfile.lock": "lock",
+  "composer.lock": "lock",
+  "poetry.lock": "lock",
+  "pipfile.lock": "lock",
+  "uv.lock": "lock",
+  "mix.lock": "lock",
+  "go.sum": "lock",
+  "flake.lock": "lock",
+  "pubspec.lock": "lock",
+  "podfile.lock": "lock",
+  "package.resolved": "lock",
+  "gradle.lockfile": "lock",
+
+  // manifests and tool config — extensionless or extension-misleading
+  dockerfile: "config",
+  containerfile: "config",
+  makefile: "config",
+  gnumakefile: "config",
+  justfile: "config",
+  procfile: "config",
+  rakefile: "config",
+  gemfile: "config",
+  pipfile: "config",
+  brewfile: "config",
+  vagrantfile: "config",
+  "cmakelists.txt": "config",
+  "meson.build": "config",
+  "package.json": "config",
+  "deno.json": "config",
+  "deno.jsonc": "config",
+  "composer.json": "config",
+  "bower.json": "config",
+  "go.mod": "config",
+  "go.work": "config",
+  "build.gradle": "config",
+  "build.gradle.kts": "config",
+  "settings.gradle": "config",
+  "settings.gradle.kts": "config",
+  gradlew: "config",
+  "gradlew.bat": "config",
+  codeowners: "config",
+  ".gitignore": "config",
+  ".gitattributes": "config",
+  ".gitmodules": "config",
+  ".gitkeep": "config",
+  ".dockerignore": "config",
+  ".npmignore": "config",
+  ".prettierignore": "config",
+  ".eslintignore": "config",
+  ".editorconfig": "config",
+  ".nvmrc": "config",
+  ".node-version": "config",
+  ".python-version": "config",
+  ".ruby-version": "config",
+  ".tool-versions": "config",
+
+  // documents — extensionless by convention
+  readme: "document",
+  license: "document",
+  licence: "document",
+  changelog: "document",
+  contributing: "document",
+  notice: "document",
+  authors: "document",
+  contributors: "document",
+  copying: "document",
+  install: "document",
+  todo: "document",
+};
+
+/**
+ * Basename patterns, tried after exact matches and before extensions. Ordered
+ * most-specific first: `tsconfig.build.json` must not be read as plain JSON,
+ * and `vite.config.ts` must not be read as TypeScript.
+ */
+const BASENAME_PATTERNS: ReadonlyArray<readonly [RegExp, FileTypeCategory]> = [
+  // .env, .env.local, .env.production.local
+  [/^\.env(\..+)?$/, "config"],
+  // vite.config.ts, jest.config.mjs, tailwind.config.js
+  [/\.config\.[^.]+$/, "config"],
+  // tsconfig.json, tsconfig.build.json, jsconfig.json
+  [/^[jt]sconfig(\..+)?\.json$/, "config"],
+  // .prettierrc, .eslintrc.json, .babelrc.cjs, .npmrc, .yarnrc.yml
+  [/^\.[a-z0-9_-]+rc(\.[a-z0-9]+)?$/, "config"],
+  // Dockerfile.dev, Dockerfile.prod
+  [/^(docker|container)file\..+$/, "config"],
+  // docker-compose.yml, compose.override.yaml
+  [/^(docker-)?compose(\..+)?\.ya?ml$/, "config"],
+];
+
+/** Basename of a POSIX or Windows path, lowercased. Mirrors `getLanguageForFile`'s split. */
+function basenameOf(filePath: string): string {
+  const posix = filePath.split("/").pop() ?? filePath;
+  return (posix.split("\\").pop() ?? posix).toLowerCase();
+}
+
+/**
+ * Icon and color for one tree row, keyed off its name alone.
+ *
+ * Resolution runs exact basename → pattern → extension → unknown, so the most
+ * specific reading of a name always wins. Every step is an O(1) lookup or a
+ * short fixed pattern list against module-scope constants; Virtuoso only ever
+ * asks about visible rows, so there is nothing here worth memoizing.
+ */
+export function getFileTypeIcon(filePath: string): FileTypeIcon {
+  const basename = basenameOf(filePath);
+
+  const exact = BASENAME_CATEGORIES[basename];
+  if (exact) return CATEGORIES[exact];
+
+  for (const [pattern, category] of BASENAME_PATTERNS) {
+    if (pattern.test(basename)) return CATEGORIES[category];
+  }
+
+  // `dotIndex > 0` keeps a leading dot from reading as an extension:
+  // `.gitignore` is a whole name, not an entry with a `gitignore` suffix.
+  const dotIndex = basename.lastIndexOf(".");
+  if (dotIndex > 0) {
+    const byExtension = EXTENSION_CATEGORIES[basename.slice(dotIndex + 1)];
+    if (byExtension) return CATEGORIES[byExtension];
+  }
+
+  return CATEGORIES.unknown;
+}

--- a/src/panels/file-browser/fileTypeIcons.ts
+++ b/src/panels/file-browser/fileTypeIcons.ts
@@ -64,6 +64,14 @@ type CategoryColor = `text-${(typeof WORKTREE_COLOR_PALETTE)[number]}`;
 /** The neutral every unrecognized file falls back to — deliberately outside the categorical palette. */
 export const UNKNOWN_FILE_COLOR_CLASS = "text-text-secondary";
 
+/**
+ * Marker class on every tree entry icon, file and folder alike. Carries no
+ * styling of its own — it exists so `@media (prefers-contrast: more)` in
+ * `src/index.css` can repaint the whole set monochrome. Exported so the
+ * component and the stylesheet's contract test agree on one spelling.
+ */
+export const FILE_TREE_ICON_CLASS = "file-tree-entry-icon";
+
 export interface FileTypeIcon {
   category: FileTypeCategory;
   Icon: LucideIcon;
@@ -74,22 +82,35 @@ export interface FileTypeIcon {
   colorClass: CategoryColor | typeof UNKNOWN_FILE_COLOR_CLASS;
 }
 
+/**
+ * Fifteen categories over eight hues, so seven pairs share a color. Pairing is
+ * by *inner mark*, not by meaning: almost every glyph here is a page outline
+ * with a symbol inside it, so the silhouette can't separate them and the
+ * symbol has to. Each pair below is a padlock against text lines, a gear
+ * against a play triangle — never two marks that read alike at 14px, which is
+ * why `document` sits beside `lock` rather than beside `spreadsheet`.
+ */
 const CATEGORIES: Record<FileTypeCategory, FileTypeIcon> = {
   source: { category: "source", Icon: FileCode, colorClass: "text-category-blue" },
+  font: { category: "font", Icon: FileType, colorClass: "text-category-blue" },
   script: { category: "script", Icon: FileTerminal, colorClass: "text-category-cyan" },
-  data: { category: "data", Icon: FileBraces, colorClass: "text-category-amber" },
-  config: { category: "config", Icon: FileCog, colorClass: "text-category-violet" },
-  lock: { category: "lock", Icon: FileLock, colorClass: "text-category-indigo" },
-  image: { category: "image", Icon: FileImage, colorClass: "text-category-pink" },
-  video: { category: "video", Icon: FilePlay, colorClass: "text-category-violet" },
   audio: { category: "audio", Icon: FileMusic, colorClass: "text-category-cyan" },
+  data: { category: "data", Icon: FileBraces, colorClass: "text-category-amber" },
+  spreadsheet: {
+    category: "spreadsheet",
+    Icon: FileSpreadsheet,
+    colorClass: "text-category-amber",
+  },
+  config: { category: "config", Icon: FileCog, colorClass: "text-category-violet" },
+  video: { category: "video", Icon: FilePlay, colorClass: "text-category-violet" },
+  lock: { category: "lock", Icon: FileLock, colorClass: "text-category-indigo" },
+  document: { category: "document", Icon: FileText, colorClass: "text-category-indigo" },
+  image: { category: "image", Icon: FileImage, colorClass: "text-category-pink" },
+  key: { category: "key", Icon: FileKey, colorClass: "text-category-pink" },
   archive: { category: "archive", Icon: FileArchive, colorClass: "text-category-orange" },
-  document: { category: "document", Icon: FileText, colorClass: "text-category-teal" },
-  spreadsheet: { category: "spreadsheet", Icon: FileSpreadsheet, colorClass: "text-category-teal" },
-  database: { category: "database", Icon: Database, colorClass: "text-category-amber" },
-  font: { category: "font", Icon: FileType, colorClass: "text-category-pink" },
-  key: { category: "key", Icon: FileKey, colorClass: "text-category-indigo" },
   binary: { category: "binary", Icon: Binary, colorClass: "text-category-orange" },
+  // The only glyph that isn't a page at all, so it needs no partner to tell it apart.
+  database: { category: "database", Icon: Database, colorClass: "text-category-teal" },
   unknown: { category: "unknown", Icon: File, colorClass: UNKNOWN_FILE_COLOR_CLASS },
 };
 
@@ -404,6 +425,8 @@ const BASENAME_CATEGORIES: Record<string, FileTypeCategory> = {
   "podfile.lock": "lock",
   "package.resolved": "lock",
   "gradle.lockfile": "lock",
+  // Ends in `.hcl`, so without an exact entry it would read as Terraform config.
+  ".terraform.lock.hcl": "lock",
 
   // manifests and tool config — extensionless or extension-misleading
   dockerfile: "config",
@@ -430,8 +453,8 @@ const BASENAME_CATEGORIES: Record<string, FileTypeCategory> = {
   "build.gradle.kts": "config",
   "settings.gradle": "config",
   "settings.gradle.kts": "config",
-  gradlew: "config",
-  "gradlew.bat": "config",
+  // The wrapper launchers are executables, not Gradle configuration.
+  gradlew: "script",
   codeowners: "config",
   ".gitignore": "config",
   ".gitattributes": "config",
@@ -470,8 +493,11 @@ const BASENAME_CATEGORIES: Record<string, FileTypeCategory> = {
 const BASENAME_PATTERNS: ReadonlyArray<readonly [RegExp, FileTypeCategory]> = [
   // .env, .env.local, .env.production.local
   [/^\.env(\..+)?$/, "config"],
-  // vite.config.ts, jest.config.mjs, tailwind.config.js
-  [/\.config\.[^.]+$/, "config"],
+  // vite.config.ts, jest.config.mjs, tailwind.config.js. The trailing format is
+  // enumerated rather than left open: `.config.` is a common enough infix that
+  // an open suffix would swallow `photo.config.png` and `payload.config.exe`,
+  // whose own extensions are the stronger signal.
+  [/\.config\.([cm]?[jt]s|jsonc?|json5|ya?ml|toml|ini)$/, "config"],
   // tsconfig.json, tsconfig.build.json, jsconfig.json
   [/^[jt]sconfig(\..+)?\.json$/, "config"],
   // .prettierrc, .eslintrc.json, .babelrc.cjs, .npmrc, .yarnrc.yml
@@ -499,8 +525,13 @@ function basenameOf(filePath: string): string {
 export function getFileTypeIcon(filePath: string): FileTypeIcon {
   const basename = basenameOf(filePath);
 
-  const exact = BASENAME_CATEGORIES[basename];
-  if (exact) return CATEGORIES[exact];
+  // `Object.hasOwn` rather than a bare lookup: these tables are plain objects,
+  // so a file genuinely named `constructor` or `__proto__` would otherwise read
+  // an inherited member, index CATEGORIES with a function, and hand back
+  // `undefined` from a signature that promises it never does.
+  if (Object.hasOwn(BASENAME_CATEGORIES, basename)) {
+    return CATEGORIES[BASENAME_CATEGORIES[basename]!];
+  }
 
   for (const [pattern, category] of BASENAME_PATTERNS) {
     if (pattern.test(basename)) return CATEGORIES[category];
@@ -510,8 +541,10 @@ export function getFileTypeIcon(filePath: string): FileTypeIcon {
   // `.gitignore` is a whole name, not an entry with a `gitignore` suffix.
   const dotIndex = basename.lastIndexOf(".");
   if (dotIndex > 0) {
-    const byExtension = EXTENSION_CATEGORIES[basename.slice(dotIndex + 1)];
-    if (byExtension) return CATEGORIES[byExtension];
+    const extension = basename.slice(dotIndex + 1);
+    if (Object.hasOwn(EXTENSION_CATEGORIES, extension)) {
+      return CATEGORIES[EXTENSION_CATEGORIES[extension]!];
+    }
   }
 
   return CATEGORIES.unknown;

--- a/src/panels/file-browser/fileTypeIcons.ts
+++ b/src/panels/file-browser/fileTypeIcons.ts
@@ -109,7 +109,8 @@ const CATEGORIES: Record<FileTypeCategory, FileTypeIcon> = {
   key: { category: "key", Icon: FileKey, colorClass: "text-category-pink" },
   archive: { category: "archive", Icon: FileArchive, colorClass: "text-category-orange" },
   binary: { category: "binary", Icon: Binary, colorClass: "text-category-orange" },
-  // The only glyph that isn't a page at all, so it needs no partner to tell it apart.
+  // A cylinder rather than a page — distinct enough on silhouette alone that it
+  // is the one category left holding a hue by itself.
   database: { category: "database", Icon: Database, colorClass: "text-category-teal" },
   unknown: { category: "unknown", Icon: File, colorClass: UNKNOWN_FILE_COLOR_CLASS },
 };


### PR DESCRIPTION
## Summary

Every row in the file browser tree rendered the same generic `File` icon at `text-daintree-text/30`, so a folder of videos looked identical to a folder of source code. This PR adds a type-aware icon resolver: file rows now get an icon matching their category (source, script, JSON/data, config, lockfile, image, video, audio, archive, document, spreadsheet, database, font, key, binary), plus a light non-accent color tint. Directories keep their folder shape and stay neutral. The near-invisible opacity is gone, icons are solid.

Resolves #11596

## Design decisions

**Colors come from the existing category-* tokens, restricted to the CVD-safe subset.** The 12-token `category-*` theme group has more hues than are safe to use here, so this pulls only from the 8-token `WORKTREE_COLOR_PALETTE` (`shared/theme/worktreeColors.ts`). `paletteDistinguishability.test.ts` already proves that set stays above the just-noticeable-difference floor under all three types of color blindness, in every built-in theme, so no new color value needed inventing. The accent color stays untouched: tinting dozens of tree rows at once is exactly the broad usage the project's accent-restraint rule forbids.

**15 categories, 8 hues, so 7 pairs share a color.** Categories are paired by inner icon mark, not by meaning. Most of these icons are a page outline with a symbol inside, so the shared silhouette is what a glance actually picks up on. That's why `document` is paired with `lock` rather than `spreadsheet`.

**Lucide only, no brand logos.** Brand icon components are filled shapes painted with `currentColor`; Lucide icons are 1.5px outline strokes. Mixing the two in a 14px icon column reads as inconsistent weight, and the more detailed brand marks turn illegible at that size anyway.

**Resolution order: exact filename, then filename pattern, then extension, then unknown.** So `package-lock.json` reads as a lockfile rather than generic JSON, and `vite.config.ts` reads as config rather than generic TypeScript source.

**`prefers-contrast: more` repaints icons in a single neutral color.** Shape alone still carries the file type once color drops out. No `forced-colors: active` counterpart was needed: icons already paint from `currentColor`, and that mode already forces text color to a system color.

## Testing

238 tests pass locally across the file browser suites and every theme/color contract test. Typecheck and formatting are clean.

Worth calling out:
- A regression test for files literally named `constructor` or `__proto__`. These broke the resolver because it reads properties off a plain JS object used as a lookup table, and both names resolve to inherited properties instead of direct ones. That returned `undefined` and the tree fell back to showing a folder icon for them.
- Test coverage driven directly off the existing `LANGUAGE_MAP` data, so a language added there later can't silently end up without an icon.
- Palette membership in tests is checked against the `WORKTREE_COLOR_PALETTE` constant itself, not hardcoded color literals.