### PR TITLE
fix(files): re-read file surfaces when the project view is revealed

### DIFF
--- a/src/hooks/__tests__/useProjectViewRevealed.test.tsx
+++ b/src/hooks/__tests__/useProjectViewRevealed.test.tsx
@@ -4,14 +4,25 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 
 type LifecyclePhase = "cached" | "active" | "revealed";
 
-const listeners = new Set<(phase: LifecyclePhase) => void>();
+// Hoisted, not a plain const: the factory below closes over it, and a
+// module-scope subscriber anywhere in the graph would reach it while a plain
+// const was still in its TDZ — which fails collection, not the test.
+const listeners = vi.hoisted(() => new Set<(phase: LifecyclePhase) => void>());
 
 const subscribeProjectViewLifecycleMock = vi.hoisted(() =>
   vi.fn<(cb: (phase: LifecyclePhase) => void) => () => void>()
 );
 
+// Every runtime export, not just the one the hook imports today: a factory is a
+// strict surface, so the day anything in this graph reaches for a missing name
+// the file fails at collection — and vitest still exits 0, silently skipping
+// every test below while the summary reads green.
 vi.mock("@/lib/viewCacheState", () => ({
   subscribeProjectViewLifecycle: subscribeProjectViewLifecycleMock,
+  isProjectViewCached: () => false,
+  __resetProjectViewCacheStateForTests: () => {
+    listeners.clear();
+  },
 }));
 
 import { useProjectViewRevealed } from "../useProjectViewRevealed";
@@ -98,6 +109,25 @@ describe("useProjectViewRevealed", () => {
 
     rerender({ enabled: true });
     expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs the deferred catch-up against the newest callback, not the one that missed the reveal", () => {
+    // The deferral's own stale-closure risk, which the immediate path can't
+    // cover: a parked pane misses a reveal, then its file or root changes
+    // before it comes back. Flushing the closure captured at reveal time would
+    // refresh the identity that is no longer on screen.
+    const stale = vi.fn();
+    const fresh = vi.fn();
+    const { rerender } = renderHook(({ cb, enabled }) => useProjectViewRevealed(cb, { enabled }), {
+      initialProps: { cb: stale, enabled: false },
+    });
+
+    emit("revealed");
+    rerender({ cb: fresh, enabled: false });
+    rerender({ cb: fresh, enabled: true });
+
+    expect(stale).not.toHaveBeenCalled();
+    expect(fresh).toHaveBeenCalledTimes(1);
   });
 
   it("does not run a catch-up on enable when no reveal was missed", () => {

--- a/src/hooks/__tests__/useProjectViewRevealed.test.tsx
+++ b/src/hooks/__tests__/useProjectViewRevealed.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+type LifecyclePhase = "cached" | "active" | "revealed";
+
+const listeners = new Set<(phase: LifecyclePhase) => void>();
+
+const subscribeProjectViewLifecycleMock = vi.hoisted(() =>
+  vi.fn<(cb: (phase: LifecyclePhase) => void) => () => void>()
+);
+
+vi.mock("@/lib/viewCacheState", () => ({
+  subscribeProjectViewLifecycle: subscribeProjectViewLifecycleMock,
+}));
+
+import { useProjectViewRevealed } from "../useProjectViewRevealed";
+
+function emit(phase: LifecyclePhase): void {
+  act(() => {
+    for (const listener of Array.from(listeners)) listener(phase);
+  });
+}
+
+beforeEach(() => {
+  listeners.clear();
+  subscribeProjectViewLifecycleMock.mockReset();
+  // A real registry rather than a bare stub, so unsubscribe assertions mean
+  // something: a leaked listener keeps firing here exactly as it would in the
+  // app.
+  subscribeProjectViewLifecycleMock.mockImplementation((cb) => {
+    listeners.add(cb);
+    return () => {
+      listeners.delete(cb);
+    };
+  });
+});
+
+describe("useProjectViewRevealed", () => {
+  it("runs the callback on revealed and ignores the other phases", () => {
+    const callback = vi.fn();
+    renderHook(() => useProjectViewRevealed(callback));
+
+    emit("cached");
+    emit("active");
+    expect(callback).not.toHaveBeenCalled();
+
+    emit("revealed");
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not subscribe again when the callback identity changes", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(({ cb }) => useProjectViewRevealed(cb), {
+      initialProps: { cb: first },
+    });
+
+    rerender({ cb: second });
+    expect(subscribeProjectViewLifecycleMock).toHaveBeenCalledTimes(1);
+
+    // The newest closure runs, not the one captured when the listener was
+    // registered — this is what lets a caller pass an inline closure over live
+    // state without churning the subscription.
+    emit("revealed");
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it("defers a reveal that lands while disabled and runs it once on enable", () => {
+    const callback = vi.fn();
+    const { rerender } = renderHook(
+      ({ enabled }) => useProjectViewRevealed(callback, { enabled }),
+      {
+        initialProps: { enabled: false },
+      }
+    );
+
+    emit("revealed");
+    expect(callback).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces several deferred reveals into a single catch-up", () => {
+    const callback = vi.fn();
+    const { rerender } = renderHook(
+      ({ enabled }) => useProjectViewRevealed(callback, { enabled }),
+      {
+        initialProps: { enabled: false },
+      }
+    );
+
+    emit("revealed");
+    emit("revealed");
+    emit("revealed");
+
+    rerender({ enabled: true });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not run a catch-up on enable when no reveal was missed", () => {
+    const callback = vi.fn();
+    const { rerender } = renderHook(
+      ({ enabled }) => useProjectViewRevealed(callback, { enabled }),
+      {
+        initialProps: { enabled: false },
+      }
+    );
+
+    rerender({ enabled: true });
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("clears the pending catch-up once it has run", () => {
+    const callback = vi.fn();
+    const { rerender } = renderHook(
+      ({ enabled }) => useProjectViewRevealed(callback, { enabled }),
+      {
+        initialProps: { enabled: false },
+      }
+    );
+
+    emit("revealed");
+    rerender({ enabled: true });
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // Going away and coming back must not replay the reveal that was already
+    // paid for.
+    rerender({ enabled: false });
+    rerender({ enabled: true });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs the callback directly while enabled instead of deferring", () => {
+    const callback = vi.fn();
+    const { rerender } = renderHook(
+      ({ enabled }) => useProjectViewRevealed(callback, { enabled }),
+      {
+        initialProps: { enabled: true },
+      }
+    );
+
+    emit("revealed");
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // No pending work was recorded, so toggling away and back adds nothing.
+    rerender({ enabled: false });
+    rerender({ enabled: true });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("unsubscribes on unmount", () => {
+    const callback = vi.fn();
+    const { unmount } = renderHook(() => useProjectViewRevealed(callback));
+
+    unmount();
+    expect(listeners.size).toBe(0);
+
+    emit("revealed");
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useProjectViewRevealed.ts
+++ b/src/hooks/useProjectViewRevealed.ts
@@ -1,0 +1,60 @@
+import { useEffect, useEffectEvent, useRef } from "react";
+import { subscribeProjectViewLifecycle } from "@/lib/viewCacheState";
+
+interface ProjectViewRevealedOptions {
+  /**
+   * Whether this consumer is on screen. A reveal arriving while false is
+   * remembered and run once the consumer becomes presented — skipping outright
+   * would strand it, since nothing re-emits the phase later.
+   */
+  enabled?: boolean;
+}
+
+/**
+ * Run one-shot catch-up work when this project view returns to the foreground.
+ *
+ * `revealed` is the phase to gate on, not `active`: a switch superseded
+ * mid-flight only ever reaches `active` (see `viewCacheState`), and a view that
+ * never became the presenting surface has nothing to catch up for. A cold page
+ * load emits no phase at all — a fresh view was never cached — so consumers keep
+ * their own initial load without needing a page-load guard here.
+ *
+ * The listener is registered once and reads the newest callback through
+ * `useEffectEvent`, so a caller can pass an inline closure over live state
+ * without churning the subscription every render.
+ */
+export function useProjectViewRevealed(
+  callback: () => void,
+  { enabled = true }: ProjectViewRevealedOptions = {}
+): void {
+  // One bit, not a count: the work is "read the current state", so a consumer
+  // hidden across several switches owes exactly one catch-up on the way back.
+  const pendingRef = useRef(false);
+  const enabledRef = useRef(enabled);
+
+  const handleReveal = useEffectEvent(() => {
+    if (!enabledRef.current) {
+      pendingRef.current = true;
+      return;
+    }
+    pendingRef.current = false;
+    callback();
+  });
+
+  const flushPending = useEffectEvent(() => {
+    if (!pendingRef.current) return;
+    pendingRef.current = false;
+    callback();
+  });
+
+  useEffect(() => {
+    return subscribeProjectViewLifecycle((phase) => {
+      if (phase === "revealed") handleReveal();
+    });
+  }, []);
+
+  useEffect(() => {
+    enabledRef.current = enabled;
+    if (enabled) flushPending();
+  }, [enabled]);
+}

--- a/src/hooks/useProjectViewRevealed.ts
+++ b/src/hooks/useProjectViewRevealed.ts
@@ -30,10 +30,16 @@ export function useProjectViewRevealed(
   // One bit, not a count: the work is "read the current state", so a consumer
   // hidden across several switches owes exactly one catch-up on the way back.
   const pendingRef = useRef(false);
-  const enabledRef = useRef(enabled);
 
+  // `enabled` is read here rather than mirrored into a ref, because an effect
+  // event sees the latest COMMITTED props while a ref assigned from a passive
+  // effect lags the commit that changed it. That gap is reachable: a consumer
+  // can go hidden and take a synchronous `revealed` from main before its effect
+  // runs, which a lagging ref would answer with "still visible" — running the
+  // refresh against something nobody can see AND consuming the reveal, so the
+  // catch-up on the way back never happens either.
   const handleReveal = useEffectEvent(() => {
-    if (!enabledRef.current) {
+    if (!enabled) {
       pendingRef.current = true;
       return;
     }
@@ -54,7 +60,6 @@ export function useProjectViewRevealed(
   }, []);
 
   useEffect(() => {
-    enabledRef.current = enabled;
     if (enabled) flushPending();
   }, [enabled]);
 }

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -39,6 +39,7 @@ import { usePreferencesStore } from "@/store/preferencesStore";
 import { flushPanelPersistence } from "@/store/slices";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { useExternalChangeTick } from "@/hooks/useExternalChangeTick";
+import { useProjectViewRevealed } from "@/hooks/useProjectViewRevealed";
 import { FileTreeView } from "./FileTreeView";
 import { FileBrowserViewer } from "./FileBrowserViewer";
 import { useFileBrowserTree } from "./useFileBrowserTree";
@@ -321,9 +322,11 @@ export function FileBrowserPane({
     treeSnapshot,
   });
 
-  // Persist the last-known tree at going-away points only (#11367): the view
-  // being hidden (project switch, window close, app quit — `visibilitychange`
-  // is the reliable detach signal, see #9914 in `resource.ts`) and unmount,
+  // Persist the last-known tree at going-away points only (#11367): the
+  // document actually being hidden (window minimize, window close, app quit —
+  // `visibilitychange` is the reliable detach signal for those, see #9914 in
+  // `resource.ts`; a project switch is NOT one of them, since caching a child
+  // WebContentsView leaves page visibility alone) and unmount,
   // which records the outgoing tree (dialog close, re-root) for the *next*
   // restore — a dialog → grid promotion's replacement pane mounts before this
   // cleanup writes, so it still cold-fetches. Never on a change tick — the
@@ -423,25 +426,43 @@ export function FileBrowserPane({
     [location, onClose, basePath, rows]
   );
 
-  // The explicit half of the refresh signal, counted apart from the ambient
+  // The foreground half of the refresh signal, counted apart from the ambient
   // change tick so Refresh also re-reads the open file, not just the tree. It
   // then travels to the viewer BOTH ways, and both are load-bearing: merged
   // into `viewerRevision` below, and handed over on its own as the media
   // previews' reload key (#11586). Dropping the direct handoff makes Refresh
   // inert for media again; substituting the merged value there restarts
   // playback on every ambient write. Keep both.
-  const [manualRefreshNonce, setManualRefreshNonce] = useState(0);
+  const [surfaceRefreshNonce, setSurfaceRefreshNonce] = useState(0);
+  const refreshAll = useCallback(
+    (options?: { manual?: boolean }) => {
+      setSurfaceRefreshNonce((nonce) => nonce + 1);
+      refresh(options);
+    },
+    [refresh]
+  );
   const handleRefresh = useCallback(() => {
-    setManualRefreshNonce((nonce) => nonce + 1);
-    refresh({ manual: true });
-  }, [refresh]);
+    refreshAll({ manual: true });
+  }, [refreshAll]);
+
+  // Returning to a project the user left. A view swap is not a page load and
+  // `document.visibilityState` never moves for a cached child WebContentsView
+  // (`viewCacheState`), so without this the tree and whatever file is open in
+  // the viewer both sit on whatever they read on the way out — media and PDFs
+  // worst of all, since the change tick deliberately never reaches their reload
+  // key. Re-reads exactly what Refresh does, minus `manual`: the spinner
+  // reports a gesture, and coming back to a project isn't one.
+  const isDockParked = usePanelStore(
+    useCallback((state) => location === "dock" && state.activeDockTerminalId !== id, [location, id])
+  );
+  useProjectViewRevealed(() => refreshAll(), { enabled: !isDockParked });
 
   // One value per refresh *cycle*, not per directory listed. Deriving it from
   // the tree's per-listing commits would make a 500-directory refresh re-read
   // the open file 500 times. Carrying the nonce here as well as separately is
   // what re-runs the viewer's classification effect, so a media file stuck in
   // `status: "error"` remounts its preview on Refresh instead of staying dead.
-  const viewerRevision = `${changeTick ?? 0}:${manualRefreshNonce}`;
+  const viewerRevision = `${changeTick ?? 0}:${surfaceRefreshNonce}`;
 
   const handleToggleDotfiles = useCallback(() => {
     setFileBrowserView(id, { browserHideDotfiles: !hideDotfiles });
@@ -1065,7 +1086,7 @@ export function FileBrowserPane({
               // out of it: the media previews may only re-fetch on the explicit
               // half of that pair, and a merged string can't say which half
               // moved (#11586).
-              manualRefreshNonce={manualRefreshNonce}
+              surfaceRefreshNonce={surfaceRefreshNonce}
               onRefresh={handleRefresh}
               isRefreshing={isRefreshing}
               sidebarCollapsed={sidebarCollapsed}

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -64,13 +64,14 @@ export interface FileBrowserViewerProps {
    */
   revision: string;
   /**
-   * Changes only when the user presses Refresh, never on an ambient worktree
-   * tick — the half of `revision` the media branches can safely honour. Typed
-   * `number` rather than `string | number` so handing it the merged `revision`
-   * (which also carries the change tick) is a compile error, not a silent
-   * regression to restarting playback on every background write.
+   * Changes on a foreground refresh — pressing Refresh, or returning to this
+   * project after it sat cached — never on an ambient worktree tick. The half
+   * of `revision` the media branches can safely honour. Typed `number` rather
+   * than `string | number` so handing it the merged `revision` (which also
+   * carries the change tick) is a compile error, not a silent regression to
+   * restarting playback on every background write.
    */
-  manualRefreshNonce: number;
+  surfaceRefreshNonce: number;
   /** Runs the pane's manual refresh — re-reads the tree and the open file. */
   onRefresh: () => void;
   /** Whether that refresh is still draining; spins the Refresh icon. */
@@ -124,7 +125,7 @@ export function FileBrowserViewer({
   fileName,
   relativePath,
   revision,
-  manualRefreshNonce,
+  surfaceRefreshNonce,
   onRefresh,
   isRefreshing,
   sidebarCollapsed,
@@ -526,16 +527,17 @@ export function FileBrowserViewer({
       case "video":
         return (
           <div className="h-full w-full overflow-auto">
-            {/* Reloaded on `manualRefreshNonce`, never on `revision`: that
+            {/* Reloaded on `surfaceRefreshNonce`, never on `revision`: that
                 ticks on every worktree write, and re-fetching would reset
-                playback whenever an agent touches any file. Pressing Refresh
-                is the one gesture that outranks continuity, so it — and only
-                it — pulls the rewritten bytes (#11586). */}
+                playback whenever an agent touches any file. Only a foreground
+                refresh outranks continuity — pressing Refresh (#11586), or
+                coming back to this project (#11588) — so only those pull the
+                rewritten bytes. */}
             <FileVideoPreview
               filePath={filePath}
               rootPath={rootPath}
               label={fileName}
-              reloadKey={manualRefreshNonce}
+              reloadKey={surfaceRefreshNonce}
               onError={(error) =>
                 setState({
                   status: "error",
@@ -557,7 +559,7 @@ export function FileBrowserViewer({
               filePath={filePath}
               rootPath={rootPath}
               label={fileName}
-              reloadKey={manualRefreshNonce}
+              reloadKey={surfaceRefreshNonce}
               onError={(error) =>
                 setState({
                   status: "error",
@@ -577,7 +579,7 @@ export function FileBrowserViewer({
             filePath={filePath}
             rootPath={rootPath}
             label={fileName}
-            reloadKey={manualRefreshNonce}
+            reloadKey={surfaceRefreshNonce}
           />
         );
 

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -68,12 +68,44 @@ interface MockPanel {
 
 const mockPanel: MockPanel = { id: "fb-1", kind: "file-browser" };
 
+// Mutable so a dock test can make this panel the active dock panel (or not) —
+// the pane defers its reveal refresh while parked offscreen (#11588).
+const dockState = { activeDockTerminalId: null as string | null };
+
 vi.mock("@/store/panelStore", () => ({
   usePanelStore: (selector: (state: unknown) => unknown) =>
     selector({
       panelsById: { "fb-1": mockPanel },
       setFileBrowserView: setFileBrowserViewMock,
+      activeDockTerminalId: dockState.activeDockTerminalId,
     }),
+}));
+
+// #11588: returning to a cached project view. A real listener registry rather
+// than a bare stub so unsubscribe-on-unmount is observable.
+//
+// `vi.hoisted`, not a plain const: this suite transitively pulls a module that
+// subscribes at module scope, so the factory's `subscribeProjectViewLifecycle`
+// runs while a module-scope `const` would still be in its TDZ. That throws
+// during collection — and vitest still exits 0, so the whole file silently
+// stops running while the summary reads green.
+type LifecyclePhase = "cached" | "active" | "revealed";
+const lifecycleListeners = vi.hoisted(() => new Set<(phase: LifecyclePhase) => void>());
+// Every runtime export, not just the one this pane imports: a factory is a
+// strict surface, and a module elsewhere in the graph reaching for a missing
+// name fails the whole file at collection rather than at the call.
+vi.mock("@/lib/viewCacheState", () => ({
+  subscribeProjectViewLifecycle: (listener: (phase: LifecyclePhase) => void) => {
+    lifecycleListeners.add(listener);
+    return () => {
+      lifecycleListeners.delete(listener);
+    };
+  },
+  // The real module's own safe default — the un-demoted answer.
+  isProjectViewCached: () => false,
+  __resetProjectViewCacheStateForTests: () => {
+    lifecycleListeners.clear();
+  },
 }));
 
 vi.mock("@/hooks/useWorktreeStore", () => ({
@@ -355,6 +387,8 @@ beforeEach(() => {
   dispatchMock.mockResolvedValue({ ok: true, result: { panelId: "file-1" } });
   worktreeTicks.git = undefined;
   worktreeTicks.fs = undefined;
+  lifecycleListeners.clear();
+  dockState.activeDockTerminalId = null;
   for (const name of ["matchMedia"] as const) {
     if (typeof window[name] !== "function") {
       Object.defineProperty(window, name, {
@@ -2042,5 +2076,161 @@ describe("FileBrowserPane refresh signal reaches both viewer paths (#11586)", ()
       URL.createObjectURL = realCreateObjectURL;
       URL.revokeObjectURL = realRevokeObjectURL;
     }
+  });
+});
+
+// #11588: a project switch is not a page load. Caching a view is
+// `removeChildView` + `setVisible(false)`, so `document.visibilityState` never
+// moves; the change tick keeps running but deliberately never reaches the media
+// previews' reload key. Coming back is the only moment the tree and the open
+// file can learn what happened while the project sat in the background.
+describe("FileBrowserPane re-reads when the project view is revealed (#11588)", () => {
+  const PDF_ROW = {
+    path: "docs/spec.pdf",
+    name: "spec.pdf",
+    isDirectory: false,
+    depth: 1,
+    isExpanded: false,
+    isLoading: false,
+  };
+
+  function paneElement(location: "grid" | "dock" = "grid") {
+    return (
+      <TooltipProvider>
+        <FileBrowserPane
+          id="fb-1"
+          title="Files"
+          worktreeId="wt-1"
+          isFocused
+          location={location}
+          onFocus={vi.fn()}
+          onClose={vi.fn()}
+        />
+      </TooltipProvider>
+    );
+  }
+
+  async function emit(phase: LifecyclePhase) {
+    await act(async () => {
+      for (const listener of Array.from(lifecycleListeners)) listener(phase);
+    });
+  }
+
+  it("re-lists the tree on reveal", async () => {
+    renderPane();
+
+    await emit("revealed");
+
+    expect(treeState.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not spin the toolbar icon: reveal is not a gesture", async () => {
+    // `manual` exists only to drive the Refresh spinner, and reporting a
+    // gesture nobody made would be a lie about who asked for the work.
+    renderPane();
+
+    await emit("revealed");
+
+    expect(treeState.refresh).toHaveBeenCalledWith(undefined);
+    expect(treeState.refresh).not.toHaveBeenCalledWith({ manual: true });
+  });
+
+  it("stays put on cached and active", async () => {
+    renderPane();
+
+    await emit("cached");
+    await emit("active");
+
+    expect(treeState.refresh).not.toHaveBeenCalled();
+  });
+
+  it("re-reads the open text file on reveal", async () => {
+    // The nonce reaches the viewer through `viewerRevision`; drop it from that
+    // formula and the tree still refreshes while the file on screen goes stale.
+    mockPanel.browserSelectedPath = "src/app.ts";
+    mockPanel.browserSidebarCollapsed = true;
+    renderPane();
+    await waitFor(() => expect(readMock).toHaveBeenCalledTimes(1));
+
+    await emit("revealed");
+
+    await waitFor(() => expect(readMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("re-navigates the open PDF on reveal", async () => {
+    // The surface with no other safety net: `revision` never reaches the PDF
+    // branch, so before this the only way to see the rewritten bytes was
+    // pressing Refresh.
+    treeState.rows = [...defaultRows, PDF_ROW];
+    mockPanel.browserSelectedPath = PDF_ROW.path;
+    mockPanel.browserSidebarCollapsed = true;
+    const { container } = renderPane();
+    await waitFor(() => expect(container.querySelector("iframe")).not.toBeNull());
+    const srcBefore = container.querySelector("iframe")?.getAttribute("src");
+
+    await emit("revealed");
+
+    await waitFor(() =>
+      expect(container.querySelector("iframe")?.getAttribute("src")).not.toBe(srcBefore)
+    );
+  });
+
+  it("leaves the open PDF alone on an ambient change tick", async () => {
+    // The invariant the reveal path must not trample: an agent writing any file
+    // in the worktree still must not throw away the reader's page and zoom.
+    treeState.rows = [...defaultRows, PDF_ROW];
+    mockPanel.browserSelectedPath = PDF_ROW.path;
+    mockPanel.browserSidebarCollapsed = true;
+    worktreeTicks.git = 100;
+    const { container, rerender } = renderPane();
+    await waitFor(() => expect(container.querySelector("iframe")).not.toBeNull());
+    const srcBefore = container.querySelector("iframe")?.getAttribute("src");
+
+    worktreeTicks.git = 200;
+    await act(async () => {
+      rerender(paneElement());
+    });
+
+    expect(container.querySelector("iframe")?.getAttribute("src")).toBe(srcBefore);
+  });
+
+  it("stops listening once the pane unmounts", () => {
+    const { unmount } = renderPane();
+
+    unmount();
+
+    expect(lifecycleListeners.size).toBe(0);
+  });
+
+  describe("dock parking", () => {
+    it("defers the refresh while parked offscreen, then runs it once on activation", async () => {
+      // A dock panel stays mounted in the offscreen parking container whether
+      // or not its popover is open, so an ungated reveal would re-list the tree
+      // and restart any media for something nobody can see.
+      dockState.activeDockTerminalId = "other-panel";
+      const { rerender } = render(paneElement("dock"));
+
+      await emit("revealed");
+      await emit("revealed");
+      expect(treeState.refresh).not.toHaveBeenCalled();
+
+      dockState.activeDockTerminalId = "fb-1";
+      await act(async () => {
+        rerender(paneElement("dock"));
+      });
+
+      // Two missed reveals owe one catch-up — the work is "list what is on disk
+      // now", not "replay every switch".
+      expect(treeState.refresh).toHaveBeenCalledTimes(1);
+    });
+
+    it("refreshes immediately when the dock panel is the active one", async () => {
+      dockState.activeDockTerminalId = "fb-1";
+      render(paneElement("dock"));
+
+      await emit("revealed");
+
+      expect(treeState.refresh).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -58,7 +58,7 @@ interface ViewerOpts {
   sidebarCollapsed?: boolean;
   onToggleSidebar?: () => void;
   revision?: string;
-  manualRefreshNonce?: number;
+  surfaceRefreshNonce?: number;
   onRefresh?: () => void;
   isRefreshing?: boolean;
 }
@@ -76,7 +76,7 @@ function viewerJsx(filePath: string | null, opts: ViewerOpts = {}) {
         fileName={fileName}
         relativePath={filePath ? fileName : null}
         revision={opts.revision ?? "r1"}
-        manualRefreshNonce={opts.manualRefreshNonce ?? 0}
+        surfaceRefreshNonce={opts.surfaceRefreshNonce ?? 0}
         onRefresh={opts.onRefresh ?? vi.fn()}
         isRefreshing={opts.isRefreshing ?? false}
         sidebarCollapsed={opts.sidebarCollapsed ?? false}
@@ -297,7 +297,7 @@ describe("FileBrowserViewer video preview (#11382)", () => {
 
     const { container, rerender } = renderViewer("/repo/media/demo.webm", {
       revision: "r1",
-      manualRefreshNonce: 0,
+      surfaceRefreshNonce: 0,
     });
     await waitFor(() => expect(container.querySelector("video")).not.toBeNull());
     const firstNode = container.querySelector("video");
@@ -305,7 +305,7 @@ describe("FileBrowserViewer video preview (#11382)", () => {
     expect(videoFetchMock).toHaveBeenCalledTimes(1);
 
     // A worktree write elsewhere: the player must be left completely alone.
-    rerender(viewerJsx("/repo/media/demo.webm", { revision: "r2", manualRefreshNonce: 0 }));
+    rerender(viewerJsx("/repo/media/demo.webm", { revision: "r2", surfaceRefreshNonce: 0 }));
     await act(async () => {});
     expect(container.querySelector("video")).toBe(firstNode);
     expect(container.querySelector("video")?.getAttribute("src")).toBe(firstSrc);
@@ -313,7 +313,7 @@ describe("FileBrowserViewer video preview (#11382)", () => {
 
     // Refresh pressed: exactly one more request, aimed at a different URL —
     // proof the nonce reached it, without pinning the leaf's `v=` spelling.
-    rerender(viewerJsx("/repo/media/demo.webm", { revision: "r2", manualRefreshNonce: 1 }));
+    rerender(viewerJsx("/repo/media/demo.webm", { revision: "r2", surfaceRefreshNonce: 1 }));
     await waitFor(() => expect(videoFetchMock).toHaveBeenCalledTimes(2));
     expect(String(videoFetchMock.mock.calls[1]?.[0])).not.toBe(
       String(videoFetchMock.mock.calls[0]?.[0])
@@ -396,14 +396,14 @@ describe("FileBrowserViewer audio preview (#11425)", () => {
     URL.createObjectURL = vi.fn(() => `blob:app://daintree/audio-${objectUrlSequence++}`);
 
     const { container, rerender } = renderViewer("/repo/media/track.mp3", {
-      manualRefreshNonce: 0,
+      surfaceRefreshNonce: 0,
     });
     await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
     const firstNode = container.querySelector("audio");
     const firstSrc = firstNode?.getAttribute("src");
     expect(audioFetchMock).toHaveBeenCalledTimes(1);
 
-    rerender(viewerJsx("/repo/media/track.mp3", { manualRefreshNonce: 1 }));
+    rerender(viewerJsx("/repo/media/track.mp3", { surfaceRefreshNonce: 1 }));
     await waitFor(() => expect(audioFetchMock).toHaveBeenCalledTimes(2));
 
     // A different URL, so the nonce genuinely reached the request rather than
@@ -435,13 +435,13 @@ describe("FileBrowserViewer audio preview (#11425)", () => {
 
     const { container, rerender } = renderViewer("/repo/media/track.mp3", {
       revision: "0:0",
-      manualRefreshNonce: 0,
+      surfaceRefreshNonce: 0,
     });
     await screen.findByText("This audio file couldn't be played");
     expect(container.querySelector("audio")).toBeNull();
 
     // Exactly what the pane emits for one Refresh press: both values move.
-    rerender(viewerJsx("/repo/media/track.mp3", { revision: "0:1", manualRefreshNonce: 1 }));
+    rerender(viewerJsx("/repo/media/track.mp3", { revision: "0:1", surfaceRefreshNonce: 1 }));
 
     await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
     expect(screen.queryByText("This audio file couldn't be played")).toBeNull();
@@ -476,7 +476,7 @@ describe("FileBrowserViewer PDF preview (#11427)", () => {
   it("re-navigates only on an explicit refresh, never on a revision tick (#11586)", async () => {
     const { container, rerender } = renderViewer("/repo/docs/spec.pdf", {
       revision: "r1",
-      manualRefreshNonce: 0,
+      surfaceRefreshNonce: 0,
     });
     await act(async () => {});
     const firstFrame = container.querySelector("iframe");
@@ -485,12 +485,12 @@ describe("FileBrowserViewer PDF preview (#11427)", () => {
     // An ambient write must not throw away the reader's page and zoom. Both a
     // changed src AND a remounted frame would do that, so pin the node too —
     // a remount carrying an identical src resets the reader just the same.
-    rerender(viewerJsx("/repo/docs/spec.pdf", { revision: "r2", manualRefreshNonce: 0 }));
+    rerender(viewerJsx("/repo/docs/spec.pdf", { revision: "r2", surfaceRefreshNonce: 0 }));
     await act(async () => {});
     expect(container.querySelector("iframe")).toBe(firstFrame);
     expect(container.querySelector("iframe")?.getAttribute("src")).toBe(firstSrc);
 
-    rerender(viewerJsx("/repo/docs/spec.pdf", { revision: "r2", manualRefreshNonce: 1 }));
+    rerender(viewerJsx("/repo/docs/spec.pdf", { revision: "r2", surfaceRefreshNonce: 1 }));
     await act(async () => {});
     const refreshed = container.querySelector("iframe");
     // Re-navigated in place rather than remounted: the same element takes a new
@@ -552,13 +552,13 @@ describe("FileBrowserViewer Refresh control (#11586)", () => {
     // it — the media tests above would all still pass.
     const { rerender } = renderViewer("/repo/src/notes.txt", {
       revision: "0:0",
-      manualRefreshNonce: 0,
+      surfaceRefreshNonce: 0,
     });
     await screen.findByTestId("code-viewer-mock");
     expect(readMock).toHaveBeenCalledTimes(1);
 
     // What the pane produces for a Refresh press on a worktree with no tick.
-    rerender(viewerJsx("/repo/src/notes.txt", { revision: "0:1", manualRefreshNonce: 1 }));
+    rerender(viewerJsx("/repo/src/notes.txt", { revision: "0:1", surfaceRefreshNonce: 1 }));
     await waitFor(() => expect(readMock).toHaveBeenCalledTimes(2));
   });
 });

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -66,6 +66,7 @@ import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { isClientAppError } from "@/utils/clientAppError";
 import { logError } from "@/utils/logger";
 import { useHeightHold } from "./useHeightHold";
+import { useProjectViewRevealed } from "@/hooks/useProjectViewRevealed";
 
 export interface FilePaneProps extends BasePanelProps {
   tabs?: TabInfo[];
@@ -126,6 +127,17 @@ function isUnderRoot(filePath: string, rootPath: string): boolean {
 // content.
 type LoadState =
   "idle" | "loading" | "loaded" | "error" | "image" | "svg" | "video" | "audio" | "pdf";
+
+// Why a read is happening, which decides two things a single boolean used to
+// conflate. `explicit` is a gesture aimed at this pane (open, toolbar Refresh,
+// Retry): it earns the loading skeleton and re-requests every rendered surface.
+// `ambient` is the filesystem talking (change tick, focus regain): it must not
+// flash the skeleton, and must not move a reload key an unrelated write would
+// otherwise use to reset playback. `revealed` is returning to this project:
+// silent like ambient, because nobody asked for a skeleton, but forcing the
+// reload key like explicit, because everything that happened while the view sat
+// cached is precisely what this pane cannot otherwise see.
+type FileLoadIntent = "explicit" | "ambient" | "revealed";
 
 // Which surface a toolbar action aims the current file at. `reveal` is always
 // offered; `browser`/`editor` is the mode-dependent open button; `file-browser`
@@ -523,7 +535,15 @@ export function FilePane({
   }, []);
 
   const loadFile = useCallback(
-    (silent: boolean) => {
+    (intent: FileLoadIntent) => {
+      // Two independent questions, and reveal answers them differently from
+      // either of the other intents. Whether to show the skeleton: only an
+      // explicit gesture earns one, because only then is someone waiting on a
+      // surface they just asked for. Whether to re-request the rendered
+      // surface: everything but an ambient pass, so returning to a project
+      // moves the reload key that a background tick deliberately leaves alone.
+      const silent = intent !== "explicit";
+      const forceSurfaceReload = intent !== "ambient";
       if (!filePath) {
         requestRef.current++;
         setContent(null);
@@ -559,10 +579,10 @@ export function FilePane({
       if (isVideoFilePath(filePath)) {
         setContent(null);
         setSanitizedSvg(null);
-        // Only an explicit load (open, toolbar Refresh) re-requests the media —
-        // a silent background pass must not remount the player and reset
-        // playback while someone is watching.
-        if (!silent) setReloadNonce((nonce) => nonce + 1);
+        // Only a foreground load (open, toolbar Refresh, returning to this
+        // project) re-requests the media — an ambient background pass must not
+        // remount the player and reset playback while someone is watching.
+        if (forceSurfaceReload) setReloadNonce((nonce) => nonce + 1);
         setLoadState("video");
         setErrorCode(null);
         setErrorMessage(null);
@@ -574,10 +594,10 @@ export function FilePane({
       if (isAudioFilePath(filePath)) {
         setContent(null);
         setSanitizedSvg(null);
-        // Only an explicit load (open, toolbar Refresh) re-requests the media —
-        // a silent background pass must not remount the player and reset
-        // playback while someone is listening.
-        if (!silent) setReloadNonce((nonce) => nonce + 1);
+        // Only a foreground load (open, toolbar Refresh, returning to this
+        // project) re-requests the media — an ambient background pass must not
+        // remount the player and reset playback while someone is listening.
+        if (forceSurfaceReload) setReloadNonce((nonce) => nonce + 1);
         setLoadState("audio");
         setErrorCode(null);
         setErrorMessage(null);
@@ -589,10 +609,10 @@ export function FilePane({
       if (isPdfFilePath(filePath)) {
         setContent(null);
         setSanitizedSvg(null);
-        // Only an explicit load (open, toolbar Refresh) re-requests the
-        // document — a silent background pass must not remount the frame and
-        // throw away the reader's page and zoom.
-        if (!silent) setReloadNonce((nonce) => nonce + 1);
+        // Only a foreground load (open, toolbar Refresh, returning to this
+        // project) re-requests the document — an ambient background pass must
+        // not remount the frame and throw away the reader's page and zoom.
+        if (forceSurfaceReload) setReloadNonce((nonce) => nonce + 1);
         setLoadState("pdf");
         setErrorCode(null);
         setErrorMessage(null);
@@ -656,13 +676,16 @@ export function FilePane({
           setHtmlPreviewUrl(previewUrl ?? null);
           // Re-navigate the preview frame so a rewritten report — or an unchanged
           // entry file whose relative asset changed — reflects the latest bytes.
-          // The nonce is the sandboxed frame's only src input, so a silent pass
-          // only bumps it when the bytes actually moved: otherwise every worktree
-          // tick, most of them writes to unrelated files, would throw away the
-          // rendered page's scroll and in-page JS state. Explicit loads (open,
-          // toolbar Refresh) stay unconditional, keeping a manual path for an
-          // asset-only change. reloadNonce isn't a loadFile dep, so neither can
-          // re-trigger the load.
+          // The nonce is the sandboxed frame's only src input, so an ambient
+          // pass only bumps it when the bytes actually moved: otherwise every
+          // worktree tick, most of them writes to unrelated files, would throw
+          // away the rendered page's scroll and in-page JS state. Foreground
+          // loads (open, toolbar Refresh, returning to this project) stay
+          // unconditional — an entry file whose relative asset was rewritten
+          // while the project sat cached reads as unchanged bytes, so the
+          // bytes-changed gate is exactly what would leave it stale.
+          // reloadNonce isn't a loadFile dep, so neither can re-trigger the
+          // load.
           //
           // Markdown opts out of the bytes-changed gate: an image embedded in the
           // document is precisely the "unchanged file whose asset changed" case,
@@ -672,7 +695,7 @@ export function FilePane({
           // needs isHtml, and the media previews need their own loadStates — and
           // a changed image src reloads in place rather than remounting, so there
           // is no scroll or playback position to lose.
-          if (!silent || bytesChanged || isMarkdownFilePath(filePath)) {
+          if (forceSurfaceReload || bytesChanged || isMarkdownFilePath(filePath)) {
             setReloadNonce((nonce) => nonce + 1);
           }
           setLoadState("loaded");
@@ -705,7 +728,7 @@ export function FilePane({
   );
 
   useEffect(() => {
-    loadFile(false);
+    loadFile("explicit");
   }, [loadFile]);
 
   // Toolbar Refresh: spin the icon until the refreshed surface settles. Capture
@@ -716,7 +739,7 @@ export function FilePane({
   const handleToolbarRefresh = useCallback(() => {
     setRefreshingMode(viewMode);
     if (viewMode === "diff") retryDiff();
-    else loadFile(false);
+    else loadFile("explicit");
   }, [viewMode, retryDiff, loadFile]);
 
   useEffect(() => {
@@ -738,7 +761,7 @@ export function FilePane({
   // silently, so a file deleted mid-view can't keep reading as present.
   const wasDiffModeRef = useRef(viewMode === "diff");
   useEffect(() => {
-    if (wasDiffModeRef.current && viewMode !== "diff") loadFile(true);
+    if (wasDiffModeRef.current && viewMode !== "diff") loadFile("ambient");
     wasDiffModeRef.current = viewMode === "diff";
   }, [viewMode, loadFile]);
 
@@ -782,7 +805,7 @@ export function FilePane({
     // happened to the file before anything was watching it is exactly what the
     // pane cannot otherwise know about.
     if (previous.watchRoot === diffWorktreePath && previous.tick === changeTick) return;
-    loadFile(true);
+    loadFile("ambient");
   }, [filePath, effectiveRootPath, diffWorktreePath, changeTick, viewMode, loadFile]);
 
   // Which surfaces a background re-read may replace. Images and inlined SVG join
@@ -805,17 +828,46 @@ export function FilePane({
   const wasFocusedRef = useRef(isFocused);
   useEffect(() => {
     if (isFocused && !wasFocusedRef.current && refetchesOnFocus) {
-      loadFile(true);
+      loadFile("ambient");
     }
     wasFocusedRef.current = isFocused;
   }, [isFocused, refetchesOnFocus, loadFile]);
 
   useEffect(() => {
     if (!refetchesOnFocus) return;
-    const handleWindowFocus = () => loadFile(true);
+    const handleWindowFocus = () => loadFile("ambient");
     window.addEventListener("focus", handleWindowFocus);
     return () => window.removeEventListener("focus", handleWindowFocus);
   }, [refetchesOnFocus, loadFile]);
+
+  // Coming back to a project the user left is the one moment nothing else
+  // covers. A view swap is not a page load and produces no window focus event,
+  // and `document.visibilityState` never moved — a cached child WebContentsView
+  // reports "visible" the whole time it is away (`viewCacheState`). So the
+  // worktree tick is the only live signal, and it deliberately cannot reach
+  // video, audio or PDF: their reload key stays put on an ambient pass so an
+  // unrelated write can't reset playback or a reader's page. Those are exactly
+  // the surfaces that come back stale.
+  //
+  // Deliberately its own trigger rather than a branch of the change-tick effect
+  // above: that one is gated on read-versus-watch root identity, which a reveal
+  // has no opinion about, and folding this in would let a watch-root quirk
+  // swallow it.
+  //
+  // No `reloadsSilently` gate either — that predicate exists to skip surfaces a
+  // background re-read would be inert for, which is the opposite of what this
+  // needs. Diff is skipped though: it owns its own freshness (`useDiffContent`
+  // raises a stale banner) and leaving it already re-reads source, so re-reading
+  // here would only replace review content nobody asked to move.
+  const isDockParked = usePanelStore(
+    useCallback((state) => location === "dock" && state.activeDockTerminalId !== id, [location, id])
+  );
+  useProjectViewRevealed(
+    () => {
+      if (viewMode !== "diff") loadFile("revealed");
+    },
+    { enabled: !isDockParked }
+  );
 
   // Route Cmd+F to the source view's find bar while this pane is focused
   // (no-op in rendered markdown, matching the dialog).
@@ -1158,7 +1210,7 @@ export function FilePane({
             {!isUnsupportedVideoFilePath(filePath) && !isUnsupportedAudioFilePath(filePath) && (
               <button
                 type="button"
-                onClick={() => loadFile(false)}
+                onClick={() => loadFile("explicit")}
                 className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-daintree-text bg-daintree-border hover:bg-daintree-border/80 rounded transition-colors"
               >
                 <RefreshCw className="w-3.5 h-3.5" />

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -41,13 +41,43 @@ const { setFileViewModeMock, setFilePanelPathMock } = vi.hoisted(() => ({
   setFileViewModeMock: vi.fn(),
   setFilePanelPathMock: vi.fn(),
 }));
+// Mutable so a dock test can make this panel the active dock panel (or not) —
+// the pane defers its reveal refresh while parked offscreen (#11588).
+const dockState = { activeDockTerminalId: null as string | null };
 vi.mock("@/store/panelStore", () => ({
   usePanelStore: (selector: (state: unknown) => unknown) =>
     selector({
       panelsById,
       setFileViewMode: setFileViewModeMock,
       setFilePanelPath: setFilePanelPathMock,
+      activeDockTerminalId: dockState.activeDockTerminalId,
     }),
+}));
+// #11588: returning to a cached project view is the pane's only signal that the
+// file may have moved while nothing was watching. Mocked with a real listener
+// registry so unsubscribe-on-unmount is observable rather than assumed.
+//
+// `vi.hoisted`, not a plain const: a module-scope subscriber anywhere in the
+// import graph would call the factory's `subscribeProjectViewLifecycle` while a
+// plain const was still in its TDZ, throwing during collection — which vitest
+// reports as a green exit code with the file's tests silently never run.
+type LifecyclePhase = "cached" | "active" | "revealed";
+const lifecycleListeners = vi.hoisted(() => new Set<(phase: LifecyclePhase) => void>());
+// Every runtime export, not just the one this pane imports: a factory is a
+// strict surface, and a module elsewhere in the graph reaching for a missing
+// name fails the whole file at collection rather than at the call.
+vi.mock("@/lib/viewCacheState", () => ({
+  subscribeProjectViewLifecycle: (listener: (phase: LifecyclePhase) => void) => {
+    lifecycleListeners.add(listener);
+    return () => {
+      lifecycleListeners.delete(listener);
+    };
+  },
+  // The real module's own safe default — the un-demoted answer.
+  isProjectViewCached: () => false,
+  __resetProjectViewCacheStateForTests: () => {
+    lifecycleListeners.clear();
+  },
 }));
 vi.mock("@/store/projectStore", () => ({
   useProjectStore: (selector: (state: unknown) => unknown) => selector({ currentProject: null }),
@@ -231,6 +261,8 @@ afterEach(() => {
   setFileViewModeMock.mockReset();
   setFilePanelPathMock.mockReset();
   markdownViewerProps.current = null;
+  lifecycleListeners.clear();
+  dockState.activeDockTerminalId = null;
 });
 
 describe("FilePane restore-control wiring", () => {
@@ -2546,6 +2578,292 @@ describe("FilePane live disk refresh (#11451)", () => {
       await commitTick(rerender);
 
       expect(container.querySelector("iframe")).toBe(frameBefore);
+      expect(container.querySelector("iframe")?.getAttribute("src")).toBe(srcBefore);
+    });
+  });
+});
+
+// #11588: a project switch is not a page load. Caching a view is
+// `removeChildView` + `setVisible(false)`, so `document.visibilityState` never
+// moves and no `window` focus event fires; the worktree tick keeps running but
+// deliberately cannot reach video, audio or PDF. Coming back is the only moment
+// this pane can learn what happened while it was away.
+describe("FilePane re-reads when the project view is revealed (#11588)", () => {
+  const WORKTREE_ID = "wt-1";
+
+  function seedWorktree(): void {
+    worktreeState.worktrees.set(WORKTREE_ID, {
+      id: WORKTREE_ID,
+      path: "/repo",
+      worktreeChanges: { changes: [], lastUpdated: 100 },
+    });
+  }
+
+  function paneElement(options: { location?: "grid" | "dock"; fileViewMode?: string } = {}) {
+    return (
+      <TooltipProvider>
+        <FilePane
+          id="file-1"
+          title="index.ts"
+          isFocused={false}
+          location={options.location ?? "grid"}
+          onFocus={() => {}}
+          onClose={() => {}}
+        />
+      </TooltipProvider>
+    );
+  }
+
+  async function renderPane(
+    options: {
+      filePath?: string;
+      fileViewMode?: string;
+      location?: "grid" | "dock";
+    } = {}
+  ) {
+    seedWorktree();
+    panelsById["file-1"] = {
+      id: "file-1",
+      kind: "file",
+      filePath: options.filePath ?? "/repo/src/index.ts",
+      worktreeId: WORKTREE_ID,
+      fileViewMode: options.fileViewMode,
+    };
+    const view = render(paneElement(options));
+    // Can't wait on readMock — image, media and PDF short-circuit before it.
+    await act(async () => {});
+    return view;
+  }
+
+  async function emit(phase: LifecyclePhase) {
+    await act(async () => {
+      for (const listener of Array.from(lifecycleListeners)) listener(phase);
+    });
+  }
+
+  function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((res) => {
+      resolve = res;
+    });
+    return { promise, resolve };
+  }
+
+  it("re-reads the open file on reveal", async () => {
+    readMock.mockResolvedValue({ content: "v1" });
+    await renderPane({});
+    const readsBefore = readMock.mock.calls.length;
+
+    await emit("revealed");
+
+    expect(readMock.mock.calls.length).toBe(readsBefore + 1);
+  });
+
+  it("stays put on cached and active", async () => {
+    // `cached` is the way out, and a switch superseded mid-flight only ever
+    // reaches `active` — neither means this pane is on screen again.
+    readMock.mockResolvedValue({ content: "v1" });
+    await renderPane({});
+    const readsBefore = readMock.mock.calls.length;
+
+    await emit("cached");
+    await emit("active");
+
+    expect(readMock.mock.calls.length).toBe(readsBefore);
+  });
+
+  it("keeps the current content on screen instead of flashing the skeleton", async () => {
+    // Nobody asked for this read, so it must not look like a load in progress.
+    readMock.mockResolvedValue({ content: "v1" });
+    const { container } = await renderPane({});
+    await waitFor(() =>
+      expect(
+        container.querySelector('[data-testid="code-viewer-mock"]')?.getAttribute("data-content")
+      ).toBe("v1")
+    );
+
+    const pending = deferred<{ content: string }>();
+    readMock.mockReturnValueOnce(pending.promise);
+    await emit("revealed");
+
+    expect(container.querySelector('[role="status"][aria-label="Loading file"]')).toBeNull();
+    expect(
+      container.querySelector('[data-testid="code-viewer-mock"]')?.getAttribute("data-content")
+    ).toBe("v1");
+
+    await act(async () => {
+      pending.resolve({ content: "v2" });
+    });
+    expect(
+      container.querySelector('[data-testid="code-viewer-mock"]')?.getAttribute("data-content")
+    ).toBe("v2");
+  });
+
+  it("re-navigates rendered HTML on reveal even when the bytes are identical", async () => {
+    // The case the bytes-changed gate cannot see: the entry file is unchanged
+    // while a relative asset it pulls in was rewritten in the background.
+    const PREVIEW_URL = "daintree-html://tok/report.html";
+    readMock.mockResolvedValue({ content: "<h1>v1</h1>", htmlPreviewUrl: PREVIEW_URL });
+    const { container } = await renderPane({
+      filePath: "/repo/dist/report.html",
+      fileViewMode: "rendered",
+    });
+    const nonce = () =>
+      container
+        .querySelector('[data-testid="html-viewer-mock"]')
+        ?.getAttribute("data-reload-nonce");
+    await waitFor(() => expect(nonce()).toBeTruthy());
+    const before = nonce();
+
+    await emit("revealed");
+
+    await waitFor(() => expect(nonce()).not.toBe(before));
+  });
+
+  it("skips the re-read in diff mode", async () => {
+    // Diff owns its own freshness (it raises a stale banner) and leaving it
+    // already re-reads source, so pulling here would only move review content
+    // nobody asked to move.
+    worktreeState.worktrees.set(WORKTREE_ID, {
+      id: WORKTREE_ID,
+      path: "/repo",
+      worktreeChanges: { changes: [{ path: "/repo/src/index.ts", status: "modified" }] },
+    });
+    const retry = vi.fn();
+    useDiffContentMock.mockReturnValue({ content: "@@ diff", stale: false, retry });
+    panelsById["file-1"] = {
+      id: "file-1",
+      kind: "file",
+      filePath: "/repo/src/index.ts",
+      worktreeId: WORKTREE_ID,
+      fileViewMode: "diff",
+    };
+    render(paneElement());
+    await act(async () => {});
+    const readsBefore = readMock.mock.calls.length;
+
+    await emit("revealed");
+
+    expect(readMock.mock.calls.length).toBe(readsBefore);
+    expect(retry).not.toHaveBeenCalled();
+  });
+
+  it("stops listening once the pane unmounts", async () => {
+    readMock.mockResolvedValue({ content: "v1" });
+    const { unmount } = await renderPane({});
+
+    unmount();
+
+    expect(lifecycleListeners.size).toBe(0);
+  });
+
+  describe("dock parking", () => {
+    it("defers the re-read while parked offscreen, then runs it once on activation", async () => {
+      // A dock panel stays mounted in the offscreen parking container whether
+      // or not its popover is open, so an ungated reveal would re-read — and
+      // restart any media — for something nobody can see.
+      readMock.mockResolvedValue({ content: "v1" });
+      dockState.activeDockTerminalId = "other-panel";
+      const { rerender } = await renderPane({ location: "dock" });
+      const readsBefore = readMock.mock.calls.length;
+
+      await emit("revealed");
+      await emit("revealed");
+      expect(readMock.mock.calls.length).toBe(readsBefore);
+
+      dockState.activeDockTerminalId = "file-1";
+      await act(async () => {
+        rerender(paneElement({ location: "dock" }));
+      });
+
+      // Two missed reveals owe one catch-up: the work is "read what is on disk
+      // now", not "replay every switch".
+      expect(readMock.mock.calls.length).toBe(readsBefore + 1);
+    });
+
+    it("re-reads immediately when the dock panel is the active one", async () => {
+      readMock.mockResolvedValue({ content: "v1" });
+      dockState.activeDockTerminalId = "file-1";
+      await renderPane({ location: "dock" });
+      const readsBefore = readMock.mock.calls.length;
+
+      await emit("revealed");
+
+      expect(readMock.mock.calls.length).toBe(readsBefore + 1);
+    });
+  });
+
+  describe("media and PDF", () => {
+    // The surfaces with no other safety net: their reload key deliberately does
+    // not move on a worktree tick, so before this the only way to see new bytes
+    // was pressing Refresh.
+    const mediaFetchMock =
+      vi.fn<
+        (
+          input: string | URL | Request
+        ) => Promise<Pick<Response, "ok" | "status" | "headers" | "blob">>
+      >();
+    const realCreateObjectURL = URL.createObjectURL;
+    const realRevokeObjectURL = URL.revokeObjectURL;
+    beforeEach(() => {
+      mediaFetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        blob: () => Promise.resolve(new Blob(["x"])),
+      });
+      vi.stubGlobal("fetch", mediaFetchMock);
+      URL.createObjectURL = vi.fn(() => "blob:app://daintree/media-preview");
+      URL.revokeObjectURL = vi.fn();
+    });
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      mediaFetchMock.mockReset();
+      URL.createObjectURL = realCreateObjectURL;
+      URL.revokeObjectURL = realRevokeObjectURL;
+    });
+
+    it("re-fetches the video on reveal", async () => {
+      const { container } = await renderPane({ filePath: "/repo/media/demo.mp4" });
+      await waitFor(() => expect(container.querySelector("video")).not.toBeNull());
+      const fetchesBefore = mediaFetchMock.mock.calls.length;
+
+      await emit("revealed");
+
+      await waitFor(() => expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore + 1));
+    });
+
+    it("re-fetches the audio on reveal", async () => {
+      // Its own nonce condition, separate from video's — a regression in one
+      // would leave the other's test green.
+      const { container } = await renderPane({ filePath: "/repo/media/track.mp3" });
+      await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+      const fetchesBefore = mediaFetchMock.mock.calls.length;
+
+      await emit("revealed");
+
+      await waitFor(() => expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore + 1));
+    });
+
+    it("re-navigates the PDF frame on reveal", async () => {
+      const { container } = await renderPane({ filePath: "/repo/docs/spec.pdf" });
+      await waitFor(() => expect(container.querySelector("iframe")).not.toBeNull());
+      const srcBefore = container.querySelector("iframe")?.getAttribute("src");
+
+      await emit("revealed");
+
+      await waitFor(() =>
+        expect(container.querySelector("iframe")?.getAttribute("src")).not.toBe(srcBefore)
+      );
+    });
+
+    it("leaves the PDF frame alone on active", async () => {
+      const { container } = await renderPane({ filePath: "/repo/docs/spec.pdf" });
+      await waitFor(() => expect(container.querySelector("iframe")).not.toBeNull());
+      const srcBefore = container.querySelector("iframe")?.getAttribute("src");
+
+      await emit("active");
+
       expect(container.querySelector("iframe")?.getAttribute("src")).toBe(srcBefore);
     });
   });


### PR DESCRIPTION
## Summary

- Content in an open file panel or the file browser could go stale after switching to another project and back, because neither surface had a deterministic re-read on the way back in.
- `FilePane`'s only live signals were the worktree change tick and a window focus listener; `FileBrowserPane` had the change tick and its manual Refresh button. A view swap is not a page load, so it reliably triggers neither.
- Media and PDFs were hit worst, since the change tick deliberately never reaches their reload key, the gate that stops an unrelated write from resetting playback or a reader's page position.

Resolves #11588

## Problem

`document.visibilityState` can't stand in for a real signal here. Caching a project view is `removeChildView` + `setVisible(false)`, and neither flips page visibility for a child `WebContentsView`, so a cached view reports `visible` the entire time it's away.

There's already a purpose-built signal for this: `subscribeProjectViewLifecycle` emits `cached`, `active`, and `revealed`. Nothing in either file surface was subscribed to it.

## The fix

**1. New `src/hooks/useProjectViewRevealed.ts`**
Subscribes to `subscribeProjectViewLifecycle`, gated on the `revealed` phase specifically. A switch superseded mid-flight only ever reaches `active`, and a cold page load emits nothing at all, so neither case needs a guard. Matches the existing one-shot catch-up precedent in `deletedWorktreeCleanup.ts`.

**2. `FilePane.loadFile(silent: boolean)` becomes `loadFile(intent: 'explicit' | 'ambient' | 'revealed')`**
The boolean was conflating two things: whether to show the loading skeleton, and whether to force the rendered surface to re-request. A reveal is silent like an ambient pass (nobody asked for a skeleton), but it forces the reload key like an explicit pass. That reload-key half is what reaches video, audio, PDF, and unchanged rendered HTML, whose relative asset can be rewritten while the entry file's bytes never move, so a bytes-changed gate alone would leave it stale.

**3. `FileBrowserPane` gains `refreshAll`**
Bumps the viewer nonce and re-lists the tree. Wired to reveal without the `manual` flag: `manual` only exists to spin the toolbar Refresh icon, and coming back to a project isn't a user gesture.

**4. `manualRefreshNonce` renamed to `surfaceRefreshNonce`** in `FileBrowserPane`/`FileBrowserViewer`, since it now covers Refresh and reveal both. The load-bearing split is unchanged: the merged `viewerRevision` reaches text/image/svg/markdown, while the bare nonce reaches only the media/PDF `reloadKey`, so an ambient tick still can't restart playback.

**5. Dock panels defer.** They stay mounted in the offscreen parking container, so a reveal there would refresh something nobody can see. Those coalesce any number of missed reveals into one catch-up when the panel becomes the active dock panel. Grid tabs need no gate, since non-active ones are unmounted.

Also fixed a comment in `FileBrowserPane` that claimed `visibilitychange` fires on a project switch. It doesn't, which is the whole reason this issue existed.

## Testing

- 19 test suites, 514 tests pass, 4 directly covering this change: a new `useProjectViewRevealed` suite, plus `FilePane`, `FileBrowserPane`, and `FileBrowserViewer`.
- `npm run typecheck` clean.
- Prettier/ESLint clean on all changed files (0 errors; 6 remaining warnings are pre-existing and outside the changed lines).

## Notes

- No E2E spec. This repo runs no E2E on PRs, so a new spec would land unvalidated and only surface at release/stabilize time. The behavior is instead covered deterministically at the unit level.
- Pre-existing, left alone: `FileBrowserViewer.test.tsx` overwrites `URL.createObjectURL`/`revokeObjectURL` but only calls `vi.unstubAllGlobals()` in teardown, which can't restore methods on `URL`. Outside this change's lines.
