### PR TITLE
feat(ui): give the palette shell an anchored form

### DIFF
--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -3,7 +3,7 @@ import Fuse, { type IFuseOptions } from "fuse.js";
 import { Plus, SquareTerminal } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { AppPalettePopover } from "@/components/ui/AppPalettePopover";
 import { AppPaletteDialog } from "@/components/ui/AppPaletteDialog";
 import { PALETTE_ROW_CLASS } from "@/components/ui/paletteRowStyles";
 import { BrandMark, Workflow } from "@/components/icons";
@@ -61,11 +61,6 @@ export function DockLaunchButton({
   // genuine pointer hover (cleared via onPointerEnter).
   const [tooltipOpen, setTooltipOpen] = useState(false);
   const isRestoringFocusRef = useRef(false);
-  // Set in onPointerDownOutside, read in onCloseAutoFocus. Lets us
-  // preventDefault() the focus restoration only for pointer dismissals so the
-  // launch pill doesn't keep its accent focus-visible ring; keyboard close
-  // (Escape/Enter) still gets default focus return for WAI-ARIA.
-  const wasPointerCloseRef = useRef(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const listboxId = useId();
   const getOptionId = useCallback((rowKey: string) => `${listboxId}-${rowKey}`, [listboxId]);
@@ -112,24 +107,7 @@ export function DockLaunchButton({
       deferFiltering: false,
     });
 
-  // Read synchronously from Radix's document-level Escape handler, which fires
-  // before React state has re-rendered. Written only from `updateQuery` (never
-  // during render) so an abandoned concurrent render can't leave the ref
-  // describing a query the user never committed.
-  const queryRef = useRef(query);
-
-  const updateQuery = useCallback(
-    (next: string) => {
-      queryRef.current = next;
-      setQuery(next);
-      // Deliberately NOT resetting the selection here: the hook's own effect
-      // reconciles it, and calling its setter with the pre-query results would
-      // stamp the old list's first row as the item to follow — after which the
-      // effect chases that row into the new results instead of settling on the
-      // top match. `activeIndex` below covers the frame before it lands.
-    },
-    [setQuery]
-  );
+  const clearQuery = useCallback(() => setQuery(""), [setQuery]);
 
   // The hook reconciles `selectedIndex` in an effect, so the render right after
   // the results change still holds the old index — which browsing can now leave
@@ -145,20 +123,10 @@ export function DockLaunchButton({
   const selectedRow = activeIndex >= 0 ? results[activeIndex] : undefined;
   const activeDescendant = selectedRow ? getOptionId(selectedRow.rowKey) : undefined;
 
-  const focusInput = useCallback(() => {
-    inputRef.current?.focus({ preventScroll: true });
+  const suppressTooltipDuringFocusRestore = useCallback(() => {
+    setTooltipOpen(false);
+    isRestoringFocusRef.current = true;
   }, []);
-
-  // Second focus attempt behind `onOpenAutoFocus`. `PopoverContent` renders
-  // nothing until its lazily imported Radix chunk resolves, so on a cold click
-  // this frame can fire before the input exists; on a warm one it runs after
-  // the mount handler already focused it and is a harmless no-op. Neither
-  // covers both orders alone.
-  useEffect(() => {
-    if (!open) return;
-    const frame = requestAnimationFrame(focusInput);
-    return () => cancelAnimationFrame(frame);
-  }, [open, focusInput]);
 
   // Re-anchor the selection each time the launcher opens. Closing only clears
   // the query, so the hook's follow-anchor still points wherever browsing
@@ -193,9 +161,9 @@ export function DockLaunchButton({
   const closeLauncher = useCallback(() => {
     // Local state, not paletteId-backed — reset it ourselves so the next open
     // starts unfiltered on the Recently launched / Pinned bands.
-    updateQuery("");
+    clearQuery();
     setOpen(false);
-  }, [updateQuery]);
+  }, [clearQuery]);
 
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {
@@ -281,8 +249,8 @@ export function DockLaunchButton({
   );
 
   return (
-    <Popover
-      open={open}
+    <AppPalettePopover
+      isOpen={open}
       onOpenChange={handleOpenChange}
       // The DropdownMenu this replaced was modal, and the launcher relies on
       // that: focus stays trapped so Tab cycles input → results instead of
@@ -298,7 +266,7 @@ export function DockLaunchButton({
         }}
       >
         <TooltipTrigger asChild>
-          <PopoverTrigger asChild>
+          <AppPalettePopover.Trigger asChild>
             <Button
               type="button"
               variant="pill"
@@ -311,108 +279,56 @@ export function DockLaunchButton({
             >
               <Plus className="w-3.5 h-3.5" />
             </Button>
-          </PopoverTrigger>
+          </AppPalettePopover.Trigger>
         </TooltipTrigger>
         <TooltipContent side="top">Open launcher</TooltipContent>
       </Tooltip>
-      <PopoverContent
+      <AppPalettePopover.Content
+        ariaLabel="Launch"
+        inputRef={inputRef}
+        onClearQuery={clearQuery}
+        onCloseAutoFocus={suppressTooltipDuringFocusRestore}
         side="top"
         align="start"
         sideOffset={4}
         className="w-[22rem] p-0"
-        // Radix renders this as role="dialog". Without a name a screen reader
-        // announces a generic dialog before reaching the combobox; match the
-        // visible header so speech control can target it by the word on screen.
-        aria-label="Launch"
-        aria-modal={true}
-        onOpenAutoFocus={(event) => {
-          // Radix would otherwise focus the content wrapper; the search box is
-          // what the user is about to type into.
-          event.preventDefault();
-          focusInput();
-        }}
-        onFocus={(event) => {
-          // A focus trap hauls focus back to the content wrapper whenever
-          // something outside steals it — a panel launched moments ago
-          // re-focusing itself on its own frame, say. The wrapper is
-          // tabIndex={-1} and owns no keys, so leaving focus parked there makes
-          // the next keystroke vanish; hand it to the search box instead.
-          if (event.target === event.currentTarget) focusInput();
-        }}
         // Catch-all behind the input's own handler, for the frame before the
-        // refocus above lands and for focus legitimately sitting on the results
-        // region. Bubble phase, so the input and body still get first refusal.
+        // shell's refocus lands and for focus legitimately sitting on the
+        // results region. Bubble phase, so the input and body still get first
+        // refusal.
         onKeyDown={handleNavigationKeyDown}
-        onPointerDownOutside={() => {
-          wasPointerCloseRef.current = true;
-        }}
-        onEscapeKeyDown={(event) => {
-          // This document-capture listener runs ahead of the input's own
-          // composition guard, so the IME check has to be repeated: mid-
-          // composition Escape belongs to the candidate window, and letting it
-          // through would wipe the query or close the launcher underneath it.
-          if (event.isComposing || event.keyCode === 229) {
-            event.preventDefault();
-            return;
-          }
-          // The dismissable layer listens on document with capture, so a
-          // stopPropagation from the input would be too late. Spend the first
-          // Escape clearing the query and block the close here — whitespace
-          // alone doesn't filter, so it must not cost the user a press.
-          if (queryRef.current.trim().length > 0) {
-            event.preventDefault();
-            updateQuery("");
-          }
-        }}
-        onCloseAutoFocus={(event) => {
-          setTooltipOpen(false);
-          isRestoringFocusRef.current = true;
-          if (wasPointerCloseRef.current) {
-            event.preventDefault();
-            wasPointerCloseRef.current = false;
-          }
-        }}
       >
-        <div
-          data-testid="dock-launcher-search-row"
-          // The header padding around the input is a click target that isn't
-          // the input, and Radix's focus scope wrapper is tabIndex={-1}, so
-          // clicking it parks focus on the content: Escape then dead-ends (the
-          // content vetoes the close while only the input clears the query).
-          // The input's own mousedown is left untouched so caret placement and
-          // drag-select still work.
-          onMouseDown={(event) => {
-            if (event.target === inputRef.current) return;
-            event.preventDefault();
-            focusInput();
-          }}
-        >
-          <AppPaletteDialog.Header label="Launch">
-            <AppPaletteDialog.Input
-              inputRef={inputRef}
-              value={query}
-              onChange={(e) => updateQuery(e.target.value)}
-              onKeyDownCapture={handleNavigationKeyDown}
-              placeholder="Search agents, panels, and recipes"
-              role="combobox"
-              // The listbox only exists when something matched, so claiming it
-              // is expanded — or pointing aria-controls at an unrendered id —
-              // would leave the combobox describing a popup that isn't there.
-              aria-expanded={results.length > 0}
-              aria-haspopup="listbox"
-              aria-label="Search agents, panels, and recipes"
-              aria-controls={results.length > 0 ? listboxId : undefined}
-              aria-activedescendant={activeDescendant}
-              autoComplete="off"
-              spellCheck={false}
-              // The focus indicator is deliberately neutral: the selected row
-              // owns this region's single accent anchor, and the input holds
-              // focus the whole time the launcher is open, so an accent ring
-              // here would be a permanently competing signal.
-              className="focus:border-daintree-border focus:ring-daintree-border/30"
-            />
-          </AppPaletteDialog.Header>
-        </div>
+        <AppPaletteDialog.Header label="Launch">
+          <AppPaletteDialog.Input
+            inputRef={inputRef}
+            value={query}
+            // Deliberately NOT resetting the selection here: the palette hook's
+            // own effect reconciles it, and calling its setter with the
+            // pre-query results would stamp the old list's first row as the item
+            // to follow — after which the effect chases that row into the new
+            // results instead of settling on the top match. `activeIndex` above
+            // covers the frame before it lands.
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDownCapture={handleNavigationKeyDown}
+            placeholder="Search agents, panels, and recipes"
+            role="combobox"
+            // The listbox only exists when something matched, so claiming it
+            // is expanded — or pointing aria-controls at an unrendered id —
+            // would leave the combobox describing a popup that isn't there.
+            aria-expanded={results.length > 0}
+            aria-haspopup="listbox"
+            aria-label="Search agents, panels, and recipes"
+            aria-controls={results.length > 0 ? listboxId : undefined}
+            aria-activedescendant={activeDescendant}
+            autoComplete="off"
+            spellCheck={false}
+            // The focus indicator is deliberately neutral: the selected row
+            // owns this region's single accent anchor, and the input holds
+            // focus the whole time the launcher is open, so an accent ring
+            // here would be a permanently competing signal.
+            className="focus:border-daintree-border focus:ring-daintree-border/30"
+          />
+        </AppPaletteDialog.Header>
 
         <AppPaletteDialog.Body
           ariaLabel="Launcher results"
@@ -440,8 +356,8 @@ export function DockLaunchButton({
         </AppPaletteDialog.Body>
 
         <AppPaletteDialog.Footer />
-      </PopoverContent>
-    </Popover>
+      </AppPalettePopover.Content>
+    </AppPalettePopover>
   );
 }
 

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -131,6 +131,7 @@ vi.mock("@/components/ui/popover", () => ({
     onEscapeKeyDown,
     onFocus,
     onKeyDown,
+    onMouseDown,
   }: {
     children: ReactNode;
     onOpenAutoFocus?: (e: { preventDefault: () => void }) => void;
@@ -139,6 +140,7 @@ vi.mock("@/components/ui/popover", () => ({
     onEscapeKeyDown?: (e: { preventDefault: () => void }) => void;
     onFocus?: React.FocusEventHandler<HTMLDivElement>;
     onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
+    onMouseDown?: React.MouseEventHandler<HTMLDivElement>;
   }) => {
     popoverOpenAutoFocusSpy = onOpenAutoFocus ?? null;
     popoverCloseAutoFocusSpy = onCloseAutoFocus ?? null;
@@ -152,6 +154,7 @@ vi.mock("@/components/ui/popover", () => ({
         tabIndex={-1}
         onFocus={onFocus}
         onKeyDown={onKeyDown}
+        onMouseDown={onMouseDown}
       >
         {children}
       </div>
@@ -165,8 +168,11 @@ vi.mock("@/components/ui/popover", () => ({
 // key handling stay under test.
 vi.mock("@/components/ui/AppPaletteDialog", () => {
   const AppPaletteDialog = {
+    // The marker is load-bearing, not decoration: the anchored shell delegates
+    // its header mousedown redirect off this attribute, so a stub without it
+    // silently stops exercising that handler.
     Header: ({ label, children }: { label: string; children: ReactNode }) => (
-      <div data-testid="dock-launcher-header">
+      <div data-testid="dock-launcher-header" data-palette-header="">
         <span>{label}</span>
         {children}
       </div>

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -1707,8 +1707,11 @@ function DropdownContent({
           // Global by role rather than scoped to this palette's own subtree
           // (the #8216 data-attribute + portal-re-provided-Context pattern is
           // the upgrade path if an unrelated menu ever holds it open).
+          //
+          // `Element`, not `HTMLElement`: menu items carry Lucide glyphs, and a
+          // click landing on the SVG would otherwise miss the guard entirely.
           const target = event.target;
-          if (target instanceof HTMLElement && target.closest('[role="menu"]')) {
+          if (target instanceof Element && target.closest('[role="menu"]')) {
             event.preventDefault();
           }
         }}

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -26,7 +26,7 @@ import { getProjectGradient } from "@/lib/colorUtils";
 import { AppPaletteDialog, KBD_CLASS } from "@/components/ui/AppPaletteDialog";
 import { PALETTE_ROW_CLASS } from "@/components/ui/paletteRowStyles";
 import { KbdChord } from "@/components/ui/Kbd";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { AppPalettePopover } from "@/components/ui/AppPalettePopover";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -81,7 +81,6 @@ import {
   OTHER_PROJECTS_SORT_MODES,
   type OtherProjectsSortMode,
 } from "@/lib/projectSort";
-import { useUIStore } from "@/store/uiStore";
 import { usePilotStore } from "@/store/pilotStore";
 import {
   useProjectSettingsStore,
@@ -1392,6 +1391,11 @@ function ProjectPaletteInner({
           }
           break;
         case "Escape":
+          // Anchored mode leaves Escape entirely to the shell, which spends the
+          // first press clearing the query. Closing here would beat that: this
+          // runs on bubble, after Radix's capture-phase dismissal has already
+          // been vetoed, so the palette would shut on a press meant to filter.
+          if (mode === "dropdown") break;
           e.preventDefault();
           e.stopPropagation();
           onClose();
@@ -1413,6 +1417,7 @@ function ProjectPaletteInner({
     [
       results,
       selectedIndex,
+      mode,
       onSelectPrevious,
       onSelectNext,
       onSelect,
@@ -1645,63 +1650,63 @@ function DropdownContent({
   mode,
   onDropdownCloseAutoFocus,
   paletteInputRef: inputRef,
+  onQueryChange,
   ...innerProps
 }: ProjectSwitcherPaletteProps & PaletteInputRefProp) {
   const listRef = useRef<HTMLDivElement>(null);
-  const overlayStackLength = useUIStore((state) => state.overlayStack.length);
-  const prevOverlayStackLengthRef = useRef<number>(overlayStackLength);
-  const focusRafRef = useRef<number | null>(null);
 
-  useEffect(() => {
-    if (!isOpen) return;
-    focusRafRef.current = requestAnimationFrame(() => {
-      inputRef.current?.focus();
-      focusRafRef.current = null;
-    });
-    return () => {
-      if (focusRafRef.current !== null) {
-        cancelAnimationFrame(focusRafRef.current);
-        focusRafRef.current = null;
-      }
-    };
-    // `inputRef` is a prop now that the search box is shared with the dialogs;
-    // it is a stable ref object, so this only satisfies the linter.
-  }, [isOpen, inputRef]);
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) onClose();
+    },
+    [onClose]
+  );
 
-  useEffect(() => {
-    if (
-      isOpen &&
-      overlayStackLength > prevOverlayStackLengthRef.current &&
-      overlayStackLength > 0
-    ) {
-      onClose();
-    }
-    prevOverlayStackLengthRef.current = overlayStackLength;
-  }, [isOpen, overlayStackLength, onClose]);
+  const handleClearQuery = useCallback(() => onQueryChange(""), [onQueryChange]);
 
   return (
-    <Popover open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <PopoverTrigger asChild>{children}</PopoverTrigger>
-      <PopoverContent
+    <AppPalettePopover
+      isOpen={isOpen}
+      onOpenChange={handleOpenChange}
+      // Non-modal on purpose: Tab leaves the palette by native traversal, and
+      // the controls the switcher renders after its results region stay
+      // reachable. The modal form is the ⌘P dialog, not this.
+      modal={false}
+      // A confirm dialog opened from one of the rows stacks above the switcher;
+      // leaving it open behind the dialog it spawned reads as two live surfaces.
+      dismissOnForeignOverlay
+    >
+      <AppPalettePopover.Trigger asChild>{children}</AppPalettePopover.Trigger>
+      <AppPalettePopover.Content
+        ariaLabel="Project switcher"
+        inputRef={inputRef}
+        onClearQuery={handleClearQuery}
+        onCloseAutoFocus={onDropdownCloseAutoFocus}
+        // Keeps the trigger's focus ring on a pointer dismissal, which is what
+        // this palette has always done. The shell's default (suppress) is the
+        // better behaviour and worth adopting — but as its own change, not
+        // folded silently into an extraction.
+        restoreFocusOnPointerDismiss
         className={cn(PALETTE_WIDTH, "p-0")}
         data-testid="project-switcher-palette"
         align={dropdownAlign}
         sideOffset={8}
-        onOpenAutoFocus={(e) => {
-          e.preventDefault();
-          inputRef.current?.focus();
-        }}
-        onCloseAutoFocus={() => onDropdownCloseAutoFocus?.()}
         onEscapeKeyDown={(event) => {
           // Radix dismisses on a document-capture listener, which beats the
           // scratch-name input's own handler. While that input owns focus,
-          // Escape means "cancel the edit", not "close the switcher".
+          // Escape means "cancel the edit", not "clear the query or close the
+          // switcher" — so veto before the shell's staged Escape runs.
           const active = document.activeElement;
           if (active instanceof HTMLElement && active.hasAttribute("data-scratch-name-input")) {
             event.preventDefault();
           }
         }}
         onInteractOutside={(event) => {
+          // A row's context menu portals outside this content, so its clicks
+          // read as "outside" and would dismiss the switcher underneath it.
+          // Global by role rather than scoped to this palette's own subtree
+          // (the #8216 data-attribute + portal-re-provided-Context pattern is
+          // the upgrade path if an unrelated menu ever holds it open).
           const target = event.target;
           if (target instanceof HTMLElement && target.closest('[role="menu"]')) {
             event.preventDefault();
@@ -1715,7 +1720,7 @@ function DropdownContent({
           results={innerProps.results}
           selectedIndex={innerProps.selectedIndex}
           mode={mode}
-          onQueryChange={innerProps.onQueryChange}
+          onQueryChange={onQueryChange}
           onSelect={innerProps.onSelect}
           onClose={onClose}
           onSelectPrevious={innerProps.onSelectPrevious}
@@ -1743,8 +1748,8 @@ function DropdownContent({
           onRenameScratch={innerProps.onRenameScratch}
           onSaveAsProject={innerProps.onSaveAsProject}
         />
-      </PopoverContent>
-    </Popover>
+      </AppPalettePopover.Content>
+    </AppPalettePopover>
   );
 }
 

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
@@ -363,6 +363,27 @@ describe("ProjectSwitcherPalette keyboard navigation", () => {
     expect(footer.textContent).not.toContain("⌥↵");
     expect(footer.textContent).toContain("Switch");
   });
+
+  it("closes on Escape in modal mode, where the input owns the key", () => {
+    const onClose = vi.fn();
+    render(<ProjectSwitcherPalette {...defaultProps} onClose={onClose} />);
+
+    fireEvent.keyDown(screen.getByTestId("palette-input"), { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves Escape to the anchored shell in dropdown mode", () => {
+    // The shell spends the first press clearing the query and vetoes Radix's
+    // capture-phase dismissal. This handler runs on bubble, afterwards — closing
+    // here would shut the palette on a press meant to filter it.
+    const onClose = vi.fn();
+    render(<ProjectSwitcherPalette {...defaultProps} mode="dropdown" onClose={onClose} />);
+
+    fireEvent.keyDown(screen.getByTestId("palette-input"), { key: "Escape" });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
 });
 
 // #11071: the palette used to render a narrower list than the one selectedIndex

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -14,6 +14,7 @@ import { ScrollShadow } from "@/components/ui/ScrollShadow";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { KBD_CLASS, KbdChord } from "@/components/ui/Kbd";
 import { AccessibilityAnnouncer } from "@/components/Accessibility/AccessibilityAnnouncer";
+import { PALETTE_HEADER_ATTR } from "./paletteHeaderAttr";
 import { useOverlayState, useEscapeStack } from "@/hooks";
 import {
   registerDialogEscapeBackstop,
@@ -288,6 +289,7 @@ AppPaletteDialog.Header = function AppPaletteHeader({
 }: AppPaletteHeaderProps) {
   return (
     <div
+      {...{ [PALETTE_HEADER_ATTR]: "" }}
       className={cn(
         "relative overflow-hidden px-3 pt-2 pb-1 border-b border-border-strong",
         className

--- a/src/components/ui/AppPalettePopover.tsx
+++ b/src/components/ui/AppPalettePopover.tsx
@@ -1,0 +1,282 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef } from "react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { PALETTE_HEADER_ATTR } from "@/components/ui/paletteHeaderAttr";
+import { useUIStore } from "@/store/uiStore";
+
+/**
+ * The anchored half of the palette shell.
+ *
+ * `AppPaletteDialog` can only be a centred modal over a scrim, so every
+ * selector that hangs off the control that opened it used to rebuild the same
+ * wiring by hand — open focus into the search box, focus return on keyboard
+ * dismissal but not pointer dismissal, Escape that clears before it closes.
+ * This carries those rules once; consumers bring the content and the policy
+ * flags. Both forms render the same `AppPaletteDialog.Header/Body/Footer`
+ * compound parts.
+ *
+ * Deliberately NOT wired into `useEscapeStack`, `registerDialogEscapeBackstop`,
+ * `clearDialogOverlays` or the tooltip dismiss registry: that machinery keys off
+ * `AppDialog`/`AppPaletteDialog` open/close transitions, and extending it to
+ * popover-type overlays was considered and rejected in #11034 because it
+ * misfires on unrelated interactions. Radix's own dismissal is the only
+ * mechanism here.
+ */
+
+interface AnchoredPaletteContextValue {
+  isOpen: boolean;
+  modal: boolean;
+}
+
+const AnchoredPaletteContext = createContext<AnchoredPaletteContextValue | null>(null);
+
+function useAnchoredPaletteContext(): AnchoredPaletteContextValue {
+  const context = useContext(AnchoredPaletteContext);
+  if (!context) {
+    throw new Error("AppPalettePopover.Content must be rendered inside AppPalettePopover");
+  }
+  return context;
+}
+
+/**
+ * Close when a foreign overlay stacks above an open palette. Compares
+ * consecutive reads rather than a snapshot taken at open, so only growth after
+ * the palette was already open counts — the palette itself never claims a slot
+ * (see the `modal` note below), so it cannot trip its own watcher.
+ */
+function useForeignOverlayDismissal(
+  isOpen: boolean,
+  enabled: boolean,
+  onOpenChange: (open: boolean) => void
+) {
+  // Selector returns a constant while disabled, so a palette that doesn't opt
+  // in never re-renders on unrelated overlay traffic.
+  const overlayStackLength = useUIStore((state) => (enabled ? state.overlayStack.length : 0));
+  const previousLengthRef = useRef(overlayStackLength);
+
+  useEffect(() => {
+    if (isOpen && overlayStackLength > previousLengthRef.current && overlayStackLength > 0) {
+      onOpenChange(false);
+    }
+    previousLengthRef.current = overlayStackLength;
+  }, [isOpen, overlayStackLength, onOpenChange]);
+}
+
+export interface AppPalettePopoverProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  /**
+   * Radix's two content primitives, not a presentation flag: `true` renders
+   * `PopoverContentModal` (focus trap, outside pointer events disabled,
+   * siblings aria-hidden) and `false` renders `PopoverContentNonModal` (Tab
+   * leaves naturally, the first outside click also activates what it hit).
+   * Required with no default so a new selector has to make the choice
+   * deliberately.
+   */
+  modal: boolean;
+  /**
+   * Close when something else stacks above the palette — a confirm dialog
+   * opened from one of its own rows, say. Off by default: a modal palette
+   * already owns the viewport through Radix, so only the non-modal form
+   * generally needs it.
+   */
+  dismissOnForeignOverlay?: boolean;
+  children: React.ReactNode;
+}
+
+export function AppPalettePopover({
+  isOpen,
+  onOpenChange,
+  modal,
+  dismissOnForeignOverlay = false,
+  children,
+}: AppPalettePopoverProps) {
+  useForeignOverlayDismissal(isOpen, dismissOnForeignOverlay, onOpenChange);
+
+  const context = useMemo(() => ({ isOpen, modal }), [isOpen, modal]);
+
+  return (
+    <AnchoredPaletteContext.Provider value={context}>
+      <Popover open={isOpen} onOpenChange={onOpenChange} modal={modal}>
+        {children}
+      </Popover>
+    </AnchoredPaletteContext.Provider>
+  );
+}
+
+AppPalettePopover.Trigger = PopoverTrigger;
+
+type PopoverContentProps = React.ComponentPropsWithoutRef<typeof PopoverContent>;
+
+export interface AppPalettePopoverContentProps extends Omit<
+  PopoverContentProps,
+  "onOpenAutoFocus" | "onCloseAutoFocus" | "onPointerDownOutside" | "aria-label"
+> {
+  /**
+   * Radix renders the content as `role="dialog"`. Without a name a screen
+   * reader announces a generic dialog before reaching the search box, so match
+   * the visible header and speech control can target it by the word on screen.
+   */
+  ariaLabel: string;
+  /** The palette's search box. Focus is driven into it on every open. */
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  /** Called when the first Escape spends itself clearing a non-empty query. */
+  onClearQuery: () => void;
+  /**
+   * Keep Radix's focus return to the trigger even when the palette was
+   * dismissed by pointer. Off by default — a pointer dismissal that restores
+   * focus leaves the trigger wearing a focus-visible ring nobody asked for
+   * (#6119). Keyboard dismissal always restores, per WAI-ARIA.
+   */
+  restoreFocusOnPointerDismiss?: boolean;
+  /**
+   * Fired before Radix restores focus, for triggers that have to suppress
+   * something on the way out (a tooltip that would re-open on focus). The shell
+   * keeps ownership of the Radix event itself.
+   */
+  onCloseAutoFocus?: () => void;
+}
+
+function AppPalettePopoverContent({
+  ariaLabel,
+  inputRef,
+  onClearQuery,
+  restoreFocusOnPointerDismiss = false,
+  onCloseAutoFocus,
+  onEscapeKeyDown,
+  onFocus,
+  onMouseDown,
+  children,
+  ...props
+}: AppPalettePopoverContentProps) {
+  const { isOpen, modal } = useAnchoredPaletteContext();
+
+  const focusInput = useCallback(() => {
+    inputRef.current?.focus({ preventScroll: true });
+  }, [inputRef]);
+
+  // Second focus attempt behind `onOpenAutoFocus`. `PopoverContent` renders
+  // nothing until its lazily imported Radix chunk resolves, so on a cold open
+  // this frame can fire before the input exists; on a warm one it runs after
+  // the mount handler already focused it and is a harmless no-op. Neither
+  // covers both orders alone — dropping either regresses one of them.
+  useEffect(() => {
+    if (!isOpen) return;
+    const frame = requestAnimationFrame(focusInput);
+    return () => cancelAnimationFrame(frame);
+  }, [isOpen, focusInput]);
+
+  // Set in onPointerDownOutside, read in onCloseAutoFocus.
+  const wasPointerCloseRef = useRef(false);
+
+  const handleOpenAutoFocus = useCallback(
+    (event: Event) => {
+      // Radix would otherwise focus the content wrapper; the search box is what
+      // the user is about to type into.
+      event.preventDefault();
+      focusInput();
+    },
+    [focusInput]
+  );
+
+  const handlePointerDownOutside = useCallback(() => {
+    wasPointerCloseRef.current = true;
+  }, []);
+
+  const handleCloseAutoFocus = useCallback(
+    (event: Event) => {
+      onCloseAutoFocus?.();
+      if (!restoreFocusOnPointerDismiss && wasPointerCloseRef.current) {
+        event.preventDefault();
+      }
+      // Cleared on every close, not just the suppressed ones: a palette that
+      // opts into restoration would otherwise stay armed after its first
+      // pointer dismissal and taint the next keyboard close.
+      wasPointerCloseRef.current = false;
+    },
+    [onCloseAutoFocus, restoreFocusOnPointerDismiss]
+  );
+
+  const handleEscapeKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      // Radix dismisses from a document-level capture listener that runs ahead
+      // of the input's own composition guard, so the IME check has to be
+      // repeated here: mid-composition Escape belongs to the candidate window,
+      // and letting it through would wipe the query or close the palette
+      // underneath it.
+      if (event.isComposing || event.keyCode === 229) {
+        event.preventDefault();
+        return;
+      }
+      // Consumer veto first. A nested editor inside the palette (the project
+      // switcher's inline scratch rename) owns Escape while it holds focus and
+      // has to be able to cancel itself without the palette spending the press.
+      onEscapeKeyDown?.(event);
+      if (event.defaultPrevented) return;
+      // Spend the first Escape clearing the query and block the close here —
+      // the dismissable layer listens on document with capture, so a
+      // stopPropagation from the input would be too late. Whitespace alone
+      // doesn't filter, so it must not cost the user a press.
+      //
+      // Read live off the DOM rather than a captured `query` prop: this fires
+      // from a capture listener before React has re-rendered, so a closed-over
+      // value can be a keystroke behind.
+      if ((inputRef.current?.value ?? "").trim().length > 0) {
+        event.preventDefault();
+        onClearQuery();
+      }
+    },
+    [inputRef, onClearQuery, onEscapeKeyDown]
+  );
+
+  const handleFocus = useCallback(
+    (event: React.FocusEvent<HTMLDivElement>) => {
+      onFocus?.(event);
+      // A focus trap hauls focus back to the content wrapper whenever something
+      // outside steals it — a panel launched moments ago re-focusing itself,
+      // say. The wrapper is tabIndex={-1} and owns no keys, so leaving focus
+      // parked there makes the next keystroke vanish; hand it to the search box.
+      if (event.target === event.currentTarget) focusInput();
+    },
+    [focusInput, onFocus]
+  );
+
+  const handleMouseDown = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      onMouseDown?.(event);
+      if (event.defaultPrevented) return;
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) return;
+      // The input's own mousedown is left untouched so caret placement and
+      // drag-select still work inside the field.
+      if (target === inputRef.current) return;
+      // The header padding around the input is a click target that isn't the
+      // input, and Radix's focus scope wrapper is tabIndex={-1}, so clicking it
+      // parks focus on the content: Escape then dead-ends, because the content
+      // vetoes the close while only the input clears the query.
+      if (!target.closest(`[${PALETTE_HEADER_ATTR}]`)) return;
+      event.preventDefault();
+      focusInput();
+    },
+    [focusInput, inputRef, onMouseDown]
+  );
+
+  return (
+    <PopoverContent
+      aria-label={ariaLabel}
+      // Radix does not set this itself. `aria-modal="false"` is noise, so the
+      // non-modal form carries nothing rather than a negation.
+      aria-modal={modal ? true : undefined}
+      onOpenAutoFocus={handleOpenAutoFocus}
+      onCloseAutoFocus={handleCloseAutoFocus}
+      onPointerDownOutside={handlePointerDownOutside}
+      onEscapeKeyDown={handleEscapeKeyDown}
+      onFocus={handleFocus}
+      onMouseDown={handleMouseDown}
+      {...props}
+    >
+      {children}
+    </PopoverContent>
+  );
+}
+
+AppPalettePopover.Content = AppPalettePopoverContent;

--- a/src/components/ui/AppPalettePopover.tsx
+++ b/src/components/ui/AppPalettePopover.tsx
@@ -38,10 +38,13 @@ function useAnchoredPaletteContext(): AnchoredPaletteContextValue {
 }
 
 /**
- * Close when a foreign overlay stacks above an open palette. Compares
- * consecutive reads rather than a snapshot taken at open, so only growth after
- * the palette was already open counts — the palette itself never claims a slot
- * (see the `modal` note below), so it cannot trip its own watcher.
+ * Close when a foreign overlay stacks above an open palette.
+ *
+ * The baseline is re-established every time the palette opens (and every time a
+ * palette opts in), then compared against, so an overlay that was already up —
+ * or one raised in the same commit as the open — is never mistaken for
+ * something stacking on top. The palette itself never claims a slot (see the
+ * `modal` note below), so it cannot trip its own watcher either.
  */
 function useForeignOverlayDismissal(
   isOpen: boolean,
@@ -49,16 +52,26 @@ function useForeignOverlayDismissal(
   onOpenChange: (open: boolean) => void
 ) {
   // Selector returns a constant while disabled, so a palette that doesn't opt
-  // in never re-renders on unrelated overlay traffic.
+  // in never re-renders on unrelated overlay traffic. The null baseline below
+  // is what keeps that sentinel from reading as "the stack just emptied".
   const overlayStackLength = useUIStore((state) => (enabled ? state.overlayStack.length : 0));
-  const previousLengthRef = useRef(overlayStackLength);
+  const baselineRef = useRef<number | null>(null);
 
   useEffect(() => {
-    if (isOpen && overlayStackLength > previousLengthRef.current && overlayStackLength > 0) {
-      onOpenChange(false);
+    if (!enabled || !isOpen) {
+      baselineRef.current = null;
+      return;
     }
-    previousLengthRef.current = overlayStackLength;
-  }, [isOpen, overlayStackLength, onOpenChange]);
+    if (baselineRef.current === null) {
+      baselineRef.current = overlayStackLength;
+      return;
+    }
+    if (overlayStackLength > baselineRef.current) {
+      onOpenChange(false);
+      return;
+    }
+    baselineRef.current = overlayStackLength;
+  }, [enabled, isOpen, overlayStackLength, onOpenChange]);
 }
 
 export interface AppPalettePopoverProps {
@@ -109,7 +122,13 @@ type PopoverContentProps = React.ComponentPropsWithoutRef<typeof PopoverContent>
 
 export interface AppPalettePopoverContentProps extends Omit<
   PopoverContentProps,
-  "onOpenAutoFocus" | "onCloseAutoFocus" | "onPointerDownOutside" | "aria-label"
+  | "onOpenAutoFocus"
+  | "onCloseAutoFocus"
+  | "onPointerDownOutside"
+  | "aria-label"
+  // Derived from `modal`. A caller free to set it independently could
+  // advertise a non-trapped, pointer-permeable surface as modal.
+  | "aria-modal"
 > {
   /**
    * Radix renders the content as `role="dialog"`. Without a name a screen
@@ -122,10 +141,15 @@ export interface AppPalettePopoverContentProps extends Omit<
   /** Called when the first Escape spends itself clearing a non-empty query. */
   onClearQuery: () => void;
   /**
-   * Keep Radix's focus return to the trigger even when the palette was
-   * dismissed by pointer. Off by default — a pointer dismissal that restores
-   * focus leaves the trigger wearing a focus-visible ring nobody asked for
-   * (#6119). Keyboard dismissal always restores, per WAI-ARIA.
+   * Leave Radix's own close-autofocus policy alone when the palette was
+   * dismissed by pointer, rather than cancelling it. Off by default — letting
+   * a pointer dismissal restore focus leaves the trigger wearing a
+   * focus-visible ring nobody asked for (#6119). Keyboard dismissal always
+   * keeps the default return, per WAI-ARIA.
+   *
+   * This only decides whether the shell suppresses; it cannot manufacture a
+   * restore Radix wasn't going to perform (non-modal content does not focus the
+   * trigger after an outside interaction).
    */
   restoreFocusOnPointerDismiss?: boolean;
   /**
@@ -143,6 +167,7 @@ function AppPalettePopoverContent({
   restoreFocusOnPointerDismiss = false,
   onCloseAutoFocus,
   onEscapeKeyDown,
+  onInteractOutside,
   onFocus,
   onMouseDown,
   children,
@@ -154,6 +179,9 @@ function AppPalettePopoverContent({
     inputRef.current?.focus({ preventScroll: true });
   }, [inputRef]);
 
+  // Set in onPointerDownOutside, read in onCloseAutoFocus.
+  const wasPointerCloseRef = useRef(false);
+
   // Second focus attempt behind `onOpenAutoFocus`. `PopoverContent` renders
   // nothing until its lazily imported Radix chunk resolves, so on a cold open
   // this frame can fire before the input exists; on a warm one it runs after
@@ -161,26 +189,42 @@ function AppPalettePopoverContent({
   // covers both orders alone — dropping either regresses one of them.
   useEffect(() => {
     if (!isOpen) return;
+    // A dismissal that got vetoed, or one reversed mid-exit, can leave the
+    // pointer flag armed with no close-autofocus to consume it.
+    wasPointerCloseRef.current = false;
     const frame = requestAnimationFrame(focusInput);
     return () => cancelAnimationFrame(frame);
   }, [isOpen, focusInput]);
 
-  // Set in onPointerDownOutside, read in onCloseAutoFocus.
-  const wasPointerCloseRef = useRef(false);
-
   const handleOpenAutoFocus = useCallback(
     (event: Event) => {
+      const element = inputRef.current;
+      // Nothing to hand focus to yet — leave Radix's own autofocus alone rather
+      // than cancelling it and stranding focus on nothing.
+      if (!element) return;
       // Radix would otherwise focus the content wrapper; the search box is what
       // the user is about to type into.
       event.preventDefault();
-      focusInput();
+      element.focus({ preventScroll: true });
     },
-    [focusInput]
+    [inputRef]
   );
 
   const handlePointerDownOutside = useCallback(() => {
     wasPointerCloseRef.current = true;
   }, []);
+
+  const handleInteractOutside = useCallback(
+    (event: Parameters<NonNullable<PopoverContentProps["onInteractOutside"]>>[0]) => {
+      onInteractOutside?.(event);
+      // Radix fires this after `onPointerDownOutside` and dismisses only if
+      // nobody vetoed. A vetoed interaction leaves the palette open with no
+      // close coming, so disarm — otherwise the next keyboard dismissal is
+      // misread as a pointer one and loses its focus return.
+      if (event.defaultPrevented) wasPointerCloseRef.current = false;
+    },
+    [onInteractOutside]
+  );
 
   const handleCloseAutoFocus = useCallback(
     (event: Event) => {
@@ -244,8 +288,10 @@ function AppPalettePopoverContent({
     (event: React.MouseEvent<HTMLDivElement>) => {
       onMouseDown?.(event);
       if (event.defaultPrevented) return;
+      // `Element`, not `HTMLElement`: a header adornment can be an SVG icon,
+      // and the click lands on the glyph rather than a wrapper.
       const target = event.target;
-      if (!(target instanceof HTMLElement)) return;
+      if (!(target instanceof Element)) return;
       // The input's own mousedown is left untouched so caret placement and
       // drag-select still work inside the field.
       if (target === inputRef.current) return;
@@ -253,7 +299,11 @@ function AppPalettePopoverContent({
       // input, and Radix's focus scope wrapper is tabIndex={-1}, so clicking it
       // parks focus on the content: Escape then dead-ends, because the content
       // vetoes the close while only the input clears the query.
-      if (!target.closest(`[${PALETTE_HEADER_ATTR}]`)) return;
+      const header = target.closest(`[${PALETTE_HEADER_ATTR}]`);
+      // React events from a portal nested inside this one still bubble through
+      // here, and that portal may carry its own stamped header — so the match
+      // has to actually live in this content, not merely in the React tree.
+      if (!header || !event.currentTarget.contains(header)) return;
       event.preventDefault();
       focusInput();
     },
@@ -261,7 +311,11 @@ function AppPalettePopoverContent({
   );
 
   return (
+    // Consumer props first: everything below is shell-owned policy, and a
+    // spread object can carry a key the prop types omit. Positioning, class
+    // names and data attributes still come through untouched.
     <PopoverContent
+      {...props}
       aria-label={ariaLabel}
       // Radix does not set this itself. `aria-modal="false"` is noise, so the
       // non-modal form carries nothing rather than a negation.
@@ -269,10 +323,10 @@ function AppPalettePopoverContent({
       onOpenAutoFocus={handleOpenAutoFocus}
       onCloseAutoFocus={handleCloseAutoFocus}
       onPointerDownOutside={handlePointerDownOutside}
+      onInteractOutside={handleInteractOutside}
       onEscapeKeyDown={handleEscapeKeyDown}
       onFocus={handleFocus}
       onMouseDown={handleMouseDown}
-      {...props}
     >
       {children}
     </PopoverContent>

--- a/src/components/ui/__tests__/AppPalettePopover.test.tsx
+++ b/src/components/ui/__tests__/AppPalettePopover.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import { useRef, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AppPalettePopover } from "../AppPalettePopover";
 import { AppPaletteDialog } from "../AppPaletteDialog";
@@ -17,6 +18,7 @@ interface CapturedContentProps {
   onCloseAutoFocus?: (event: Event) => void;
   onPointerDownOutside?: () => void;
   onEscapeKeyDown?: (event: KeyboardEvent) => void;
+  onInteractOutside?: (event: Event) => void;
   onFocus?: React.FocusEventHandler<HTMLDivElement>;
   onMouseDown?: React.MouseEventHandler<HTMLDivElement>;
   onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
@@ -93,6 +95,8 @@ interface HarnessProps {
   sideOffset?: number;
   /** Omits the search box, reproducing a cold open before the chunk resolves. */
   withInput?: boolean;
+  /** Renders a second stamped header in a portal outside this content's DOM. */
+  withNestedPortal?: boolean;
 }
 
 function Harness({
@@ -106,6 +110,7 @@ function Harness({
   align,
   sideOffset,
   withInput = true,
+  withNestedPortal = false,
   ...contentOverrides
 }: HarnessProps) {
   const [openState, setOpen] = useState(initialOpen);
@@ -151,6 +156,18 @@ function Harness({
         <button type="button" data-testid="row">
           A row
         </button>
+        {/* A real portal: its events bubble through this content in the React
+            tree while its DOM lives elsewhere — the case `contains()` guards. */}
+        {withNestedPortal
+          ? createPortal(
+              <div data-palette-header="">
+                <button type="button" data-testid="portal-target">
+                  Nested
+                </button>
+              </div>,
+              document.body
+            )
+          : null}
       </AppPalettePopover.Content>
     </AppPalettePopover>
   );
@@ -314,8 +331,19 @@ describe("AppPalettePopover", () => {
     });
 
     it("survives the open frame firing before the input exists", () => {
-      // Same cold path, the RAF half — it must no-op rather than throw.
-      expect(() => render(<Harness withInput={false} />)).not.toThrow();
+      // Same cold path, the RAF half. The guard lives inside the callback, so
+      // the frame has to actually run — a test that only mounts proves nothing
+      // and passes even with the effect deleted.
+      const frames: FrameRequestCallback[] = [];
+      const raf = vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+        frames.push(callback);
+        return frames.length;
+      });
+      render(<Harness withInput={false} />);
+      raf.mockRestore();
+
+      expect(frames.length).toBeGreaterThan(0);
+      expect(() => frames.forEach((frame) => frame(0))).not.toThrow();
     });
 
     it("hands focus back to the search box when it parks on the content wrapper", () => {
@@ -373,6 +401,17 @@ describe("AppPalettePopover", () => {
 
       expect(fireEvent.mouseDown(glyph)).toBe(false);
       expect(document.activeElement).toBe(input(container));
+    });
+
+    it("ignores a stamped header living in a nested portal", () => {
+      // React bubbles the portal's mousedown through this content, so
+      // `closest()` finds that portal's own header. Redirecting focus into the
+      // palette behind it would steal the click from whatever the portal is.
+      const { container, getByTestId } = render(<Harness withNestedPortal={true} />);
+      input(container).blur();
+
+      expect(fireEvent.mouseDown(getByTestId("portal-target"))).toBe(true);
+      expect(document.activeElement).not.toBe(input(container));
     });
 
     it("defers to a consumer handler that already cancelled the event", () => {

--- a/src/components/ui/__tests__/AppPalettePopover.test.tsx
+++ b/src/components/ui/__tests__/AppPalettePopover.test.tsx
@@ -1,0 +1,499 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
+import { useRef, useState, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AppPalettePopover } from "../AppPalettePopover";
+import { AppPaletteDialog } from "../AppPaletteDialog";
+import { useUIStore } from "@/store/uiStore";
+
+/**
+ * Radix is stubbed so the shell's own policy is what's under test: which
+ * handlers it installs, what they do, and which props it forwards. The real
+ * primitive's focus trap and dismissal are Radix's contract, covered by the
+ * consumers' E2E specs.
+ */
+interface CapturedContentProps {
+  onOpenAutoFocus?: (event: Event) => void;
+  onCloseAutoFocus?: (event: Event) => void;
+  onPointerDownOutside?: () => void;
+  onEscapeKeyDown?: (event: KeyboardEvent) => void;
+  onFocus?: React.FocusEventHandler<HTMLDivElement>;
+  onMouseDown?: React.MouseEventHandler<HTMLDivElement>;
+  onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
+  children?: ReactNode;
+  [key: string]: unknown;
+}
+
+let rootProps: { open?: boolean; modal?: boolean } = {};
+let contentProps: CapturedContentProps = {};
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({
+    children,
+    open,
+    modal,
+  }: {
+    children: ReactNode;
+    open?: boolean;
+    modal?: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }) => {
+    rootProps = { open, modal };
+    return <>{children}</>;
+  },
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  // Content renders unconditionally so the shell's handlers stay reachable
+  // without driving Radix's presence machinery. tabIndex mirrors the real
+  // focus-scope wrapper, which is what focus parks on.
+  PopoverContent: ({
+    children,
+    onFocus,
+    onMouseDown,
+    onKeyDown,
+    ...rest
+  }: CapturedContentProps) => {
+    contentProps = { children, onFocus, onMouseDown, onKeyDown, ...rest };
+    return (
+      <div
+        data-testid="content"
+        tabIndex={-1}
+        onFocus={onFocus}
+        onMouseDown={onMouseDown}
+        onKeyDown={onKeyDown}
+      >
+        {children}
+      </div>
+    );
+  },
+}));
+
+interface HarnessProps {
+  modal?: boolean;
+  dismissOnForeignOverlay?: boolean;
+  restoreFocusOnPointerDismiss?: boolean;
+  initialOpen?: boolean;
+  /** Drives the open state from the test, overriding the harness's own. */
+  open?: boolean;
+  initialQuery?: string;
+  onCloseAutoFocus?: () => void;
+  onEscapeKeyDown?: (event: KeyboardEvent) => void;
+  onFocus?: React.FocusEventHandler<HTMLDivElement>;
+  onMouseDown?: React.MouseEventHandler<HTMLDivElement>;
+  onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
+  onOpenChange?: (open: boolean) => void;
+  align?: "start" | "center" | "end";
+  sideOffset?: number;
+}
+
+function Harness({
+  modal = true,
+  dismissOnForeignOverlay = false,
+  restoreFocusOnPointerDismiss,
+  initialOpen = true,
+  open: openOverride,
+  initialQuery = "",
+  onOpenChange,
+  align,
+  sideOffset,
+  ...contentOverrides
+}: HarnessProps) {
+  const [openState, setOpen] = useState(initialOpen);
+  const [query, setQuery] = useState(initialQuery);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const open = openOverride ?? openState;
+
+  return (
+    <AppPalettePopover
+      isOpen={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        onOpenChange?.(next);
+      }}
+      modal={modal}
+      dismissOnForeignOverlay={dismissOnForeignOverlay}
+    >
+      <AppPalettePopover.Trigger asChild>
+        <button type="button">Open</button>
+      </AppPalettePopover.Trigger>
+      <AppPalettePopover.Content
+        ariaLabel="Test palette"
+        inputRef={inputRef}
+        onClearQuery={() => setQuery("")}
+        restoreFocusOnPointerDismiss={restoreFocusOnPointerDismiss}
+        align={align}
+        sideOffset={sideOffset}
+        {...contentOverrides}
+      >
+        {/* The real Header, so the marker the shell's mousedown delegation
+            looks for is the one the shell actually stamps. */}
+        <AppPaletteDialog.Header label="Test">
+          <AppPaletteDialog.Input
+            inputRef={inputRef}
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+        </AppPaletteDialog.Header>
+        <button type="button" data-testid="row">
+          A row
+        </button>
+      </AppPalettePopover.Content>
+    </AppPalettePopover>
+  );
+}
+
+/**
+ * Real events, not shaped literals: the shell branches on `defaultPrevented`
+ * after handing the event to a consumer veto, and only a cancelable DOM event
+ * reports that honestly.
+ */
+function fireEscape(overrides: KeyboardEventInit = {}) {
+  const event = new KeyboardEvent("keydown", { key: "Escape", cancelable: true, ...overrides });
+  const preventDefault = vi.spyOn(event, "preventDefault");
+  act(() => contentProps.onEscapeKeyDown?.(event));
+  return { preventDefault };
+}
+
+function fireOpenAutoFocus() {
+  const event = new Event("openAutoFocus", { cancelable: true });
+  const preventDefault = vi.spyOn(event, "preventDefault");
+  act(() => contentProps.onOpenAutoFocus?.(event));
+  return { preventDefault };
+}
+
+function fireCloseAutoFocus() {
+  const event = new Event("closeAutoFocus", { cancelable: true });
+  const preventDefault = vi.spyOn(event, "preventDefault");
+  act(() => contentProps.onCloseAutoFocus?.(event));
+  return { preventDefault };
+}
+
+function input(container: HTMLElement): HTMLInputElement {
+  const element = container.querySelector("input");
+  if (!element) throw new Error("search input not found");
+  return element;
+}
+
+beforeEach(() => {
+  rootProps = {};
+  contentProps = {};
+  useUIStore.setState({ overlayStack: [] });
+});
+
+describe("AppPalettePopover", () => {
+  it("forwards the open state and the required modal choice to the popover root", () => {
+    const { unmount } = render(<Harness modal={true} />);
+    expect(rootProps).toEqual({ open: true, modal: true });
+    unmount();
+
+    render(<Harness modal={false} />);
+    expect(rootProps).toEqual({ open: true, modal: false });
+  });
+
+  it("names the content and mirrors aria-modal onto the modal form only", () => {
+    const { unmount } = render(<Harness modal={true} />);
+    expect(contentProps["aria-label"]).toBe("Test palette");
+    expect(contentProps["aria-modal"]).toBe(true);
+    unmount();
+
+    render(<Harness modal={false} />);
+    // `aria-modal="false"` is noise, so the non-modal form carries nothing.
+    expect(contentProps["aria-modal"]).toBeUndefined();
+  });
+
+  it("forwards positioning props through to the popover content", () => {
+    render(<Harness align="end" sideOffset={12} />);
+    expect(contentProps.align).toBe("end");
+    expect(contentProps.sideOffset).toBe(12);
+  });
+
+  it("never claims the app overlay stack", () => {
+    render(<Harness />);
+    expect(useUIStore.getState().overlayStack).toEqual([]);
+  });
+
+  it("throws when the content is rendered outside its root", () => {
+    const inputRef = { current: null };
+    expect(() =>
+      render(
+        <AppPalettePopover.Content ariaLabel="Orphan" inputRef={inputRef} onClearQuery={vi.fn()}>
+          <span />
+        </AppPalettePopover.Content>
+      )
+    ).toThrow(/inside AppPalettePopover/);
+  });
+
+  describe("open focus", () => {
+    it("takes over the mount autofocus and drives it into the search box", () => {
+      const { container } = render(<Harness />);
+      input(container).blur();
+
+      const { preventDefault } = fireOpenAutoFocus();
+
+      // Radix would otherwise focus the content wrapper.
+      expect(preventDefault).toHaveBeenCalledTimes(1);
+      expect(document.activeElement).toBe(input(container));
+    });
+
+    it("also focuses the search box a frame after opening", async () => {
+      // The two paths cover opposite orderings of the lazy Radix chunk
+      // resolving; neither covers both alone, so both must survive. This is the
+      // path that runs without `onOpenAutoFocus` ever firing.
+      const { container, rerender } = render(<Harness open={false} />);
+      input(container).blur();
+      expect(document.activeElement).not.toBe(input(container));
+
+      rerender(<Harness open={true} />);
+
+      await waitFor(() => expect(document.activeElement).toBe(input(container)));
+    });
+
+    it("cancels the pending frame when the palette closes", () => {
+      const cancel = vi.spyOn(window, "cancelAnimationFrame");
+      const { rerender } = render(<Harness open={true} />);
+      const before = cancel.mock.calls.length;
+
+      rerender(<Harness open={false} />);
+
+      // A frame left queued would focus an input the user has already left.
+      expect(cancel.mock.calls.length).toBeGreaterThan(before);
+      cancel.mockRestore();
+    });
+
+    it("hands focus back to the search box when it parks on the content wrapper", () => {
+      const { container, getByTestId } = render(<Harness />);
+      input(container).blur();
+
+      fireEvent.focus(getByTestId("content"));
+
+      expect(document.activeElement).toBe(input(container));
+    });
+
+    it("leaves focus alone when it lands on something inside the content", () => {
+      const { container, getByTestId } = render(<Harness />);
+      const row = getByTestId("row");
+      input(container).blur();
+      row.focus();
+
+      fireEvent.focus(row);
+
+      expect(document.activeElement).toBe(row);
+    });
+  });
+
+  describe("header mousedown", () => {
+    it("redirects a click on the padding around the search box into it", () => {
+      const { container } = render(<Harness />);
+      const header = container.querySelector("[data-palette-header]");
+      if (!(header instanceof HTMLElement)) throw new Error("header not found");
+      input(container).blur();
+
+      // Cancelled, so Radix's tabIndex={-1} wrapper never takes the focus.
+      expect(fireEvent.mouseDown(header)).toBe(false);
+      expect(document.activeElement).toBe(input(container));
+    });
+
+    it("leaves the search box's own mousedown alone so the caret can be placed", () => {
+      const { container } = render(<Harness />);
+      expect(fireEvent.mouseDown(input(container))).toBe(true);
+    });
+
+    it("ignores a mousedown outside the header", () => {
+      const { getByTestId } = render(<Harness />);
+      expect(fireEvent.mouseDown(getByTestId("row"))).toBe(true);
+    });
+
+    it("defers to a consumer handler that already cancelled the event", () => {
+      const onMouseDown = vi.fn((event: React.MouseEvent<HTMLDivElement>) => {
+        event.preventDefault();
+      });
+      const { container } = render(<Harness onMouseDown={onMouseDown} />);
+      const header = container.querySelector("[data-palette-header]");
+      if (!(header instanceof HTMLElement)) throw new Error("header not found");
+      input(container).blur();
+
+      fireEvent.mouseDown(header);
+
+      expect(onMouseDown).toHaveBeenCalledTimes(1);
+      expect(document.activeElement).not.toBe(input(container));
+    });
+  });
+
+  describe("staged escape", () => {
+    it("spends the first press clearing a non-empty query and blocks the close", () => {
+      const { container } = render(<Harness initialQuery="review" />);
+
+      const { preventDefault } = fireEscape();
+
+      expect(preventDefault).toHaveBeenCalledTimes(1);
+      expect(input(container).value).toBe("");
+    });
+
+    it("leaves the press alone once the query is empty so the palette closes", () => {
+      render(<Harness initialQuery="" />);
+      expect(fireEscape().preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("does not spend a press on whitespace, which never filtered anything", () => {
+      render(<Harness initialQuery="   " />);
+      expect(fireEscape().preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("reads the live query, not a render-stale copy", () => {
+      // Radix dismisses from a capture listener that beats React's re-render,
+      // so a closed-over query would be a keystroke behind.
+      const { container } = render(<Harness initialQuery="" />);
+      fireEvent.change(input(container), { target: { value: "review" } });
+
+      expect(fireEscape().preventDefault).toHaveBeenCalledTimes(1);
+      expect(input(container).value).toBe("");
+    });
+
+    it("leaves a composing keystroke to the IME candidate window", () => {
+      const { container } = render(<Harness initialQuery="review" />);
+
+      const { preventDefault } = fireEscape({ isComposing: true });
+
+      expect(preventDefault).toHaveBeenCalledTimes(1);
+      // Blocked, not consumed: the query survives for the candidate window.
+      expect(input(container).value).toBe("review");
+    });
+
+    it("also honours the keyCode 229 half of the IME signal", () => {
+      // Chromium can emit 229 before `isComposing` flips true.
+      const { container } = render(<Harness initialQuery="review" />);
+
+      fireEscape({ isComposing: false, keyCode: 229 });
+
+      expect(input(container).value).toBe("review");
+    });
+
+    it("lets a consumer veto run first and short-circuit the clear", () => {
+      const onEscapeKeyDown = vi.fn((event: KeyboardEvent) => event.preventDefault());
+      const { container } = render(
+        <Harness initialQuery="review" onEscapeKeyDown={onEscapeKeyDown} />
+      );
+
+      fireEscape();
+
+      expect(onEscapeKeyDown).toHaveBeenCalledTimes(1);
+      // A nested editor cancelling itself must not also cost the query.
+      expect(input(container).value).toBe("review");
+    });
+
+    it("still stages the clear when the consumer veto passes", () => {
+      const onEscapeKeyDown = vi.fn();
+      const { container } = render(
+        <Harness initialQuery="review" onEscapeKeyDown={onEscapeKeyDown} />
+      );
+
+      fireEscape();
+
+      expect(onEscapeKeyDown).toHaveBeenCalledTimes(1);
+      expect(input(container).value).toBe("");
+    });
+  });
+
+  describe("close focus restore", () => {
+    it("lets a keyboard dismissal return focus to the trigger", () => {
+      render(<Harness />);
+
+      expect(fireCloseAutoFocus().preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("suppresses the return on a pointer dismissal so the trigger keeps no ring", () => {
+      render(<Harness />);
+      act(() => contentProps.onPointerDownOutside?.());
+
+      expect(fireCloseAutoFocus().preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-arms after a single pointer dismissal", () => {
+      render(<Harness />);
+      act(() => contentProps.onPointerDownOutside?.());
+      fireCloseAutoFocus();
+
+      expect(fireCloseAutoFocus().preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("keeps the return when the consumer opts in, and still clears the flag", () => {
+      render(<Harness restoreFocusOnPointerDismiss={true} />);
+      act(() => contentProps.onPointerDownOutside?.());
+
+      expect(fireCloseAutoFocus().preventDefault).not.toHaveBeenCalled();
+      // A stale flag here would taint the next close if the prop ever flipped.
+      expect(fireCloseAutoFocus().preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("notifies the consumer before Radix restores focus", () => {
+      const onCloseAutoFocus = vi.fn();
+      render(<Harness onCloseAutoFocus={onCloseAutoFocus} />);
+
+      fireCloseAutoFocus();
+
+      expect(onCloseAutoFocus).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("foreign overlay dismissal", () => {
+    it("closes when something stacks above an open palette", () => {
+      const onOpenChange = vi.fn();
+      render(<Harness dismissOnForeignOverlay={true} onOpenChange={onOpenChange} />);
+
+      act(() => useUIStore.getState().addOverlayClaim("confirm-dialog"));
+
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it("stays open when the palette did not opt in", () => {
+      const onOpenChange = vi.fn();
+      render(<Harness dismissOnForeignOverlay={false} onOpenChange={onOpenChange} />);
+
+      act(() => useUIStore.getState().addOverlayClaim("confirm-dialog"));
+
+      expect(onOpenChange).not.toHaveBeenCalled();
+    });
+
+    it("ignores a stack that shrinks", () => {
+      const onOpenChange = vi.fn();
+      act(() => useUIStore.getState().addOverlayClaim("existing"));
+      render(<Harness dismissOnForeignOverlay={true} onOpenChange={onOpenChange} />);
+
+      act(() => useUIStore.getState().removeOverlayClaim("existing"));
+
+      expect(onOpenChange).not.toHaveBeenCalled();
+    });
+
+    it("does not fire for an overlay that was already up when it opened", () => {
+      const onOpenChange = vi.fn();
+      act(() => useUIStore.getState().addOverlayClaim("existing"));
+
+      render(<Harness dismissOnForeignOverlay={true} onOpenChange={onOpenChange} />);
+
+      expect(onOpenChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("consumer handler composition", () => {
+    it("composes rather than replaces the content focus handler", () => {
+      const onFocus = vi.fn();
+      const { container, getByTestId } = render(<Harness onFocus={onFocus} />);
+      input(container).blur();
+
+      fireEvent.focus(getByTestId("content"));
+
+      // Not a call count: React's focus events bubble, so the shell's own
+      // redirect into the input re-enters this handler a second time.
+      expect(onFocus).toHaveBeenCalled();
+      expect(document.activeElement).toBe(input(container));
+    });
+
+    it("passes an unrecognised handler straight through", () => {
+      const onKeyDown = vi.fn();
+      const { getByTestId } = render(<Harness onKeyDown={onKeyDown} />);
+
+      fireEvent.keyDown(getByTestId("content"), { key: "ArrowDown" });
+
+      expect(onKeyDown).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/components/ui/__tests__/AppPalettePopover.test.tsx
+++ b/src/components/ui/__tests__/AppPalettePopover.test.tsx
@@ -25,6 +25,7 @@ interface CapturedContentProps {
 }
 
 let rootProps: { open?: boolean; modal?: boolean } = {};
+let rootOpenChange: ((open: boolean) => void) | null = null;
 let contentProps: CapturedContentProps = {};
 
 vi.mock("@/components/ui/popover", () => ({
@@ -32,6 +33,7 @@ vi.mock("@/components/ui/popover", () => ({
     children,
     open,
     modal,
+    onOpenChange,
   }: {
     children: ReactNode;
     open?: boolean;
@@ -39,12 +41,14 @@ vi.mock("@/components/ui/popover", () => ({
     onOpenChange?: (open: boolean) => void;
   }) => {
     rootProps = { open, modal };
+    rootOpenChange = onOpenChange ?? null;
     return <>{children}</>;
   },
   PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
   // Content renders unconditionally so the shell's handlers stay reachable
   // without driving Radix's presence machinery. tabIndex mirrors the real
-  // focus-scope wrapper, which is what focus parks on.
+  // focus-scope wrapper, which is what focus parks on. ARIA is rendered rather
+  // than only captured, so those assertions read the DOM a screen reader sees.
   PopoverContent: ({
     children,
     onFocus,
@@ -56,6 +60,9 @@ vi.mock("@/components/ui/popover", () => ({
     return (
       <div
         data-testid="content"
+        role="dialog"
+        aria-label={typeof rest["aria-label"] === "string" ? rest["aria-label"] : undefined}
+        aria-modal={rest["aria-modal"] === true ? true : undefined}
         tabIndex={-1}
         onFocus={onFocus}
         onMouseDown={onMouseDown}
@@ -80,9 +87,12 @@ interface HarnessProps {
   onFocus?: React.FocusEventHandler<HTMLDivElement>;
   onMouseDown?: React.MouseEventHandler<HTMLDivElement>;
   onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
+  onInteractOutside?: (event: Event) => void;
   onOpenChange?: (open: boolean) => void;
   align?: "start" | "center" | "end";
   sideOffset?: number;
+  /** Omits the search box, reproducing a cold open before the chunk resolves. */
+  withInput?: boolean;
 }
 
 function Harness({
@@ -95,6 +105,7 @@ function Harness({
   onOpenChange,
   align,
   sideOffset,
+  withInput = true,
   ...contentOverrides
 }: HarnessProps) {
   const [openState, setOpen] = useState(initialOpen);
@@ -127,11 +138,15 @@ function Harness({
         {/* The real Header, so the marker the shell's mousedown delegation
             looks for is the one the shell actually stamps. */}
         <AppPaletteDialog.Header label="Test">
-          <AppPaletteDialog.Input
-            inputRef={inputRef}
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-          />
+          {withInput ? (
+            <AppPaletteDialog.Input
+              inputRef={inputRef}
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+            />
+          ) : (
+            <span data-testid="header-adornment">no input yet</span>
+          )}
         </AppPaletteDialog.Header>
         <button type="button" data-testid="row">
           A row
@@ -175,29 +190,59 @@ function input(container: HTMLElement): HTMLInputElement {
 
 beforeEach(() => {
   rootProps = {};
+  rootOpenChange = null;
   contentProps = {};
   useUIStore.setState({ overlayStack: [] });
 });
 
 describe("AppPalettePopover", () => {
   it("forwards the open state and the required modal choice to the popover root", () => {
-    const { unmount } = render(<Harness modal={true} />);
-    expect(rootProps).toEqual({ open: true, modal: true });
+    const { unmount } = render(<Harness modal={true} open={false} />);
+    // The closed case matters: a shell that hardcoded `open` would still pass
+    // every other test in this file.
+    expect(rootProps).toEqual({ open: false, modal: true });
     unmount();
 
-    render(<Harness modal={false} />);
+    render(<Harness modal={false} open={true} />);
     expect(rootProps).toEqual({ open: true, modal: false });
   });
 
+  it("hands Radix's own open changes back to the consumer", () => {
+    const onOpenChange = vi.fn();
+    render(<Harness onOpenChange={onOpenChange} />);
+
+    act(() => rootOpenChange?.(false));
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+
+    act(() => rootOpenChange?.(true));
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+  });
+
   it("names the content and mirrors aria-modal onto the modal form only", () => {
-    const { unmount } = render(<Harness modal={true} />);
-    expect(contentProps["aria-label"]).toBe("Test palette");
-    expect(contentProps["aria-modal"]).toBe(true);
+    const { unmount, getByTestId } = render(<Harness modal={true} />);
+    const modalContent = getByTestId("content");
+    expect(modalContent.getAttribute("aria-label")).toBe("Test palette");
+    expect(modalContent.getAttribute("aria-modal")).toBe("true");
     unmount();
 
-    render(<Harness modal={false} />);
+    const nonModal = render(<Harness modal={false} />);
     // `aria-modal="false"` is noise, so the non-modal form carries nothing.
-    expect(contentProps["aria-modal"]).toBeUndefined();
+    expect(nonModal.getByTestId("content").hasAttribute("aria-modal")).toBe(false);
+  });
+
+  it("keeps shell-owned policy when a consumer spread tries to override it", () => {
+    // Prop types omit these, but a spread object carries whatever it likes.
+    const smuggled = {
+      "aria-modal": false,
+      "aria-label": "Hijacked",
+      onEscapeKeyDown: undefined,
+    } as Partial<HarnessProps>;
+    const { getByTestId } = render(<Harness modal={true} {...smuggled} />);
+
+    const content = getByTestId("content");
+    expect(content.getAttribute("aria-modal")).toBe("true");
+    expect(content.getAttribute("aria-label")).toBe("Test palette");
+    expect(contentProps.onEscapeKeyDown).toBeTypeOf("function");
   });
 
   it("forwards positioning props through to the popover content", () => {
@@ -259,6 +304,20 @@ describe("AppPalettePopover", () => {
       cancel.mockRestore();
     });
 
+    it("leaves Radix's autofocus alone when the input has not mounted yet", () => {
+      // The cold open: the lazy Radix chunk resolves after the open frame, so
+      // this handler can run with nothing to focus. Cancelling Radix's default
+      // there would strand focus on nothing at all.
+      render(<Harness withInput={false} />);
+
+      expect(fireOpenAutoFocus().preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("survives the open frame firing before the input exists", () => {
+      // Same cold path, the RAF half — it must no-op rather than throw.
+      expect(() => render(<Harness withInput={false} />)).not.toThrow();
+    });
+
     it("hands focus back to the search box when it parks on the content wrapper", () => {
       const { container, getByTestId } = render(<Harness />);
       input(container).blur();
@@ -302,6 +361,20 @@ describe("AppPalettePopover", () => {
       expect(fireEvent.mouseDown(getByTestId("row"))).toBe(true);
     });
 
+    it("redirects when the click lands on a non-HTML header adornment", () => {
+      // Header adornments are Lucide glyphs; an SVG target is not an
+      // HTMLElement, so a narrower type guard would silently skip it.
+      const { container } = render(<Harness />);
+      const header = container.querySelector("[data-palette-header]");
+      if (!(header instanceof HTMLElement)) throw new Error("header not found");
+      const glyph = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+      header.appendChild(glyph);
+      input(container).blur();
+
+      expect(fireEvent.mouseDown(glyph)).toBe(false);
+      expect(document.activeElement).toBe(input(container));
+    });
+
     it("defers to a consumer handler that already cancelled the event", () => {
       const onMouseDown = vi.fn((event: React.MouseEvent<HTMLDivElement>) => {
         event.preventDefault();
@@ -339,13 +412,14 @@ describe("AppPalettePopover", () => {
     });
 
     it("reads the live query, not a render-stale copy", () => {
-      // Radix dismisses from a capture listener that beats React's re-render,
-      // so a closed-over query would be a keystroke behind.
+      // Written straight to the DOM with no React change event, which is what
+      // Radix's capture listener sees when it beats the re-render. A shell
+      // reading a closed-over `query` would still see "" here and let the
+      // palette close on a press that should have cleared.
       const { container } = render(<Harness initialQuery="" />);
-      fireEvent.change(input(container), { target: { value: "review" } });
+      input(container).value = "review";
 
       expect(fireEscape().preventDefault).toHaveBeenCalledTimes(1);
-      expect(input(container).value).toBe("");
     });
 
     it("leaves a composing keystroke to the IME candidate window", () => {
@@ -362,8 +436,11 @@ describe("AppPalettePopover", () => {
       // Chromium can emit 229 before `isComposing` flips true.
       const { container } = render(<Harness initialQuery="review" />);
 
-      fireEscape({ isComposing: false, keyCode: 229 });
+      const { preventDefault } = fireEscape({ isComposing: false, keyCode: 229 });
 
+      // Both halves: Radix is blocked from dismissing AND the query survives.
+      // Asserting only the query would pass if the guard were deleted.
+      expect(preventDefault).toHaveBeenCalledTimes(1);
       expect(input(container).value).toBe("review");
     });
 
@@ -415,13 +492,46 @@ describe("AppPalettePopover", () => {
       expect(fireCloseAutoFocus().preventDefault).not.toHaveBeenCalled();
     });
 
-    it("keeps the return when the consumer opts in, and still clears the flag", () => {
+    it("keeps the return when the consumer opts in", () => {
       render(<Harness restoreFocusOnPointerDismiss={true} />);
       act(() => contentProps.onPointerDownOutside?.());
 
       expect(fireCloseAutoFocus().preventDefault).not.toHaveBeenCalled();
-      // A stale flag here would taint the next close if the prop ever flipped.
+    });
+
+    it("does not leave the flag armed after an opted-in pointer dismissal", () => {
+      const { rerender } = render(<Harness restoreFocusOnPointerDismiss={true} />);
+      act(() => contentProps.onPointerDownOutside?.());
+      fireCloseAutoFocus();
+
+      // Flipping the policy is what exposes a stale flag: repeating the close
+      // under the same prop value could never tell the two apart.
+      rerender(<Harness restoreFocusOnPointerDismiss={false} />);
+
       expect(fireCloseAutoFocus().preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("disarms when the consumer vetoes the outside interaction", () => {
+      // The switcher holds itself open for a row's context menu. The palette
+      // never closed, so a later keyboard dismissal must keep its focus return.
+      render(<Harness onInteractOutside={(event) => event.preventDefault()} />);
+      act(() => contentProps.onPointerDownOutside?.());
+      act(() => {
+        const event = new Event("interactOutside", { cancelable: true });
+        contentProps.onInteractOutside?.(event);
+      });
+
+      expect(fireCloseAutoFocus().preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("still suppresses when the outside interaction is allowed through", () => {
+      render(<Harness />);
+      act(() => contentProps.onPointerDownOutside?.());
+      act(() => {
+        contentProps.onInteractOutside?.(new Event("interactOutside", { cancelable: true }));
+      });
+
+      expect(fireCloseAutoFocus().preventDefault).toHaveBeenCalledTimes(1);
     });
 
     it("notifies the consumer before Radix restores focus", () => {
@@ -470,6 +580,37 @@ describe("AppPalettePopover", () => {
       render(<Harness dismissOnForeignOverlay={true} onOpenChange={onOpenChange} />);
 
       expect(onOpenChange).not.toHaveBeenCalled();
+    });
+
+    it("re-baselines rather than closing when a palette opts in mid-flight", () => {
+      // The disabled selector reads a sentinel 0, so a naive diff would see the
+      // pre-existing overlay appear the instant the option is switched on.
+      const onOpenChange = vi.fn();
+      const { rerender } = render(
+        <Harness dismissOnForeignOverlay={false} onOpenChange={onOpenChange} />
+      );
+      act(() => useUIStore.getState().addOverlayClaim("existing"));
+
+      rerender(<Harness dismissOnForeignOverlay={true} onOpenChange={onOpenChange} />);
+
+      expect(onOpenChange).not.toHaveBeenCalled();
+    });
+
+    it("re-baselines on each open so a stale count cannot close the next one", () => {
+      const onOpenChange = vi.fn();
+      const { rerender } = render(
+        <Harness dismissOnForeignOverlay={true} open={true} onOpenChange={onOpenChange} />
+      );
+
+      rerender(<Harness dismissOnForeignOverlay={true} open={false} onOpenChange={onOpenChange} />);
+      act(() => useUIStore.getState().addOverlayClaim("while-closed"));
+      rerender(<Harness dismissOnForeignOverlay={true} open={true} onOpenChange={onOpenChange} />);
+
+      expect(onOpenChange).not.toHaveBeenCalled();
+
+      // The watcher is still live, not merely silenced.
+      act(() => useUIStore.getState().addOverlayClaim("after-reopen"));
+      expect(onOpenChange).toHaveBeenCalledWith(false);
     });
   });
 

--- a/src/components/ui/paletteHeaderAttr.ts
+++ b/src/components/ui/paletteHeaderAttr.ts
@@ -1,0 +1,12 @@
+/**
+ * Marks a palette's header region so the anchored shell (`AppPalettePopover`)
+ * can redirect a mousedown on the padding around the search box back into the
+ * input. Inert in the modal form, which has no focus-scope wrapper for focus to
+ * park on.
+ *
+ * Its own module rather than an `AppPaletteDialog` export because suites stub
+ * that component wholesale: a mock factory that omits the constant would leave
+ * the shell matching `[undefined]`, which throws on the first mousedown that
+ * reaches it.
+ */
+export const PALETTE_HEADER_ATTR = "data-palette-header";


### PR DESCRIPTION
## Summary

`AppPaletteDialog` only knew how to render as a centered modal over a scrim, so every trigger-anchored selector rebuilt the Radix Popover wiring by hand. Two consumers had already done it independently: `ProjectSwitcherPalette`'s `DropdownContent` arm, and `DockLaunchButton` (from the just-merged #11593). This adds `AppPalettePopover`, an anchored sibling of the same shell, and migrates both consumers onto it.

Resolves #11594

## What the shell carries, once

- Opening focus into the search box via both an `onOpenAutoFocus` handler and a `requestAnimationFrame` effect. Both are load-bearing, not redundant: `PopoverContent` renders nothing until its lazily-imported Radix chunk resolves, so cold opens and warm opens fire the two mechanisms in the opposite order.
- Focus returning to the trigger on keyboard dismissal, suppressed on pointer dismissal (per #6119).
- Escape that clears a non-empty query on the first press and closes on the second, with an IME composition guard and a veto slot for the consumer, ahead of it.
- A refocus when the focus trap parks focus on the `tabIndex={-1}` content wrapper.
- A header mousedown redirect so clicking the padding around the input doesn't dead-end Escape.

`modal` is a required prop with no default. Radix's `modal={true}` and `modal={false}` are materially different primitives, and the two consumers genuinely need different ones. `dismissOnForeignOverlay` and `restoreFocusOnPointerDismiss` are likewise left as explicit per-consumer policy rather than standardized away.

Deliberately not wired into `useEscapeStack`, `registerDialogEscapeBackstop`, `clearDialogOverlays`, or the tooltip dismiss registry. That machinery is scoped to `AppDialog`/`AppPaletteDialog` open/close transitions, and extending it to popover-type overlays was considered and rejected in #11034.

## Two intentional behavior changes

1. The project switcher's dropdown now stages Escape (first press clears the query, second closes), matching the rule the issue asks the shell to carry. This required `ProjectPaletteInner`'s bubble-phase Escape handler to stop closing immediately in dropdown mode. Modal mode is unchanged.
2. The project switcher keeps its existing pointer-dismiss focus behavior via an explicit `restoreFocusOnPointerDismiss` prop, rather than silently adopting the shell's suppress-by-default. Flipping that default is defensible, but it belongs in its own change.

## Changes

- `src/components/ui/AppPalettePopover.tsx` (new): the anchored shell.
- `src/components/ui/paletteHeaderAttr.ts` (new): shared header marker helper.
- `src/components/ui/AppPaletteDialog.tsx`: stamps the same header marker.
- `src/components/Layout/DockLaunchButton.tsx`: migrated onto the shell, net smaller.
- `src/components/Project/ProjectSwitcherPalette.tsx`: migrated onto the shell, net smaller.
- `src/components/ui/__tests__/AppPalettePopover.test.tsx` (new, 46 tests), plus updates to `DockLaunchButton.test.tsx` and `ProjectSwitcherPalette.keyboard.test.tsx`.

## Testing

- 309 unit tests across the shell, both migrated consumers, and all `AppPaletteDialog`/`ProjectSwitcher*` suites: all pass.
- All 7 specs in `e2e/full/panels/core-dock-launcher-search.spec.ts` pass against real Radix (real focus trap, staged Escape, Tab containment).
- Full `npm run typecheck` and `npm run build` pass.
- eslint and prettier clean on all 8 changed files.
