### PR TITLE
fix(files): give paths outside every worktree a live change signal

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -85,6 +85,8 @@ export const CHANNELS = {
   FILE_BROWSER_LIST_DIRECTORY: "file-browser:list-directory",
   FILE_BROWSER_STAT_PATHS: "file-browser:stat-paths",
 
+  FILE_WATCH_FINGERPRINT: "file-watch:fingerprint",
+
   TERMINAL_ACTIVITY: "terminal:activity",
 
   ARTIFACT_DETECTED: "artifact:detected",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -32,6 +32,7 @@ import { registerMenuHandlers } from "./handlers/menu.js";
 import { registerFilesHandlers } from "./handlers/files.js";
 import { registerDiffMediaHandlers } from "./handlers/diffMedia.js";
 import { registerFileBrowserHandlers } from "./handlers/fileBrowser.js";
+import { registerFileWatchHandlers } from "./handlers/fileWatch.js";
 import { registerSlashCommandHandlers } from "./handlers/slashCommands.js";
 import { registerGeminiHandlers } from "./handlers/gemini.js";
 import { registerEventsHandlers } from "./handlers/events.js";
@@ -128,6 +129,7 @@ export function registerIpcHandlers(deps: HandlerDependencies): () => void {
     register(() => registerFilesHandlers());
     register(() => registerDiffMediaHandlers());
     register(() => registerFileBrowserHandlers(deps));
+    register(() => registerFileWatchHandlers());
     register(() => registerCopyTreeHandlers(deps));
     register(() => registerAiHandlers(deps));
     register(() => registerSlashCommandHandlers());

--- a/electron/ipc/handlers/fileWatch.preload.ts
+++ b/electron/ipc/handlers/fileWatch.preload.ts
@@ -1,0 +1,24 @@
+import type { IpcInvokeMap } from "../../types/index.js";
+
+export const FILE_WATCH_METHOD_CHANNELS = {
+  fingerprint: "file-watch:fingerprint",
+} as const satisfies Record<string, keyof IpcInvokeMap>;
+
+type Methods = typeof FILE_WATCH_METHOD_CHANNELS;
+
+export type FileWatchPreloadBindings = {
+  [M in keyof Methods]: (
+    ...args: IpcInvokeMap[Methods[M]]["args"]
+  ) => Promise<IpcInvokeMap[Methods[M]]["result"]>;
+};
+
+type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
+
+export function buildFileWatchPreloadBindings(invoke: Invoker): FileWatchPreloadBindings {
+  const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const method of Object.keys(FILE_WATCH_METHOD_CHANNELS) as Array<keyof Methods>) {
+    const channel = FILE_WATCH_METHOD_CHANNELS[method];
+    out[method as string] = (...args) => invoke(channel, ...args);
+  }
+  return out as unknown as FileWatchPreloadBindings;
+}

--- a/electron/ipc/handlers/fileWatch.ts
+++ b/electron/ipc/handlers/fileWatch.ts
@@ -1,0 +1,56 @@
+import { defineIpcNamespace, opValidated } from "../define.js";
+import { checkRateLimit } from "../utils.js";
+import { FILE_WATCH_METHOD_CHANNELS } from "./fileWatch.preload.js";
+import { FileWatchFingerprintPayloadSchema } from "../../schemas/ipc.js";
+import { fingerprintPaths } from "../../services/pathFingerprint.js";
+import type {
+  FileWatchFingerprintPayload,
+  FileWatchFingerprintResult,
+} from "../../../shared/types/ipc/fileWatch.js";
+
+/**
+ * Sized against the polling cadence the file surfaces actually use, not a
+ * guess. Each visible pane with no worktree behind it samples roughly every two
+ * seconds, so a window showing a dozen such panes sits near 60 calls per ten
+ * seconds. The headroom above that absorbs a burst of panes becoming visible at
+ * once (a project switch revealing a saved layout) without letting a refresh
+ * loop run unbounded. The budget is shared across windows, matching the other
+ * file-browser limits.
+ */
+const FINGERPRINT_MAX_CALLS = 400;
+const FINGERPRINT_WINDOW_MS = 10_000;
+
+export function buildFileWatchNamespace() {
+  const handleFingerprint = async (
+    payload: FileWatchFingerprintPayload
+  ): Promise<FileWatchFingerprintResult> => {
+    checkRateLimit(
+      FILE_WATCH_METHOD_CHANNELS.fingerprint,
+      FINGERPRINT_MAX_CALLS,
+      FINGERPRINT_WINDOW_MS
+    );
+
+    // Filesystem trouble never throws from here: the caller polls on a timer and
+    // compares successive answers, so an unreadable root or a path that escaped
+    // it comes back as `null` fingerprints rather than an error the renderer
+    // would have to tell apart from "nothing changed". Schema validation and the
+    // rate limiter above still reject — those are transport failures, and the
+    // caller treats them as a skipped sample.
+    return fingerprintPaths(payload.rootPath, payload.paths);
+  };
+
+  return defineIpcNamespace({
+    name: "fileWatch",
+    ops: {
+      fingerprint: opValidated(
+        FILE_WATCH_METHOD_CHANNELS.fingerprint,
+        FileWatchFingerprintPayloadSchema,
+        handleFingerprint
+      ),
+    },
+  });
+}
+
+export function registerFileWatchHandlers(): () => void {
+  return buildFileWatchNamespace().register();
+}

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -60,6 +60,7 @@ import { buildTelemetryPreloadBindings } from "./ipc/handlers/telemetry.preload.
 import { buildConnectivityPreloadBindings } from "./ipc/handlers/connectivity.preload.js";
 import { buildDiffMediaPreloadBindings } from "./ipc/handlers/diffMedia.preload.js";
 import { buildFileBrowserPreloadBindings } from "./ipc/handlers/fileBrowser.preload.js";
+import { buildFileWatchPreloadBindings } from "./ipc/handlers/fileWatch.preload.js";
 import { buildHibernationPreloadBindings } from "./ipc/handlers/hibernation.preload.js";
 import { buildIdleTerminalPreloadBindings } from "./ipc/handlers/idleTerminals.preload.js";
 import { buildIdleBackgroundAutoClosePreloadBindings } from "./ipc/handlers/idleBackgroundAutoClose.preload.js";
@@ -1363,6 +1364,9 @@ function buildElectronApi(): ElectronAPI {
 
     // File browser API — lazy directory listings for the read-only browser panel
     fileBrowser: buildFileBrowserPreloadBindings(_unwrappingInvoke),
+
+    // File watch API — the change signal for paths no git watcher covers
+    fileWatch: buildFileWatchPreloadBindings(_unwrappingInvoke),
 
     // Watchdog API — surfaces the main-process deadlock detector's disabled
     // state to the renderer and exposes a manual restart path.

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -572,6 +572,29 @@ export const FileBrowserStatPathsPayloadSchema = z.object({
   paths: z.array(z.string().min(1).max(4096)).max(32),
 });
 
+// Capped at the widest tree the file browser polls in one sample: its root plus
+// the directories it has expanded. A caller with more expanded than this sends
+// the closest ones to the root — the cap is what keeps a restored 500-directory
+// panel from turning one poll into 500 stats.
+export const FileWatchFingerprintPayloadSchema = z.object({
+  rootPath: z
+    .string()
+    .min(1)
+    .max(4096)
+    // eslint-disable-next-line no-control-regex
+    .regex(/^[^\x00]*$/, "Null bytes not allowed"),
+  paths: z
+    .array(
+      z
+        .string()
+        .min(1)
+        .max(4096)
+        // eslint-disable-next-line no-control-regex
+        .regex(/^[^\x00]*$/, "Null bytes not allowed")
+    )
+    .max(32),
+});
+
 export const FileReadPayloadSchema = z.object({
   path: z
     .string()

--- a/electron/services/__tests__/pathFingerprint.test.ts
+++ b/electron/services/__tests__/pathFingerprint.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { fingerprintPaths } from "../pathFingerprint.js";
+
+/**
+ * Exercised against a real filesystem rather than a mocked `fs`: the whole point
+ * of the fingerprint is which physical changes it can and cannot distinguish,
+ * and a mock would only ever confirm the assertions were written to match the
+ * implementation.
+ */
+describe("fingerprintPaths", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-fingerprint-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("returns one fingerprint per requested path, positionally", async () => {
+    const a = path.join(root, "a.txt");
+    const b = path.join(root, "b.txt");
+    await fs.writeFile(a, "a");
+    await fs.writeFile(b, "b");
+
+    const [first, second, third] = await fingerprintPaths(root, [
+      a,
+      path.join(root, "missing.txt"),
+      b,
+    ]);
+
+    expect(first).not.toBeNull();
+    expect(second).toBeNull();
+    expect(third).not.toBeNull();
+  });
+
+  it("is stable across samples when nothing changed", async () => {
+    const file = path.join(root, "stable.txt");
+    await fs.writeFile(file, "unchanged");
+
+    const before = await fingerprintPaths(root, [root, file]);
+    const after = await fingerprintPaths(root, [root, file]);
+
+    expect(after).toEqual(before);
+  });
+
+  it("moves a file's fingerprint on a rewrite that preserves its length", async () => {
+    // Same byte count on purpose: a fingerprint built from size alone would call
+    // this unchanged, and an agent rewriting a line in place is the common case.
+    const file = path.join(root, "edited.txt");
+    await fs.writeFile(file, "aaaa");
+    const [before] = await fingerprintPaths(root, [file]);
+
+    await fs.writeFile(file, "bbbb");
+    const [after] = await fingerprintPaths(root, [file]);
+
+    expect(after).not.toBe(before);
+  });
+
+  it("separates two directories that differ only in the names they hold", async () => {
+    // Both are stamped to the same mtime and hold the same number of entries, so
+    // the only thing left to tell them apart is the digest of their children —
+    // which is what a same-count rename inside one directory relies on. Two
+    // directories rather than one renamed twice, because `utimes` cannot restore
+    // a nanosecond-precision mtime exactly and the comparison would then pass on
+    // the timestamp instead of the digest.
+    const left = path.join(root, "left");
+    const right = path.join(root, "right");
+    await fs.mkdir(left);
+    await fs.mkdir(right);
+    await fs.writeFile(path.join(left, "one.txt"), "x");
+    await fs.writeFile(path.join(right, "two.txt"), "x");
+
+    const stamp = new Date(1_700_000_000_000);
+    await fs.utimes(left, stamp, stamp);
+    await fs.utimes(right, stamp, stamp);
+
+    const [leftStats, rightStats] = await Promise.all([fs.stat(left), fs.stat(right)]);
+    // Precondition: without this the assertion below could pass on a timestamp
+    // difference and prove nothing about the digest.
+    expect(leftStats.mtimeMs).toBe(rightStats.mtimeMs);
+
+    const [leftPrint, rightPrint] = await fingerprintPaths(root, [left, right]);
+    expect(leftPrint).not.toBeNull();
+    expect(leftPrint).not.toBe(rightPrint);
+  });
+
+  it("is insensitive to the order readdir happens to return entries in", async () => {
+    // The digest is order-independent by construction; this pins that a second
+    // sample of an untouched directory cannot drift just because the platform
+    // enumerated it differently.
+    const wide = path.join(root, "wide");
+    await fs.mkdir(wide);
+    await Promise.all(
+      Array.from({ length: 50 }, (_, index) => fs.writeFile(path.join(wide, `f${index}`), "x"))
+    );
+
+    const [first] = await fingerprintPaths(root, [wide]);
+    const [second] = await fingerprintPaths(root, [wide]);
+
+    expect(first).toBe(second);
+  });
+
+  it("fingerprints a batch wider than its worker pool without losing positions", async () => {
+    // More paths than the concurrency bound, alternating present and absent, so
+    // an off-by-one in the pool's index handout would misalign the answers.
+    const files = await Promise.all(
+      Array.from({ length: 12 }, async (_, index) => {
+        const target = path.join(root, `batch-${index}`);
+        if (index % 2 === 0) await fs.writeFile(target, `content-${index}`);
+        return target;
+      })
+    );
+
+    const results = await fingerprintPaths(root, files);
+
+    expect(results).toHaveLength(files.length);
+    expect(results.map((value) => value !== null)).toEqual(
+      files.map((_, index) => index % 2 === 0)
+    );
+  });
+
+  it("moves a directory's fingerprint on a rename that keeps the entry count", async () => {
+    // The case a directory mtime alone cannot be trusted for: same number of
+    // entries, and on a coarse-granularity filesystem potentially the same
+    // timestamp. Only the hashed child-name list separates these two states.
+    await fs.writeFile(path.join(root, "one.txt"), "x");
+    await fs.writeFile(path.join(root, "two.txt"), "y");
+    const [before] = await fingerprintPaths(root, [root]);
+
+    await fs.rename(path.join(root, "two.txt"), path.join(root, "three.txt"));
+    const [after] = await fingerprintPaths(root, [root]);
+
+    expect(after).not.toBe(before);
+  });
+
+  it("distinguishes a file from a directory of the same name", async () => {
+    // A delete-then-recreate that swaps an entry's kind is a change the tree
+    // renders, and folding both to one fingerprint shape would hide it.
+    const target = path.join(root, "swap");
+    await fs.mkdir(target);
+    const [asDirectory] = await fingerprintPaths(root, [target]);
+
+    await fs.rmdir(target);
+    await fs.writeFile(target, "now a file");
+    const [asFile] = await fingerprintPaths(root, [target]);
+
+    expect(asDirectory).not.toBeNull();
+    expect(asFile).not.toBeNull();
+    expect(asFile).not.toBe(asDirectory);
+  });
+
+  it("reports a path appearing and disappearing", async () => {
+    const file = path.join(root, "transient.txt");
+
+    const [absent] = await fingerprintPaths(root, [file]);
+    await fs.writeFile(file, "here");
+    const [present] = await fingerprintPaths(root, [file]);
+    await fs.rm(file);
+    const [goneAgain] = await fingerprintPaths(root, [file]);
+
+    expect(absent).toBeNull();
+    expect(present).not.toBeNull();
+    expect(goneAgain).toBeNull();
+  });
+
+  it("refuses a path that resolves outside the root", async () => {
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-outside-"));
+    try {
+      const secret = path.join(outside, "secret.txt");
+      await fs.writeFile(secret, "not yours");
+      const escape = path.join(root, "escape");
+      await fs.symlink(outside, escape);
+
+      // Both the direct path and the in-root symlink that reaches it: `stat`
+      // follows intermediate links, so only resolving first keeps this from
+      // being an existence probe for arbitrary paths.
+      const [direct, viaSymlink] = await fingerprintPaths(root, [
+        secret,
+        path.join(escape, "secret.txt"),
+      ]);
+
+      expect(direct).toBeNull();
+      expect(viaSymlink).toBeNull();
+    } finally {
+      await fs.rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("answers every path with null once the root itself is gone", async () => {
+    const file = path.join(root, "doomed.txt");
+    await fs.writeFile(file, "x");
+    const [before] = await fingerprintPaths(root, [file]);
+
+    await fs.rm(root, { recursive: true, force: true });
+    const after = await fingerprintPaths(root, [root, file]);
+
+    expect(before).not.toBeNull();
+    expect(after.every((value) => value === null)).toBe(true);
+  });
+
+  it("returns nothing for an empty request without touching the filesystem", async () => {
+    expect(await fingerprintPaths(root, [])).toEqual([]);
+  });
+
+  it("refuses a relative root rather than resolving it against the process cwd", async () => {
+    const results = await fingerprintPaths("relative/root", [path.join(root, "a.txt")]);
+    expect(results).toEqual([null]);
+  });
+});

--- a/electron/services/__tests__/pathFingerprint.test.ts
+++ b/electron/services/__tests__/pathFingerprint.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import fs from "fs/promises";
 import os from "os";
 import path from "path";
@@ -207,6 +207,39 @@ describe("fingerprintPaths", () => {
 
     expect(before).not.toBeNull();
     expect(after.every((value) => value === null)).toBe(true);
+  });
+
+  it("stops probing a root once a path inside it hangs, not only the root itself", async () => {
+    // A dead mount below a live root: the root keeps answering instantly, so
+    // the root-level probe never times out and only the member's own hang can
+    // stop the caller re-issuing it every poll. `realpath` is stubbed to never
+    // settle for that one path — the same shape as a disconnected share, which
+    // takes the OS a minute or more to give up on.
+    const member = path.join(root, "member.txt");
+    await fs.writeFile(member, "readable");
+
+    const beforeHang = await fingerprintPaths(root, [member]);
+
+    const realRealpath = fs.realpath;
+    const spy = vi
+      .spyOn(fs, "realpath")
+      .mockImplementation(((target: string, options?: unknown) =>
+        target === member
+          ? new Promise<string>(() => {})
+          : (realRealpath as (p: string, o?: unknown) => Promise<string>)(
+              target,
+              options
+            )) as typeof fs.realpath);
+    const duringHang = await fingerprintPaths(root, [member]).finally(() => spy.mockRestore());
+
+    // Nothing is stubbed any more and both paths are still on disk, so the only
+    // thing that can answer null now is the cooldown the hung member left on
+    // its root — and it covers the root, not just the path that hung.
+    const afterHang = await fingerprintPaths(root, [root, member]);
+
+    expect(beforeHang.every((value) => value !== null)).toBe(true);
+    expect(duringHang).toEqual([null]);
+    expect(afterHang).toEqual([null, null]);
   });
 
   it("returns nothing for an empty request without touching the filesystem", async () => {

--- a/electron/services/__tests__/pathFingerprint.test.ts
+++ b/electron/services/__tests__/pathFingerprint.test.ts
@@ -79,20 +79,26 @@ describe("fingerprintPaths", () => {
     await fs.utimes(left, stamp, stamp);
     await fs.utimes(right, stamp, stamp);
 
-    const [leftStats, rightStats] = await Promise.all([fs.stat(left), fs.stat(right)]);
-    // Precondition: without this the assertion below could pass on a timestamp
-    // difference and prove nothing about the digest.
-    expect(leftStats.mtimeMs).toBe(rightStats.mtimeMs);
+    const [leftStats, rightStats] = await Promise.all([
+      fs.stat(left, { bigint: true }),
+      fs.stat(right, { bigint: true }),
+    ]);
+    // Precondition, at the same nanosecond precision the fingerprint uses:
+    // without this the assertion below could pass on a timestamp difference and
+    // prove nothing about the digest.
+    expect(leftStats.mtimeNs).toBe(rightStats.mtimeNs);
 
     const [leftPrint, rightPrint] = await fingerprintPaths(root, [left, right]);
     expect(leftPrint).not.toBeNull();
     expect(leftPrint).not.toBe(rightPrint);
   });
 
-  it("is insensitive to the order readdir happens to return entries in", async () => {
-    // The digest is order-independent by construction; this pins that a second
-    // sample of an untouched directory cannot drift just because the platform
-    // enumerated it differently.
+  it("is stable across repeated samples of an untouched wide directory", async () => {
+    // Names enough entries that an implementation depending on enumeration order
+    // has room to drift. It cannot force two different `readdir` orders, so it
+    // pins stability rather than proving order-independence — the digest's
+    // commutativity is what provides that, and the two-directory test above is
+    // what proves the digest is consulted at all.
     const wide = path.join(root, "wide");
     await fs.mkdir(wide);
     await Promise.all(

--- a/electron/services/pathFingerprint.ts
+++ b/electron/services/pathFingerprint.ts
@@ -46,12 +46,14 @@ export type PathFingerprint = string | null;
 /**
  * An order-independent digest of a directory's entries.
  *
- * XOR-folding each entry's own hash makes `readdir`'s platform-dependent
- * ordering irrelevant without paying for a sort, which is what a per-poll digest
- * of a wide directory would otherwise cost. Entry names within a directory are
- * unique, so the usual XOR hazard — a pair cancelling out — cannot arise. The
- * running sum and the count are folded in alongside so a permutation of hash
- * bits alone can't collide.
+ * XOR and modular addition are both commutative, so folding each entry's own
+ * hash makes `readdir`'s platform-dependent ordering irrelevant without paying
+ * for a sort — which is what a per-poll digest of a wide directory would
+ * otherwise cost. Entry names within a directory are unique, so the usual XOR
+ * hazard of a duplicated pair cancelling out cannot arise, and the running sum
+ * alongside it means two sets would have to collide under both folds at once.
+ * This is cache invalidation, not authentication: a collision costs a missed
+ * refresh, so incidental strength is enough and an adversary is not in scope.
  */
 function digestEntries(entries: string[]): string {
   const accumulator = Buffer.alloc(20);
@@ -164,12 +166,18 @@ export async function fingerprintPaths(
   if (paths.length === 0) return [];
   if (!path.isAbsolute(rootPath)) return paths.map(() => null);
 
-  const cooldownUntil = hungRoots.get(rootPath);
-  if (cooldownUntil !== undefined) {
-    // Evicted on expiry rather than left to accumulate, so a remounted share
-    // starts answering again on its own instead of staying dead until restart.
-    if (Date.now() < cooldownUntil) return paths.map(() => null);
-    hungRoots.delete(rootPath);
+  // Swept on every call rather than only when the same root comes back: a root
+  // that hung once and was then closed would otherwise sit in the map forever,
+  // and the map is only ever as large as the set of roots that timed out inside
+  // one cooldown window, so the walk is trivial.
+  if (hungRoots.size > 0) {
+    const now = Date.now();
+    for (const [hungRoot, until] of hungRoots) {
+      if (now >= until) hungRoots.delete(hungRoot);
+    }
+    // A remounted share therefore starts answering on its own rather than
+    // staying dead until the app restarts.
+    if (hungRoots.has(rootPath)) return paths.map(() => null);
   }
 
   const rootRealPath = await withTimeout(

--- a/electron/services/pathFingerprint.ts
+++ b/electron/services/pathFingerprint.ts
@@ -94,7 +94,18 @@ async function fingerprintDirectory(target: string, mtime: bigint): Promise<Path
   return `d:${mtime}:${entries.length}:${digestEntries(names)}`;
 }
 
-async function fingerprintOne(target: string, rootRealPath: string): Promise<PathFingerprint> {
+/**
+ * `onHang` fires when a call under this path timed out, so the caller can put
+ * the whole root on cooldown. A dead mount below a live root — a network share
+ * inside a browsed folder, or the file a `FilePane` happens to hold — hangs here
+ * while the root itself keeps answering instantly, and nothing in the root-level
+ * probe would ever notice.
+ */
+async function fingerprintOne(
+  target: string,
+  rootRealPath: string,
+  onHang: () => void
+): Promise<PathFingerprint> {
   try {
     // Resolved before anything is read: `stat` follows symlinks — including
     // intermediate ones — so a symlink inside the root pointing out of it would
@@ -127,11 +138,13 @@ async function fingerprintOne(target: string, rootRealPath: string): Promise<Pat
     }
     // A socket, fifo or device has no content the file surfaces can render.
     return null;
-  } catch {
+  } catch (error) {
     // Every failure folds to the same "nothing readable" value on purpose. The
     // caller is diffing successive samples, and distinguishing ENOENT from
     // EACCES from a dead mount would only let a transient permission blip read
-    // as a change.
+    // as a change. A hang is still reported sideways, because giving up waiting
+    // does not release the libuv worker the syscall is sitting on.
+    if (error instanceof TimeoutError) onHang();
     return null;
   }
 }
@@ -204,7 +217,9 @@ export async function fingerprintPaths(
       const target = paths[index];
       results[index] =
         target !== undefined && path.isAbsolute(target)
-          ? await fingerprintOne(target, rootRealPath)
+          ? await fingerprintOne(target, rootRealPath, () =>
+              hungRoots.set(rootPath, Date.now() + ROOT_COOLDOWN_MS)
+            )
           : null;
     }
   });

--- a/electron/services/pathFingerprint.ts
+++ b/electron/services/pathFingerprint.ts
@@ -1,0 +1,205 @@
+import path from "path";
+import fs from "fs/promises";
+import { createHash } from "crypto";
+import { TimeoutError, withTimeout } from "../utils/withTimeout.js";
+import { isPathInside } from "../../shared/utils/path.js";
+
+/**
+ * A change signal for paths no git watcher covers.
+ *
+ * Worktrees get their liveness from `GitFileWatcher`'s recursive
+ * `@parcel/watcher` subscription in the workspace-host subprocess. A scratch
+ * folder, a worktree-less project and a file picked from anywhere else on disk
+ * have no host and no watcher, so the file surfaces that render them had no
+ * tick to subscribe to at all (#11590).
+ *
+ * Rather than start a second native watcher — in Main, where a persistent
+ * FSEvents/inotify thread is an app-quit teardown hazard and every existing
+ * `@parcel/watcher` call site deliberately lives in a subprocess — this reduces
+ * each watched path to a cheap fingerprint the renderer polls and diffs. The
+ * poll IS the reconcile, so the two failure modes a watcher would bring with it
+ * (silently dropped overflow events, and a subscription that cannot report the
+ * deletion of its own root) simply don't exist here.
+ */
+
+/** Bounds a single hung `fs.stat`/`fs.readdir` — see `withTimeout`'s module comment. */
+const FS_TIMEOUT_MS = 2_000;
+
+/**
+ * How many `stat`/`readdir` calls may be in flight at once.
+ *
+ * libuv's threadpool is 4 threads by default and `fs.stat` takes no
+ * AbortSignal, so a timed-out call keeps its worker until the OS gives up.
+ * Staying at or below the pool size means one wedged path can't starve
+ * unrelated fs work process-wide.
+ */
+const FS_CONCURRENCY = 4;
+
+/**
+ * `null` means "nothing readable here" — absent, permission-denied, outside the
+ * root, or a hung mount. It is a legitimate fingerprint value, not an error: a
+ * path going from present to absent is exactly the change a caller wants to see,
+ * and the root's own deletion registers the same way.
+ */
+export type PathFingerprint = string | null;
+
+/**
+ * An order-independent digest of a directory's entries.
+ *
+ * XOR-folding each entry's own hash makes `readdir`'s platform-dependent
+ * ordering irrelevant without paying for a sort, which is what a per-poll digest
+ * of a wide directory would otherwise cost. Entry names within a directory are
+ * unique, so the usual XOR hazard — a pair cancelling out — cannot arise. The
+ * running sum and the count are folded in alongside so a permutation of hash
+ * bits alone can't collide.
+ */
+function digestEntries(entries: string[]): string {
+  const accumulator = Buffer.alloc(20);
+  let sum = 0n;
+  for (const entry of entries) {
+    const digest = createHash("sha1").update(entry).digest();
+    for (let index = 0; index < accumulator.length; index++) {
+      accumulator[index] ^= digest[index] as number;
+    }
+    sum = (sum + digest.readBigUInt64BE(0)) & 0xffffffffffffffffn;
+  }
+  return `${accumulator.toString("hex").slice(0, 16)}.${sum.toString(16)}`;
+}
+
+/**
+ * Directories are fingerprinted by their direct children, not just `mtimeNs`.
+ *
+ * A directory's mtime moves when an entry is added or removed, which covers
+ * most of what a file tree renders — but a rename that keeps the entry count
+ * the same, or two operations inside one filesystem timestamp granule, can land
+ * on an identical mtime. Digesting the `name` + entry-kind list closes that gap
+ * for the one level the tree actually shows. Deliberately non-recursive: a
+ * collapsed subtree isn't rendered, and re-expanding it re-reads from scratch
+ * anyway.
+ *
+ * Every directory is digested regardless of width. An earlier revision skipped
+ * the digest past a size threshold, which put the rename blind spot straight
+ * back for exactly the wide build-output directories that threshold targeted —
+ * and `readdir` has already paid the dominant enumeration cost by then.
+ */
+async function fingerprintDirectory(target: string, mtime: bigint): Promise<PathFingerprint> {
+  const entries = await withTimeout(
+    fs.readdir(target, { withFileTypes: true }),
+    FS_TIMEOUT_MS,
+    `readdir timed out: ${target}`
+  );
+  const names = entries.map((entry) => `${entry.name}/${entry.isDirectory() ? "d" : "f"}`);
+  return `d:${mtime}:${entries.length}:${digestEntries(names)}`;
+}
+
+async function fingerprintOne(target: string, rootRealPath: string): Promise<PathFingerprint> {
+  try {
+    // Resolved before anything is read: `stat` follows symlinks — including
+    // intermediate ones — so a symlink inside the root pointing out of it would
+    // otherwise turn this into an existence probe for arbitrary paths. Same
+    // containment model `files:read` applies to the read itself.
+    const realPath = await withTimeout(
+      fs.realpath(target),
+      FS_TIMEOUT_MS,
+      `realpath timed out: ${target}`
+    );
+    // `isPathInside` already answers true for the root itself, which the file
+    // browser watches as its first path.
+    if (!isPathInside(realPath, rootRealPath)) return null;
+
+    // `bigint: true` for nanosecond mtimes: a second-resolution timestamp
+    // cannot distinguish two writes inside the same second, which is the common
+    // case when an agent rewrites a file it just wrote.
+    const stats = await withTimeout(
+      fs.stat(realPath, { bigint: true }),
+      FS_TIMEOUT_MS,
+      `stat timed out: ${target}`
+    );
+
+    if (stats.isDirectory()) return await fingerprintDirectory(realPath, stats.mtimeNs);
+    // `ctimeNs` alongside `mtimeNs`: a tool that rewrites a file in place and
+    // then restores its timestamps (`touch -r`, some generators) leaves mtime,
+    // size and inode all identical, and only the inode-change time still moves.
+    if (stats.isFile()) {
+      return `f:${stats.mtimeNs}:${stats.ctimeNs}:${stats.size}:${stats.ino}`;
+    }
+    // A socket, fifo or device has no content the file surfaces can render.
+    return null;
+  } catch {
+    // Every failure folds to the same "nothing readable" value on purpose. The
+    // caller is diffing successive samples, and distinguishing ENOENT from
+    // EACCES from a dead mount would only let a transient permission blip read
+    // as a change.
+    return null;
+  }
+}
+
+/**
+ * How long a root that just hung is skipped outright.
+ *
+ * `withTimeout` bounds how long *we* wait, not the syscall — `fs.realpath` takes
+ * no AbortSignal, so a timed-out call keeps its libuv worker until the OS gives
+ * up, which on a disconnected SMB share is a minute or more. Callers poll every
+ * couple of seconds, so without a cooldown a single dead mount would queue
+ * dozens of orphaned probes against a four-thread pool and stall unrelated
+ * filesystem work process-wide. One probe per window instead of thirty.
+ */
+const ROOT_COOLDOWN_MS = 30_000;
+
+/** Root real path → the time its cooldown lapses. Only timeouts are recorded. */
+const hungRoots = new Map<string, number>();
+
+/**
+ * Fingerprint each path in `paths`, in order, so a caller can detect change by
+ * comparing successive results.
+ *
+ * Every path is confined to `rootPath`; anything resolving outside it comes back
+ * `null` rather than throwing, so one bad entry can't discard the batch's answer
+ * for the rest.
+ */
+export async function fingerprintPaths(
+  rootPath: string,
+  paths: readonly string[]
+): Promise<PathFingerprint[]> {
+  if (paths.length === 0) return [];
+  if (!path.isAbsolute(rootPath)) return paths.map(() => null);
+
+  const cooldownUntil = hungRoots.get(rootPath);
+  if (cooldownUntil !== undefined) {
+    // Evicted on expiry rather than left to accumulate, so a remounted share
+    // starts answering again on its own instead of staying dead until restart.
+    if (Date.now() < cooldownUntil) return paths.map(() => null);
+    hungRoots.delete(rootPath);
+  }
+
+  const rootRealPath = await withTimeout(
+    fs.realpath(rootPath),
+    FS_TIMEOUT_MS,
+    `realpath timed out: ${rootPath}`
+  ).catch((error: unknown) => {
+    // Only a hang earns a cooldown. A merely missing root is cheap to re-probe,
+    // and suppressing it for half a minute would delay noticing it came back.
+    if (error instanceof TimeoutError) hungRoots.set(rootPath, Date.now() + ROOT_COOLDOWN_MS);
+    return null;
+  });
+  if (rootRealPath === null) return paths.map(() => null);
+
+  const results: PathFingerprint[] = new Array<PathFingerprint>(paths.length).fill(null);
+  let next = 0;
+  // A fixed pool rather than `Promise.all` over every path: the batch is capped
+  // at the IPC boundary, but even a capped batch issued at once would occupy
+  // more libuv workers than the process has.
+  const workers = Array.from({ length: Math.min(FS_CONCURRENCY, paths.length) }, async () => {
+    for (;;) {
+      const index = next++;
+      if (index >= paths.length) return;
+      const target = paths[index];
+      results[index] =
+        target !== undefined && path.isAbsolute(target)
+          ? await fingerprintOne(target, rootRealPath)
+          : null;
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -245,6 +245,9 @@ export type {
   FileReadPayload,
   FileReadResult,
   FileReadErrorCode,
+  // Live-change signal for paths no worktree covers
+  FileWatchFingerprintPayload,
+  FileWatchFingerprintResult,
   // Diff media (image compare) types
   DiffMediaReadFileVersionsPayload,
   DiffMediaSide,

--- a/shared/types/ipc/fileWatch.ts
+++ b/shared/types/ipc/fileWatch.ts
@@ -1,0 +1,36 @@
+/**
+ * Sample the paths a file surface is showing so the renderer can tell whether
+ * any of them moved since the last sample.
+ *
+ * The answer for a path inside a worktree already arrives over the workspace
+ * host's MessagePort; this covers everything else — a scratch folder, a
+ * worktree-less project, a file opened from an unregistered repo (#11590).
+ * Deliberately a poll rather than a subscription: main holds no per-renderer
+ * watcher state, so there is nothing to tear down when a view is evicted, and
+ * the sample doubles as the reconcile a real watcher would still need.
+ */
+export interface FileWatchFingerprintPayload {
+  /**
+   * Containment root every entry in `paths` must resolve inside. Named by the
+   * renderer, exactly as `files:read` does, because the caller's root is not
+   * always a workspace main knows about: a file picked from outside every
+   * project is rooted at its own parent directory.
+   */
+  rootPath: string;
+  /**
+   * Absolute paths to sample, at most 32 per call. The file viewer sends one
+   * file; the file browser sends its root plus the directories it currently has
+   * expanded.
+   */
+  paths: string[];
+}
+
+/**
+ * One opaque fingerprint per requested path, in order. `null` means nothing
+ * readable is there — absent, unreadable, or outside the root — which is itself
+ * a value worth diffing, since that is how a deleted file or root shows up.
+ *
+ * The strings carry no guaranteed structure; callers must only ever compare
+ * them for equality against an earlier sample of the same path.
+ */
+export type FileWatchFingerprintResult = (string | null)[];

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -162,6 +162,11 @@ export interface GeneratedElectronAPI {
       ...args: IpcInvokeMap["file-browser:stat-paths"]["args"]
     ): Promise<IpcInvokeMap["file-browser:stat-paths"]["result"]>;
   };
+  fileWatch: {
+    fingerprint(
+      ...args: IpcInvokeMap["file-watch:fingerprint"]["args"]
+    ): Promise<IpcInvokeMap["file-watch:fingerprint"]["result"]>;
+  };
   forgeAudit: {
     clearLog(
       ...args: IpcInvokeMap["forge-audit:clear-log"]["args"]

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -361,6 +361,10 @@ export interface GeneratedIpcInvokeMap {
     args: [payload: import("./fileBrowser.js").FileBrowserStatPathsPayload];
     result: import("./fileBrowser.js").FileBrowserStatPathsResult;
   };
+  "file-watch:fingerprint": {
+    args: [payload: import("./fileWatch.js").FileWatchFingerprintPayload];
+    result: import("./fileWatch.js").FileWatchFingerprintResult;
+  };
   "forge-audit:clear-log": {
     args: [];
     result: void;

--- a/shared/types/ipc/index.ts
+++ b/shared/types/ipc/index.ts
@@ -19,6 +19,7 @@ export * from "./gitPush.js";
 export * from "./files.js";
 export * from "./diffMedia.js";
 export * from "./fileBrowser.js";
+export * from "./fileWatch.js";
 export * from "./config.js";
 export * from "./devPreview.js";
 export * from "./connectivity.js";

--- a/src/clients/fileWatchClient.ts
+++ b/src/clients/fileWatchClient.ts
@@ -1,0 +1,7 @@
+import type { FileWatchFingerprintPayload, FileWatchFingerprintResult } from "@shared/types";
+
+export const fileWatchClient = {
+  fingerprint: (payload: FileWatchFingerprintPayload): Promise<FileWatchFingerprintResult> => {
+    return window.electron.fileWatch.fingerprint(payload);
+  },
+};

--- a/src/hooks/__tests__/useExternalChangeTick.test.tsx
+++ b/src/hooks/__tests__/useExternalChangeTick.test.tsx
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+// The channel's real schema, so the cap is asserted against the contract it
+// exists to satisfy rather than against a number copied out of the hook.
+import { FileWatchFingerprintPayloadSchema } from "../../../electron/schemas/ipc";
+import { useExternalChangeTick } from "../useExternalChangeTick";
+
+const fingerprint = vi.fn<(payload: { rootPath: string; paths: string[] }) => Promise<string[]>>();
+
+/** Every promise the hook has been handed, so a flush can await the real work. */
+const issued: Array<Promise<unknown>> = [];
+
+vi.mock("@/clients/fileWatchClient", () => ({
+  fileWatchClient: {
+    fingerprint: (payload: { rootPath: string; paths: string[] }) => {
+      const pending = fingerprint(payload);
+      issued.push(pending);
+      return pending;
+    },
+  },
+}));
+
+/**
+ * Settle the mount-time sample. Testing Library's `waitFor` schedules its own
+ * timers, which never fire under `vi.useFakeTimers()`, and a fixed number of
+ * microtask turns would silently stop being enough the moment the hook grows
+ * another promise boundary. Awaiting the mock's own recorded promise ties the
+ * wait to the thing being waited on.
+ */
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.allSettled(issued);
+  });
+}
+
+/**
+ * Fire the next scheduled poll and settle it. `advanceTimersToNextTimerAsync`
+ * rather than a literal delay: copying the production cadence here would mean
+ * changing the interval forces the same edit in this file.
+ */
+async function pollOnce(): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersToNextTimerAsync();
+    await Promise.allSettled(issued);
+  });
+}
+
+describe("useExternalChangeTick", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    issued.length = 0;
+    fingerprint.mockReset();
+    fingerprint.mockResolvedValue(["fp-1"]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    Object.defineProperty(document, "hidden", { configurable: true, value: false });
+  });
+
+  it("establishes a baseline without emitting a tick", async () => {
+    const { result } = renderHook(() => useExternalChangeTick("/root", ["/root/a.txt"], true));
+
+    await flush();
+    expect(fingerprint).toHaveBeenCalled();
+    // The pane has just read this file explicitly. A tick here would make it
+    // read the same bytes a second time for no reason.
+    expect(result.current).toBeUndefined();
+  });
+
+  it("emits once the fingerprint moves, and not again while it holds", async () => {
+    const { result } = renderHook(() => useExternalChangeTick("/root", ["/root/a.txt"], true));
+    await flush();
+    expect(fingerprint).toHaveBeenCalledTimes(1);
+
+    fingerprint.mockResolvedValue(["fp-2"]);
+    await pollOnce();
+    const afterChange = result.current;
+    expect(afterChange).toBeDefined();
+
+    await pollOnce();
+    expect(result.current).toBe(afterChange);
+  });
+
+  it("treats a path becoming unreadable as a change", async () => {
+    // Deletion is exactly the staleness the pane cannot otherwise notice, so a
+    // null fingerprint has to be a value in the comparison, not a skip.
+    const { result } = renderHook(() => useExternalChangeTick("/root", ["/root/a.txt"], true));
+    await flush();
+    expect(fingerprint).toHaveBeenCalledTimes(1);
+
+    fingerprint.mockResolvedValue([null as unknown as string]);
+    await pollOnce();
+
+    expect(result.current).toBeDefined();
+  });
+
+  it("does not poll at all when disabled", async () => {
+    renderHook(() => useExternalChangeTick("/root", ["/root/a.txt"], false));
+    await pollOnce();
+    expect(fingerprint).not.toHaveBeenCalled();
+  });
+
+  it("does not poll without a root to confine the paths to", async () => {
+    renderHook(() => useExternalChangeTick("", ["/root/a.txt"], true));
+    await pollOnce();
+    expect(fingerprint).not.toHaveBeenCalled();
+  });
+
+  it("keeps its baseline when the caller re-derives an equivalent path list", async () => {
+    // Both panes rebuild this array every render; re-keying on identity would
+    // reset the baseline continuously and the tick would never fire.
+    const { result, rerender } = renderHook(
+      ({ paths }: { paths: string[] }) => useExternalChangeTick("/root", paths, true),
+      { initialProps: { paths: ["/root/b", "/root/a"] } }
+    );
+    await flush();
+    expect(fingerprint).toHaveBeenCalledTimes(1);
+
+    rerender({ paths: ["/root/a", "/root/b", "/root/a"] });
+    fingerprint.mockResolvedValue(["fp-2", "fp-2"]);
+    await pollOnce();
+
+    // A reordered, duplicate-bearing rebuild of the same set still compares
+    // against the earlier sample rather than starting over.
+    expect(result.current).toBeDefined();
+  });
+
+  it("repeats the same request for an unchanged set", async () => {
+    const { rerender } = renderHook(
+      ({ paths }: { paths: string[] }) => useExternalChangeTick("/root", paths, true),
+      { initialProps: { paths: ["/root/a", "/root/b"] } }
+    );
+    await flush();
+    expect(fingerprint).toHaveBeenCalledTimes(1);
+    const first = fingerprint.mock.calls[0]?.[0]?.paths;
+
+    rerender({ paths: ["/root/a", "/root/b"] });
+    await pollOnce();
+    // A second call must actually have happened, or comparing "the last call"
+    // would just be re-reading the mount call.
+    expect(fingerprint.mock.calls.length).toBeGreaterThan(1);
+    const second = fingerprint.mock.calls[fingerprint.mock.calls.length - 1]?.[0]?.paths;
+
+    expect(second).toEqual(first);
+  });
+
+  it("emits a request the channel's own schema accepts", async () => {
+    // Asserted through the schema rather than against a copied number: the cap
+    // exists to satisfy this contract, so the contract is what should fail if
+    // the two ever drift apart.
+    const many = Array.from({ length: 80 }, (_, index) => `/root/dir-${index}`);
+    renderHook(() => useExternalChangeTick("/root", ["/root", ...many], true));
+
+    await flush();
+    const payload = fingerprint.mock.calls[0]?.[0];
+
+    expect(FileWatchFingerprintPayloadSchema.safeParse(payload).success).toBe(true);
+    // Priority order decides who survives the cap, so the caller's first entry
+    // is the one thing that can never be dropped.
+    expect(payload?.paths[0]).toBe("/root");
+  });
+
+  it("keeps a path containing a newline intact", async () => {
+    // A newline is legal in a POSIX filename. A delimiter-joined key would split
+    // this into two paths that both fingerprint to null — a file that silently
+    // never updates again.
+    const awkward = "/root/two\nlines.txt";
+    renderHook(() => useExternalChangeTick("/root", [awkward], true));
+
+    await flush();
+
+    expect(fingerprint.mock.calls[0]?.[0]?.paths).toEqual([awkward]);
+  });
+
+  it("discards a response for a set the caller has already moved off", async () => {
+    // The switch happens while the first request is still pending. Adopting that
+    // late answer would emit a tick describing paths the pane no longer shows.
+    let resolveFirst: ((value: string[]) => void) | undefined;
+    fingerprint.mockImplementationOnce(
+      () =>
+        new Promise<string[]>((resolve) => {
+          resolveFirst = resolve;
+        })
+    );
+
+    const { result, rerender } = renderHook(
+      ({ paths }: { paths: string[] }) => useExternalChangeTick("/root", paths, true),
+      { initialProps: { paths: ["/root/a"] } }
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    rerender({ paths: ["/root/b"] });
+    await act(async () => {
+      resolveFirst?.(["changed-a"]);
+      await Promise.allSettled(issued);
+    });
+
+    expect(result.current).toBeUndefined();
+    // The new set must not be stuck behind the abandoned request's latch.
+    expect(fingerprint.mock.calls.some(([payload]) => payload.paths[0] === "/root/b")).toBe(true);
+  });
+
+  it("stops polling while hidden and diffs immediately on reveal", async () => {
+    const { result } = renderHook(() => useExternalChangeTick("/root", ["/root/a.txt"], true));
+    await flush();
+    const afterBaseline = fingerprint.mock.calls.length;
+
+    Object.defineProperty(document, "hidden", { configurable: true, value: true });
+    document.dispatchEvent(new Event("visibilitychange"));
+    await pollOnce();
+    expect(fingerprint).toHaveBeenCalledTimes(afterBaseline);
+
+    // The write lands while the view is backgrounded — the case that would
+    // otherwise need a manual refresh to surface.
+    fingerprint.mockResolvedValue(["fp-2"]);
+    Object.defineProperty(document, "hidden", { configurable: true, value: false });
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+      await Promise.allSettled(issued);
+    });
+
+    expect(fingerprint.mock.calls.length).toBeGreaterThan(afterBaseline);
+    expect(result.current).toBeDefined();
+  });
+
+  it("survives a bridge that isn't there", async () => {
+    // A pane can render before the preload bridge is wired; losing the live
+    // tick is degraded, throwing out of the effect is broken.
+    fingerprint.mockImplementation(() => {
+      throw new TypeError("Cannot read properties of undefined");
+    });
+
+    const { result } = renderHook(() => useExternalChangeTick("/root", ["/root/a.txt"], true));
+    await pollOnce();
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it("leaves the baseline intact when a sample fails", async () => {
+    const { result } = renderHook(() => useExternalChangeTick("/root", ["/root/a.txt"], true));
+    await flush();
+    expect(fingerprint).toHaveBeenCalledTimes(1);
+
+    fingerprint.mockRejectedValueOnce(new Error("rate limited"));
+    await pollOnce();
+    expect(result.current).toBeUndefined();
+
+    // The next good sample compares against the original baseline, so a change
+    // that landed during the failed poll is still reported.
+    fingerprint.mockResolvedValue(["fp-2"]);
+    await pollOnce();
+    expect(result.current).toBeDefined();
+  });
+});

--- a/src/hooks/__tests__/useExternalChangeTick.test.tsx
+++ b/src/hooks/__tests__/useExternalChangeTick.test.tsx
@@ -6,7 +6,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FileWatchFingerprintPayloadSchema } from "../../../electron/schemas/ipc";
 import { useExternalChangeTick } from "../useExternalChangeTick";
 
-const fingerprint = vi.fn<(payload: { rootPath: string; paths: string[] }) => Promise<string[]>>();
+// Mirrors FileWatchFingerprintResult, so a `null` entry — the "nothing readable
+// there" answer — needs no cast to express.
+const fingerprint =
+  vi.fn<(payload: { rootPath: string; paths: string[] }) => Promise<Array<string | null>>>();
 
 /** Every promise the hook has been handed, so a flush can await the real work. */
 const issued: Array<Promise<unknown>> = [];
@@ -90,7 +93,7 @@ describe("useExternalChangeTick", () => {
     await flush();
     expect(fingerprint).toHaveBeenCalledTimes(1);
 
-    fingerprint.mockResolvedValue([null as unknown as string]);
+    fingerprint.mockResolvedValue([null]);
     await pollOnce();
 
     expect(result.current).toBeDefined();

--- a/src/hooks/__tests__/useExternalChangeTick.test.tsx
+++ b/src/hooks/__tests__/useExternalChangeTick.test.tsx
@@ -108,23 +108,24 @@ describe("useExternalChangeTick", () => {
     expect(fingerprint).not.toHaveBeenCalled();
   });
 
-  it("keeps its baseline when the caller re-derives an equivalent path list", async () => {
-    // Both panes rebuild this array every render; re-keying on identity would
-    // reset the baseline continuously and the tick would never fire.
-    const { result, rerender } = renderHook(
+  it("does not re-baseline when the caller rebuilds an equivalent path list", async () => {
+    // Both panes rebuild this array every render. Re-keying on array identity
+    // would restart the baseline continuously, and a change arriving between two
+    // rebuilds would be folded into the new baseline instead of reported.
+    const { rerender } = renderHook(
       ({ paths }: { paths: string[] }) => useExternalChangeTick("/root", paths, true),
-      { initialProps: { paths: ["/root/b", "/root/a"] } }
+      { initialProps: { paths: ["/root/a", "/root/b"] } }
     );
     await flush();
     expect(fingerprint).toHaveBeenCalledTimes(1);
 
-    rerender({ paths: ["/root/a", "/root/b", "/root/a"] });
-    fingerprint.mockResolvedValue(["fp-2", "fp-2"]);
-    await pollOnce();
+    // A fresh array with the same contents, and a duplicate the hook must fold
+    // away rather than treat as a new set.
+    rerender({ paths: ["/root/a", "/root/b", "/root/b"] });
+    await flush();
 
-    // A reordered, duplicate-bearing rebuild of the same set still compares
-    // against the earlier sample rather than starting over.
-    expect(result.current).toBeDefined();
+    // No new request: an unchanged set means the standing baseline still holds.
+    expect(fingerprint).toHaveBeenCalledTimes(1);
   });
 
   it("repeats the same request for an unchanged set", async () => {
@@ -202,6 +203,13 @@ describe("useExternalChangeTick", () => {
     expect(result.current).toBeUndefined();
     // The new set must not be stuck behind the abandoned request's latch.
     expect(fingerprint.mock.calls.some(([payload]) => payload.paths[0] === "/root/b")).toBe(true);
+
+    // The load-bearing half: without the guard the late answer overwrites the
+    // baseline under the OLD key, so B's next sample looks like B's first one
+    // and this genuine change is silently swallowed instead of reported.
+    fingerprint.mockResolvedValue(["changed-b"]);
+    await pollOnce();
+    expect(result.current).toBeDefined();
   });
 
   it("stops polling while hidden and diffs immediately on reveal", async () => {

--- a/src/hooks/useExternalChangeTick.ts
+++ b/src/hooks/useExternalChangeTick.ts
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { FileWatchFingerprintResult } from "@shared/types";
+import { fileWatchClient } from "@/clients/fileWatchClient";
+import { useVisibilityAwareInterval } from "@/hooks/useVisibilityAwareInterval";
+
+/**
+ * A live "something moved on disk" tick for paths no worktree covers.
+ *
+ * The worktree store is the authority wherever it has an answer — its tick
+ * rides the workspace host's recursive watcher and is both cheaper and finer
+ * than this. But a scratch folder, a worktree-less project and a file opened
+ * from outside every registered repo have no host and no watcher, so those
+ * surfaces had no tick to subscribe to at all and only ever refreshed on demand
+ * (#11590). Callers compose the two: `worktreeTick ?? useExternalChangeTick(…)`,
+ * keeping one tick contract for the consumer.
+ *
+ * Polled rather than pushed: main stays stateless, so there is no subscription
+ * to leak when a view is evicted, and the sample is its own reconcile — no
+ * dropped-overflow blind spot, and a deleted root reads as a change like
+ * anything else.
+ */
+
+/**
+ * Two seconds is under the threshold where a rewritten file reads as "the app
+ * noticed", while being long enough that a pane sampling a handful of paths
+ * costs nothing measurable. The interval only runs while the document is
+ * visible, so a backgrounded project view polls nothing at all.
+ */
+const POLL_INTERVAL_MS = 2_000;
+
+/**
+ * Matches the per-call cap the channel's schema enforces. Paths are kept in the
+ * order the caller supplied, so a caller with more than this many decides what
+ * survives by listing the paths that matter first — the alternative (refusing
+ * the batch) would turn a wide tree into no live signal at all.
+ */
+const MAX_WATCHED_PATHS = 32;
+
+/** Shared empty identity so a caller can pass "nothing to watch" without churn. */
+export const NO_WATCHED_PATHS: readonly string[] = Object.freeze([]);
+
+export function useExternalChangeTick(
+  rootPath: string,
+  paths: readonly string[],
+  enabled: boolean
+): number | undefined {
+  /**
+   * The watched set, serialized. JSON rather than a delimiter join: a newline is
+   * a legal character in a POSIX filename, so splitting on one would shred that
+   * path into fragments that all fingerprint to `null` — a file that silently
+   * never updates. Serializing here also gives the effects a primitive to key
+   * on, so a caller re-deriving an equivalent array every render (which both
+   * panes do) neither re-baselines nor re-requests.
+   */
+  const watchKey = useMemo(() => {
+    if (!enabled || !rootPath) return "";
+    const unique: string[] = [];
+    const seen = new Set<string>();
+    for (const candidate of paths) {
+      if (!candidate || seen.has(candidate)) continue;
+      seen.add(candidate);
+      unique.push(candidate);
+      if (unique.length === MAX_WATCHED_PATHS) break;
+    }
+    return unique.length === 0 ? "" : JSON.stringify(unique);
+  }, [enabled, rootPath, paths]);
+
+  const [tick, setTick] = useState<number | undefined>(undefined);
+
+  // The last sample, and the identity it was taken for. Held in a ref rather
+  // than state so recording a baseline doesn't itself cause a render.
+  const baselineRef = useRef<{ key: string; root: string; sample: string } | null>(null);
+  // Keeps a slow poll from overlapping the next interval.
+  const inFlightRef = useRef(false);
+  // Bumped whenever the watched set changes, so a response issued for the
+  // previous set is recognizable on arrival. A closure comparison cannot do
+  // this: `sample` captures the key it was built with, so checking that against
+  // itself would always agree.
+  const generationRef = useRef(0);
+
+  const sample = useCallback(() => {
+    if (!watchKey || inFlightRef.current) return;
+    const key = watchKey;
+    const root = rootPath;
+    const generation = generationRef.current;
+    let pending: Promise<FileWatchFingerprintResult>;
+    try {
+      pending = fileWatchClient.fingerprint({
+        rootPath: root,
+        paths: JSON.parse(key) as string[],
+      });
+    } catch {
+      // A pane can render before (or without) the preload bridge — a test
+      // harness, a view torn down mid-render. Losing the live tick is a
+      // degraded pane; throwing out of the effect would be a broken one.
+      return;
+    }
+    inFlightRef.current = true;
+    void pending
+      .then((fingerprints) => {
+        // The watched set changed while this was in flight: the answer describes
+        // paths the caller is no longer showing, so emitting off it would make
+        // the new set re-read for a change that happened to the old one.
+        if (generation !== generationRef.current) return;
+        // A separator no fingerprint can contain, so two different per-path
+        // answers can never join to the same string.
+        const next = fingerprints.map((value) => value ?? "-").join("");
+        const previous = baselineRef.current;
+        baselineRef.current = { key, root, sample: next };
+        // The first sample of a set establishes what "unchanged" looks like and
+        // deliberately emits nothing: the pane has just read these paths
+        // explicitly, and a tick here would make it read them a second time.
+        if (previous === null || previous.key !== key || previous.root !== root) return;
+        if (previous.sample === next) return;
+        // Wall-clock so the value composes with the worktree store's own
+        // `lastUpdated`-shaped ticks, but forced upward: consumers treat a new
+        // identity as the signal, and a clock correction that moved this
+        // backwards onto a value already seen would drop the change.
+        setTick((current) => Math.max(Date.now(), (current ?? 0) + 1));
+      })
+      .catch(() => {
+        // A rejected sample (rate limit, teardown mid-call) leaves the baseline
+        // untouched, so the next successful one still compares against real
+        // prior state rather than restarting from scratch.
+      })
+      .finally(() => {
+        // Only the current generation may release the latch: an abandoned
+        // request settling later must not clear it out from under the request
+        // that replaced it.
+        if (generation === generationRef.current) inFlightRef.current = false;
+      });
+  }, [watchKey, rootPath]);
+
+  // Baseline the new set now rather than one interval from now: everything that
+  // happens between the pane's explicit read and the first sample would
+  // otherwise be folded into the baseline and never reported.
+  useEffect(() => {
+    // Abandon whatever is in flight for the previous set and release the latch,
+    // so the new set samples now rather than waiting out the old request.
+    generationRef.current += 1;
+    inFlightRef.current = false;
+    if (!watchKey || document.hidden) return;
+    sample();
+  }, [watchKey, rootPath, sample]);
+
+  // Pauses while the document is hidden and re-samples immediately on reveal —
+  // which is what keeps a change that landed while a project view was
+  // backgrounded from needing a manual refresh to surface.
+  useVisibilityAwareInterval(sample, POLL_INTERVAL_MS, watchKey !== "");
+
+  return watchKey === "" ? undefined : tick;
+}

--- a/src/hooks/useExternalChangeTick.ts
+++ b/src/hooks/useExternalChangeTick.ts
@@ -54,16 +54,31 @@ export function useExternalChangeTick(
    */
   const watchKey = useMemo(() => {
     if (!enabled || !rootPath) return "";
-    const unique: string[] = [];
+    const list: string[] = [];
     const seen = new Set<string>();
     for (const candidate of paths) {
       if (!candidate || seen.has(candidate)) continue;
       seen.add(candidate);
-      unique.push(candidate);
-      if (unique.length === MAX_WATCHED_PATHS) break;
+      list.push(candidate);
+      if (list.length === MAX_WATCHED_PATHS) break;
     }
-    return unique.length === 0 ? "" : JSON.stringify(unique);
+    return list.length === 0 ? "" : JSON.stringify(list);
   }, [enabled, rootPath, paths]);
+
+  /**
+   * The request payload, derived back from the key so everything downstream
+   * depends on that one primitive. Deriving it here rather than returning it
+   * alongside the key keeps a caller that rebuilds an equivalent array from
+   * producing a fresh object identity, which would re-run the effects below and
+   * re-baseline on every render.
+   */
+  const watchList = useMemo<string[]>(() => {
+    if (watchKey === "") return [];
+    const parsed: unknown = JSON.parse(watchKey);
+    return Array.isArray(parsed)
+      ? parsed.filter((entry): entry is string => typeof entry === "string")
+      : [];
+  }, [watchKey]);
 
   const [tick, setTick] = useState<number | undefined>(undefined);
 
@@ -85,10 +100,7 @@ export function useExternalChangeTick(
     const generation = generationRef.current;
     let pending: Promise<FileWatchFingerprintResult>;
     try {
-      pending = fileWatchClient.fingerprint({
-        rootPath: root,
-        paths: JSON.parse(key) as string[],
-      });
+      pending = fileWatchClient.fingerprint({ rootPath: root, paths: watchList });
     } catch {
       // A pane can render before (or without) the preload bridge — a test
       // harness, a view torn down mid-render. Losing the live tick is a
@@ -129,7 +141,7 @@ export function useExternalChangeTick(
         // that replaced it.
         if (generation === generationRef.current) inFlightRef.current = false;
       });
-  }, [watchKey, rootPath]);
+  }, [watchKey, watchList, rootPath]);
 
   // Baseline the new set now rather than one interval from now: everything that
   // happens between the pane's explicit read and the first sample would

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -38,6 +38,7 @@ import { usePanelStore } from "@/store/panelStore";
 import { usePreferencesStore } from "@/store/preferencesStore";
 import { flushPanelPersistence } from "@/store/slices";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
+import { useExternalChangeTick } from "@/hooks/useExternalChangeTick";
 import { FileTreeView } from "./FileTreeView";
 import { FileBrowserViewer } from "./FileBrowserViewer";
 import { useFileBrowserTree } from "./useFileBrowserTree";
@@ -258,13 +259,48 @@ export function FileBrowserPane({
       [sourceWorktreeId]
     )
   );
-  // A single monotonic signal for "re-read the tree/file": whichever moved most
+  // A single monotonic signal for "re-read the tree": whichever moved most
   // recently. `|| undefined` so a never-changed worktree keeps the "no tick"
   // identity the hook expects. Both sources are worktree-store maps, so a
-  // workspace root has no tick at all and refreshes on demand only (#11482).
-  const changeTick = Math.max(gitChangeTick ?? 0, fsChangeTick ?? 0) || undefined;
+  // workspace root gets nothing from them (#11482) — `externalChangeTick` below
+  // is what covers it.
+  const worktreeChangeTick = Math.max(gitChangeTick ?? 0, fsChangeTick ?? 0) || undefined;
 
   const stableExpandedPaths = useMemo(() => expandedPaths ?? EMPTY_PATHS, [expandedPaths]);
+
+  // What a workspace-rooted panel watches, in the order that decides who
+  // survives the hook's per-sample cap.
+  //
+  // The tree's own root comes first — that is the re-rooted subdirectory when
+  // there is one, not the workspace folder above it, or a write directly into
+  // the browsed folder would be invisible. The selected file comes second and
+  // ahead of every directory: an in-place rewrite moves neither its parent's
+  // mtime nor that parent's child-name digest, so nothing else in this set can
+  // see it, and it is what the viewer beside the tree is showing. Expanded
+  // directories fill the rest; a collapsed subtree isn't rendered and is re-read
+  // from scratch when it reopens.
+  const watchedPaths = useMemo(() => {
+    if (!basePath || isWorktreeSource) return EMPTY_PATHS;
+    const treeRoot = join(basePath, rootPath);
+    const selectedFile = selectedPath === null ? [] : [join(basePath, selectedPath)];
+    return [
+      treeRoot,
+      ...selectedFile,
+      ...stableExpandedPaths.map((relative) => join(basePath, relative)),
+    ];
+  }, [basePath, isWorktreeSource, rootPath, selectedPath, stableExpandedPaths]);
+
+  // Polled from main rather than watched: a scratch or worktree-less project has
+  // no workspace host to hang a watcher on, and the poll is its own reconcile
+  // (#11590).
+  const externalChangeTick = useExternalChangeTick(
+    basePath,
+    watchedPaths,
+    Boolean(basePath) && !isWorktreeSource
+  );
+
+  // One tick contract for `useFileBrowserTree`, whichever side supplied it.
+  const changeTick = worktreeChangeTick ?? externalChangeTick;
 
   const {
     rows,

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -205,6 +205,20 @@ vi.mock("../useWorkspaceRootPath", () => ({
   useWorkspaceRootPath: () => workspaceRootPathMock(),
 }));
 
+// The live signal for a root no worktree covers (#11590). Mocked so a test can
+// drive the tick directly and so the real hook's IPC poll never runs here —
+// without this the pane would depend on a `window.electron` jsdom doesn't have.
+const { externalChangeTickMock } = vi.hoisted(() => ({
+  externalChangeTickMock: vi.fn<(root: string, paths: readonly string[]) => number | undefined>(
+    () => undefined
+  ),
+}));
+vi.mock("@/hooks/useExternalChangeTick", () => ({
+  NO_WATCHED_PATHS: Object.freeze([]),
+  useExternalChangeTick: (root: string, paths: readonly string[], enabled: boolean) =>
+    enabled ? externalChangeTickMock(root, paths) : undefined,
+}));
+
 const { copyContextWithFeedbackMock } = vi.hoisted(() => ({
   copyContextWithFeedbackMock: vi.fn<
     typeof import("@/hooks/useWorktreeActions").copyContextWithFeedback
@@ -303,6 +317,8 @@ beforeEach(() => {
   copyContextWithFeedbackMock.mockClear();
   workspaceRootPathMock.mockReset();
   workspaceRootPathMock.mockReturnValue("");
+  externalChangeTickMock.mockReset();
+  externalChangeTickMock.mockReturnValue(undefined);
   // Module-global and never reset by the store itself, so a message left by an
   // earlier test would satisfy the next one's announcement assertion.
   useAnnouncerStore.setState({ polite: null, assertive: null });
@@ -327,6 +343,7 @@ beforeEach(() => {
   mockPanel.browserShowIgnored = undefined;
   mockPanel.browserSidebarWidth = undefined;
   mockPanel.browserWorkspaceRooted = undefined;
+  mockPanel.browserExpandedPaths = undefined;
   treeArgs.changeTick = undefined;
   treeProps.onActivate = undefined;
   treeProps.onInsertFileReference = undefined;
@@ -1331,9 +1348,9 @@ describe("promoted workspace-rooted browser (#11489)", () => {
   });
 
   it("ignores the placement worktree's change ticks once workspace-rooted", () => {
-    // Both tick maps are keyed by worktree, so a workspace source has no tick at
-    // all — following the placement worktree's would refresh the tree on writes
-    // in a folder this panel isn't showing.
+    // Both worktree tick maps are keyed by worktree id, so following the
+    // placement worktree's would refresh the tree on writes in a folder this
+    // panel isn't showing. Its own signal comes from the external tick instead.
     worktreeTicks.git = 120;
     worktreeTicks.fs = 450;
     workspaceRootPathMock.mockReturnValue("/scratches/one");
@@ -1341,6 +1358,47 @@ describe("promoted workspace-rooted browser (#11489)", () => {
     renderPane({ worktreeId: "wt-1" });
 
     expect(treeArgs.changeTick).toBeUndefined();
+  });
+
+  it("takes its tick from the external signal once workspace-rooted (#11590)", () => {
+    worktreeTicks.git = 120;
+    worktreeTicks.fs = 450;
+    workspaceRootPathMock.mockReturnValue("/scratches/one");
+    mockPanel.browserWorkspaceRooted = true;
+    externalChangeTickMock.mockReturnValue(777);
+    renderPane({ worktreeId: "wt-1" });
+
+    // Not either worktree tick: the external signal is the only one describing
+    // the folder this panel is actually showing.
+    expect(treeArgs.changeTick).toBe(777);
+  });
+
+  it("watches the browsed root and the selected file, in that priority order", () => {
+    // The selected file has to be in the watched set: an in-place rewrite moves
+    // neither its parent directory's mtime nor that parent's child-name digest,
+    // so nothing else in the set can see it — and the viewer beside the tree is
+    // what's showing it.
+    workspaceRootPathMock.mockReturnValue("/scratches/one");
+    mockPanel.browserWorkspaceRooted = true;
+    mockPanel.browserRootPath = "src";
+    mockPanel.browserSelectedPath = "src/notes.md";
+    mockPanel.browserExpandedPaths = ["src/deep"];
+    renderPane({ worktreeId: "wt-1" });
+
+    const [root, watched] = externalChangeTickMock.mock.calls[0] ?? [];
+    expect(root).toBe("/scratches/one");
+    expect(watched?.slice(0, 2)).toEqual(["/scratches/one/src", "/scratches/one/src/notes.md"]);
+    expect(watched).toContain("/scratches/one/src/deep");
+  });
+
+  it("does not poll externally when the source is a worktree", () => {
+    // The workspace host's recursive watcher already covers a worktree, and a
+    // second signal for it would be pure duplicate work.
+    workspaceRootPathMock.mockReturnValue("/scratches/one");
+    mockPanel.browserWorkspaceRooted = false;
+    renderPane({ worktreeId: "wt-1" });
+
+    expect(externalChangeTickMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -60,6 +60,7 @@ import { usePanelStore } from "@/store/panelStore";
 import { useProjectStore } from "@/store/projectStore";
 import { usePreferencesStore } from "@/store/preferencesStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
+import { NO_WATCHED_PATHS, useExternalChangeTick } from "@/hooks/useExternalChangeTick";
 import { useDohertyGate } from "@/hooks/useDeferredLoading";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { isClientAppError } from "@/utils/clientAppError";
@@ -316,9 +317,9 @@ export function FilePane({
   // filesystem tick misses nothing but says nothing about git. Whichever moved
   // most recently wins, matching FileBrowserPane (#11330). Scalar for the same
   // reason as `localChangeStatus` — an object would re-render on every poll.
-  // `undefined` when the file is in no known worktree: no watcher covers it, so
-  // there is simply no live signal to give.
-  const changeTick = useWorktreeStore(
+  // `undefined` when the file is in no known worktree — `externalChangeTick`
+  // below is what covers that case.
+  const worktreeChangeTick = useWorktreeStore(
     useCallback(
       (state): number | undefined => {
         if (!diffWorktreePath) return undefined;
@@ -444,6 +445,25 @@ export function FilePane({
       parentDirectory(filePath)
     );
   }, [filePath, worktreePath, projectPath]);
+
+  // The live signal for a file no worktree contains: a scratch folder, a
+  // worktree-less project, a path picked from anywhere else on disk. Polled
+  // from main rather than watched, and only while this view is visible, so the
+  // cost is one stat every couple of seconds per visible pane (#11590). Rooted
+  // at the same path the pane reads through, which for a file outside every
+  // project is its own parent directory.
+  const watchedPaths = useMemo(() => (filePath ? [filePath] : NO_WATCHED_PATHS), [filePath]);
+  const externalChangeTick = useExternalChangeTick(
+    effectiveRootPath,
+    watchedPaths,
+    Boolean(filePath) && !diffWorktreePath
+  );
+
+  // One tick contract for the effect below, whichever side supplied it. The
+  // worktree store stays authoritative wherever it has an answer — its tick
+  // rides the host's recursive watcher, which is finer and cheaper than a poll,
+  // so the external signal only ever fills the gap where there is no worktree.
+  const changeTick = worktreeChangeTick ?? externalChangeTick;
 
   const [content, setContent] = useState<string | null>(null);
   const [sanitizedSvg, setSanitizedSvg] = useState<string | null>(null);
@@ -738,7 +758,10 @@ export function FilePane({
     // and raises a stale banner — and leaving Diff already re-reads source, so a
     // tick on either side of that transition would only duplicate the work.
     if (viewMode === "diff" || previous.viewMode === "diff") return;
-    if (!filePath || !diffWorktreePath || changeTick === undefined) return;
+    // No `diffWorktreePath` requirement: a file outside every worktree now has
+    // a tick of its own, and demanding a containing worktree here is exactly
+    // what left those files frozen at whatever they read when opened (#11590).
+    if (!filePath || changeTick === undefined) return;
     // What the pane reads, versus what it watches. Only a change to the former
     // implies an explicit load already happened — `loadFile` is keyed on those
     // two alone, so acquiring a watcher moves `watchRoot` while leaving the read

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -88,6 +88,19 @@ vi.mock("@/hooks/useWorktreeStore", () => ({
 vi.mock("@/store/accessibilityAnnouncerStore", () => ({
   useAnnouncerStore: { getState: () => ({ announce: vi.fn() }) },
 }));
+// The live signal for a file no worktree contains (#11590). Mocked so a test can
+// drive the tick directly, and so the real hook's IPC poll never runs here —
+// without this the pane would depend on a `window.electron` jsdom doesn't have.
+const { externalChangeTickMock } = vi.hoisted(() => ({
+  externalChangeTickMock: vi.fn<(root: string, paths: readonly string[]) => number | undefined>(
+    () => undefined
+  ),
+}));
+vi.mock("@/hooks/useExternalChangeTick", () => ({
+  NO_WATCHED_PATHS: Object.freeze([]),
+  useExternalChangeTick: (root: string, paths: readonly string[], enabled: boolean) =>
+    enabled ? externalChangeTickMock(root, paths) : undefined,
+}));
 const { readMock, searchMock } = vi.hoisted(() => ({
   readMock: vi.fn(),
   searchMock: vi.fn(),
@@ -176,6 +189,8 @@ beforeEach(() => {
   useDiffContentMock.mockReturnValue({ content: undefined, stale: false, retry: vi.fn() });
   worktreeState.worktrees.clear();
   worktreeState.workingTreeChangedAtById.clear();
+  externalChangeTickMock.mockReset();
+  externalChangeTickMock.mockReturnValue(undefined);
   // Reset per test so a prior test's read call can't satisfy a later
   // toHaveBeenCalledWith assertion (cross-test contamination).
   readMock.mockReset();
@@ -1992,9 +2007,9 @@ describe("FilePane live disk refresh (#11451)", () => {
     expect(readMock.mock.calls.length).toBe(initialReads + 1);
   });
 
-  it("stays quiet for a file outside every known worktree", async () => {
-    // No watcher covers it, so there is no tick to resolve — it must degrade to
-    // no live signal rather than reading on every unrelated worktree update.
+  it("ignores unrelated worktree ticks for a file outside every known worktree", async () => {
+    // A worktree that doesn't contain the file says nothing about it, so its
+    // ticks must not reach this pane — the external signal below is what does.
     seedWorktree(OUTER_ID, "/repo", { git: 100 });
     readMock.mockResolvedValue({ content: "v1" });
     const { rerender } = await renderPane({ filePath: "/elsewhere/notes.txt" });
@@ -2007,6 +2022,32 @@ describe("FilePane live disk refresh (#11451)", () => {
     await commitTick(rerender);
 
     expect(readMock).not.toHaveBeenCalled();
+  });
+
+  it("re-reads a file outside every known worktree on its external tick (#11590)", async () => {
+    seedWorktree(OUTER_ID, "/repo", { git: 100 });
+    readMock.mockResolvedValue({ content: "v1" });
+    const { rerender } = await renderPane({ filePath: "/elsewhere/notes.txt" });
+    expect(readMock).toHaveBeenCalled();
+    // The file itself is what gets watched — its parent has no worktree, so
+    // nothing else could report a rewrite of it.
+    expect(externalChangeTickMock.mock.calls[0]?.[1]).toEqual(["/elsewhere/notes.txt"]);
+    readMock.mockClear();
+
+    externalChangeTickMock.mockReturnValue(500);
+    await commitTick(rerender);
+
+    expect(readMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves a file inside a worktree on the worktree's own signal", async () => {
+    // The host's recursive watcher already covers it, so polling would be
+    // duplicate work — the hook must not even be enabled here.
+    seedWorktree(OUTER_ID, "/repo", { git: 100 });
+    readMock.mockResolvedValue({ content: "v1" });
+    await renderPane({ filePath: "/repo/src/index.ts" });
+
+    expect(externalChangeTickMock).not.toHaveBeenCalled();
   });
 
   it("re-reads once, not twice, when a tick lands together with leaving Diff", async () => {


### PR DESCRIPTION
## Summary
- `FilePane` and `FileBrowserPane` both read their re-read tick from worktree store maps keyed by worktree id, so a scratch folder under `userData`, a worktree-less project, or a file opened from an unregistered repo had `changeTick` undefined and never live-refreshed. The viewer kept showing whatever it read when the file was opened.
- Added a stateless polled fingerprint instead of a second filesystem watcher. Main exposes one IPC op, `fileWatch.fingerprint({ rootPath, paths })`, which the renderer polls every 2 seconds while the view is visible and diffs against the previous answer.
- No subscription state lives in main, so nothing leaks when a view is evicted, and the poll is its own reconcile, which sidesteps the dropped-overflow and cannot-see-its-own-root-deleted blind spots a watcher would bring.

Resolves #11590

## Approach

Deliberately not a persistent `@parcel/watcher` instance in Electron main: every existing call site in this repo lives in the workspace-host subprocess, and a persistent native FSEvents/inotify thread in main is an app-quit teardown hazard.

**Fingerprint.** File fingerprints are `mtimeNs`/`ctimeNs`/`size`/`ino`, with ctime included so an in-place rewrite that restores timestamps still registers. Directory fingerprints are `mtimeNs` plus entry count plus an order-independent digest of the direct child name/kind list, so a rename that keeps the entry count can't slip past a bare mtime check.

**Safety.** Every sampled path is realpath-confined to the caller's root, each filesystem call is bounded with a timeout wrapper, concurrency is capped at libuv's default thread pool size, and a root that hangs goes on a 30-second cooldown so a dead SMB mount can't queue orphaned probes against that pool on every poll.

**Renderer.** A single shared hook, `useExternalChangeTick`, is the one signal source. Both panes compose `worktreeChangeTick ?? externalChangeTick`, so the worktree store stays authoritative wherever it has an answer and the poll only fills the gap. `FilePane`'s background re-read bail also drops its `!diffWorktreePath` clause, since that clause was what froze a file with no containing worktree.

The file browser watches its browsed tree root and the selected file ahead of expanded directories, since an in-place rewrite moves neither the parent's mtime nor its child digest, so nothing else in the watched set would notice the change.

## Changes
- `electron/services/pathFingerprint.ts`: new fingerprinting service (realpath confinement, timeouts, concurrency cap, hung-root cooldown).
- `electron/ipc/handlers/fileWatch.ts` + `.preload.ts`, `electron/ipc/channels.ts`, `electron/ipc/handlers.ts`, `electron/preload.cts`: new `fileWatch.fingerprint` IPC namespace.
- `electron/schemas/ipc.ts`, `shared/types/ipc/fileWatch.ts`, `shared/types/ipc/generated*.ts`, `shared/types/ipc/index.ts`, `shared/types/index.ts`: schema + generated types for the new channel.
- `src/clients/fileWatchClient.ts`: renderer client for the new op.
- `src/hooks/useExternalChangeTick.ts`: shared polling hook.
- `src/panels/file/FilePane.tsx`, `src/panels/file-browser/FileBrowserPane.tsx`: compose `worktreeChangeTick ?? externalChangeTick`; `FilePane` drops the `!diffWorktreePath` bail clause.

No new dependency; `@parcel/watcher` is untouched.

## Testing
- New: `electron/services/__tests__/pathFingerprint.test.ts` (13 tests, real filesystem in a tmpdir) and `src/hooks/__tests__/useExternalChangeTick.test.tsx` (13 tests).
- Extended `FilePane` and `FileBrowserPane` test suites with real assertions; they previously passed only because jsdom has no `window.electron`.
- Locally: 268 tests green across the touched suites, typecheck clean, lint ratchet flat, both IPC codegen guards pass.
