### PR TITLE
feat(file-browser): surface git status in tree and idle pane

### DIFF
--- a/src/components/Worktree/FileChangeList.tsx
+++ b/src/components/Worktree/FileChangeList.tsx
@@ -8,8 +8,9 @@ import {
   useRef,
   useState,
 } from "react";
-import type { FileChangeDetail, GitStatus } from "../../types";
+import type { FileChangeDetail } from "../../types";
 import { cn } from "../../lib/utils";
+import { getGitStatusPresentation } from "@/lib/gitStatusPresentation";
 import { Folder } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { basename, dirname, isAbsolute, join } from "@shared/utils/path";
@@ -26,17 +27,6 @@ import { usePanelDialogStore } from "@/store/panelDialogStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeIdForPath } from "@/panels/diff/useWorktreeIdForPath";
 import { FileDecorationBadge } from "@/components/Plugin/FileDecorationBadge";
-
-const STATUS_CONFIG: Record<GitStatus, { label: string; color: string }> = {
-  modified: { label: "M", color: "text-status-warning" },
-  added: { label: "A", color: "text-status-success" },
-  deleted: { label: "D", color: "text-status-error" },
-  untracked: { label: "?", color: "text-status-success" },
-  renamed: { label: "R", color: "text-status-info" },
-  copied: { label: "C", color: "text-status-info" },
-  ignored: { label: "I", color: "text-daintree-text/40" },
-  conflicted: { label: "!", color: "text-status-error" },
-};
 
 interface FileChangeListProps {
   changes: FileChangeDetail[];
@@ -238,7 +228,7 @@ export const FileChangeList = forwardRef<FileChangeListHandle, FileChangeListPro
     }
 
     const renderFileItem = (change: WorkingTreeFileChange, showDir: boolean) => {
-      const config = STATUS_CONFIG[change.status] || STATUS_CONFIG.untracked;
+      const presentation = getGitStatusPresentation(change.status);
       const { dir, base } = splitPath(change.relativePath);
       const displayDir = formatDirForDisplay(dir);
       const key = getWorkingTreeChangeKey(change);
@@ -266,7 +256,9 @@ export const FileChangeList = forwardRef<FileChangeListHandle, FileChangeListPro
                 }
               }}
             >
-              <span className={cn("w-4 font-bold shrink-0", config.color)}>{config.label}</span>
+              <span className={cn("w-4 font-bold shrink-0", presentation.colorClass)}>
+                {presentation.marker}
+              </span>
 
               <div className="flex-1 min-w-0 flex items-center mr-2">
                 {showDir && displayDir && (

--- a/src/lib/__tests__/gitStatusPresentation.test.ts
+++ b/src/lib/__tests__/gitStatusPresentation.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import type { GitStatus } from "@shared/types/git";
 import { GIT_STATUS_PRESENTATION, getGitStatusPresentation } from "../gitStatusPresentation";
 
-const ALL_STATUSES = Object.keys(GIT_STATUS_PRESENTATION) as GitStatus[];
+const ALL_STATUSES = Object.keys(GIT_STATUS_PRESENTATION).filter(
+  (key): key is GitStatus => key in GIT_STATUS_PRESENTATION
+);
 
 describe("getGitStatusPresentation", () => {
   it("resolves every status the type admits", () => {
@@ -34,7 +36,9 @@ describe("getGitStatusPresentation", () => {
   });
 
   it("falls back rather than leaving a changed row unmarked", () => {
-    // `status` crosses IPC, so a value outside the union can arrive at runtime.
+    // The assertion is deliberately unsafe: a value the union forbids but IPC
+    // can still deliver is the entire scenario under test.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- exercising an out-of-union runtime value
     const rogue = getGitStatusPresentation("something-new" as GitStatus);
 
     expect(rogue).toBe(getGitStatusPresentation("untracked"));

--- a/src/lib/__tests__/gitStatusPresentation.test.ts
+++ b/src/lib/__tests__/gitStatusPresentation.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import type { GitStatus } from "@shared/types/git";
+import { GIT_STATUS_PRESENTATION, getGitStatusPresentation } from "../gitStatusPresentation";
+
+const ALL_STATUSES = Object.keys(GIT_STATUS_PRESENTATION) as GitStatus[];
+
+describe("getGitStatusPresentation", () => {
+  it("resolves every status the type admits", () => {
+    for (const status of ALL_STATUSES) {
+      const presentation = getGitStatusPresentation(status);
+      expect(presentation.marker).not.toBe("");
+      expect(presentation.name).not.toBe("");
+      expect(presentation.colorClass).not.toBe("");
+    }
+  });
+
+  it("keeps every marker to a single character so a dense row can hold it", () => {
+    for (const status of ALL_STATUSES) {
+      expect(getGitStatusPresentation(status).marker).toHaveLength(1);
+    }
+  });
+
+  it("never spends the accent on status, which is inherently multi-element", () => {
+    for (const status of ALL_STATUSES) {
+      expect(getGitStatusPresentation(status).colorClass).not.toMatch(/accent/);
+    }
+  });
+
+  it("distinguishes the statuses a reader has to tell apart at a glance", () => {
+    const distinguishable: GitStatus[] = ["modified", "added", "deleted", "conflicted"];
+    const markers = distinguishable.map((status) => getGitStatusPresentation(status).marker);
+
+    expect(new Set(markers).size).toBe(distinguishable.length);
+  });
+
+  it("falls back rather than leaving a changed row unmarked", () => {
+    // `status` crosses IPC, so a value outside the union can arrive at runtime.
+    const rogue = getGitStatusPresentation("something-new" as GitStatus);
+
+    expect(rogue).toBe(getGitStatusPresentation("untracked"));
+  });
+});

--- a/src/lib/gitStatusPresentation.ts
+++ b/src/lib/gitStatusPresentation.ts
@@ -1,0 +1,40 @@
+import type { GitStatus } from "@shared/types/git";
+
+export interface GitStatusPresentation {
+  /** Single-character marker for dense rows, where a word would not fit. */
+  marker: string;
+  /** The status spelled out, for accessible names and pointer tooltips. */
+  name: string;
+  /**
+   * Semantic foreground token. Never an accent token: the accent is reserved
+   * for one load-bearing signal per focus region, and status is inherently
+   * multi-element. The marker letter is what carries the meaning for anyone
+   * who cannot separate the hues — colour is the secondary channel here.
+   */
+  colorClass: string;
+}
+
+/**
+ * How a git status reads across the app. Shared so the worktree change list,
+ * the file browser's tree markers and its changed-files summary cannot drift
+ * into three different letters for the same state.
+ */
+export const GIT_STATUS_PRESENTATION = {
+  modified: { marker: "M", name: "Modified", colorClass: "text-status-warning" },
+  added: { marker: "A", name: "Added", colorClass: "text-status-success" },
+  deleted: { marker: "D", name: "Deleted", colorClass: "text-status-error" },
+  untracked: { marker: "?", name: "Untracked", colorClass: "text-status-success" },
+  renamed: { marker: "R", name: "Renamed", colorClass: "text-status-info" },
+  copied: { marker: "C", name: "Copied", colorClass: "text-status-info" },
+  ignored: { marker: "I", name: "Ignored", colorClass: "text-daintree-text/40" },
+  conflicted: { marker: "!", name: "Conflicted", colorClass: "text-status-error" },
+} satisfies Record<GitStatus, GitStatusPresentation>;
+
+/**
+ * Falls back rather than returning undefined: `status` arrives over IPC, so a
+ * value outside the union is a runtime possibility the type system can't rule
+ * out, and a row with no marker at all would read as "unchanged".
+ */
+export function getGitStatusPresentation(status: GitStatus): GitStatusPresentation {
+  return GIT_STATUS_PRESENTATION[status] || GIT_STATUS_PRESENTATION.untracked;
+}

--- a/src/panels/file-browser/FileBrowserChangeSummary.tsx
+++ b/src/panels/file-browser/FileBrowserChangeSummary.tsx
@@ -1,0 +1,104 @@
+import { cn } from "@/lib/utils";
+import { getGitStatusPresentation } from "@/lib/gitStatusPresentation";
+import { getWorkingTreeChangeKey, type WorkingTreeFileChange } from "@/lib/workingTreeDiff";
+
+export interface FileBrowserChangeSummaryProps {
+  /**
+   * The worktree's changed files, already churn-sorted, with paths relative to
+   * the worktree root — the same strings the tree's rows and the pane's
+   * selection use.
+   */
+  changes: readonly WorkingTreeFileChange[];
+  /**
+   * Opens the file in the viewer beside the tree. Never a diff: that is what
+   * `worktree.openChanges` is for, and this pane exists to *read* the file an
+   * agent just touched.
+   */
+  onSelect: (relativePath: string) => void;
+}
+
+function splitPath(filePath: string): { dir: string; base: string } {
+  const cut = filePath.lastIndexOf("/");
+  return cut === -1
+    ? { dir: "", base: filePath }
+    : { dir: filePath.slice(0, cut), base: filePath.slice(cut + 1) };
+}
+
+/**
+ * What the browser shows when nothing is selected: the answer to "what did the
+ * agent just change in here". Fills the pane rather than centring a placeholder
+ * in it, because on a dirty worktree this is the pane's primary content.
+ */
+export function FileBrowserChangeSummary({ changes, onSelect }: FileBrowserChangeSummaryProps) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="shrink-0 px-4 pb-2 pt-4">
+        <h2 className="text-sm font-medium text-daintree-text">Changed files</h2>
+        <p className="mt-0.5 text-xs text-daintree-text/60">Pick a file to read it here</p>
+      </div>
+      <ul className="min-h-0 flex-1 overflow-y-auto px-2 pb-3">
+        {changes.map((change) => {
+          const presentation = getGitStatusPresentation(change.status);
+          // A deleted file has nothing on disk to read. It stays listed — the
+          // summary would be lying about the change set otherwise — but it does
+          // not pretend to be openable: activating it would land the viewer on a
+          // file-not-found error with no way back to what went wrong.
+          const isReadable = change.status !== "deleted";
+          const { dir, base } = splitPath(change.relativePath);
+          const insertions = change.insertions ?? 0;
+          const deletions = change.deletions ?? 0;
+
+          return (
+            <li key={getWorkingTreeChangeKey(change)}>
+              <button
+                type="button"
+                // aria-disabled rather than `disabled`: the row keeps its place
+                // in the tab order so a keyboard user can reach the explanation
+                // instead of the row silently not existing for them.
+                aria-disabled={!isReadable}
+                aria-label={
+                  isReadable
+                    ? `Read ${change.relativePath}, ${presentation.name}`
+                    : `${change.relativePath}, deleted file isn't available to read`
+                }
+                title={isReadable ? change.relativePath : "Deleted file isn't available to read"}
+                onClick={
+                  isReadable
+                    ? () => {
+                        onSelect(change.relativePath);
+                      }
+                    : undefined
+                }
+                className={cn(
+                  "flex w-full items-center gap-2 rounded px-2 py-1 text-left font-mono text-xs",
+                  "transition-colors duration-150 ease-out",
+                  isReadable
+                    ? "cursor-pointer text-daintree-text/80 hover:bg-tint/5 hover:text-daintree-text"
+                    : "cursor-default text-daintree-text/40"
+                )}
+              >
+                <span
+                  className={cn("w-3 shrink-0 text-center font-bold", presentation.colorClass)}
+                  aria-hidden="true"
+                >
+                  {presentation.marker}
+                </span>
+                <span className="flex min-w-0 flex-1 items-center">
+                  {dir !== "" && <span className="truncate text-daintree-text/50">{dir}/</span>}
+                  <span className="truncate font-medium">{base}</span>
+                </span>
+                <span
+                  className="flex shrink-0 items-center gap-1.5 text-[11px] tabular-nums"
+                  aria-hidden="true"
+                >
+                  {insertions > 0 && <span className="text-status-success/80">+{insertions}</span>}
+                  {deletions > 0 && <span className="text-status-error/80">-{deletions}</span>}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -291,11 +291,16 @@ export function FileBrowserPane({
     const changesRoot = worktreeChanges?.rootPath;
     const changes = worktreeChanges?.changes;
     if (!changesRoot || !Array.isArray(changes)) return null;
-    return buildWorkingTreeDiffModel(changes, changesRoot).sortedChanges.filter((change) =>
+    const safe = buildWorkingTreeDiffModel(changes, changesRoot).sortedChanges.filter((change) =>
       // Anything still absolute here is a strip that missed. Dropping it keeps a
       // path that can't address a row from ever reaching the selection.
       isReadableRelativePath(change.relativePath)
     );
+    // Git reported changes but none of them survived. That is an unusable
+    // snapshot, not an empty one — reporting it as "clean" would state the
+    // opposite of what git said. Fall back to "status unavailable".
+    if (safe.length === 0 && changes.length > 0) return null;
+    return safe;
   }, [isWorktreeSource, worktreeChanges]);
 
   const gitStatusIndex = useMemo(
@@ -418,6 +423,26 @@ export function FileBrowserPane({
       setFileBrowserView(id, { browserSelectedPath: path });
     },
     [id, setFileBrowserView]
+  );
+
+  // Picking a file from the changed-files summary also opens its ancestors, so
+  // the row is waiting in the tree once the summary is replaced by the file.
+  // That is the whole reason both halves of #11614 shipped together — a file
+  // surfaced in the summary has to stay findable afterwards.
+  //
+  // It also keeps the selection honest over time: with the row flattened, the
+  // tree itself witnesses that the path is a file, so the viewer holds the file
+  // open after an agent commits it and git stops reporting it as changed.
+  const handleSelectChangedFile = useCallback(
+    (path: string) => {
+      const expanded = new Set(stableExpandedPaths);
+      for (const ancestor of ancestorDirectories(path)) expanded.add(ancestor);
+      setFileBrowserView(id, {
+        browserSelectedPath: path,
+        browserExpandedPaths: [...expanded].sort(),
+      });
+    },
+    [id, stableExpandedPaths, setFileBrowserView]
   );
 
   // Enter and double-click open the row's file as its own panel (#11496), which
@@ -931,7 +956,13 @@ export function FileBrowserPane({
   // Positively a file, not merely "not known to be a directory": collapsing a
   // parent hides the selected row without clearing the selection, and treating
   // that unknown node as a file makes the viewer try to read a directory.
-  const isSelectedReadableFile = selectedNode?.isDirectory === false || isSelectedChangedFile;
+  //
+  // Git only gets a vote when the tree has no opinion. A known directory is a
+  // hard veto — git reports a dirty submodule as a changed path while the
+  // filesystem calls it a directory, and letting the change set override the row
+  // would hand the viewer a directory to read.
+  const isSelectedReadableFile =
+    selectedNode === undefined ? isSelectedChangedFile : selectedNode.isDirectory === false;
   const selectedFilePath =
     selectedPath && basePath && isSelectedReadableFile ? join(basePath, selectedPath) : null;
   const selectedFileName = selectedPath ? (selectedPath.split("/").pop() ?? selectedPath) : "";
@@ -1146,7 +1177,7 @@ export function FileBrowserPane({
               onToggleSidebar={handleToggleSidebar}
               treeSidebarId={treeSidebarId}
               changedFiles={changedFiles}
-              onSelectChangedFile={handleSelect}
+              onSelectChangedFile={handleSelectChangedFile}
             />
           </div>
         )}

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -42,6 +42,8 @@ import { useExternalChangeTick } from "@/hooks/useExternalChangeTick";
 import { useProjectViewRevealed } from "@/hooks/useProjectViewRevealed";
 import { FileTreeView } from "./FileTreeView";
 import { FileBrowserViewer } from "./FileBrowserViewer";
+import { buildWorkingTreeDiffModel } from "@/lib/workingTreeDiff";
+import { buildFileBrowserGitStatusIndex, isReadableRelativePath } from "./fileBrowserGitStatus";
 import { useFileBrowserTree } from "./useFileBrowserTree";
 import { useInsertFileReference } from "./useInsertFileReference";
 import { INSERT_FILE_REFERENCE_COMBO } from "./fileReference";
@@ -238,17 +240,20 @@ export function FileBrowserPane({
   // A stable primitive for the menu callback's dependencies — the source object
   // is rebuilt every render.
   const isWorktreeSource = source?.kind === "worktree";
-  // The worktree's git-status change tick — already coalesced by the watcher's
-  // adaptive burst debounce, so a bulk write lands as one tick.
-  const gitChangeTick = useWorktreeStore(
+  // The whole snapshot, not just its tick: the per-file statuses on it are what
+  // the tree markers and the idle pane's summary read (#11614). Selecting the
+  // object is safe for Zustand — it is a stored reference, so an unchanged
+  // snapshot returns identically and re-renders nothing.
+  const worktreeChanges = useWorktreeStore(
     useCallback(
       (state) =>
-        sourceWorktreeId
-          ? state.worktrees.get(sourceWorktreeId)?.worktreeChanges?.lastUpdated
-          : undefined,
+        sourceWorktreeId ? state.worktrees.get(sourceWorktreeId)?.worktreeChanges : undefined,
       [sourceWorktreeId]
     )
   );
+  // The worktree's git-status change tick — already coalesced by the watcher's
+  // adaptive burst debounce, so a bulk write lands as one tick.
+  const gitChangeTick = worktreeChanges?.lastUpdated;
   // The raw filesystem-write tick, independent of git status. Combining the two
   // is the fix for the issue's reproduction: a write into a gitignored folder
   // moves this even though `worktreeChanges` (which dedups content-identical
@@ -266,6 +271,37 @@ export function FileBrowserPane({
   // workspace root gets nothing from them (#11482) — `externalChangeTick` below
   // is what covers it.
   const worktreeChangeTick = Math.max(gitChangeTick ?? 0, fsChangeTick ?? 0) || undefined;
+
+  // The changed files this browser can mark up and summarise.
+  //
+  // Relativized against `worktreeChanges.rootPath` — the realpath-resolved root
+  // each `change.path` was itself resolved against — and never against
+  // `basePath`, which is the raw worktree path off the store. The two denote the
+  // same directory but not the same string whenever an ancestor is a symlink
+  // (/tmp -> /private/tmp on macOS), and the strip in `buildWorkingTreeDiffModel`
+  // fails *silently* on a mismatch: it hands back the untouched absolute path,
+  // which matches no tree row, so the feature would look shipped and mark
+  // nothing on exactly the machines it was written for.
+  //
+  // `null` means no git status is available at all — a workspace root has no
+  // worktree behind it, and a snapshot may not have arrived yet. That is a
+  // different thing from `[]`, which says the worktree is clean.
+  const changedFiles = useMemo(() => {
+    if (!isWorktreeSource) return null;
+    const changesRoot = worktreeChanges?.rootPath;
+    const changes = worktreeChanges?.changes;
+    if (!changesRoot || !Array.isArray(changes)) return null;
+    return buildWorkingTreeDiffModel(changes, changesRoot).sortedChanges.filter((change) =>
+      // Anything still absolute here is a strip that missed. Dropping it keeps a
+      // path that can't address a row from ever reaching the selection.
+      isReadableRelativePath(change.relativePath)
+    );
+  }, [isWorktreeSource, worktreeChanges]);
+
+  const gitStatusIndex = useMemo(
+    () => (changedFiles === null ? null : buildFileBrowserGitStatusIndex(changedFiles)),
+    [changedFiles]
+  );
 
   const stableExpandedPaths = useMemo(() => expandedPaths ?? EMPTY_PATHS, [expandedPaths]);
 
@@ -874,13 +910,30 @@ export function FileBrowserPane({
     () => rows.find((row) => row.path === selectedPath),
     [rows, selectedPath]
   );
+  // Picking a file from the changed-files summary selects a path whose tree row
+  // may not be flattened at all — its ancestors are collapsed, so `selectedNode`
+  // is undefined for it. Git is the second witness that it is a readable file:
+  // every entry here is a path git just reported as changed.
+  //
+  // Deleted files are excluded on purpose. They are listed in the summary (the
+  // change set would be a lie without them) but there is nothing on disk to
+  // read, and admitting one here would swap the placeholder for a file-not-found
+  // error the moment a live delete landed on the open selection.
+  const isSelectedChangedFile = useMemo(
+    () =>
+      selectedPath !== null &&
+      changedFiles !== null &&
+      changedFiles.some(
+        (change) => change.relativePath === selectedPath && change.status !== "deleted"
+      ),
+    [changedFiles, selectedPath]
+  );
   // Positively a file, not merely "not known to be a directory": collapsing a
   // parent hides the selected row without clearing the selection, and treating
   // that unknown node as a file makes the viewer try to read a directory.
+  const isSelectedReadableFile = selectedNode?.isDirectory === false || isSelectedChangedFile;
   const selectedFilePath =
-    selectedPath && basePath && selectedNode?.isDirectory === false
-      ? join(basePath, selectedPath)
-      : null;
+    selectedPath && basePath && isSelectedReadableFile ? join(basePath, selectedPath) : null;
   const selectedFileName = selectedPath ? (selectedPath.split("/").pop() ?? selectedPath) : "";
 
   return (
@@ -1080,7 +1133,7 @@ export function FileBrowserPane({
               filePath={selectedFilePath}
               rootPath={basePath}
               fileName={selectedFileName}
-              relativePath={selectedNode?.isDirectory === false ? (selectedPath ?? null) : null}
+              relativePath={isSelectedReadableFile ? (selectedPath ?? null) : null}
               revision={viewerRevision}
               // Handed over separately from `revision` rather than pulled back
               // out of it: the media previews may only re-fetch on the explicit
@@ -1092,6 +1145,8 @@ export function FileBrowserPane({
               sidebarCollapsed={sidebarCollapsed}
               onToggleSidebar={handleToggleSidebar}
               treeSidebarId={treeSidebarId}
+              changedFiles={changedFiles}
+              onSelectChangedFile={handleSelect}
             />
           </div>
         )}
@@ -1224,6 +1279,7 @@ export function FileBrowserPane({
           // join the insert-reference and copy-path handlers above use.
           basePath={basePath}
           label={`Files in ${title}`}
+          gitStatusIndex={gitStatusIndex}
         />
         {/* Below the tree, never above: the strip unmounts the instant a
             click makes the selection reachable, and sitting above the rows it

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -7,7 +7,7 @@ import {
   RefreshCw,
   XCircle,
 } from "lucide-react";
-import { FolderOpen } from "@/components/icons";
+import { CircleCheck, FolderOpen } from "@/components/icons";
 import { actionService } from "@/services/ActionService";
 import { CodeViewer } from "@/components/FileViewer/CodeViewer";
 import { FileViewerToolbar } from "@/components/FileViewer/FileViewerToolbar";
@@ -47,6 +47,8 @@ import { isClientAppError } from "@/utils/clientAppError";
 import { sanitizeSvg } from "@shared/utils/svgSanitizer";
 import type { FileRenderMode } from "@shared/types/panel";
 import { logError } from "@/utils/logger";
+import type { WorkingTreeFileChange } from "@/lib/workingTreeDiff";
+import { FileBrowserChangeSummary } from "./FileBrowserChangeSummary";
 
 export interface FileBrowserViewerProps {
   /** Absolute path of the selected file; null when nothing is selected. */
@@ -85,6 +87,19 @@ export interface FileBrowserViewerProps {
    * only while the column is mounted (open); the pane unmounts it when collapsed.
    */
   treeSidebarId: string;
+  /**
+   * The worktree's changed files, churn-sorted, with worktree-relative paths.
+   * Drives what fills the pane when nothing is selected.
+   *
+   * Three states, and the empty array is not the same as null: `null` means no
+   * git status is available (a workspace root has no worktree behind it, and a
+   * snapshot may not have arrived yet), while `[]` is a positive statement that
+   * the worktree is clean. Collapsing them would report an unknown worktree as
+   * clean, which is the one thing this pane must not do.
+   */
+  changedFiles: readonly WorkingTreeFileChange[] | null;
+  /** Opens a file picked from the changed-files summary in this viewer. */
+  onSelectChangedFile: (relativePath: string) => void;
 }
 
 /** Which external surface a toolbar action aims the current file at. */
@@ -131,6 +146,8 @@ export function FileBrowserViewer({
   sidebarCollapsed,
   onToggleSidebar,
   treeSidebarId,
+  changedFiles,
+  onSelectChangedFile,
 }: FileBrowserViewerProps) {
   const [state, setState] = useState<ViewerState>({ status: "idle" });
   // Sticky Source/Rendered choice for markdown, defaulting to the rendered view
@@ -442,25 +459,49 @@ export function FileBrowserViewer({
         />
       )}
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-        {filePath ? (
-          renderBody()
-        ) : (
-          // flex-1 + min-h-0, not h-full: below the now-persistent toolbar a
-          // 100%-height body would overflow the viewer column.
-          <div className="flex min-h-0 flex-1 items-center justify-center p-6">
-            <EmptyState
-              variant="zero-data"
-              scale="canvas"
-              icon={<FileText className="h-6 w-6" />}
-              title="Nothing selected"
-              description="Pick a file in the tree to read it here."
-              className="w-full"
-            />
-          </div>
-        )}
+        {filePath ? renderBody() : renderIdleBody()}
       </div>
     </>
   );
+
+  /**
+   * What fills the pane with nothing selected. The browser is opened to answer
+   * "what did the agent just change in here", so on a dirty worktree that answer
+   * is the body — not a placeholder apologising for the absence of one.
+   */
+  function renderIdleBody() {
+    if (changedFiles !== null && changedFiles.length > 0) {
+      return <FileBrowserChangeSummary changes={changedFiles} onSelect={onSelectChangedFile} />;
+    }
+
+    // flex-1 + min-h-0, not h-full: below the now-persistent toolbar a
+    // 100%-height body would overflow the viewer column.
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center p-6">
+        {changedFiles === null ? (
+          <EmptyState
+            variant="zero-data"
+            scale="canvas"
+            icon={<FileText className="h-6 w-6" />}
+            title="Nothing selected"
+            description="Pick a file in the tree to read it here."
+            className="w-full"
+          />
+        ) : (
+          // A clean worktree is a finished state, not an empty one: the
+          // `user-cleared` variant stays quiet and takes no action, since there
+          // is nothing here the user failed to do.
+          <EmptyState
+            variant="user-cleared"
+            scale="canvas"
+            icon={<CircleCheck className="h-6 w-6" />}
+            title="Worktree is clean"
+            className="w-full"
+          />
+        )}
+      </div>
+    );
+  }
 
   function renderBody() {
     // Narrows `filePath` for this closure — the caller only reaches here through

--- a/src/panels/file-browser/FileTreeView.tsx
+++ b/src/panels/file-browser/FileTreeView.tsx
@@ -11,6 +11,8 @@ import { useDeferredLoading } from "@/hooks/useDeferredLoading";
 import { comboToAriaKeyshortcuts } from "@/lib/kbdShortcut";
 import { isMac } from "@/lib/platform";
 import { resolveTreeKey, type FlatTreeRow } from "./fileBrowserTree";
+import { getFileBrowserRowGitStatus, type FileBrowserGitStatusIndex } from "./fileBrowserGitStatus";
+import { getGitStatusPresentation } from "@/lib/gitStatusPresentation";
 import { FILE_TREE_ICON_CLASS, UNKNOWN_FILE_COLOR_CLASS, getFileTypeIcon } from "./fileTypeIcons";
 import { INSERT_FILE_REFERENCE_COMBO, matchesInsertFileReferenceCombo } from "./fileReference";
 
@@ -54,6 +56,17 @@ export interface FileTreeViewProps {
   basePath: string;
   /** Accessible name for the tree, since the panel header isn't part of it. */
   label: string;
+  /**
+   * Git status for the rows, keyed by the same worktree-relative paths
+   * `row.path` uses. Absent or null when nothing git-shaped backs this tree (a
+   * workspace root, or a worktree whose snapshot hasn't arrived), which is the
+   * signal to render no markers at all rather than markers meaning "unchanged".
+   *
+   * Deliberately a separate channel from `rows`: a directory listing doesn't
+   * change when a file's status does, and threading status through the flat
+   * rows would tie the two update cadences together.
+   */
+  gitStatusIndex?: FileBrowserGitStatusIndex | null;
 }
 
 /**
@@ -98,6 +111,7 @@ export function FileTreeView({
   canInsertFileReference = false,
   basePath,
   label,
+  gitStatusIndex = null,
 }: FileTreeViewProps) {
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -252,6 +266,7 @@ export function FileTreeView({
       hasDirectories,
       instanceId,
       basePath,
+      gitStatusIndex,
     }),
     [
       selectedPath,
@@ -263,6 +278,7 @@ export function FileTreeView({
       hasDirectories,
       instanceId,
       basePath,
+      gitStatusIndex,
     ]
   );
 
@@ -323,6 +339,7 @@ interface TreeContext {
   hasDirectories: boolean;
   instanceId: string;
   basePath: string;
+  gitStatusIndex: FileBrowserGitStatusIndex | null;
 }
 
 /**
@@ -440,14 +457,31 @@ function FileTreeRow({ row, isSelected, context }: FileTreeRowProps) {
   const RowIcon = fileIcon?.Icon ?? FolderIcon;
   const rowIconColor = fileIcon?.colorClass ?? UNKNOWN_FILE_COLOR_CLASS;
 
+  // A file's own status; a folder's is the worst thing anywhere beneath it, so a
+  // collapsed branch still says that something inside it changed.
+  const gitStatus = getFileBrowserRowGitStatus(context.gitStatusIndex, row.path, row.isDirectory);
+  const gitPresentation = gitStatus ? getGitStatusPresentation(gitStatus) : null;
+  const gitDescription = gitPresentation
+    ? row.isDirectory
+      ? `Contains ${gitPresentation.name.toLowerCase()} changes`
+      : gitPresentation.name
+    : null;
+  const rowId = rowDomId(context.instanceId, row.path);
+  const gitMarkerId = gitPresentation ? `${rowId}-git` : undefined;
+
   const menuItems = context.rowContextMenu?.(row);
   const rowSurface = (
     <div
-      id={rowDomId(context.instanceId, row.path)}
+      id={rowId}
       role="treeitem"
       // Pin the accessible name to the row name so the nested loading
       // `role="status"` (below) can't fold "Loading folder contents" into it.
       aria-label={row.name}
+      // The status rides a description, not the name: the name is pinned to the
+      // filename above, and rows are virtualized — folding status into the name
+      // would rewrite every accessible row query and re-announce the row as a
+      // different thing whenever an agent touched the file.
+      {...(gitMarkerId && { "aria-describedby": gitMarkerId })}
       aria-level={row.depth + 1}
       aria-selected={isSelected}
       {...(row.isDirectory && { "aria-expanded": row.isExpanded })}
@@ -504,7 +538,22 @@ function FileTreeRow({ row, isSelected, context }: FileTreeRowProps) {
         className={cn(FILE_TREE_ICON_CLASS, "h-3.5 w-3.5 shrink-0", rowIconColor)}
         aria-hidden="true"
       />
-      <span className={cn("truncate", isSelected && "font-medium")}>{row.name}</span>
+      {/* `min-w-0` is what lets `truncate` actually shrink here: a flex item
+          defaults to `min-width: auto` and would otherwise push the trailing
+          status marker out of the row instead of ellipsing the name. */}
+      <span className={cn("min-w-0 truncate", isSelected && "font-medium")}>{row.name}</span>
+      {gitPresentation && (
+        // `ml-auto` parks the marker at the trailing edge so a column of them
+        // scans vertically, rather than tracking each name's ragged end.
+        <span
+          id={gitMarkerId}
+          title={gitDescription ?? undefined}
+          className={cn("ml-auto w-3 shrink-0 text-center font-bold", gitPresentation.colorClass)}
+        >
+          <span className="sr-only">{gitDescription}</span>
+          <span aria-hidden="true">{gitPresentation.marker}</span>
+        </span>
+      )}
       {showLoadingSpinner && (
         // Subdued via `text-daintree-text/40` (Spinner strokes currentColor) so
         // it stays quiet even on a selected row, per accent restraint.

--- a/src/panels/file-browser/__tests__/FileBrowserChangeSummary.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserChangeSummary.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { GitStatus } from "@shared/types/git";
+import type { WorkingTreeFileChange } from "@/lib/workingTreeDiff";
+import { FileBrowserChangeSummary } from "../FileBrowserChangeSummary";
+
+function change(
+  relativePath: string,
+  status: GitStatus,
+  churn: { insertions?: number; deletions?: number } = {}
+): WorkingTreeFileChange {
+  return {
+    path: `/repo/${relativePath}`,
+    relativePath,
+    status,
+    insertions: churn.insertions ?? null,
+    deletions: churn.deletions ?? null,
+  };
+}
+
+function renderSummary(changes: WorkingTreeFileChange[], onSelect = vi.fn()) {
+  render(<FileBrowserChangeSummary changes={changes} onSelect={onSelect} />);
+  return onSelect;
+}
+
+describe("FileBrowserChangeSummary", () => {
+  it("renders the changes in the order it is given", () => {
+    renderSummary([
+      change("src/big.ts", "modified"),
+      change("src/small.ts", "modified"),
+      change("docs/notes.md", "added"),
+    ]);
+
+    const rendered = screen.getAllByRole("button").map((button) => button.getAttribute("title"));
+
+    expect(rendered).toEqual(["src/big.ts", "src/small.ts", "docs/notes.md"]);
+  });
+
+  it("hands the worktree-relative path to the selection callback", () => {
+    const onSelect = renderSummary([change("src/app.ts", "modified")]);
+
+    screen.getByRole("button", { name: /src\/app\.ts/ }).click();
+
+    expect(onSelect).toHaveBeenCalledWith("src/app.ts");
+  });
+
+  it("names each row by what activating it does, plus the status", () => {
+    renderSummary([change("src/app.ts", "modified")]);
+
+    expect(screen.getByRole("button", { name: "Read src/app.ts, Modified" })).toBeTruthy();
+  });
+
+  it("distinguishes statuses in the accessible name, not by colour alone", () => {
+    renderSummary([change("src/new.ts", "added"), change("src/old.ts", "modified")]);
+
+    expect(screen.getByRole("button", { name: /Added/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Modified/ })).toBeTruthy();
+  });
+
+  it("lists a deleted file but refuses to open it", () => {
+    const onSelect = renderSummary([change("src/gone.ts", "deleted")]);
+    const row = screen.getByRole("button", { name: /src\/gone\.ts/ });
+
+    expect(row.getAttribute("aria-disabled")).toBe("true");
+
+    row.click();
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("keeps a deleted row reachable by keyboard so its reason is discoverable", () => {
+    renderSummary([change("src/gone.ts", "deleted")]);
+    const row = screen.getByRole("button", { name: /deleted file isn't available to read/i });
+
+    // aria-disabled, not `disabled` — a disabled button drops out of the tab
+    // order and the explanation becomes unreachable.
+    expect(row.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("still opens readable siblings of a deleted file", () => {
+    const onSelect = renderSummary([
+      change("src/gone.ts", "deleted"),
+      change("src/kept.ts", "modified"),
+    ]);
+
+    screen.getByRole("button", { name: /Read src\/kept\.ts/ }).click();
+
+    expect(onSelect).toHaveBeenCalledWith("src/kept.ts");
+  });
+
+  it("shows churn only for the sides that actually moved", () => {
+    renderSummary([
+      change("src/grew.ts", "modified", { insertions: 12, deletions: 0 }),
+      change("src/shrank.ts", "modified", { insertions: 0, deletions: 7 }),
+    ]);
+
+    expect(screen.getByText("+12")).toBeTruthy();
+    expect(screen.getByText("-7")).toBeTruthy();
+    expect(screen.queryByText("+0")).toBeNull();
+    expect(screen.queryByText("-0")).toBeNull();
+  });
+
+  it("splits a nested path so the filename stays readable beside its folder", () => {
+    renderSummary([change("src/panels/app.ts", "modified")]);
+
+    expect(screen.getByText("src/panels/")).toBeTruthy();
+    expect(screen.getByText("app.ts")).toBeTruthy();
+  });
+
+  it("renders a root-level file without an empty directory fragment", () => {
+    renderSummary([change("README.md", "modified")]);
+
+    expect(screen.getByText("README.md")).toBeTruthy();
+    expect(screen.queryByText("/")).toBeNull();
+  });
+
+  it("keeps rows distinct when one path appears under two statuses", () => {
+    // Staged and unstaged are separate rows for the same file; a path-only key
+    // would collapse them and React would warn about duplicates.
+    renderSummary([change("src/app.ts", "modified"), change("src/app.ts", "added")]);
+
+    expect(screen.getAllByRole("button")).toHaveLength(2);
+  });
+});

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -2340,9 +2340,10 @@ describe("FileBrowserPane git status derivation", () => {
       row.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
-    expect(setFileBrowserViewMock).toHaveBeenCalledWith("fb-1", {
-      browserSelectedPath: "src/app.ts",
-    });
+    expect(setFileBrowserViewMock).toHaveBeenCalledWith(
+      "fb-1",
+      expect.objectContaining({ browserSelectedPath: "src/app.ts" })
+    );
 
     // The store mock is non-reactive, so replay the write the pane just asked
     // for and re-render to see what the selection resolves to.
@@ -2378,13 +2379,62 @@ describe("FileBrowserPane git status derivation", () => {
     });
     renderPane();
 
-    await waitFor(() => expect(treeProps.gitStatusIndex).toBeTruthy());
-    const index = treeProps.gitStatusIndex as FileBrowserGitStatusIndex;
-
-    expect(index.fileStatus.size).toBe(0);
-    // An empty *safe* set is still a valid clean snapshot for the tree, but the
-    // summary must not offer an unopenable row.
+    await screen.findByText("Nothing selected");
+    // Git said there were changes and none survived: that is an unusable
+    // snapshot, not an empty one. Calling it clean would state the opposite of
+    // what git reported.
+    expect(screen.queryByText("Worktree is clean")).toBeNull();
     expect(screen.queryByRole("button", { name: /Read/ })).toBeNull();
+    expect(treeProps.gitStatusIndex).toBeNull();
+  });
+
+  it("expands a summarised file's ancestors so it stays findable in the tree", async () => {
+    // Both halves of the feature exist for this: the summary is replaced by the
+    // file the moment it opens, so the row has to be waiting behind it.
+    treeState.rows = [
+      {
+        path: "src",
+        name: "src",
+        isDirectory: true,
+        depth: 0,
+        isExpanded: false,
+        isLoading: false,
+      },
+    ];
+    setChanges([{ path: "/repo/src/panels/app.ts", status: "modified" }]);
+    renderPane();
+
+    const row = await screen.findByRole("button", { name: /Read src\/panels\/app\.ts/ });
+    await act(async () => {
+      row.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(setFileBrowserViewMock).toHaveBeenCalledWith("fb-1", {
+      browserSelectedPath: "src/panels/app.ts",
+      browserExpandedPaths: ["src", "src/panels"],
+    });
+  });
+
+  it("refuses to read a changed path the tree knows is a directory", async () => {
+    // Git reports a dirty submodule as a changed path while the filesystem calls
+    // it a directory. The row wins: handing the viewer a directory to read is
+    // exactly what the original file check existed to prevent.
+    treeState.rows = [
+      {
+        path: "vendor",
+        name: "vendor",
+        isDirectory: true,
+        depth: 0,
+        isExpanded: false,
+        isLoading: false,
+      },
+    ];
+    setChanges([{ path: "/repo/vendor", status: "modified" }]);
+    mockPanel.browserSelectedPath = "vendor";
+    renderPane();
+
+    await waitFor(() => expect(treeProps.gitStatusIndex).toBeTruthy());
+    expect(readMock).not.toHaveBeenCalled();
   });
 
   it("says the worktree is clean only on a populated, empty snapshot", async () => {

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -2306,10 +2306,13 @@ describe("FileBrowserPane git status derivation", () => {
     renderPane();
 
     await waitFor(() => expect(treeProps.gitStatusIndex).toBeTruthy());
-    const index = treeProps.gitStatusIndex as FileBrowserGitStatusIndex;
 
-    expect(getFileBrowserRowGitStatus(index, "src/app.ts", false)).toBe("modified");
-    expect(getFileBrowserRowGitStatus(index, "src", true)).toBe("modified");
+    // Passed straight through: the lookup already accepts a missing index, so a
+    // null one fails these assertions rather than needing a cast to rule out.
+    expect(getFileBrowserRowGitStatus(treeProps.gitStatusIndex, "src/app.ts", false)).toBe(
+      "modified"
+    );
+    expect(getFileBrowserRowGitStatus(treeProps.gitStatusIndex, "src", true)).toBe("modified");
   });
 
   it("summarises the changed files when nothing is selected", async () => {

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -9,49 +9,65 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // FileBrowserViewer so the toggle and the shared toolbar `Root` actually render
 // — that's what makes the aria-controls and header-alignment invariants real.
 
-const { setFileBrowserViewMock, readMock, treeState, defaultRows, treeArgs, worktreeTicks } =
-  vi.hoisted(() => {
-    const defaultRows = [
-      {
-        path: "src",
-        name: "src",
-        isDirectory: true,
-        depth: 0,
-        isExpanded: true,
-        isLoading: false,
-      },
-      // A file row so a selection can resolve a real viewer path.
-      {
-        path: "src/app.ts",
-        name: "app.ts",
-        isDirectory: false,
-        depth: 1,
-        isExpanded: false,
-        isLoading: false,
-      },
-    ];
-    return {
-      setFileBrowserViewMock: vi.fn(),
-      readMock: vi.fn(),
-      defaultRows,
-      // Mutable so individual tests can drive error/loading/capture states.
-      treeState: {
-        rows: defaultRows as typeof defaultRows,
-        isInitialLoading: false,
-        rootError: null as string | null,
-        hasHiddenDotfiles: false,
-        ensureLoaded: vi.fn(),
-        refresh: vi.fn(),
-        isRefreshing: false,
-        captureSnapshot: (() => null) as () => unknown,
-      },
-      // What the pane last handed the tree hook, so a test can assert the derived
-      // change tick rather than only what renders.
-      treeArgs: { changeTick: undefined as number | undefined },
-      // Ticks the worktree store reports for wt-1; both default to "never moved".
-      worktreeTicks: { git: undefined as number | undefined, fs: undefined as number | undefined },
-    };
-  });
+const {
+  setFileBrowserViewMock,
+  readMock,
+  treeState,
+  defaultRows,
+  treeArgs,
+  worktreeTicks,
+  worktreeMock,
+} = vi.hoisted(() => {
+  const defaultRows = [
+    {
+      path: "src",
+      name: "src",
+      isDirectory: true,
+      depth: 0,
+      isExpanded: true,
+      isLoading: false,
+    },
+    // A file row so a selection can resolve a real viewer path.
+    {
+      path: "src/app.ts",
+      name: "app.ts",
+      isDirectory: false,
+      depth: 1,
+      isExpanded: false,
+      isLoading: false,
+    },
+  ];
+  return {
+    setFileBrowserViewMock: vi.fn(),
+    readMock: vi.fn(),
+    defaultRows,
+    // Mutable so individual tests can drive error/loading/capture states.
+    treeState: {
+      rows: defaultRows as typeof defaultRows,
+      isInitialLoading: false,
+      rootError: null as string | null,
+      hasHiddenDotfiles: false,
+      ensureLoaded: vi.fn(),
+      refresh: vi.fn(),
+      isRefreshing: false,
+      captureSnapshot: (() => null) as () => unknown,
+    },
+    // What the pane last handed the tree hook, so a test can assert the derived
+    // change tick rather than only what renders.
+    treeArgs: { changeTick: undefined as number | undefined },
+    // Ticks the worktree store reports for wt-1; both default to "never moved".
+    worktreeTicks: { git: undefined as number | undefined, fs: undefined as number | undefined },
+    // The rest of what the store reports for wt-1. `changes` stays null by
+    // default so the bulk of this suite keeps the lastUpdated-only snapshot
+    // shape it was written against — which is also a real runtime state (the
+    // pane must not read a snapshot that hasn't populated yet).
+    worktreeMock: {
+      path: "/repo",
+      changes: null as { path: string; status: string }[] | null,
+      changesRootPath: "/repo",
+    },
+  };
+});
 
 interface MockPanel {
   id: string;
@@ -115,9 +131,22 @@ vi.mock("@/hooks/useWorktreeStore", () => ({
         [
           "wt-1",
           {
-            path: "/repo",
+            path: worktreeMock.path,
             worktreeChanges:
-              worktreeTicks.git === undefined ? undefined : { lastUpdated: worktreeTicks.git },
+              worktreeTicks.git === undefined && worktreeMock.changes === null
+                ? undefined
+                : {
+                    lastUpdated: worktreeTicks.git,
+                    // Only present once a test supplies them: the shipped store
+                    // populates all three together, but the pane must survive a
+                    // snapshot that carries the tick alone.
+                    ...(worktreeMock.changes === null
+                      ? {}
+                      : {
+                          changes: worktreeMock.changes,
+                          rootPath: worktreeMock.changesRootPath,
+                        }),
+                  },
           },
         ],
       ]),
@@ -167,6 +196,10 @@ const { treeProps } = vi.hoisted(() => ({
     onInsertFileReference: undefined as ((path: string) => void) | undefined,
     canInsertFileReference: undefined as boolean | undefined,
     basePath: undefined as string | undefined,
+    // The derived git model the pane hands the tree. Captured rather than
+    // rendered: what this suite owns is the derivation and the join, while how a
+    // marker is drawn belongs to FileTreeView's own suite.
+    gitStatusIndex: undefined as FileBrowserGitStatusIndex | null | undefined,
   },
 }));
 vi.mock("../FileTreeView", () => ({
@@ -176,17 +209,20 @@ vi.mock("../FileTreeView", () => ({
     onInsertFileReference,
     canInsertFileReference,
     basePath,
+    gitStatusIndex,
   }: {
     rowContextMenu?: (row: unknown) => React.ReactNode;
     onActivate?: (path: string) => void;
     onInsertFileReference?: (path: string) => void;
     canInsertFileReference?: boolean;
     basePath?: string;
+    gitStatusIndex?: FileBrowserGitStatusIndex | null;
   }) => {
     treeProps.onActivate = onActivate;
     treeProps.onInsertFileReference = onInsertFileReference;
     treeProps.canInsertFileReference = canInsertFileReference;
     treeProps.basePath = basePath;
+    treeProps.gitStatusIndex = gitStatusIndex;
     return (
       <div data-testid="file-tree-view" role="tree" tabIndex={-1}>
         {rowContextMenu?.(FOLDER_ROW)}
@@ -312,6 +348,10 @@ import {
   FILE_BROWSER_SIDEBAR_RESIZE_STEP_COARSE as COARSE_W,
 } from "../sidebarWidth";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import {
+  getFileBrowserRowGitStatus,
+  type FileBrowserGitStatusIndex,
+} from "../fileBrowserGitStatus";
 
 function paneJsx(props: { worktreeId?: string } = { worktreeId: "wt-1" }) {
   return (
@@ -387,6 +427,10 @@ beforeEach(() => {
   dispatchMock.mockResolvedValue({ ok: true, result: { panelId: "file-1" } });
   worktreeTicks.git = undefined;
   worktreeTicks.fs = undefined;
+  worktreeMock.path = "/repo";
+  worktreeMock.changes = null;
+  worktreeMock.changesRootPath = "/repo";
+  treeProps.gitStatusIndex = undefined;
   lifecycleListeners.clear();
   dockState.activeDockTerminalId = null;
   for (const name of ["matchMedia"] as const) {
@@ -2232,5 +2276,153 @@ describe("FileBrowserPane re-reads when the project view is revealed (#11588)", 
 
       expect(treeState.refresh).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+// Git status reaching the tree and the idle viewer (#11614). The store snapshot
+// already carried per-file status; the pane only read its tick.
+describe("FileBrowserPane git status derivation", () => {
+  /** The realpath-resolved root git reports, distinct from the worktree path. */
+  function setChanges(
+    changes: { path: string; status: string }[],
+    opts: { worktreePath?: string; changesRootPath?: string } = {}
+  ) {
+    worktreeTicks.git = 100;
+    worktreeMock.path = opts.worktreePath ?? "/repo";
+    worktreeMock.changesRootPath = opts.changesRootPath ?? worktreeMock.path;
+    worktreeMock.changes = changes;
+  }
+
+  it("joins changes on the snapshot root, not the raw worktree path", async () => {
+    // The regression this whole derivation exists to avoid. On macOS a worktree
+    // under a symlinked ancestor reports `/tmp/...` as its path while git
+    // resolves `/private/tmp/...`; stripping the worktree path off an absolute
+    // change would leave it absolute, matching no row, and the feature would
+    // silently mark nothing on exactly the machines it was written for.
+    setChanges([{ path: "/private/tmp/wt/src/app.ts", status: "modified" }], {
+      worktreePath: "/tmp/wt",
+      changesRootPath: "/private/tmp/wt",
+    });
+    renderPane();
+
+    await waitFor(() => expect(treeProps.gitStatusIndex).toBeTruthy());
+    const index = treeProps.gitStatusIndex as FileBrowserGitStatusIndex;
+
+    expect(getFileBrowserRowGitStatus(index, "src/app.ts", false)).toBe("modified");
+    expect(getFileBrowserRowGitStatus(index, "src", true)).toBe("modified");
+  });
+
+  it("summarises the changed files when nothing is selected", async () => {
+    setChanges([{ path: "/repo/src/app.ts", status: "modified" }]);
+    renderPane();
+
+    expect(await screen.findByRole("button", { name: /Read src\/app\.ts/ })).toBeTruthy();
+  });
+
+  it("opens a summarised file whose tree row is not flattened", async () => {
+    // `src` is collapsed here, so the changed file has no row at all. Requiring
+    // one would make the summary click do nothing visible.
+    treeState.rows = [
+      {
+        path: "src",
+        name: "src",
+        isDirectory: true,
+        depth: 0,
+        isExpanded: false,
+        isLoading: false,
+      },
+    ];
+    setChanges([{ path: "/repo/src/app.ts", status: "modified" }]);
+    const { rerender } = renderPane();
+
+    const row = await screen.findByRole("button", { name: /Read src\/app\.ts/ });
+    await act(async () => {
+      row.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(setFileBrowserViewMock).toHaveBeenCalledWith("fb-1", {
+      browserSelectedPath: "src/app.ts",
+    });
+
+    // The store mock is non-reactive, so replay the write the pane just asked
+    // for and re-render to see what the selection resolves to.
+    mockPanel.browserSelectedPath = "src/app.ts";
+    await act(async () => {
+      rerender(paneJsx());
+    });
+
+    await waitFor(() => expect(readMock).toHaveBeenCalled());
+    expect(readMock.mock.calls[0]?.[0]).toMatchObject({ path: "/repo/src/app.ts" });
+  });
+
+  it("refuses to open a deleted file that has no row", async () => {
+    // Nothing on disk to read: admitting it would swap the pane for a
+    // file-not-found error the moment a live delete landed on the open
+    // selection. The pane stays on its idle body — here the summary, since the
+    // deletion is itself a change worth listing.
+    treeState.rows = [];
+    setChanges([{ path: "/repo/src/gone.ts", status: "deleted" }]);
+    mockPanel.browserSelectedPath = "src/gone.ts";
+    renderPane();
+
+    const row = await screen.findByRole("button", { name: /src\/gone\.ts/ });
+    expect(row.getAttribute("aria-disabled")).toBe("true");
+    expect(readMock).not.toHaveBeenCalled();
+  });
+
+  it("drops a change whose path could not be made worktree-relative", async () => {
+    // A root that doesn't prefix the change leaves it absolute; persisting one
+    // as the selection would aim the viewer outside the worktree.
+    setChanges([{ path: "/elsewhere/src/app.ts", status: "modified" }], {
+      changesRootPath: "/repo",
+    });
+    renderPane();
+
+    await waitFor(() => expect(treeProps.gitStatusIndex).toBeTruthy());
+    const index = treeProps.gitStatusIndex as FileBrowserGitStatusIndex;
+
+    expect(index.fileStatus.size).toBe(0);
+    // An empty *safe* set is still a valid clean snapshot for the tree, but the
+    // summary must not offer an unopenable row.
+    expect(screen.queryByRole("button", { name: /Read/ })).toBeNull();
+  });
+
+  it("says the worktree is clean only on a populated, empty snapshot", async () => {
+    setChanges([]);
+    renderPane();
+
+    expect(await screen.findByText("Worktree is clean")).toBeTruthy();
+  });
+
+  it("keeps the generic placeholder when the snapshot carries only a tick", async () => {
+    // The shape the store reports before changes populate. Reporting it as clean
+    // would tell the user nothing changed when nothing is actually known.
+    worktreeTicks.git = 100;
+    worktreeMock.changes = null;
+    renderPane();
+
+    expect(await screen.findByText("Nothing selected")).toBeTruthy();
+    expect(screen.queryByText("Worktree is clean")).toBeNull();
+    expect(treeProps.gitStatusIndex).toBeNull();
+  });
+
+  it("gives a workspace-rooted browser no git status at all", async () => {
+    workspaceRootPathMock.mockReturnValue("/workspace");
+    setChanges([{ path: "/repo/src/app.ts", status: "modified" }]);
+    renderPane({});
+
+    expect(await screen.findByText("Nothing selected")).toBeTruthy();
+    expect(treeProps.gitStatusIndex).toBeNull();
+  });
+
+  it("still derives the combined change tick from the fuller snapshot", async () => {
+    // The tick now comes off the selected object rather than its own selector;
+    // the fs side must still win when it is the more recent of the two.
+    setChanges([{ path: "/repo/src/app.ts", status: "modified" }]);
+    worktreeTicks.git = 120;
+    worktreeTicks.fs = 450;
+    renderPane();
+
+    await waitFor(() => expect(treeArgs.changeTick).toBe(450));
   });
 });

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -53,6 +53,8 @@ vi.mock("@/components/ui/SpinningIcon", () => ({
 
 import { FileBrowserViewer } from "../FileBrowserViewer";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import type { GitStatus } from "@shared/types/git";
+import type { WorkingTreeFileChange } from "@/lib/workingTreeDiff";
 
 interface ViewerOpts {
   sidebarCollapsed?: boolean;
@@ -61,6 +63,23 @@ interface ViewerOpts {
   surfaceRefreshNonce?: number;
   onRefresh?: () => void;
   isRefreshing?: boolean;
+  /**
+   * Defaults to `null` — "no git status available" — because that is what a
+   * workspace-rooted browser passes, and it keeps every pre-existing case in
+   * this suite on the generic placeholder it was written against.
+   */
+  changedFiles?: readonly WorkingTreeFileChange[] | null;
+  onSelectChangedFile?: (relativePath: string) => void;
+}
+
+function change(relativePath: string, status: GitStatus = "modified"): WorkingTreeFileChange {
+  return {
+    path: `/repo/${relativePath}`,
+    relativePath,
+    status,
+    insertions: null,
+    deletions: null,
+  };
 }
 
 // Defaults live here, never on the component: the props are required there so a
@@ -82,6 +101,8 @@ function viewerJsx(filePath: string | null, opts: ViewerOpts = {}) {
         sidebarCollapsed={opts.sidebarCollapsed ?? false}
         onToggleSidebar={opts.onToggleSidebar ?? vi.fn()}
         treeSidebarId="file-tree-column"
+        changedFiles={opts.changedFiles ?? null}
+        onSelectChangedFile={opts.onSelectChangedFile ?? vi.fn()}
       />
     </TooltipProvider>
   );
@@ -560,5 +581,54 @@ describe("FileBrowserViewer Refresh control (#11586)", () => {
     // What the pane produces for a Refresh press on a worktree with no tick.
     rerender(viewerJsx("/repo/src/notes.txt", { revision: "0:1", surfaceRefreshNonce: 1 }));
     await waitFor(() => expect(readMock).toHaveBeenCalledTimes(2));
+  });
+});
+
+// With nothing selected the pane answers "what did the agent just change in
+// here" (#11614). The three states are distinct on purpose: no git status at
+// all, a snapshot saying clean, and a snapshot with changes.
+describe("FileBrowserViewer idle body", () => {
+  it("summarises the changed files instead of a placeholder", () => {
+    renderViewer(null, {
+      changedFiles: [change("src/app.ts"), change("docs/notes.md", "added")],
+    });
+
+    expect(screen.getByRole("button", { name: /Read src\/app\.ts/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Read docs\/notes\.md/ })).toBeTruthy();
+    expect(screen.queryByText("Nothing selected")).toBeNull();
+  });
+
+  it("opens a summarised file through the pane's selection callback", () => {
+    const onSelectChangedFile = vi.fn();
+    renderViewer(null, { changedFiles: [change("src/app.ts")], onSelectChangedFile });
+
+    screen.getByRole("button", { name: /Read src\/app\.ts/ }).click();
+
+    expect(onSelectChangedFile).toHaveBeenCalledWith("src/app.ts");
+  });
+
+  it("says the worktree is clean when the snapshot reports no changes", () => {
+    renderViewer(null, { changedFiles: [] });
+
+    expect(screen.getByText("Worktree is clean")).toBeTruthy();
+    expect(screen.queryByText("Nothing selected")).toBeNull();
+  });
+
+  it("keeps the generic placeholder when no git status is available", () => {
+    // A workspace-rooted browser has no worktree behind it, and a worktree whose
+    // snapshot hasn't arrived is equally unknown. Neither may claim "clean".
+    renderViewer(null, { changedFiles: null });
+
+    expect(screen.getByText("Nothing selected")).toBeTruthy();
+    expect(screen.queryByText("Worktree is clean")).toBeNull();
+  });
+
+  it("shows the selected file rather than the summary once one is picked", async () => {
+    readMock.mockResolvedValue({ content: "hello" });
+    renderViewer("/repo/src/app.ts", { changedFiles: [change("src/app.ts")] });
+
+    await screen.findByTestId("code-viewer-mock");
+
+    expect(screen.queryByRole("button", { name: /Read src\/app\.ts/ })).toBeNull();
   });
 });

--- a/src/panels/file-browser/__tests__/FileTreeView.test.tsx
+++ b/src/panels/file-browser/__tests__/FileTreeView.test.tsx
@@ -706,7 +706,8 @@ describe("FileTreeView git status markers", () => {
     // aria-hidden content, so the decorative marker letter drops out and only
     // the spelled-out status is announced. Raw textContent would run the two
     // together and assert a string no user ever hears.
-    const announced = target.cloneNode(true) as HTMLElement;
+    const announced = target.cloneNode(true);
+    if (!(announced instanceof HTMLElement)) return null;
     for (const hidden of announced.querySelectorAll('[aria-hidden="true"]')) hidden.remove();
     return announced.textContent;
   }

--- a/src/panels/file-browser/__tests__/FileTreeView.test.tsx
+++ b/src/panels/file-browser/__tests__/FileTreeView.test.tsx
@@ -8,6 +8,7 @@ import { ContextMenuItem } from "@/components/ui/context-menu";
 import { FILE_DRAG_MIME, decodeFileDragPaths } from "@/lib/fileDragPayload";
 import { FileTreeView } from "../FileTreeView";
 import type { FlatTreeRow } from "../fileBrowserTree";
+import { buildFileBrowserGitStatusIndex } from "../fileBrowserGitStatus";
 import { FILE_TREE_ICON_CLASS, getFileTypeIcon } from "../fileTypeIcons";
 
 // `isMac` reads navigator.platform, which jsdom reports as neither — drive it
@@ -685,5 +686,148 @@ describe("FileTreeView menu contract", () => {
       />
     );
     expect(getByRole("tree").hasAttribute("data-row-menu")).toBe(false);
+  });
+});
+
+// Git status markers (#11614). The index is a parallel channel to `rows` — a
+// directory listing doesn't change when a file's status does — so these prove
+// the join and the invalidation seam, not the rows.
+describe("FileTreeView git status markers", () => {
+  /** What the row's status is announced as, via its description. */
+  function describedStatus(container: HTMLElement, name: string): string | null {
+    const treeitem = container.querySelector(`[role="treeitem"][aria-label="${name}"]`);
+    const describedBy = treeitem?.getAttribute("aria-describedby");
+    if (!describedBy) return null;
+    // getElementById rather than a `#id` selector: row ids are URI-encoded
+    // paths, which need escaping the jsdom build here has no `CSS.escape` for.
+    const target = container.ownerDocument.getElementById(describedBy);
+    if (!target) return null;
+    // What a screen reader actually computes: an accessible description skips
+    // aria-hidden content, so the decorative marker letter drops out and only
+    // the spelled-out status is announced. Raw textContent would run the two
+    // together and assert a string no user ever hears.
+    const announced = target.cloneNode(true) as HTMLElement;
+    for (const hidden of announced.querySelectorAll('[aria-hidden="true"]')) hidden.remove();
+    return announced.textContent;
+  }
+
+  const NESTED_ROWS = [row("src", true), row("src/app.ts"), row("README.md")];
+
+  it("marks a changed file and leaves its unchanged siblings bare", () => {
+    const { container } = renderTree({
+      rows: NESTED_ROWS,
+      gitStatusIndex: buildFileBrowserGitStatusIndex([
+        { relativePath: "src/app.ts", status: "modified" },
+      ]),
+    });
+
+    expect(describedStatus(container, "app.ts")).toBe("Modified");
+    expect(describedStatus(container, "README.md")).toBeNull();
+  });
+
+  it("marks a collapsed folder from a descendant it has never listed", () => {
+    // `src` is collapsed, so no child row exists for the changed file at all —
+    // the aggregate is the only thing that can surface it.
+    const { container } = renderTree({
+      rows: [row("src", true), row("README.md")],
+      gitStatusIndex: buildFileBrowserGitStatusIndex([
+        { relativePath: "src/deep/nested/app.ts", status: "modified" },
+      ]),
+    });
+
+    expect(describedStatus(container, "src")).toBe("Contains modified changes");
+  });
+
+  it("phrases a folder as containing changes, not as being changed itself", () => {
+    const { container } = renderTree({
+      rows: NESTED_ROWS,
+      gitStatusIndex: buildFileBrowserGitStatusIndex([
+        { relativePath: "src/app.ts", status: "added" },
+      ]),
+    });
+
+    expect(describedStatus(container, "src")).toBe("Contains added changes");
+    expect(describedStatus(container, "app.ts")).toBe("Added");
+  });
+
+  it("shows a folder its most urgent descendant when several changed", () => {
+    const { container } = renderTree({
+      rows: [row("src", true)],
+      gitStatusIndex: buildFileBrowserGitStatusIndex([
+        { relativePath: "src/a.ts", status: "untracked" },
+        { relativePath: "src/b.ts", status: "conflicted" },
+      ]),
+    });
+
+    expect(describedStatus(container, "src")).toBe("Contains conflicted changes");
+  });
+
+  it("renders no markers at all when the source has no git behind it", () => {
+    const { container } = renderTree({ rows: NESTED_ROWS, gitStatusIndex: null });
+
+    expect(container.querySelector("[aria-describedby]")).toBeNull();
+  });
+
+  it("repaints markers when only the index changes, with identical rows", () => {
+    // The invalidation seam: an agent editing a file moves the status without
+    // touching the listing, so a marker that only followed `rows` would be
+    // stale until the next expansion.
+    const { container, rerender } = renderTree({
+      rows: NESTED_ROWS,
+      gitStatusIndex: buildFileBrowserGitStatusIndex([]),
+    });
+    expect(describedStatus(container, "app.ts")).toBeNull();
+
+    rerender(
+      <FileTreeView
+        rows={NESTED_ROWS}
+        selectedPath={null}
+        onSelect={vi.fn()}
+        onToggleExpanded={vi.fn()}
+        rowContextMenu={() => <div />}
+        basePath={BASE_PATH}
+        label="Files"
+        gitStatusIndex={buildFileBrowserGitStatusIndex([
+          { relativePath: "src/app.ts", status: "conflicted" },
+        ])}
+      />
+    );
+
+    expect(describedStatus(container, "app.ts")).toBe("Conflicted");
+  });
+
+  it("keeps the row's accessible name the filename alone", () => {
+    // Folding status into the name would rewrite every accessible row query and
+    // re-announce the row as a different thing on each agent write.
+    const { getByRole } = renderTree({
+      rows: NESTED_ROWS,
+      gitStatusIndex: buildFileBrowserGitStatusIndex([
+        { relativePath: "src/app.ts", status: "modified" },
+      ]),
+    });
+
+    expect(getByRole("treeitem", { name: "app.ts" })).toBeTruthy();
+  });
+
+  it("shows the status marker alongside a folder's loading spinner", async () => {
+    vi.useFakeTimers();
+    try {
+      const loadingFolder: FlatTreeRow = { ...row("src", true), isLoading: true };
+      const { container } = renderTree({
+        rows: [loadingFolder],
+        gitStatusIndex: buildFileBrowserGitStatusIndex([
+          { relativePath: "src/app.ts", status: "modified" },
+        ]),
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(UI_INLINE_LOADING_GATE_MS + 10);
+      });
+
+      expect(describedStatus(container, "src")).toBe("Contains modified changes");
+      expect(container.querySelector('[role="status"]')).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/panels/file-browser/__tests__/fileBrowserGitStatus.test.ts
+++ b/src/panels/file-browser/__tests__/fileBrowserGitStatus.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import type { GitStatus } from "@shared/types/git";
+import {
+  buildFileBrowserGitStatusIndex,
+  getFileBrowserRowGitStatus,
+  isReadableRelativePath,
+} from "../fileBrowserGitStatus";
+
+function change(relativePath: string, status: GitStatus) {
+  return { relativePath, status };
+}
+
+describe("buildFileBrowserGitStatusIndex", () => {
+  it("marks a changed file at its own path and nothing else", () => {
+    const index = buildFileBrowserGitStatusIndex([change("src/app.ts", "modified")]);
+
+    expect(getFileBrowserRowGitStatus(index, "src/app.ts", false)).toBe("modified");
+    expect(getFileBrowserRowGitStatus(index, "src/other.ts", false)).toBeUndefined();
+    // A file lookup must never fall through to the folder map, or every sibling
+    // in a dirty directory would claim the directory's status.
+    expect(getFileBrowserRowGitStatus(index, "src", false)).toBeUndefined();
+  });
+
+  it("propagates a change to every ancestor directory", () => {
+    const index = buildFileBrowserGitStatusIndex([change("a/b/c/deep.ts", "added")]);
+
+    expect(getFileBrowserRowGitStatus(index, "a", true)).toBe("added");
+    expect(getFileBrowserRowGitStatus(index, "a/b", true)).toBe("added");
+    expect(getFileBrowserRowGitStatus(index, "a/b/c", true)).toBe("added");
+    // The file's own path is not a directory entry.
+    expect(getFileBrowserRowGitStatus(index, "a/b/c/deep.ts", true)).toBeUndefined();
+  });
+
+  it("gives a root-level file no ancestor entries at all", () => {
+    const index = buildFileBrowserGitStatusIndex([change("README.md", "modified")]);
+
+    expect(getFileBrowserRowGitStatus(index, "README.md", false)).toBe("modified");
+    expect(index.folderStatus.size).toBe(0);
+  });
+
+  it("aggregates a folder to its most urgent descendant, not the last one seen", () => {
+    const index = buildFileBrowserGitStatusIndex([
+      change("src/a.ts", "untracked"),
+      change("src/b.ts", "conflicted"),
+      change("src/c.ts", "modified"),
+    ]);
+
+    expect(getFileBrowserRowGitStatus(index, "src", true)).toBe("conflicted");
+  });
+
+  it("aggregates identically whichever order the changes arrive in", () => {
+    const forward = buildFileBrowserGitStatusIndex([
+      change("src/a.ts", "modified"),
+      change("src/b.ts", "deleted"),
+    ]);
+    const reversed = buildFileBrowserGitStatusIndex([
+      change("src/b.ts", "deleted"),
+      change("src/a.ts", "modified"),
+    ]);
+
+    expect(getFileBrowserRowGitStatus(forward, "src", true)).toBe(
+      getFileBrowserRowGitStatus(reversed, "src", true)
+    );
+    // Deletion outranks a plain edit: the content is gone, not merely different.
+    expect(getFileBrowserRowGitStatus(forward, "src", true)).toBe("deleted");
+  });
+
+  it("ranks conflicted above deletion, which the churn sort's order would not", () => {
+    const index = buildFileBrowserGitStatusIndex([
+      change("src/gone.ts", "deleted"),
+      change("src/clash.ts", "conflicted"),
+    ]);
+
+    expect(getFileBrowserRowGitStatus(index, "src", true)).toBe("conflicted");
+  });
+
+  it("keeps the more urgent status when one path appears twice", () => {
+    // Staged and unstaged are separate entries for the same file.
+    const index = buildFileBrowserGitStatusIndex([
+      change("src/app.ts", "modified"),
+      change("src/app.ts", "conflicted"),
+    ]);
+
+    expect(getFileBrowserRowGitStatus(index, "src/app.ts", false)).toBe("conflicted");
+  });
+
+  it("does not leak a status onto a sibling that merely shares a name prefix", () => {
+    const index = buildFileBrowserGitStatusIndex([change("src/app.ts", "modified")]);
+
+    expect(getFileBrowserRowGitStatus(index, "src/app.test.ts", false)).toBeUndefined();
+    expect(getFileBrowserRowGitStatus(index, "srcs", true)).toBeUndefined();
+  });
+
+  it("scales with changed paths rather than with tree size", () => {
+    // A folder holding one changed file among a hundred thousand notional
+    // siblings costs exactly one entry per path segment.
+    const index = buildFileBrowserGitStatusIndex([change("packages/app/src/main.ts", "modified")]);
+
+    expect(index.fileStatus.size).toBe(1);
+    expect(index.folderStatus.size).toBe(3);
+  });
+
+  it("ignores an empty path instead of minting a blank entry", () => {
+    const index = buildFileBrowserGitStatusIndex([change("", "modified")]);
+
+    expect(index.fileStatus.size).toBe(0);
+    expect(index.folderStatus.size).toBe(0);
+  });
+
+  it("reports nothing when no index is available", () => {
+    expect(getFileBrowserRowGitStatus(null, "src/app.ts", false)).toBeUndefined();
+    expect(getFileBrowserRowGitStatus(undefined, "src", true)).toBeUndefined();
+  });
+});
+
+describe("isReadableRelativePath", () => {
+  it("accepts the worktree-relative shape the tree rows use", () => {
+    expect(isReadableRelativePath("src/app.ts")).toBe(true);
+    expect(isReadableRelativePath("README.md")).toBe(true);
+    // A name may legitimately contain dots without escaping anywhere.
+    expect(isReadableRelativePath("src/..hidden/a.ts")).toBe(true);
+  });
+
+  it("rejects an absolute path, which is what a failed root strip leaves behind", () => {
+    expect(isReadableRelativePath("/private/tmp/wt/src/app.ts")).toBe(false);
+  });
+
+  it("rejects a path that escapes the worktree", () => {
+    expect(isReadableRelativePath("../outside.ts")).toBe(false);
+    expect(isReadableRelativePath("src/../../outside.ts")).toBe(false);
+  });
+
+  it("rejects an empty path", () => {
+    expect(isReadableRelativePath("")).toBe(false);
+  });
+});

--- a/src/panels/file-browser/fileBrowserGitStatus.ts
+++ b/src/panels/file-browser/fileBrowserGitStatus.ts
@@ -1,0 +1,107 @@
+import type { GitStatus } from "@shared/types/git";
+import { isAbsolute } from "@shared/utils/path";
+
+/**
+ * Worst-first order for the single marker a folder row can carry.
+ *
+ * Deliberately not `workingTreeDiff`'s `STATUS_PRIORITY`, which is a tie-break
+ * for a churn sort and ranks `conflicted` *last*. A folder badge answers "how
+ * much does what's inside here want my attention", so a conflict — which blocks
+ * the branch outright — has to come first, a deletion next (the content is gone,
+ * not merely edited), and gitignored noise last.
+ */
+const FOLDER_STATUS_SEVERITY: Record<GitStatus, number> = {
+  conflicted: 0,
+  deleted: 1,
+  modified: 2,
+  added: 3,
+  renamed: 4,
+  copied: 5,
+  untracked: 6,
+  ignored: 7,
+};
+
+export interface FileBrowserGitStatusIndex {
+  /** Status of each changed file, keyed by its worktree-relative path. */
+  readonly fileStatus: ReadonlyMap<string, GitStatus>;
+  /**
+   * Worst status anywhere below a directory, keyed by its worktree-relative
+   * path. This is what lets a collapsed folder say "something in here changed"
+   * without its children ever having been listed.
+   */
+  readonly folderStatus: ReadonlyMap<string, GitStatus>;
+}
+
+/** The shape this module needs off a change; anything wider is the caller's. */
+interface IndexableChange {
+  relativePath: string;
+  status: GitStatus;
+}
+
+/**
+ * Two flat maps rather than a trie: nothing here enumerates a prefix, it only
+ * ever asks "what is the status at exactly this path", so the extra structure
+ * would buy nothing and cost a walk per lookup.
+ *
+ * Built from the changed files alone — dozens to hundreds of entries — never
+ * from the tree's lazily-loaded listings, which run to tens of thousands of
+ * nodes on a real repository. Construction is linear in total path segments and
+ * every lookup is O(1).
+ */
+export function buildFileBrowserGitStatusIndex(
+  changes: readonly IndexableChange[]
+): FileBrowserGitStatusIndex {
+  const fileStatus = new Map<string, GitStatus>();
+  const folderStatus = new Map<string, GitStatus>();
+
+  for (const change of changes) {
+    const path = change.relativePath;
+    if (path === "") continue;
+    // The same path can arrive twice (staged and unstaged are separate rows),
+    // so keep the more urgent of the two rather than whichever landed last.
+    mergeWorst(fileStatus, path, change.status);
+
+    let cut = path.lastIndexOf("/");
+    while (cut > 0) {
+      mergeWorst(folderStatus, path.slice(0, cut), change.status);
+      cut = path.lastIndexOf("/", cut - 1);
+    }
+  }
+
+  return { fileStatus, folderStatus };
+}
+
+function mergeWorst(target: Map<string, GitStatus>, key: string, status: GitStatus): void {
+  const existing = target.get(key);
+  if (existing === undefined || severityOf(status) < severityOf(existing)) {
+    target.set(key, status);
+  }
+}
+
+function severityOf(status: GitStatus): number {
+  // Same IPC-boundary defence as the presentation table: an unrecognised status
+  // sorts last rather than ranking itself above a real conflict.
+  return FOLDER_STATUS_SEVERITY[status] ?? Number.MAX_SAFE_INTEGER;
+}
+
+/** The marker for one tree row, or undefined when nothing under it changed. */
+export function getFileBrowserRowGitStatus(
+  index: FileBrowserGitStatusIndex | null | undefined,
+  path: string,
+  isDirectory: boolean
+): GitStatus | undefined {
+  if (!index) return undefined;
+  return isDirectory ? index.folderStatus.get(path) : index.fileStatus.get(path);
+}
+
+/**
+ * Is this the worktree-relative shape the tree rows and the viewer both join
+ * on? `buildWorkingTreeDiffModel` returns the *untouched absolute path* when its
+ * root strip misses, so an unfiltered model can carry entries that would never
+ * match a row — and persisting one as the selection would aim the viewer at a
+ * path outside the worktree it is scoped to.
+ */
+export function isReadableRelativePath(path: string): boolean {
+  if (path === "" || isAbsolute(path)) return false;
+  return !path.split("/").includes("..");
+}


### PR DESCRIPTION
## Summary

- The file browser panel ignored git status entirely, even though the store snapshot it already subscribes to, `worktreeChanges`, carries per-file status, insertions, deletions and mtime. The pane only read `lastUpdated` off it, as a refresh tick.
- Tree rows now carry a git status marker, and the idle pane summarises the worktree's changed files instead of a "Nothing selected" placeholder.
- Both halves ship together on purpose: a file surfaced in the summary has to stay findable in the tree once the summary is replaced.

Resolves #11614

## Changes

**Tree markers.** Each row carries its git status. A collapsed folder shows the worst status among its descendants, so a change is visible without expanding it. This is built from the changed-file list alone (dozens to hundreds of entries) as two flat maps, never by walking the lazily-loaded file listings, which run to tens of thousands of nodes. O(1) lookup per row.

**Idle pane.** With nothing selected, the pane summarises the worktree's changed files instead of showing the placeholder. Clicking a row opens the file in the viewer for reading, not a diff. `worktree.openChanges` already covers diffs. Picking a file also expands its ancestors in the tree so the row is waiting behind it. A clean worktree says so explicitly. A workspace-rooted browser has no worktree behind it and keeps the old placeholder.

**The load-bearing detail.** Changes are relativized against `worktreeChanges.rootPath`, the realpath-resolved root each change path was built from, never against the raw worktree path. The two denote the same directory but not the same string under a symlinked ancestor (`/tmp` resolving to `/private/tmp` on macOS), and the strip fails silently, handing back an absolute path that matches no row. Joining on the wrong one produces a feature that typechecks, passes fixture-clean tests, and marks nothing on a real macOS worktree. There's a regression test pinning this, verified by mutation: reverting to the naive join turns three tests red.

**Shared status presentation.** `STATUS_CONFIG` was private to `FileChangeList`. It's now a shared `gitStatusPresentation` module, so the tree, the summary and the worktree change list can't drift to different letters for the same state.

## Known limitations

Matter-of-fact, all pre-existing:

- The store's `worktreeChangesEqual` compares aggregate counts and totals, not per-file status, so a status flip with identical aggregates can retain a stale snapshot. This already affects the sidebar's change list built from the same data. Fixing it means changing a core store equality function whose comments say fields were deliberately kept out to avoid churning the `worktrees` Map identity per poll.
- Path matching is case-sensitive, so git's spelling and readdir's can differ on case-insensitive filesystems. Pre-existing across every consumer of this data.
- A dirty submodule is reported by git as a changed path but is a directory on disk. The tree row now vetoes it, so the viewer is never handed a directory to read. The summary row is still clickable and lands on a read error.

## Testing

- 2008 tests pass across `src/components/Worktree`, `src/panels/file-browser`, `src/panels/diff` and the new lib test.
- `npm run typecheck` passes.
- eslint is clean on all changed files: 0 errors, no new warnings for any rule.
- E2E was not run locally: `e2e/full/panels/core-file-browser.spec.ts` is blocked by a missing `dist/` build in this worktree (an Electron launch timeout, not an assertion failure). PR CI doesn't run E2E; that suite gates releases.