### PR TITLE
feat(palette): give grouped palettes one shared keyboard model

### DIFF
--- a/src/components/ActionPalette/ActionPaletteItem.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { Pin, PinOff, EyeOff, TriangleAlert } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { PALETTE_ROW_CLASS } from "@/components/ui/paletteRowStyles";
 import type { ActionPaletteItem as ActionPaletteItemType } from "@/hooks/useActionPalette";
 import { ACTION_CATEGORY_COLORS, ACTION_CATEGORY_DEFAULT_COLOR } from "@/config/categoryColors";
 
@@ -128,12 +129,10 @@ function ActionPaletteItemInner({
   return (
     <div
       className={cn(
-        "group relative w-full flex items-start gap-3 px-3 py-2 rounded-[var(--radius-md)] transition-colors",
-        "border border-transparent text-daintree-text/70",
+        PALETTE_ROW_CLASS,
+        "group w-full flex items-start gap-3 px-3 py-2 rounded-[var(--radius-md)]",
+        "text-daintree-text/70",
         "hover:bg-overlay-subtle hover:text-daintree-text",
-        "aria-selected:bg-overlay-raised aria-selected:border-overlay aria-selected:text-daintree-text",
-        "aria-selected:before:absolute aria-selected:before:left-0 aria-selected:before:top-2 aria-selected:before:bottom-2",
-        "aria-selected:before:w-[2px] aria-selected:before:bg-daintree-accent aria-selected:before:content-['']",
         !item.enabled && "opacity-50"
       )}
       id={`action-option-${item.id}`}

--- a/src/components/Pilot/PilotView.tsx
+++ b/src/components/Pilot/PilotView.tsx
@@ -562,6 +562,12 @@ export function PilotView() {
         group,
         header: {
           rowId: `group:${group.workspaceId}`,
+          // The runs container's id, which is what the disclosure button
+          // `aria-controls`. Safe only because the header is not navigable, so
+          // this id never reaches `aria-activedescendant`. Making headers
+          // navigable here would first have to give the header element an id
+          // of its own — pointing the active descendant at a role-less
+          // container is the dangling reference #11071 was about.
           domId: groupDomId(group.workspaceId),
           navigable: false,
         },

--- a/src/components/Pilot/PilotView.tsx
+++ b/src/components/Pilot/PilotView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getProjectGradient } from "@/lib/colorUtils";
@@ -24,6 +24,12 @@ import {
 import { PilotRunState } from "./PilotRunState";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { AppPaletteDialog, KBD_CLASS } from "@/components/ui/AppPaletteDialog";
+import { PALETTE_ROW_CLASS } from "@/components/ui/paletteRowStyles";
+import {
+  usePaletteTreeNavigation,
+  type NavigablePaletteTreeRow,
+  type PaletteTreeGroupInput,
+} from "@/hooks/usePaletteTreeNavigation";
 import { Skeleton, SkeletonBone, SkeletonHint } from "@/components/ui/Skeleton";
 import { CircleHelp, FileText } from "@/components/icons";
 import { useEffectiveCombo } from "@/hooks/useKeybinding";
@@ -52,13 +58,10 @@ function runDomId(runId: string): string {
   return `pilot-option-run-${runId}`;
 }
 
-/**
- * Selection styling, lifted verbatim from the switcher's rows so one palette
- * doesn't invent a second vocabulary for "this is the row Enter will act on".
- */
+/** Layout only; the selected treatment comes from the shared row class. */
 const ROW_BASE = cn(
-  "relative flex w-full cursor-pointer items-center rounded-[var(--radius-md)] border border-transparent text-left transition-colors",
-  "before:absolute before:top-2 before:bottom-2 before:left-0 before:w-[2px] before:rounded-r before:bg-daintree-accent before:opacity-0 before:transition-opacity before:content-[''] aria-selected:before:opacity-100"
+  PALETTE_ROW_CLASS,
+  "flex w-full cursor-pointer items-center rounded-[var(--radius-md)] text-left"
 );
 
 /**
@@ -113,36 +116,8 @@ function groupSummary(group: PilotProjectGroup): string {
   return rest > 0 ? `${lead} · ${rest} more` : lead;
 }
 
-function rowTone(isSelected: boolean): string {
-  return isSelected
-    ? "bg-overlay-raised border-overlay text-daintree-text"
-    : "text-daintree-text/70 hover:bg-overlay-subtle hover:text-daintree-text";
-}
-
-/**
- * One project and the runs of it that are currently on screen.
- *
- * The rendered structure and the arrow-key domain are derived from this single
- * value in one pass — the flat nav list below is `groups.flatMap(g => g.rows)`,
- * never an independently re-filtered array. Two lists built separately is how a
- * highlight ends up addressing a row that isn't on screen (the switcher's
- * #11071); deriving both from one source makes drift unrepresentable.
- *
- * A project is structure, not content: it is not a navigation stop and not a
- * selection target, so only its runs appear here as selectable rows.
- */
-interface PilotGroupNode {
-  group: PilotProjectGroup;
-  isCollapsed: boolean;
-  /** Empty while collapsed, so a hidden run can never be selected. */
-  visibleRows: PilotRow[];
-}
-
-interface PilotNavRow {
-  domId: string;
-  workspaceId: string;
-  row: PilotRow;
-}
+/** The resting tone. Selected is the shared row class's to own, off the attribute. */
+const ROW_TONE = "text-daintree-text/70 hover:bg-overlay-subtle hover:text-daintree-text";
 
 const TILE_BASE =
   "flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-lg)] text-base";
@@ -303,7 +278,7 @@ function RunRow({
       // The header's own column structure — same padding, the chevron column,
       // then a tile-width column — rather than a hand-computed indent, so
       // titles line up with the project title above them by construction.
-      className={cn(ROW_BASE, rowTone(isSelected), "gap-2 py-1.5 pr-3 pl-3")}
+      className={cn(ROW_BASE, ROW_TONE, "gap-2 py-1.5 pr-3 pl-3")}
     >
       {/*
         State rides the chevron column, so every agent's spinner or amber circle
@@ -571,91 +546,51 @@ export function PilotView() {
 
   const isSearching = query.trim().length > 0;
 
-  const groupNodes = useMemo<PilotGroupNode[]>(
+  /**
+   * The tree, in the shared model's shape.
+   *
+   * A project is structure, not content: its header is `navigable: false`, so
+   * the arrow keys walk agents and never stop on a heading on the way past.
+   * That kept the common case — compare what is working against what is waiting
+   * — from costing an extra keystroke per project, and kept Enter from sitting
+   * one mistake away from collapsing a group instead of opening the run.
+   */
+  const paletteGroups = useMemo<PaletteTreeGroupInput<PilotProjectGroup, PilotRow>[]>(
     () =>
-      visibleGroups.map((group) => {
+      visibleGroups.map((group) => ({
+        groupId: group.workspaceId,
+        group,
+        header: {
+          rowId: `group:${group.workspaceId}`,
+          domId: groupDomId(group.workspaceId),
+          navigable: false,
+        },
         // A collapsed group that contains a match opens itself — making someone
         // click to reveal the thing they just searched for is the search
         // failing to do its job.
-        const isCollapsed = isSearching
+        isCollapsed: isSearching
           ? searchCollapsed.includes(group.workspaceId)
-          : collapsedIds.includes(group.workspaceId);
-        return { group, isCollapsed, visibleRows: isCollapsed ? [] : group.rows };
-      }),
+          : collapsedIds.includes(group.workspaceId),
+        items: group.rows.map((row) => ({
+          rowId: row.run.runId,
+          domId: runDomId(row.run.runId),
+          navigable: true,
+          item: row,
+        })),
+      })),
     [visibleGroups, isSearching, searchCollapsed, collapsedIds]
   );
 
-  // The arrow-key domain, derived from exactly what is rendered. Agents only:
-  // a project is a heading, not a stop on the way to one.
-  const navRows = useMemo<PilotNavRow[]>(
-    () =>
-      groupNodes.flatMap((node) =>
-        node.visibleRows.map((row) => ({
-          domId: runDomId(row.run.runId),
-          workspaceId: node.group.workspaceId,
-          row,
-        }))
-      ),
-    [groupNodes]
-  );
-
-  /**
-   * The selected ROW is the state; its index is derived. Tracking an index
-   * instead would let it outlive the row it pointed at — this list shrinks
-   * under the open dialog whenever an agent exits or a group collapses, and the
-   * index would then address a different row than the user selected, with Enter
-   * committing that one (the switcher's #11071).
-   */
-  const [selectedDomId, setSelectedDomId] = useState<string | null>(null);
-  /**
-   * The project the keyboard last collapsed, so Right can re-open it.
-   *
-   * A ref, not state: nothing renders from it, and it must not re-run the memos
-   * that build the list — it only ever answers "what did Left just close".
-   */
-  const lastCollapsedRef = useRef<string | null>(null);
-  /** Unmoved, the highlight sits on the most urgent agent — the list's top. */
-  const selectedIndex = useMemo(() => {
-    if (navRows.length === 0) return -1;
-    const index = selectedDomId ? navRows.findIndex((row) => row.domId === selectedDomId) : -1;
-    return index >= 0 ? index : 0;
-  }, [navRows, selectedDomId]);
-  const selectedRow = selectedIndex >= 0 ? navRows[selectedIndex] : undefined;
-
-  // A new query re-ranks the list, so fall back to the top match, and the
-  // search-scoped collapses belong to the query that produced them. Closing
-  // drops both so a reopen doesn't restore state from a fleet that has moved on.
+  // The search-scoped collapses belong to the query that produced them, and
+  // closing drops them so a reopen doesn't restore state from a fleet that has
+  // moved on. The selection resets alongside, inside the navigation model.
   useEffect(() => {
-    setSelectedDomId(null);
     setSearchCollapsed([]);
   }, [query, isOpen]);
 
   useEffect(() => {
     if (!isOpen) setQuery("");
   }, [isOpen]);
-
-  // Keyed on the id rather than the row object: the row is rebuilt on every
-  // snapshot, and re-running this each tick would fight the user's own scroll.
-  const selectedRowDomId = selectedRow?.domId;
-  useEffect(() => {
-    if (selectedRowDomId === undefined) return;
-    document.getElementById(selectedRowDomId)?.scrollIntoView({ block: "nearest" });
-  }, [selectedRowDomId]);
-
-  const step = useCallback(
-    (delta: number) => {
-      if (navRows.length === 0) return;
-      // Resolve the current row from the id inside the updater so two calls
-      // batched into one tick compose instead of collapsing into one.
-      setSelectedDomId((previousId) => {
-        const current = previousId ? navRows.findIndex((row) => row.domId === previousId) : -1;
-        const from = current >= 0 ? current : 0;
-        const next = (from + delta + navRows.length) % navRows.length;
-        return navRows[next]!.domId;
-      });
-    },
-    [navRows]
-  );
 
   const setGroupCollapsed = useCallback(
     (workspaceId: string, collapsed: boolean) => {
@@ -672,112 +607,34 @@ export function PilotView() {
     [isSearching, collapsedIds, toggleCollapsed]
   );
 
-  const activate = useCallback((row: PilotNavRow) => {
-    setSelectedDomId(row.domId);
+  const activate = useCallback((row: NavigablePaletteTreeRow<PilotProjectGroup, PilotRow>) => {
+    if (row.kind !== "item") return;
     void actionService.dispatch("pilot.openRun", {
-      runId: row.row.run.runId,
-      workspaceId: row.workspaceId,
+      runId: row.item.run.runId,
+      workspaceId: row.groupId,
     });
   }, []);
 
   /**
-   * `allowCaretKeys` is true where a caret exists to protect, and the list's
-   * structural keys stand down for it.
+   * `shouldPreserveInputCaretKey` is true where a caret exists to protect, and
+   * the list's structural keys stand down for it.
    *
    * Home/End/←/→ are structural keys, but they are also the search box's
    * editing keys, and the box owns focus by default. While the query is
    * non-empty they stay with the caret; an empty box has nothing to edit, so
    * they navigate. Search force-expands every matching group anyway, which is
    * where collapse would matter least.
-   *
-   * ←/→ act on the group holding the SELECTED RUN rather than on a selected
-   * project, because a project is never selected. Collapsing moves the
-   * selection to the next still-visible run so the highlight cannot end up
-   * inside a group that just closed.
    */
-  const handleNavigationKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLElement>, allowCaretKeys: boolean) => {
-      const consume = () => {
-        e.preventDefault();
-        e.stopPropagation();
-      };
+  const navigation = usePaletteTreeNavigation<PilotProjectGroup, PilotRow>({
+    groups: paletteGroups,
+    isActive: isOpen,
+    selectionScopeKey: query,
+    onActivate: activate,
+    onGroupCollapsedChange: setGroupCollapsed,
+    shouldPreserveInputCaretKey: () => query.length > 0,
+  });
 
-      // Expand runs BEFORE the empty-list guard, because collapsing the last
-      // expanded project is exactly what empties the list — and the disclosures
-      // are not tab stops, so bailing here would strand a keyboard user with
-      // every project shut and no way to reopen one.
-      if (e.key === "ArrowRight" && !allowCaretKeys) {
-        const target =
-          lastCollapsedRef.current ??
-          selectedRow?.workspaceId ??
-          groupNodes.find((node) => node.isCollapsed)?.group.workspaceId;
-        if (target !== undefined) {
-          consume();
-          setGroupCollapsed(target, false);
-          lastCollapsedRef.current = null;
-        }
-        return;
-      }
-
-      // Nothing listed means nothing to navigate or open. Swallowing the key
-      // anyway would leave the region eating Enter and the arrows during
-      // loading and empty states, where the browser's own behaviour is the
-      // only useful one left.
-      if (navRows.length === 0) return;
-
-      switch (e.key) {
-        case "ArrowDown":
-          consume();
-          step(1);
-          break;
-        case "ArrowUp":
-          consume();
-          step(-1);
-          break;
-        case "Home":
-          if (allowCaretKeys) break;
-          consume();
-          setSelectedDomId(navRows[0]!.domId);
-          break;
-        case "End":
-          if (allowCaretKeys) break;
-          consume();
-          setSelectedDomId(navRows[navRows.length - 1]!.domId);
-          break;
-        case "ArrowLeft": {
-          if (allowCaretKeys || !selectedRow) break;
-          consume();
-          lastCollapsedRef.current = selectedRow.workspaceId;
-          setGroupCollapsed(selectedRow.workspaceId, true);
-          // The highlight needs no explicit move: a hidden row is no longer in
-          // `navRows`, so `selectedIndex` falls back to the first visible one.
-          break;
-        }
-        case "Enter":
-          consume();
-          if (selectedRow) activate(selectedRow);
-          break;
-      }
-    },
-    [step, navRows, selectedRow, groupNodes, setGroupCollapsed, activate]
-  );
-
-  const handleInputKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
-      // Escape is deliberately NOT intercepted to clear the query first. The
-      // project switcher — which opens this and sits beside it — closes on the
-      // first Escape, and two adjacent palettes that hand off to each other
-      // must not disagree about what the key does.
-      handleNavigationKeyDown(e, query.length > 0);
-    },
-    [handleNavigationKeyDown, query]
-  );
-
-  const handleBodyKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLDivElement>) => handleNavigationKeyDown(e, false),
-    [handleNavigationKeyDown]
-  );
+  const { selectedRow, activeDescendantId, renderGroups } = navigation;
 
   /**
    * What the surface can honestly claim right now.
@@ -812,14 +669,15 @@ export function PilotView() {
             : "";
 
   // Every selectable row is an agent now, so the verb never changes.
-  const actionLabel = selectedRow === undefined ? null : "Open";
+  const actionLabel = selectedRow === null ? null : "Open";
 
-  const hasTree = groupNodes.length > 0;
+  const hasTree = renderGroups.length > 0;
   // Stale counts as well as live: retained runs are real rows, so a query that
   // matches none of them is a true statement about the query rather than a claim
   // that the fleet is clear. `loading` and `unavailable` stay out — they already
   // render the skeleton and the can't-reach-host message.
-  const showEmpty = (status.kind === "live" || status.kind === "stale") && groupNodes.length === 0;
+  const showEmpty =
+    (status.kind === "live" || status.kind === "stale") && renderGroups.length === 0;
   const showSkeleton = useDeferredLoading(status.kind === "loading", UI_DOHERTY_THRESHOLD);
 
   return (
@@ -834,7 +692,7 @@ export function PilotView() {
           className="bg-overlay-soft border-[var(--border-overlay)]"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          onKeyDown={handleInputKeyDown}
+          onKeyDown={navigation.handleInputKeyDown}
           placeholder="Search agents…"
           aria-label="Search agents"
           // The role is constant, not conditional on there being results. A
@@ -846,7 +704,7 @@ export function PilotView() {
           aria-expanded={hasTree}
           aria-haspopup="listbox"
           aria-controls={LIST_ID}
-          aria-activedescendant={selectedRow?.domId}
+          aria-activedescendant={activeDescendantId}
           data-testid="pilot-search"
         />
       </AppPaletteDialog.Header>
@@ -855,8 +713,8 @@ export function PilotView() {
         maxHeight={PALETTE_MAX_HEIGHT}
         className="p-0"
         ariaLabel="Agents"
-        activeDescendant={selectedRow?.domId}
-        onNavigationKeyDown={handleBodyKeyDown}
+        activeDescendant={activeDescendantId}
+        onNavigationKeyDown={navigation.handleBodyKeyDown}
       >
         {showSkeleton && (
           /*
@@ -930,48 +788,40 @@ export function PilotView() {
           id={LIST_ID}
           {...(hasTree ? { role: "listbox", "aria-label": "Agents by project" } : {})}
         >
-          {groupNodes.map((node, groupIndex) => {
-            const groupId = groupDomId(node.group.workspaceId);
-            return (
-              // `role="group"` is a permitted listbox child and carries the
-              // project's name as the label for every option inside it, which
-              // is how a screen reader still hears which project a run belongs
-              // to now that the header itself is not an item.
-              <div
-                key={groupId}
-                role="group"
-                aria-label={node.group.name}
-                // The scroller spaces siblings equally, so after a long run list
-                // the next project arrives with no more separation than one more
-                // agent. Only between groups — a leading gap would push the list
-                // off its own top edge.
-                className={groupIndex > 0 ? "mt-2" : undefined}
-              >
-                <GroupHeader
-                  group={node.group}
-                  isCollapsed={node.isCollapsed}
-                  groupId={groupId}
-                  onToggle={() => setGroupCollapsed(node.group.workspaceId, !node.isCollapsed)}
-                />
-                <div id={groupId}>
-                  {node.visibleRows.map((row) => {
-                    const domId = runDomId(row.run.runId);
-                    return (
-                      <RunRow
-                        key={domId}
-                        row={row}
-                        isSelected={domId === selectedRow?.domId}
-                        domId={domId}
-                        onActivate={() =>
-                          activate({ domId, workspaceId: node.group.workspaceId, row })
-                        }
-                      />
-                    );
-                  })}
-                </div>
+          {renderGroups.map(({ header, items }, groupIndex) => (
+            // `role="group"` is a permitted listbox child and carries the
+            // project's name as the label for every option inside it, which
+            // is how a screen reader still hears which project a run belongs
+            // to now that the header itself is not an item.
+            <div
+              key={header.domId}
+              role="group"
+              aria-label={header.group.name}
+              // The scroller spaces siblings equally, so after a long run list
+              // the next project arrives with no more separation than one more
+              // agent. Only between groups — a leading gap would push the list
+              // off its own top edge.
+              className={groupIndex > 0 ? "mt-2" : undefined}
+            >
+              <GroupHeader
+                group={header.group}
+                isCollapsed={header.isCollapsed}
+                groupId={header.domId}
+                onToggle={() => setGroupCollapsed(header.groupId, !header.isCollapsed)}
+              />
+              <div id={header.domId}>
+                {items.map((row) => (
+                  <RunRow
+                    key={row.domId}
+                    row={row.item}
+                    isSelected={row.rowId === selectedRow?.rowId}
+                    domId={row.domId}
+                    onActivate={() => navigation.activateRow(row.rowId)}
+                  />
+                ))}
               </div>
-            );
-          })}
+            </div>
+          ))}
         </div>
       </AppPaletteDialog.Body>
 

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -24,6 +24,7 @@ import {
 import { cn } from "@/lib/utils";
 import { getProjectGradient } from "@/lib/colorUtils";
 import { AppPaletteDialog, KBD_CLASS } from "@/components/ui/AppPaletteDialog";
+import { PALETTE_ROW_CLASS } from "@/components/ui/paletteRowStyles";
 import { KbdChord } from "@/components/ui/Kbd";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
@@ -273,28 +274,16 @@ function ProjectListItem({
       role="option"
       aria-selected={isSelected}
       className={cn(
-        "group relative w-full flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors border border-transparent",
-        // The accent bar is always laid out and only its opacity changes, so it
-        // rides the same transition as the row background. Toggling `content`
-        // instead meant the pseudo-element popped into existence with nothing to
-        // transition, and the bar arrived at the new row while the highlight was
-        // still fading in behind it. Duration and easing are deliberately left
-        // to match `transition-colors` above — a tier of its own would only move
-        // the desync rather than remove it.
-        "before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-[''] before:opacity-0 before:transition-opacity aria-selected:before:opacity-100",
+        PALETTE_ROW_CLASS,
+        "group w-full flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] text-left cursor-pointer",
         project.isActive
-          ? cn(
-              "text-daintree-text cursor-pointer",
-              isSelected && "bg-overlay-raised border-overlay"
-            )
+          ? "text-daintree-text"
           : project.isMissing
-            ? cn(
-                "text-daintree-text/50 cursor-pointer",
-                isSelected ? "bg-overlay-raised border-overlay" : "hover:bg-overlay-subtle"
-              )
-            : isSelected
-              ? "bg-overlay-raised border-overlay text-daintree-text cursor-pointer"
-              : "text-daintree-text/70 hover:bg-overlay-subtle hover:text-daintree-text cursor-pointer"
+            ? // A missing project stays dimmed while selected: the row's own
+              // brightness is what says the folder is gone, and restoring it
+              // under the highlight would erase that.
+              "text-daintree-text/50 hover:bg-overlay-subtle aria-selected:text-daintree-text/50"
+            : "text-daintree-text/70 hover:bg-overlay-subtle hover:text-daintree-text"
       )}
       // The current project is selectable too: picking where you already are is
       // a "never mind", and the handler closes the palette rather than sitting
@@ -473,13 +462,11 @@ function ScratchListItem({
       role="option"
       aria-selected={isSelected}
       className={cn(
-        "group relative w-full flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors border border-transparent cursor-pointer",
-        "before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-[''] before:opacity-0 before:transition-opacity aria-selected:before:opacity-100",
-        isSelected
-          ? "bg-overlay-raised border-overlay text-daintree-text"
-          : scratch.isActive
-            ? "text-daintree-text hover:bg-overlay-subtle"
-            : "text-daintree-text/70 hover:bg-overlay-subtle hover:text-daintree-text"
+        PALETTE_ROW_CLASS,
+        "group w-full flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] text-left cursor-pointer",
+        scratch.isActive
+          ? "text-daintree-text hover:bg-overlay-subtle"
+          : "text-daintree-text/70 hover:bg-overlay-subtle hover:text-daintree-text"
       )}
       onClick={() => onSelect(scratch)}
     >

--- a/src/components/QuickSwitcher/QuickSwitcherItem.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcherItem.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils";
+import { PALETTE_ROW_CLASS } from "@/components/ui/paletteRowStyles";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { FolderGit2 } from "@/components/icons";
 import type { QuickSwitcherItem as QuickSwitcherItemData } from "@/hooks/useQuickSwitcher";
@@ -27,12 +28,10 @@ export function QuickSwitcherItem({
       onPointerDown={(e) => e.preventDefault()}
       onPointerMove={onHover}
       className={cn(
-        "group relative w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left",
-        "transition-colors border border-transparent text-daintree-text/70",
-        "hover:bg-overlay-subtle hover:text-daintree-text",
-        "aria-selected:bg-overlay-soft aria-selected:border-overlay aria-selected:text-daintree-text",
-        "aria-selected:before:absolute aria-selected:before:left-0 aria-selected:before:top-2 aria-selected:before:bottom-2",
-        "aria-selected:before:w-[2px] aria-selected:before:bg-daintree-accent aria-selected:before:content-['']"
+        PALETTE_ROW_CLASS,
+        "group w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left",
+        "text-daintree-text/70",
+        "hover:bg-overlay-subtle hover:text-daintree-text"
       )}
       onClick={() => onSelect(item)}
       aria-selected={isSelected}

--- a/src/components/Terminal/ResumeSessionsPalette.tsx
+++ b/src/components/Terminal/ResumeSessionsPalette.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { AppPaletteDialog, PaletteFooterHints } from "@/components/ui/AppPaletteDialog";
+import { PALETTE_ROW_CLASS } from "@/components/ui/paletteRowStyles";
 import { PaletteOverflowNotice } from "@/components/ui/PaletteOverflowNotice";
 import { HighlightedText, findMatchIndices } from "@/components/ui/HighlightedText";
 import { PanelKindIcon } from "@/components/PanelPalette/PanelKindIcon";
@@ -29,10 +30,10 @@ function ResumeSessionRow({ item, isSelected, matches, onSelect, itemRef }: Resu
       aria-disabled={item.isStale || undefined}
       ref={itemRef}
       className={cn(
-        "relative w-full flex items-start gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors border",
-        isSelected
-          ? "bg-overlay-raised border-overlay text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:bg-daintree-accent before:content-['']"
-          : "border-transparent text-daintree-text/70 hover:bg-overlay-subtle hover:text-daintree-text",
+        PALETTE_ROW_CLASS,
+        "w-full flex items-start gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left",
+        "text-daintree-text/70",
+        "hover:bg-overlay-subtle hover:text-daintree-text",
         item.isStale && "opacity-50"
       )}
       onClick={() => onSelect(item)}

--- a/src/components/Terminal/__tests__/ResumeSessionsPalette.test.tsx
+++ b/src/components/Terminal/__tests__/ResumeSessionsPalette.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import type { ResumeSessionItem } from "@/services/resumeSessionItems";
+
+const paletteState = {
+  isOpen: true,
+  query: "",
+  results: [] as ResumeSessionItem[],
+  totalResults: 0,
+  selectedIndex: 0,
+  matchesById: new Map(),
+  setQuery: vi.fn(),
+  selectPrevious: vi.fn(),
+  selectNext: vi.fn(),
+  close: vi.fn(),
+  isLoading: false,
+  isSearching: false,
+  visibleResults: [] as ResumeSessionItem[],
+  hiddenCount: 0,
+  showMore: vi.fn(),
+};
+
+vi.mock("@/hooks/useResumeSessionsPalette", () => ({
+  useResumeSessionsPalette: () => paletteState,
+  RESUME_PAGE_SIZE: 20,
+}));
+
+vi.mock("@/hooks/useResumeAgentSession", () => ({
+  useResumeAgentSession: () => vi.fn(),
+}));
+
+vi.mock("@/hooks/useKeybinding", () => ({
+  useEffectiveCombo: () => "Cmd+K Cmd+R",
+}));
+
+// jsdom ships none of these, and the palette body's scroll-shadow hook and the
+// dialog's motion query both reach for them on mount.
+globalThis.ResizeObserver ??= class implements ResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+};
+Element.prototype.scrollIntoView ??= function scrollIntoView(): void {};
+globalThis.matchMedia ??= function matchMedia(query: string): MediaQueryList {
+  const list: MediaQueryList = {
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  };
+  return list;
+};
+
+const { ResumeSessionsPalette } = await import("@/components/Terminal/ResumeSessionsPalette");
+
+function makeItem(id: string, overrides: Partial<ResumeSessionItem> = {}): ResumeSessionItem {
+  return {
+    id,
+    // Only forwarded to the resume launcher, which is mocked out here.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- journal-record fixture stub
+    session: { sessionId: id } as ResumeSessionItem["session"],
+    name: `Session ${id}`,
+    iconId: "claude",
+    color: "#fff",
+    description: "model · agent · location",
+    searchAliases: [],
+    isStale: false,
+    ...overrides,
+  };
+}
+
+function rowFor(id: string): HTMLElement {
+  const row = document.getElementById(`resume-session-option-${id}`);
+  if (row === null) throw new Error(`no row rendered for ${id}`);
+  return row;
+}
+
+describe("ResumeSessionsPalette", () => {
+  beforeEach(() => {
+    cleanup();
+    const items = [makeItem("a"), makeItem("b"), makeItem("c", { isStale: true })];
+    paletteState.results = items;
+    paletteState.visibleResults = items;
+    paletteState.totalResults = items.length;
+    paletteState.selectedIndex = 0;
+  });
+
+  it("marks exactly one row selected and points the active descendant at it", () => {
+    render(<ResumeSessionsPalette />);
+
+    const selected = screen.getAllByRole("option").filter((el) => el.ariaSelected === "true");
+    expect(selected).toHaveLength(1);
+    expect(selected[0]!.id).toBe("resume-session-option-a");
+
+    // The referenced element must exist, or assistive tech is pointed at nothing.
+    const owner = screen.getByRole("combobox");
+    const referenced = owner.getAttribute("aria-activedescendant");
+    expect(referenced).not.toBeNull();
+    expect(document.getElementById(referenced!)).not.toBeNull();
+  });
+
+  it("moves the selected row and the active descendant together", () => {
+    const { unmount } = render(<ResumeSessionsPalette />);
+    const firstReferenced = screen.getByRole("combobox").getAttribute("aria-activedescendant");
+    unmount();
+
+    paletteState.selectedIndex = 1;
+    render(<ResumeSessionsPalette />);
+
+    const referenced = screen.getByRole("combobox").getAttribute("aria-activedescendant");
+    expect(referenced).not.toBe(firstReferenced);
+    expect(rowFor("b").ariaSelected).toBe("true");
+    expect(rowFor("a").ariaSelected).toBe("false");
+    expect(document.getElementById(referenced!)).not.toBeNull();
+  });
+
+  it("styles selection from the attribute, so a row's class list does not depend on it", () => {
+    // The regression this guards: the selected treatment used to live inside a
+    // JS `isSelected` ternary, which let the rendered attribute and the visible
+    // highlight drift apart and left the rail with nothing to transition.
+    render(<ResumeSessionsPalette />);
+    const selectedClass = rowFor("a").className;
+    const unselectedClass = rowFor("b").className;
+
+    expect(rowFor("a").ariaSelected).toBe("true");
+    expect(rowFor("b").ariaSelected).toBe("false");
+    expect(selectedClass).toBe(unselectedClass);
+  });
+
+  it("keeps a stale row visually distinct from a merely unselected one", () => {
+    render(<ResumeSessionsPalette />);
+
+    // Staleness is still a class-level difference — it is a property of the
+    // item, not of the selection, so it must not have been folded away.
+    expect(rowFor("c").className).not.toBe(rowFor("b").className);
+    expect(rowFor("c").getAttribute("aria-disabled")).toBe("true");
+  });
+});

--- a/src/components/Terminal/__tests__/ResumeSessionsPalette.test.tsx
+++ b/src/components/Terminal/__tests__/ResumeSessionsPalette.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, beforeAll, afterAll } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PALETTE_ROW_CLASS } from "@/components/ui/paletteRowStyles";
 import type { ResumeSessionItem } from "@/services/resumeSessionItems";
 
 const paletteState = {
@@ -35,14 +36,18 @@ vi.mock("@/hooks/useKeybinding", () => ({
 }));
 
 // jsdom ships none of these, and the palette body's scroll-shadow hook and the
-// dialog's motion query both reach for them on mount.
-globalThis.ResizeObserver ??= class implements ResizeObserver {
+// dialog's motion query both reach for them on mount. Stubbed through vitest
+// rather than assigned onto `globalThis`: neither is a jsdom-owned key, so a
+// raw assignment survives environment teardown and leaks into whatever file
+// this worker runs next — an always-false motion query is exactly the kind of
+// thing that then passes for the wrong reason.
+class ResizeObserverStub implements ResizeObserver {
   observe(): void {}
   unobserve(): void {}
   disconnect(): void {}
-};
-Element.prototype.scrollIntoView ??= function scrollIntoView(): void {};
-globalThis.matchMedia ??= function matchMedia(query: string): MediaQueryList {
+}
+
+function matchMediaStub(query: string): MediaQueryList {
   const list: MediaQueryList = {
     matches: false,
     media: query,
@@ -54,7 +59,20 @@ globalThis.matchMedia ??= function matchMedia(query: string): MediaQueryList {
     dispatchEvent: () => false,
   };
   return list;
-};
+}
+
+const originalScrollIntoView = Element.prototype.scrollIntoView;
+
+beforeAll(() => {
+  vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+  vi.stubGlobal("matchMedia", matchMediaStub);
+  Element.prototype.scrollIntoView = function scrollIntoView(): void {};
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+  Element.prototype.scrollIntoView = originalScrollIntoView;
+});
 
 const { ResumeSessionsPalette } = await import("@/components/Terminal/ResumeSessionsPalette");
 
@@ -82,7 +100,7 @@ function rowFor(id: string): HTMLElement {
 
 describe("ResumeSessionsPalette", () => {
   beforeEach(() => {
-    cleanup();
+    vi.clearAllMocks();
     const items = [makeItem("a"), makeItem("b"), makeItem("c", { isStale: true })];
     paletteState.results = items;
     paletteState.visibleResults = items;
@@ -130,6 +148,14 @@ describe("ResumeSessionsPalette", () => {
     expect(rowFor("a").ariaSelected).toBe("true");
     expect(rowFor("b").ariaSelected).toBe("false");
     expect(selectedClass).toBe(unselectedClass);
+
+    // Identical class lists alone would also hold if the row simply stopped
+    // carrying any selected treatment, so pin that it still composes the
+    // shared definition. Referencing the constant rather than restating its
+    // utilities keeps this honest if the recipe itself changes.
+    const applied = new Set(selectedClass.split(/\s+/));
+    const missing = PALETTE_ROW_CLASS.split(/\s+/).filter((token) => !applied.has(token));
+    expect(missing).toEqual([]);
   });
 
   it("keeps a stale row visually distinct from a merely unselected one", () => {

--- a/src/components/ui/paletteRowStyles.ts
+++ b/src/components/ui/paletteRowStyles.ts
@@ -1,0 +1,33 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * The one definition of "this is the row Enter will act on".
+ *
+ * Five palettes had grown five spellings of the same visual: two drove it from
+ * a JS `isSelected` ternary and three from the `aria-selected` attribute, two
+ * rounded the rail's trailing edge and three did not, and two cross-faded the
+ * rail while three popped it into existence with nothing to transition — which
+ * left the rail arriving on the new row while the surface behind it was still
+ * fading in.
+ *
+ * Authority is the rendered `aria-selected` attribute, not a prop. One source
+ * of truth means the announcement and the highlight cannot disagree, and a row's
+ * children can key off `group-aria-selected:` without a second boolean being
+ * threaded down to them.
+ *
+ * Layout is deliberately NOT here. These rows are different shapes — some align
+ * to the first line, some centre, and their padding and gaps differ — so each
+ * site keeps its own box and its own resting tone, and takes only the selected
+ * treatment from this.
+ */
+export const PALETTE_ROW_CLASS = cn(
+  // `relative` is the rail's containing block; the transparent border reserves
+  // the selected border's width so the row cannot shift when it arrives.
+  "relative border border-transparent transition-colors",
+  "aria-selected:bg-overlay-raised aria-selected:border-overlay aria-selected:text-daintree-text",
+  // The rail is always laid out and only its opacity changes. Toggling
+  // `content` instead gave the pseudo-element nothing to transition from.
+  "before:absolute before:top-2 before:bottom-2 before:left-0 before:w-[2px] before:rounded-r",
+  "before:bg-daintree-accent before:opacity-0 before:transition-opacity before:content-['']",
+  "aria-selected:before:opacity-100"
+);

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -131,14 +131,12 @@ const DURABLE_ALLOWLIST = new Set([
   // primary anchor per active focus region)
   "src/components/Layout/DockLaunchMenuItems.tsx",
 
-  // ResumeSessionsPalette selected-row left-edge accent stripe (single primary anchor per active focus region)
-  "src/components/Terminal/ResumeSessionsPalette.tsx",
-
-  // ProjectSwitcherPalette selected-row left-edge accent stripe (single primary anchor per active focus region)
-  "src/components/Project/ProjectSwitcherPalette.tsx",
-
-  // PilotView selected-row left-edge accent stripe (single primary anchor per active focus region)
-  "src/components/Pilot/PilotView.tsx",
+  // The one definition of the palette selected-row left-edge accent stripe,
+  // shared by every palette row (single primary anchor per active focus region).
+  // PilotView, ProjectSwitcherPalette, ResumeSessionsPalette, QuickSwitcherItem
+  // and ActionPaletteItem all take the stripe from here rather than spelling it
+  // out themselves, which is why none of them appears in a bucket any more.
+  "src/components/ui/paletteRowStyles.ts",
 
   // PluginQuickPickDialog selected-row left-edge accent stripe (single primary anchor per active focus region)
   "src/components/Plugin/PluginQuickPickDialog.tsx",
@@ -177,7 +175,6 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
     "plugins/builtin/github/renderer/components/CommitList.tsx",
     "plugins/builtin/github/renderer/components/GitHubListItem.tsx",
     "plugins/builtin/github/renderer/components/GitHubResourceList.tsx",
-    "src/components/ActionPalette/ActionPaletteItem.tsx",
     "src/components/Browser/WebviewDialog.tsx",
     "src/components/Commands/CommandBuilder.tsx",
     "src/components/Commands/CommandPicker.tsx",
@@ -203,7 +200,6 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
     "src/components/Project/GitInitDialog.tsx",
     "src/components/Project/ProjectNotificationsTab.tsx",
     "src/components/Project/WelcomeScreen.tsx",
-    "src/components/QuickSwitcher/QuickSwitcherItem.tsx",
     "src/components/Recovery/CrashRecoveryDialog.tsx",
     "src/components/Settings/AgentSelectorDropdown.tsx",
     "src/components/Settings/EditorIntegrationTab.tsx",

--- a/src/hooks/__tests__/usePaletteTreeNavigation.test.tsx
+++ b/src/hooks/__tests__/usePaletteTreeNavigation.test.tsx
@@ -1,0 +1,537 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import type { KeyboardEvent } from "react";
+import {
+  usePaletteTreeNavigation,
+  type NavigablePaletteTreeRow,
+  type PaletteTreeGroupInput,
+} from "@/hooks/usePaletteTreeNavigation";
+
+interface TestGroup {
+  name: string;
+}
+
+interface TestItem {
+  label: string;
+}
+
+/** `[groupId, itemIds, { collapsed, navigableHeader }]` */
+type GroupSpec = [
+  string,
+  string[],
+  { collapsed?: boolean; navigableHeader?: boolean; skipItems?: string[] }?,
+];
+
+function buildGroups(specs: GroupSpec[]): PaletteTreeGroupInput<TestGroup, TestItem>[] {
+  return specs.map(([groupId, itemIds, options = {}]) => ({
+    groupId,
+    group: { name: groupId.toUpperCase() },
+    header: {
+      rowId: `h:${groupId}`,
+      domId: `dom-h-${groupId}`,
+      navigable: options.navigableHeader ?? false,
+    },
+    isCollapsed: options.collapsed ?? false,
+    items: itemIds.map((itemId) => ({
+      rowId: `i:${itemId}`,
+      domId: `dom-i-${itemId}`,
+      navigable: !(options.skipItems ?? []).includes(itemId),
+      item: { label: itemId },
+    })),
+  }));
+}
+
+/**
+ * The handlers read only `key`, the composition fields, and the two consume
+ * methods, so a minimal stand-in exercises them faithfully. Built here once so
+ * the cast lives in a single place rather than at every call site.
+ */
+function keyEvent(
+  key: string,
+  overrides: { isComposing?: boolean; keyCode?: number; value?: string } = {}
+) {
+  const preventDefault = vi.fn();
+  const stopPropagation = vi.fn();
+  const event = {
+    key,
+    preventDefault,
+    stopPropagation,
+    currentTarget: { value: overrides.value ?? "" },
+    nativeEvent: {
+      isComposing: overrides.isComposing ?? false,
+      keyCode: overrides.keyCode ?? 0,
+    },
+  };
+  return {
+    // The handlers touch only the fields above; a real synthetic event cannot
+    // be constructed outside React's own dispatch, so this stand-in is the
+    // faithful option rather than a shortcut.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- hand-built keyboard event stand-in
+    event: event as unknown as KeyboardEvent<HTMLInputElement>,
+    preventDefault,
+    stopPropagation,
+  };
+}
+
+/** A consumed key is one the handler both cancelled and kept to itself. */
+function expectConsumed(handle: ReturnType<typeof keyEvent>, consumed: boolean, label: string) {
+  expect(handle.preventDefault.mock.calls.length > 0, label).toBe(consumed);
+  expect(handle.stopPropagation.mock.calls.length > 0, label).toBe(consumed);
+}
+
+/** Typed so `mock.calls[0][0]` is the row union, not `any` needing a cast. */
+const makeActivateSpy = () => vi.fn<(row: NavigablePaletteTreeRow<TestGroup, TestItem>) => void>();
+
+function setup(
+  specs: GroupSpec[],
+  options: {
+    onActivate?: (row: NavigablePaletteTreeRow<TestGroup, TestItem>) => void;
+    onGroupCollapsedChange?: (groupId: string, collapsed: boolean) => void;
+    shouldPreserveInputCaretKey?: (event: KeyboardEvent<HTMLInputElement>) => boolean;
+    selectionScopeKey?: string;
+    isActive?: boolean;
+  } = {}
+) {
+  const onActivate = options.onActivate ?? vi.fn();
+  return renderHook(
+    ({ groups, scope }: { groups: PaletteTreeGroupInput<TestGroup, TestItem>[]; scope?: string }) =>
+      usePaletteTreeNavigation<TestGroup, TestItem>({
+        groups,
+        isActive: options.isActive ?? true,
+        selectionScopeKey: scope ?? null,
+        onActivate,
+        onGroupCollapsedChange: options.onGroupCollapsedChange,
+        shouldPreserveInputCaretKey: options.shouldPreserveInputCaretKey,
+      }),
+    { initialProps: { groups: buildGroups(specs), scope: options.selectionScopeKey } }
+  );
+}
+
+const rowIds = <T extends { rowId: string }>(rows: readonly T[]) => rows.map((row) => row.rowId);
+
+/** Typed to the real signature so the assignment to the prototype checks. */
+const makeScrollSpy = () => vi.fn<(options?: boolean | ScrollIntoViewOptions) => void>();
+
+describe("usePaletteTreeNavigation", () => {
+  describe("flattening", () => {
+    it("emits each header immediately before only that group's items", () => {
+      const { result } = setup([
+        ["a", ["a1", "a2"]],
+        ["b", ["b1"]],
+      ]);
+
+      expect(rowIds(result.current.rows)).toEqual(["h:a", "i:a1", "i:a2", "h:b", "i:b1"]);
+    });
+
+    it("keeps a collapsed group's header while structurally excluding its items", () => {
+      const { result } = setup([
+        ["a", ["a1", "a2"], { collapsed: true }],
+        ["b", ["b1"]],
+      ]);
+
+      expect(rowIds(result.current.rows)).toEqual(["h:a", "h:b", "i:b1"]);
+      // The render model and the nav domain are the same objects, so a hidden
+      // row cannot exist in one and not the other.
+      const rendered = result.current.renderGroups.flatMap((g) => [g.header, ...g.items]);
+      expect(rendered).toEqual(result.current.rows);
+    });
+
+    it("hands the render model the same row objects the arrow keys walk", () => {
+      const { result } = setup([["a", ["a1"]]]);
+
+      const renderedItem = result.current.renderGroups[0]!.items[0]!;
+      const walkedItem = result.current.rows.find((row) => row.rowId === "i:a1");
+      expect(walkedItem).toBe(renderedItem);
+    });
+  });
+
+  describe("stepping", () => {
+    it("skips non-navigable headers when crossing a group boundary", () => {
+      const { result } = setup([
+        ["a", ["a1"]],
+        ["b", ["b1"]],
+      ]);
+
+      act(() => result.current.step(1));
+      expect(result.current.selectedRowId).toBe("i:b1");
+    });
+
+    it("stops on headers that are marked navigable", () => {
+      const { result } = setup([
+        ["a", ["a1"], { navigableHeader: true }],
+        ["b", ["b1"], { navigableHeader: true }],
+      ]);
+
+      expect(result.current.selectedRowId).toBe("h:a");
+      act(() => result.current.step(1));
+      expect(result.current.selectedRowId).toBe("i:a1");
+      act(() => result.current.step(1));
+      expect(result.current.selectedRowId).toBe("h:b");
+    });
+
+    it("skips an individual item marked non-navigable", () => {
+      const { result } = setup([["a", ["a1", "a2", "a3"], { skipItems: ["a2"] }]]);
+
+      act(() => result.current.step(1));
+      expect(result.current.selectedRowId).toBe("i:a3");
+    });
+
+    it("wraps forward off the end and backward off the start", () => {
+      const { result } = setup([
+        ["a", ["a1"]],
+        ["b", ["b1"]],
+      ]);
+
+      act(() => result.current.step(-1));
+      expect(result.current.selectedRowId).toBe("i:b1");
+      act(() => result.current.step(1));
+      expect(result.current.selectedRowId).toBe("i:a1");
+    });
+
+    it("composes two steps issued in one React batch", () => {
+      const { result } = setup([["a", ["a1", "a2", "a3"]]]);
+
+      // Both calls in ONE act: batched into a single tick, which is the case a
+      // step resolved from a stale outer closure would collapse into one move.
+      act(() => {
+        result.current.step(1);
+        result.current.step(1);
+      });
+
+      expect(result.current.selectedRowId).toBe("i:a3");
+    });
+
+    it("does nothing when no row is navigable", () => {
+      const { result } = setup([["a", [], { navigableHeader: false }]]);
+
+      act(() => result.current.step(1));
+      expect(result.current.selectedRowId).toBeNull();
+      expect(result.current.selectedRowIndex).toBe(-1);
+    });
+  });
+
+  describe("selection identity (#11071)", () => {
+    it("follows the selected row when a row above it disappears", () => {
+      const { result, rerender } = setup([["a", ["a1", "a2", "a3"]]]);
+
+      act(() => result.current.selectRow("i:a3"));
+      rerender({ groups: buildGroups([["a", ["a2", "a3"]]]), scope: undefined });
+
+      expect(result.current.selectedRowId).toBe("i:a3");
+      // Its position moved, which is exactly what a stored index would have missed.
+      expect(result.current.selectedRowIndex).toBe(2);
+    });
+
+    it("falls back to the first navigable row when the selected row is gone", () => {
+      const { result, rerender } = setup([["a", ["a1", "a2"]]]);
+
+      act(() => result.current.selectRow("i:a2"));
+      rerender({ groups: buildGroups([["a", ["a1"]]]), scope: undefined });
+
+      expect(result.current.selectedRowId).toBe("i:a1");
+    });
+
+    it("never names an active descendant that is absent from the rendered rows", () => {
+      const { result, rerender } = setup([
+        ["a", ["a1", "a2"]],
+        ["b", ["b1"]],
+      ]);
+
+      act(() => result.current.selectRow("i:b1"));
+      expect(result.current.activeDescendantId).toBe("dom-i-b1");
+
+      // Collapsing b removes the selected row from the model entirely.
+      rerender({
+        groups: buildGroups([
+          ["a", ["a1", "a2"]],
+          ["b", ["b1"], { collapsed: true }],
+        ]),
+        scope: undefined,
+      });
+
+      const renderedDomIds = result.current.rows.map((row) => row.domId);
+      expect(renderedDomIds).not.toContain("dom-i-b1");
+      expect(renderedDomIds).toContain(result.current.activeDescendantId);
+    });
+
+    it("reports no active descendant when nothing is navigable", () => {
+      const { result } = setup([["a", [], {}]]);
+
+      expect(result.current.activeDescendantId).toBeUndefined();
+      expect(result.current.selectedRow).toBeNull();
+    });
+
+    it("drops the selection back to the top when the selection scope changes", () => {
+      const { result, rerender } = setup([["a", ["a1", "a2"]]], { selectionScopeKey: "q1" });
+
+      act(() => result.current.selectRow("i:a2"));
+      rerender({ groups: buildGroups([["a", ["a1", "a2"]]]), scope: "q2" });
+
+      expect(result.current.selectedRowId).toBe("i:a1");
+    });
+  });
+
+  describe("disclosure", () => {
+    it("collapses the selected row's group on ArrowLeft", () => {
+      const onGroupCollapsedChange = vi.fn();
+      const { result } = setup(
+        [
+          ["a", ["a1"]],
+          ["b", ["b1"]],
+        ],
+        { onGroupCollapsedChange }
+      );
+
+      act(() => result.current.selectRow("i:b1"));
+      const { event } = keyEvent("ArrowLeft");
+      act(() => result.current.handleBodyKeyDown(event));
+
+      expect(onGroupCollapsedChange).toHaveBeenCalledWith("b", true);
+    });
+
+    it("handles ArrowRight before the no-navigable-row guard", () => {
+      const onGroupCollapsedChange = vi.fn();
+      // Every group shut: nothing is navigable, so a guard placed first would
+      // strand the user with no way to reopen anything.
+      const { result } = setup([["a", ["a1"], { collapsed: true }]], { onGroupCollapsedChange });
+
+      expect(result.current.selectedRow).toBeNull();
+      const right = keyEvent("ArrowRight");
+      act(() => result.current.handleBodyKeyDown(right.event));
+
+      expect(onGroupCollapsedChange).toHaveBeenCalledWith("a", false);
+      expectConsumed(right, true, "ArrowRight with every group shut");
+    });
+
+    it("reopens the group ArrowLeft just closed rather than the first collapsed one", () => {
+      const onGroupCollapsedChange = vi.fn();
+      const { result, rerender } = setup(
+        [
+          ["a", ["a1"], { collapsed: true }],
+          ["b", ["b1"]],
+        ],
+        { onGroupCollapsedChange }
+      );
+
+      act(() => result.current.selectRow("i:b1"));
+      act(() => result.current.handleBodyKeyDown(keyEvent("ArrowLeft").event));
+      expect(onGroupCollapsedChange).toHaveBeenLastCalledWith("b", true);
+
+      rerender({
+        groups: buildGroups([
+          ["a", ["a1"], { collapsed: true }],
+          ["b", ["b1"], { collapsed: true }],
+        ]),
+        scope: undefined,
+      });
+      act(() => result.current.handleBodyKeyDown(keyEvent("ArrowRight").event));
+
+      expect(onGroupCollapsedChange).toHaveBeenLastCalledWith("b", false);
+    });
+
+    it("falls through to a still-collapsed group when the remembered one is gone", () => {
+      const onGroupCollapsedChange = vi.fn();
+      const { result, rerender } = setup(
+        [
+          ["a", ["a1"], { collapsed: true }],
+          ["b", ["b1"]],
+        ],
+        { onGroupCollapsedChange }
+      );
+
+      act(() => result.current.selectRow("i:b1"));
+      act(() => result.current.handleBodyKeyDown(keyEvent("ArrowLeft").event));
+
+      // b disappears entirely while the palette is open; the remembered target
+      // is now stale, and consuming the key against it would do nothing.
+      rerender({ groups: buildGroups([["a", ["a1"], { collapsed: true }]]), scope: undefined });
+      act(() => result.current.handleBodyKeyDown(keyEvent("ArrowRight").event));
+
+      expect(onGroupCollapsedChange).toHaveBeenLastCalledWith("a", false);
+    });
+
+    it("leaves the horizontal arrows alone when no collapse handler is supplied", () => {
+      const { result } = setup([["a", ["a1"]]]);
+
+      const left = keyEvent("ArrowLeft");
+      const right = keyEvent("ArrowRight");
+      act(() => result.current.handleBodyKeyDown(left.event));
+      act(() => result.current.handleBodyKeyDown(right.event));
+
+      expectConsumed(left, false, "ArrowLeft without a collapse handler");
+      expectConsumed(right, false, "ArrowRight without a collapse handler");
+    });
+  });
+
+  describe("caret arbitration", () => {
+    it("leaves Home, End and the horizontal arrows to the caret when the predicate says so", () => {
+      const onGroupCollapsedChange = vi.fn();
+      const { result } = setup([["a", ["a1", "a2"]]], {
+        onGroupCollapsedChange,
+        shouldPreserveInputCaretKey: (event) => event.currentTarget.value.length > 0,
+      });
+
+      for (const key of ["Home", "End", "ArrowLeft", "ArrowRight"]) {
+        const handle = keyEvent(key, { value: "typed" });
+        act(() => result.current.handleInputKeyDown(handle.event));
+        expectConsumed(handle, false, `${key} should stay with the caret`);
+      }
+      expect(onGroupCollapsedChange).not.toHaveBeenCalled();
+      expect(result.current.selectedRowId).toBe("i:a1");
+    });
+
+    it("still moves the highlight vertically while the caret keys are preserved", () => {
+      const { result } = setup([["a", ["a1", "a2"]]], {
+        shouldPreserveInputCaretKey: () => true,
+      });
+
+      const handle = keyEvent("ArrowDown", { value: "typed" });
+      act(() => result.current.handleInputKeyDown(handle.event));
+
+      expectConsumed(handle, true, "ArrowDown is not a caret key");
+      expect(result.current.selectedRowId).toBe("i:a2");
+    });
+
+    it("takes the caret keys once the predicate releases them", () => {
+      const { result } = setup([["a", ["a1", "a2"]]], {
+        shouldPreserveInputCaretKey: (event) => event.currentTarget.value.length > 0,
+      });
+
+      const handle = keyEvent("End", { value: "" });
+      act(() => result.current.handleInputKeyDown(handle.event));
+
+      expectConsumed(handle, true, "End with an empty box");
+      expect(result.current.selectedRowId).toBe("i:a2");
+    });
+
+    it("never consults the predicate on the body region, which has no caret", () => {
+      const shouldPreserveInputCaretKey = vi.fn(() => true);
+      const { result } = setup([["a", ["a1", "a2"]]], { shouldPreserveInputCaretKey });
+
+      const handle = keyEvent("End");
+      act(() => result.current.handleBodyKeyDown(handle.event));
+
+      expect(shouldPreserveInputCaretKey).not.toHaveBeenCalled();
+      expectConsumed(handle, true, "End on the body region");
+      expect(result.current.selectedRowId).toBe("i:a2");
+    });
+  });
+
+  describe("input guards", () => {
+    it("ignores a key delivered mid-composition", () => {
+      const { result } = setup([["a", ["a1", "a2"]]]);
+
+      const handle = keyEvent("ArrowDown", { isComposing: true });
+      act(() => result.current.handleInputKeyDown(handle.event));
+
+      expectConsumed(handle, false, "ArrowDown mid-composition");
+      expect(result.current.selectedRowId).toBe("i:a1");
+    });
+
+    it("ignores the legacy composition keyCode", () => {
+      const { result } = setup([["a", ["a1", "a2"]]]);
+
+      const handle = keyEvent("Enter", { keyCode: 229 });
+      act(() => result.current.handleInputKeyDown(handle.event));
+
+      expectConsumed(handle, false, "Enter accepting an IME candidate");
+    });
+
+    it("leaves Enter and the vertical arrows to the browser when nothing is navigable", () => {
+      const { result } = setup([["a", [], {}]]);
+
+      for (const key of ["Enter", "ArrowDown", "ArrowUp"]) {
+        const handle = keyEvent(key);
+        act(() => result.current.handleBodyKeyDown(handle.event));
+        expectConsumed(handle, false, `${key} should fall through`);
+      }
+    });
+
+    it("leaves every other key untouched", () => {
+      const { result } = setup([["a", ["a1"]]]);
+
+      for (const key of ["Escape", "Tab", "Backspace", "PageDown", "a"]) {
+        const handle = keyEvent(key);
+        act(() => result.current.handleInputKeyDown(handle.event));
+        expectConsumed(handle, false, `${key} should not be consumed`);
+      }
+    });
+  });
+
+  describe("activation", () => {
+    it("activates the row the active descendant names", () => {
+      const onActivate = makeActivateSpy();
+      const { result } = setup([["a", ["a1", "a2"]]], { onActivate });
+
+      act(() => result.current.step(1));
+      act(() => result.current.handleBodyKeyDown(keyEvent("Enter").event));
+
+      expect(onActivate).toHaveBeenCalledTimes(1);
+      const activated = onActivate.mock.calls[0]![0];
+      expect(activated.domId).toBe(result.current.activeDescendantId);
+    });
+
+    it("carries the caller's item through to the activation callback", () => {
+      const onActivate = makeActivateSpy();
+      const { result } = setup([["a", ["a1"]]], { onActivate });
+
+      act(() => result.current.activateRow("i:a1"));
+
+      const activated = onActivate.mock.calls[0]![0];
+      expect(activated.kind === "item" && activated.item.label).toBe("a1");
+      expect(activated.group.name).toBe("A");
+    });
+
+    it("ignores activation of a row that is not navigable", () => {
+      const onActivate = vi.fn();
+      const { result } = setup([["a", ["a1"]]], { onActivate });
+
+      act(() => result.current.activateRow("h:a"));
+
+      expect(onActivate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("scrolling", () => {
+    let scrollIntoView: ReturnType<typeof makeScrollSpy>;
+    let original: typeof Element.prototype.scrollIntoView;
+
+    beforeEach(() => {
+      original = Element.prototype.scrollIntoView;
+      scrollIntoView = makeScrollSpy();
+      Element.prototype.scrollIntoView = scrollIntoView;
+      const node = document.createElement("div");
+      node.id = "dom-i-a1";
+      document.body.append(node);
+    });
+
+    afterEach(() => {
+      Element.prototype.scrollIntoView = original;
+      document.body.innerHTML = "";
+    });
+
+    it("scrolls the selected row into view", () => {
+      setup([["a", ["a1"]]]);
+
+      expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not re-scroll when rows are rebuilt under an unchanged selection", () => {
+      const { rerender } = setup([["a", ["a1"]]]);
+      scrollIntoView.mockClear();
+
+      // A fresh array of fresh objects with the same ids — what a live data
+      // refresh produces, and what must not yank the user's own scroll.
+      rerender({ groups: buildGroups([["a", ["a1"]]]), scope: undefined });
+
+      expect(scrollIntoView).not.toHaveBeenCalled();
+    });
+
+    it("stands down while the palette is inactive", () => {
+      setup([["a", ["a1"]]], { isActive: false });
+
+      expect(scrollIntoView).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hooks/__tests__/usePaletteTreeNavigation.test.tsx
+++ b/src/hooks/__tests__/usePaletteTreeNavigation.test.tsx
@@ -207,7 +207,30 @@ describe("usePaletteTreeNavigation", () => {
 
       act(() => result.current.step(1));
       expect(result.current.selectedRowId).toBeNull();
-      expect(result.current.selectedRowIndex).toBe(-1);
+      expect(result.current.selectedNavigableIndex).toBe(-1);
+    });
+
+    it("wraps a delta larger than the list rather than running off the end", () => {
+      // A single `+ length` in the modulo only rescues a delta of -1; this is a
+      // shared API that may be handed a page-sized jump.
+      const { result } = setup([["a", ["a1", "a2", "a3"]]]);
+
+      act(() => result.current.step(-4));
+      expect(result.current.selectedRowId).toBe("i:a3");
+
+      act(() => result.current.step(7));
+      expect(result.current.selectedRowId).toBe("i:a1");
+    });
+
+    it("counts the navigable sequence, not the rows that include headers", () => {
+      const { result } = setup([
+        ["a", ["a1"]],
+        ["b", ["b1"]],
+      ]);
+
+      act(() => result.current.step(1));
+      // Third entry in `rows` (h:a, i:a1, h:b, i:b1) but second navigable one.
+      expect(result.current.selectedNavigableIndex).toBe(1);
     });
   });
 
@@ -220,7 +243,27 @@ describe("usePaletteTreeNavigation", () => {
 
       expect(result.current.selectedRowId).toBe("i:a3");
       // Its position moved, which is exactly what a stored index would have missed.
-      expect(result.current.selectedRowIndex).toBe(2);
+      expect(result.current.selectedNavigableIndex).toBe(1);
+    });
+
+    it("commits a fallback selection when Enter activates it", () => {
+      // The highlight can be a DERIVED fallback: the stored row vanished and
+      // the first navigable one took over. Activating without storing that id
+      // leaves the next list change move the highlight off the row the user
+      // just acted on — palettes that stay open on a failed activation show it.
+      const onActivate = makeActivateSpy();
+      const { result, rerender } = setup([["a", ["a1", "a2"]]], { onActivate });
+
+      act(() => result.current.selectRow("i:a2"));
+      rerender({ groups: buildGroups([["a", ["a1"]]]), scope: undefined });
+      expect(result.current.selectedRowId).toBe("i:a1");
+
+      act(() => result.current.handleBodyKeyDown(keyEvent("Enter").event));
+      expect(onActivate.mock.calls[0]![0].rowId).toBe("i:a1");
+
+      // A row arriving above the activated one must not steal the highlight.
+      rerender({ groups: buildGroups([["a", ["a0", "a1"]]]), scope: undefined });
+      expect(result.current.selectedRowId).toBe("i:a1");
     });
 
     it("falls back to the first navigable row when the selected row is gone", () => {
@@ -349,6 +392,34 @@ describe("usePaletteTreeNavigation", () => {
       act(() => result.current.handleBodyKeyDown(keyEvent("ArrowRight").event));
 
       expect(onGroupCollapsedChange).toHaveBeenLastCalledWith("a", false);
+    });
+
+    it("remembers the keyboard-collapsed group across a selection-scope change", () => {
+      // A new query re-ranks the list but says nothing about which group the
+      // keyboard last shut, so → must still reopen that one rather than
+      // whichever group happens to sit first.
+      const onGroupCollapsedChange = vi.fn();
+      const { result, rerender } = setup(
+        [
+          ["a", ["a1"], { collapsed: true }],
+          ["b", ["b1"]],
+        ],
+        { onGroupCollapsedChange, selectionScopeKey: "q1" }
+      );
+
+      act(() => result.current.selectRow("i:b1"));
+      act(() => result.current.handleBodyKeyDown(keyEvent("ArrowLeft").event));
+
+      rerender({
+        groups: buildGroups([
+          ["a", ["a1"], { collapsed: true }],
+          ["b", ["b1"], { collapsed: true }],
+        ]),
+        scope: "q2",
+      });
+      act(() => result.current.handleBodyKeyDown(keyEvent("ArrowRight").event));
+
+      expect(onGroupCollapsedChange).toHaveBeenLastCalledWith("b", false);
     });
 
     it("leaves the horizontal arrows alone when no collapse handler is supplied", () => {

--- a/src/hooks/usePaletteTreeNavigation.ts
+++ b/src/hooks/usePaletteTreeNavigation.ts
@@ -1,0 +1,382 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { KeyboardEvent, KeyboardEventHandler } from "react";
+
+/**
+ * The keyboard model for a palette whose list has groups.
+ *
+ * Every selector that needed section headers used to write this itself, and the
+ * three that existed disagreed on what selection even is — a DOM id, a row id,
+ * an index. The index-keyed one carried the bug the others had worked around:
+ * a list that shrinks under an open palette leaves the index addressing a row
+ * the user never selected, and Enter commits that one (#11071).
+ *
+ * The invariant this hook exists to make structural: the rendered rows and the
+ * arrow-key domain are one derivation, never two. `renderGroups` and `rows`
+ * hold the same row objects, built in a single pass — a caller that renders
+ * `renderGroups` cannot show a row the arrows can't reach, or reach one that
+ * isn't on screen. Collapsed items are absent from both rather than filtered
+ * out of one, so `aria-activedescendant` can only ever name a rendered row.
+ */
+
+/** What every row carries, header or item. */
+export interface PaletteTreeRowIdentity {
+  /** Stable across re-renders; this is what selection is keyed on. */
+  rowId: string;
+  /** The element's DOM id, for `aria-activedescendant` and scrolling. */
+  domId: string;
+  /**
+   * Whether the arrow keys stop here.
+   *
+   * A flag per row rather than one option for the whole palette: a listbox
+   * whose headers are labels and a tree whose parents are stops are the same
+   * model with different rows, and a group can hold a mix. Making it a row's
+   * own property also keeps the skip decision next to the row it describes,
+   * so no second, independently filtered array is needed to express it.
+   */
+  navigable: boolean;
+}
+
+export interface PaletteTreeItemInput<TItem> extends PaletteTreeRowIdentity {
+  item: TItem;
+}
+
+/**
+ * One group as the caller has already ordered and filtered it.
+ *
+ * Collapse is the caller's to store — palettes split it across persisted and
+ * search-scoped state for reasons that belong to their domain — so this takes
+ * the resolved answer and reports changes back through `onGroupCollapsedChange`.
+ */
+export interface PaletteTreeGroupInput<TGroup, TItem> {
+  groupId: string;
+  group: TGroup;
+  header: PaletteTreeRowIdentity;
+  isCollapsed: boolean;
+  items: readonly PaletteTreeItemInput<TItem>[];
+}
+
+export type PaletteTreeRow<TGroup, TItem> =
+  | (PaletteTreeRowIdentity & {
+      kind: "group";
+      groupId: string;
+      group: TGroup;
+      isCollapsed: boolean;
+    })
+  | (PaletteTreeRowIdentity & {
+      kind: "item";
+      groupId: string;
+      group: TGroup;
+      item: TItem;
+    });
+
+export type PaletteTreeGroupRow<TGroup, TItem> = Extract<
+  PaletteTreeRow<TGroup, TItem>,
+  { kind: "group" }
+>;
+
+export type PaletteTreeItemRow<TGroup, TItem> = Extract<
+  PaletteTreeRow<TGroup, TItem>,
+  { kind: "item" }
+>;
+
+export type NavigablePaletteTreeRow<TGroup, TItem> = PaletteTreeRow<TGroup, TItem> & {
+  navigable: true;
+};
+
+/**
+ * The render shape: the same row objects `rows` walks, grouped for markup.
+ *
+ * Returning both from one pass is the whole point — a caller that maps over
+ * this is rendering exactly what the arrows address.
+ */
+export interface PaletteTreeRenderGroup<TGroup, TItem> {
+  header: PaletteTreeGroupRow<TGroup, TItem>;
+  items: readonly PaletteTreeItemRow<TGroup, TItem>[];
+}
+
+export interface UsePaletteTreeNavigationOptions<TGroup, TItem> {
+  groups: readonly PaletteTreeGroupInput<TGroup, TItem>[];
+  /** False parks the model: selection resets and the scroll effect stands down. */
+  isActive: boolean;
+  /**
+   * Changing this drops the selection back to the top row.
+   *
+   * A palette's query re-ranks its list, so holding the old row would leave the
+   * highlight somewhere down the new ranking rather than on its best match.
+   */
+  selectionScopeKey?: string | number | null;
+  onActivate: (row: NavigablePaletteTreeRow<TGroup, TItem>) => void;
+  /** Omitted, the horizontal arrows stay with the caret and nothing collapses. */
+  onGroupCollapsedChange?: (groupId: string, collapsed: boolean) => void;
+  /**
+   * Whether a caret exists that the structural keys must stand down for.
+   *
+   * Home/End/←/→ are this list's structural keys, but they are also the search
+   * box's editing keys and the box owns focus by default. Consulted only for
+   * those four, and only on the input — the body region has no caret. Defaults
+   * to preserving them, because editable text should win unless a caller says
+   * otherwise.
+   */
+  shouldPreserveInputCaretKey?: (event: KeyboardEvent<HTMLInputElement>) => boolean;
+}
+
+export interface UsePaletteTreeNavigationResult<TGroup, TItem> {
+  renderGroups: readonly PaletteTreeRenderGroup<TGroup, TItem>[];
+  rows: readonly PaletteTreeRow<TGroup, TItem>[];
+  selectedRowId: string | null;
+  /** -1 when nothing is navigable, so callers can gate on a row existing. */
+  selectedRowIndex: number;
+  selectedRow: NavigablePaletteTreeRow<TGroup, TItem> | null;
+  /** Undefined unless it names a row that is actually rendered. */
+  activeDescendantId: string | undefined;
+  selectRow: (rowId: string) => void;
+  activateRow: (rowId: string) => void;
+  step: (delta: number) => void;
+  handleInputKeyDown: KeyboardEventHandler<HTMLInputElement>;
+  handleBodyKeyDown: KeyboardEventHandler<HTMLElement>;
+}
+
+const CARET_KEYS = new Set(["Home", "End", "ArrowLeft", "ArrowRight"]);
+
+function isNavigable<TGroup, TItem>(
+  row: PaletteTreeRow<TGroup, TItem>
+): row is NavigablePaletteTreeRow<TGroup, TItem> {
+  return row.navigable;
+}
+
+export function usePaletteTreeNavigation<TGroup, TItem>({
+  groups,
+  isActive,
+  selectionScopeKey = null,
+  onActivate,
+  onGroupCollapsedChange,
+  shouldPreserveInputCaretKey,
+}: UsePaletteTreeNavigationOptions<TGroup, TItem>): UsePaletteTreeNavigationResult<TGroup, TItem> {
+  /**
+   * The render model and the flat nav list, built together.
+   *
+   * A collapsed group contributes no item rows at all rather than contributing
+   * them and hiding them later: a row that isn't built can't be selected, which
+   * is what makes the drift unrepresentable instead of merely guarded against.
+   */
+  const renderGroups = useMemo<PaletteTreeRenderGroup<TGroup, TItem>[]>(
+    () =>
+      groups.map((input) => ({
+        header: {
+          kind: "group",
+          rowId: input.header.rowId,
+          domId: input.header.domId,
+          navigable: input.header.navigable,
+          groupId: input.groupId,
+          group: input.group,
+          isCollapsed: input.isCollapsed,
+        },
+        items: input.isCollapsed
+          ? []
+          : input.items.map((item) => ({
+              kind: "item" as const,
+              rowId: item.rowId,
+              domId: item.domId,
+              navigable: item.navigable,
+              groupId: input.groupId,
+              group: input.group,
+              item: item.item,
+            })),
+      })),
+    [groups]
+  );
+
+  const rows = useMemo<PaletteTreeRow<TGroup, TItem>[]>(
+    () => renderGroups.flatMap((group) => [group.header, ...group.items]),
+    [renderGroups]
+  );
+
+  const navigableRows = useMemo(() => rows.filter(isNavigable), [rows]);
+
+  /**
+   * The selected ROW is the state; its index is derived. Tracking an index
+   * instead would let it outlive the row it pointed at — the list shrinks under
+   * an open palette whenever a group collapses or an entry disappears, and the
+   * index would then address a different row than the user selected (#11071).
+   */
+  const [selectedRowId, setSelectedRowId] = useState<string | null>(null);
+  /** The group the keyboard last closed, so → can re-open that one. */
+  const lastCollapsedGroupIdRef = useRef<string | null>(null);
+
+  /** Unmoved, the highlight sits on the first row the arrows can reach. */
+  const selectedNavigableIndex = useMemo(() => {
+    if (navigableRows.length === 0) return -1;
+    const index = selectedRowId
+      ? navigableRows.findIndex((row) => row.rowId === selectedRowId)
+      : -1;
+    return index >= 0 ? index : 0;
+  }, [navigableRows, selectedRowId]);
+
+  const selectedRow =
+    selectedNavigableIndex >= 0 ? (navigableRows[selectedNavigableIndex] ?? null) : null;
+
+  const selectedRowIndex = useMemo(
+    () => (selectedRow ? rows.findIndex((row) => row.rowId === selectedRow.rowId) : -1),
+    [rows, selectedRow]
+  );
+
+  useEffect(() => {
+    setSelectedRowId(null);
+    lastCollapsedGroupIdRef.current = null;
+  }, [selectionScopeKey, isActive]);
+
+  // Keyed on the id rather than the row object: rows are rebuilt whenever their
+  // content refreshes, and re-running this each tick would fight the user's own
+  // scroll.
+  const activeDescendantId = selectedRow?.domId;
+  useEffect(() => {
+    if (!isActive || activeDescendantId === undefined) return;
+    document.getElementById(activeDescendantId)?.scrollIntoView({ block: "nearest" });
+  }, [isActive, activeDescendantId]);
+
+  const step = useCallback(
+    (delta: number) => {
+      if (navigableRows.length === 0) return;
+      // Resolve the current row from the id inside the updater so two calls
+      // batched into one tick compose instead of collapsing into one.
+      setSelectedRowId((previousId) => {
+        const current = previousId
+          ? navigableRows.findIndex((row) => row.rowId === previousId)
+          : -1;
+        const from = current >= 0 ? current : 0;
+        const next = (from + delta + navigableRows.length) % navigableRows.length;
+        return navigableRows[next]!.rowId;
+      });
+    },
+    [navigableRows]
+  );
+
+  const selectRow = useCallback((rowId: string) => setSelectedRowId(rowId), []);
+
+  const activateRow = useCallback(
+    (rowId: string) => {
+      const row = navigableRows.find((candidate) => candidate.rowId === rowId);
+      if (!row) return;
+      setSelectedRowId(row.rowId);
+      onActivate(row);
+    },
+    [navigableRows, onActivate]
+  );
+
+  /**
+   * ←/→ act on the group holding the selected row, which is what lets a palette
+   * whose headers are not stops still open and close its groups.
+   */
+  const handleNavigationKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLElement>, allowCaretKeys: boolean) => {
+      const consume = () => {
+        event.preventDefault();
+        event.stopPropagation();
+      };
+
+      // Expand BEFORE the empty-list guard, because collapsing the last open
+      // group is exactly what empties the list — and disclosures need not be
+      // tab stops, so bailing here could strand a keyboard user with every
+      // group shut and no way to reopen one.
+      if (event.key === "ArrowRight" && !allowCaretKeys && onGroupCollapsedChange) {
+        const remembered = lastCollapsedGroupIdRef.current;
+        // Validate the remembered group against the current list: it may have
+        // disappeared while the palette was open, and reopening a group that is
+        // no longer there would be a write against stale data.
+        const rememberedStillCollapsed =
+          remembered !== null &&
+          renderGroups.some(
+            (group) => group.header.groupId === remembered && group.header.isCollapsed
+          );
+        const target = rememberedStillCollapsed
+          ? remembered
+          : selectedRow && isCollapsedGroup(renderGroups, selectedRow.groupId)
+            ? selectedRow.groupId
+            : renderGroups.find((group) => group.header.isCollapsed)?.header.groupId;
+        if (target !== undefined) {
+          consume();
+          onGroupCollapsedChange(target, false);
+          lastCollapsedGroupIdRef.current = null;
+        }
+        return;
+      }
+
+      // Nothing to navigate means the browser's own behaviour is the only
+      // useful one left; swallowing the key would leave the region eating
+      // Enter and the arrows through loading and empty states.
+      if (navigableRows.length === 0) return;
+
+      switch (event.key) {
+        case "ArrowDown":
+          consume();
+          step(1);
+          break;
+        case "ArrowUp":
+          consume();
+          step(-1);
+          break;
+        case "Home":
+          if (allowCaretKeys) break;
+          consume();
+          setSelectedRowId(navigableRows[0]!.rowId);
+          break;
+        case "End":
+          if (allowCaretKeys) break;
+          consume();
+          setSelectedRowId(navigableRows[navigableRows.length - 1]!.rowId);
+          break;
+        case "ArrowLeft": {
+          if (allowCaretKeys || !selectedRow || !onGroupCollapsedChange) break;
+          consume();
+          lastCollapsedGroupIdRef.current = selectedRow.groupId;
+          onGroupCollapsedChange(selectedRow.groupId, true);
+          // The highlight needs no explicit move: a hidden row is no longer in
+          // `rows`, so the derived index falls back to the first visible one.
+          break;
+        }
+        case "Enter":
+          consume();
+          if (selectedRow) onActivate(selectedRow);
+          break;
+      }
+    },
+    [navigableRows, onActivate, onGroupCollapsedChange, renderGroups, selectedRow, step]
+  );
+
+  const handleInputKeyDown = useCallback<KeyboardEventHandler<HTMLInputElement>>(
+    (event) => {
+      if (event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229) return;
+      const allowCaretKeys =
+        CARET_KEYS.has(event.key) &&
+        (shouldPreserveInputCaretKey ? shouldPreserveInputCaretKey(event) : true);
+      handleNavigationKeyDown(event, allowCaretKeys);
+    },
+    [handleNavigationKeyDown, shouldPreserveInputCaretKey]
+  );
+
+  const handleBodyKeyDown = useCallback<KeyboardEventHandler<HTMLElement>>(
+    (event) => handleNavigationKeyDown(event, false),
+    [handleNavigationKeyDown]
+  );
+
+  return {
+    renderGroups,
+    rows,
+    selectedRowId: selectedRow?.rowId ?? null,
+    selectedRowIndex,
+    selectedRow,
+    activeDescendantId,
+    selectRow,
+    activateRow,
+    step,
+    handleInputKeyDown,
+    handleBodyKeyDown,
+  };
+}
+
+function isCollapsedGroup<TGroup, TItem>(
+  renderGroups: readonly PaletteTreeRenderGroup<TGroup, TItem>[],
+  groupId: string
+): boolean {
+  return renderGroups.some((group) => group.header.groupId === groupId && group.header.isCollapsed);
+}

--- a/src/hooks/usePaletteTreeNavigation.ts
+++ b/src/hooks/usePaletteTreeNavigation.ts
@@ -20,7 +20,13 @@ import type { KeyboardEvent, KeyboardEventHandler } from "react";
 
 /** What every row carries, header or item. */
 export interface PaletteTreeRowIdentity {
-  /** Stable across re-renders; this is what selection is keyed on. */
+  /**
+   * Stable across re-renders; this is what selection is keyed on.
+   *
+   * Must be unique across the WHOLE tree, not just within its group: selection
+   * and activation resolve it by first match, so a group-local id reused under
+   * another group would make the second row act as the first.
+   */
   rowId: string;
   /** The element's DOM id, for `aria-activedescendant` and scrolling. */
   domId: string;
@@ -124,8 +130,12 @@ export interface UsePaletteTreeNavigationResult<TGroup, TItem> {
   renderGroups: readonly PaletteTreeRenderGroup<TGroup, TItem>[];
   rows: readonly PaletteTreeRow<TGroup, TItem>[];
   selectedRowId: string | null;
-  /** -1 when nothing is navigable, so callers can gate on a row existing. */
-  selectedRowIndex: number;
+  /**
+   * Position among the NAVIGABLE rows — the sequence the arrows walk, headers
+   * excluded — so it lines up with a flat `results`-style array. Not an index
+   * into `rows`, which counts headers. -1 when nothing is navigable.
+   */
+  selectedNavigableIndex: number;
   selectedRow: NavigablePaletteTreeRow<TGroup, TItem> | null;
   /** Undefined unless it names a row that is actually rendered. */
   activeDescendantId: string | undefined;
@@ -215,15 +225,17 @@ export function usePaletteTreeNavigation<TGroup, TItem>({
   const selectedRow =
     selectedNavigableIndex >= 0 ? (navigableRows[selectedNavigableIndex] ?? null) : null;
 
-  const selectedRowIndex = useMemo(
-    () => (selectedRow ? rows.findIndex((row) => row.rowId === selectedRow.rowId) : -1),
-    [rows, selectedRow]
-  );
-
   useEffect(() => {
     setSelectedRowId(null);
-    lastCollapsedGroupIdRef.current = null;
   }, [selectionScopeKey, isActive]);
+
+  // Disclosure history is NOT selection state: a new query re-ranks the list
+  // but says nothing about which group the keyboard last closed, and dropping
+  // the memory there would send the next → to the first collapsed group
+  // instead of the one the user just shut. Only closing forgets it.
+  useEffect(() => {
+    lastCollapsedGroupIdRef.current = null;
+  }, [isActive]);
 
   // Keyed on the id rather than the row object: rows are rebuilt whenever their
   // content refreshes, and re-running this each tick would fight the user's own
@@ -244,7 +256,10 @@ export function usePaletteTreeNavigation<TGroup, TItem>({
           ? navigableRows.findIndex((row) => row.rowId === previousId)
           : -1;
         const from = current >= 0 ? current : 0;
-        const next = (from + delta + navigableRows.length) % navigableRows.length;
+        // Normalised both ways: a single `+ length` only rescues a delta of -1,
+        // and this is a shared API that may be handed a page-sized jump.
+        const size = navigableRows.length;
+        const next = (((from + delta) % size) + size) % size;
         return navigableRows[next]!.rowId;
       });
     },
@@ -336,7 +351,16 @@ export function usePaletteTreeNavigation<TGroup, TItem>({
         }
         case "Enter":
           consume();
-          if (selectedRow) onActivate(selectedRow);
+          if (selectedRow) {
+            // Commit the id, not just the activation. The highlight may be a
+            // DERIVED fallback — the stored row disappeared and the first
+            // navigable one took over — and activating without storing would
+            // leave the next list change move the highlight off the row the
+            // user just acted on. Palettes that stay open on a failed
+            // activation are where that shows.
+            setSelectedRowId(selectedRow.rowId);
+            onActivate(selectedRow);
+          }
           break;
       }
     },
@@ -363,7 +387,7 @@ export function usePaletteTreeNavigation<TGroup, TItem>({
     renderGroups,
     rows,
     selectedRowId: selectedRow?.rowId ?? null,
-    selectedRowIndex,
+    selectedNavigableIndex,
     selectedRow,
     activeDescendantId,
     selectRow,


### PR DESCRIPTION
`SearchablePalette` only ever handled a flat list, so every selector that needed section headers wrote its own keyboard model. The three that existed disagreed on what selection even *is* — `PilotView` keyed on a DOM id, the switcher on a row id, `SearchablePalette` on an index — and the index-keyed one still carried the bug the other two had worked around (#11071: a list shrinking under an open palette strands the index on a different row, and Enter commits that one).

This adds the shared grouped-nav domain and proves it by rewiring `PilotView` onto it, then collapses the four-way drift in the selected-row accent bar down to one definition.

## The nav model

`src/hooks/usePaletteTreeNavigation.ts`. The load-bearing property is that `renderGroups` and `rows` are built in one pass and hold **the same row objects** — a caller rendering `renderGroups` cannot show a row the arrows can't reach, or reach one that isn't on screen. A collapsed group contributes no item rows at all rather than contributing them and hiding them later, so the #11071 drift is unrepresentable rather than merely guarded against.

- Selection is a `rowId`; the index is derived every render and falls back to the first navigable row.
- Group headers are first-class rows carrying a per-row `navigable` flag, rather than one `headersAreStops` switch for the whole palette. A listbox whose headers are labels and a tree whose parents are stops are the same model with different rows, and a group can hold a mix.
- Collapse stays the caller's to store (palettes split it across persisted and search-scoped state for their own reasons); the hook takes the resolved answer and reports changes back.
- ←/→ disclosure, with the remembered group validated against the current list so a stale target can't silently swallow the key — the old code consumed it against a group that might no longer be collapsed and did nothing.
- Home/End/Enter, the IME guard, and id-keyed `scrollIntoView` come along.

Per APG, the horizontal arrows belong to the caret in an editable combobox, so disclosure is gated behind a caller-supplied predicate; PilotView keeps its existing "only when the query is empty" rule.

`PilotView` loses ~200 lines and its existing keyboard suite passes untouched, which is the result I wanted from the extraction.

## The row layer

`PALETTE_ROW_CLASS` in `src/components/ui/paletteRowStyles.ts` is now the only definition of the selected-row treatment. Before this, five sites spelled the same visual five ways: two drove it from a JS `isSelected` ternary and three from the `aria-selected` attribute, two rounded the rail and three didn't, two cross-faded it and three popped it in with nothing to transition. Authority is the rendered attribute now, so the announcement and the highlight can't disagree.

Layout deliberately stays per-site — these rows are genuinely different shapes.

Two intentional visual changes: QuickSwitcher's selected fill moves from `overlay-soft` to `overlay-raised` (the canonical recipe, and what the issue called out), and the rail gains rounding plus a cross-fade everywhere. A missing project keeps its dimmed text while selected — the row's brightness is what says the folder is gone.

`accentGuard`'s ratchet is bidirectional, so the five files that lost the token are removed from their buckets and the shared module added, in the same commit.

## Testing

New hook suite covers the flattening invariant, id-follows-shrink, header skipping, wraparound, batched steps composing, disclosure, caret arbitration, and the IME guard. `ResumeSessionsPalette` gets its first coverage — it had none.

Local: 1638 tests across every module this touches, plus both `accentGuard` and `colorSystem` contract tests (normally CI-only, run here because this PR moves accent tokens between files).

## Deliberately not in this PR

`ProjectSwitcherPalette` and `ActionPalette` keep their own navigation models. Both are already id-derived and structurally sound, they carry ~3400 lines of tests between them, and migrating them is a separate change — the point of this one is that the destination now exists. `ActionPalette`'s `role="option" aria-disabled="true"` section headers stay too: that workaround is justified by an observed Chromium+VoiceOver failure, and I'm not trading it for an APG-correct `role="group"` without an actual screen-reader test.

About ten other palettes (`PanelPalette`, `WorktreePalette`, `ThemePalette`, `CommandPicker`, `PromptHistoryPalette` among them) still carry their own copy of the rail with the same drift. Mechanical to convert now that the constant exists, but each has its own tests and the issue named a specific set.

One latent thing I left documented rather than fixed: PilotView's header row reuses the runs container's DOM id. Harmless while its headers are non-navigable, but anything flipping that flag has to give the header its own id first.

Resolves #11595