### PR TITLE
fix(ui): keep menu shortcut hints off the item label

### DIFF
--- a/src/components/ui/__tests__/menu-shortcut-gutter.test.tsx
+++ b/src/components/ui/__tests__/menu-shortcut-gutter.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ContextMenuShortcut } from "../context-menu";
+import { DropdownMenuShortcut } from "../dropdown-menu";
+
+afterEach(cleanup);
+
+// Both primitives are plain spans with no `useRadixPrimitives()` call, so they
+// render standalone — no `primeRadix()` needed.
+const PRIMITIVES = [
+  { name: "ContextMenuShortcut", Shortcut: ContextMenuShortcut },
+  { name: "DropdownMenuShortcut", Shortcut: DropdownMenuShortcut },
+] as const;
+
+const COMBO = "⌘I";
+
+// An inline-start padding utility at a non-zero scale. `pl-0`/`px-0` would
+// satisfy a bare `p[lx]-` match while leaving the hint flush, so they have to
+// fail this.
+const GUTTER = /^p[lx]-(?!0$)/;
+
+function renderShortcut(Shortcut: (typeof PRIMITIVES)[number]["Shortcut"]): HTMLElement {
+  render(<Shortcut>{COMBO}</Shortcut>);
+  return screen.getByText(COMBO);
+}
+
+function classesOf(el: HTMLElement): string[] {
+  return el.className.split(/\s+/).filter(Boolean);
+}
+
+describe("menu shortcut gutter — issue #11598", () => {
+  it.each(PRIMITIVES)(
+    "$name separates the hint from the label with padding, which flex cannot collapse",
+    ({ Shortcut }) => {
+      // `ml-auto` distributes leftover space, so it renders a gap only on rows
+      // that have some. Menu width is set by the widest row, and a row carrying
+      // both a label and a hint is typically that row — leaving it zero slack,
+      // collapsing its auto margin to 0, and butting the hint against the
+      // label. The separation therefore has to come from a box-model layer flex
+      // cannot redistribute.
+      //
+      // jsdom has no compiled Tailwind and no flex layout, so this asserts the
+      // utility is present and non-zero, not the rendered pixel gap. The gap
+      // itself is a visual check.
+      expect(
+        classesOf(renderShortcut(Shortcut)).some((c) => GUTTER.test(c)),
+        "shortcut needs a non-zero inline-start padding, not just `ml-auto`"
+      ).toBe(true);
+    }
+  );
+
+  it("keeps both menu families visually identical", () => {
+    // #11598 reported the context menu, but `DropdownMenuShortcut` carried the
+    // same class string and the same defect. These are duplicated wrappers kept
+    // in sync by hand, so fixing one and missing the other is the realistic
+    // regression — and it can only be resolved by editing the other primitive,
+    // never by editing this test.
+    const context = classesOf(renderShortcut(ContextMenuShortcut)).sort();
+    cleanup();
+    const dropdown = classesOf(renderShortcut(DropdownMenuShortcut)).sort();
+
+    expect(dropdown).toEqual(context);
+  });
+});

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -360,7 +360,7 @@ ContextMenuLabel.displayName = "ContextMenuLabel";
 const ContextMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
   return (
     <span
-      className={cn("ml-auto text-[11px] font-mono text-daintree-text/50", className)}
+      className={cn("ml-auto pl-2 text-[11px] font-mono text-daintree-text/50", className)}
       {...props}
     />
   );

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -401,7 +401,7 @@ DropdownMenuLabel.displayName = "DropdownMenuLabel";
 const DropdownMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
   return (
     <span
-      className={cn("ml-auto text-[11px] font-mono text-daintree-text/50", className)}
+      className={cn("ml-auto pl-2 text-[11px] font-mono text-daintree-text/50", className)}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
- In the file browser context menu, the `⌘I` hint on "Insert file reference" was rendering flush against the label, reading as `Insert file reference⌘I`.
- `ContextMenuShortcut` relied on `ml-auto` alone for the gap. An auto margin only distributes leftover space in a flex row, so it only produces a gap on rows that have slack. The menu width is set by its widest row, and a row carrying both a label and a hint is typically that widest row, so it defines the width, is left with zero slack, and the auto margin collapses to zero.
- `DropdownMenuShortcut` carried the identical class string and had the same defect, which is why the issue asked for both to be fixed together.

Resolves #11598

## Changes
- Added `pl-2` to both `ContextMenuShortcut` and `DropdownMenuShortcut`. Padding is part of an element's intrinsic outer size, so flex layout can't redistribute it away, while `ml-auto` still handles right alignment whenever there's slack. This matches the existing `ml-auto pl-2` pattern already used for trailing metadata at `src/components/Layout/DockLaunchMenuItems.tsx:149`.
- Deliberately left out `shrink-0`, `whitespace-nowrap`, a parent `gap` utility, and call-site label truncation. A parent gap would double the spacing on every icon and label pair, since icons already use a per-call-site `mr-2`. And no consumer is width-constrained: Radix Popper sets `minWidth` to `max-content`, so long labels widen the menu instead of squeezing the hint.
- This touches around 18 shortcut call sites across the file browser, terminal context menu, toolbar overflow, agent and plugin trays, and worktree session submenus. None of them pass a custom `className` to either component, so there's no override collision to worry about.
- Added `src/components/ui/__tests__/menu-shortcut-gutter.test.tsx`, asserting each component carries a non-zero inline-start padding gutter and that the two menu families keep identical class sets, so fixing one and missing the other fails the test. Assertions use a regex rather than the literal class name, per the repo's rule against tautological assertions. Verified by mutating `pl-2` to `pl-0`, which fails two tests.

## Testing
- `vitest` across the `ui` tests directory plus the `Toolbar` overflow, `FileBrowserPane`, `TerminalContextMenu` `fileBrowser`, `AgentTrayButton`, and `PluginTrayButton` suites: all 937 tests pass.
- `prettier` and `eslint` clean on the three changed files.
