### PR TITLE
fix(dock): rebuild the launcher search on a popover palette

### DIFF
--- a/e2e/full/panels/core-dock-launcher-search.spec.ts
+++ b/e2e/full/panels/core-dock-launcher-search.spec.ts
@@ -175,6 +175,12 @@ test.describe.serial("Core: Dock launcher search", () => {
 
     await openLauncher(window);
     await searchBox(window).fill("review");
+    // Enter confirms whatever `selectedIndex` points at, so pin the row itself
+    // first — otherwise a failure here can't tell "launched the wrong thing"
+    // apart from "launched nothing".
+    await expect(window.locator(SELECTED_OPTION)).toContainText("Review", { timeout: T_MEDIUM });
+    expect(await searchBoxHasFocus(window)).toBe(true);
+
     // Typing and confirming in quick succession must rank against the query the
     // user actually typed, not the previous one.
     await window.keyboard.press("Enter");

--- a/e2e/full/panels/core-dock-launcher-search.spec.ts
+++ b/e2e/full/panels/core-dock-launcher-search.spec.ts
@@ -6,23 +6,29 @@ import { ensureWindowFocused } from "../../helpers/focus";
 import { getGridPanelIds, getDockPanelIds, openTerminal } from "../../helpers/panels";
 import { T_SHORT, T_MEDIUM, T_SETTLE } from "../../helpers/timeouts";
 
-// #11521 — the dock `+` launcher gained a search field and a complete panel
-// list. The unit suite mocks `@/components/ui/dropdown-menu` wholesale, so the
-// parts that only exist in real Radix are unverifiable there:
+// #11521 / #11593 — the dock `+` launcher is a Radix `Popover` hosting the
+// standard palette chrome. The unit suite mocks `@/components/ui/popover`
+// wholesale, so the parts that only exist in real Radix are unverifiable there:
 //
-//   1. `onOpenAutoFocus` must hand focus to the search box, not the first item.
-//   2. Radix menu items focus themselves on pointer move — the launcher
-//      preventDefaults that, or hovering a row while typing kills the input.
+//   1. `onOpenAutoFocus` must hand focus to the search box, not the content
+//      wrapper — and it must win on a cold open, where `PopoverContent` renders
+//      nothing until its lazy Radix chunk resolves.
+//   2. Hovering a row must not move DOM focus off the input, in either the
+//      browse list or the filtered results.
 //   3. Escape is caught by DismissibleLayer at the *document* level with
 //      capture, so "first Escape clears, second closes" needs the content's
 //      `onEscapeKeyDown` veto, not a bubble-phase stopPropagation.
-//   4. Radix's typeahead steals printable keys unless the input stops them.
+//   4. The popover is modal, so Tab stays inside it rather than escaping to the
+//      dock behind.
 //
 // This spec pins all four against the real wiring, plus the honesty contract
 // that a grid-only kind launched from the launcher actually lands in the grid.
 
 const LAUNCH_BUTTON = '[aria-label="Open launcher"]';
-const SEARCH_BOX = '[role="searchbox"]';
+// The accessible name, not `[role="combobox"]` — other surfaces use that role.
+const SEARCH_BOX = '[aria-label="Search agents, panels, and recipes"]';
+const OPTION = '[role="option"]';
+const SELECTED_OPTION = '[role="option"][aria-selected="true"]';
 
 function searchBox(page: Page) {
   return page.locator(SEARCH_BOX);
@@ -61,41 +67,84 @@ test.describe.serial("Core: Dock launcher search", () => {
     fixtureCleanup?.();
   });
 
-  test("hands focus to the search box instead of the first menu item", async () => {
+  test("hands focus to the search box instead of the content wrapper", async () => {
     const { window, app } = ctx;
     await ensureWindowFocused(app);
 
+    // This is the first open of the session, so it is also the cold-load case:
+    // the lazy Radix chunk resolves after the click, and `onOpenAutoFocus` is
+    // what covers the frame the open-state rAF can miss.
     await openLauncher(window);
-    // Radix's default onOpenAutoFocus focuses the first item; the rAF-deferred
-    // override must win that race.
     await expect.poll(() => searchBoxHasFocus(window), { timeout: T_MEDIUM }).toBe(true);
 
     await window.keyboard.press("Escape");
     await expect(searchBox(window)).not.toBeVisible({ timeout: T_MEDIUM });
   });
 
-  test("keeps focus in the input while the pointer crosses result rows", async () => {
+  test("arrow keys drive one selection across the unfiltered bands", async () => {
     const { window, app } = ctx;
     await ensureWindowFocused(app);
     await openLauncher(window);
 
+    // Popover carries no roving focus, so the browse list is navigated by the
+    // same selectedIndex the filtered results use — not by moving DOM focus.
+    await expect(window.locator(SELECTED_OPTION)).toHaveCount(1);
+    const first = await window.locator(SELECTED_OPTION).textContent();
+
+    await window.keyboard.press("ArrowDown");
+    await expect(window.locator(SELECTED_OPTION)).toHaveCount(1);
+    expect(await window.locator(SELECTED_OPTION).textContent()).not.toBe(first);
+    expect(await searchBoxHasFocus(window)).toBe(true);
+
+    await window.keyboard.press("Escape");
+    await expect(searchBox(window)).not.toBeVisible({ timeout: T_MEDIUM });
+  });
+
+  test("keeps focus in the input while the pointer crosses rows", async () => {
+    const { window, app } = ctx;
+    await ensureWindowFocused(app);
+    await openLauncher(window);
+
+    // Browse rows first — the state the user is in the instant the menu opens,
+    // and the one the old DropdownMenu left unguarded.
+    const browseRows = window.locator(OPTION);
+    await expect.poll(() => browseRows.count(), { timeout: T_MEDIUM }).toBeGreaterThan(1);
+    await browseRows.nth(1).hover();
+    await window.waitForTimeout(T_SETTLE);
+    expect(await searchBoxHasFocus(window)).toBe(true);
+
     await searchBox(window).fill("e");
-    const rows = window.locator("[data-selected-row]");
+    const rows = window.locator(OPTION);
     await expect.poll(() => rows.count(), { timeout: T_MEDIUM }).toBeGreaterThan(1);
 
-    // Radix's own pointer-move handler would call .focus() on the row here.
     await rows.nth(1).hover();
     await window.waitForTimeout(T_SETTLE);
     expect(await searchBoxHasFocus(window)).toBe(true);
 
     // The hovered row becomes the selection, and only that one.
-    await expect(window.locator("[data-selected-row='true']")).toHaveCount(1);
+    await expect(window.locator(SELECTED_OPTION)).toHaveCount(1);
 
-    // Typing still reaches the input rather than Radix's typeahead.
+    // Typing still reaches the input.
     await window.keyboard.type("vi");
     await expect(searchBox(window)).toHaveValue("evi");
 
     await window.keyboard.press("Escape");
+    await expect(searchBox(window)).toHaveValue("");
+    await window.keyboard.press("Escape");
+    await expect(searchBox(window)).not.toBeVisible({ timeout: T_MEDIUM });
+  });
+
+  test("Tab stays inside the modal popover", async () => {
+    const { window, app } = ctx;
+    await ensureWindowFocused(app);
+    await openLauncher(window);
+
+    await window.keyboard.press("Tab");
+    await window.waitForTimeout(T_SETTLE);
+    // Focus moved off the input but stayed within the popover, so the launcher
+    // is still up rather than dismissed by a focus-outside.
+    await expect(searchBox(window)).toBeVisible();
+
     await window.keyboard.press("Escape");
     await expect(searchBox(window)).not.toBeVisible({ timeout: T_MEDIUM });
   });

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -1,31 +1,25 @@
-import { useCallback, useEffect, useId, useRef, useState } from "react";
-import type { IFuseOptions } from "fuse.js";
-import { Plus, Search } from "lucide-react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import Fuse, { type IFuseOptions } from "fuse.js";
+import { Plus, SquareTerminal } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { AppPaletteDialog } from "@/components/ui/AppPaletteDialog";
+import { BrandMark, Workflow } from "@/components/icons";
+import { PanelKindIcon } from "@/components/PanelPalette/PanelKindIcon";
+import { cn } from "@/lib/utils";
+import { isAgentBlocked, isAgentLaunchable } from "@shared/utils/agentAvailability";
 import { useSearchablePalette } from "@/hooks/useSearchablePalette";
-import { DockLaunchMenuItems, type DockLaunchMenuComponents } from "./DockLaunchMenuItems";
 import {
+  activateCreateRecipeCue,
   activateDockLaunchItem,
   useDockLaunchModel,
+  DOCK_LAUNCH_BAND_LABELS,
   type DockLaunchAgent,
   type DockLaunchItem,
+  type DockLaunchRow,
 } from "./dockLaunchItems";
 import type { RecipeContext } from "@/utils/recipeVariables";
-
-const DROPDOWN_COMPONENTS: DockLaunchMenuComponents = {
-  Item: DropdownMenuItem,
-  Label: DropdownMenuLabel,
-  Separator: DropdownMenuSeparator,
-};
 
 // Same weighting as the ⌘⇧P panel palette so a name match outranks an alias or
 // destination match across all three categories.
@@ -38,6 +32,9 @@ const DOCK_LAUNCH_FUSE_OPTIONS: IFuseOptions<DockLaunchItem> = {
   threshold: 0.4,
   includeScore: true,
 };
+
+/** Ranked results are capped; the browse list always renders in full. */
+const SEARCH_RESULT_CAP = 30;
 
 interface DockLaunchButtonProps {
   agents: ReadonlyArray<DockLaunchAgent>;
@@ -57,7 +54,7 @@ export function DockLaunchButton({
   recipeContext,
 }: DockLaunchButtonProps) {
   const [open, setOpen] = useState(false);
-  // Mirror AgentButton.tsx's tooltip-suppression pattern: when the dropdown
+  // Mirror AgentButton.tsx's tooltip-suppression pattern: when the launcher
   // closes, Radix restores focus to the trigger and the tooltip would re-fire
   // on top of newly-launched panels. Hold suppression open until the next
   // genuine pointer hover (cleared via onPointerEnter).
@@ -70,6 +67,7 @@ export function DockLaunchButton({
   const wasPointerCloseRef = useRef(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const listboxId = useId();
+  const getOptionId = useCallback((rowKey: string) => `${listboxId}-${rowKey}`, [listboxId]);
 
   const model = useDockLaunchModel({
     agents,
@@ -78,12 +76,35 @@ export function DockLaunchButton({
     surface: "dock",
   });
 
+  const fuse = useMemo(
+    () => new Fuse(model.searchItems, DOCK_LAUNCH_FUSE_OPTIONS),
+    [model.searchItems]
+  );
+
+  // One flat row list drives selection in both modes: browsing renders the
+  // grouped bands, searching renders the ranked matches, and either way
+  // `selectedIndex` indexes the same array. Fuse runs over the de-duplicated
+  // `searchItems` so a recently-launched agent can't rank twice.
+  const filterRows = useCallback(
+    (rows: DockLaunchRow[], nextQuery: string): DockLaunchRow[] => {
+      const trimmed = nextQuery.trim();
+      if (!trimmed) return rows;
+      return fuse
+        .search(trimmed)
+        .slice(0, SEARCH_RESULT_CAP)
+        .map(({ item }) => ({ rowKey: item.key, band: "results" as const, item }));
+    },
+    [fuse]
+  );
+
   const { query, results, selectedIndex, setQuery, setSelectedIndex, selectPrevious, selectNext } =
-    useSearchablePalette<DockLaunchItem>({
-      items: model.searchItems,
-      fuseOptions: DOCK_LAUNCH_FUSE_OPTIONS,
-      getItemId: (item) => item.key,
-      maxResults: 30,
+    useSearchablePalette<DockLaunchRow>({
+      items: model.browseRows,
+      filterFn: filterRows,
+      getItemId: (row) => row.rowKey,
+      // `filterRows` caps ranked search itself and the browse list must render
+      // every row, so the hook's own cap must never truncate either one.
+      maxResults: Number.MAX_SAFE_INTEGER,
       // Enter can land in the same tick as the last keystroke here, and a
       // deferred pass would rank it against the previous query — launching a
       // row the user never saw.
@@ -104,19 +125,31 @@ export function DockLaunchButton({
     [setQuery]
   );
 
-  // Whitespace alone doesn't filter, so it must not count as "has a query"
-  // anywhere — including the two Escape checks, or a stray space would cost the
-  // user an extra Escape to close a menu that looks unfiltered.
-  const isFiltering = query.trim().length > 0;
+  const selectedRow = results[selectedIndex];
+  const activeDescendant = selectedRow ? getOptionId(selectedRow.rowKey) : undefined;
 
-  // The content only mounts while open, so this fires exactly on open. Radix's
-  // own mount autofocus lands on the first menu item synchronously; the rAF is
-  // required to run after it, otherwise the search box never keeps focus.
+  const focusInput = useCallback(() => {
+    inputRef.current?.focus({ preventScroll: true });
+  }, []);
+
+  // Second focus attempt behind `onOpenAutoFocus`. `PopoverContent` renders
+  // nothing until its lazily imported Radix chunk resolves, so on a cold click
+  // this frame can fire before the input exists; on a warm one it runs after
+  // the mount handler already focused it and is a harmless no-op. Neither
+  // covers both orders alone.
   useEffect(() => {
     if (!open) return;
-    const frame = requestAnimationFrame(() => inputRef.current?.focus({ preventScroll: true }));
+    const frame = requestAnimationFrame(focusInput);
     return () => cancelAnimationFrame(frame);
-  }, [open]);
+  }, [open, focusInput]);
+
+  // Keep the active option in view as the selection moves. `getElementById`
+  // rather than a `#id` query: both `useId()` and the item keys contain colons,
+  // which are illegal in a CSS id selector.
+  useEffect(() => {
+    if (!activeDescendant) return;
+    document.getElementById(activeDescendant)?.scrollIntoView({ block: "nearest" });
+  }, [activeDescendant]);
 
   // Single close path. Radix only calls onOpenChange for closes it initiates, so
   // the Enter-to-launch path (which sets `open` directly) would otherwise skip
@@ -140,96 +173,88 @@ export function DockLaunchButton({
     [closeLauncher]
   );
 
-  const handleKeyDownCapture = useCallback(
-    (event: React.KeyboardEvent<HTMLInputElement>) => {
+  const activateRow = useCallback(
+    (row: DockLaunchRow) => {
+      closeLauncher();
+      if (!row.item) {
+        activateCreateRecipeCue(activeWorktreeId, "menu");
+        return;
+      }
+      activateDockLaunchItem(row.item, {
+        cwd,
+        activeWorktreeId,
+        recipeContext,
+        onLaunchAgent,
+        settingsSource: "menu",
+      });
+    },
+    [activeWorktreeId, closeLauncher, cwd, onLaunchAgent, recipeContext]
+  );
+
+  // Shared by the input and the results region, so navigation keeps working
+  // after Tab moves focus onto the scroll container.
+  const handleNavigationKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
       // Let an IME candidate window own the keystroke. Chromium can emit
       // keyCode 229 before `isComposing` flips true, so both are checked —
       // the same pair guarded across the other palettes and terminal input.
       if (event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229) return;
 
-      if (event.key === "Escape") {
-        // Dismissal itself is blocked in onEscapeKeyDown (Radix listens on
-        // document with capture, so it runs before this handler); here we just
-        // clear the query for that first press.
-        if (queryRef.current.trim().length > 0) {
-          event.stopPropagation();
-          updateQuery("");
-        }
-        return;
-      }
+      // Escape is handled on the content's `onEscapeKeyDown`: Radix dismisses
+      // from a document-level capture listener that runs before this one, so
+      // clearing here would be too late to also veto the close.
+      if (event.key === "Escape") return;
 
-      // With no query the menu shows the grouped bands, which have no selected
-      // row — so arrows must fall through to Radix and move real menu-item
-      // focus, exactly as they did before search existed. Swallowing them here
-      // would strand keyboard users with an invisible selection they can't act
-      // on. Once filtering, the rows are ours to drive.
       if (event.key === "ArrowDown" || event.key === "ArrowUp") {
-        if (!isFiltering) return;
         event.preventDefault();
         event.stopPropagation();
         if (event.key === "ArrowDown") selectNext();
         else selectPrevious();
         return;
       }
-      if (event.key === "Home" && isFiltering) {
+      if (event.key === "Home") {
         event.preventDefault();
         event.stopPropagation();
         setSelectedIndex(0);
         return;
       }
-      if (event.key === "End" && isFiltering) {
+      if (event.key === "End") {
         event.preventDefault();
         event.stopPropagation();
         setSelectedIndex(Math.max(0, results.length - 1));
         return;
       }
       if (event.key === "Enter") {
-        if (!isFiltering) return;
-        const selected = results[selectedIndex];
-        // No match (or an out-of-range index): swallow the key rather than
-        // letting Radix confirm whatever item it thinks is focused.
+        // No row (or an out-of-range index): swallow the key rather than
+        // letting it escape to whatever is behind the launcher.
         event.preventDefault();
         event.stopPropagation();
-        if (!selected) return;
-        closeLauncher();
-        activateDockLaunchItem(selected, {
-          cwd,
-          activeWorktreeId,
-          recipeContext,
-          onLaunchAgent,
-          settingsSource: "menu",
-        });
+        const row = results[selectedIndex];
+        if (row) activateRow(row);
         return;
       }
 
       if (event.key === "Tab") return;
       // Leave shortcuts alone — swallowing modified keys here would break app
-      // keybindings while the launcher is open. Plain typing still needs
-      // stopping so Radix's typeahead doesn't hijack it.
-      if (event.metaKey || event.ctrlKey || event.altKey) return;
-      // Everything else is ordinary text editing. Stop it reaching the menu so
-      // Radix's typeahead doesn't jump focus to an item on each character;
+      // keybindings while the launcher is open. Plain typing is still stopped
+      // so a letter can't reach the dock's own key handling behind the popover;
       // propagation only, so the input still receives the key natively.
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
       event.stopPropagation();
     },
-    [
-      activeWorktreeId,
-      closeLauncher,
-      cwd,
-      isFiltering,
-      onLaunchAgent,
-      recipeContext,
-      results,
-      selectedIndex,
-      selectNext,
-      selectPrevious,
-      updateQuery,
-      setSelectedIndex,
-    ]
+    [activateRow, results, selectedIndex, selectNext, selectPrevious, setSelectedIndex]
   );
 
   return (
-    <DropdownMenu open={open} onOpenChange={handleOpenChange}>
+    <Popover
+      open={open}
+      onOpenChange={handleOpenChange}
+      // The DropdownMenu this replaced was modal, and the launcher relies on
+      // that: focus stays trapped so Tab cycles input → results instead of
+      // escaping to the dock behind it, and the first outside click is spent
+      // dismissing rather than also activating what it landed on.
+      modal={true}
+    >
       <Tooltip
         open={tooltipOpen}
         onOpenChange={(nextOpen) => {
@@ -238,7 +263,7 @@ export function DockLaunchButton({
         }}
       >
         <TooltipTrigger asChild>
-          <DropdownMenuTrigger asChild>
+          <PopoverTrigger asChild>
             <Button
               type="button"
               variant="pill"
@@ -251,95 +276,210 @@ export function DockLaunchButton({
             >
               <Plus className="w-3.5 h-3.5" />
             </Button>
-          </DropdownMenuTrigger>
+          </PopoverTrigger>
         </TooltipTrigger>
         <TooltipContent side="top">Open launcher</TooltipContent>
       </Tooltip>
-      <DropdownMenuContent
+      <PopoverContent
         side="top"
         align="start"
         sideOffset={4}
-        className="min-w-[16rem]"
+        className="w-[22rem] p-0"
+        onOpenAutoFocus={(event) => {
+          // Radix would otherwise focus the content wrapper; the search box is
+          // what the user is about to type into.
+          event.preventDefault();
+          focusInput();
+        }}
         onPointerDownOutside={() => {
           wasPointerCloseRef.current = true;
         }}
-        onEscapeKeyDown={(e) => {
+        onEscapeKeyDown={(event) => {
           // The dismissable layer listens on document with capture, so a
-          // stopPropagation from the input would be too late. Block the close
-          // here for the first Escape; the input clears the query.
-          if (queryRef.current.trim().length > 0) e.preventDefault();
+          // stopPropagation from the input would be too late. Spend the first
+          // Escape clearing the query and block the close here — whitespace
+          // alone doesn't filter, so it must not cost the user a press.
+          if (queryRef.current.trim().length > 0) {
+            event.preventDefault();
+            updateQuery("");
+          }
         }}
-        onCloseAutoFocus={(e) => {
+        onCloseAutoFocus={(event) => {
           setTooltipOpen(false);
           isRestoringFocusRef.current = true;
           if (wasPointerCloseRef.current) {
-            e.preventDefault();
+            event.preventDefault();
             wasPointerCloseRef.current = false;
           }
         }}
       >
         <div
-          className="flex items-center gap-2 px-2 pb-1.5"
-          // The icon, the gap and the padding are click targets that aren't the
-          // input, and Radix's focus scope wrapper is tabIndex={-1}, so clicking
-          // one parks focus on the menu content: typing then feeds Radix's
-          // typeahead and Escape dead-ends (the content vetoes the close while
-          // only the input clears the query). The input's own mousedown is left
-          // untouched so caret placement and drag-select still work.
-          onMouseDown={(e) => {
-            if (e.target === inputRef.current) return;
-            e.preventDefault();
-            inputRef.current?.focus({ preventScroll: true });
+          data-testid="dock-launcher-search-row"
+          // The header padding around the input is a click target that isn't
+          // the input, and Radix's focus scope wrapper is tabIndex={-1}, so
+          // clicking it parks focus on the content: Escape then dead-ends (the
+          // content vetoes the close while only the input clears the query).
+          // The input's own mousedown is left untouched so caret placement and
+          // drag-select still work.
+          onMouseDown={(event) => {
+            if (event.target === inputRef.current) return;
+            event.preventDefault();
+            focusInput();
           }}
         >
-          <Search className="w-3.5 h-3.5 shrink-0 text-text-muted" aria-hidden="true" />
-          <input
-            ref={inputRef}
-            type="text"
-            role="searchbox"
-            value={query}
-            onChange={(e) => updateQuery(e.target.value)}
-            onKeyDownCapture={handleKeyDownCapture}
-            placeholder="Search agents, panels, and recipes"
-            aria-label="Search agents, panels, and recipes"
-            aria-controls={listboxId}
-            aria-activedescendant={
-              isFiltering && results[selectedIndex]
-                ? `${listboxId}-${results[selectedIndex]!.key}`
-                : undefined
-            }
-            autoComplete="off"
-            spellCheck={false}
-            // The focus indicator is deliberately neutral: the selected result
-            // row owns this region's single accent anchor, so an accent ring
-            // here would be a competing signal. The hidden-outline utility is
-            // used rather than the outline-suppressing one so a real outline
-            // survives in forced-colors mode.
-            className="w-full bg-transparent text-sm text-daintree-text placeholder:text-text-muted border-none outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-border"
-          />
+          <AppPaletteDialog.Header label="Launch">
+            <AppPaletteDialog.Input
+              inputRef={inputRef}
+              value={query}
+              onChange={(e) => updateQuery(e.target.value)}
+              onKeyDownCapture={handleNavigationKeyDown}
+              placeholder="Search agents, panels, and recipes"
+              role="combobox"
+              aria-expanded={true}
+              aria-haspopup="listbox"
+              aria-label="Search agents, panels, and recipes"
+              aria-controls={listboxId}
+              aria-activedescendant={activeDescendant}
+              autoComplete="off"
+              spellCheck={false}
+              // The focus indicator is deliberately neutral: the selected row
+              // owns this region's single accent anchor, and the input holds
+              // focus the whole time the launcher is open, so an accent ring
+              // here would be a permanently competing signal.
+              className="focus:border-daintree-border focus:ring-daintree-border/30"
+            />
+          </AppPaletteDialog.Header>
         </div>
-        <DropdownMenuSeparator />
-        <div id={listboxId}>
-          <DockLaunchMenuItems
-            components={DROPDOWN_COMPONENTS}
-            agents={agents}
-            pinnedCount={pinnedCount}
-            activeWorktreeId={activeWorktreeId}
-            cwd={cwd}
-            recipeContext={recipeContext}
-            onLaunchAgent={onLaunchAgent}
-            surface="dock"
-            model={model}
-            search={{
-              query,
-              results,
-              selectedIndex,
-              getOptionId: (key) => `${listboxId}-${key}`,
-              onHoverIndex: setSelectedIndex,
-            }}
-          />
+
+        <AppPaletteDialog.Body
+          ariaLabel="Launcher results"
+          activeDescendant={activeDescendant}
+          onNavigationKeyDown={handleNavigationKeyDown}
+        >
+          {results.length === 0 ? (
+            <AppPaletteDialog.Empty query={query} emptyMessage="Nothing to launch" />
+          ) : (
+            <div id={listboxId} role="listbox" aria-label="Launcher results">
+              {results.map((row, index) => (
+                <DockLaunchOption
+                  key={row.rowKey}
+                  row={row}
+                  index={index}
+                  isSelected={index === selectedIndex}
+                  showBandLabel={row.band !== results[index - 1]?.band}
+                  optionId={getOptionId(row.rowKey)}
+                  onHover={setSelectedIndex}
+                  onActivate={activateRow}
+                />
+              ))}
+            </div>
+          )}
+        </AppPaletteDialog.Body>
+
+        <AppPaletteDialog.Footer />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+interface DockLaunchOptionProps {
+  row: DockLaunchRow;
+  index: number;
+  isSelected: boolean;
+  showBandLabel: boolean;
+  optionId: string;
+  onHover: (index: number) => void;
+  onActivate: (row: DockLaunchRow) => void;
+}
+
+function DockLaunchOption({
+  row,
+  index,
+  isSelected,
+  showBandLabel,
+  optionId,
+  onHover,
+  onActivate,
+}: DockLaunchOptionProps) {
+  const { item } = row;
+  // A filtered row must carry the same warnings as its unfiltered twin: a
+  // blocked agent that silently opens Settings, or a shadowed recipe that
+  // resolves to a different winner, is worse when the row looks ordinary.
+  const unavailableAgent =
+    item?.category === "agent" && !isAgentLaunchable(item.agent.availability) ? item : null;
+  const isDimmed = unavailableAgent !== null || (item?.category === "recipe" && item.isShadowed);
+  const title = unavailableAgent
+    ? isAgentBlocked(unavailableAgent.agent.availability)
+      ? `${unavailableAgent.name} is blocked by endpoint security. Click to configure.`
+      : `${unavailableAgent.name} needs setup. Click to configure.`
+    : undefined;
+
+  return (
+    <>
+      {showBandLabel && (
+        <div
+          // Decorative inside the listbox — the band is conveyed by the row's
+          // own trailing label, and an extra child would break option counting.
+          aria-hidden="true"
+          data-testid="dock-launcher-band"
+          className="px-2 pt-2 pb-1 text-[11px] text-text-muted select-none first:pt-0"
+        >
+          {DOCK_LAUNCH_BAND_LABELS[row.band]}
         </div>
-      </DropdownMenuContent>
-    </DropdownMenu>
+      )}
+      <button
+        type="button"
+        id={optionId}
+        role="option"
+        aria-selected={isSelected}
+        tabIndex={-1}
+        title={title}
+        // Keeps DOM focus on the search box when a row is clicked or hovered,
+        // so typing never lands anywhere else.
+        onPointerDown={(event) => event.preventDefault()}
+        onPointerEnter={() => onHover(index)}
+        onClick={() => onActivate(row)}
+        className={cn(
+          "relative w-full flex items-center px-2 py-1.5 rounded-[var(--radius-md)] text-left text-sm transition-colors",
+          isDimmed && "opacity-70",
+          isSelected
+            ? "bg-overlay-raised before:absolute before:left-0 before:top-1 before:bottom-1 before:w-[2px] before:bg-daintree-accent before:content-['']"
+            : "hover:bg-overlay-subtle"
+        )}
+      >
+        <DockLaunchOptionIcon row={row} />
+        <span className="truncate">{item ? item.name : "Create a recipe"}</span>
+        {item && (
+          <span className="ml-auto pl-2 text-[11px] text-text-muted shrink-0">
+            {item.category === "panel"
+              ? item.location === "dock"
+                ? "Dock"
+                : "Grid"
+              : item.category === "recipe"
+                ? item.isShadowed
+                  ? `${item.scopeLabel} · Overridden by Team`
+                  : item.scopeLabel
+                : "Agent"}
+          </span>
+        )}
+      </button>
+    </>
+  );
+}
+
+function DockLaunchOptionIcon({ row }: { row: DockLaunchRow }) {
+  const { item } = row;
+  if (!item || item.category === "recipe") {
+    return <Workflow className="w-3.5 h-3.5 mr-2 shrink-0" />;
+  }
+  if (item.category === "panel") {
+    return <PanelKindIcon iconId={item.iconId} color={item.color} size={14} className="mr-2" />;
+  }
+  return item.agent.icon ? (
+    <BrandMark brandColor={item.agent.brandColor} className="w-3.5 h-3.5 mr-2">
+      <item.agent.icon className="w-3.5 h-3.5" brandColor={item.agent.brandColor} />
+    </BrandMark>
+  ) : (
+    <SquareTerminal className="w-3.5 h-3.5 mr-2 shrink-0" />
   );
 }

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { AppPaletteDialog } from "@/components/ui/AppPaletteDialog";
+import { PALETTE_ROW_CLASS } from "@/components/ui/paletteRowStyles";
 import { BrandMark, Workflow } from "@/components/icons";
 import { PanelKindIcon } from "@/components/PanelPalette/PanelKindIcon";
 import { cn } from "@/lib/utils";
@@ -502,11 +503,10 @@ function DockLaunchOption({
         onPointerEnter={() => onHover(index)}
         onClick={() => onActivate(row)}
         className={cn(
-          "relative w-full flex items-center px-2 py-1.5 rounded-[var(--radius-md)] text-left text-sm transition-colors",
-          isDimmed && "opacity-70",
-          isSelected
-            ? "bg-overlay-raised before:absolute before:left-0 before:top-1 before:bottom-1 before:w-[2px] before:bg-daintree-accent before:content-['']"
-            : "hover:bg-overlay-subtle"
+          PALETTE_ROW_CLASS,
+          "relative w-full flex items-center px-2 py-1.5 rounded-[var(--radius-md)] text-left text-sm",
+          "hover:bg-overlay-subtle",
+          isDimmed && "opacity-70"
         )}
       >
         <DockLaunchOptionIcon row={row} />

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -121,11 +121,27 @@ export function DockLaunchButton({
     (next: string) => {
       queryRef.current = next;
       setQuery(next);
+      // Deliberately NOT resetting the selection here: the hook's own effect
+      // reconciles it, and calling its setter with the pre-query results would
+      // stamp the old list's first row as the item to follow — after which the
+      // effect chases that row into the new results instead of settling on the
+      // top match. `activeIndex` below covers the frame before it lands.
     },
     [setQuery]
   );
 
-  const selectedRow = results[selectedIndex];
+  // The hook reconciles `selectedIndex` in an effect, so the render right after
+  // the results change still holds the old index — which browsing can now leave
+  // well past the end of a narrowed list, where the old menu always left it at
+  // 0. Fall back to the top row (not the last) so this frame agrees with where
+  // that effect settles; unhandled, it highlights nothing and Enter no-ops.
+  const activeIndex =
+    selectedIndex >= 0 && selectedIndex < results.length
+      ? selectedIndex
+      : results.length > 0
+        ? 0
+        : -1;
+  const selectedRow = activeIndex >= 0 ? results[activeIndex] : undefined;
   const activeDescendant = selectedRow ? getOptionId(selectedRow.rowKey) : undefined;
 
   const focusInput = useCallback(() => {
@@ -225,12 +241,11 @@ export function DockLaunchButton({
         return;
       }
       if (event.key === "Enter") {
-        // No row (or an out-of-range index): swallow the key rather than
-        // letting it escape to whatever is behind the launcher.
+        // No rows at all: swallow the key rather than letting it escape to
+        // whatever is behind the launcher.
         event.preventDefault();
         event.stopPropagation();
-        const row = results[selectedIndex];
-        if (row) activateRow(row);
+        if (selectedRow) activateRow(selectedRow);
         return;
       }
 
@@ -242,7 +257,7 @@ export function DockLaunchButton({
       if (event.metaKey || event.ctrlKey || event.altKey) return;
       event.stopPropagation();
     },
-    [activateRow, results, selectedIndex, selectNext, selectPrevious, setSelectedIndex]
+    [activateRow, results.length, selectedRow, selectNext, selectPrevious, setSelectedIndex]
   );
 
   return (
@@ -291,6 +306,18 @@ export function DockLaunchButton({
           event.preventDefault();
           focusInput();
         }}
+        onFocus={(event) => {
+          // A focus trap hauls focus back to the content wrapper whenever
+          // something outside steals it — a panel launched moments ago
+          // re-focusing itself on its own frame, say. The wrapper is
+          // tabIndex={-1} and owns no keys, so leaving focus parked there makes
+          // the next keystroke vanish; hand it to the search box instead.
+          if (event.target === event.currentTarget) focusInput();
+        }}
+        // Catch-all behind the input's own handler, for the frame before the
+        // refocus above lands and for focus legitimately sitting on the results
+        // region. Bubble phase, so the input and body still get first refusal.
+        onKeyDown={handleNavigationKeyDown}
         onPointerDownOutside={() => {
           wasPointerCloseRef.current = true;
         }}
@@ -365,7 +392,7 @@ export function DockLaunchButton({
                   key={row.rowKey}
                   row={row}
                   index={index}
-                  isSelected={index === selectedIndex}
+                  isSelected={index === activeIndex}
                   showBandLabel={row.band !== results[index - 1]?.band}
                   optionId={getOptionId(row.rowKey)}
                   onHover={setSelectedIndex}

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -159,6 +159,25 @@ export function DockLaunchButton({
     return () => cancelAnimationFrame(frame);
   }, [open, focusInput]);
 
+  // Re-anchor the selection each time the launcher opens. Closing only clears
+  // the query, so the hook's follow-anchor still points wherever browsing
+  // ended, while the reopened popover mounts its scroller at the top and the
+  // active row keeps its id — so the scroll effect below never re-runs and
+  // Enter launches a row that was never on screen.
+  //
+  // In an effect rather than the open handler: the Recently launched band is
+  // rebuilt from MRU that can change while the launcher is closed without
+  // re-rendering it, so the handler's closure would anchor a row the opening
+  // render is about to displace. Gated on the transition because
+  // `setSelectedIndex` takes a new identity every render (the hook's results
+  // memo keys on an inline `getItemId`), and resetting on each of those would
+  // undo the deliberate follow-the-selection behaviour while typing.
+  const wasOpenRef = useRef(false);
+  useEffect(() => {
+    if (open && !wasOpenRef.current) setSelectedIndex(0);
+    wasOpenRef.current = open;
+  }, [open, setSelectedIndex]);
+
   // Keep the active option in view as the selection moves. `getElementById`
   // rather than a `#id` query: both `useId()` and the item keys contain colons,
   // which are illegal in a CSS id selector.
@@ -180,21 +199,13 @@ export function DockLaunchButton({
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {
       if (nextOpen) {
-        // The palette hook follows the selected row across result changes, and
-        // closing only resets the query — so the anchor still points wherever
-        // browsing ended. A reopened popover mounts its scroller at the top and
-        // the active row never changes id, so the scroll effect below won't
-        // re-run: without this the highlight sits offscreen and Enter launches
-        // a row the user can't see. Re-anchoring to the top row is enough; the
-        // hook re-follows from there once the user types.
-        setSelectedIndex(0);
         setOpen(true);
         setTooltipOpen(false);
       } else {
         closeLauncher();
       }
     },
-    [closeLauncher, setSelectedIndex]
+    [closeLauncher]
   );
 
   const activateRow = useCallback(

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -180,13 +180,21 @@ export function DockLaunchButton({
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {
       if (nextOpen) {
+        // The palette hook follows the selected row across result changes, and
+        // closing only resets the query — so the anchor still points wherever
+        // browsing ended. A reopened popover mounts its scroller at the top and
+        // the active row never changes id, so the scroll effect below won't
+        // re-run: without this the highlight sits offscreen and Enter launches
+        // a row the user can't see. Re-anchoring to the top row is enough; the
+        // hook re-follows from there once the user types.
+        setSelectedIndex(0);
         setOpen(true);
         setTooltipOpen(false);
       } else {
         closeLauncher();
       }
     },
-    [closeLauncher]
+    [closeLauncher, setSelectedIndex]
   );
 
   const activateRow = useCallback(
@@ -300,6 +308,11 @@ export function DockLaunchButton({
         align="start"
         sideOffset={4}
         className="w-[22rem] p-0"
+        // Radix renders this as role="dialog". Without a name a screen reader
+        // announces a generic dialog before reaching the combobox; match the
+        // visible header so speech control can target it by the word on screen.
+        aria-label="Launch"
+        aria-modal={true}
         onOpenAutoFocus={(event) => {
           // Radix would otherwise focus the content wrapper; the search box is
           // what the user is about to type into.
@@ -322,6 +335,14 @@ export function DockLaunchButton({
           wasPointerCloseRef.current = true;
         }}
         onEscapeKeyDown={(event) => {
+          // This document-capture listener runs ahead of the input's own
+          // composition guard, so the IME check has to be repeated: mid-
+          // composition Escape belongs to the candidate window, and letting it
+          // through would wipe the query or close the launcher underneath it.
+          if (event.isComposing || event.keyCode === 229) {
+            event.preventDefault();
+            return;
+          }
           // The dismissable layer listens on document with capture, so a
           // stopPropagation from the input would be too late. Spend the first
           // Escape clearing the query and block the close here — whitespace
@@ -362,10 +383,13 @@ export function DockLaunchButton({
               onKeyDownCapture={handleNavigationKeyDown}
               placeholder="Search agents, panels, and recipes"
               role="combobox"
-              aria-expanded={true}
+              // The listbox only exists when something matched, so claiming it
+              // is expanded — or pointing aria-controls at an unrendered id —
+              // would leave the combobox describing a popup that isn't there.
+              aria-expanded={results.length > 0}
               aria-haspopup="listbox"
               aria-label="Search agents, panels, and recipes"
-              aria-controls={listboxId}
+              aria-controls={results.length > 0 ? listboxId : undefined}
               aria-activedescendant={activeDescendant}
               autoComplete="off"
               spellCheck={false}

--- a/src/components/Layout/DockLaunchMenuItems.tsx
+++ b/src/components/Layout/DockLaunchMenuItems.tsx
@@ -4,16 +4,14 @@ import { SquareTerminal } from "lucide-react";
 import { BrandMark, Workflow } from "@/components/icons";
 import { PanelKindIcon } from "@/components/PanelPalette/PanelKindIcon";
 import type { RecipeContext } from "@/utils/recipeVariables";
-import { actionService } from "@/services/ActionService";
-import { cn } from "@/lib/utils";
 import type { ActionSource } from "@shared/types";
 import { isAgentBlocked, isAgentLaunchable } from "@shared/utils/agentAvailability";
 import {
+  activateCreateRecipeCue,
   activateDockLaunchItem,
   useDockLaunchModel,
   type DockLaunchAgent,
   type DockLaunchItem,
-  type DockLaunchModel,
   type DockLaunchPanelItem,
   type DockLaunchRecipeItem,
   type DockLaunchSurface,
@@ -27,20 +25,6 @@ export interface DockLaunchMenuComponents {
   Item: MenuComponent;
   Label: MenuComponent;
   Separator: MenuComponent;
-}
-
-/**
- * Search state owned by the `+` dropdown. Absent for the dock's right-click
- * context menu, where a text input doesn't belong — the item set is shared, the
- * search field is not.
- */
-export interface DockLaunchSearchState {
-  query: string;
-  results: ReadonlyArray<DockLaunchItem>;
-  selectedIndex: number;
-  /** DOM id for a result row, so the input can point `aria-activedescendant` at it. */
-  getOptionId: (key: string) => string;
-  onHoverIndex: (index: number) => void;
 }
 
 interface DockLaunchMenuItemsProps {
@@ -69,15 +53,14 @@ interface DockLaunchMenuItemsProps {
    * the grid, so it must not offer a dock destination it won't honour.
    */
   surface: DockLaunchSurface;
-  search?: DockLaunchSearchState;
-  /**
-   * Model built by the caller. The `+` dropdown already derives one to feed its
-   * search index and passes it down so both halves render from one snapshot;
-   * the context menu omits it and the component derives its own.
-   */
-  model?: DockLaunchModel;
 }
 
+/**
+ * The banded launcher list rendered through a caller-supplied menu primitive.
+ * Both right-click context menus (the dock's and the grid's) use it; the `+`
+ * launcher renders its own searchable palette rows instead, because a
+ * `role="option"` row and a Radix menu item have incompatible contracts.
+ */
 export function DockLaunchMenuItems({
   components: C,
   agents,
@@ -88,11 +71,8 @@ export function DockLaunchMenuItems({
   pinnedCount,
   settingsSource = "menu",
   surface,
-  search,
-  model: providedModel,
 }: DockLaunchMenuItemsProps) {
-  const derivedModel = useDockLaunchModel({ agents, pinnedCount, activeWorktreeId, surface });
-  const model = providedModel ?? derivedModel;
+  const model = useDockLaunchModel({ agents, pinnedCount, activeWorktreeId, surface });
 
   const activate = (item: DockLaunchItem) =>
     activateDockLaunchItem(item, {
@@ -152,116 +132,14 @@ export function DockLaunchMenuItems({
     </C.Item>
   );
 
-  // First-run discovery cue: route into recipes instead of hiding the section,
-  // so users who have never made one can find their way in. With an active
-  // worktree, open the editor scoped to it; without one (the common first-run
-  // case), fall back to the manager — the editor's event handler hard-requires
-  // a string worktreeId and silently no-ops on undefined, so dispatching the
-  // editor here would do nothing. Both actions are danger:"safe" and MRU-eligible.
   const renderCreateRecipeCue = () => (
-    <C.Item
-      onSelect={() => {
-        if (activeWorktreeId) {
-          void actionService.dispatch(
-            "recipe.editor.open",
-            { worktreeId: activeWorktreeId },
-            { source: settingsSource }
-          );
-        } else {
-          void actionService.dispatch("recipe.manager.open", {}, { source: settingsSource });
-        }
-      }}
-    >
+    <C.Item onSelect={() => activateCreateRecipeCue(activeWorktreeId, settingsSource)}>
       <Workflow className="w-3.5 h-3.5 mr-2" />
       Create a recipe
     </C.Item>
   );
 
-  const isFiltering = search !== undefined && search.query.trim().length > 0;
   const isSplitByDestination = model.dockPanels.length > 0 && model.gridPanels.length > 0;
-
-  if (isFiltering) {
-    if (search.results.length === 0) {
-      return (
-        <>
-          <C.Label>Search results</C.Label>
-          <C.Item disabled>Try a different search</C.Item>
-        </>
-      );
-    }
-
-    return (
-      <>
-        <C.Label>Search results</C.Label>
-        {search.results.map((item, index) => {
-          const isSelected = index === search.selectedIndex;
-          // A filtered row must carry the same warnings as its unfiltered twin:
-          // a blocked agent that silently opens Settings, or a shadowed recipe
-          // that resolves to a different winner, is worse when the row looks
-          // ordinary.
-          const isDimmed =
-            item.category === "agent"
-              ? !isAgentLaunchable(item.agent.availability)
-              : item.category === "recipe" && item.isShadowed;
-          const rowTitle =
-            item.category === "agent" && !isAgentLaunchable(item.agent.availability)
-              ? isAgentBlocked(item.agent.availability)
-                ? `${item.name} is blocked by endpoint security. Click to configure.`
-                : `${item.name} needs setup. Click to configure.`
-              : undefined;
-          return (
-            <C.Item
-              key={item.key}
-              id={search.getOptionId(item.key)}
-              title={rowTitle}
-              data-selected-row={isSelected ? "true" : "false"}
-              // Radix focuses a menu item on pointer move unless the event is
-              // prevented, which would yank DOM focus off the search input the
-              // moment the pointer crosses a row. Keep focus on the input and
-              // mirror the hover into the visual selection instead.
-              onPointerMove={(event: React.PointerEvent) => {
-                event.preventDefault();
-                search.onHoverIndex(index);
-              }}
-              className={cn(
-                "relative",
-                isDimmed && "opacity-70",
-                isSelected &&
-                  "bg-overlay-raised before:absolute before:left-0 before:top-1 before:bottom-1 before:w-[2px] before:bg-daintree-accent before:content-['']"
-              )}
-              onSelect={() => activate(item)}
-            >
-              {item.category === "agent" ? (
-                item.agent.icon ? (
-                  <BrandMark brandColor={item.agent.brandColor} className="w-3.5 h-3.5 mr-2">
-                    <item.agent.icon className="w-3.5 h-3.5" brandColor={item.agent.brandColor} />
-                  </BrandMark>
-                ) : (
-                  <SquareTerminal className="w-3.5 h-3.5 mr-2" />
-                )
-              ) : item.category === "panel" ? (
-                <PanelKindIcon iconId={item.iconId} color={item.color} size={14} className="mr-2" />
-              ) : (
-                <Workflow className="w-3.5 h-3.5 mr-2 shrink-0" />
-              )}
-              <span className="truncate">{item.name}</span>
-              <span className="ml-auto pl-2 text-[11px] text-text-muted shrink-0">
-                {item.category === "panel"
-                  ? item.location === "dock"
-                    ? "Dock"
-                    : "Grid"
-                  : item.category === "recipe"
-                    ? item.isShadowed
-                      ? `${item.scopeLabel} · Overridden by Team`
-                      : item.scopeLabel
-                    : "Agent"}
-              </span>
-            </C.Item>
-          );
-        })}
-      </>
-    );
-  }
 
   return (
     <>

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -451,14 +451,14 @@ describe("DockLaunchButton", () => {
       expect(queryByText("Claude")).toBeNull();
     });
 
-    it("dims a blocked agent in the results and keeps its setup tooltip", () => {
+    it("explains a blocked agent in the results with its setup tooltip", () => {
       // A filtered row that looks ordinary but silently opens Settings is worse
-      // than the unfiltered one, which dims and explains itself.
+      // than the unfiltered one, which explains itself before you click. The
+      // dimming that accompanies it is styling, so it isn't asserted here.
       const { container, getByText } = renderButton();
       fireEvent.change(searchInput(container), { target: { value: "gemini" } });
 
       const row = getByText("Gemini").closest("button");
-      expect(row?.className).toContain("opacity-70");
       expect(row?.getAttribute("title")).toContain("blocked by endpoint security");
     });
 
@@ -491,6 +491,23 @@ describe("DockLaunchButton", () => {
       fireEvent.change(input, { target: { value: "e" } });
       expect(input.getAttribute("aria-activedescendant")).toBe(selectedOption(container)?.id);
       expect(input.getAttribute("aria-activedescendant")).toBeTruthy();
+    });
+
+    it("stops advertising a listbox once nothing matches", () => {
+      // The listbox is only rendered alongside results, so an unconditional
+      // expanded/controls pair leaves the combobox naming an element that isn't
+      // in the document — a dangling IDREF a screen reader can't resolve.
+      const { container } = renderButton();
+      const input = searchInput(container);
+
+      expect(input.getAttribute("aria-expanded")).toBe("true");
+      expect(document.getElementById(input.getAttribute("aria-controls")!)).not.toBeNull();
+
+      fireEvent.change(input, { target: { value: "zzqqxxvv" } });
+
+      expect(options(container)).toHaveLength(0);
+      expect(input.getAttribute("aria-expanded")).toBe("false");
+      expect(input.getAttribute("aria-controls")).toBeNull();
     });
 
     it("snaps the selection back to the top result on every query change", () => {
@@ -1149,6 +1166,26 @@ describe("DockLaunchButton", () => {
 
       fireEvent.change(input, { target: { value: "" } });
       expect(getByText("Recently launched")).toBeTruthy();
+    });
+
+    it("re-anchors the selection to the top row on reopen", () => {
+      // Closing only clears the query, so the hook's follow-anchor still points
+      // at wherever browsing ended. A reopened popover mounts its scroller at
+      // the top and the active row keeps its id, so the scroll effect never
+      // re-runs — leaving the highlight offscreen while Enter still launches
+      // the row the user walked to in the previous session.
+      const { container } = renderButton({ agents: MANY });
+      const input = searchInput(container);
+
+      fireEvent.keyDown(input, { key: "End" });
+      const before = options(container);
+      expect(selectedOption(container)).toBe(before[before.length - 1]);
+
+      act(() => popoverOpenChangeSpy!(false));
+      act(() => popoverOpenChangeSpy!(true));
+
+      expect(selectedOption(container)).toBe(options(container)[0]);
+      expect(container.querySelectorAll(SELECTED_OPTION)).toHaveLength(1);
     });
   });
 });

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -129,18 +129,33 @@ vi.mock("@/components/ui/popover", () => ({
     onCloseAutoFocus,
     onPointerDownOutside,
     onEscapeKeyDown,
+    onFocus,
+    onKeyDown,
   }: {
     children: ReactNode;
     onOpenAutoFocus?: (e: { preventDefault: () => void }) => void;
     onCloseAutoFocus?: (e: { preventDefault: () => void }) => void;
     onPointerDownOutside?: () => void;
     onEscapeKeyDown?: (e: { preventDefault: () => void }) => void;
+    onFocus?: React.FocusEventHandler<HTMLDivElement>;
+    onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
   }) => {
     popoverOpenAutoFocusSpy = onOpenAutoFocus ?? null;
     popoverCloseAutoFocusSpy = onCloseAutoFocus ?? null;
     popoverPointerDownOutsideSpy = onPointerDownOutside ?? null;
     popoverEscapeKeyDownSpy = onEscapeKeyDown ?? null;
-    return <div data-testid="dock-launcher-content">{children}</div>;
+    // Radix renders FocusScope/DismissableLayer with asChild, so these land on
+    // the same node the focus trap parks focus on. tabIndex mirrors that.
+    return (
+      <div
+        data-testid="dock-launcher-content"
+        tabIndex={-1}
+        onFocus={onFocus}
+        onKeyDown={onKeyDown}
+      >
+        {children}
+      </div>
+    );
   },
 }));
 
@@ -478,6 +493,40 @@ describe("DockLaunchButton", () => {
       expect(input.getAttribute("aria-activedescendant")).toBeTruthy();
     });
 
+    it("snaps the selection back to the top result on every query change", () => {
+      // The hook reconciles selectedIndex in an effect, a frame behind. Left to
+      // it, the render right after a query change still holds the old index —
+      // highlighting nothing when it points past the narrowed list, or the
+      // wrong row when it happens to stay in range. Neither was reachable
+      // before browsing carried a selection of its own.
+      const { container } = renderButton();
+      const input = searchInput(container);
+
+      // Walk to the end of the browse list, then narrow.
+      fireEvent.keyDown(input, { key: "End" });
+      expect(container.querySelectorAll(SELECTED_OPTION)).toHaveLength(1);
+
+      fireEvent.change(input, { target: { value: "e" } });
+      const rows = options(container);
+      expect(rows.length).toBeGreaterThan(1);
+      expect(selectedOption(container)).toBe(rows[0]);
+      expect(input.getAttribute("aria-activedescendant")).toBe(rows[0]!.id);
+    });
+
+    it("Enter launches the top result after narrowing from deep in the browse list", () => {
+      // Type-then-confirm in quick succession must fire on the row the user is
+      // looking at, not on wherever the previous selection happened to sit.
+      const onLaunchAgent = vi.fn();
+      const { container } = renderButton({ onLaunchAgent });
+      const input = searchInput(container);
+
+      fireEvent.keyDown(input, { key: "End" });
+      fireEvent.change(input, { target: { value: "claude" } });
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(onLaunchAgent).toHaveBeenCalledWith("claude");
+    });
+
     it("Enter launches the top result", () => {
       const onLaunchAgent = vi.fn();
       const { container } = renderButton({ onLaunchAgent });
@@ -713,6 +762,46 @@ describe("DockLaunchButton", () => {
       // The focus is deferred a frame, so poll rather than racing it — a frame
       // awaited here would be scheduled before the effect's own.
       await waitFor(() => expect(document.activeElement).toBe(searchInput(container)));
+    });
+
+    it("hands focus back to the input when the focus trap parks it on the content", () => {
+      // The modal FocusScope hauls focus onto the tabIndex={-1} content wrapper
+      // whenever anything outside steals it. Left there, the wrapper owns no
+      // keys and the next keystroke disappears.
+      const { container, getByTestId } = renderButton();
+      const content = getByTestId("dock-launcher-content");
+
+      searchInput(container).blur();
+      fireEvent.focus(content);
+
+      expect(document.activeElement).toBe(searchInput(container));
+    });
+
+    it("still navigates when a key arrives with focus on the content", () => {
+      // Covers the frame before the refocus above lands: the catch-all handler
+      // on the content means Enter can never silently do nothing.
+      const onLaunchAgent = vi.fn();
+      const { container, getByTestId } = renderButton({ onLaunchAgent });
+      const content = getByTestId("dock-launcher-content");
+
+      const rows = options(container);
+      fireEvent.keyDown(content, { key: "ArrowDown" });
+      expect(selectedOption(container)).toBe(rows[1]);
+
+      // Back to Claude, the one launchable agent in this fixture.
+      fireEvent.keyDown(content, { key: "Home" });
+      fireEvent.keyDown(content, { key: "Enter" });
+      expect(onLaunchAgent).toHaveBeenCalledWith("claude");
+    });
+
+    it("does not double-handle a key the input already consumed", () => {
+      // The input's capture handler stops propagation, so the content catch-all
+      // must not move the selection a second time.
+      const { container } = renderButton();
+      const rows = options(container);
+
+      fireEvent.keyDown(searchInput(container), { key: "ArrowDown" });
+      expect(selectedOption(container)).toBe(rows[1]);
     });
 
     it("keeps focus in the input when the header around it is clicked", () => {

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -1156,6 +1156,25 @@ describe("DockLaunchButton", () => {
       expect(getByText("Recently launched")).toBeTruthy();
     });
 
+    it("anchors the reopened selection to a row the recency band inserted while closed", () => {
+      // Same no-re-render MRU update as above, but aimed at the selection: the
+      // open handler's closure still describes the pre-launch rows, so
+      // re-anchoring from there would land on the row the opening render is
+      // about to displace and the hook would then follow it down to index 1.
+      mockMruEntries = [];
+      const { container } = renderButton({ agents: MANY });
+      expect(options(container)[0]?.textContent).not.toContain("Codex");
+
+      mockMruEntries = [{ id: "agent.codex", score: 1, lastAccessedAt: 7000 }];
+
+      act(() => popoverOpenChangeSpy!(false));
+      act(() => popoverOpenChangeSpy!(true));
+
+      const rows = options(container);
+      expect(rows[0]?.textContent).toContain("Codex");
+      expect(selectedOption(container)).toBe(rows[0]);
+    });
+
     it("survives an unfiltered reopen after a search is cleared", () => {
       mockMruEntries = [{ id: "agent.codex", score: 3, lastAccessedAt: 3000 }];
       const { container, queryByText, getByText } = renderButton({ agents: MANY });

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -22,10 +22,12 @@ const notifySpawnFailuresMock = vi.fn();
 const actionDispatchMock = vi.fn();
 const recordActionMruMock = vi.fn();
 const addPanelMock = vi.fn();
-let dropdownCloseAutoFocusSpy: ((e: { preventDefault: () => void }) => void) | null = null;
-let dropdownPointerDownOutsideSpy: (() => void) | null = null;
-let dropdownEscapeKeyDownSpy: ((e: { preventDefault: () => void }) => void) | null = null;
-let dropdownOpenChangeSpy: ((open: boolean) => void) | null = null;
+let popoverCloseAutoFocusSpy: ((e: { preventDefault: () => void }) => void) | null = null;
+let popoverPointerDownOutsideSpy: (() => void) | null = null;
+let popoverEscapeKeyDownSpy: ((e: { preventDefault: () => void }) => void) | null = null;
+let popoverOpenAutoFocusSpy: ((e: { preventDefault: () => void }) => void) | null = null;
+let popoverOpenChangeSpy: ((open: boolean) => void) | null = null;
+let popoverModal: boolean | undefined = undefined;
 
 // See dockLaunchItems.test.ts — avoid the real registry's eager TerminalPane import.
 vi.mock("@/registry", () => ({
@@ -90,8 +92,9 @@ vi.mock("@/services/ActionService", () => ({
 
 // Mock UI primitives so the test focuses on this component's behavior, not
 // Radix's pointer-event semantics inside jsdom. Mirrors AgentButton.test.tsx.
-// Radix's real focus/dismiss behaviour (pointer-move focus steal, document-level
-// Escape capture) is covered by e2e/full/panels/core-dock-launcher-search.spec.ts.
+// Radix's real focus/dismiss behaviour (mount autofocus winning the lazy-chunk
+// race, document-level Escape capture, the modal focus trap) is covered by
+// e2e/full/panels/core-dock-launcher-search.spec.ts.
 vi.mock("@/components/ui/tooltip", () => ({
   Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
   TooltipContent: ({ children }: { children: ReactNode }) => (
@@ -101,75 +104,86 @@ vi.mock("@/components/ui/tooltip", () => ({
   TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
-vi.mock("@/components/ui/dropdown-menu", () => ({
+vi.mock("@/components/ui/popover", () => ({
   // Content is rendered unconditionally (not gated on `open`) so the existing
-  // item-level assertions keep working without an open step; open/close is
+  // row-level assertions keep working without an open step; open/close is
   // exercised through the captured onOpenChange.
-  DropdownMenu: ({
+  Popover: ({
     children,
     onOpenChange,
+    modal,
   }: {
     children: ReactNode;
     open?: boolean;
+    modal?: boolean;
     onOpenChange?: (open: boolean) => void;
   }) => {
-    dropdownOpenChangeSpy = onOpenChange ?? null;
+    popoverOpenChangeSpy = onOpenChange ?? null;
+    popoverModal = modal;
     return <>{children}</>;
   },
-  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
-  DropdownMenuContent: ({
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverContent: ({
     children,
+    onOpenAutoFocus,
     onCloseAutoFocus,
     onPointerDownOutside,
     onEscapeKeyDown,
   }: {
     children: ReactNode;
+    onOpenAutoFocus?: (e: { preventDefault: () => void }) => void;
     onCloseAutoFocus?: (e: { preventDefault: () => void }) => void;
     onPointerDownOutside?: () => void;
     onEscapeKeyDown?: (e: { preventDefault: () => void }) => void;
   }) => {
-    dropdownCloseAutoFocusSpy = onCloseAutoFocus ?? null;
-    dropdownPointerDownOutsideSpy = onPointerDownOutside ?? null;
-    dropdownEscapeKeyDownSpy = onEscapeKeyDown ?? null;
+    popoverOpenAutoFocusSpy = onOpenAutoFocus ?? null;
+    popoverCloseAutoFocusSpy = onCloseAutoFocus ?? null;
+    popoverPointerDownOutsideSpy = onPointerDownOutside ?? null;
+    popoverEscapeKeyDownSpy = onEscapeKeyDown ?? null;
     return <div data-testid="dock-launcher-content">{children}</div>;
   },
-  DropdownMenuItem: ({
-    children,
-    onSelect,
-    disabled,
-    title,
-    className,
-    onPointerMove,
-    id,
-    ...rest
-  }: {
-    children: ReactNode;
-    onSelect?: () => void;
-    disabled?: boolean;
-    title?: string;
-    className?: string;
-    onPointerMove?: (e: unknown) => void;
-    id?: string;
-    [key: string]: unknown;
-  }) => (
-    <button
-      type="button"
-      onClick={() => onSelect?.()}
-      disabled={disabled}
-      title={title}
-      className={className}
-      id={id}
-      onPointerMove={onPointerMove}
-      data-selected-row={rest["data-selected-row"] as string | undefined}
-    >
-      {children}
-    </button>
-  ),
-  DropdownMenuLabel: ({ children }: { children: ReactNode }) => (
-    <div data-testid="dock-launcher-label">{children}</div>
-  ),
-  DropdownMenuSeparator: () => <hr data-testid="dock-launcher-separator" />,
 }));
+
+// The palette chrome is a shared, separately-tested surface; stubbing it keeps
+// this suite on the launcher's own wiring and off ScrollShadow's ResizeObserver
+// and the dialog escape-stack. Props are spread through so the input's ARIA and
+// key handling stay under test.
+vi.mock("@/components/ui/AppPaletteDialog", () => {
+  const AppPaletteDialog = {
+    Header: ({ label, children }: { label: string; children: ReactNode }) => (
+      <div data-testid="dock-launcher-header">
+        <span>{label}</span>
+        {children}
+      </div>
+    ),
+    Input: ({
+      inputRef,
+      ...props
+    }: {
+      inputRef?: React.Ref<HTMLInputElement>;
+    } & React.InputHTMLAttributes<HTMLInputElement>) => (
+      <input ref={inputRef} type="text" {...props} />
+    ),
+    Body: ({
+      children,
+      onNavigationKeyDown,
+    }: {
+      children: ReactNode;
+      ariaLabel: string;
+      activeDescendant?: string;
+      onNavigationKeyDown: React.KeyboardEventHandler<HTMLDivElement>;
+    }) => (
+      <div data-testid="dock-launcher-body" onKeyDown={onNavigationKeyDown}>
+        {children}
+      </div>
+    ),
+    Footer: () => <div data-testid="dock-launcher-footer" />,
+    Empty: ({ query }: { query: string }) => (
+      <div data-testid="dock-launcher-empty">{query.trim() ? "no matches" : "nothing"}</div>
+    ),
+  };
+  return { AppPaletteDialog };
+});
 
 import { DockLaunchButton } from "../DockLaunchButton";
 import type { DockLaunchAgent } from "../DockLaunchMenuItems";
@@ -191,12 +205,27 @@ function renderButton(props: Partial<Parameters<typeof DockLaunchButton>[0]> = {
   );
 }
 
+const OPTION = '[role="option"]';
+const SELECTED_OPTION = '[role="option"][aria-selected="true"]';
+
+function options(container: HTMLElement): HTMLButtonElement[] {
+  return Array.from(container.querySelectorAll<HTMLButtonElement>(OPTION));
+}
+
+function selectedOption(container: HTMLElement): HTMLElement | null {
+  return container.querySelector<HTMLElement>(SELECTED_OPTION);
+}
+
 /** The launcher's search box — the only textbox inside the menu. */
 function searchInput(container: HTMLElement): HTMLInputElement {
   const input = container.querySelector("input");
   if (!input) throw new Error("search input not found");
   return input;
 }
+
+// jsdom implements no layout, so it ships no scrollIntoView at all. The
+// launcher scrolls the active option into view on every selection move.
+Element.prototype.scrollIntoView = vi.fn();
 
 beforeEach(() => {
   mockRecipes = [];
@@ -210,10 +239,12 @@ beforeEach(() => {
   actionDispatchMock.mockReset();
   recordActionMruMock.mockReset();
   addPanelMock.mockReset();
-  dropdownCloseAutoFocusSpy = null;
-  dropdownPointerDownOutsideSpy = null;
-  dropdownEscapeKeyDownSpy = null;
-  dropdownOpenChangeSpy = null;
+  popoverCloseAutoFocusSpy = null;
+  popoverPointerDownOutsideSpy = null;
+  popoverEscapeKeyDownSpy = null;
+  popoverOpenAutoFocusSpy = null;
+  popoverOpenChangeSpy = null;
+  popoverModal = undefined;
 });
 
 describe("DockLaunchButton", () => {
@@ -226,14 +257,14 @@ describe("DockLaunchButton", () => {
     mockRecipes = [{ id: "r-1", name: "My recipe", worktreeId: undefined }];
     const { getAllByTestId } = renderButton();
 
-    const labels = getAllByTestId("dock-launcher-label").map((el) => el.textContent);
+    const labels = getAllByTestId("dock-launcher-band").map((el) => el.textContent);
     expect(labels).toEqual(["Launch agent", "Open in dock", "Open in grid", "Launch recipe"]);
   });
 
   it("splits agents into Pinned/Other groups when pinnedCount is a strict subset", () => {
     const { getAllByTestId, container } = renderButton({ pinnedCount: 1 });
 
-    const labels = getAllByTestId("dock-launcher-label").map((el) => el.textContent);
+    const labels = getAllByTestId("dock-launcher-band").map((el) => el.textContent);
     expect(labels.slice(0, 2)).toEqual(["Pinned", "Other"]);
 
     // Assert document order so a regression that puts both agents under one
@@ -246,7 +277,7 @@ describe("DockLaunchButton", () => {
 
   it("keeps a flat Launch agent group when all agents are pinned", () => {
     const { getAllByTestId } = renderButton({ pinnedCount: AGENTS.length });
-    const labels = getAllByTestId("dock-launcher-label").map((el) => el.textContent);
+    const labels = getAllByTestId("dock-launcher-band").map((el) => el.textContent);
     expect(labels[0]).toBe("Launch agent");
   });
 
@@ -286,11 +317,15 @@ describe("DockLaunchButton", () => {
       ],
     });
 
-    expect(getByText("Claude").getAttribute("title")).toBeNull();
-    expect(getByText("Gemini").getAttribute("title")).toBe(
+    // The name sits in its own span for truncation, so the warning lives on the
+    // row itself.
+    expect(getByText("Claude").closest("button")?.getAttribute("title")).toBeNull();
+    expect(getByText("Gemini").closest("button")?.getAttribute("title")).toBe(
       "Gemini is blocked by endpoint security. Click to configure."
     );
-    expect(getByText("Codex").getAttribute("title")).toBe("Codex needs setup. Click to configure.");
+    expect(getByText("Codex").closest("button")?.getAttribute("title")).toBe(
+      "Codex needs setup. Click to configure."
+    );
   });
 
   it("treats unauthenticated agents as launchable (CLI handles auth at runtime)", () => {
@@ -366,7 +401,7 @@ describe("DockLaunchButton", () => {
 
       fireEvent.change(searchInput(container), { target: { value: "review" } });
 
-      const labels = getAllByTestId("dock-launcher-label").map((el) => el.textContent);
+      const labels = getAllByTestId("dock-launcher-band").map((el) => el.textContent);
       expect(labels).toEqual(["Search results"]);
       expect(queryByText("Open in dock")).toBeNull();
       expect(queryByText("Claude")).toBeNull();
@@ -427,8 +462,20 @@ describe("DockLaunchButton", () => {
       const { container } = renderButton();
       fireEvent.change(searchInput(container), { target: { value: "e" } });
 
-      const selected = container.querySelectorAll("[data-selected-row='true']");
-      expect(selected).toHaveLength(1);
+      expect(container.querySelectorAll(SELECTED_OPTION)).toHaveLength(1);
+    });
+
+    it("points aria-activedescendant at the selected option in both modes", () => {
+      const { container } = renderButton();
+      const input = searchInput(container);
+
+      // Browsing and searching share one selection, so the input must name the
+      // active option either way — not only once a query narrows the list.
+      expect(input.getAttribute("aria-activedescendant")).toBe(selectedOption(container)?.id);
+
+      fireEvent.change(input, { target: { value: "e" } });
+      expect(input.getAttribute("aria-activedescendant")).toBe(selectedOption(container)?.id);
+      expect(input.getAttribute("aria-activedescendant")).toBeTruthy();
     });
 
     it("Enter launches the top result", () => {
@@ -448,10 +495,10 @@ describe("DockLaunchButton", () => {
       const input = searchInput(container);
 
       fireEvent.change(input, { target: { value: "e" } });
-      const firstName = container.querySelector("[data-selected-row='true']")?.textContent;
+      const firstName = selectedOption(container)?.textContent;
 
       fireEvent.keyDown(input, { key: "ArrowDown" });
-      const moved = container.querySelector("[data-selected-row='true']");
+      const moved = selectedOption(container);
       expect(moved?.textContent).not.toBe(firstName);
 
       // Actually confirm it — the previous version never pressed Enter, so it
@@ -476,20 +523,52 @@ describe("DockLaunchButton", () => {
       expect(actionDispatchMock).not.toHaveBeenCalled();
     });
 
-    it("leaves arrow keys to the menu while unfiltered so items stay reachable", () => {
-      // The unfiltered bands have no selected-row styling, so swallowing arrows
-      // here would strand keyboard users with an invisible selection.
+    it("drives the unfiltered bands with the same selection as the results", () => {
+      // A Popover has no roving focus to fall through to, so the browse list is
+      // navigated by selectedIndex exactly as the filtered list is. Arrows that
+      // escaped to the container here would move nothing at all.
       const { container } = renderButton();
       const input = searchInput(container);
 
-      const menuSaw = vi.fn();
-      container.addEventListener("keydown", menuSaw);
-      input.dispatchEvent(
-        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true })
-      );
-      container.removeEventListener("keydown", menuSaw);
+      const rows = options(container);
+      expect(rows.length).toBeGreaterThan(1);
+      expect(selectedOption(container)).toBe(rows[0]);
 
-      expect(menuSaw).toHaveBeenCalledTimes(1);
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+      expect(selectedOption(container)).toBe(rows[1]);
+      expect(container.querySelectorAll(SELECTED_OPTION)).toHaveLength(1);
+
+      fireEvent.keyDown(input, { key: "ArrowUp" });
+      expect(selectedOption(container)).toBe(rows[0]);
+
+      fireEvent.keyDown(input, { key: "End" });
+      expect(selectedOption(container)).toBe(rows[rows.length - 1]);
+
+      fireEvent.keyDown(input, { key: "Home" });
+      expect(selectedOption(container)).toBe(rows[0]);
+    });
+
+    it("Enter launches the selected row while unfiltered", () => {
+      const onLaunchAgent = vi.fn();
+      const { container } = renderButton({ onLaunchAgent });
+      const input = searchInput(container);
+
+      // Claude is the first agent and the first browse row.
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(onLaunchAgent).toHaveBeenCalledWith("claude");
+    });
+
+    it("keeps the recency band navigable without highlighting its twin", () => {
+      // The band repeats agents listed again below, so the two rows must be
+      // keyed apart — sharing an id would light both up at once.
+      mockMruEntries = [{ id: "agent.claude", score: 1, lastAccessedAt: 1000 }];
+      const { container } = renderButton();
+
+      const rows = options(container);
+      const claudeRows = rows.filter((row) => row.textContent?.includes("Claude"));
+      expect(claudeRows).toHaveLength(2);
+      expect(claudeRows[0]!.id).not.toBe(claudeRows[1]!.id);
+      expect(container.querySelectorAll(SELECTED_OPTION)).toHaveLength(1);
     });
 
     it("does not swallow modified keys, so app shortcuts still work", () => {
@@ -541,7 +620,7 @@ describe("DockLaunchButton", () => {
       // The menu already looks unfiltered, so Escape must close rather than
       // being spent clearing invisible whitespace.
       const event = { preventDefault: vi.fn() };
-      dropdownEscapeKeyDownSpy!(event);
+      popoverEscapeKeyDownSpy!(event);
       expect(event.preventDefault).not.toHaveBeenCalled();
     });
 
@@ -563,67 +642,87 @@ describe("DockLaunchButton", () => {
       expect(menuSaw).not.toHaveBeenCalled();
     });
 
-    it("stops printable keys reaching Radix's typeahead", () => {
+    it("stops plain typing escaping to the app behind the launcher", () => {
+      // A letter that reached the dock's own key handling would act on the
+      // panel underneath while the user is only filling the search box.
       const { container } = renderButton();
       const input = searchInput(container);
 
-      const menuSaw = vi.fn();
-      container.addEventListener("keydown", menuSaw);
+      const outsideSaw = vi.fn();
+      container.addEventListener("keydown", outsideSaw);
       input.dispatchEvent(new KeyboardEvent("keydown", { key: "r", bubbles: true }));
-      container.removeEventListener("keydown", menuSaw);
+      container.removeEventListener("keydown", outsideSaw);
 
-      expect(menuSaw).not.toHaveBeenCalled();
+      expect(outsideSaw).not.toHaveBeenCalled();
     });
 
-    it("shows a recovery cue when nothing matches", () => {
-      const { container, getByText } = renderButton();
+    it("shows a recovery cue and no options when nothing matches", () => {
+      const { container, getByTestId } = renderButton();
       fireEvent.change(searchInput(container), { target: { value: "zzzzqqqq" } });
-      expect(getByText("Try a different search")).toBeTruthy();
+
+      expect(getByTestId("dock-launcher-empty")).toBeTruthy();
+      expect(options(container)).toHaveLength(0);
     });
 
-    it("first Escape clears the query and blocks the menu close; second closes", () => {
+    it("first Escape clears the query and blocks the close; second closes", () => {
       const { container } = renderButton();
       const input = searchInput(container);
       fireEvent.change(input, { target: { value: "review" } });
 
-      // With a query present the content handler vetoes dismissal...
+      // Radix dismisses from a document-capture listener that beats any handler
+      // on the input, so the content handler both vetoes the close and clears.
       const withQuery = { preventDefault: vi.fn() };
-      dropdownEscapeKeyDownSpy!(withQuery);
+      act(() => popoverEscapeKeyDownSpy!(withQuery));
       expect(withQuery.preventDefault).toHaveBeenCalledTimes(1);
-
-      // ...and the input clears it.
-      fireEvent.keyDown(input, { key: "Escape" });
       expect(input.value).toBe("");
 
-      // Now empty, Escape is left alone so the menu actually closes.
+      // Now empty, Escape is left alone so the launcher actually closes.
       const whenEmpty = { preventDefault: vi.fn() };
-      dropdownEscapeKeyDownSpy!(whenEmpty);
+      act(() => popoverEscapeKeyDownSpy!(whenEmpty));
       expect(whenEmpty.preventDefault).not.toHaveBeenCalled();
     });
 
-    it("moves focus to the input once the menu is open", async () => {
-      // Radix's mount autofocus lands on the first item synchronously, so the
-      // launcher re-focuses on the next frame. e2e covers the real race; here we
-      // only pin that opening drives focus to the search box at all.
+    it("opens modal so Tab cannot leave the launcher", () => {
+      renderButton();
+      expect(popoverModal).toBe(true);
+    });
+
+    it("takes over the mount autofocus and drives it into the input", () => {
+      // Radix would otherwise focus the content wrapper. This is the handler
+      // that covers a cold open, where the lazy Radix chunk resolves after the
+      // open-state frame has already come and gone.
       const { container } = renderButton();
+      expect(popoverOpenAutoFocusSpy).toBeTruthy();
+
+      const event = { preventDefault: vi.fn() };
+      act(() => popoverOpenAutoFocusSpy!(event));
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(document.activeElement).toBe(searchInput(container));
+    });
+
+    it("re-focuses the input a frame after opening", async () => {
+      // Second attempt behind the mount handler, for the warm open where the
+      // content is already mounted when `open` flips.
+      const { container } = renderButton();
+      searchInput(container).blur();
       expect(document.activeElement).not.toBe(searchInput(container));
 
-      act(() => dropdownOpenChangeSpy!(true));
+      act(() => popoverOpenChangeSpy!(true));
 
       // The focus is deferred a frame, so poll rather than racing it — a frame
       // awaited here would be scheduled before the effect's own.
       await waitFor(() => expect(document.activeElement).toBe(searchInput(container)));
     });
 
-    it("keeps focus in the input when the search row itself is clicked", () => {
-      // Clicking the magnifier, the gap or the row padding used to park focus on
-      // Radix's tabIndex={-1} content, after which typing hit the typeahead and
-      // Escape became a no-op.
-      const { container } = renderButton();
+    it("keeps focus in the input when the header around it is clicked", () => {
+      // The padding around the input parks focus on Radix's tabIndex={-1} focus
+      // scope, after which Escape dead-ends (the content vetoes the close while
+      // only the input clears the query).
+      const { container, getByTestId } = renderButton();
       const input = searchInput(container);
-      const row = input.parentElement!;
 
-      expect(fireEvent.mouseDown(row)).toBe(false);
+      expect(fireEvent.mouseDown(getByTestId("dock-launcher-header"))).toBe(false);
       expect(document.activeElement).toBe(input);
     });
 
@@ -640,25 +739,38 @@ describe("DockLaunchButton", () => {
       fireEvent.change(input, { target: { value: "review" } });
       expect(input.value).toBe("review");
 
-      act(() => dropdownOpenChangeSpy!(false));
+      act(() => popoverOpenChangeSpy!(false));
       expect(input.value).toBe("");
     });
 
-    it("mirrors pointer hover into selection without letting Radix steal focus", () => {
+    it("mirrors pointer hover into selection and keeps focus off the row", () => {
       const { container } = renderButton();
-      const input = searchInput(container);
-      fireEvent.change(input, { target: { value: "e" } });
+      fireEvent.change(searchInput(container), { target: { value: "e" } });
 
-      const rows = Array.from(
-        container.querySelectorAll<HTMLButtonElement>("button[data-selected-row]")
-      );
+      const rows = options(container);
       expect(rows.length).toBeGreaterThan(1);
 
       const second = rows[1]!;
-      const moved = fireEvent.pointerMove(second);
-      // preventDefault is what stops Radix's item-focus handler from running.
-      expect(moved).toBe(false);
-      expect(second.getAttribute("data-selected-row")).toBe("true");
+      fireEvent.pointerEnter(second);
+      expect(second.getAttribute("aria-selected")).toBe("true");
+      expect(container.querySelectorAll(SELECTED_OPTION)).toHaveLength(1);
+
+      // preventDefault on pointerdown is what stops the click focusing the row
+      // and pulling DOM focus off the search box.
+      expect(fireEvent.pointerDown(second)).toBe(false);
+    });
+
+    it("hovering an unfiltered band row also moves the selection", () => {
+      // The state the user is in the instant the launcher opens — the browse
+      // rows were the ones left unguarded against pointer focus-steal.
+      const { container } = renderButton();
+
+      const rows = options(container);
+      expect(rows.length).toBeGreaterThan(1);
+
+      fireEvent.pointerEnter(rows[1]!);
+      expect(selectedOption(container)).toBe(rows[1]);
+      expect(fireEvent.pointerDown(rows[1]!)).toBe(false);
     });
   });
 
@@ -761,25 +873,25 @@ describe("DockLaunchButton", () => {
 
   it("calls preventDefault on pointer close so the trigger does not keep its focus ring (issue #6119)", () => {
     renderButton();
-    expect(dropdownCloseAutoFocusSpy).toBeTruthy();
-    expect(dropdownPointerDownOutsideSpy).toBeTruthy();
+    expect(popoverCloseAutoFocusSpy).toBeTruthy();
+    expect(popoverPointerDownOutsideSpy).toBeTruthy();
 
     // Keyboard close (no prior pointer-down-outside) must NOT preventDefault
     // — focus restoration is required for WAI-ARIA Escape/Enter.
     const keyboardPreventDefault = vi.fn();
-    dropdownCloseAutoFocusSpy!({ preventDefault: keyboardPreventDefault });
+    popoverCloseAutoFocusSpy!({ preventDefault: keyboardPreventDefault });
     expect(keyboardPreventDefault).not.toHaveBeenCalled();
 
     // Pointer close suppresses the focus ring.
-    dropdownPointerDownOutsideSpy!();
+    popoverPointerDownOutsideSpy!();
     const pointerPreventDefault = vi.fn();
-    dropdownCloseAutoFocusSpy!({ preventDefault: pointerPreventDefault });
+    popoverCloseAutoFocusSpy!({ preventDefault: pointerPreventDefault });
     expect(pointerPreventDefault).toHaveBeenCalledTimes(1);
 
     // The pointer flag must reset after one onCloseAutoFocus or a later
     // keyboard-driven close would inherit suppression and break focus return.
     const resetPreventDefault = vi.fn();
-    dropdownCloseAutoFocusSpy!({ preventDefault: resetPreventDefault });
+    popoverCloseAutoFocusSpy!({ preventDefault: resetPreventDefault });
     expect(resetPreventDefault).not.toHaveBeenCalled();
   });
 
@@ -872,7 +984,7 @@ describe("DockLaunchButton", () => {
         agents: MANY,
       });
 
-      const labels = getAllByTestId("dock-launcher-label").map((el) => el.textContent);
+      const labels = getAllByTestId("dock-launcher-band").map((el) => el.textContent);
       expect(labels[0]).toBe("Recently launched");
       expect(getByText("Recently launched")).toBeTruthy();
 
@@ -932,8 +1044,8 @@ describe("DockLaunchButton", () => {
       // A launch elsewhere records MRU while this component stays mounted.
       mockMruEntries = [{ id: "agent.codex", score: 1, lastAccessedAt: 7000 }];
 
-      act(() => dropdownOpenChangeSpy!(false));
-      act(() => dropdownOpenChangeSpy!(true));
+      act(() => popoverOpenChangeSpy!(false));
+      act(() => popoverOpenChangeSpy!(true));
 
       expect(getByText("Recently launched")).toBeTruthy();
     });

--- a/src/components/Layout/__tests__/DockLaunchMenuItems.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchMenuItems.test.tsx
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import type { ReactNode } from "react";
+import {
+  getPanelKindIds,
+  getPanelKindConfig,
+  type PanelKindConfig,
+} from "@shared/config/panelKindRegistry";
+
+// #11593 split the `+` launcher onto its own palette renderer, leaving this
+// component to the two right-click menus alone. These pin the contract those
+// consumers depend on — the banded list, the recency shortcut, and activation
+// through a caller-supplied menu primitive — so a later launcher-side change
+// can't quietly take the context menus with it.
+
+let mockRecipes: Array<{ id: string; name: string; worktreeId?: string }> = [];
+let mockMruEntries: Array<{ id: string; score: number; lastAccessedAt: number }> = [];
+const actionDispatchMock = vi.fn();
+const recordActionMruMock = vi.fn();
+const addPanelMock = vi.fn();
+
+// See dockLaunchItems.test.ts — avoid the real registry's eager TerminalPane import.
+vi.mock("@/registry", () => ({
+  getSpawnablePanelKinds: (): PanelKindConfig[] =>
+    getPanelKindIds()
+      .filter((id) => id !== "agent")
+      .map((id) => getPanelKindConfig(id))
+      .filter((c): c is PanelKindConfig => c !== undefined && c.showInPalette !== false),
+  subscribeToPanelKindDefinitions: () => () => {},
+  getPanelKindDefinitionsSnapshot: () => 0,
+}));
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: { getState: () => ({ addPanel: addPanelMock }) },
+}));
+
+vi.mock("@/store/recipeStore", () => ({
+  useRecipeStore: Object.assign(
+    (selector: (s: { recipes: typeof mockRecipes }) => unknown) =>
+      selector({ recipes: mockRecipes }),
+    { getState: () => ({ runRecipeWithResults: vi.fn() }) }
+  ),
+}));
+
+const getSortedActionMruListMock = () => mockMruEntries;
+vi.mock("@/store/actionMruStore", () => ({
+  useActionMruStore: Object.assign(
+    (selector: (s: { getSortedActionMruList: () => typeof mockMruEntries }) => unknown) =>
+      selector({ getSortedActionMruList: getSortedActionMruListMock }),
+    { getState: () => ({ recordActionMru: recordActionMruMock }) }
+  ),
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: (...args: unknown[]) => actionDispatchMock(...args) },
+}));
+
+vi.mock("@/utils/recipeNotify", () => ({ notifyRecipeSpawnFailures: vi.fn() }));
+
+vi.mock("@/components/PanelPalette/PanelKindIcon", () => ({
+  PanelKindIcon: ({ iconId }: { iconId: string }) => <span data-icon={iconId} />,
+}));
+
+import { DockLaunchMenuItems, type DockLaunchAgent } from "../DockLaunchMenuItems";
+
+// Stand-ins for the Radix ContextMenu primitives the real consumers pass. The
+// point is that this component drives them through `onSelect`, not `onClick`.
+const MENU_COMPONENTS = {
+  Item: ({
+    children,
+    onSelect,
+    title,
+    className,
+  }: {
+    children: ReactNode;
+    onSelect?: () => void;
+    title?: string;
+    className?: string;
+  }) => (
+    <button type="button" onClick={() => onSelect?.()} title={title} className={className}>
+      {children}
+    </button>
+  ),
+  Label: ({ children }: { children: ReactNode }) => <div data-testid="label">{children}</div>,
+  Separator: () => <hr data-testid="separator" />,
+};
+
+const AGENTS: DockLaunchAgent[] = [
+  { id: "claude", name: "Claude", availability: "ready" },
+  { id: "gemini", name: "Gemini", availability: "blocked" },
+];
+
+function renderItems(props: Partial<Parameters<typeof DockLaunchMenuItems>[0]> = {}) {
+  return render(
+    <DockLaunchMenuItems
+      components={MENU_COMPONENTS}
+      agents={AGENTS}
+      activeWorktreeId={null}
+      cwd="/tmp"
+      onLaunchAgent={vi.fn()}
+      surface="dock"
+      {...props}
+    />
+  );
+}
+
+beforeEach(() => {
+  mockRecipes = [];
+  mockMruEntries = [];
+  actionDispatchMock.mockReset();
+  recordActionMruMock.mockReset();
+  addPanelMock.mockReset();
+});
+
+describe("DockLaunchMenuItems", () => {
+  it("renders the banded list for a dock surface", () => {
+    mockRecipes = [{ id: "r-1", name: "My recipe" }];
+    const { getAllByTestId } = renderItems();
+
+    expect(getAllByTestId("label").map((el) => el.textContent)).toEqual([
+      "Launch agent",
+      "Open in dock",
+      "Open in grid",
+      "Launch recipe",
+    ]);
+  });
+
+  it("collapses to one panel heading on the grid surface, where nothing docks", () => {
+    const { getAllByTestId } = renderItems({ surface: "grid" });
+    expect(getAllByTestId("label").map((el) => el.textContent)).toContain("Launch panel");
+  });
+
+  it("splits agents into Pinned/Other for a strict subset", () => {
+    const { getAllByTestId, container } = renderItems({ pinnedCount: 1 });
+
+    expect(
+      getAllByTestId("label")
+        .map((el) => el.textContent)
+        .slice(0, 2)
+    ).toEqual(["Pinned", "Other"]);
+    const text = container.textContent ?? "";
+    expect(text.indexOf("Pinned")).toBeLessThan(text.indexOf("Claude"));
+    expect(text.indexOf("Claude")).toBeLessThan(text.indexOf("Other"));
+  });
+
+  it("keeps the recency band as a duplicate shortcut above the agent group", () => {
+    mockMruEntries = [{ id: "agent.claude", score: 1, lastAccessedAt: 1000 }];
+    const { getAllByText, getByText } = renderItems();
+
+    expect(getByText("Recently launched")).toBeTruthy();
+    // Listed twice: once as the shortcut, once in the group it belongs to.
+    expect(getAllByText("Claude")).toHaveLength(2);
+  });
+
+  it("launches an agent through onSelect and records MRU", () => {
+    const onLaunchAgent = vi.fn();
+    const { getByText } = renderItems({ onLaunchAgent });
+
+    fireEvent.click(getByText("Claude"));
+    expect(onLaunchAgent).toHaveBeenCalledWith("claude");
+    expect(recordActionMruMock).toHaveBeenCalledWith("agent.claude");
+  });
+
+  it("routes a blocked agent to its settings subtab under the caller's source", () => {
+    const onLaunchAgent = vi.fn();
+    const { getByText } = renderItems({ onLaunchAgent, settingsSource: "context-menu" });
+
+    fireEvent.click(getByText("Gemini"));
+    expect(onLaunchAgent).not.toHaveBeenCalled();
+    expect(actionDispatchMock).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "agents", subtab: "gemini" },
+      { source: "context-menu" }
+    );
+    expect(recordActionMruMock).not.toHaveBeenCalled();
+  });
+
+  it("routes the create-recipe cue to the manager when no worktree is active", () => {
+    const { getByText } = renderItems();
+
+    fireEvent.click(getByText("Create a recipe"));
+    expect(actionDispatchMock).toHaveBeenCalledWith("recipe.manager.open", {}, { source: "menu" });
+  });
+
+  it("scopes the create-recipe cue to the active worktree when there is one", () => {
+    const { getByText } = renderItems({ activeWorktreeId: "wt-1" });
+
+    fireEvent.click(getByText("Create a recipe"));
+    expect(actionDispatchMock).toHaveBeenCalledWith(
+      "recipe.editor.open",
+      { worktreeId: "wt-1" },
+      { source: "menu" }
+    );
+  });
+
+  it("creates a grid-only panel at the location its heading advertises", () => {
+    const { getByText } = renderItems();
+
+    fireEvent.click(getByText("Review"));
+    expect(addPanelMock).toHaveBeenCalledWith(expect.objectContaining({ location: "grid" }));
+  });
+});

--- a/src/components/Layout/__tests__/dockLaunchItems.test.ts
+++ b/src/components/Layout/__tests__/dockLaunchItems.test.ts
@@ -297,6 +297,68 @@ describe("buildDockLaunchModel — bands and recipes", () => {
   });
 });
 
+describe("buildDockLaunchModel — browse rows", () => {
+  const mru = [{ id: "agent.claude", score: 1, lastAccessedAt: 1000 }];
+
+  it("orders rows exactly as the launcher renders its bands", () => {
+    const model = build({ mruEntries: mru, recipes: [recipe({ id: "r-1", name: "Deploy" })] });
+
+    // The launcher navigates this array with a single selectedIndex, so a band
+    // ordering that drifts from the render order would move the highlight to a
+    // row the user isn't looking at.
+    const bands: string[] = [];
+    for (const row of model.browseRows) {
+      if (bands[bands.length - 1] !== row.band) bands.push(row.band);
+    }
+    expect(bands).toEqual(["recent", "agents", "dock-panels", "grid-panels", "recipes"]);
+  });
+
+  it("keys a recency row apart from its twin in the agent group", () => {
+    const model = build({ mruEntries: mru });
+
+    const claudeRows = model.browseRows.filter((row) => row.item?.key === "agent:claude");
+    expect(claudeRows).toHaveLength(2);
+    expect(new Set(claudeRows.map((row) => row.rowKey)).size).toBe(2);
+  });
+
+  it("gives every row a unique key so selection can never light two at once", () => {
+    const model = build({
+      mruEntries: mru,
+      pinnedCount: 1,
+      recipes: [recipe({ id: "r-1", name: "Deploy" })],
+    });
+
+    const keys = model.browseRows.map((row) => row.rowKey);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("splits the agent bands the same way the Pinned/Other groups do", () => {
+    const model = build({ pinnedCount: 1 });
+    const bands = model.browseRows.filter((row) => row.item?.category === "agent");
+
+    expect(bands.map((row) => row.band)).toEqual(["pinned", "other"]);
+  });
+
+  it("collapses the panel bands when every panel shares one destination", () => {
+    const model = build({ surface: "grid" });
+    const panelBands = new Set(
+      model.browseRows.filter((row) => row.item?.category === "panel").map((row) => row.band)
+    );
+    expect([...panelBands]).toEqual(["panels"]);
+  });
+
+  it("carries the create-recipe cue as an item-less row when there are none", () => {
+    const withNone = build();
+    const cue = withNone.browseRows.filter((row) => row.item === undefined);
+    expect(cue).toHaveLength(1);
+    expect(cue[0]!.band).toBe("recipes");
+
+    // With recipes present the cue is gone, so it can't be navigated to.
+    const withSome = build({ recipes: [recipe({ id: "r-1", name: "Deploy" })] });
+    expect(withSome.browseRows.every((row) => row.item !== undefined)).toBe(true);
+  });
+});
+
 describe("activateDockLaunchItem", () => {
   const ctx = {
     cwd: "/repo",

--- a/src/components/Layout/dockLaunchItems.ts
+++ b/src/components/Layout/dockLaunchItems.ts
@@ -45,6 +45,9 @@ const AGENT_LAUNCH_PANEL_KINDS: ReadonlySet<string> = new Set([
  * launcher's most-used entry, so it is added back explicitly here. */
 const TERMINAL_KIND_ID = "terminal";
 
+/** Row id of the "Create a recipe" cue — the one browse row with no item. */
+export const CREATE_RECIPE_ROW_KEY = "create-recipe";
+
 export type LaunchAgentIcon = React.ComponentType<{ className?: string; brandColor?: string }>;
 
 export interface DockLaunchAgent {
@@ -87,6 +90,47 @@ export interface DockLaunchRecipeItem extends DockLaunchItemBase {
 
 export type DockLaunchItem = DockLaunchAgentItem | DockLaunchPanelItem | DockLaunchRecipeItem;
 
+/** Heading a launcher row renders under. `results` is the filtered list. */
+export type DockLaunchBandId =
+  | "recent"
+  | "pinned"
+  | "other"
+  | "agents"
+  | "dock-panels"
+  | "grid-panels"
+  | "panels"
+  | "recipes"
+  | "results";
+
+export const DOCK_LAUNCH_BAND_LABELS: Record<DockLaunchBandId, string> = {
+  recent: "Recently launched",
+  pinned: "Pinned",
+  other: "Other",
+  agents: "Launch agent",
+  "dock-panels": "Open in dock",
+  "grid-panels": "Open in grid",
+  panels: "Launch panel",
+  recipes: "Launch recipe",
+  results: "Search results",
+};
+
+/**
+ * One rendered row of the `+` launcher palette. The launcher drives arrow-key
+ * navigation off a single flat row list for both the browse bands and the
+ * filtered results, so every row needs an index in the same space.
+ */
+export interface DockLaunchRow {
+  /**
+   * Unique per rendered row — NOT the item key. The recency band repeats agents
+   * that also appear under Pinned/Other, and two rows sharing an id would
+   * highlight together and break `aria-activedescendant`.
+   */
+  rowKey: string;
+  band: DockLaunchBandId;
+  /** Absent for the "Create a recipe" discovery cue, which opens the editor. */
+  item?: DockLaunchItem;
+}
+
 export interface DockLaunchModel {
   /** Capped frecency band; entries also appear in the agent groups below. */
   recentAgents: DockLaunchAgent[];
@@ -97,6 +141,12 @@ export interface DockLaunchModel {
   recipes: DockLaunchRecipeItem[];
   /** Flat, de-duplicated set fed to Fuse — the recency band is not repeated. */
   searchItems: DockLaunchItem[];
+  /**
+   * Every browse row in render order, recency duplicates included. This is the
+   * launcher's navigation space when nothing is typed; `searchItems` stays
+   * de-duplicated so a recent agent can't rank twice in the results.
+   */
+  browseRows: DockLaunchRow[];
 }
 
 /**
@@ -160,6 +210,27 @@ export function selectRecentAgents(
 }
 
 /**
+ * The "Recently launched" rows of {@link DockLaunchModel.browseRows}. Split out
+ * because `useDockLaunchModel` derives the band outside its memo (see there) and
+ * has to splice it back onto a `browseRows` built without it.
+ *
+ * The band repeats agents that are listed again under Pinned/Other. That
+ * duplication is deliberate — a quick-reach shortcut — so the rows are keyed
+ * apart rather than de-duplicated: dropping an agent from Pinned because it was
+ * recently launched would make that heading lie.
+ */
+export function buildRecentBrowseRows(
+  agentItems: ReadonlyArray<DockLaunchAgentItem>,
+  recentAgentIds: ReadonlyArray<string>
+): DockLaunchRow[] {
+  const byKey = new Map(agentItems.map((item) => [item.key, item]));
+  return recentAgentIds
+    .map((id) => byKey.get(`agent:${id}`))
+    .filter((item): item is DockLaunchAgentItem => item !== undefined)
+    .map((item) => ({ rowKey: `recent:${item.key}`, band: "recent" as const, item }));
+}
+
+/**
  * Derive every launchable entry for a launcher surface. Panels come from the
  * shared spawnable-kind selector (so the launcher can't drift from ⌘⇧P) plus
  * Terminal, partitioned by where they will actually land rather than filtered
@@ -219,13 +290,54 @@ export function buildDockLaunchModel({
     searchAliases: [agent.id, "agent"],
   }));
 
+  const showAgentGroups =
+    pinnedCount !== undefined && pinnedCount > 0 && pinnedCount < agents.length;
+  const isSplitByDestination = dockPanels.length > 0 && gridPanels.length > 0;
+
+  const browseRows: DockLaunchRow[] = [];
+  const pushRows = (band: DockLaunchBandId, items: ReadonlyArray<DockLaunchItem>) => {
+    for (const item of items) {
+      browseRows.push({ rowKey: item.key, band, item });
+    }
+  };
+
+  browseRows.push(
+    ...buildRecentBrowseRows(
+      agentItems,
+      recentAgents.map((agent) => agent.id)
+    )
+  );
+
+  if (agentItems.length > 0) {
+    if (showAgentGroups) {
+      pushRows("pinned", agentItems.slice(0, pinnedCount));
+      pushRows("other", agentItems.slice(pinnedCount));
+    } else {
+      pushRows("agents", agentItems);
+    }
+  }
+
+  if (isSplitByDestination) {
+    pushRows("dock-panels", dockPanels);
+    pushRows("grid-panels", gridPanels);
+  } else {
+    pushRows("panels", [...dockPanels, ...gridPanels]);
+  }
+
+  if (recipeItems.length > 0) {
+    pushRows("recipes", recipeItems);
+  } else {
+    browseRows.push({ rowKey: CREATE_RECIPE_ROW_KEY, band: "recipes" });
+  }
+
   return {
     recentAgents,
-    showAgentGroups: pinnedCount !== undefined && pinnedCount > 0 && pinnedCount < agents.length,
+    showAgentGroups,
     dockPanels,
     gridPanels,
     recipes: recipeItems,
     searchItems: [...agentItems, ...panelItems, ...recipeItems],
+    browseRows,
   };
 }
 
@@ -289,7 +401,39 @@ export function useDockLaunchModel(options: {
     [agents, pinnedCount, activeWorktreeId, recipes, surface, kindRegistry, definitionRegistry]
   );
 
-  return { ...stable, recentAgents: selectRecentAgents(agents, getSortedActionMruList()) };
+  const recentAgents = selectRecentAgents(agents, getSortedActionMruList());
+  // `stable` was built with an empty MRU, so its `browseRows` carry no recency
+  // band — splice it back on here. Keyed on the id signature rather than the
+  // array, which `selectRecentAgents` mints fresh on every render.
+  const recentSignature = recentAgents.map((agent) => agent.id).join(",");
+  const browseRows = useMemo(() => {
+    const agentItems = stable.searchItems.filter(
+      (item): item is DockLaunchAgentItem => item.category === "agent"
+    );
+    const recentIds = recentSignature ? recentSignature.split(",") : [];
+    return [...buildRecentBrowseRows(agentItems, recentIds), ...stable.browseRows];
+  }, [stable, recentSignature]);
+
+  return { ...stable, recentAgents, browseRows };
+}
+
+/**
+ * First-run discovery cue: route into recipes instead of hiding the section, so
+ * users who have never made one can find their way in. With an active worktree,
+ * open the editor scoped to it; without one (the common first-run case), fall
+ * back to the manager — the editor's event handler hard-requires a string
+ * worktreeId and silently no-ops on undefined, so dispatching the editor here
+ * would do nothing. Both actions are danger:"safe" and MRU-eligible.
+ */
+export function activateCreateRecipeCue(
+  activeWorktreeId: string | null,
+  source: ActionSource
+): void {
+  if (activeWorktreeId) {
+    void actionService.dispatch("recipe.editor.open", { worktreeId: activeWorktreeId }, { source });
+  } else {
+    void actionService.dispatch("recipe.manager.open", {}, { source });
+  }
 }
 
 export interface ActivateDockLaunchItemContext {

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -127,15 +127,12 @@ const DURABLE_ALLOWLIST = new Set([
   // PanelPalette selected-row left-edge accent stripe (single primary anchor per active focus region)
   "src/components/PanelPalette/PanelPalette.tsx",
 
-  // Dock launcher selected-option left-edge accent stripe (single primary
-  // anchor per active focus region)
-  "src/components/Layout/DockLaunchButton.tsx",
-
   // The one definition of the palette selected-row left-edge accent stripe,
   // shared by every palette row (single primary anchor per active focus region).
-  // PilotView, ProjectSwitcherPalette, ResumeSessionsPalette, QuickSwitcherItem
-  // and ActionPaletteItem all take the stripe from here rather than spelling it
-  // out themselves, which is why none of them appears in a bucket any more.
+  // PilotView, ProjectSwitcherPalette, ResumeSessionsPalette, QuickSwitcherItem,
+  // ActionPaletteItem and DockLaunchButton all take the stripe from here rather
+  // than spelling it out themselves, which is why none of them appears in a
+  // bucket any more.
   "src/components/ui/paletteRowStyles.ts",
 
   // PluginQuickPickDialog selected-row left-edge accent stripe (single primary anchor per active focus region)

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -127,9 +127,9 @@ const DURABLE_ALLOWLIST = new Set([
   // PanelPalette selected-row left-edge accent stripe (single primary anchor per active focus region)
   "src/components/PanelPalette/PanelPalette.tsx",
 
-  // Dock launcher filtered-result selected-row left-edge accent stripe (single
-  // primary anchor per active focus region)
-  "src/components/Layout/DockLaunchMenuItems.tsx",
+  // Dock launcher selected-option left-edge accent stripe (single primary
+  // anchor per active focus region)
+  "src/components/Layout/DockLaunchButton.tsx",
 
   // The one definition of the palette selected-row left-edge accent stripe,
   // shared by every palette row (single primary anchor per active focus region).

--- a/src/panels/review/ReviewPane.tsx
+++ b/src/panels/review/ReviewPane.tsx
@@ -24,6 +24,15 @@ export function ReviewPane({
 }: ReviewPaneProps) {
   const isDialog = location === "dialog";
 
+  // Both roots below carry `data-panel-id`/`data-panel-location`. ContentPanel
+  // is the only other writer of that pair, and review is the one built-in kind
+  // that renders no ContentPanel — so without these its root is invisible to
+  // every consumer that resolves a panel through the DOM: Cmd+W's grid/dock
+  // ancestor gate (useGlobalKeybindings), grid navigation, type-anywhere,
+  // optimistic close, and the e2e panel helpers. Pass `location` through rather
+  // than hardcoding "grid": a dialog-hosted review must report "dialog" so it
+  // stays out of the grid/dock selectors, exactly as ContentPanel does.
+
   // ReviewHubContent wires its Close button as `onClick={onClose}`, so React
   // would hand the MouseEvent straight through as `force` — a truthy object
   // that routes the panel handler to permanent removal instead of the
@@ -83,6 +92,8 @@ export function ReviewPane({
     return (
       <div
         ref={setContainerEl}
+        data-panel-id={id}
+        data-panel-location={location}
         tabIndex={-1}
         className="flex h-full w-full items-center justify-center"
       >
@@ -104,6 +115,8 @@ export function ReviewPane({
     // `flex-1 min-h-0` only bounds its scroller once this root is bounded too.
     <div
       ref={setContainerEl}
+      data-panel-id={id}
+      data-panel-location={location}
       tabIndex={-1}
       className="flex h-full min-h-0 w-full flex-1 flex-col bg-daintree-bg"
     >

--- a/src/panels/review/__tests__/ReviewPane.test.tsx
+++ b/src/panels/review/__tests__/ReviewPane.test.tsx
@@ -95,3 +95,68 @@ describe("ReviewPane close wiring", () => {
     expect(force).toBeFalsy();
   });
 });
+
+// ContentPanel is the only other writer of `data-panel-id`/`data-panel-location`,
+// and review is the one built-in kind that renders no ContentPanel — so this pane
+// owns that identity contract itself. Six production consumers resolve a panel by
+// walking the DOM up from a descendant (useGlobalKeybindings' Cmd+W grid/dock
+// gate, useGridNavigation, useTypeAnywhere/typeAnywhere, optimisticPanelClose),
+// so these assert the lookup the way those consumers perform it. Checking the
+// attributes in isolation would pass even if they landed on an inner node that
+// no `closest()` walk from real content can reach.
+describe("ReviewPane panel DOM contract", () => {
+  // Verbatim from lib/typeAnywhere.ts and useGlobalKeybindings.ts respectively —
+  // if either consumer's selector drifts, these stop describing production.
+  const PANEL_ROOT = "[data-panel-id]";
+  const GRID_OR_DOCK = "[data-panel-location='grid'],[data-panel-location='dock']";
+
+  it.each(["grid", "dialog"] as const)(
+    "reports the pane's own id and its %s location to a descendant walking up",
+    (location) => {
+      // Derive the id from the case so a hardcoded attribute can't satisfy this.
+      const id = `review-${location}-panel`;
+      render(
+        <ReviewPane id={id} worktreeId="wt-1" onClose={vi.fn()} location={location} />
+      );
+
+      const root = screen.getByTestId("review-hub-close").closest(PANEL_ROOT);
+
+      expect(root).not.toBeNull();
+      expect(root?.getAttribute("data-panel-id")).toBe(id);
+      expect(root?.getAttribute("data-panel-location")).toBe(location);
+    }
+  );
+
+  it("answers the grid/dock gate for a grid pane but not a dialog-hosted one", () => {
+    // The consequence that matters: Cmd+W closes a focused grid panel, while a
+    // dialog-hosted review must fall through to the escape stack (AppDialog owns
+    // that layer). Both come from the same prop, so a hardcoded "grid" would
+    // pass the case above and still break the dialog by trashing the panel.
+    const grid = render(
+      <ReviewPane id="review-grid" worktreeId="wt-1" onClose={vi.fn()} location="grid" />
+    );
+    expect(grid.container.querySelector(PANEL_ROOT)?.matches(GRID_OR_DOCK)).toBe(true);
+    grid.unmount();
+
+    const dialog = render(
+      <ReviewPane id="review-grid" worktreeId="wt-1" onClose={vi.fn()} location="dialog" />
+    );
+    expect(dialog.container.querySelector(PANEL_ROOT)?.matches(GRID_OR_DOCK)).toBe(false);
+  });
+
+  it("stays identifiable when the worktree path has not resolved", () => {
+    // The empty-state branch is a separate root. A panel that lost its identity
+    // whenever its worktree was briefly unavailable would drop out of optimistic
+    // close and grid navigation mid-flight, and would make grid counts flicker
+    // across the empty-to-loaded transition.
+    const { container } = render(<ReviewPane id="review-empty" onClose={vi.fn()} />);
+
+    const roots = container.querySelectorAll(PANEL_ROOT);
+
+    // Exactly one: a future wrapper that re-tags the pane would nest a second
+    // root, and `closest()` would then resolve consumers to the wrong element.
+    expect(roots).toHaveLength(1);
+    expect(roots[0]?.getAttribute("data-panel-id")).toBe("review-empty");
+    expect(roots[0]?.matches(GRID_OR_DOCK)).toBe(true);
+  });
+});

--- a/src/panels/review/__tests__/ReviewPane.test.tsx
+++ b/src/panels/review/__tests__/ReviewPane.test.tsx
@@ -115,9 +115,7 @@ describe("ReviewPane panel DOM contract", () => {
     (location) => {
       // Derive the id from the case so a hardcoded attribute can't satisfy this.
       const id = `review-${location}-panel`;
-      render(
-        <ReviewPane id={id} worktreeId="wt-1" onClose={vi.fn()} location={location} />
-      );
+      render(<ReviewPane id={id} worktreeId="wt-1" onClose={vi.fn()} location={location} />);
 
       const root = screen.getByTestId("review-hub-close").closest(PANEL_ROOT);
 
@@ -130,8 +128,9 @@ describe("ReviewPane panel DOM contract", () => {
   it("answers the grid/dock gate for a grid pane but not a dialog-hosted one", () => {
     // The consequence that matters: Cmd+W closes a focused grid panel, while a
     // dialog-hosted review must fall through to the escape stack (AppDialog owns
-    // that layer). Both come from the same prop, so a hardcoded "grid" would
-    // pass the case above and still break the dialog by trashing the panel.
+    // that layer). Asserting the selector match rather than the attribute value
+    // pins what the consumers actually run, so a drift between the two — the
+    // gate's selector widening, or a new location joining it — surfaces here.
     const grid = render(
       <ReviewPane id="review-grid" worktreeId="wt-1" onClose={vi.fn()} location="grid" />
     );


### PR DESCRIPTION
Rebuilds the dock `+` launcher on a modal `Popover` carrying the standard `AppPaletteDialog` chrome, per the original issue. The earlier draft of this PR carried a "do not merge" warning about a regression that turned out not to exist. Details below, but the short version: this is ready.

## What changed

A menu with a text search input fights the menu's own roving focus, typeahead, and pointer-move item focus. None of that exists on a popover, which is why the launcher moves off Radix `DropdownMenu` onto a modal `Popover`.

- **Focus.** `onOpenAutoFocus` drives mount focus into the search box, with an open-state `requestAnimationFrame` kept as a second attempt. `PopoverContent` renders nothing until its lazy Radix chunk resolves, so on a cold click the frame can fire before the input exists, and on a warm click the mount handler has already run. Neither order alone covers both cases.
- **Pointer.** Rows are plain `role="option"` buttons that call `preventDefault()` on their own `pointerdown`, including in the unfiltered bands. Those were the rows left unguarded before, and they're the ones the pointer is resting on the instant the menu opens.
- **Presentation.** `AppPaletteDialog.Header` / `.Input` / `.Body` / `.Footer`, with `role="combobox"` and `role="listbox"`/`option` ARIA, following the precedent set by `PanelPalette`.
- **Keyboard.** A popover has no roving focus to fall back on, so browse and search now share one flat selection. `DockLaunchModel` gains a `browseRows` list, keyed per row, so the "Recently launched" band can repeat an agent also listed under "Pinned" without both being highlighted at once.

## The "regression" was not a regression

This is the part that matters. The earlier draft said launching a grid-located panel from the launcher added it to the store correctly but the grid never rendered it, and that I couldn't track it down. That diagnosis was wrong: there was no regression to track down.

`ContentPanel` (`src/components/Panel/ContentPanel.tsx:490-493`) is the only place in the renderer that emits the `data-panel-id` and `data-panel-location` attributes. `GridPanel` renders each registered panel kind as `<ErrorBoundary><PanelComponent /></ErrorBoundary>`, with no `ContentPanel` wrapper, so it's on each kind's own component to emit those attributes itself. `ReviewPane` was the one built-in kind that renders no `ContentPanel`, something its own comment already said. So a review panel in the grid never emitted `data-panel-location="grid"`, and the e2e helper (`e2e/helpers/selectors.ts:71`) structurally could not see it, at any timing. That's why the store state was always perfect and durable, and why every bisection axis I tried (modal on/off, activation ordering, inlining the chrome, reverting to `DropdownMenu`) failed to move it even slightly.

It was also never a regression from this branch. The failing assertion landed on `develop` in `9eb41d47c` (2026-07-31), and the last Stabilize run was 2026-07-30. E2E doesn't run in PR CI, so that assertion had never once actually executed in CI. It fails on `develop` too.

It's a real product bug beyond the test, though: `src/hooks/useGlobalKeybindings.ts:265` gates on that same selector, so review panels were failing the "am I inside a panel" check. Fixed at the producer: both of `ReviewPane`'s roots (the worktree-unavailable empty state and the main one) are now tagged, and `location` is passed through as a prop instead of hardcoded, so a dialog-hosted review reports `"dialog"` and stays out of the grid and dock selectors.

## Review fixes

From two rounds of adversarial review:

- Re-anchored the launcher's selection on reopen. Closing only cleared the search query, so the follow-anchor still pointed at wherever browsing had left off, while the remounted list sat scrolled to the top, meaning Enter right after reopening could launch an offscreen row. Fixed in a transition-gated effect rather than the open handler, so it anchors against the rows that actually rendered (the recency band rebuilds from MRU data that can change while closed, with nothing re-rendering to catch it).
- Gave the modal popover an accessible name. It was announcing to screen readers as an unnamed dialog.
- Repeated the IME composition guard on Radix's document-level capture-phase Escape handler, which runs ahead of the search input's own. An Escape press mid-composition belongs to the IME candidate window, not the app.
- Drop `aria-expanded`/`aria-controls` when nothing matches, so the combobox stops naming a listbox that isn't rendered.

## Verification

- 240 unit tests across 9 files.
- `core-dock-launcher-search.spec.ts`: 7/7, including the previously failing "Enter launches a searched grid-only panel into the grid".
- Eslint and prettier clean on changed files. 3 remaining warnings all trace back to commits already on `develop` (`d7331726`, `9eb41d47c`), not this branch.
- Both new regression tests verified to fail without their fix.
- E2E doesn't run in PR CI, so the green check here doesn't cover it.

## Known follow-up (out of scope)

`ReviewPane` accepts no `onFocus`, so DOM focus and `focusedId` can diverge after clicking an unfocused review panel: panel A is store-focused, the user clicks inside review panel B, and Cmd+W closes A instead of B. Pre-existing, and needs its own interaction design. A naive bubbling `onClick={onFocus}` isn't safe because `ReviewHubContent`'s close button doesn't stop propagation, so it could refocus a panel that was just closed.

Also transient and out of scope: lazy Suspense skeletons for the browser, review, file, diff, and file-browser panel kinds don't emit panel identity while resolving. `dev-preview` already has parity.

Resolves #11593
