### PR TITLE
feat(files): give a selected folder its own state in the file browser

### DIFF
--- a/electron/services/FileTreeService.ts
+++ b/electron/services/FileTreeService.ts
@@ -105,9 +105,13 @@ export class FileTreeService {
         if (!result) continue;
         const { fileStat, name, gitRelativePath } = result;
 
+        // Both branches read `mtimeMs` off the `lstat` above rather than
+        // stat-ing again: the modified column in the file browser's folder
+        // listing (#11620) is free here and would otherwise cost one extra
+        // syscall per entry on every directory read and bulk scan.
         const isDirectory = fileStat.isDirectory();
         if (isDirectory) {
-          nodes.push({ name, path: gitRelativePath, isDirectory });
+          nodes.push({ name, path: gitRelativePath, isDirectory, mtimeMs: fileStat.mtimeMs });
           continue;
         }
 
@@ -117,6 +121,7 @@ export class FileTreeService {
             path: gitRelativePath,
             isDirectory,
             size: fileStat.size,
+            mtimeMs: fileStat.mtimeMs,
           });
         } catch {
           // skip entries where size read fails

--- a/electron/services/__tests__/CopyTreeService.fileTree.test.ts
+++ b/electron/services/__tests__/CopyTreeService.fileTree.test.ts
@@ -214,8 +214,18 @@ describe("CopyTreeService.getFileTree", () => {
       { includeExcluded: true }
     );
 
+    // `mtimeMs` rides along like `size` does: the verdict is applied to the raw
+    // FileTreeService nodes rather than to freshly built ones, so every field
+    // that listing reads reaches this surface. Matched loosely because it is a
+    // real filesystem timestamp.
     expect(nodes).toEqual([
-      { name: "pkg", path: "node_modules/pkg", isDirectory: true, excluded: true },
+      {
+        name: "pkg",
+        path: "node_modules/pkg",
+        isDirectory: true,
+        excluded: true,
+        mtimeMs: expect.any(Number),
+      },
     ]);
   });
 
@@ -242,7 +252,15 @@ describe("CopyTreeService.getFileTree", () => {
 
     const nodes = await copyTreeService.getFileTree(tempDir, "", {}, { includeExcluded: true });
 
-    expect(nodes).toEqual([{ name: "empty", path: "empty", isDirectory: true, excluded: true }]);
+    expect(nodes).toEqual([
+      {
+        name: "empty",
+        path: "empty",
+        isDirectory: true,
+        excluded: true,
+        mtimeMs: expect.any(Number),
+      },
+    ]);
   });
 
   it("preserves the raw listing's directories-first ordering while filtering", async () => {
@@ -265,7 +283,9 @@ describe("CopyTreeService.getFileTree", () => {
 
     const nodes = await copyTreeService.getFileTree(tempDir, "src");
 
-    expect(nodes).toEqual([{ name: "a.ts", path: "src/a.ts", isDirectory: false, size: 0 }]);
+    expect(nodes).toEqual([
+      { name: "a.ts", path: "src/a.ts", isDirectory: false, size: 0, mtimeMs: expect.any(Number) },
+    ]);
   });
 
   it("scans the whole root rather than scoping to the listed directory", async () => {

--- a/electron/services/__tests__/FileTreeService.test.ts
+++ b/electron/services/__tests__/FileTreeService.test.ts
@@ -196,3 +196,69 @@ describe("FileTreeService", () => {
     }
   });
 });
+
+describe("FileTreeService mtimeMs (#11620)", () => {
+  let tempDir: string;
+  let service: FileTreeService;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-file-tree-mtime-"));
+    service = new FileTreeService();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("reports a file's modified time, matching what the filesystem records", async () => {
+    const filePath = path.join(tempDir, "a.ts");
+    await fs.writeFile(filePath, "x");
+    const stat = await fs.lstat(filePath);
+
+    const nodes = await service.getFileTree(tempDir, "");
+    const node = nodes.find((n) => n.name === "a.ts");
+
+    // Compared against the real stat rather than a literal: this asserts the
+    // value is actually plumbed through, not that a constant was copied.
+    expect(node?.mtimeMs).toBe(stat.mtimeMs);
+  });
+
+  it("reports a directory's modified time too", async () => {
+    // The directory branch returns early, before the size read — it needs its
+    // own mtime treatment or every folder row would show an em-dash.
+    const dirPath = path.join(tempDir, "pkg");
+    await fs.mkdir(dirPath);
+    const stat = await fs.lstat(dirPath);
+
+    const nodes = await service.getFileTree(tempDir, "");
+    const node = nodes.find((n) => n.name === "pkg");
+
+    expect(node?.isDirectory).toBe(true);
+    expect(node?.mtimeMs).toBe(stat.mtimeMs);
+  });
+
+  it("reflects a rewrite rather than caching the first read", async () => {
+    const filePath = path.join(tempDir, "a.ts");
+    await fs.writeFile(filePath, "one");
+    const first = (await service.getFileTree(tempDir, "")).find((n) => n.name === "a.ts")?.mtimeMs;
+
+    // Push the mtime forward explicitly: a same-millisecond rewrite would make
+    // the assertion below vacuous on a fast filesystem.
+    const later = new Date(Date.now() + 60_000);
+    await fs.writeFile(filePath, "two");
+    await fs.utimes(filePath, later, later);
+
+    const second = (await service.getFileTree(tempDir, "")).find((n) => n.name === "a.ts")?.mtimeMs;
+
+    expect(second).toBeGreaterThan(first!);
+  });
+
+  it("still reports a byte size alongside the modified time", async () => {
+    await fs.writeFile(path.join(tempDir, "a.ts"), "hello");
+
+    const node = (await service.getFileTree(tempDir, "")).find((n) => n.name === "a.ts");
+
+    expect(node).toMatchObject({ size: 5 });
+    expect(node?.mtimeMs).toBeGreaterThan(0);
+  });
+});

--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -6,6 +6,8 @@ import type {
   ViewportPresetId,
   FileViewMode,
   DiffSource,
+  FileBrowserSortDirection,
+  FileBrowserSortKey,
   FileBrowserTreeSnapshot,
 } from "./panel.js";
 import type { GitStatus, DiffChangeSetEntry } from "./git.js";
@@ -291,6 +293,16 @@ export interface FileBrowserPanelOptions extends AddPanelOptionsBase {
    * decides this, so openers never pass it.
    */
   browserWorkspaceRooted?: boolean;
+  /**
+   * Order to restore the tree and folder listing in (#11620); absent = the
+   * `name`/`asc` default. Present here, not just on the panel record, because
+   * restoring a panel goes snapshot → deserializer → *these options* →
+   * `createFileBrowserDefaults`, and a field this type does not name is
+   * dropped on that last hop no matter how faithfully it was persisted.
+   */
+  browserSortKey?: FileBrowserSortKey;
+  /** Direction for `browserSortKey`; absent = `asc`. */
+  browserSortDirection?: FileBrowserSortDirection;
 }
 
 /**

--- a/shared/types/ipc/copyTree.ts
+++ b/shared/types/ipc/copyTree.ts
@@ -258,6 +258,15 @@ export interface FileTreeNode {
   isDirectory: boolean;
   /** File size in bytes (directories have size 0) */
   size?: number;
+  /**
+   * Last-modified time in epoch milliseconds, read off the `lstat` the listing
+   * already performs — never its own syscall. Absent on nodes that did not come
+   * from a live directory read: a tree rehydrated from a persisted snapshot
+   * (which stores structure only) and the CopyTree context listing (which is
+   * rebuilt from the SDK manifest) both leave it undefined, so every consumer
+   * has to have an answer for "unknown" rather than treating it as 0.
+   */
+  mtimeMs?: number;
   /** Children (only populated for directories if expanded) */
   children?: FileTreeNode[];
   /**

--- a/shared/types/ipc/copyTree.ts
+++ b/shared/types/ipc/copyTree.ts
@@ -260,11 +260,14 @@ export interface FileTreeNode {
   size?: number;
   /**
    * Last-modified time in epoch milliseconds, read off the `lstat` the listing
-   * already performs — never its own syscall. Absent on nodes that did not come
-   * from a live directory read: a tree rehydrated from a persisted snapshot
-   * (which stores structure only) and the CopyTree context listing (which is
-   * rebuilt from the SDK manifest) both leave it undefined, so every consumer
-   * has to have an answer for "unknown" rather than treating it as 0.
+   * already performs — never its own syscall.
+   *
+   * Absent on nodes that did not come from a live directory read: a tree
+   * rehydrated from a persisted snapshot stores structure only, so every
+   * consumer needs an answer for "unknown" rather than treating it as 0. It
+   * does reach the CopyTree context listing, which applies its include/exclude
+   * verdict to the raw listing nodes rather than rebuilding them — the same
+   * route `size` already travels.
    */
   mtimeMs?: number;
   /** Children (only populated for directories if expanded) */

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -746,6 +746,14 @@ export interface FileBrowserTreeSnapshot {
 }
 
 /**
+ * What the file browser orders directory entries by (#11620). Lives here
+ * rather than beside the comparator in the renderer because it is a persisted
+ * panel field, and `shared/` cannot import from `src/`.
+ */
+export type FileBrowserSortKey = "name" | "modified" | "size" | "type";
+export type FileBrowserSortDirection = "asc" | "desc";
+
+/**
  * File browser panel — a lazily-expanded directory tree over one folder with a
  * read-only viewer beside it. Every field is relative rather than absolute (the
  * root comes from `worktreeId`, like `DiffPanelData.filePath`), so moving or
@@ -832,6 +840,18 @@ export interface FileBrowserPanelData extends BasePanelData {
    * the user never asked for (#11489). Only `true` is persisted.
    */
   browserWorkspaceRooted?: boolean;
+  /**
+   * What the tree and the folder listing are ordered by (#11620). Absent = the
+   * `name`/`asc` default, which is the order the listing service already
+   * returns, so only a non-default choice earns a persisted field.
+   *
+   * One setting drives both surfaces deliberately: the sort menu is a single
+   * control, and letting the two columns disagree about the order of the same
+   * directory would make the listing read as a different folder.
+   */
+  browserSortKey?: FileBrowserSortKey;
+  /** Direction for `browserSortKey`. Absent = `asc`; only `desc` is persisted. */
+  browserSortDirection?: FileBrowserSortDirection;
 }
 
 export type PanelInstance =

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -9,6 +9,8 @@ import type {
   ViewportPresetId,
   FileViewMode,
   DiffSource,
+  FileBrowserSortDirection,
+  FileBrowserSortKey,
   FileBrowserTreeSnapshot,
 } from "./panel.js";
 import type { CommandOverride } from "./commands.js";
@@ -238,6 +240,10 @@ export interface PanelSnapshot {
   browserTreeSnapshot?: FileBrowserTreeSnapshot;
   /** File browser tree column width in px (only a non-default, in-range value persisted) */
   browserSidebarWidth?: number;
+  /** What a file browser panel orders entries by (#11620; only a non-default value persisted) */
+  browserSortKey?: FileBrowserSortKey;
+  /** Direction for `browserSortKey` (only `desc` persisted) */
+  browserSortDirection?: FileBrowserSortDirection;
   /**
    * Whether a file browser panel browses the view's workspace root rather than
    * its `worktreeId`, which for such a panel is grid placement only (#11489).

--- a/src/config/__tests__/panelKindSerialisers.test.ts
+++ b/src/config/__tests__/panelKindSerialisers.test.ts
@@ -109,6 +109,56 @@ describe("panelKindSerialisers", () => {
   describe("file-browser", () => {
     const deserialize = () => getDeserializer("file-browser")!;
 
+    describe("sort fields (#11620)", () => {
+      it("restores a recognized non-default sort key", () => {
+        expect(deserialize()({ id: "fb1", browserSortKey: "modified" }).browserSortKey).toBe(
+          "modified"
+        );
+      });
+
+      it("drops an unrecognized key rather than letting it reach the comparator", () => {
+        // An unknown key would order by nothing, leaving the tree in service
+        // order while the menu claimed otherwise.
+        expect(
+          deserialize()({ id: "fb1", browserSortKey: "churn" }).browserSortKey
+        ).toBeUndefined();
+        expect(deserialize()({ id: "fb1", browserSortKey: 7 }).browserSortKey).toBeUndefined();
+        expect(deserialize()({ id: "fb1", browserSortKey: {} }).browserSortKey).toBeUndefined();
+      });
+
+      it("leaves the default key absent rather than materializing it", () => {
+        // The serializer never writes "name"; restoring it as an explicit value
+        // would make the record less sparse than it was written.
+        expect(deserialize()({ id: "fb1", browserSortKey: "name" }).browserSortKey).toBeUndefined();
+      });
+
+      it("restores only a literal desc direction", () => {
+        expect(
+          deserialize()({ id: "fb1", browserSortDirection: "desc" }).browserSortDirection
+        ).toBe("desc");
+        expect(
+          deserialize()({ id: "fb1", browserSortDirection: "asc" }).browserSortDirection
+        ).toBeUndefined();
+        expect(
+          deserialize()({ id: "fb1", browserSortDirection: "sideways" }).browserSortDirection
+        ).toBeUndefined();
+      });
+
+      it("round-trips a non-default order through serialize and back", () => {
+        const panel = {
+          id: "fb1",
+          kind: "file-browser",
+          title: "Files",
+          cwd: "/repo",
+          browserSortKey: "size",
+          browserSortDirection: "desc",
+        } as unknown as FileBrowserPanelData;
+        const restored = deserialize()({ id: "fb1", ...serializeFileBrowser(panel) });
+        expect(restored.browserSortKey).toBe("size");
+        expect(restored.browserSortDirection).toBe("desc");
+      });
+    });
+
     it("keeps safe relative paths and drops everything that could escape the root", () => {
       const result = deserialize()({
         id: "fb1",

--- a/src/config/__tests__/panelKindSerialisers.test.ts
+++ b/src/config/__tests__/panelKindSerialisers.test.ts
@@ -608,3 +608,55 @@ describe("panelKindSerialisers", () => {
     });
   });
 });
+
+describe("file-browser sort survives the whole restore path (#11620)", () => {
+  // The deserializer is only the middle of the restore chain: a restored panel
+  // is rebuilt as snapshot → deserializer → panel *options* → the creation
+  // factory. A field the factory does not copy is dropped there no matter how
+  // faithfully it was persisted, which is invisible to a test that stops at the
+  // deserializer.
+  function restore(panel: Partial<FileBrowserPanelData>): Partial<FileBrowserPanelData> {
+    const saved = serializeFileBrowser({
+      id: "fb1",
+      kind: "file-browser",
+      title: "Files",
+      cwd: "/repo",
+      ...panel,
+    } as unknown as FileBrowserPanelData);
+    const options = getDeserializer("file-browser")!({ id: "fb1", ...saved });
+    return createFileBrowserDefaults({
+      kind: "file-browser",
+      worktreeId: "wt-1",
+      ...options,
+    });
+  }
+
+  const KEYS = ["name", "modified", "size", "type"] as const;
+  const DIRECTIONS = ["asc", "desc"] as const;
+
+  for (const key of KEYS) {
+    for (const direction of DIRECTIONS) {
+      it(`round-trips ${key}/${direction} through serialize → deserialize → create`, () => {
+        const restored = restore({ browserSortKey: key, browserSortDirection: direction });
+        // Read the way the pane reads it, so the sparse absence of a default is
+        // treated as the default rather than as a loss.
+        expect({
+          key: restored.browserSortKey ?? "name",
+          direction: restored.browserSortDirection ?? "asc",
+        }).toEqual({ key, direction });
+      });
+    }
+  }
+
+  it("keeps the restored record sparse for the default order", () => {
+    const restored = restore({ browserSortKey: "name", browserSortDirection: "asc" });
+    expect("browserSortKey" in restored).toBe(false);
+    expect("browserSortDirection" in restored).toBe(false);
+  });
+
+  it("restores nothing for a panel that was never sorted", () => {
+    const restored = restore({});
+    expect(restored.browserSortKey).toBeUndefined();
+    expect(restored.browserSortDirection).toBeUndefined();
+  });
+});

--- a/src/config/__tests__/panelKindSerialisers.test.ts
+++ b/src/config/__tests__/panelKindSerialisers.test.ts
@@ -649,9 +649,30 @@ describe("file-browser sort survives the whole restore path (#11620)", () => {
   }
 
   it("keeps the restored record sparse for the default order", () => {
-    const restored = restore({ browserSortKey: "name", browserSortDirection: "asc" });
+    // Handed the defaults EXPLICITLY, bypassing the serializer that would
+    // already have stripped them — otherwise a factory that wrongly
+    // materializes "name"/"asc" would still pass this.
+    const restored = createFileBrowserDefaults({
+      kind: "file-browser",
+      worktreeId: "wt-1",
+      browserSortKey: "name",
+      browserSortDirection: "asc",
+    });
     expect("browserSortKey" in restored).toBe(false);
     expect("browserSortDirection" in restored).toBe(false);
+  });
+
+  it("materializes a non-default order handed straight to the factory", () => {
+    // The mirror of the above: the factory must copy what it is given, not
+    // pass everything through a filter that happens to drop it.
+    expect(
+      createFileBrowserDefaults({
+        kind: "file-browser",
+        worktreeId: "wt-1",
+        browserSortKey: "type",
+        browserSortDirection: "desc",
+      })
+    ).toMatchObject({ browserSortKey: "type", browserSortDirection: "desc" });
   });
 
   it("restores nothing for a panel that was never sorted", () => {

--- a/src/config/__tests__/panelKindSerialisers.test.ts
+++ b/src/config/__tests__/panelKindSerialisers.test.ts
@@ -145,14 +145,14 @@ describe("panelKindSerialisers", () => {
       });
 
       it("round-trips a non-default order through serialize and back", () => {
-        const panel = {
+        const panel: FileBrowserPanelData = {
           id: "fb1",
           kind: "file-browser",
           title: "Files",
-          cwd: "/repo",
+          location: "grid",
           browserSortKey: "size",
           browserSortDirection: "desc",
-        } as unknown as FileBrowserPanelData;
+        };
         const restored = deserialize()({ id: "fb1", ...serializeFileBrowser(panel) });
         expect(restored.browserSortKey).toBe("size");
         expect(restored.browserSortDirection).toBe("desc");
@@ -620,9 +620,9 @@ describe("file-browser sort survives the whole restore path (#11620)", () => {
       id: "fb1",
       kind: "file-browser",
       title: "Files",
-      cwd: "/repo",
+      location: "grid",
       ...panel,
-    } as unknown as FileBrowserPanelData);
+    });
     const options = getDeserializer("file-browser")!({ id: "fb1", ...saved });
     return createFileBrowserDefaults({
       kind: "file-browser",

--- a/src/config/__tests__/panelKindSerialisers.test.ts
+++ b/src/config/__tests__/panelKindSerialisers.test.ts
@@ -624,10 +624,13 @@ describe("file-browser sort survives the whole restore path (#11620)", () => {
       ...panel,
     });
     const options = getDeserializer("file-browser")!({ id: "fb1", ...saved });
+    // `options` spreads last-wins, and the deserializer types `kind` as the open
+    // `PanelKind` union — pinning the discriminant after the spread is what
+    // keeps this a file-browser options object rather than widening it.
     return createFileBrowserDefaults({
+      ...options,
       kind: "file-browser",
       worktreeId: "wt-1",
-      ...options,
     });
   }
 

--- a/src/config/panelKindSerialisers.ts
+++ b/src/config/panelKindSerialisers.ts
@@ -1,5 +1,10 @@
 import type { BuiltInPanelKind, PanelKind, ViewportPresetId } from "@/types";
-import type { FileViewMode, DiffSource, FileBrowserTreeSnapshot } from "@shared/types/panel";
+import type {
+  FileViewMode,
+  DiffSource,
+  FileBrowserSortKey,
+  FileBrowserTreeSnapshot,
+} from "@shared/types/panel";
 import type { GitStatus } from "@shared/types/git";
 import type { AddTerminalArgs, SavedTerminalData } from "@/utils/stateHydration/statePatcher";
 import { VIEWPORT_PRESETS } from "@/panels/dev-preview/viewportPresets";
@@ -96,6 +101,12 @@ function canonicalRelativePath(value: unknown): string | undefined {
  * nothing expanded" is a real state, distinct from "this panel predates the
  * field".
  */
+function sanitizeSortKey(value: unknown): FileBrowserSortKey | undefined {
+  // "name" is the default, so restoring it as an explicit value would only make
+  // the record less sparse than the serializer left it.
+  return value === "modified" || value === "size" || value === "type" ? value : undefined;
+}
+
 function sanitizeExpandedPaths(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) return undefined;
   const seen = new Set<string>();
@@ -283,6 +294,12 @@ const BUILT_IN_DESERIALIZERS = {
     // path re-derives rooting from `worktreeId` instead of trusting a corrupted
     // value to redirect the browse root (#11489).
     browserWorkspaceRooted: saved.browserWorkspaceRooted === true ? true : undefined,
+    // Membership-tested against the known keys rather than cast: an unknown
+    // string would reach the comparator and order by nothing, silently leaving
+    // the tree in the service's order while the menu claimed otherwise
+    // (#11620). Anything unrecognized falls back to the absent default.
+    browserSortKey: sanitizeSortKey(saved.browserSortKey),
+    browserSortDirection: saved.browserSortDirection === "desc" ? "desc" : undefined,
   }),
   diff: (saved) => ({
     filePath: saved.filePath,

--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -291,6 +291,11 @@ const FILE_BROWSER_FIELD_CLASSIFICATION = {
   // at creation — a promoted panel carries an adopted placement id by save time
   // (#11489) — so it has to ride the record like any other user intent.
   browserWorkspaceRooted: true,
+  // What the tree and the folder listing are ordered by (#11620). User intent,
+  // chosen from the toolbar menu, so it rides the record — only a non-default
+  // value is written, which keeps a never-sorted panel sparse.
+  browserSortKey: true,
+  browserSortDirection: true,
   // BasePanelData carrier-bookkeeping timestamps — written by the base
   // serialization layer in panelToSnapshot, not per-kind serializers.
   createdAt: false,
@@ -487,6 +492,11 @@ const fileBrowserFixture: FileBrowserPanelData = {
   // the key instead of dropping it as a default.
   browserSidebarWidth: 360,
   browserWorkspaceRooted: true,
+  // A non-default order for the same reason as the width above: the serializer
+  // omits name/ascending, so a default fixture would drop both keys and the
+  // coverage spread could not tell that from a missing implementation (#11620).
+  browserSortKey: "size",
+  browserSortDirection: "desc",
 };
 
 const savedFileBrowser: SavedTerminalData = {
@@ -501,6 +511,8 @@ const savedFileBrowser: SavedTerminalData = {
   browserTreeSnapshot: browserTreeSnapshotFixture,
   browserSidebarWidth: 360,
   browserWorkspaceRooted: true,
+  browserSortKey: "size",
+  browserSortDirection: "desc",
 };
 
 const diffFixture: DiffPanelData = {

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -1251,8 +1251,6 @@ export function FileBrowserPane({
               folderHasHiddenDotfiles={hideDotfiles && listingHasHiddenDotfiles}
               onShowDotfiles={handleShowDotfiles}
               onSelectEntry={handleSelect}
-              onActivateEntry={handleActivate}
-              onRootFolder={handleSetRoot}
               rowContextMenu={rowContextMenu}
               basePath={basePath}
               sort={sort}

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -60,8 +60,9 @@ import {
   createVisibilityFilter,
   isRowPathVisible,
   parentRootPath,
+  type FileBrowserSortOrder,
   type FileBrowserSource,
-  type FlatTreeRow,
+  type FileEntryLike,
 } from "./fileBrowserTree";
 import { useWorkspaceRootPath } from "./useWorkspaceRootPath";
 
@@ -125,6 +126,31 @@ export function FileBrowserPane({
   );
   const alwaysHiddenPatterns = usePreferencesStore(
     (state) => state.fileBrowserAlwaysHiddenPatterns
+  );
+  // Selected as two primitives rather than one object: a selector returning a
+  // fresh object would fail the store's reference check and re-render this
+  // panel on every unrelated store write.
+  const sortKey = usePanelStore(
+    useCallback(
+      (state) => {
+        const panel = state.panelsById[id];
+        return panel?.kind === "file-browser" ? (panel.browserSortKey ?? "name") : "name";
+      },
+      [id]
+    )
+  );
+  const sortDirection = usePanelStore(
+    useCallback(
+      (state) => {
+        const panel = state.panelsById[id];
+        return panel?.kind === "file-browser" ? (panel.browserSortDirection ?? "asc") : "asc";
+      },
+      [id]
+    )
+  );
+  const sort = useMemo<FileBrowserSortOrder>(
+    () => ({ key: sortKey, direction: sortDirection }),
+    [sortKey, sortDirection]
   );
   const rootPath = usePanelStore(
     useCallback(
@@ -353,6 +379,11 @@ export function FileBrowserPane({
     refresh,
     isRefreshing,
     captureSnapshot,
+    selectedNode,
+    listingPath,
+    listingRows,
+    listingStatus,
+    listingHasHiddenDotfiles,
   } = useFileBrowserTree({
     source,
     expandedPaths: stableExpandedPaths,
@@ -361,6 +392,8 @@ export function FileBrowserPane({
     rootPath,
     changeTick,
     treeSnapshot,
+    sort,
+    selectedPath,
   });
 
   // Persist the last-known tree at going-away points only (#11367): the
@@ -528,6 +561,23 @@ export function FileBrowserPane({
   const handleToggleDotfiles = useCallback(() => {
     setFileBrowserView(id, { browserHideDotfiles: !hideDotfiles });
   }, [id, hideDotfiles, setFileBrowserView]);
+
+  // Unconditionally turns the filter off, unlike the toggle above: it backs the
+  // "Show dotfiles" recovery on an empty state, where the only reason the
+  // control is offered is that the filter is currently hiding something.
+  const handleShowDotfiles = useCallback(() => {
+    setFileBrowserView(id, { browserHideDotfiles: false });
+  }, [id, setFileBrowserView]);
+
+  // Both halves in one write: the setter's no-op guard compares each against
+  // its own default, so sending them separately would let a key change land
+  // while a simultaneous direction change was still being judged unchanged.
+  const handleSortChange = useCallback(
+    (next: FileBrowserSortOrder) => {
+      setFileBrowserView(id, { browserSortKey: next.key, browserSortDirection: next.direction });
+    },
+    [id, setFileBrowserView]
+  );
 
   // A selection the junk list or dotfile toggle now hides. The viewer already
   // clears (the hidden row isn't in `rows`, so `selectedNode` is undefined),
@@ -840,8 +890,13 @@ export function FileBrowserPane({
     [basePath, reveal]
   );
 
+  // Typed on the shared entry shape rather than on `FlatTreeRow` so the tree and
+  // the folder listing hand it their own row types and get the identical menu
+  // (#11620). Nothing below reads a tree-only field — the handlers all take a
+  // path or a name — and a second copy of this menu for the listing would be
+  // sixty lines that have to stay in lockstep forever.
   const rowContextMenu = useCallback(
-    (row: FlatTreeRow) => (
+    (row: FileEntryLike) => (
       <>
         {row.isDirectory && (
           <>
@@ -931,10 +986,6 @@ export function FileBrowserPane({
     setFileBrowserView(id, { browserExpandedPaths: [...current].sort() });
   }, [id, selectedPath, stableExpandedPaths, setFileBrowserView]);
 
-  const selectedNode = useMemo(
-    () => rows.find((row) => row.path === selectedPath),
-    [rows, selectedPath]
-  );
   // Picking a file from the changed-files summary selects a path whose tree row
   // may not be flattened at all — its ancestors are collapsed, so `selectedNode`
   // is undefined for it. Git is the second witness that it is a readable file:
@@ -961,10 +1012,22 @@ export function FileBrowserPane({
   // hard veto — git reports a dirty submodule as a changed path while the
   // filesystem calls it a directory, and letting the change set override the row
   // would hand the viewer a directory to read.
+  //
+  // `selectedNode` now comes from the tree hook, resolved against its listings
+  // map rather than against the rendered rows (#11620), so it already answers
+  // for an entry picked out of a folder listing whose parent is collapsed. Git
+  // still covers what that cannot: a path whose parent directory has not been
+  // listed at all, where there is no node to consult either way.
   const isSelectedReadableFile =
     selectedNode === undefined ? isSelectedChangedFile : selectedNode.isDirectory === false;
+  // `selectionFilteredHidden` is part of the gate, not decoration: resolving the
+  // node from the listings map means it survives the filter that removed its
+  // row, so without this an entry hidden by the dotfile toggle would keep its
+  // contents on screen in the viewer while the tree stopped showing it at all.
   const selectedFilePath =
-    selectedPath && basePath && isSelectedReadableFile ? join(basePath, selectedPath) : null;
+    selectedPath && basePath && isSelectedReadableFile && !selectionFilteredHidden
+      ? join(basePath, selectedPath)
+      : null;
   const selectedFileName = selectedPath ? (selectedPath.split("/").pop() ?? selectedPath) : "";
 
   return (
@@ -1178,6 +1241,22 @@ export function FileBrowserPane({
               treeSidebarId={treeSidebarId}
               changedFiles={changedFiles}
               onSelectChangedFile={handleSelectChangedFile}
+              // The folder-selected state (#11620). `folderPath` and `filePath`
+              // are mutually exclusive by construction — both are derived from
+              // the same resolved `selectedNode`, so the viewer never has to
+              // decide which one wins.
+              folderPath={listingPath}
+              folderRows={listingRows}
+              folderStatus={listingStatus}
+              folderHasHiddenDotfiles={hideDotfiles && listingHasHiddenDotfiles}
+              onShowDotfiles={handleShowDotfiles}
+              onSelectEntry={handleSelect}
+              onActivateEntry={handleActivate}
+              onRootFolder={handleSetRoot}
+              rowContextMenu={rowContextMenu}
+              basePath={basePath}
+              sort={sort}
+              onSortChange={handleSortChange}
             />
           </div>
         )}

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -50,6 +50,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -134,12 +135,13 @@ export interface FileBrowserViewerProps {
   folderHasHiddenDotfiles: boolean;
   /** Turns the dotfile filter off; offered from the filtered-empty state. */
   onShowDotfiles: () => void;
-  /** Selecting an entry in the listing — a folder steps in, a file opens. */
+  /**
+   * Selecting an entry in the listing — a folder steps in, a file opens. The
+   * listing's only click gesture; re-rooting and opening in a panel live in the
+   * row's context menu and in the tree, which is why no activate/root callback
+   * is threaded through here (see `FolderListingView`).
+   */
   onSelectEntry: (path: string) => void;
-  /** Double-click on a listing file: open it in its own panel. */
-  onActivateEntry: (path: string) => void;
-  /** Double-click on a listing folder: re-root the browser there. */
-  onRootFolder: (path: string) => void;
   /** Menu items for a listing row's right-click menu — the tree's own callback. */
   rowContextMenu?: (row: FileEntryLike) => React.ReactNode;
   /** Absolute base the listing's relative paths hang off, for drags (#11576). */
@@ -157,16 +159,19 @@ const SORT_OPTIONS: Array<{ value: FileBrowserSortKey; label: string }> = [
   { value: "type", label: "Type" },
 ];
 
+/** Narrow a menu value back to a known key, falling back to the current one. */
+function toSortKey(value: string, fallback: FileBrowserSortKey): FileBrowserSortKey {
+  return SORT_OPTIONS.find((option) => option.value === value)?.value ?? fallback;
+}
+
 /**
- * Picking the key already in use flips direction; picking a different one keeps
- * the current direction. Mirrors the review hub's sort menu (`applySortChange`)
- * so the two menus in the app behave identically — re-picking as "toggle" is
- * the only way a single radio group can express direction at all.
+ * The sort control's accessible name. Spells out both halves because the arrow
+ * icon that shows the direction is decorative — the name is the only place a
+ * screen reader can learn which way the list runs.
  */
-function nextSort(current: FileBrowserSortOrder, value: string): FileBrowserSortOrder {
-  const key = SORT_OPTIONS.find((option) => option.value === value)?.value ?? current.key;
-  if (key !== current.key) return { key, direction: current.direction };
-  return { key, direction: current.direction === "asc" ? "desc" : "asc" };
+function sortLabel(sort: FileBrowserSortOrder): string {
+  const key = SORT_OPTIONS.find((option) => option.value === sort.key)?.label ?? "Name";
+  return `Sort files (${key}, ${sort.direction === "asc" ? "ascending" : "descending"})`;
 }
 
 /** Which external surface a toolbar action aims the current file at. */
@@ -221,8 +226,6 @@ export function FileBrowserViewer({
   folderHasHiddenDotfiles,
   onShowDotfiles,
   onSelectEntry,
-  onActivateEntry,
-  onRootFolder,
   rowContextMenu,
   basePath,
   sort,
@@ -498,43 +501,54 @@ export function FileBrowserViewer({
                 <DropdownMenuTrigger asChild>
                   <button
                     type="button"
-                    aria-label="Sort files"
+                    // Carries the current order, not just the verb: the arrow
+                    // below is decorative, so without this a screen reader
+                    // could never tell which way the list is sorted.
+                    aria-label={sortLabel(sort)}
                     data-testid="file-browser-sort-menu"
                     className="toolbar-icon-button rounded p-1.5 text-daintree-text/60"
                   >
                     {sort.direction === "asc" ? (
-                      <ArrowUpNarrowWide className="h-4 w-4" />
+                      <ArrowUpNarrowWide className="h-4 w-4" aria-hidden="true" />
                     ) : (
-                      <ArrowDownNarrowWide className="h-4 w-4" />
+                      <ArrowDownNarrowWide className="h-4 w-4" aria-hidden="true" />
                     )}
                   </button>
                 </DropdownMenuTrigger>
               </TooltipTrigger>
-              <TooltipContent side="bottom">Sort files</TooltipContent>
+              <TooltipContent side="bottom">{sortLabel(sort)}</TooltipContent>
             </Tooltip>
             <DropdownMenuContent align="end" className="min-w-[180px]">
+              {/* Key and direction are two labelled radio groups rather than one
+                  group that reverses when its active item is re-picked. The
+                  compact version hides the direction behind a gesture nothing
+                  announces — the checked item stays checked, so a screen reader
+                  reports no change at all — and leaves no way to set a
+                  direction outright. Two groups cost one extra label and make
+                  both halves readable and directly settable. */}
               <DropdownMenuLabel>Sort by</DropdownMenuLabel>
-              {/* One radio group, no separate direction control: re-picking the
-                  active key flips it, which keeps the menu to a single list of
-                  choices instead of a key list plus a direction list that can
-                  disagree. The arrow marks which key carries the direction. */}
               <DropdownMenuRadioGroup
                 value={sort.key}
-                onValueChange={(value) => onSortChange(nextSort(sort, value))}
+                onValueChange={(value) =>
+                  onSortChange({ ...sort, key: toSortKey(value, sort.key) })
+                }
               >
                 {SORT_OPTIONS.map((option) => (
                   <DropdownMenuRadioItem key={option.value} value={option.value}>
-                    <span className="flex flex-1 items-center gap-2">
-                      {option.label}
-                      {sort.key === option.value &&
-                        (sort.direction === "asc" ? (
-                          <ArrowUpNarrowWide className="ml-auto h-3 w-3 text-daintree-text/40" />
-                        ) : (
-                          <ArrowDownNarrowWide className="ml-auto h-3 w-3 text-daintree-text/40" />
-                        ))}
-                    </span>
+                    {option.label}
                   </DropdownMenuRadioItem>
                 ))}
+              </DropdownMenuRadioGroup>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel>Order</DropdownMenuLabel>
+              <DropdownMenuRadioGroup
+                value={sort.direction}
+                onValueChange={(value) =>
+                  onSortChange({ ...sort, direction: value === "desc" ? "desc" : "asc" })
+                }
+              >
+                <DropdownMenuRadioItem value="asc">Ascending</DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="desc">Descending</DropdownMenuRadioItem>
               </DropdownMenuRadioGroup>
             </DropdownMenuContent>
           </DropdownMenu>
@@ -652,6 +666,7 @@ export function FileBrowserViewer({
    */
   function renderFolderBody() {
     if (folderPath === null) return null;
+    const folderName = folderPath.split("/").pop() ?? folderPath;
 
     if (folderStatus === "error") {
       return (
@@ -705,7 +720,10 @@ export function FileBrowserViewer({
             scale="canvas"
             className="w-full"
             {...(canRevealDotfiles ? {} : { icon: <FolderTree className="h-6 w-6" /> })}
-            title={canRevealDotfiles ? "Dotfiles are hidden here" : "This folder is empty"}
+            title={canRevealDotfiles ? "Dotfiles are hidden here" : "Nothing in this folder yet"}
+            {...(canRevealDotfiles
+              ? {}
+              : { description: "Add a file to it and it'll show up here." })}
             action={
               canRevealDotfiles ? (
                 <button
@@ -725,13 +743,10 @@ export function FileBrowserViewer({
     return (
       <FolderListingView
         rows={folderRows}
-        selectedPath={null}
         onSelect={onSelectEntry}
-        onActivateFile={onActivateEntry}
-        onRootFolder={onRootFolder}
-        rowContextMenu={rowContextMenu}
+        {...(rowContextMenu ? { rowContextMenu } : {})}
         basePath={basePath}
-        label={`Contents of ${fileName}`}
+        label={`Contents of ${folderName}`}
       />
     );
   }

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -526,8 +526,14 @@ export function FileBrowserViewer({
                   reports no change at all — and leaves no way to set a
                   direction outright. Two groups cost one extra label and make
                   both halves readable and directly settable. */}
+              {/* Each group carries its own `aria-label`: Radix renders these as
+                  `role="group"`, and the visible label above is a sibling
+                  element, not an association — without it both groups announce
+                  as unnamed containers and the two halves become
+                  indistinguishable. */}
               <DropdownMenuLabel>Sort by</DropdownMenuLabel>
               <DropdownMenuRadioGroup
+                aria-label="Sort by"
                 value={sort.key}
                 onValueChange={(value) =>
                   onSortChange({ ...sort, key: toSortKey(value, sort.key) })
@@ -542,6 +548,7 @@ export function FileBrowserViewer({
               <DropdownMenuSeparator />
               <DropdownMenuLabel>Order</DropdownMenuLabel>
               <DropdownMenuRadioGroup
+                aria-label="Order"
                 value={sort.direction}
                 onValueChange={(value) =>
                   onSortChange({ ...sort, direction: value === "desc" ? "desc" : "asc" })

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
+  ArrowDownNarrowWide,
+  ArrowUpNarrowWide,
   ExternalLink,
   FileText,
+  FolderTree,
   PanelLeftClose,
   PanelLeftOpen,
   RefreshCw,
@@ -41,7 +44,24 @@ import { EmptyState } from "@/components/ui/EmptyState";
 import { SpinningIcon } from "@/components/ui/SpinningIcon";
 import { Skeleton, SkeletonBone, SkeletonText } from "@/components/ui/Skeleton";
 import { SegmentedToggle } from "@/components/ui/SegmentedToggle";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useDohertyGate } from "@/hooks/useDeferredLoading";
+import { FolderListingView } from "./FolderListingView";
+import type {
+  FileBrowserSortKey,
+  FileBrowserSortOrder,
+  FileEntryLike,
+  FolderListingRow,
+} from "./fileBrowserTree";
+import type { FolderListingStatus } from "./useFileBrowserTree";
 import { filesClient } from "@/clients/filesClient";
 import { isClientAppError } from "@/utils/clientAppError";
 import { sanitizeSvg } from "@shared/utils/svgSanitizer";
@@ -100,6 +120,53 @@ export interface FileBrowserViewerProps {
   changedFiles: readonly WorkingTreeFileChange[] | null;
   /** Opens a file picked from the changed-files summary in this viewer. */
   onSelectChangedFile: (relativePath: string) => void;
+  /**
+   * Worktree-relative path of the selected *folder*, or null when the selection
+   * is a file or nothing (#11620). Mutually exclusive with `filePath` — the
+   * pane resolves the selection's kind once and hands over exactly one.
+   */
+  folderPath: string | null;
+  /** Rows for `folderPath`'s contents; null when no folder is selected. */
+  folderRows: FolderListingRow[] | null;
+  /** Raw fetch state for `folderPath` — never anti-flicker gated (#10083). */
+  folderStatus: FolderListingStatus;
+  /** Whether the dotfile toggle is what's hiding this folder's entries. */
+  folderHasHiddenDotfiles: boolean;
+  /** Turns the dotfile filter off; offered from the filtered-empty state. */
+  onShowDotfiles: () => void;
+  /** Selecting an entry in the listing — a folder steps in, a file opens. */
+  onSelectEntry: (path: string) => void;
+  /** Double-click on a listing file: open it in its own panel. */
+  onActivateEntry: (path: string) => void;
+  /** Double-click on a listing folder: re-root the browser there. */
+  onRootFolder: (path: string) => void;
+  /** Menu items for a listing row's right-click menu — the tree's own callback. */
+  rowContextMenu?: (row: FileEntryLike) => React.ReactNode;
+  /** Absolute base the listing's relative paths hang off, for drags (#11576). */
+  basePath: string;
+  /** Current order for the tree and the listing; driven by the toolbar menu. */
+  sort: FileBrowserSortOrder;
+  onSortChange: (sort: FileBrowserSortOrder) => void;
+}
+
+/** Toolbar sort menu entries, in menu order. */
+const SORT_OPTIONS: Array<{ value: FileBrowserSortKey; label: string }> = [
+  { value: "name", label: "Name" },
+  { value: "modified", label: "Modified" },
+  { value: "size", label: "Size" },
+  { value: "type", label: "Type" },
+];
+
+/**
+ * Picking the key already in use flips direction; picking a different one keeps
+ * the current direction. Mirrors the review hub's sort menu (`applySortChange`)
+ * so the two menus in the app behave identically — re-picking as "toggle" is
+ * the only way a single radio group can express direction at all.
+ */
+function nextSort(current: FileBrowserSortOrder, value: string): FileBrowserSortOrder {
+  const key = SORT_OPTIONS.find((option) => option.value === value)?.value ?? current.key;
+  if (key !== current.key) return { key, direction: current.direction };
+  return { key, direction: current.direction === "asc" ? "desc" : "asc" };
 }
 
 /** Which external surface a toolbar action aims the current file at. */
@@ -148,6 +215,18 @@ export function FileBrowserViewer({
   treeSidebarId,
   changedFiles,
   onSelectChangedFile,
+  folderPath,
+  folderRows,
+  folderStatus,
+  folderHasHiddenDotfiles,
+  onShowDotfiles,
+  onSelectEntry,
+  onActivateEntry,
+  onRootFolder,
+  rowContextMenu,
+  basePath,
+  sort,
+  onSortChange,
 }: FileBrowserViewerProps) {
   const [state, setState] = useState<ViewerState>({ status: "idle" });
   // Sticky Source/Rendered choice for markdown, defaulting to the rendered view
@@ -405,6 +484,60 @@ export function FileBrowserViewer({
             with nothing selected would otherwise offer no way to refresh
             anything. */}
         <FileViewerToolbar.Actions>
+          {/* The single home for sort (#11620). Deliberately not duplicated as
+              clickable column headers in the listing below: two controls for
+              one setting is the same trap the Refresh comment above avoids, and
+              a header that looks sortable in one column but has no counterpart
+              in the tree would misdescribe what the setting governs. Always
+              present, because it orders the tree as well as the listing —
+              gating it on a folder selection would hide the control that
+              explains the tree's own order. */}
+          <DropdownMenu>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label="Sort files"
+                    data-testid="file-browser-sort-menu"
+                    className="toolbar-icon-button rounded p-1.5 text-daintree-text/60"
+                  >
+                    {sort.direction === "asc" ? (
+                      <ArrowUpNarrowWide className="h-4 w-4" />
+                    ) : (
+                      <ArrowDownNarrowWide className="h-4 w-4" />
+                    )}
+                  </button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Sort files</TooltipContent>
+            </Tooltip>
+            <DropdownMenuContent align="end" className="min-w-[180px]">
+              <DropdownMenuLabel>Sort by</DropdownMenuLabel>
+              {/* One radio group, no separate direction control: re-picking the
+                  active key flips it, which keeps the menu to a single list of
+                  choices instead of a key list plus a direction list that can
+                  disagree. The arrow marks which key carries the direction. */}
+              <DropdownMenuRadioGroup
+                value={sort.key}
+                onValueChange={(value) => onSortChange(nextSort(sort, value))}
+              >
+                {SORT_OPTIONS.map((option) => (
+                  <DropdownMenuRadioItem key={option.value} value={option.value}>
+                    <span className="flex flex-1 items-center gap-2">
+                      {option.label}
+                      {sort.key === option.value &&
+                        (sort.direction === "asc" ? (
+                          <ArrowUpNarrowWide className="ml-auto h-3 w-3 text-daintree-text/40" />
+                        ) : (
+                          <ArrowDownNarrowWide className="ml-auto h-3 w-3 text-daintree-text/40" />
+                        ))}
+                    </span>
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
           {/* Only while the tree column is collapsed away. Its header owns the
               Refresh the rest of the time, and two identical buttons in one
               panel would read as two different actions — the same
@@ -459,7 +592,10 @@ export function FileBrowserViewer({
         />
       )}
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-        {filePath ? renderBody() : renderIdleBody()}
+        {/* A selected folder outranks the idle body: the changed-files summary
+            answers "nothing is selected", and a folder selection is a
+            selection (#11620). */}
+        {filePath ? renderBody() : folderPath !== null ? renderFolderBody() : renderIdleBody()}
       </div>
     </>
   );
@@ -500,6 +636,103 @@ export function FileBrowserViewer({
           />
         )}
       </div>
+    );
+  }
+
+  /**
+   * The folder-selected state (#11620) — what a selected folder shows instead
+   * of the same "Nothing selected" a bare panel shows.
+   *
+   * Branches on `folderStatus`, the raw fetch state, never on a Doherty-gated
+   * flag: a gated boolean is false both before the gate opens and after the
+   * data arrives, so branching on it renders "this folder is empty" for the
+   * first 400ms of every load. The gate below decides only whether the skeleton
+   * paints during a pending window — under 400ms this renders nothing at all,
+   * which is the point.
+   */
+  function renderFolderBody() {
+    if (folderPath === null) return null;
+
+    if (folderStatus === "error") {
+      return (
+        <div className="flex h-full w-full items-center justify-center p-6">
+          <EmptyState
+            variant="zero-data"
+            scale="canvas"
+            icon={<FolderTree className="h-6 w-6" />}
+            title="Can't show this folder"
+            description="The folder couldn't be read. It may have been moved or deleted."
+            action={
+              <button
+                type="button"
+                onClick={onRefresh}
+                className="text-xs underline underline-offset-2"
+              >
+                Retry
+              </button>
+            }
+            className="w-full"
+          />
+        </div>
+      );
+    }
+
+    // `== null`, so an absent value is treated the same as an explicit null:
+    // "no rows yet" is the honest reading either way, and reaching `.length`
+    // on it below would throw rather than degrade.
+    if (folderStatus === "pending" || folderRows == null) {
+      return (
+        // Predictable shape (a column of rows), so a skeleton rather than a
+        // spinner — and `Skeleton` carries the 400ms gate itself, so a listing
+        // already in the cache shows nothing before the rows appear.
+        <div className="p-3">
+          <Skeleton label="Loading folder">
+            <SkeletonText lines={10} />
+          </Skeleton>
+        </div>
+      );
+    }
+
+    if (folderRows.length === 0) {
+      // "Filtered" only when turning the dotfile toggle off would actually
+      // reveal something here — otherwise the folder is genuinely empty, and
+      // offering a control that changes nothing would be a dead end.
+      const canRevealDotfiles = folderHasHiddenDotfiles;
+      return (
+        <div className="flex min-h-0 flex-1 items-center justify-center p-6">
+          <EmptyState
+            variant={canRevealDotfiles ? "filtered-empty" : "zero-data"}
+            scale="canvas"
+            className="w-full"
+            {...(canRevealDotfiles ? {} : { icon: <FolderTree className="h-6 w-6" /> })}
+            title={canRevealDotfiles ? "Dotfiles are hidden here" : "This folder is empty"}
+            action={
+              canRevealDotfiles ? (
+                <button
+                  type="button"
+                  onClick={onShowDotfiles}
+                  className="text-xs underline underline-offset-2"
+                >
+                  Show dotfiles
+                </button>
+              ) : undefined
+            }
+          />
+        </div>
+      );
+    }
+
+    return (
+      <FolderListingView
+        rows={folderRows}
+        selectedPath={null}
+        onSelect={onSelectEntry}
+        onActivateFile={onActivateEntry}
+        onRootFolder={onRootFolder}
+        rowContextMenu={rowContextMenu}
+        basePath={basePath}
+        label={`Contents of ${fileName}`}
+      />
     );
   }
 

--- a/src/panels/file-browser/FileTreeView.tsx
+++ b/src/panels/file-browser/FileTreeView.tsx
@@ -10,7 +10,7 @@ import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/component
 import { useDeferredLoading } from "@/hooks/useDeferredLoading";
 import { comboToAriaKeyshortcuts } from "@/lib/kbdShortcut";
 import { isMac } from "@/lib/platform";
-import { resolveTreeKey, type FlatTreeRow } from "./fileBrowserTree";
+import { resolveTreeKey, type FileEntryLike, type FlatTreeRow } from "./fileBrowserTree";
 import { getFileBrowserRowGitStatus, type FileBrowserGitStatusIndex } from "./fileBrowserGitStatus";
 import { getGitStatusPresentation } from "@/lib/gitStatusPresentation";
 import { FILE_TREE_ICON_CLASS, UNKNOWN_FILE_COLOR_CLASS, getFileTypeIcon } from "./fileTypeIcons";
@@ -37,7 +37,7 @@ export interface FileTreeViewProps {
    * the menu visibly targets it, without moving the selection); the pane owns
    * what the items do.
    */
-  rowContextMenu?: (row: FlatTreeRow) => React.ReactNode;
+  rowContextMenu?: (row: FileEntryLike) => React.ReactNode;
   /**
    * Send the selected row to the last agent the user typed to (#11577). Fired
    * by the tree-local Cmd+I, which only exists while a row is selected and a
@@ -335,7 +335,7 @@ interface TreeContext {
   onToggleExpanded: (path: string, expand: boolean) => void;
   onActivate?: ((path: string) => void) | undefined;
   onRootFolder?: ((path: string) => void) | undefined;
-  rowContextMenu?: ((row: FlatTreeRow) => React.ReactNode) | undefined;
+  rowContextMenu?: ((row: FileEntryLike) => React.ReactNode) | undefined;
   hasDirectories: boolean;
   instanceId: string;
   basePath: string;

--- a/src/panels/file-browser/FolderListingView.tsx
+++ b/src/panels/file-browser/FolderListingView.tsx
@@ -1,0 +1,265 @@
+import { useCallback, useMemo } from "react";
+import { Virtuoso } from "react-virtuoso";
+import { Folder } from "lucide-react";
+import { join } from "@shared/utils/path";
+import { cn } from "@/lib/utils";
+import { formatBytes } from "@/lib/formatBytes";
+import { formatRelativeTime } from "@/lib/formatRelativeTime";
+import { FILE_DRAG_MIME, encodeFileDragPaths } from "@/lib/fileDragPayload";
+import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
+import type { FileEntryLike, FolderListingRow } from "./fileBrowserTree";
+import { FILE_TREE_ICON_CLASS, UNKNOWN_FILE_COLOR_CLASS, getFileTypeIcon } from "./fileTypeIcons";
+
+const ROW_HEIGHT_PX = 28;
+
+/**
+ * Stands in for a column with nothing to show. A folder has no byte size and a
+ * snapshot-restored row has neither size nor modified time (#11367 stores
+ * structure only), so both columns need a rendering for "unknown" that isn't a
+ * misleading zero.
+ */
+const UNKNOWN = "—";
+
+export interface FolderListingViewProps {
+  rows: FolderListingRow[];
+  selectedPath: string | null;
+  /** Selecting an entry — a folder re-points this listing, a file opens it in the viewer. */
+  onSelect: (path: string) => void;
+  /** Double-click: re-root on a folder, open in a panel on a file. Mirrors the tree. */
+  onActivateFile?: (path: string) => void;
+  onRootFolder?: (path: string) => void;
+  /** Same callback the tree uses, so both surfaces offer the identical menu. */
+  rowContextMenu?: (row: FileEntryLike) => React.ReactNode;
+  /**
+   * Absolute path the rows are relative to. Empty when no source resolves,
+   * which is the signal that rows can't be dragged anywhere useful (#11576).
+   */
+  basePath: string;
+  /** Accessible name; the column headers are decorative and can't supply one. */
+  label: string;
+}
+
+/**
+ * Virtualized listing of one folder's contents (#11620) — the viewer-column
+ * counterpart to `FileTreeView`, showing what a folder holds rather than
+ * leaving a selected folder looking the same as no selection at all.
+ *
+ * Rendered as flex rows through `react-virtuoso` rather than a table: the tree
+ * beside it is already virtualized the same way, and a real `<table>` can't be
+ * windowed without either fixing every column width or giving up on the
+ * semantics that made it a table.
+ *
+ * The header is a plain sticky sibling of the list, not part of it. That is
+ * partly forced — `fixedHeaderContent` exists only on `TableVirtuoso` — and
+ * partly the point: the labels are decorative (sorting lives in the toolbar
+ * menu, the single home for that control), so keeping them outside the
+ * virtualized DOM lets them be `aria-hidden` without hiding any row.
+ */
+export function FolderListingView({
+  rows,
+  selectedPath,
+  onSelect,
+  onActivateFile,
+  onRootFolder,
+  rowContextMenu,
+  basePath,
+  label,
+}: FolderListingViewProps) {
+  const context: ListingContext = useMemo(
+    () => ({
+      selectedPath,
+      onSelect,
+      onActivateFile,
+      onRootFolder,
+      rowContextMenu,
+      basePath,
+    }),
+    [selectedPath, onSelect, onActivateFile, onRootFolder, rowContextMenu, basePath]
+  );
+
+  return (
+    // A labelled group rather than a `listbox`: Virtuoso renders an element
+    // between its scroller and the rows, so `option` children would not be
+    // owned by the list that claimed them — and this surface has no roving
+    // focus or arrow-key navigation to back the role up either. The tree next
+    // to it is the keyboard-navigable view of the same data; this one states
+    // what it is and marks the current row, and promises nothing more.
+    <div
+      role="group"
+      aria-label={label}
+      className="flex min-h-0 w-full flex-1 flex-col overflow-hidden"
+    >
+      {/*
+        Decorative, and deliberately not a sortable header: sorting has exactly
+        one home (the toolbar menu), and a header that looks clickable but isn't
+        is worse than one that never invited the click. `aria-hidden` rather
+        than `role="columnheader"` for the same reason — with no `aria-sort` to
+        carry and no table to head, announcing them would promise a structure
+        the list doesn't have.
+      */}
+      <div
+        aria-hidden="true"
+        className="flex shrink-0 items-center gap-3 border-b border-overlay px-3 py-1 text-[11px] font-medium text-daintree-text/40"
+      >
+        <span className="min-w-0 flex-1">Name</span>
+        <span className="w-20 shrink-0 text-right">Size</span>
+        <span className="w-24 shrink-0 text-right">Modified</span>
+      </div>
+      <div className="min-h-0 flex-1">
+        <Virtuoso<FolderListingRow, ListingContext>
+          data={rows}
+          context={context}
+          computeItemKey={computeRowKey}
+          itemContent={renderRow}
+          fixedItemHeight={ROW_HEIGHT_PX}
+          skipAnimationFrameInResizeObserver
+          className="h-full w-full overflow-y-auto"
+        />
+      </div>
+    </div>
+  );
+}
+
+interface ListingContext {
+  selectedPath: string | null;
+  onSelect: (path: string) => void;
+  onActivateFile?: ((path: string) => void) | undefined;
+  onRootFolder?: ((path: string) => void) | undefined;
+  rowContextMenu?: ((row: FileEntryLike) => React.ReactNode) | undefined;
+  basePath: string;
+}
+
+/**
+ * Keyed by path, never by index: re-sorting from the toolbar menu reorders
+ * every row at once, and an index key would have Virtuoso reuse a row's DOM for
+ * a different entry rather than move it.
+ */
+function computeRowKey(_index: number, row: FolderListingRow): string {
+  return row.path;
+}
+
+function renderRow(_index: number, row: FolderListingRow, context: ListingContext) {
+  return (
+    <FolderListingRowView
+      row={row}
+      isSelected={context.selectedPath === row.path}
+      context={context}
+    />
+  );
+}
+
+interface FolderListingRowViewProps {
+  row: FolderListingRow;
+  isSelected: boolean;
+  context: ListingContext;
+}
+
+function FolderListingRowView({ row, isSelected, context }: FolderListingRowViewProps) {
+  const { onSelect, onActivateFile, onRootFolder } = context;
+
+  // Single click selects, exactly as in the tree. On a folder that also
+  // re-points this listing at it — the tree's click toggles expansion, and
+  // stepping into the folder is the listing's equivalent of that "look inside"
+  // gesture, since a flat listing has nothing to expand.
+  const handleClick = useCallback(() => {
+    onSelect(row.path);
+  }, [onSelect, row.path]);
+
+  // Same split as the tree's double-click (#11496): a folder re-roots the whole
+  // browser, a file opens in its own panel.
+  const handleDoubleClick = row.isDirectory
+    ? onRootFolder
+      ? () => {
+          onRootFolder(row.path);
+        }
+      : undefined
+    : onActivateFile
+      ? () => {
+          onActivateFile(row.path);
+        }
+      : undefined;
+
+  // Byte-for-byte the tree's drag contract (#11576), down to the single MIME
+  // type and the absent `text/plain`: a row dragged from either column has to
+  // arrive at an agent as the same reference, or the two would be different
+  // affordances that merely look alike.
+  const handleDragStart = (event: React.DragEvent<HTMLDivElement>) => {
+    const { dataTransfer } = event;
+    if (context.basePath === "") {
+      event.preventDefault();
+      return;
+    }
+    dataTransfer.setData(FILE_DRAG_MIME, encodeFileDragPaths([join(context.basePath, row.path)]));
+    dataTransfer.effectAllowed = "copy";
+    dataTransfer.setDragImage(event.currentTarget, 12, ROW_HEIGHT_PX / 2);
+  };
+
+  const fileIcon = row.isDirectory ? null : getFileTypeIcon(row.name);
+  const RowIcon = fileIcon?.Icon ?? Folder;
+  const rowIconColor = fileIcon?.colorClass ?? UNKNOWN_FILE_COLOR_CLASS;
+
+  const menuItems = context.rowContextMenu?.(row);
+  const rowSurface = (
+    <div
+      // `aria-current`, not `aria-selected`: the latter is only meaningful
+      // inside a role that owns selection, which this group deliberately isn't.
+      {...(isSelected && { "aria-current": true })}
+      aria-label={row.name}
+      draggable={context.basePath !== ""}
+      onDragStart={handleDragStart}
+      onClick={handleClick}
+      onDoubleClick={handleDoubleClick}
+      className={cn(
+        "flex h-7 w-full cursor-default select-none items-center gap-3 rounded px-2 font-mono text-xs",
+        // Neutral surface lift, not an accent fill — the same restraint the
+        // tree's selection follows, and both columns can be showing a selection
+        // at once.
+        "transition-colors duration-150 ease-out",
+        isSelected ? "bg-overlay-subtle text-daintree-text" : "text-daintree-text/70",
+        !isSelected && "hover:bg-tint/5",
+        "data-[state=open]:bg-overlay-raised data-[state=open]:text-daintree-text"
+      )}
+    >
+      <span className="flex min-w-0 flex-1 items-center gap-1.5">
+        <RowIcon
+          className={cn(FILE_TREE_ICON_CLASS, "h-3.5 w-3.5 shrink-0", rowIconColor)}
+          aria-hidden="true"
+        />
+        <span className={cn("truncate", isSelected && "font-medium")}>{row.name}</span>
+      </span>
+      <span className="w-20 shrink-0 text-right tabular-nums text-daintree-text/50">
+        {formatSize(row)}
+      </span>
+      <span className="w-24 shrink-0 truncate text-right text-daintree-text/50">
+        {row.mtimeMs == null ? UNKNOWN : formatRelativeTime(row.mtimeMs)}
+      </span>
+    </div>
+  );
+
+  if (!menuItems) {
+    return <div className="h-7 w-full px-1">{rowSurface}</div>;
+  }
+
+  return (
+    <div className="h-7 w-full px-1">
+      <ContextMenu>
+        <ContextMenuTrigger asChild>{rowSurface}</ContextMenuTrigger>
+        <ContextMenuContent>{menuItems}</ContextMenuContent>
+      </ContextMenu>
+    </div>
+  );
+}
+
+/**
+ * A folder reports how many entries it holds, never a byte total: summing a
+ * directory means walking it, and this listing is built entirely from what is
+ * already cached. A count is only known when that folder happens to have been
+ * listed too — otherwise the column says nothing rather than claiming zero.
+ */
+function formatSize(row: FolderListingRow): string {
+  if (row.isDirectory) {
+    if (row.itemCount == null) return UNKNOWN;
+    return row.itemCount === 1 ? "1 item" : `${row.itemCount} items`;
+  }
+  return row.size == null ? UNKNOWN : formatBytes(row.size);
+}

--- a/src/panels/file-browser/FolderListingView.tsx
+++ b/src/panels/file-browser/FolderListingView.tsx
@@ -22,12 +22,17 @@ const UNKNOWN = "—";
 
 export interface FolderListingViewProps {
   rows: FolderListingRow[];
-  selectedPath: string | null;
-  /** Selecting an entry — a folder re-points this listing, a file opens it in the viewer. */
+  /**
+   * Selecting an entry, which is this surface's whole click contract: a folder
+   * re-points the listing at itself, a file opens in the viewer.
+   *
+   * Deliberately no double-click counterpart to the tree's (#11496). Selecting
+   * is what replaces the listing's contents, so the first click of any
+   * double-click unmounts the row before the second arrives — a dblclick
+   * handler here could never fire. Re-rooting a folder from this surface lives
+   * in the row's context menu ("Set as root"), which is reachable.
+   */
   onSelect: (path: string) => void;
-  /** Double-click: re-root on a folder, open in a panel on a file. Mirrors the tree. */
-  onActivateFile?: (path: string) => void;
-  onRootFolder?: (path: string) => void;
   /** Same callback the tree uses, so both surfaces offer the identical menu. */
   rowContextMenu?: (row: FileEntryLike) => React.ReactNode;
   /**
@@ -57,24 +62,14 @@ export interface FolderListingViewProps {
  */
 export function FolderListingView({
   rows,
-  selectedPath,
   onSelect,
-  onActivateFile,
-  onRootFolder,
   rowContextMenu,
   basePath,
   label,
 }: FolderListingViewProps) {
   const context: ListingContext = useMemo(
-    () => ({
-      selectedPath,
-      onSelect,
-      onActivateFile,
-      onRootFolder,
-      rowContextMenu,
-      basePath,
-    }),
-    [selectedPath, onSelect, onActivateFile, onRootFolder, rowContextMenu, basePath]
+    () => ({ onSelect, rowContextMenu, basePath }),
+    [onSelect, rowContextMenu, basePath]
   );
 
   return (
@@ -121,10 +116,7 @@ export function FolderListingView({
 }
 
 interface ListingContext {
-  selectedPath: string | null;
   onSelect: (path: string) => void;
-  onActivateFile?: ((path: string) => void) | undefined;
-  onRootFolder?: ((path: string) => void) | undefined;
   rowContextMenu?: ((row: FileEntryLike) => React.ReactNode) | undefined;
   basePath: string;
 }
@@ -139,45 +131,25 @@ function computeRowKey(_index: number, row: FolderListingRow): string {
 }
 
 function renderRow(_index: number, row: FolderListingRow, context: ListingContext) {
-  return (
-    <FolderListingRowView
-      row={row}
-      isSelected={context.selectedPath === row.path}
-      context={context}
-    />
-  );
+  return <FolderListingRowView row={row} context={context} />;
 }
 
 interface FolderListingRowViewProps {
   row: FolderListingRow;
-  isSelected: boolean;
   context: ListingContext;
 }
 
-function FolderListingRowView({ row, isSelected, context }: FolderListingRowViewProps) {
-  const { onSelect, onActivateFile, onRootFolder } = context;
+function FolderListingRowView({ row, context }: FolderListingRowViewProps) {
+  const { onSelect } = context;
 
-  // Single click selects, exactly as in the tree. On a folder that also
-  // re-points this listing at it — the tree's click toggles expansion, and
-  // stepping into the folder is the listing's equivalent of that "look inside"
-  // gesture, since a flat listing has nothing to expand.
+  // Single click selects, and selecting is the whole gesture here: a folder
+  // re-points this listing at itself (the flat equivalent of the tree's
+  // expand-on-click "look inside"), and a file opens in the viewer. Either way
+  // the listing's contents change, which is why there is no double-click
+  // counterpart — see the note on `onSelect` in the props above.
   const handleClick = useCallback(() => {
     onSelect(row.path);
   }, [onSelect, row.path]);
-
-  // Same split as the tree's double-click (#11496): a folder re-roots the whole
-  // browser, a file opens in its own panel.
-  const handleDoubleClick = row.isDirectory
-    ? onRootFolder
-      ? () => {
-          onRootFolder(row.path);
-        }
-      : undefined
-    : onActivateFile
-      ? () => {
-          onActivateFile(row.path);
-        }
-      : undefined;
 
   // Byte-for-byte the tree's drag contract (#11576), down to the single MIME
   // type and the absent `text/plain`: a row dragged from either column has to
@@ -201,22 +173,16 @@ function FolderListingRowView({ row, isSelected, context }: FolderListingRowView
   const menuItems = context.rowContextMenu?.(row);
   const rowSurface = (
     <div
-      // `aria-current`, not `aria-selected`: the latter is only meaningful
-      // inside a role that owns selection, which this group deliberately isn't.
-      {...(isSelected && { "aria-current": true })}
       aria-label={row.name}
       draggable={context.basePath !== ""}
       onDragStart={handleDragStart}
       onClick={handleClick}
-      onDoubleClick={handleDoubleClick}
       className={cn(
         "flex h-7 w-full cursor-default select-none items-center gap-3 rounded px-2 font-mono text-xs",
-        // Neutral surface lift, not an accent fill — the same restraint the
-        // tree's selection follows, and both columns can be showing a selection
-        // at once.
-        "transition-colors duration-150 ease-out",
-        isSelected ? "bg-overlay-subtle text-daintree-text" : "text-daintree-text/70",
-        !isSelected && "hover:bg-tint/5",
+        // Neutral hover, no selected state: clicking a row always replaces what
+        // this listing is showing, so no row is ever the standing selection —
+        // a highlight would only ever paint for the frame before it unmounts.
+        "text-daintree-text/70 transition-colors duration-150 ease-out hover:bg-tint/5",
         "data-[state=open]:bg-overlay-raised data-[state=open]:text-daintree-text"
       )}
     >
@@ -225,7 +191,7 @@ function FolderListingRowView({ row, isSelected, context }: FolderListingRowView
           className={cn(FILE_TREE_ICON_CLASS, "h-3.5 w-3.5 shrink-0", rowIconColor)}
           aria-hidden="true"
         />
-        <span className={cn("truncate", isSelected && "font-medium")}>{row.name}</span>
+        <span className="truncate">{row.name}</span>
       </span>
       <span className="w-20 shrink-0 text-right tabular-nums text-daintree-text/50">
         {formatSize(row)}

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -51,10 +51,22 @@ const {
       refresh: vi.fn(),
       isRefreshing: false,
       captureSnapshot: (() => null) as () => unknown,
+      // Folder-listing surface (#11620). Defaulted to "no folder is being
+      // listed" so every case below keeps exercising the file/empty branches;
+      // `selectedNode` is filled in per render by the mock factory, which is
+      // where the selected path is actually known.
+      listingPath: null as string | null,
+      listingRows: null as unknown[] | null,
+      listingStatus: "ready" as "pending" | "ready" | "error",
+      listingHasHiddenDotfiles: false,
     },
     // What the pane last handed the tree hook, so a test can assert the derived
     // change tick rather than only what renders.
-    treeArgs: { changeTick: undefined as number | undefined },
+    treeArgs: {
+      changeTick: undefined as number | undefined,
+      sort: undefined as { key: string; direction: string } | undefined,
+      selectedPath: undefined as string | null | undefined,
+    },
     // Ticks the worktree store reports for wt-1; both default to "never moved".
     worktreeTicks: { git: undefined as number | undefined, fs: undefined as number | undefined },
     // The rest of what the store reports for wt-1. `changes` stays null by
@@ -162,9 +174,23 @@ vi.mock("@/hooks/useWorktreeStore", () => ({
 // state bag so the tree column renders its header (and the FileTreeView stub
 // below) without touching filesClient, and tests can drive error states.
 vi.mock("../useFileBrowserTree", () => ({
-  useFileBrowserTree: (args: { changeTick?: number }) => {
+  useFileBrowserTree: (args: {
+    changeTick?: number;
+    sort?: { key: string; direction: string };
+    selectedPath?: string | null;
+  }) => {
     treeArgs.changeTick = args.changeTick;
-    return { ...treeState };
+    treeArgs.sort = args.sort;
+    treeArgs.selectedPath = args.selectedPath;
+    // The real hook resolves this against its listings map; here the stubbed
+    // rows are the only data there is, so match by path against them. That
+    // reproduces what the pane used to compute for itself, keeping the
+    // selection cases below unchanged by the move (#11620).
+    const selectedNode =
+      args.selectedPath == null
+        ? undefined
+        : treeState.rows.find((row) => row.path === args.selectedPath);
+    return { ...treeState, selectedNode };
   },
 }));
 

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -87,6 +87,7 @@ interface MockPanel {
   browserSelectedPath?: string;
   browserExpandedPaths?: string[];
   browserShowIgnored?: boolean;
+  browserHideDotfiles?: boolean;
   browserRootPath?: string;
   browserSidebarCollapsed?: boolean;
   browserViewerCollapsed?: boolean;
@@ -2503,5 +2504,44 @@ describe("FileBrowserPane git status derivation", () => {
     renderPane();
 
     await waitFor(() => expect(treeArgs.changeTick).toBe(450));
+  });
+});
+
+describe("a selection the dotfile filter hides (#11620)", () => {
+  beforeEach(() => {
+    treeState.rows = [
+      {
+        path: ".env",
+        name: ".env",
+        isDirectory: false,
+        depth: 0,
+        isExpanded: false,
+        isLoading: false,
+      },
+    ] as typeof treeState.rows;
+    mockPanel.browserSelectedPath = ".env";
+    mockPanel.browserHideDotfiles = false;
+  });
+
+  afterEach(() => {
+    treeState.rows = defaultRows as typeof treeState.rows;
+    delete mockPanel.browserSelectedPath;
+    delete mockPanel.browserHideDotfiles;
+  });
+
+  it("previews a dotfile while dotfiles are visible", () => {
+    renderPane();
+    expect(treeArgs.selectedPath).toBe(".env");
+    expect(screen.queryByText("Nothing selected")).toBeNull();
+  });
+
+  it("stops previewing it once the dotfile toggle hides it", () => {
+    // The node now resolves from the listings map rather than from the
+    // rendered rows, so it survives the filter that removed its row — without
+    // an explicit visibility gate the viewer would keep the file's contents on
+    // screen while the tree stopped showing the file at all.
+    mockPanel.browserHideDotfiles = true;
+    renderPane();
+    expect(screen.getByText("Nothing selected")).toBeTruthy();
   });
 });

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { forwardRef, type ReactNode } from "react";
+import { createContext, forwardRef, useContext, type ReactNode } from "react";
 import { fireEvent, render, act, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Type-only: erased before the vi.mock factory runs, so it cannot pull the real
@@ -63,6 +63,7 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
     asChild ? <>{children}</> : <button type="button">{children}</button>,
   DropdownMenuContent: ({ children }: { children: ReactNode }) => <div role="menu">{children}</div>,
   DropdownMenuLabel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <hr />,
   DropdownMenuRadioGroup: ({
     children,
     value,
@@ -72,24 +73,24 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
     value: string;
     onValueChange: (v: string) => void;
   }) => (
-    <div data-value={value} data-onvaluechange={registerValueChange(onValueChange)}>
-      {children}
-    </div>
+    <RadioGroupContext.Provider value={onValueChange}>
+      <div data-value={value}>{children}</div>
+    </RadioGroupContext.Provider>
   ),
-  DropdownMenuRadioItem: ({ children, value }: { children: ReactNode; value: string }) => (
-    <div role="menuitemradio" onClick={() => currentValueChange?.(value)}>
-      {children}
-    </div>
-  ),
+  DropdownMenuRadioItem: ({ children, value }: { children: ReactNode; value: string }) => {
+    const onValueChange = useContext(RadioGroupContext);
+    return (
+      <div role="menuitemradio" onClick={() => onValueChange?.(value)}>
+        {children}
+      </div>
+    );
+  },
 }));
 
-// The radio group owns the change handler but the items are what get clicked,
-// so the handler is stashed as the group renders and read back by the item.
-let currentValueChange: ((value: string) => void) | null = null;
-function registerValueChange(handler: (value: string) => void): string {
-  currentValueChange = handler;
-  return "registered";
-}
+// Context, not a module-level stash: there are two radio groups now (key and
+// direction), and a single shared handler would route every click to whichever
+// group rendered last — passing the tests for the wrong reason.
+const RadioGroupContext = createContext<((value: string) => void) | null>(null);
 
 // The folder listing (#11620) virtualizes its rows, and a real Virtuoso renders
 // none of them in jsdom, where every element measures zero. Render them all —
@@ -142,8 +143,6 @@ interface ViewerOpts {
   folderHasHiddenDotfiles?: boolean;
   onShowDotfiles?: () => void;
   onSelectEntry?: (path: string) => void;
-  onActivateEntry?: (path: string) => void;
-  onRootFolder?: (path: string) => void;
   rowContextMenu?: (row: FileEntryLike) => React.ReactNode;
   sort?: FileBrowserSortOrder;
   onSortChange?: (sort: FileBrowserSortOrder) => void;
@@ -186,8 +185,6 @@ function viewerJsx(filePath: string | null, opts: ViewerOpts = {}) {
         folderHasHiddenDotfiles={opts.folderHasHiddenDotfiles ?? false}
         onShowDotfiles={opts.onShowDotfiles ?? vi.fn()}
         onSelectEntry={opts.onSelectEntry ?? vi.fn()}
-        onActivateEntry={opts.onActivateEntry ?? vi.fn()}
-        onRootFolder={opts.onRootFolder ?? vi.fn()}
         {...(opts.rowContextMenu ? { rowContextMenu: opts.rowContextMenu } : {})}
         basePath="/repo"
         sort={opts.sort ?? { key: "name", direction: "asc" }}
@@ -751,13 +748,13 @@ describe("folder-selected state (#11620)", () => {
     // The #10083 trap: branching on a Doherty-gated flag would paint "This
     // folder is empty" for the first 400ms of every folder load.
     renderViewer(null, { folderPath: "src", folderRows: null, folderStatus: "pending" });
-    expect(screen.queryByText("This folder is empty")).toBeNull();
+    expect(screen.queryByText("Nothing in this folder yet")).toBeNull();
     expect(screen.queryByText("Nothing selected")).toBeNull();
   });
 
   it("shows the empty state for a folder that really holds nothing", () => {
     renderViewer(null, { folderPath: "src", folderRows: [], folderStatus: "ready" });
-    expect(screen.getByText("This folder is empty")).toBeTruthy();
+    expect(screen.getByText("Nothing in this folder yet")).toBeTruthy();
   });
 
   it("offers Show dotfiles only when unhiding them would reveal something", () => {
@@ -816,26 +813,43 @@ describe("folder-selected state (#11620)", () => {
 describe("sort menu (#11620)", () => {
   it("stays available with no selection, since it also orders the tree", () => {
     renderViewer(null);
-    expect(screen.getByRole("button", { name: "Sort files" })).toBeTruthy();
+    expect(screen.getByTestId("file-browser-sort-menu")).toBeTruthy();
   });
 
-  it("flips direction when the active key is re-picked", async () => {
-    const onSortChange = vi.fn();
-    renderViewer(null, { sort: { key: "name", direction: "asc" }, onSortChange });
-    fireEvent.click(await screen.findByRole("menuitemradio", { name: /Name/ }));
-    expect(onSortChange).toHaveBeenCalledWith({ key: "name", direction: "desc" });
+  it("names the current key and direction so the arrow icon isn't the only cue", () => {
+    // The arrow is aria-hidden, so the accessible name is the only place a
+    // screen reader can learn which way the list runs.
+    renderViewer(null, { sort: { key: "size", direction: "desc" } });
+    expect(screen.getByRole("button", { name: "Sort files (Size, descending)" })).toBeTruthy();
   });
 
-  it("keeps the current direction when a different key is picked", async () => {
+  it("changes the key without disturbing the direction", () => {
     const onSortChange = vi.fn();
     renderViewer(null, { sort: { key: "name", direction: "desc" }, onSortChange });
-    fireEvent.click(await screen.findByRole("menuitemradio", { name: /Size/ }));
+    fireEvent.click(screen.getByRole("menuitemradio", { name: "Size" }));
     expect(onSortChange).toHaveBeenCalledWith({ key: "size", direction: "desc" });
   });
 
-  it("offers exactly the four documented sort keys", async () => {
+  it("changes the direction without disturbing the key", () => {
+    const onSortChange = vi.fn();
+    renderViewer(null, { sort: { key: "modified", direction: "asc" }, onSortChange });
+    fireEvent.click(screen.getByRole("menuitemradio", { name: "Descending" }));
+    expect(onSortChange).toHaveBeenCalledWith({ key: "modified", direction: "desc" });
+  });
+
+  it("can set a direction outright rather than only reversing the current one", () => {
+    // The reason this is a radio group and not a re-pick-to-flip gesture:
+    // choosing the direction already in effect is a no-op the user can rely on,
+    // not a silent reversal.
+    const onSortChange = vi.fn();
+    renderViewer(null, { sort: { key: "name", direction: "asc" }, onSortChange });
+    fireEvent.click(screen.getByRole("menuitemradio", { name: "Ascending" }));
+    expect(onSortChange).toHaveBeenCalledWith({ key: "name", direction: "asc" });
+  });
+
+  it("offers the four documented keys and both directions", () => {
     renderViewer(null);
-    const items = await screen.findAllByRole("menuitemradio");
-    expect(items.map((i) => i.textContent?.trim())).toEqual(["Name", "Modified", "Size", "Type"]);
+    const names = screen.getAllByRole("menuitemradio").map((i) => i.textContent?.trim());
+    expect(names).toEqual(["Name", "Modified", "Size", "Type", "Ascending", "Descending"]);
   });
 });

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { render, act, screen, waitFor } from "@testing-library/react";
+import { forwardRef, type ReactNode } from "react";
+import { fireEvent, render, act, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Type-only: erased before the vi.mock factory runs, so it cannot pull the real
 // module in ahead of its own mock.
@@ -51,10 +52,73 @@ vi.mock("@/components/ui/SpinningIcon", () => ({
   ),
 }));
 
+// Radix's dropdown opens on a pointer sequence and portals its content, neither
+// of which jsdom drives faithfully. Render the menu inline and let the radio
+// items fire their own onValueChange — what this suite owns is the sort
+// contract (which keys, and how re-picking flips direction), not Radix's
+// open/close choreography. Mirrors the ReviewHub sort-menu suite.
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children, asChild }: { children: ReactNode; asChild?: boolean }) =>
+    asChild ? <>{children}</> : <button type="button">{children}</button>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div role="menu">{children}</div>,
+  DropdownMenuLabel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuRadioGroup: ({
+    children,
+    value,
+    onValueChange,
+  }: {
+    children: ReactNode;
+    value: string;
+    onValueChange: (v: string) => void;
+  }) => (
+    <div data-value={value} data-onvaluechange={registerValueChange(onValueChange)}>
+      {children}
+    </div>
+  ),
+  DropdownMenuRadioItem: ({ children, value }: { children: ReactNode; value: string }) => (
+    <div role="menuitemradio" onClick={() => currentValueChange?.(value)}>
+      {children}
+    </div>
+  ),
+}));
+
+// The radio group owns the change handler but the items are what get clicked,
+// so the handler is stashed as the group renders and read back by the item.
+let currentValueChange: ((value: string) => void) | null = null;
+function registerValueChange(handler: (value: string) => void): string {
+  currentValueChange = handler;
+  return "registered";
+}
+
+// The folder listing (#11620) virtualizes its rows, and a real Virtuoso renders
+// none of them in jsdom, where every element measures zero. Render them all —
+// what this suite owns is which body the viewer picks, not how it windows.
+vi.mock("react-virtuoso", () => ({
+  Virtuoso: forwardRef(function VirtuosoStub(
+    props: {
+      data: unknown[];
+      context: unknown;
+      itemContent: (index: number, row: never, context: unknown) => ReactNode;
+    },
+    _ref
+  ) {
+    return (
+      <div>
+        {props.data.map((row, index) => (
+          <div key={index}>{props.itemContent(index, row as never, props.context)}</div>
+        ))}
+      </div>
+    );
+  }),
+}));
+
 import { FileBrowserViewer } from "../FileBrowserViewer";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { GitStatus } from "@shared/types/git";
 import type { WorkingTreeFileChange } from "@/lib/workingTreeDiff";
+import type { FileBrowserSortOrder, FileEntryLike, FolderListingRow } from "../fileBrowserTree";
+import type { FolderListingStatus } from "../useFileBrowserTree";
 
 interface ViewerOpts {
   sidebarCollapsed?: boolean;
@@ -70,6 +134,19 @@ interface ViewerOpts {
    */
   changedFiles?: readonly WorkingTreeFileChange[] | null;
   onSelectChangedFile?: (relativePath: string) => void;
+  // Folder-selected state (#11620). Defaulted to "no folder" so every existing
+  // file-preview case keeps exercising the file branch untouched.
+  folderPath?: string | null;
+  folderRows?: FolderListingRow[] | null;
+  folderStatus?: FolderListingStatus;
+  folderHasHiddenDotfiles?: boolean;
+  onShowDotfiles?: () => void;
+  onSelectEntry?: (path: string) => void;
+  onActivateEntry?: (path: string) => void;
+  onRootFolder?: (path: string) => void;
+  rowContextMenu?: (row: FileEntryLike) => React.ReactNode;
+  sort?: FileBrowserSortOrder;
+  onSortChange?: (sort: FileBrowserSortOrder) => void;
 }
 
 function change(relativePath: string, status: GitStatus = "modified"): WorkingTreeFileChange {
@@ -103,6 +180,18 @@ function viewerJsx(filePath: string | null, opts: ViewerOpts = {}) {
         treeSidebarId="file-tree-column"
         changedFiles={opts.changedFiles ?? null}
         onSelectChangedFile={opts.onSelectChangedFile ?? vi.fn()}
+        folderPath={opts.folderPath ?? null}
+        folderRows={opts.folderRows ?? null}
+        folderStatus={opts.folderStatus ?? "ready"}
+        folderHasHiddenDotfiles={opts.folderHasHiddenDotfiles ?? false}
+        onShowDotfiles={opts.onShowDotfiles ?? vi.fn()}
+        onSelectEntry={opts.onSelectEntry ?? vi.fn()}
+        onActivateEntry={opts.onActivateEntry ?? vi.fn()}
+        onRootFolder={opts.onRootFolder ?? vi.fn()}
+        {...(opts.rowContextMenu ? { rowContextMenu: opts.rowContextMenu } : {})}
+        basePath="/repo"
+        sort={opts.sort ?? { key: "name", direction: "asc" }}
+        onSortChange={opts.onSortChange ?? vi.fn()}
       />
     </TooltipProvider>
   );
@@ -630,5 +719,123 @@ describe("FileBrowserViewer idle body", () => {
     await screen.findByTestId("code-viewer-mock");
 
     expect(screen.queryByRole("button", { name: /Read src\/app\.ts/ })).toBeNull();
+  });
+});
+
+describe("folder-selected state (#11620)", () => {
+  const FOLDER_ROWS: FolderListingRow[] = [
+    { path: "src/pkg", name: "pkg", isDirectory: true, itemCount: 2 },
+    { path: "src/a.ts", name: "a.ts", isDirectory: false, size: 100, mtimeMs: 1_700_000_000_000 },
+  ];
+
+  it("lists a selected folder's contents instead of the nothing-selected state", () => {
+    renderViewer(null, { folderPath: "src", folderRows: FOLDER_ROWS });
+    expect(screen.queryByText("Nothing selected")).toBeNull();
+    expect(screen.getByLabelText("pkg")).toBeTruthy();
+    expect(screen.getByLabelText("a.ts")).toBeTruthy();
+  });
+
+  it("still shows the nothing-selected state when neither a file nor a folder is selected", () => {
+    renderViewer(null);
+    expect(screen.getByText("Nothing selected")).toBeTruthy();
+  });
+
+  it("prefers the file preview when a file is selected", () => {
+    // The two are mutually exclusive by construction; if both ever arrived, the
+    // file must win rather than the viewer rendering two bodies.
+    renderViewer("/repo/a.ts", { folderPath: "src", folderRows: FOLDER_ROWS });
+    expect(screen.queryByLabelText("pkg")).toBeNull();
+  });
+
+  it("does not render the empty state while the listing is still pending", () => {
+    // The #10083 trap: branching on a Doherty-gated flag would paint "This
+    // folder is empty" for the first 400ms of every folder load.
+    renderViewer(null, { folderPath: "src", folderRows: null, folderStatus: "pending" });
+    expect(screen.queryByText("This folder is empty")).toBeNull();
+    expect(screen.queryByText("Nothing selected")).toBeNull();
+  });
+
+  it("shows the empty state for a folder that really holds nothing", () => {
+    renderViewer(null, { folderPath: "src", folderRows: [], folderStatus: "ready" });
+    expect(screen.getByText("This folder is empty")).toBeTruthy();
+  });
+
+  it("offers Show dotfiles only when unhiding them would reveal something", () => {
+    renderViewer(null, {
+      folderPath: "src",
+      folderRows: [],
+      folderStatus: "ready",
+      folderHasHiddenDotfiles: true,
+    });
+    expect(screen.getByText("Dotfiles are hidden here")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Show dotfiles" })).toBeTruthy();
+  });
+
+  it("does not offer Show dotfiles when the folder is genuinely empty", () => {
+    renderViewer(null, {
+      folderPath: "src",
+      folderRows: [],
+      folderStatus: "ready",
+      folderHasHiddenDotfiles: false,
+    });
+    expect(screen.queryByRole("button", { name: "Show dotfiles" })).toBeNull();
+  });
+
+  it("runs the dotfile recovery from the filtered-empty state", async () => {
+    const onShowDotfiles = vi.fn();
+    renderViewer(null, {
+      folderPath: "src",
+      folderRows: [],
+      folderStatus: "ready",
+      folderHasHiddenDotfiles: true,
+      onShowDotfiles,
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Show dotfiles" }));
+    expect(onShowDotfiles).toHaveBeenCalled();
+  });
+
+  it("surfaces a readable error with a retry when the folder can't be read", () => {
+    renderViewer(null, { folderPath: "src", folderRows: null, folderStatus: "error" });
+    expect(screen.getByText("Can't show this folder")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+  });
+
+  it("retries through the pane's refresh", async () => {
+    const onRefresh = vi.fn();
+    renderViewer(null, {
+      folderPath: "src",
+      folderRows: null,
+      folderStatus: "error",
+      onRefresh,
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRefresh).toHaveBeenCalled();
+  });
+});
+
+describe("sort menu (#11620)", () => {
+  it("stays available with no selection, since it also orders the tree", () => {
+    renderViewer(null);
+    expect(screen.getByRole("button", { name: "Sort files" })).toBeTruthy();
+  });
+
+  it("flips direction when the active key is re-picked", async () => {
+    const onSortChange = vi.fn();
+    renderViewer(null, { sort: { key: "name", direction: "asc" }, onSortChange });
+    fireEvent.click(await screen.findByRole("menuitemradio", { name: /Name/ }));
+    expect(onSortChange).toHaveBeenCalledWith({ key: "name", direction: "desc" });
+  });
+
+  it("keeps the current direction when a different key is picked", async () => {
+    const onSortChange = vi.fn();
+    renderViewer(null, { sort: { key: "name", direction: "desc" }, onSortChange });
+    fireEvent.click(await screen.findByRole("menuitemradio", { name: /Size/ }));
+    expect(onSortChange).toHaveBeenCalledWith({ key: "size", direction: "desc" });
+  });
+
+  it("offers exactly the four documented sort keys", async () => {
+    renderViewer(null);
+    const items = await screen.findAllByRole("menuitemradio");
+    expect(items.map((i) => i.textContent?.trim())).toEqual(["Name", "Modified", "Size", "Type"]);
   });
 });

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -96,18 +96,18 @@ const RadioGroupContext = createContext<((value: string) => void) | null>(null);
 // none of them in jsdom, where every element measures zero. Render them all —
 // what this suite owns is which body the viewer picks, not how it windows.
 vi.mock("react-virtuoso", () => ({
-  Virtuoso: forwardRef(function VirtuosoStub(
+  Virtuoso: forwardRef(function VirtuosoStub<Row>(
     props: {
-      data: unknown[];
+      data: Row[];
       context: unknown;
-      itemContent: (index: number, row: never, context: unknown) => ReactNode;
+      itemContent: (index: number, row: Row, context: unknown) => ReactNode;
     },
-    _ref
+    _ref: unknown
   ) {
     return (
       <div>
         {props.data.map((row, index) => (
-          <div key={index}>{props.itemContent(index, row as never, props.context)}</div>
+          <div key={index}>{props.itemContent(index, row, props.context)}</div>
         ))}
       </div>
     );

--- a/src/panels/file-browser/__tests__/FolderListingView.test.tsx
+++ b/src/panels/file-browser/__tests__/FolderListingView.test.tsx
@@ -32,6 +32,19 @@ function row(path: string, extra: Partial<FolderListingRow> = {}): FolderListing
   return { path, name: path.split("/").pop()!, isDirectory: false, ...extra };
 }
 
+/** The em-dash the listing renders for a column it has no value for. */
+const UNKNOWN = "—";
+
+/**
+ * `[name, size, modified]` as actually rendered for one row. Reading all three
+ * cells is what makes the unknown-metadata assertions mean something: checking
+ * only that "0 B" is absent would also pass for a blank or missing cell.
+ */
+function cellsOf(name: string): string[] {
+  const rowEl = screen.getByLabelText(name);
+  return Array.from(rowEl.children).map((cell) => cell.textContent?.trim() ?? "");
+}
+
 function renderListing(
   rows: FolderListingRow[],
   props: Partial<Parameters<typeof FolderListingView>[0]> = {}
@@ -39,7 +52,6 @@ function renderListing(
   return render(
     <FolderListingView
       rows={rows}
-      selectedPath={null}
       onSelect={vi.fn()}
       basePath="/repo"
       label="Contents of src"
@@ -72,11 +84,19 @@ describe("FolderListingView", () => {
     expect(container.querySelector("[role='columnheader']")).toBeNull();
   });
 
-  it("renders a file's byte size and an em-dash when the size is unknown", () => {
+  it("renders a file's byte size, and an em-dash in the row that has none", () => {
     renderListing([row("src/known.ts", { size: 2048 }), row("src/unknown.ts")]);
-    expect(screen.getByText("2 KB")).toBeTruthy();
-    // A snapshot-restored row has no size; it must not read as "0 B".
-    expect(screen.queryByText("0 B")).toBeNull();
+    expect(cellsOf("known.ts")).toEqual(["known.ts", "2 KB", UNKNOWN]);
+    // A snapshot-restored row has neither size nor mtime; both cells must say
+    // "unknown" rather than "0 B" / a fabricated date.
+    expect(cellsOf("unknown.ts")).toEqual(["unknown.ts", UNKNOWN, UNKNOWN]);
+  });
+
+  it("renders a modified time when the row carries one", () => {
+    renderListing([row("src/a.ts", { size: 1, mtimeMs: Date.now() - 60_000 })]);
+    const [, , modified] = cellsOf("a.ts");
+    expect(modified).not.toBe(UNKNOWN);
+    expect(modified).toMatch(/minute/);
   });
 
   it("reports a folder's item count rather than a byte size", () => {
@@ -89,11 +109,11 @@ describe("FolderListingView", () => {
     expect(screen.getByText("1 item")).toBeTruthy();
   });
 
-  it("shows nothing rather than zero for a folder whose contents are unknown", () => {
+  it("shows an em-dash rather than zero for a folder whose contents are unknown", () => {
     // Never walked, never counted — "0 items" would be a claim the listing has
     // no basis for, since counting means listing.
     renderListing([row("src/pkg", { isDirectory: true })]);
-    expect(screen.queryByText("0 items")).toBeNull();
+    expect(cellsOf("pkg")).toEqual(["pkg", UNKNOWN, UNKNOWN]);
   });
 
   it("selects a row on single click", () => {
@@ -101,29 +121,6 @@ describe("FolderListingView", () => {
     renderListing([row("src/a.ts")], { onSelect });
     fireEvent.click(screen.getByLabelText("a.ts"));
     expect(onSelect).toHaveBeenCalledWith("src/a.ts");
-  });
-
-  it("opens a file in its own panel on double click, mirroring the tree", () => {
-    const onActivateFile = vi.fn();
-    renderListing([row("src/a.ts")], { onActivateFile });
-    fireEvent.doubleClick(screen.getByLabelText("a.ts"));
-    expect(onActivateFile).toHaveBeenCalledWith("src/a.ts");
-  });
-
-  it("re-roots the browser on a folder double click, mirroring the tree", () => {
-    const onRootFolder = vi.fn();
-    const onActivateFile = vi.fn();
-    renderListing([row("src/pkg", { isDirectory: true })], { onRootFolder, onActivateFile });
-    fireEvent.doubleClick(screen.getByLabelText("pkg"));
-    expect(onRootFolder).toHaveBeenCalledWith("src/pkg");
-    // A folder must never take the file path — the two gestures are distinct.
-    expect(onActivateFile).not.toHaveBeenCalled();
-  });
-
-  it("marks the selected row as current without claiming list-selection semantics", () => {
-    renderListing([row("src/a.ts"), row("src/b.ts")], { selectedPath: "src/a.ts" });
-    expect(screen.getByLabelText("a.ts").getAttribute("aria-current")).toBe("true");
-    expect(screen.getByLabelText("b.ts").getAttribute("aria-current")).toBeNull();
   });
 
   it("makes rows draggable when a base path resolves", () => {
@@ -162,5 +159,31 @@ describe("FolderListingView", () => {
     renderListing([row("src/z.ts"), row("src/a.ts")]);
     const names = screen.getAllByText(/\.ts$/).map((node) => node.textContent);
     expect(names).toEqual(["z.ts", "a.ts"]);
+  });
+});
+
+describe("FolderListingView has no double-click gesture", () => {
+  it("treats a real double-click as nothing but its two clicks", () => {
+    // A native double-click is click, click, dblclick. If a dblclick handler
+    // existed it would fire a third, different action here; the row exposes
+    // only selection, so the gesture degrades to two ordinary selects rather
+    // than half-invoking something that can't work.
+    const onSelect = vi.fn();
+    renderListing([row("src/a.ts")], { onSelect });
+    const rowEl = screen.getByLabelText("a.ts");
+    fireEvent.click(rowEl);
+    fireEvent.click(rowEl);
+    fireEvent.doubleClick(rowEl);
+    expect(onSelect.mock.calls).toEqual([["src/a.ts"], ["src/a.ts"]]);
+  });
+
+  it("re-points on a single click, which is what makes a second click land elsewhere", () => {
+    const onSelect = vi.fn();
+    renderListing([row("src/pkg", { isDirectory: true })], { onSelect });
+    fireEvent.click(screen.getByLabelText("pkg"));
+    // One selection per click; the pane re-points the listing off the back of
+    // it, which is the behaviour that rules a double-click out.
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith("src/pkg");
   });
 });

--- a/src/panels/file-browser/__tests__/FolderListingView.test.tsx
+++ b/src/panels/file-browser/__tests__/FolderListingView.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+import { forwardRef, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { FolderListingRow } from "../fileBrowserTree";
+
+// Render every row: virtualization itself is not under test, and the row
+// interactions below need a real DOM node per item.
+vi.mock("react-virtuoso", () => ({
+  Virtuoso: forwardRef(function VirtuosoStub(
+    props: {
+      data: FolderListingRow[];
+      context: unknown;
+      itemContent: (index: number, row: FolderListingRow, context: unknown) => ReactNode;
+    },
+    _ref
+  ) {
+    return (
+      <div>
+        {props.data.map((row, index) => (
+          <div key={row.path}>{props.itemContent(index, row, props.context)}</div>
+        ))}
+      </div>
+    );
+  }),
+}));
+
+import { FolderListingView } from "../FolderListingView";
+import { ContextMenuItem } from "@/components/ui/context-menu";
+
+function row(path: string, extra: Partial<FolderListingRow> = {}): FolderListingRow {
+  return { path, name: path.split("/").pop()!, isDirectory: false, ...extra };
+}
+
+function renderListing(
+  rows: FolderListingRow[],
+  props: Partial<Parameters<typeof FolderListingView>[0]> = {}
+) {
+  return render(
+    <FolderListingView
+      rows={rows}
+      selectedPath={null}
+      onSelect={vi.fn()}
+      basePath="/repo"
+      label="Contents of src"
+      {...props}
+    />
+  );
+}
+
+describe("FolderListingView", () => {
+  it("labels the region so the listing is identifiable without its headers", () => {
+    // The column headers are aria-hidden, so the group label is the only
+    // accessible name this surface has.
+    renderListing([row("src/a.ts")]);
+    expect(screen.getByRole("group", { name: "Contents of src" })).toBeTruthy();
+  });
+
+  it("hides the column headers from assistive tech", () => {
+    // Decorative by contract: sorting lives in the toolbar menu, so headers must
+    // not read as sortable columns.
+    const { container } = renderListing([row("src/a.ts")]);
+    const header = container.querySelector('[aria-hidden="true"]');
+    expect(header?.textContent).toContain("Name");
+    expect(header?.textContent).toContain("Size");
+    expect(header?.textContent).toContain("Modified");
+  });
+
+  it("does not mark any header as a sortable column", () => {
+    const { container } = renderListing([row("src/a.ts")]);
+    expect(container.querySelector("[aria-sort]")).toBeNull();
+    expect(container.querySelector("[role='columnheader']")).toBeNull();
+  });
+
+  it("renders a file's byte size and an em-dash when the size is unknown", () => {
+    renderListing([row("src/known.ts", { size: 2048 }), row("src/unknown.ts")]);
+    expect(screen.getByText("2 KB")).toBeTruthy();
+    // A snapshot-restored row has no size; it must not read as "0 B".
+    expect(screen.queryByText("0 B")).toBeNull();
+  });
+
+  it("reports a folder's item count rather than a byte size", () => {
+    renderListing([row("src/pkg", { isDirectory: true, itemCount: 3 })]);
+    expect(screen.getByText("3 items")).toBeTruthy();
+  });
+
+  it("singularizes a one-item folder", () => {
+    renderListing([row("src/pkg", { isDirectory: true, itemCount: 1 })]);
+    expect(screen.getByText("1 item")).toBeTruthy();
+  });
+
+  it("shows nothing rather than zero for a folder whose contents are unknown", () => {
+    // Never walked, never counted — "0 items" would be a claim the listing has
+    // no basis for, since counting means listing.
+    renderListing([row("src/pkg", { isDirectory: true })]);
+    expect(screen.queryByText("0 items")).toBeNull();
+  });
+
+  it("selects a row on single click", () => {
+    const onSelect = vi.fn();
+    renderListing([row("src/a.ts")], { onSelect });
+    fireEvent.click(screen.getByLabelText("a.ts"));
+    expect(onSelect).toHaveBeenCalledWith("src/a.ts");
+  });
+
+  it("opens a file in its own panel on double click, mirroring the tree", () => {
+    const onActivateFile = vi.fn();
+    renderListing([row("src/a.ts")], { onActivateFile });
+    fireEvent.doubleClick(screen.getByLabelText("a.ts"));
+    expect(onActivateFile).toHaveBeenCalledWith("src/a.ts");
+  });
+
+  it("re-roots the browser on a folder double click, mirroring the tree", () => {
+    const onRootFolder = vi.fn();
+    const onActivateFile = vi.fn();
+    renderListing([row("src/pkg", { isDirectory: true })], { onRootFolder, onActivateFile });
+    fireEvent.doubleClick(screen.getByLabelText("pkg"));
+    expect(onRootFolder).toHaveBeenCalledWith("src/pkg");
+    // A folder must never take the file path — the two gestures are distinct.
+    expect(onActivateFile).not.toHaveBeenCalled();
+  });
+
+  it("marks the selected row as current without claiming list-selection semantics", () => {
+    renderListing([row("src/a.ts"), row("src/b.ts")], { selectedPath: "src/a.ts" });
+    expect(screen.getByLabelText("a.ts").getAttribute("aria-current")).toBe("true");
+    expect(screen.getByLabelText("b.ts").getAttribute("aria-current")).toBeNull();
+  });
+
+  it("makes rows draggable when a base path resolves", () => {
+    renderListing([row("src/a.ts")]);
+    expect(screen.getByLabelText("a.ts").getAttribute("draggable")).toBe("true");
+  });
+
+  it("refuses to advertise a drag with no base path to make it absolute", () => {
+    // A drag carrying no data is one Chromium starts and nothing can accept,
+    // which reads as broken rather than absent (#11576).
+    renderListing([row("src/a.ts")], { basePath: "" });
+    expect(screen.getByLabelText("a.ts").getAttribute("draggable")).toBe("false");
+  });
+
+  it("wraps rows in a context menu when the pane supplies one", async () => {
+    renderListing([row("src/a.ts")], {
+      rowContextMenu: (r) => <ContextMenuItem>Copy {r.name}</ContextMenuItem>,
+    });
+    fireEvent.contextMenu(screen.getByLabelText("a.ts"));
+    expect(await screen.findByText("Copy a.ts")).toBeTruthy();
+  });
+
+  it("hands the menu builder the same entry shape the tree does", () => {
+    // Proves the widened callback signature is satisfied by a listing row —
+    // the whole reason both surfaces can share one menu.
+    const rowContextMenu = vi.fn(() => <ContextMenuItem>Item</ContextMenuItem>);
+    renderListing([row("src/pkg", { isDirectory: true })], { rowContextMenu });
+    expect(rowContextMenu).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "src/pkg", name: "pkg", isDirectory: true })
+    );
+  });
+
+  it("renders rows in the order it is given, without re-sorting", () => {
+    // Ordering is decided upstream by one comparator shared with the tree; a
+    // second sort here could disagree with the column beside it.
+    renderListing([row("src/z.ts"), row("src/a.ts")]);
+    const names = screen.getAllByText(/\.ts$/).map((node) => node.textContent);
+    expect(names).toEqual(["z.ts", "a.ts"]);
+  });
+});

--- a/src/panels/file-browser/__tests__/fileBrowserTree.test.ts
+++ b/src/panels/file-browser/__tests__/fileBrowserTree.test.ts
@@ -2,11 +2,16 @@ import { describe, expect, it } from "vitest";
 import type { FileTreeNode } from "@shared/types";
 import {
   ancestorDirectories,
+  buildFolderListingRows,
   canonicalizeRootPath,
   createVisibilityFilter,
+  DEFAULT_FILE_SORT,
+  findNodeInListings,
+  parentDirectoryOf,
   flattenTree,
   isRowPathVisible,
   listingsFromSnapshot,
+  sortFileNodes,
   MAX_SNAPSHOT_LISTINGS,
   MAX_SNAPSHOT_NODES,
   MAX_SNAPSHOT_TEXT_CHARS,
@@ -669,5 +674,316 @@ describe("listingsFromSnapshot", () => {
     expect(pathsOf(flattenTree(restored, new Set(["src"]), new Set()))).toEqual(
       pathsOf(flattenTree(listings, new Set(["src"]), new Set()))
     );
+  });
+});
+
+describe("sortFileNodes", () => {
+  const SORT_NAME_DESC = { key: "name", direction: "desc" } as const;
+  const SORT_SIZE_ASC = { key: "size", direction: "asc" } as const;
+  const SORT_SIZE_DESC = { key: "size", direction: "desc" } as const;
+  const SORT_MODIFIED_DESC = { key: "modified", direction: "desc" } as const;
+  const SORT_TYPE_ASC = { key: "type", direction: "asc" } as const;
+
+  it("returns the input array itself for the default order", () => {
+    // Identity, not just equality: the service already emits this order, so the
+    // default path must allocate nothing and keep the memoized rows stable.
+    const nodes = [dir("src"), file("a.ts")];
+    expect(sortFileNodes(nodes, DEFAULT_FILE_SORT)).toBe(nodes);
+  });
+
+  it("keeps directories ahead of files in both directions", () => {
+    const nodes = [file("b.ts", { size: 1 }), dir("zz"), file("a.ts", { size: 9 })];
+    for (const sort of [SORT_SIZE_ASC, SORT_SIZE_DESC, SORT_NAME_DESC]) {
+      const sorted = sortFileNodes(nodes, sort);
+      expect(sorted[0]?.isDirectory).toBe(true);
+      expect(sorted.slice(1).every((node) => !node.isDirectory)).toBe(true);
+    }
+  });
+
+  it("orders files by size and reverses on descending", () => {
+    const nodes = [
+      file("big.ts", { size: 300 }),
+      file("mid.ts", { size: 20 }),
+      file("sm.ts", { size: 1 }),
+    ];
+    expect(sortFileNodes(nodes, SORT_SIZE_ASC).map((n) => n.name)).toEqual([
+      "sm.ts",
+      "mid.ts",
+      "big.ts",
+    ]);
+    expect(sortFileNodes(nodes, SORT_SIZE_DESC).map((n) => n.name)).toEqual([
+      "big.ts",
+      "mid.ts",
+      "sm.ts",
+    ]);
+  });
+
+  it("sorts nodes with no size last in BOTH directions", () => {
+    // A snapshot-restored node carries no size. It is missing data, not a small
+    // value, so a descending sort must not float it to the top.
+    const nodes = [
+      file("known.ts", { size: 10 }),
+      file("unknown.ts"),
+      file("other.ts", { size: 2 }),
+    ];
+    expect(sortFileNodes(nodes, SORT_SIZE_ASC).at(-1)?.name).toBe("unknown.ts");
+    expect(sortFileNodes(nodes, SORT_SIZE_DESC).at(-1)?.name).toBe("unknown.ts");
+  });
+
+  it("sorts nodes with no mtime last in BOTH directions", () => {
+    const nodes = [
+      file("new.ts", { mtimeMs: 900 }),
+      file("stale.ts"),
+      file("old.ts", { mtimeMs: 5 }),
+    ];
+    expect(sortFileNodes(nodes, { key: "modified", direction: "asc" }).at(-1)?.name).toBe(
+      "stale.ts"
+    );
+    expect(sortFileNodes(nodes, SORT_MODIFIED_DESC).at(-1)?.name).toBe("stale.ts");
+  });
+
+  it("falls back to name order when every node lacks the sorted field", () => {
+    // The restored-panel case: structure-only nodes must still land in a
+    // sensible, deterministic order rather than whatever the map iterated.
+    const nodes = [file("c.ts"), file("a.ts"), file("b.ts")];
+    expect(sortFileNodes(nodes, SORT_SIZE_ASC).map((n) => n.name)).toEqual([
+      "a.ts",
+      "b.ts",
+      "c.ts",
+    ]);
+  });
+
+  it("groups by extension when sorting by type", () => {
+    const nodes = [file("b.ts"), file("a.md"), file("c.ts"), file("d.md")];
+    expect(sortFileNodes(nodes, SORT_TYPE_ASC).map((n) => n.name)).toEqual([
+      "a.md",
+      "d.md",
+      "b.ts",
+      "c.ts",
+    ]);
+  });
+
+  it("treats a dotfile as having no extension rather than splitting its name", () => {
+    const nodes = [file("a.ts"), file(".gitignore")];
+    // "" sorts before "ts", so the dotfile leads — it is not filed under
+    // "gitignore" as a type.
+    expect(sortFileNodes(nodes, SORT_TYPE_ASC).map((n) => n.name)).toEqual([".gitignore", "a.ts"]);
+  });
+
+  it("breaks ties on name in the same direction as the primary key", () => {
+    const nodes = [file("a.ts", { size: 5 }), file("b.ts", { size: 5 })];
+    expect(sortFileNodes(nodes, SORT_SIZE_ASC).map((n) => n.name)).toEqual(["a.ts", "b.ts"]);
+    expect(sortFileNodes(nodes, SORT_SIZE_DESC).map((n) => n.name)).toEqual(["b.ts", "a.ts"]);
+  });
+
+  it("does not mutate the array it was given", () => {
+    // The listings map it reads from is what gets persisted and what unsorted
+    // consumers read, so sorting has to be non-destructive.
+    const nodes = [file("b.ts", { size: 2 }), file("a.ts", { size: 1 })];
+    const before = nodes.map((n) => n.name);
+    sortFileNodes(nodes, SORT_SIZE_DESC);
+    expect(nodes.map((n) => n.name)).toEqual(before);
+  });
+});
+
+describe("flattenTree sorting", () => {
+  it("orders each level independently rather than across the whole tree", () => {
+    const listings = listingsOf({
+      "": [dir("src"), file("z.ts", { size: 1 })],
+      src: [file("src/b.ts", { size: 900 }), file("src/a.ts", { size: 2 })],
+    });
+
+    const rows = flattenTree(listings, new Set(["src"]), new Set(), "", undefined, {
+      key: "size",
+      direction: "desc",
+    });
+
+    // The root's own entries are ordered among themselves (dir first, then the
+    // file); src's children are ordered among themselves — the 900-byte child
+    // does not jump above the root-level file.
+    expect(pathsOf(rows)).toEqual(["src", "src/b.ts", "src/a.ts", "z.ts"]);
+  });
+
+  it("leaves the tree in service order for the default sort", () => {
+    const listings = listingsOf({ "": [dir("src"), file("a.ts", { size: 500 })] });
+    expect(
+      pathsOf(flattenTree(listings, new Set(), new Set(), "", undefined, DEFAULT_FILE_SORT))
+    ).toEqual(pathsOf(flattenTree(listings, new Set(), new Set())));
+  });
+});
+
+describe("buildFolderListingRows", () => {
+  it("returns null for a directory that has not been listed", () => {
+    // Distinguishable from an empty array on purpose: null is "still pending",
+    // [] is "this folder really holds nothing".
+    expect(buildFolderListingRows(listingsOf({ "": [dir("src")] }), "src")).toBeNull();
+  });
+
+  it("returns an empty array for a listed but empty directory", () => {
+    expect(buildFolderListingRows(listingsOf({ "": [dir("src")], src: [] }), "src")).toEqual([]);
+  });
+
+  it("carries size and mtime through, and omits them when absent", () => {
+    const listings = listingsOf({
+      src: [file("src/a.ts", { size: 12, mtimeMs: 1_700_000 }), file("src/b.ts")],
+    });
+    const rows = buildFolderListingRows(listings, "src")!;
+    expect(rows[0]).toMatchObject({ path: "src/a.ts", size: 12, mtimeMs: 1_700_000 });
+    expect(rows[1]?.size).toBeUndefined();
+    expect(rows[1]?.mtimeMs).toBeUndefined();
+  });
+
+  it("applies the same visibility filter the tree uses", () => {
+    const listings = listingsOf({ src: [file("src/.env"), file("src/a.ts")] });
+    const isVisible = createVisibilityFilter({ hideDotfiles: true, alwaysHiddenPatterns: [] });
+    expect(buildFolderListingRows(listings, "src", isVisible)!.map((r) => r.name)).toEqual([
+      "a.ts",
+    ]);
+  });
+
+  it("counts a child folder's items only when that folder is already cached", () => {
+    const listings = listingsOf({
+      src: [dir("src/known"), dir("src/unknown")],
+      "src/known": [file("src/known/a.ts"), file("src/known/b.ts")],
+    });
+    const rows = buildFolderListingRows(listings, "src")!;
+    expect(rows.find((r) => r.name === "known")?.itemCount).toBe(2);
+    // Never fetched, never walked — the column says nothing rather than "0".
+    expect(rows.find((r) => r.name === "unknown")?.itemCount).toBeUndefined();
+  });
+
+  it("counts only the visible entries of a child folder", () => {
+    const listings = listingsOf({
+      src: [dir("src/nested")],
+      "src/nested": [file("src/nested/.env"), file("src/nested/a.ts")],
+    });
+    const isVisible = createVisibilityFilter({ hideDotfiles: true, alwaysHiddenPatterns: [] });
+    // The count has to agree with what opening the folder would actually show.
+    expect(buildFolderListingRows(listings, "src", isVisible)![0]?.itemCount).toBe(1);
+  });
+
+  it("never reports a byte size for a directory row", () => {
+    const listings = listingsOf({ src: [dir("src/nested")] });
+    expect(buildFolderListingRows(listings, "src")![0]?.size).toBeUndefined();
+  });
+
+  it("orders rows by the requested sort, folders first", () => {
+    const listings = listingsOf({
+      src: [file("src/a.ts", { size: 1 }), dir("src/z"), file("src/b.ts", { size: 900 })],
+    });
+    const rows = buildFolderListingRows(listings, "src", undefined, {
+      key: "size",
+      direction: "desc",
+    })!;
+    expect(rows.map((r) => r.name)).toEqual(["z", "b.ts", "a.ts"]);
+  });
+});
+
+describe("findNodeInListings", () => {
+  it("resolves a node through its parent directory's listing", () => {
+    const listings = listingsOf({ "": [dir("src")], src: [file("src/a.ts", { size: 4 })] });
+    expect(findNodeInListings(listings, "src/a.ts")?.size).toBe(4);
+  });
+
+  it("resolves a root-level entry", () => {
+    expect(findNodeInListings(listingsOf({ "": [dir("src")] }), "src")?.isDirectory).toBe(true);
+  });
+
+  it("returns undefined when the parent directory has not been listed", () => {
+    // The pruned-parent case: unknown, which the caller must not treat as a file.
+    expect(findNodeInListings(listingsOf({ "": [dir("src")] }), "src/a.ts")).toBeUndefined();
+  });
+
+  it("answers for an entry whose parent is not expanded in the tree", () => {
+    // The whole reason this exists: the folder listing selects entries the tree
+    // has no row for, and those must still resolve to a real kind.
+    const listings = listingsOf({ "": [dir("src")], src: [file("src/deep.ts")] });
+    const rows = flattenTree(listings, new Set(), new Set());
+    expect(pathsOf(rows)).not.toContain("src/deep.ts");
+    expect(findNodeInListings(listings, "src/deep.ts")?.isDirectory).toBe(false);
+  });
+});
+
+describe("pruneListings keepPath", () => {
+  it("retains the folder being listed even when it is not expanded", () => {
+    const listings = listingsOf({
+      "": [dir("src")],
+      src: [file("src/a.ts")],
+    });
+    expect([...pruneListings(listings, new Set(), "", ["src"]).keys()]).toEqual(["", "src"]);
+  });
+
+  it("still drops other collapsed directories alongside the retained one", () => {
+    const listings = listingsOf({
+      "": [dir("src"), dir("docs")],
+      src: [file("src/a.ts")],
+      docs: [file("docs/b.md")],
+    });
+    expect([...pruneListings(listings, new Set(), "", ["src"]).keys()]).toEqual(["", "src"]);
+  });
+
+  it("drops everything but the root when no folder is being listed", () => {
+    const listings = listingsOf({ "": [dir("src")], src: [file("src/a.ts")] });
+    expect([...pruneListings(listings, new Set(), "").keys()]).toEqual([""]);
+  });
+});
+
+describe("refreshTargets keepPath", () => {
+  it("re-lists the folder being viewed even though it is collapsed", () => {
+    const listings = listingsOf({ "": [dir("src")], src: [file("src/a.ts")] });
+    expect(refreshTargets(listings, new Set(), "", undefined, "src")).toEqual(["", "src"]);
+  });
+
+  it("does not list the viewed folder twice when it is also expanded", () => {
+    const listings = listingsOf({ "": [dir("src")], src: [file("src/a.ts")] });
+    expect(refreshTargets(listings, new Set(["src"]), "", undefined, "src")).toEqual(["", "src"]);
+  });
+
+  it("does not duplicate the root when the root itself is being viewed", () => {
+    const listings = listingsOf({ "": [dir("src")] });
+    expect(refreshTargets(listings, new Set(), "", undefined, "")).toEqual([""]);
+  });
+});
+
+describe("parentDirectoryOf", () => {
+  it("names the directory a path lives in", () => {
+    expect(parentDirectoryOf("src/lib/util.ts")).toBe("src/lib");
+  });
+
+  it("returns the root for a top-level entry", () => {
+    expect(parentDirectoryOf("README.md")).toBe("");
+  });
+});
+
+describe("pruneListings retains what the selection needs", () => {
+  it("keeps the parent that answers what a selected file is", () => {
+    // Clicking a file inside a folder listing turns that folder from "being
+    // listed" into "merely the parent". Dropping it right then would forget the
+    // file's own kind at the exact moment it was selected — the viewer would
+    // blank on the click that was supposed to open it.
+    const listings = listingsOf({ "": [dir("src")], src: [file("src/a.ts")] });
+    expect([...pruneListings(listings, new Set(), "", ["src"]).keys()]).toContain("src");
+  });
+
+  it("keeps both the listed folder and the selection's parent at once", () => {
+    const listings = listingsOf({
+      "": [dir("src"), dir("docs")],
+      src: [file("src/a.ts")],
+      docs: [file("docs/b.md")],
+    });
+    expect([...pruneListings(listings, new Set(), "", ["docs", "src"]).keys()].sort()).toEqual([
+      "",
+      "docs",
+      "src",
+    ]);
+  });
+
+  it("still drops a collapsed directory nothing is depending on", () => {
+    const listings = listingsOf({
+      "": [dir("src"), dir("docs")],
+      src: [file("src/a.ts")],
+      docs: [file("docs/b.md")],
+    });
+    expect([...pruneListings(listings, new Set(), "", ["src"]).keys()]).toEqual(["", "src"]);
   });
 });

--- a/src/panels/file-browser/__tests__/fileBrowserTree.test.ts
+++ b/src/panels/file-browser/__tests__/fileBrowserTree.test.ts
@@ -987,3 +987,50 @@ describe("pruneListings retains what the selection needs", () => {
     expect([...pruneListings(listings, new Set(), "", ["src"]).keys()]).toEqual(["", "src"]);
   });
 });
+
+describe("sortFileNodes stays a valid total order", () => {
+  // A comparator that is not antisymmetric is undefined behaviour for
+  // Array.prototype.sort, so these are laws, not preferences. Corrupt metadata
+  // is the realistic source: a hand-edited or migrated record can carry a value
+  // the filesystem would never produce.
+  const ODD_VALUES = [undefined, 0, 1, 1024, Number.NaN, Infinity, -Infinity];
+
+  function nodesFor(key: "size" | "modified") {
+    return ODD_VALUES.map((value, index) =>
+      file(`f${index}.ts`, value === undefined ? {} : { [key]: value })
+    );
+  }
+
+  for (const key of ["size", "modified"] as const) {
+    for (const direction of ["asc", "desc"] as const) {
+      it(`is antisymmetric for ${key}/${direction} across corrupt values`, () => {
+        const nodes = nodesFor(key);
+        const sorted = sortFileNodes(nodes, { key, direction });
+        // Sorting is deterministic and stable across repeats — the observable
+        // consequence of a consistent comparator.
+        expect(sortFileNodes(nodes, { key, direction }).map((n) => n.name)).toEqual(
+          sorted.map((n) => n.name)
+        );
+        // And reversing the input cannot change the result of a total order.
+        expect(sortFileNodes([...nodes].reverse(), { key, direction }).map((n) => n.name)).toEqual(
+          sorted.map((n) => n.name)
+        );
+      });
+    }
+  }
+
+  it("treats a NaN size as unknown rather than as a value", () => {
+    // NaN compares false against everything including itself; left in-band it
+    // would make the comparator report `a > b` and `b > a` at once.
+    const nodes = [file("nan.ts", { size: Number.NaN }), file("real.ts", { size: 5 })];
+    expect(sortFileNodes(nodes, { key: "size", direction: "asc" }).at(-1)?.name).toBe("nan.ts");
+    expect(sortFileNodes(nodes, { key: "size", direction: "desc" }).at(-1)?.name).toBe("nan.ts");
+  });
+
+  it("treats an infinite mtime as unknown rather than as the newest file", () => {
+    const nodes = [file("inf.ts", { mtimeMs: Infinity }), file("real.ts", { mtimeMs: 5 })];
+    expect(sortFileNodes(nodes, { key: "modified", direction: "desc" }).at(-1)?.name).toBe(
+      "inf.ts"
+    );
+  });
+});

--- a/src/panels/file-browser/__tests__/serializer.test.ts
+++ b/src/panels/file-browser/__tests__/serializer.test.ts
@@ -63,7 +63,7 @@ describe("serializeFileBrowser", () => {
     // The old field's meaning was inverted; an old panel that showed gitignored
     // files must NOT hydrate as hiding dotfiles (#10938-class trap). The
     // serializer only knows the new field, so the stale key is simply dropped.
-    const legacy = { ...basePanel, browserShowIgnored: true } as FileBrowserPanelData;
+    const legacy = { ...basePanel, browserShowIgnored: true } as unknown as FileBrowserPanelData;
 
     const snapshot = serializeFileBrowser(legacy);
 
@@ -250,5 +250,63 @@ describe("createFileBrowserDefaults", () => {
         browserWorkspaceRooted: true,
       })
     ).toEqual({ browserWorkspaceRooted: true });
+  });
+});
+
+describe("serializeFileBrowser sort fields (#11620)", () => {
+  function base(): FileBrowserPanelData {
+    return {
+      id: "p1",
+      kind: "file-browser",
+      title: "Files",
+      cwd: "/repo",
+    } as unknown as FileBrowserPanelData;
+  }
+
+  it("persists neither field for the default name/ascending order", () => {
+    // The default is the order the listing service already returns, so a
+    // never-sorted panel must stay as sparse as it was before the feature.
+    const snapshot = serializeFileBrowser({
+      ...base(),
+      browserSortKey: "name",
+      browserSortDirection: "asc",
+    });
+    expect(snapshot.browserSortKey).toBeUndefined();
+    expect(snapshot.browserSortDirection).toBeUndefined();
+  });
+
+  it("persists neither field when the panel has never been sorted", () => {
+    const snapshot = serializeFileBrowser(base());
+    expect("browserSortKey" in snapshot).toBe(false);
+    expect("browserSortDirection" in snapshot).toBe(false);
+  });
+
+  it("persists a non-default key", () => {
+    expect(serializeFileBrowser({ ...base(), browserSortKey: "size" }).browserSortKey).toBe("size");
+  });
+
+  it("persists a descending direction even under the default key", () => {
+    // Name-descending is a real choice, and the two halves are written
+    // independently — dropping the direction because its key is the default
+    // would silently reset the order on restore.
+    const snapshot = serializeFileBrowser({
+      ...base(),
+      browserSortKey: "name",
+      browserSortDirection: "desc",
+    });
+    expect(snapshot.browserSortKey).toBeUndefined();
+    expect(snapshot.browserSortDirection).toBe("desc");
+  });
+
+  it("round-trips a non-default order through serialize", () => {
+    const snapshot = serializeFileBrowser({
+      ...base(),
+      browserSortKey: "modified",
+      browserSortDirection: "desc",
+    });
+    expect(snapshot).toMatchObject({
+      browserSortKey: "modified",
+      browserSortDirection: "desc",
+    });
   });
 });

--- a/src/panels/file-browser/__tests__/serializer.test.ts
+++ b/src/panels/file-browser/__tests__/serializer.test.ts
@@ -255,12 +255,7 @@ describe("createFileBrowserDefaults", () => {
 
 describe("serializeFileBrowser sort fields (#11620)", () => {
   function base(): FileBrowserPanelData {
-    return {
-      id: "p1",
-      kind: "file-browser",
-      title: "Files",
-      cwd: "/repo",
-    } as unknown as FileBrowserPanelData;
+    return { ...basePanel };
   }
 
   it("persists neither field for the default name/ascending order", () => {

--- a/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
+++ b/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
@@ -1541,3 +1541,244 @@ describe("workspace source", () => {
     expect(listDirectory).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("useFileBrowserTree folder listing (#11620)", () => {
+  beforeEach(() => {
+    listDirectory.mockReset();
+  });
+
+  function renderTree(selectedPath: string | null, expandedPaths: string[] = []) {
+    return renderHook(
+      (props: { selectedPath: string | null; expandedPaths: string[] }) =>
+        useFileBrowserTree({
+          source: wtSource("wt-1"),
+          expandedPaths: props.expandedPaths,
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
+          changeTick: undefined,
+          selectedPath: props.selectedPath,
+        }),
+      { initialProps: { selectedPath, expandedPaths } }
+    );
+  }
+
+  it("reports no listing when nothing is selected", async () => {
+    listDirectory.mockResolvedValue([dir("src")]);
+
+    const { result } = renderTree(null);
+
+    await waitFor(() => expect(result.current.isInitialLoading).toBe(false));
+    expect(result.current.listingPath).toBeNull();
+    expect(result.current.listingRows).toBeNull();
+  });
+
+  it("reports no listing when the selection is a file", async () => {
+    listDirectory.mockResolvedValue([file("README.md")]);
+
+    const { result } = renderTree("README.md");
+
+    await waitFor(() => expect(result.current.isInitialLoading).toBe(false));
+    expect(result.current.listingPath).toBeNull();
+    expect(result.current.selectedNode?.isDirectory).toBe(false);
+  });
+
+  it("fetches a selected folder that was never expanded, and lists its contents", async () => {
+    // Selecting from the keyboard never expands, so nothing else would ask for
+    // this folder's children.
+    listDirectory.mockImplementation(async (payload) =>
+      payload.dirPath === "src" ? [file("src/a.ts")] : [dir("src")]
+    );
+
+    const { result } = renderTree("src");
+
+    await waitFor(() => expect(result.current.listingRows).not.toBeNull());
+    expect(result.current.listingPath).toBe("src");
+    expect(result.current.listingRows?.map((r) => r.path)).toEqual(["src/a.ts"]);
+  });
+
+  it("reports pending until the folder's listing arrives", async () => {
+    const gate = deferred<FileTreeNode[]>();
+    listDirectory.mockImplementation(async (payload) =>
+      payload.dirPath === "src" ? gate.promise : [dir("src")]
+    );
+
+    const { result } = renderTree("src");
+
+    // Raw pending, not a gated flag — the consumer needs this apart from
+    // "loaded and empty" to choose between a skeleton and an empty state.
+    await waitFor(() => expect(result.current.listingStatus).toBe("pending"));
+    expect(result.current.listingRows).toBeNull();
+
+    await act(async () => {
+      gate.resolve([file("src/a.ts")]);
+      await gate.promise;
+    });
+
+    await waitFor(() => expect(result.current.listingStatus).toBe("ready"));
+  });
+
+  it("distinguishes an empty folder from one still loading", async () => {
+    listDirectory.mockImplementation(async (payload) =>
+      payload.dirPath === "src" ? [] : [dir("src")]
+    );
+
+    const { result } = renderTree("src");
+
+    await waitFor(() => expect(result.current.listingStatus).toBe("ready"));
+    // [] not null: the folder really holds nothing.
+    expect(result.current.listingRows).toEqual([]);
+  });
+
+  it("reports an error instead of pending forever when the folder can't be read", async () => {
+    // Per-directory failures are silent for the tree, which would otherwise
+    // leave the listing on a skeleton with no way out.
+    listDirectory.mockImplementation(async (payload) => {
+      if (payload.dirPath === "src") throw new Error("EACCES");
+      return [dir("src")];
+    });
+
+    const { result } = renderTree("src");
+
+    await waitFor(() => expect(result.current.listingStatus).toBe("error"));
+    expect(result.current.listingRows).toBeNull();
+  });
+
+  it("does not re-request a folder whose fetch already failed", async () => {
+    listDirectory.mockImplementation(async (payload) => {
+      if (payload.dirPath === "src") throw new Error("EACCES");
+      return [dir("src")];
+    });
+
+    const { result } = renderTree("src");
+
+    await waitFor(() => expect(result.current.listingStatus).toBe("error"));
+    const afterFailure = listDirectory.mock.calls.filter((c) => c[0].dirPath === "src").length;
+
+    // A failed path is in neither the listings map nor the in-flight set, so
+    // without an explicit guard this would refire on every render.
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(listDirectory.mock.calls.filter((c) => c[0].dirPath === "src")).toHaveLength(
+      afterFailure
+    );
+  });
+
+  it("keeps the listed folder's contents when an unrelated folder collapses", async () => {
+    // The prune drops collapsed subtrees; the folder on screen is being read
+    // right now, so it is not the stale unused entry that prune exists for.
+    listDirectory.mockImplementation(async (payload) => {
+      if (payload.dirPath === "src") return [file("src/a.ts")];
+      if (payload.dirPath === "docs") return [file("docs/b.md")];
+      return [dir("src"), dir("docs")];
+    });
+
+    const { result, rerender } = renderTree("src", ["docs"]);
+
+    await waitFor(() => expect(result.current.listingRows).not.toBeNull());
+
+    // Collapse the unrelated folder — the listed one must survive the prune.
+    rerender({ selectedPath: "src", expandedPaths: [] });
+
+    await waitFor(() => expect(result.current.listingStatus).toBe("ready"));
+    expect(result.current.listingRows?.map((r) => r.path)).toEqual(["src/a.ts"]);
+  });
+
+  it("resolves a node whose parent is not expanded in the tree", async () => {
+    // The reason selection resolution moved off the rendered rows: an entry
+    // picked from the folder listing has no tree row at all.
+    listDirectory.mockImplementation(async (payload) =>
+      payload.dirPath === "src" ? [file("src/deep.ts")] : [dir("src")]
+    );
+
+    const { result, rerender } = renderTree("src");
+
+    await waitFor(() => expect(result.current.listingRows).not.toBeNull());
+    rerender({ selectedPath: "src/deep.ts", expandedPaths: [] });
+
+    await waitFor(() => expect(result.current.selectedNode?.path).toBe("src/deep.ts"));
+    expect(result.current.selectedNode?.isDirectory).toBe(false);
+    // It is genuinely absent from the tree's rows — that is the whole point.
+    expect(result.current.rows.map((r) => r.path)).not.toContain("src/deep.ts");
+  });
+
+  it("stops listing a folder the dotfile filter has just hidden", async () => {
+    listDirectory.mockImplementation(async (payload) =>
+      payload.dirPath === ".config" ? [file(".config/a.ts")] : [dir(".config")]
+    );
+
+    const { result, rerender } = renderHook(
+      (props: { hideDotfiles: boolean }) =>
+        useFileBrowserTree({
+          source: wtSource("wt-1"),
+          expandedPaths: [],
+          hideDotfiles: props.hideDotfiles,
+          alwaysHiddenPatterns: [],
+          changeTick: undefined,
+          selectedPath: ".config",
+        }),
+      { initialProps: { hideDotfiles: false } }
+    );
+
+    await waitFor(() => expect(result.current.listingPath).toBe(".config"));
+
+    rerender({ hideDotfiles: true });
+
+    // The selection survives in the panel record but has no row, so it must
+    // stop driving a listing the tree cannot show.
+    await waitFor(() => expect(result.current.listingPath).toBeNull());
+  });
+
+  it("orders the tree and the listing by the same sort", async () => {
+    listDirectory.mockImplementation(async (payload) =>
+      payload.dirPath === "src"
+        ? [
+            { name: "a.ts", path: "src/a.ts", isDirectory: false, size: 1 },
+            { name: "b.ts", path: "src/b.ts", isDirectory: false, size: 900 },
+          ]
+        : [dir("src")]
+    );
+
+    const { result } = renderHook(() =>
+      useFileBrowserTree({
+        source: wtSource("wt-1"),
+        expandedPaths: ["src"],
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
+        changeTick: undefined,
+        selectedPath: "src",
+        sort: { key: "size", direction: "desc" },
+      })
+    );
+
+    await waitFor(() => expect(result.current.listingRows).not.toBeNull());
+
+    const listingOrder = result.current.listingRows?.map((r) => r.path);
+    const treeOrder = result.current.rows.map((r) => r.path).filter((p) => p.startsWith("src/"));
+
+    expect(listingOrder).toEqual(["src/b.ts", "src/a.ts"]);
+    // Two columns showing the same directory in different orders would read as
+    // two different folders.
+    expect(treeOrder).toEqual(listingOrder);
+  });
+
+  it("reports whether the dotfile toggle is hiding anything in the listed folder", async () => {
+    listDirectory.mockImplementation(async (payload) =>
+      payload.dirPath === "src" ? [file("src/.env")] : [dir("src")]
+    );
+
+    const { result } = renderHook(() =>
+      useFileBrowserTree({
+        source: wtSource("wt-1"),
+        expandedPaths: [],
+        hideDotfiles: true,
+        alwaysHiddenPatterns: [],
+        changeTick: undefined,
+        selectedPath: "src",
+      })
+    );
+
+    await waitFor(() => expect(result.current.listingStatus).toBe("ready"));
+    expect(result.current.listingRows).toEqual([]);
+    // Filtered-empty, not zero-data: offering "Show dotfiles" here actually helps.
+    expect(result.current.listingHasHiddenDotfiles).toBe(true);
+  });
+});

--- a/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
+++ b/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
@@ -4,7 +4,7 @@ import { act, render, renderHook, waitFor } from "@testing-library/react";
 import type { FileTreeNode } from "@shared/types";
 import type { FileBrowserListDirectoryPayload } from "@shared/types/ipc/fileBrowser";
 import { useFileBrowserTree } from "../useFileBrowserTree";
-import type { FileBrowserSource } from "../fileBrowserTree";
+import type { FileBrowserSortOrder, FileBrowserSource } from "../fileBrowserTree";
 
 const listDirectory =
   vi.fn<(payload: FileBrowserListDirectoryPayload) => Promise<FileTreeNode[]>>();
@@ -44,6 +44,15 @@ const SETTLE_MS = 50;
 function settle(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, SETTLE_MS));
 }
+
+/**
+ * Declared as a typed const rather than inline: `renderHook` infers its prop
+ * type from `initialProps`, so inline literals would narrow `sort` to exactly
+ * the initial value and reject the re-sort the test exists to perform.
+ */
+const INITIAL_SORT_PROPS: { sort: FileBrowserSortOrder } = {
+  sort: { key: "name", direction: "asc" },
+};
 
 /** A deferred promise so a listing can be held open mid-flight. */
 function deferred<T>() {
@@ -1978,7 +1987,7 @@ describe("useFileBrowserTree listing recovery and revalidation (#11620)", () => 
     );
 
     const { result, rerender } = renderHook(
-      (props: { sort: { key: "name" | "size"; direction: "asc" | "desc" } }) =>
+      (props: { sort: FileBrowserSortOrder }) =>
         useFileBrowserTree({
           source: wtSource("wt-1"),
           expandedPaths: [],
@@ -1988,7 +1997,7 @@ describe("useFileBrowserTree listing recovery and revalidation (#11620)", () => 
           selectedPath: "src",
           sort: props.sort,
         }),
-      { initialProps: { sort: { key: "name" as const, direction: "asc" as const } } }
+      { initialProps: INITIAL_SORT_PROPS }
     );
 
     await waitFor(() => expect(result.current.listingRows).not.toBeNull());

--- a/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
+++ b/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
@@ -1782,3 +1782,205 @@ describe("useFileBrowserTree folder listing (#11620)", () => {
     expect(result.current.listingHasHiddenDotfiles).toBe(true);
   });
 });
+
+describe("useFileBrowserTree listing recovery and revalidation (#11620)", () => {
+  beforeEach(() => {
+    listDirectory.mockReset();
+  });
+
+  it("recovers a failed folder listing when the user refreshes", () => {
+    // End to end, not just the callback wiring: fail, assert the error state,
+    // then drive the same refresh the viewer's Retry runs and assert real rows.
+    let failNext = true;
+    listDirectory.mockImplementation(async (payload) => {
+      if (payload.dirPath === "src") {
+        if (failNext) throw new Error("EACCES");
+        return [file("src/a.ts")];
+      }
+      return [dir("src")];
+    });
+
+    const { result } = renderHook(() =>
+      useFileBrowserTree({
+        source: wtSource("wt-1"),
+        expandedPaths: [],
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
+        changeTick: undefined,
+        selectedPath: "src",
+      })
+    );
+
+    return waitFor(() => expect(result.current.listingStatus).toBe("error"))
+      .then(() => {
+        failNext = false;
+        act(() => result.current.refresh({ manual: true }));
+        return waitFor(() => expect(result.current.listingStatus).toBe("ready"));
+      })
+      .then(() => {
+        expect(result.current.listingRows?.map((r) => r.path)).toEqual(["src/a.ts"]);
+      });
+  });
+
+  it("does not re-request a failed expanded directory every time a sibling lands", async () => {
+    // A restored tree with one unreadable directory used to re-enqueue it on
+    // every listing commit, because a failed path is in neither the listings
+    // map nor the in-flight set.
+    listDirectory.mockImplementation(async (payload) => {
+      if (payload.dirPath === "bad") throw new Error("EACCES");
+      if (payload.dirPath === "a") return [file("a/1.ts")];
+      if (payload.dirPath === "b") return [file("b/1.ts")];
+      return [dir("bad"), dir("a"), dir("b")];
+    });
+
+    const { result } = renderHook(() =>
+      useFileBrowserTree({
+        source: wtSource("wt-1"),
+        expandedPaths: ["bad", "a", "b"],
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
+        changeTick: undefined,
+      })
+    );
+
+    await waitFor(() => expect(result.current.rows.length).toBeGreaterThan(0));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(listDirectory.mock.calls.filter((c) => c[0].dirPath === "bad")).toHaveLength(1);
+  });
+
+  it("retries a failed directory after it is collapsed and re-expanded", async () => {
+    // Collapsing clears the recorded failure, so the natural try-again gesture
+    // works rather than being refused forever by the skip above.
+    listDirectory.mockImplementation(async (payload) => {
+      if (payload.dirPath === "bad") throw new Error("EACCES");
+      return [dir("bad")];
+    });
+
+    const { result, rerender } = renderHook(
+      (props: { expandedPaths: string[] }) =>
+        useFileBrowserTree({
+          source: wtSource("wt-1"),
+          expandedPaths: props.expandedPaths,
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
+          changeTick: undefined,
+        }),
+      { initialProps: { expandedPaths: ["bad"] } }
+    );
+
+    await waitFor(() =>
+      expect(listDirectory.mock.calls.filter((c) => c[0].dirPath === "bad")).toHaveLength(1)
+    );
+
+    rerender({ expandedPaths: [] });
+    rerender({ expandedPaths: ["bad"] });
+
+    await waitFor(() =>
+      expect(listDirectory.mock.calls.filter((c) => c[0].dirPath === "bad")).toHaveLength(2)
+    );
+    void result;
+  });
+
+  it("re-reads a selected collapsed folder that was seeded from a snapshot", async () => {
+    // The snapshot is structure-only, so its rows carry no size or mtime. If
+    // the restore revalidation skipped the selected folder, the listing would
+    // sit on those metadata-less rows indefinitely.
+    listDirectory.mockImplementation(async (payload) =>
+      payload.dirPath === "src"
+        ? [{ name: "a.ts", path: "src/a.ts", isDirectory: false, size: 42, mtimeMs: 1_700_000 }]
+        : [dir("src")]
+    );
+
+    const { result } = renderHook(() =>
+      useFileBrowserTree({
+        source: wtSource("wt-1"),
+        expandedPaths: [],
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
+        changeTick: undefined,
+        selectedPath: "src",
+        treeSnapshot: {
+          worktreeId: "wt-1",
+          basePath: "/repo/wt-1",
+          rootPath: "",
+          listings: [
+            { dirPath: "", nodes: [{ name: "src", path: "src", isDirectory: true }] },
+            { dirPath: "src", nodes: [{ name: "a.ts", path: "src/a.ts", isDirectory: false }] },
+          ],
+        },
+      })
+    );
+
+    // Seeded rows paint immediately with no metadata...
+    await waitFor(() => expect(result.current.listingRows).not.toBeNull());
+    // ...and the live re-read replaces them with real size/mtime.
+    await waitFor(() => expect(result.current.listingRows?.[0]?.size).toBe(42));
+    expect(result.current.listingRows?.[0]?.mtimeMs).toBe(1_700_000);
+  });
+
+  it("keeps a selected file's parent listing when the folder stops being listed", async () => {
+    // Selecting a file out of a folder listing flips that folder from "being
+    // listed" to "merely the parent". Dropping it there would forget the file's
+    // kind on the very click that selected it.
+    listDirectory.mockImplementation(async (payload) =>
+      payload.dirPath === "src" ? [file("src/a.ts")] : [dir("src")]
+    );
+
+    const { result, rerender } = renderHook(
+      (props: { selectedPath: string }) =>
+        useFileBrowserTree({
+          source: wtSource("wt-1"),
+          expandedPaths: [],
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
+          changeTick: undefined,
+          selectedPath: props.selectedPath,
+        }),
+      { initialProps: { selectedPath: "src" } }
+    );
+
+    await waitFor(() => expect(result.current.listingRows).not.toBeNull());
+    rerender({ selectedPath: "src/a.ts" });
+
+    await waitFor(() => expect(result.current.listingPath).toBeNull());
+    // The kind still resolves, which is what keeps the viewer on the file.
+    expect(result.current.selectedNode?.isDirectory).toBe(false);
+  });
+
+  it("re-orders an on-screen listing without re-fetching it", async () => {
+    listDirectory.mockImplementation(async (payload) =>
+      payload.dirPath === "src"
+        ? [
+            { name: "a.ts", path: "src/a.ts", isDirectory: false, size: 1 },
+            { name: "b.ts", path: "src/b.ts", isDirectory: false, size: 900 },
+          ]
+        : [dir("src")]
+    );
+
+    const { result, rerender } = renderHook(
+      (props: { sort: { key: "name" | "size"; direction: "asc" | "desc" } }) =>
+        useFileBrowserTree({
+          source: wtSource("wt-1"),
+          expandedPaths: [],
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
+          changeTick: undefined,
+          selectedPath: "src",
+          sort: props.sort,
+        }),
+      { initialProps: { sort: { key: "name" as const, direction: "asc" as const } } }
+    );
+
+    await waitFor(() => expect(result.current.listingRows).not.toBeNull());
+    const callsBefore = listDirectory.mock.calls.length;
+
+    rerender({ sort: { key: "size", direction: "desc" } });
+
+    await waitFor(() =>
+      expect(result.current.listingRows?.map((r) => r.name)).toEqual(["b.ts", "a.ts"])
+    );
+    // Sorting is a client-side reorder of cached rows — it must cost no IPC.
+    expect(listDirectory.mock.calls).toHaveLength(callsBefore);
+  });
+});

--- a/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
+++ b/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
@@ -1776,8 +1776,11 @@ describe("useFileBrowserTree folder listing (#11620)", () => {
       })
     );
 
-    await waitFor(() => expect(result.current.listingStatus).toBe("ready"));
-    expect(result.current.listingRows).toEqual([]);
+    // Waits on the rows, not on `listingStatus`: status is also "ready" while
+    // no folder is selected at all, which is true on the very first render and
+    // would let this assert against a tree that had not loaded anything yet.
+    await waitFor(() => expect(result.current.listingRows).toEqual([]));
+    expect(result.current.listingStatus).toBe("ready");
     // Filtered-empty, not zero-data: offering "Show dotfiles" here actually helps.
     expect(result.current.listingHasHiddenDotfiles).toBe(true);
   });
@@ -1982,5 +1985,153 @@ describe("useFileBrowserTree listing recovery and revalidation (#11620)", () => 
     );
     // Sorting is a client-side reorder of cached rows — it must cost no IPC.
     expect(listDirectory.mock.calls).toHaveLength(callsBefore);
+  });
+});
+
+describe("useFileBrowserTree failure recovery edge cases (#11620)", () => {
+  beforeEach(() => {
+    listDirectory.mockReset();
+  });
+
+  it("retries a directory whose request failed only after it was collapsed", async () => {
+    // The prune's failure-clearing pass runs on collapse. A rejection that
+    // lands after it would leave a failure nothing clears, and the expansion
+    // effect would then refuse to re-request it — re-expanding the folder would
+    // silently do nothing.
+    const gate = deferred<FileTreeNode[]>();
+    listDirectory.mockImplementation(async (payload) =>
+      payload.dirPath === "bad" ? gate.promise : [dir("bad")]
+    );
+
+    const { rerender } = renderHook(
+      (props: { expandedPaths: string[] }) =>
+        useFileBrowserTree({
+          source: wtSource("wt-1"),
+          expandedPaths: props.expandedPaths,
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
+          changeTick: undefined,
+        }),
+      { initialProps: { expandedPaths: ["bad"] } }
+    );
+
+    await waitFor(() =>
+      expect(listDirectory.mock.calls.filter((c) => c[0].dirPath === "bad")).toHaveLength(1)
+    );
+
+    // Collapse while the request is still in flight, THEN let it reject.
+    rerender({ expandedPaths: [] });
+    await act(async () => {
+      gate.reject(new Error("EACCES"));
+      await gate.promise.catch(() => {});
+    });
+
+    rerender({ expandedPaths: ["bad"] });
+
+    await waitFor(() =>
+      expect(listDirectory.mock.calls.filter((c) => c[0].dirPath === "bad")).toHaveLength(2)
+    );
+  });
+
+  it("reports an error when a folder cached as empty then fails to re-read", async () => {
+    // An empty cached listing has nothing to protect, so claiming "ready" would
+    // put "this folder is empty" on screen for a folder we in fact failed to
+    // read — a confident claim built on a failure.
+    let failNext = false;
+    listDirectory.mockImplementation(async (payload) => {
+      if (payload.dirPath === "src") {
+        if (failNext) throw new Error("EACCES");
+        return [];
+      }
+      return [dir("src")];
+    });
+
+    const { result } = renderHook(() =>
+      useFileBrowserTree({
+        source: wtSource("wt-1"),
+        expandedPaths: [],
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
+        changeTick: undefined,
+        selectedPath: "src",
+      })
+    );
+
+    await waitFor(() => expect(result.current.listingRows).toEqual([]));
+    expect(result.current.listingStatus).toBe("ready");
+
+    failNext = true;
+    act(() => result.current.refresh({ manual: true }));
+
+    await waitFor(() => expect(result.current.listingStatus).toBe("error"));
+  });
+
+  it("keeps showing a populated listing whose re-read failed", async () => {
+    // The other half of the same rule: real rows on screen are not blanked for
+    // an error banner, matching the tree's own root-error branch.
+    let failNext = false;
+    listDirectory.mockImplementation(async (payload) => {
+      if (payload.dirPath === "src") {
+        if (failNext) throw new Error("EACCES");
+        return [file("src/a.ts")];
+      }
+      return [dir("src")];
+    });
+
+    const { result } = renderHook(() =>
+      useFileBrowserTree({
+        source: wtSource("wt-1"),
+        expandedPaths: [],
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
+        changeTick: undefined,
+        selectedPath: "src",
+      })
+    );
+
+    await waitFor(() => expect(result.current.listingRows?.length).toBe(1));
+
+    failNext = true;
+    act(() => result.current.refresh({ manual: true }));
+    await waitFor(() => expect(result.current.isRefreshing).toBe(false));
+
+    expect(result.current.listingStatus).toBe("ready");
+    expect(result.current.listingRows?.map((r) => r.path)).toEqual(["src/a.ts"]);
+  });
+
+  it("accepts a listing that lands while it is the selection's parent, not the listed folder", async () => {
+    // The completion guard must agree with what the prune retains. A result
+    // arriving after the user clicked into a file must still be accepted, or
+    // the parent that identifies that file is never cached at all.
+    const gate = deferred<FileTreeNode[]>();
+    listDirectory.mockImplementation(async (payload) =>
+      payload.dirPath === "src" ? gate.promise : [dir("src")]
+    );
+
+    const { result, rerender } = renderHook(
+      (props: { selectedPath: string }) =>
+        useFileBrowserTree({
+          source: wtSource("wt-1"),
+          expandedPaths: [],
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
+          changeTick: undefined,
+          selectedPath: props.selectedPath,
+        }),
+      { initialProps: { selectedPath: "src" } }
+    );
+
+    await waitFor(() => expect(result.current.listingStatus).toBe("pending"));
+
+    // Selection moves to a child before the parent's listing lands, so "src" is
+    // now selectionParent rather than listingPath.
+    rerender({ selectedPath: "src/a.ts" });
+    await act(async () => {
+      gate.resolve([file("src/a.ts")]);
+      await gate.promise;
+    });
+
+    await waitFor(() => expect(result.current.selectedNode?.path).toBe("src/a.ts"));
+    expect(result.current.selectedNode?.isDirectory).toBe(false);
   });
 });

--- a/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
+++ b/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
@@ -33,6 +33,18 @@ function file(path: string): FileTreeNode {
   return { name: path.split("/").pop()!, path, isDirectory: false };
 }
 
+/**
+ * Long enough for any effect-driven re-request to have been enqueued and
+ * pumped, so "no further calls after this" is a real statement about the
+ * implementation rather than about the test's timing.
+ */
+const SETTLE_MS = 50;
+
+/** Give pending effects and their queued fetches a chance to fire. */
+function settle(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, SETTLE_MS));
+}
+
 /** A deferred promise so a listing can be held open mid-flight. */
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -1624,9 +1636,13 @@ describe("useFileBrowserTree folder listing (#11620)", () => {
 
     const { result } = renderTree("src");
 
-    await waitFor(() => expect(result.current.listingStatus).toBe("ready"));
-    // [] not null: the folder really holds nothing.
-    expect(result.current.listingRows).toEqual([]);
+    // Waits on the rows, not on `listingStatus`: status is also "ready" while
+    // no folder has resolved yet, which is true on the very first render and
+    // would let this pass before anything had loaded.
+    await waitFor(() => expect(result.current.listingRows).toEqual([]));
+    // [] not null: the folder really holds nothing, which is a different answer
+    // from "not fetched yet".
+    expect(result.current.listingStatus).toBe("ready");
   });
 
   it("reports an error instead of pending forever when the folder can't be read", async () => {
@@ -1656,7 +1672,7 @@ describe("useFileBrowserTree folder listing (#11620)", () => {
 
     // A failed path is in neither the listings map nor the in-flight set, so
     // without an explicit guard this would refire on every render.
-    await new Promise((resolve) => setTimeout(resolve, 30));
+    await settle();
     expect(listDirectory.mock.calls.filter((c) => c[0].dirPath === "src")).toHaveLength(
       afterFailure
     );
@@ -1847,7 +1863,7 @@ describe("useFileBrowserTree listing recovery and revalidation (#11620)", () => 
     );
 
     await waitFor(() => expect(result.current.rows.length).toBeGreaterThan(0));
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await settle();
 
     expect(listDirectory.mock.calls.filter((c) => c[0].dirPath === "bad")).toHaveLength(1);
   });

--- a/src/panels/file-browser/defaults.ts
+++ b/src/panels/file-browser/defaults.ts
@@ -50,5 +50,14 @@ export function createFileBrowserDefaults(
     ...(width != null &&
       width !== FILE_BROWSER_SIDEBAR_DEFAULT_WIDTH && { browserSidebarWidth: width }),
     ...(workspaceRooted && { browserWorkspaceRooted: true }),
+    // Same sparse rule as the serializer wrote them with (#11620): "name" and
+    // "asc" are the defaults the reader falls back to, so materializing them
+    // would only make the record less sparse than it was persisted. Both must
+    // be copied here even though sort is a runtime toolbar toggle rather than
+    // a spawn-time option — restoring a panel routes the deserialized snapshot
+    // through this factory, and a field it does not copy is silently dropped.
+    ...(options.browserSortKey != null &&
+      options.browserSortKey !== "name" && { browserSortKey: options.browserSortKey }),
+    ...(options.browserSortDirection === "desc" && { browserSortDirection: "desc" as const }),
   };
 }

--- a/src/panels/file-browser/fileBrowserTree.ts
+++ b/src/panels/file-browser/fileBrowserTree.ts
@@ -1,5 +1,9 @@
 import type { FileTreeNode } from "@shared/types";
-import type { FileBrowserTreeSnapshot } from "@shared/types/panel";
+import type {
+  FileBrowserSortDirection,
+  FileBrowserSortKey,
+  FileBrowserTreeSnapshot,
+} from "@shared/types/panel";
 
 /**
  * What a browser panel is rooted at.
@@ -50,6 +54,157 @@ export interface FlatTreeRow {
   isLoading: boolean;
   /** Byte size for files; undefined for directories */
   size?: number;
+}
+
+/**
+ * The part of a row every entry-level action actually needs: which path, what
+ * it's called, and whether it's a directory. Both `FlatTreeRow` and
+ * `FolderListingRow` satisfy it structurally, which is what lets the tree and
+ * the folder listing share one context-menu builder instead of maintaining two
+ * copies of the same menu (#11620).
+ */
+export interface FileEntryLike {
+  path: string;
+  name: string;
+  isDirectory: boolean;
+}
+
+/**
+ * One rendered line of a folder's contents listing (#11620) — the flat,
+ * depth-less counterpart to `FlatTreeRow`. Built from one already-cached
+ * directory listing, never its own fetch.
+ */
+export interface FolderListingRow {
+  /** Worktree-relative path; unique within the folder, so it doubles as the React key */
+  path: string;
+  name: string;
+  isDirectory: boolean;
+  /** Byte size for files; undefined for directories and for snapshot-restored nodes */
+  size?: number;
+  /** Epoch ms; undefined for snapshot-restored nodes, which carry structure only */
+  mtimeMs?: number;
+  /**
+   * Visible entries directly inside this directory — never recursive, and only
+   * when that directory's own listing already happens to be cached. Undefined
+   * means "not known", which the row renders as unknown rather than as zero: a
+   * folder the user has never opened is not an empty folder.
+   */
+  itemCount?: number;
+}
+
+export type { FileBrowserSortDirection, FileBrowserSortKey };
+
+/** The sort menu's full state: what to order by, and which way. */
+export interface FileBrowserSortOrder {
+  key: FileBrowserSortKey;
+  direction: FileBrowserSortDirection;
+}
+
+/**
+ * The order the service already returns: folders first, then natural-numeric
+ * name (see `FileTreeService`). Sorting by it is a no-op, which is what lets
+ * `sortFileNodes` hand back the original array untouched on the default path.
+ */
+export const DEFAULT_FILE_SORT: FileBrowserSortOrder = { key: "name", direction: "asc" };
+
+export function isDefaultFileSort(sort: FileBrowserSortOrder): boolean {
+  return sort.key === DEFAULT_FILE_SORT.key && sort.direction === DEFAULT_FILE_SORT.direction;
+}
+
+/**
+ * Same collation the service sorts with (`FileTreeService`'s `NAME_COLLATOR`):
+ * natural-numeric so `version_10` follows `version_9`, host locale, default
+ * sensitivity. Constructed once at module scope — a re-sort touches every node
+ * in a directory, and per-call collator construction is costly.
+ */
+const NAME_COLLATOR = new Intl.Collator(undefined, { numeric: true });
+
+/**
+ * Total, deterministic name order. Numeric collation alone is not a total
+ * order — `file1`, `file01` and `file001` all compare equal — so ties fall
+ * through to codepoint comparison rather than to the array's incoming order,
+ * which mirrors the service and keeps a client re-sort stable across platforms.
+ */
+function compareNames(a: string, b: string): number {
+  const collated = NAME_COLLATOR.compare(a, b);
+  if (collated !== 0) return collated;
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/**
+ * Everything after the last dot, lowercased; "" for a dotfile or a name with no
+ * dot. `.gitignore` is a name, not an extension — treating its suffix as a type
+ * would file every dotfile under a different heading.
+ */
+function fileExtension(name: string): string {
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0) return "";
+  return name.slice(dot + 1).toLowerCase();
+}
+
+/**
+ * Compare two nodes for one sort key, with unknowns pushed last.
+ *
+ * A node restored from a persisted snapshot carries neither `size` nor
+ * `mtimeMs` (the snapshot is structure-only by design, #11367), so those keys
+ * have to answer for "unknown". Unknowns sort last in *both* directions rather
+ * than flipping to the top on descending: they are absent data, not a low
+ * value, and a column of em-dashes above the real rows would read as the sort
+ * being broken.
+ */
+function compareByKey(a: FileTreeNode, b: FileTreeNode, key: FileBrowserSortKey): number {
+  switch (key) {
+    case "modified":
+      return compareOptionalNumbers(a.mtimeMs, b.mtimeMs);
+    case "size":
+      return compareOptionalNumbers(a.size, b.size);
+    case "type":
+      return compareNames(fileExtension(a.name), fileExtension(b.name));
+    case "name":
+      return 0;
+  }
+}
+
+/** Ascending, with `undefined` always last regardless of the caller's direction. */
+function compareOptionalNumbers(a: number | undefined, b: number | undefined): number {
+  if (a === undefined && b === undefined) return 0;
+  // Signalled to the caller as a fixed order by `sortFileNodes`, which skips
+  // the direction flip whenever this returns a non-zero for a missing value.
+  if (a === undefined) return Number.POSITIVE_INFINITY;
+  if (b === undefined) return Number.NEGATIVE_INFINITY;
+  return a === b ? 0 : a < b ? -1 : 1;
+}
+
+/**
+ * Order one directory's entries for display.
+ *
+ * Folders always lead, in every key and both directions — the grouping is
+ * structural (it is what makes a listing scannable), not part of what the user
+ * chose to sort by, and it matches what every file manager does. Direction
+ * flips only *within* each group.
+ *
+ * Returns the input array by reference when the order asked for is the one the
+ * service already produced, so the default path costs nothing and the tree's
+ * memoized rows keep their identity.
+ */
+export function sortFileNodes(
+  nodes: readonly FileTreeNode[],
+  sort: FileBrowserSortOrder
+): readonly FileTreeNode[] {
+  if (isDefaultFileSort(sort)) return nodes;
+  const flip = sort.direction === "desc" ? -1 : 1;
+  return [...nodes].sort((a, b) => {
+    if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1;
+    const primary = compareByKey(a, b, sort.key);
+    // An infinite result marks a missing value, which holds its place at the
+    // bottom instead of being flipped to the top by a descending sort.
+    if (!Number.isFinite(primary)) return primary > 0 ? 1 : -1;
+    if (primary !== 0) return primary * flip;
+    // Name is the tie-break for every other key, and it flips with the
+    // direction too — otherwise a descending size sort would list equal-sized
+    // files ascending, which reads as the sort half-applying.
+    return compareNames(a.name, b.name) * flip;
+  });
 }
 
 /**
@@ -152,7 +307,8 @@ export function flattenTree(
   expandedPaths: ReadonlySet<string>,
   loadingPaths: ReadonlySet<string>,
   rootPath = "",
-  isVisible?: (name: string) => boolean
+  isVisible?: (name: string) => boolean,
+  sort: FileBrowserSortOrder = DEFAULT_FILE_SORT
 ): FlatTreeRow[] {
   const rows: FlatTreeRow[] = [];
 
@@ -161,8 +317,14 @@ export function flattenTree(
     // the caller) would otherwise recurse until the stack blows. The service
     // skips symlinks, so this is a backstop, not the primary defense.
     if (depth > MAX_TREE_DEPTH) return;
-    const children = listings.get(dirPath);
-    if (!children) return;
+    const listed = listings.get(dirPath);
+    if (!listed) return;
+    // Per level, not across the whole tree: each directory's entries are
+    // ordered among themselves, which is the only ordering a tree can express.
+    // Never in place — the listings map is what `snapshotFromListings` persists
+    // and what an unsorted consumer reads, so it must stay as the service sent
+    // it.
+    const children = sortFileNodes(listed, sort);
 
     for (const node of children) {
       // A hidden entry contributes no row and, for a directory, no subtree —
@@ -187,6 +349,75 @@ export function flattenTree(
 }
 
 export const MAX_TREE_DEPTH = 64;
+
+/**
+ * Build the rows for one folder's contents listing (#11620) from the listing
+ * that folder already has cached — never a fetch, and never recursive.
+ *
+ * Returns null when that folder has not been listed yet, which is the caller's
+ * raw "still pending" signal: it is deliberately distinguishable from an empty
+ * array (a folder that really holds nothing) so the two never collapse into one
+ * indistinguishable state.
+ *
+ * A directory row's `itemCount` is filled in only when that child's own listing
+ * happens to already be cached — expanding it in the tree is what puts it
+ * there. Counting means counting *visible* entries, so the number always agrees
+ * with what opening the folder would show.
+ */
+export function buildFolderListingRows(
+  listings: DirectoryListings,
+  dirPath: string,
+  isVisible?: (name: string) => boolean,
+  sort: FileBrowserSortOrder = DEFAULT_FILE_SORT
+): FolderListingRow[] | null {
+  const listed = listings.get(dirPath);
+  if (!listed) return null;
+  const visible = isVisible ? listed.filter((node) => isVisible(node.name)) : listed;
+  return sortFileNodes(visible, sort).map((node) => {
+    const childListing = node.isDirectory ? listings.get(node.path) : undefined;
+    const itemCount =
+      childListing === undefined
+        ? undefined
+        : isVisible
+          ? childListing.filter((child) => isVisible(child.name)).length
+          : childListing.length;
+    return {
+      path: node.path,
+      name: node.name,
+      isDirectory: node.isDirectory,
+      ...(node.size != null && { size: node.size }),
+      ...(node.mtimeMs != null && { mtimeMs: node.mtimeMs }),
+      ...(itemCount != null && { itemCount }),
+    };
+  });
+}
+
+/**
+ * Look one worktree-relative path up in the loaded listings by asking its
+ * parent directory, or undefined when that parent has not been listed.
+ *
+ * This is how the panel learns whether a selection is a file or a folder.
+ * Deriving it from the rendered tree rows instead would make the answer depend
+ * on what is expanded — and the folder listing can select an entry whose parent
+ * is collapsed in the tree, which has no row at all.
+ */
+export function findNodeInListings(
+  listings: DirectoryListings,
+  relativePath: string
+): FileTreeNode | undefined {
+  const parent = parentDirectoryOf(relativePath);
+  return listings.get(parent)?.find((node) => node.path === relativePath);
+}
+
+/**
+ * The directory a worktree-relative path lives in; "" for a root-level entry.
+ * This is the listing that answers what the path is, which is why the prune
+ * has to keep it alive for as long as something is asking.
+ */
+export function parentDirectoryOf(relativePath: string): string {
+  const slash = relativePath.lastIndexOf("/");
+  return slash === -1 ? "" : relativePath.slice(0, slash);
+}
 
 /**
  * Canonical forward-slash form of a worktree-relative browse root: collapses
@@ -318,15 +549,26 @@ function findParentRow(rows: readonly FlatTreeRow[], index: number): FlatTreeRow
  * a worktree an agent is actively writing to, that is the wrong answer often
  * enough to matter. The root listing is always retained — it is what the tree
  * renders from.
+ *
+ * `keepPaths` retains directories the viewer still depends on even when they
+ * are collapsed (#11620): the folder whose contents are being listed, and the
+ * parent that answers what the current selection *is*. Neither is the stale,
+ * unused listing this prune exists to drop — and both matter because selection
+ * and expansion are independent. Without the first, collapsing any *other*
+ * folder evicts the listing being read; without the second, picking a file out
+ * of that listing drops the very listing that knows it is a file, and the
+ * viewer blanks the instant it is clicked.
  */
 export function pruneListings(
   listings: DirectoryListings,
   expandedPaths: ReadonlySet<string>,
-  rootPath = ""
+  rootPath = "",
+  keepPaths: readonly string[] = []
 ): Map<string, readonly FileTreeNode[]> {
   const next = new Map<string, readonly FileTreeNode[]>();
   for (const [dirPath, nodes] of listings) {
-    if (dirPath === rootPath || expandedPaths.has(dirPath)) next.set(dirPath, nodes);
+    if (dirPath === rootPath || keepPaths.includes(dirPath) || expandedPaths.has(dirPath))
+      next.set(dirPath, nodes);
   }
   return next;
 }
@@ -449,9 +691,17 @@ export function refreshTargets(
   listings: DirectoryListings,
   expandedPaths: ReadonlySet<string>,
   rootPath = "",
-  isVisible?: (name: string) => boolean
+  isVisible?: (name: string) => boolean,
+  keepPath: string | null = null
 ): string[] {
   const targets = [rootPath];
+  // The folder the viewer is listing is re-read like an expanded one even when
+  // it is collapsed in the tree (#11620) — it is on screen, so leaving it out
+  // would let it go stale while the tree beside it updates. Added up front and
+  // guarded below so the walk can't list it twice.
+  if (keepPath !== null && keepPath !== rootPath && !expandedPaths.has(keepPath)) {
+    targets.push(keepPath);
+  }
   const walk = (dirPath: string, depth: number): void => {
     if (depth > MAX_TREE_DEPTH) return;
     const children = listings.get(dirPath);

--- a/src/panels/file-browser/fileBrowserTree.ts
+++ b/src/panels/file-browser/fileBrowserTree.ts
@@ -165,14 +165,21 @@ function compareByKey(a: FileTreeNode, b: FileTreeNode, key: FileBrowserSortKey)
   }
 }
 
-/** Ascending, with `undefined` always last regardless of the caller's direction. */
+/**
+ * Ascending, with unknown values always last regardless of the caller's
+ * direction. Anything non-finite counts as unknown: `NaN` compares false
+ * against everything including itself, which would make this comparator
+ * non-antisymmetric and hand V8 an inconsistent ordering to act on.
+ */
 function compareOptionalNumbers(a: number | undefined, b: number | undefined): number {
-  if (a === undefined && b === undefined) return 0;
+  const knownA = a !== undefined && Number.isFinite(a);
+  const knownB = b !== undefined && Number.isFinite(b);
+  if (!knownA && !knownB) return 0;
   // Signalled to the caller as a fixed order by `sortFileNodes`, which skips
-  // the direction flip whenever this returns a non-zero for a missing value.
-  if (a === undefined) return Number.POSITIVE_INFINITY;
-  if (b === undefined) return Number.NEGATIVE_INFINITY;
-  return a === b ? 0 : a < b ? -1 : 1;
+  // the direction flip whenever this returns a non-finite result.
+  if (!knownA) return Number.POSITIVE_INFINITY;
+  if (!knownB) return Number.NEGATIVE_INFINITY;
+  return a === b ? 0 : (a as number) < (b as number) ? -1 : 1;
 }
 
 /**

--- a/src/panels/file-browser/serializer.ts
+++ b/src/panels/file-browser/serializer.ts
@@ -39,5 +39,13 @@ export function serializeFileBrowser(t: FileBrowserPanelData): Partial<PanelSnap
     // `worktreeId`, because a promoted panel carries an adopted placement
     // `worktreeId` by the time it is saved (#11489).
     ...(t.browserWorkspaceRooted === true ? { browserWorkspaceRooted: true } : {}),
+    // Same non-default rule as the sidebar width: "name" ascending is the order
+    // the listing service already returns, so a panel left on the default sort
+    // persists neither field (#11620). The two are written independently — a
+    // descending name sort is a real choice even though its key is the default.
+    ...(t.browserSortKey != null && t.browserSortKey !== "name"
+      ? { browserSortKey: t.browserSortKey }
+      : {}),
+    ...(t.browserSortDirection === "desc" ? { browserSortDirection: "desc" } : {}),
   };
 }

--- a/src/panels/file-browser/useFileBrowserTree.ts
+++ b/src/panels/file-browser/useFileBrowserTree.ts
@@ -348,11 +348,25 @@ export function useFileBrowserTree({
     isRowPathVisible(selectedPath, rootPath, isVisible)
       ? selectedPath
       : null;
+  /**
+   * Directories the viewer depends on that expansion alone would not keep: the
+   * folder being listed, and the parent that resolves what the selection is.
+   * One set, so the prune, the fetch-completion guard and the refresh cannot
+   * drift apart — a guard stricter than the prune drops results for entries
+   * that are then kept forever stale, and a prune stricter than the guard
+   * evicts what is on screen.
+   */
+  const retainedPaths = useMemo(
+    () => [listingPath, selectionParent].filter((path): path is string => path !== null),
+    [listingPath, selectionParent]
+  );
+
   // Read inside `fetchDirectory`'s completion guard and the prune, both of
-  // which run outside the render that knows the current listing target. Kept in
-  // sync in the same layout effect as `expandedSetRef` so the two are never
-  // read at different vintages.
+  // which run outside the render that knows the current targets. Kept in sync
+  // in the same layout effect as `expandedSetRef` so the two are never read at
+  // different vintages.
   const listingPathRef = useRef(listingPath);
+  const retainedPathsRef = useRef(retainedPaths);
 
   // Set when a refresh could not run because its targets were already in
   // flight. Without it, a tick that arrives mid-flight is consumed by a request
@@ -416,12 +430,16 @@ export function useFileBrowserTree({
         // A directory collapsed while its listing was in flight has already
         // been pruned; re-inserting it here would resurrect a cache entry the
         // user closed, and re-expanding later would show that stale snapshot
-        // instead of re-reading. The folder the viewer is listing is exempt: it
-        // is on screen without being expanded (#11620), so dropping its result
-        // here would leave it pending forever.
+        // instead of re-reading.
+        //
+        // Tested against the same retained set the prune keeps, not just
+        // against expansion: the viewer depends on two unexpanded directories
+        // (#11620), and a guard stricter than the prune would drop a result for
+        // a listing that is about to be kept — leaving it permanently stale
+        // with nothing queued to replace it.
         if (
           dirPath !== rootPath &&
-          dirPath !== listingPathRef.current &&
+          !retainedPathsRef.current.includes(dirPath) &&
           !expandedSetRef.current.has(dirPath)
         )
           return;
@@ -600,7 +618,8 @@ export function useFileBrowserTree({
     pumpRef.current = pump;
     treeSnapshotRef.current = treeSnapshot;
     listingPathRef.current = listingPath;
-  }, [listings, expandedSet, isVisible, pump, treeSnapshot, listingPath]);
+    retainedPathsRef.current = retainedPaths;
+  }, [listings, expandedSet, isVisible, pump, treeSnapshot, listingPath, retainedPaths]);
 
   // Cancel a pending root retry synchronously when the identity changes or the
   // panel unmounts. The generation bump that would invalidate the retry lives in
@@ -711,7 +730,19 @@ export function useFileBrowserTree({
       // honours the concurrency ceiling. The refs read here are published in a
       // layout effect, so they are current before this passive effect runs.
       enqueueTargets(
-        refreshTargets(seeded, expandedSetRef.current, rootPath, isVisibleRef.current),
+        // The listed folder is revalidated alongside the root and the seeded
+        // expansions: a snapshot can carry a selected-but-collapsed folder
+        // (the prune keeps it), and its seeded rows are structure-only — no
+        // size, no mtime. Leaving it out of the revalidation would paint that
+        // folder's listing as a column of em-dashes until something unrelated
+        // happened to refresh it.
+        refreshTargets(
+          seeded,
+          expandedSetRef.current,
+          rootPath,
+          isVisibleRef.current,
+          listingPathRef.current
+        ),
         generationRef.current
       );
       pumpRef.current();
@@ -729,6 +760,13 @@ export function useFileBrowserTree({
     const pendingTargets: string[] = [];
     for (const dirPath of expandedSet) {
       if (listings.has(dirPath) || inFlightRef.current.has(dirPath)) continue;
+      // A directory whose last fetch failed is in neither of those, so without
+      // this it would be re-requested every time any sibling listing lands and
+      // rebuilds the map. On a restored tree with hundreds of expansions and
+      // one unreadable directory, that is hundreds of redundant calls against
+      // a shared IPC rate limit. Collapsing it clears the flag (see the prune
+      // effect), and an explicit Refresh re-queues it directly.
+      if (failedListings.has(dirPath)) continue;
       // Only fetch directories the tree can actually reach. A persisted
       // expansion whose parent is collapsed (or gone) would otherwise fire a
       // request for a folder the user cannot see.
@@ -742,7 +780,16 @@ export function useFileBrowserTree({
     if (pendingTargets.length === 0) return;
     enqueueTargets(pendingTargets, generationRef.current);
     pump();
-  }, [expandedSet, listings, hasLoadedRoot, rootPath, isVisible, enqueueTargets, pump]);
+  }, [
+    expandedSet,
+    listings,
+    failedListings,
+    hasLoadedRoot,
+    rootPath,
+    isVisible,
+    enqueueTargets,
+    pump,
+  ]);
 
   // The folder the viewer is listing is fetched on demand, the same way an
   // expansion is — selecting a folder from the keyboard, or from the listing
@@ -774,15 +821,22 @@ export function useFileBrowserTree({
   // folder on screen in the viewer is retained even when collapsed (#11620) —
   // it is being read right now, so it is not the unused cache entry this drops.
   useEffect(() => {
-    const retained = [listingPath, selectionParent].filter((path): path is string => path !== null);
     setListings((previous) => {
-      const next = pruneListings(previous, expandedSet, rootPath, retained);
+      const next = pruneListings(previous, expandedSet, rootPath, retainedPaths);
       return next.size === previous.size ? previous : next;
     });
-    // Both retained paths are plain strings, so they belong in the dep list
-    // directly — the array above is rebuilt inside the effect rather than
-    // memoized, since a fresh array each render would re-run this every pass.
-  }, [expandedSet, rootPath, listingPath, selectionParent]);
+    // Collapsing a directory clears any recorded failure for it, so the natural
+    // collapse-then-expand gesture retries rather than being refused forever by
+    // the expansion effect's skip below.
+    setFailedListings((previous) => {
+      if (previous.size === 0) return previous;
+      const next = new Set<string>();
+      for (const path of previous) {
+        if (expandedSet.has(path) || retainedPaths.includes(path)) next.add(path);
+      }
+      return next.size === previous.size ? previous : next;
+    });
+  }, [expandedSet, rootPath, retainedPaths]);
 
   // Live updates. The tick is the worktree's own change signal, so this
   // inherits its coalescing.
@@ -814,6 +868,14 @@ export function useFileBrowserTree({
   // "loaded and empty" into one value, and the consumer needs them apart to
   // pick between a skeleton and an empty state (#10083). The gate belongs in
   // the consumer, deciding only whether the skeleton paints.
+  //
+  // Rows win over a recorded failure deliberately. A failure with rows already
+  // on screen is a *refresh* that failed, and blanking readable content for an
+  // error banner is the thing the tree's own root-error branch refuses to do —
+  // the last-known contents stay, exactly as a non-root directory failure is
+  // already silent for the tree. Only a folder with nothing to show at all
+  // reports the error, because that is the only case where the error is the
+  // whole story.
   const listingStatus: FolderListingStatus =
     listingPath === null || listingRows !== null
       ? "ready"

--- a/src/panels/file-browser/useFileBrowserTree.ts
+++ b/src/panels/file-browser/useFileBrowserTree.ts
@@ -5,17 +5,23 @@ import { fileBrowserClient } from "@/clients/fileBrowserClient";
 import { logError } from "@/utils/logger";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import {
+  buildFolderListingRows,
   createVisibilityFilter,
+  DEFAULT_FILE_SORT,
+  findNodeInListings,
   flattenTree,
   isRowPathVisible,
+  parentDirectoryOf,
   listingsFromSnapshot,
   pruneListings,
   refreshTargets,
   snapshotFromListings,
   snapshotMatchesSource,
   sourceIdentityKey,
+  type FileBrowserSortOrder,
   type FileBrowserSource,
   type FlatTreeRow,
+  type FolderListingRow,
 } from "./fileBrowserTree";
 
 /**
@@ -81,7 +87,26 @@ export interface UseFileBrowserTreeArgs {
    * other root) is ignored and the tree cold-starts as before.
    */
   treeSnapshot?: FileBrowserTreeSnapshot;
+  /**
+   * What every directory's entries are ordered by (#11620). Applied per level
+   * to the tree and to the folder listing from this one value, so the two
+   * columns can never disagree about the order of the same directory.
+   */
+  sort?: FileBrowserSortOrder;
+  /**
+   * The selected worktree-relative path, whatever kind it turns out to be.
+   *
+   * Resolved here rather than by the caller because deciding whether it names a
+   * folder needs the listings map this hook owns — and if it does, that folder
+   * is fetched on demand like an expansion, kept across an unrelated collapse,
+   * and re-read on a change tick (#11620). A folder can be listed without being
+   * expanded, so those three things have to be arranged for it explicitly.
+   */
+  selectedPath?: string | null;
 }
+
+/** What the viewer's folder listing is doing right now (#11620). */
+export type FolderListingStatus = "pending" | "ready" | "error";
 
 export interface UseFileBrowserTreeResult {
   rows: FlatTreeRow[];
@@ -117,6 +142,37 @@ export interface UseFileBrowserTreeResult {
    * change tick, so persistence writes stay off the refresh path.
    */
   captureSnapshot: () => FileBrowserTreeSnapshot | null;
+  /**
+   * The node `selectedPath` names, looked up through its parent directory's
+   * listing, or undefined when that parent has not been read. Resolved this way
+   * rather than from the rendered tree rows because the folder listing can
+   * select an entry whose parent is collapsed in the tree (#11620) — such an
+   * entry has no row, and asking `rows` would report a real file as unknown.
+   */
+  selectedNode: FileTreeNode | undefined;
+  /**
+   * The folder currently being listed, or null when the selection is a file,
+   * nothing, or hidden by the current filters.
+   */
+  listingPath: string | null;
+  /**
+   * Rows for `listingPath`'s contents, or null when no folder is being listed.
+   * Empty array and null are deliberately different answers: empty is a folder
+   * that really holds nothing, null is no folder selected.
+   */
+  listingRows: FolderListingRow[] | null;
+  /**
+   * Raw state of `listingPath`'s fetch — never gated by an anti-flicker timer.
+   * A gated flag cannot tell "still loading" from "loaded and empty", so the
+   * consumer branches on this and uses its own deferred flag only to decide
+   * whether a skeleton paints (#10083).
+   */
+  listingStatus: FolderListingStatus;
+  /**
+   * Whether the dotfile toggle is hiding something in the folder being listed,
+   * so its empty state can offer "Show dotfiles" only when that would help.
+   */
+  listingHasHiddenDotfiles: boolean;
 }
 
 interface QueueEntry {
@@ -151,6 +207,8 @@ export function useFileBrowserTree({
   rootPath = "",
   changeTick,
   treeSnapshot,
+  sort = DEFAULT_FILE_SORT,
+  selectedPath = null,
 }: UseFileBrowserTreeArgs): UseFileBrowserTreeResult {
   // A primitive standing in for `source` in effect dependency lists: the pane
   // rebuilds the object every render, so depending on it directly would reset
@@ -183,6 +241,13 @@ export function useFileBrowserTree({
     () => seedListings(treeSnapshot, source, rootPath) ?? new Map()
   );
   const [loadingPaths, setLoadingPaths] = useState<ReadonlySet<string>>(new Set());
+  // Non-root directories whose last fetch failed. Per-directory failures are
+  // otherwise silent by design (only the root gets a banner), which leaves a
+  // folder listing with no way to tell "failed" from "still loading" — it would
+  // sit on a skeleton forever. Kept as state, not a ref, because the listing
+  // has to re-render when a fetch fails; cleared on success and on any identity
+  // reset.
+  const [failedListings, setFailedListings] = useState<ReadonlySet<string>>(new Set());
   const [rootError, setRootError] = useState<string | null>(null);
   const [hasLoadedRoot, setHasLoadedRoot] = useState(false);
   // True when the current identity's listings were seeded from a persisted
@@ -232,6 +297,14 @@ export function useFileBrowserTree({
   const rootRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const rootRetryStateRef = useRef<RootRetryState>({ generation: 0, nextDelayIndex: 0 });
 
+  // Re-keyed on its two primitives rather than used directly: the pane builds a
+  // fresh object each render, so depending on the prop would invalidate the row
+  // memos below on every pass — the exact cost virtualization exists to avoid.
+  const sortKeyed = useMemo(
+    () => ({ key: sort.key, direction: sort.direction }),
+    [sort.key, sort.direction]
+  );
+
   const expandedSet = useMemo(() => new Set(expandedPaths), [expandedPaths]);
   const expandedSetRef = useRef(expandedSet);
 
@@ -250,6 +323,36 @@ export function useFileBrowserTree({
     [hideDotfiles, alwaysHiddenPatterns]
   );
   const isVisibleRef = useRef(isVisible);
+
+  // The directory whose listing answers what the selection is. Held onto
+  // through the prune below: picking a file out of a folder listing collapses
+  // that folder's role from "being listed" to "merely the parent", and dropping
+  // it right then would forget the file's own kind the moment it was clicked.
+  const selectionParent = selectedPath === null ? null : parentDirectoryOf(selectedPath);
+
+  // What the selection actually is, answered by its parent directory's listing
+  // rather than by the rendered rows — the folder listing can select an entry
+  // whose parent is collapsed in the tree, and that entry has no row (#11620).
+  const selectedNode = useMemo(
+    () => (selectedPath === null ? undefined : findNodeInListings(listings, selectedPath)),
+    [listings, selectedPath]
+  );
+
+  // The folder to list: positively a directory, and still reachable under the
+  // current filters. A folder the dotfile toggle has just hidden keeps its
+  // stale `browserSelectedPath` but has no row to select, so it must stop
+  // driving a listing rather than keep one on screen the tree can't show.
+  const listingPath =
+    selectedPath !== null &&
+    selectedNode?.isDirectory === true &&
+    isRowPathVisible(selectedPath, rootPath, isVisible)
+      ? selectedPath
+      : null;
+  // Read inside `fetchDirectory`'s completion guard and the prune, both of
+  // which run outside the render that knows the current listing target. Kept in
+  // sync in the same layout effect as `expandedSetRef` so the two are never
+  // read at different vintages.
+  const listingPathRef = useRef(listingPath);
 
   // Set when a refresh could not run because its targets were already in
   // flight. Without it, a tick that arrives mid-flight is consumed by a request
@@ -313,12 +416,28 @@ export function useFileBrowserTree({
         // A directory collapsed while its listing was in flight has already
         // been pruned; re-inserting it here would resurrect a cache entry the
         // user closed, and re-expanding later would show that stale snapshot
-        // instead of re-reading.
-        if (dirPath !== rootPath && !expandedSetRef.current.has(dirPath)) return;
+        // instead of re-reading. The folder the viewer is listing is exempt: it
+        // is on screen without being expanded (#11620), so dropping its result
+        // here would leave it pending forever.
+        if (
+          dirPath !== rootPath &&
+          dirPath !== listingPathRef.current &&
+          !expandedSetRef.current.has(dirPath)
+        )
+          return;
 
         setListings((previous) => {
           const next = new Map(previous);
           next.set(dirPath, nodes);
+          return next;
+        });
+        // A directory that has just been read is no longer failed, whether or
+        // not it ever was — clearing unconditionally would churn a new Set on
+        // every listing, so only an actual member triggers a write.
+        setFailedListings((previous) => {
+          if (!previous.has(dirPath)) return previous;
+          const next = new Set(previous);
+          next.delete(dirPath);
           return next;
         });
         if (dirPath === rootPath) {
@@ -328,6 +447,17 @@ export function useFileBrowserTree({
         }
       } catch (error) {
         if (generation !== generationRef.current) return;
+        if (dirPath !== rootPath) {
+          // Recorded rather than surfaced: the tree still shows nothing for this
+          // directory, exactly as before, but a folder listing pointed at it can
+          // now tell a failure from a fetch still in flight (#11620).
+          setFailedListings((previous) => {
+            if (previous.has(dirPath)) return previous;
+            const next = new Set(previous);
+            next.add(dirPath);
+            return next;
+          });
+        }
         if (dirPath === rootPath) {
           // Only the root surfaces an error: it is the difference between "the
           // browser works" and "it doesn't". A single directory that failed
@@ -432,7 +562,13 @@ export function useFileBrowserTree({
       refreshPendingRef.current = false;
       const generation = generationRef.current;
       enqueueTargets(
-        refreshTargets(listingsRef.current, expandedSetRef.current, rootPath, isVisibleRef.current),
+        refreshTargets(
+          listingsRef.current,
+          expandedSetRef.current,
+          rootPath,
+          isVisibleRef.current,
+          listingPathRef.current
+        ),
         generation
       );
       pumpRef.current();
@@ -463,7 +599,8 @@ export function useFileBrowserTree({
     isVisibleRef.current = isVisible;
     pumpRef.current = pump;
     treeSnapshotRef.current = treeSnapshot;
-  }, [listings, expandedSet, isVisible, pump, treeSnapshot]);
+    listingPathRef.current = listingPath;
+  }, [listings, expandedSet, isVisible, pump, treeSnapshot, listingPath]);
 
   // Cancel a pending root retry synchronously when the identity changes or the
   // panel unmounts. The generation bump that would invalidate the retry lives in
@@ -508,7 +645,8 @@ export function useFileBrowserTree({
         listingsRef.current,
         expandedSetRef.current,
         rootPath,
-        isVisibleRef.current
+        isVisibleRef.current,
+        listingPathRef.current
       );
       // A user press should spin the toolbar icon until the re-list drains. Set
       // this before `pump` so the flag is up if fetches start synchronously; a
@@ -559,6 +697,10 @@ export function useFileBrowserTree({
     const seededRoot = seeded !== null;
     setListings(seeded ?? new Map());
     setLoadingPaths(new Set());
+    // A failure belongs to the identity it happened under: carrying it across
+    // would leave a folder permanently unfetchable in a worktree that never
+    // failed to list it.
+    setFailedListings(new Set());
     setRootError(null);
     setHasLoadedRoot(false);
     setHasSeededRoot(seededRoot);
@@ -602,14 +744,45 @@ export function useFileBrowserTree({
     pump();
   }, [expandedSet, listings, hasLoadedRoot, rootPath, isVisible, enqueueTargets, pump]);
 
-  // Forget collapsed subtrees so re-expanding re-reads rather than replaying a
-  // listing that may be minutes stale on an actively-written worktree.
+  // The folder the viewer is listing is fetched on demand, the same way an
+  // expansion is — selecting a folder from the keyboard, or from the listing
+  // itself, never expands it, so nothing else would ask for its contents.
+  // Gated on the root having landed for the same reason the expansion effect
+  // is, and skipped once a fetch has failed: a failed directory is in neither
+  // `listings` nor `inFlightRef`, so without that check this would re-request
+  // it on every render.
   useEffect(() => {
+    if (!hasLoadedRoot || listingPath === null) return;
+    if (listings.has(listingPath) || failedListings.has(listingPath)) return;
+    if (inFlightRef.current.has(listingPath)) return;
+    if (!isRowPathVisible(listingPath, rootPath, isVisible)) return;
+    enqueueTargets([listingPath], generationRef.current);
+    pump();
+  }, [
+    listingPath,
+    listings,
+    failedListings,
+    hasLoadedRoot,
+    rootPath,
+    isVisible,
+    enqueueTargets,
+    pump,
+  ]);
+
+  // Forget collapsed subtrees so re-expanding re-reads rather than replaying a
+  // listing that may be minutes stale on an actively-written worktree. The
+  // folder on screen in the viewer is retained even when collapsed (#11620) —
+  // it is being read right now, so it is not the unused cache entry this drops.
+  useEffect(() => {
+    const retained = [listingPath, selectionParent].filter((path): path is string => path !== null);
     setListings((previous) => {
-      const next = pruneListings(previous, expandedSet, rootPath);
+      const next = pruneListings(previous, expandedSet, rootPath, retained);
       return next.size === previous.size ? previous : next;
     });
-  }, [expandedSet, rootPath]);
+    // Both retained paths are plain strings, so they belong in the dep list
+    // directly — the array above is rebuilt inside the effect rather than
+    // memoized, since a fresh array each render would re-run this every pass.
+  }, [expandedSet, rootPath, listingPath, selectionParent]);
 
   // Live updates. The tick is the worktree's own change signal, so this
   // inherits its coalescing.
@@ -625,18 +798,46 @@ export function useFileBrowserTree({
   }, [changeTick, hasLoadedRoot, refresh]);
 
   const rows = useMemo(
-    () => flattenTree(listings, expandedSet, loadingPaths, rootPath, isVisible),
-    [listings, expandedSet, loadingPaths, rootPath, isVisible]
+    () => flattenTree(listings, expandedSet, loadingPaths, rootPath, isVisible, sortKeyed),
+    [listings, expandedSet, loadingPaths, rootPath, isVisible, sortKeyed]
   );
+
+  const listingRows = useMemo(
+    () =>
+      listingPath === null
+        ? null
+        : buildFolderListingRows(listings, listingPath, isVisible, sortKeyed),
+    [listings, listingPath, isVisible, sortKeyed]
+  );
+
+  // Raw, never anti-flicker-gated: a gated flag collapses "still loading" and
+  // "loaded and empty" into one value, and the consumer needs them apart to
+  // pick between a skeleton and an empty state (#10083). The gate belongs in
+  // the consumer, deciding only whether the skeleton paints.
+  const listingStatus: FolderListingStatus =
+    listingPath === null || listingRows !== null
+      ? "ready"
+      : failedListings.has(listingPath)
+        ? "error"
+        : "pending";
 
   // Would toggling the dotfile filter off reveal anything at this root? A
   // root-level dot entry that the junk list is *not* already hiding.
-  const hasHiddenDotfiles = useMemo(() => {
-    const rootNodes = listings.get(rootPath);
-    if (!rootNodes) return false;
-    const notJunk = createVisibilityFilter({ hideDotfiles: false, alwaysHiddenPatterns });
-    return rootNodes.some((node) => node.name.startsWith(".") && notJunk(node.name));
-  }, [listings, rootPath, alwaysHiddenPatterns]);
+  const hasHiddenDotfiles = useMemo(
+    () => directoryHasHiddenDotfiles(listings, rootPath, alwaysHiddenPatterns),
+    [listings, rootPath, alwaysHiddenPatterns]
+  );
+
+  // The same question asked of the folder being listed rather than of the root
+  // (#11620) — its empty state offers "Show dotfiles" only when that would
+  // actually put something on screen.
+  const listingHasHiddenDotfiles = useMemo(
+    () =>
+      listingPath === null
+        ? false
+        : directoryHasHiddenDotfiles(listings, listingPath, alwaysHiddenPatterns),
+    [listings, listingPath, alwaysHiddenPatterns]
+  );
 
   // Keyed on `sourceKey` for two reasons: the pane runs its going-away capture
   // in an effect keyed on this callback, so without it a source change that
@@ -660,7 +861,29 @@ export function useFileBrowserTree({
     refresh,
     isRefreshing,
     captureSnapshot,
+    selectedNode,
+    listingPath,
+    listingRows,
+    listingStatus,
+    listingHasHiddenDotfiles,
   };
+}
+
+/**
+ * Whether one loaded directory holds a dot-prefixed entry the junk list is not
+ * already hiding — i.e. whether turning the dotfile toggle off would reveal
+ * anything there. False for a directory that has not been listed: nothing is
+ * known to be hidden in a folder nothing is known about.
+ */
+function directoryHasHiddenDotfiles(
+  listings: ReadonlyMap<string, readonly FileTreeNode[]>,
+  dirPath: string,
+  alwaysHiddenPatterns: readonly string[]
+): boolean {
+  const nodes = listings.get(dirPath);
+  if (!nodes) return false;
+  const notJunk = createVisibilityFilter({ hideDotfiles: false, alwaysHiddenPatterns });
+  return nodes.some((node) => node.name.startsWith(".") && notJunk(node.name));
 }
 
 /**

--- a/src/panels/file-browser/useFileBrowserTree.ts
+++ b/src/panels/file-browser/useFileBrowserTree.ts
@@ -465,10 +465,21 @@ export function useFileBrowserTree({
         }
       } catch (error) {
         if (generation !== generationRef.current) return;
-        if (dirPath !== rootPath) {
-          // Recorded rather than surfaced: the tree still shows nothing for this
-          // directory, exactly as before, but a folder listing pointed at it can
-          // now tell a failure from a fetch still in flight (#11620).
+        // Recorded rather than surfaced: the tree still shows nothing for this
+        // directory, exactly as before, but a folder listing pointed at it can
+        // now tell a failure from a fetch still in flight (#11620).
+        //
+        // Only for a directory something still wants, tested the same way the
+        // success path tests it. A request that fails *after* the user collapsed
+        // its directory would otherwise leave a failure nothing goes on to
+        // clear — the prune's clearing pass has already run for that collapse —
+        // and the expansion effect would then refuse to re-request it, making
+        // re-expanding the folder silently do nothing.
+        const stillWanted =
+          dirPath === rootPath ||
+          retainedPathsRef.current.includes(dirPath) ||
+          expandedSetRef.current.has(dirPath);
+        if (dirPath !== rootPath && stillWanted) {
           setFailedListings((previous) => {
             if (previous.has(dirPath)) return previous;
             const next = new Set(previous);
@@ -873,15 +884,21 @@ export function useFileBrowserTree({
   // on screen is a *refresh* that failed, and blanking readable content for an
   // error banner is the thing the tree's own root-error branch refuses to do —
   // the last-known contents stay, exactly as a non-root directory failure is
-  // already silent for the tree. Only a folder with nothing to show at all
-  // reports the error, because that is the only case where the error is the
-  // whole story.
+  // already silent for the tree. Only a folder with nothing to show reports the
+  // error, because that is the only case where the error is the whole story.
+  //
+  // "Nothing to show" means no rows, not merely no listing: a folder cached as
+  // empty whose re-read then fails has nothing to protect, and reporting it as
+  // ready would put "Nothing in this folder yet" on screen for a folder we in
+  // fact failed to read — a confident claim built on a failure.
   const listingStatus: FolderListingStatus =
-    listingPath === null || listingRows !== null
+    listingPath === null || (listingRows !== null && listingRows.length > 0)
       ? "ready"
       : failedListings.has(listingPath)
         ? "error"
-        : "pending";
+        : listingRows !== null
+          ? "ready"
+          : "pending";
 
   // Would toggling the dotfile filter off reveal anything at this root? A
   // root-level dot entry that the junk list is *not* already hiding.

--- a/src/store/slices/panelRegistry/__tests__/fileBrowser.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/fileBrowser.test.ts
@@ -308,3 +308,78 @@ describe("setFileBrowserView", () => {
     expect(store.get()).toBe(before);
   });
 });
+
+describe("setFileBrowserView sort fields (#11620)", () => {
+  let store: ReturnType<typeof makeSet>;
+  let setFileBrowserView: ReturnType<typeof createFileBrowserPanelActions>["setFileBrowserView"];
+
+  beforeEach(() => {
+    store = makeSet({
+      panelsById: { "panel-1": browserPanel() },
+      panelIds: ["panel-1"],
+    });
+    setFileBrowserView = createFileBrowserPanelActions(store.set).setFileBrowserView;
+  });
+
+  it("stores a non-default sort key and direction", () => {
+    setFileBrowserView("panel-1", { browserSortKey: "size", browserSortDirection: "desc" });
+
+    expect(store.get().panelsById["panel-1"]).toMatchObject({
+      browserSortKey: "size",
+      browserSortDirection: "desc",
+    });
+  });
+
+  it("treats patching the default order onto a never-sorted panel as a no-op", () => {
+    // Absent and name/asc are the same state, so this must not dirty the panel
+    // record (and with it the persisted layout) for nothing.
+    const before = store.get();
+
+    setFileBrowserView("panel-1", { browserSortKey: "name", browserSortDirection: "asc" });
+
+    expect(store.get()).toBe(before);
+  });
+
+  it("commits a direction change even when the key is unchanged", () => {
+    // The direction gets its own comparison rather than riding the key's:
+    // folding them together would make every flip a silent no-op.
+    setFileBrowserView("panel-1", { browserSortKey: "name", browserSortDirection: "desc" });
+
+    expect(store.get().panelsById["panel-1"]).toMatchObject({ browserSortDirection: "desc" });
+  });
+
+  it("commits a key change even when the direction is unchanged", () => {
+    setFileBrowserView("panel-1", { browserSortKey: "type", browserSortDirection: "asc" });
+
+    expect(store.get().panelsById["panel-1"]).toMatchObject({ browserSortKey: "type" });
+  });
+
+  it("writes both halves in one commit", () => {
+    // The pane always sends them together; a split write could land a key while
+    // its direction was still being judged unchanged.
+    setFileBrowserView("panel-1", { browserSortKey: "modified", browserSortDirection: "desc" });
+    const panel = store.get().panelsById["panel-1"];
+
+    expect(panel).toMatchObject({ browserSortKey: "modified", browserSortDirection: "desc" });
+  });
+
+  it("leaves an existing sort alone when the patch names neither field", () => {
+    setFileBrowserView("panel-1", { browserSortKey: "size", browserSortDirection: "desc" });
+    setFileBrowserView("panel-1", { browserSelectedPath: "src/app.ts" });
+
+    expect(store.get().panelsById["panel-1"]).toMatchObject({
+      browserSortKey: "size",
+      browserSortDirection: "desc",
+      browserSelectedPath: "src/app.ts",
+    });
+  });
+
+  it("is a no-op when re-patching the sort already in effect", () => {
+    setFileBrowserView("panel-1", { browserSortKey: "size", browserSortDirection: "desc" });
+    const before = store.get();
+
+    setFileBrowserView("panel-1", { browserSortKey: "size", browserSortDirection: "desc" });
+
+    expect(store.get()).toBe(before);
+  });
+});

--- a/src/store/slices/panelRegistry/fileBrowser.ts
+++ b/src/store/slices/panelRegistry/fileBrowser.ts
@@ -1,4 +1,8 @@
-import type { FileBrowserTreeSnapshot } from "@shared/types/panel";
+import type {
+  FileBrowserSortDirection,
+  FileBrowserSortKey,
+  FileBrowserTreeSnapshot,
+} from "@shared/types/panel";
 import { deepEqualIgnoringUndefined } from "@shared/utils/layoutMerge";
 import type { PanelRegistryStoreApi, PanelRegistrySlice } from "./types";
 import { saveNormalized } from "./persistence";
@@ -23,6 +27,10 @@ export interface FileBrowserViewPatch {
   browserTreeSnapshot?: FileBrowserTreeSnapshot;
   /** Tree column width in px; clamped into range before it lands. */
   browserSidebarWidth?: number;
+  /** What the tree and folder listing order entries by (#11620). */
+  browserSortKey?: FileBrowserSortKey;
+  /** Direction for `browserSortKey`; `asc` and absent are the same state. */
+  browserSortDirection?: FileBrowserSortDirection;
 }
 
 function sameStringList(a: string[] | undefined, b: string[]): boolean {
@@ -92,6 +100,15 @@ export const createFileBrowserPanelActions = (
       const widthUnchanged =
         nextWidth === undefined ||
         nextWidth === (panel.browserSidebarWidth ?? FILE_BROWSER_SIDEBAR_DEFAULT_WIDTH);
+      // Both sort halves normalize absent to their default before comparing,
+      // like the collapse flags: patching "name"/"asc" onto a never-sorted
+      // panel is the state it is already in, not a change worth a write.
+      const sortKeyUnchanged =
+        patch.browserSortKey === undefined ||
+        patch.browserSortKey === (panel.browserSortKey ?? "name");
+      const sortDirectionUnchanged =
+        patch.browserSortDirection === undefined ||
+        patch.browserSortDirection === (panel.browserSortDirection ?? "asc");
 
       // Bail on a no-op write. The tree calls this on every arrow key, and a
       // drag calls it on every mousemove; a fresh panel object each time would
@@ -105,7 +122,9 @@ export const createFileBrowserPanelActions = (
         sidebarCollapsedUnchanged &&
         viewerCollapsedUnchanged &&
         treeSnapshotUnchanged &&
-        widthUnchanged
+        widthUnchanged &&
+        sortKeyUnchanged &&
+        sortDirectionUnchanged
       )
         return state;
 
@@ -133,6 +152,12 @@ export const createFileBrowserPanelActions = (
           browserTreeSnapshot: patch.browserTreeSnapshot,
         }),
         ...(nextWidth !== undefined && { browserSidebarWidth: nextWidth }),
+        ...(patch.browserSortKey !== undefined && {
+          browserSortKey: patch.browserSortKey,
+        }),
+        ...(patch.browserSortDirection !== undefined && {
+          browserSortDirection: patch.browserSortDirection,
+        }),
       };
 
       const newById = { ...state.panelsById, [id]: nextPanel };

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -4,6 +4,8 @@ import type { BrowserHistory } from "@shared/types/browser";
 import type {
   FileViewMode,
   DiffSource,
+  FileBrowserSortDirection,
+  FileBrowserSortKey,
   FileBrowserTreeSnapshot,
   PanelExitBehavior,
   PanelTitleMode,
@@ -70,6 +72,8 @@ export interface AddTerminalArgs extends AddPanelOptionsBase {
   browserTreeSnapshot?: FileBrowserTreeSnapshot;
   browserSidebarWidth?: number;
   browserWorkspaceRooted?: boolean;
+  browserSortKey?: FileBrowserSortKey;
+  browserSortDirection?: FileBrowserSortDirection;
   /**
    * Preserved user-initiated focus timestamp from the saved snapshot. The
    * post-hydration focus picker in `useAppHydration` reads this off
@@ -136,6 +140,8 @@ export interface SavedTerminalData {
   browserTreeSnapshot?: unknown;
   browserSidebarWidth?: unknown;
   browserWorkspaceRooted?: unknown;
+  browserSortKey?: unknown;
+  browserSortDirection?: unknown;
   exitBehavior?: PanelExitBehavior;
   agentSessionId?: string;
   agentLaunchFlags?: string[];


### PR DESCRIPTION
## Summary

- Selecting a folder in the file browser tree used to hit the same "Nothing selected" placeholder as selecting nothing at all. It now renders a virtualized listing of that folder's contents in the viewer column.
- Adds a toolbar sort menu (sort key: name / modified / size / type, sort order: ascending / descending) that orders both the tree and the new listing from one setting.
- Review during development turned up and fixed a restart bug where sort state was silently dropped, plus a few smaller correctness issues below.

Resolves #11620

## Changes

- New `src/panels/file-browser/FolderListingView.tsx`: name / size / modified columns, folders first, virtualized through `react-virtuoso` with a sticky decorative header. Single click selects a row (a folder steps into itself, a file opens), right click gets the same context menu as the tree, and rows drag with the same `FILE_DRAG_MIME` payload as the tree (#11576).
- Toolbar sort menu with two radio groups for key and order. Sorting is applied per directory level and persists sparsely per panel: the default name/ascending order isn't persisted, since that's already what the underlying listing service returns.
- A folder's "size" is a visible item count, filled in only when that folder's own listing is already cached in memory, never from a recursive filesystem walk. Unknown size or modified values render as an em dash rather than a fabricated zero.
- Added `mtimeMs` to `FileTreeNode`, read off the `lstat` call the directory listing already performs, for both directory and file entries, so no new syscall.
- Loading, empty, filtered, and error states are explicitly defined and branched on the raw fetch state rather than a debounced loading flag, since a debounced boolean can't tell "still loading" apart from "loaded and empty."

Two deliberate deviations from the issue worth flagging:

- No double click gesture in the listing. A single click already replaces the listing's contents, so the first click of any double click unmounts the row before a second click could arrive. Re-rooting to a folder from the listing is available instead from its context menu, under "Set as root."
- The listing is a labelled `role="group"` with `aria-current`, not a `listbox`/`option` pair. `react-virtuoso` renders a wrapper element between the scroller and the rows, so full option ownership semantics couldn't be honestly implemented, and there's no roving focus here to back them up anyway. The tree next to it remains the keyboard-navigable view of the same data.

Caught and fixed in review:

- Sort settings were being silently dropped on every app restart. Restore runs through a snapshot step, a deserializer, panel options, and then a defaults factory, and that factory wasn't copying the new sort fields, so 7 of 8 sort states were lost on restore despite the rest of the persistence chain being correct.
- A selected file hidden by the dotfile filter kept showing its preview.
- A failed directory listing request could be re-issued on every sibling listing request.
- An internal pruning step could evict the listing the viewer was actively reading from.

This branch was rebased onto `develop` after a separate change landed that added git status to the file browser tree, since both touch the same files. The conflict resolved with a selected folder taking priority over the nothing-selected state in the changed-files summary: a folder selection is still a selection.

## Testing

- 1013 targeted tests passing locally: file browser panel suites, panel-kind serializers, panel registry store, field coverage, state hydration, `FileTreeService`.
- Typecheck clean.
- Prettier and eslint clean on changed files.
