### PR TITLE
fix(ui): route AppDialog.Body's className to the element that holds the fields

### DIFF
--- a/e2e/full/worktree/dialog-body-spacing.spec.ts
+++ b/e2e/full/worktree/dialog-body-spacing.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * `AppDialog.Body` forwards its `className` to the padded scroll box that
+ * directly parents the body content. Callers pass sibling-spacing utilities
+ * (`space-y-*`), and those only take effect on the fields' immediate parent —
+ * when the class landed on ScrollShadow's outer wrapper instead, every field
+ * group in twelve dialogs rendered flush against the next.
+ *
+ * Measured against real rendered geometry rather than class names: the bug was
+ * invisible to jsdom (which computes no Tailwind styles) and to any assertion
+ * that only checks a class is present somewhere in the tree.
+ */
+import { test, expect } from "@playwright/test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, mockOpenDialog, type AppContext } from "../../helpers/launch";
+import { dismissBlockingPalette } from "../../helpers/overlays";
+import { T_SHORT, T_MEDIUM } from "../../helpers/timeouts";
+
+let ctx: AppContext;
+let plainDir: string;
+
+/**
+ * Vertical gap between two elements, in CSS pixels. Reads back what the user
+ * actually sees, so it fails on the real symptom (controls touching) no matter
+ * which layer caused it.
+ */
+async function verticalGap(
+  above: import("@playwright/test").Locator,
+  below: import("@playwright/test").Locator
+): Promise<number> {
+  const top = await above.boundingBox();
+  const bottom = await below.boundingBox();
+  if (!top || !bottom) throw new Error("expected both elements to be laid out");
+  return bottom.y - (top.y + top.height);
+}
+
+test.describe.serial("AppDialog body spacing", () => {
+  test.beforeAll(async () => {
+    // A plain folder with no .git — this is what routes the open flow into the
+    // non-git dialog and, from there, into project setup.
+    plainDir = mkdtempSync(path.join(tmpdir(), "daintree-plain-"));
+    writeFileSync(path.join(plainDir, "notes.txt"), "not a repo\n");
+
+    ctx = await launchApp();
+    await mockOpenDialog(ctx.app, plainDir);
+    await ctx.window.getByRole("button", { name: "Open folder" }).click();
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    if (plainDir) rmSync(plainDir, { recursive: true, force: true });
+  });
+
+  test("separates the non-git dialog's path caption from its explanation", async () => {
+    const { window } = ctx;
+    await dismissBlockingPalette(window);
+
+    const dialog = window.getByRole("dialog", { name: /^Open ‘/ });
+    await expect(dialog).toBeVisible({ timeout: T_MEDIUM });
+
+    const caption = dialog.locator("p").first();
+    const explanation = dialog.getByText(/isn’t a git repository/);
+    await expect(explanation).toBeVisible({ timeout: T_SHORT });
+
+    // Asserts separation exists, not its exact token value: pinning the pixel
+    // count here would just copy `space-y-3` back out of the source. Zero is
+    // the regression — the two paragraphs rendered as one block of text.
+    expect(await verticalGap(caption, explanation)).toBeGreaterThan(4);
+  });
+
+  test("separates the setup dialog's template select from the commit checkbox", async () => {
+    const { window } = ctx;
+
+    const nonGitDialog = window.getByRole("dialog", { name: /^Open ‘/ });
+    await nonGitDialog.getByRole("button", { name: "Initialize repository" }).click();
+
+    const setup = window.getByRole("dialog", { name: "Set up project" });
+    await expect(setup).toBeVisible({ timeout: T_MEDIUM });
+
+    // The reported symptom: the checkbox sat flush against the select above it.
+    const select = setup.locator("select#git-init-template");
+    const checkbox = setup.getByRole("checkbox", { name: "Create initial commit" });
+    await expect(select).toBeVisible({ timeout: T_SHORT });
+
+    const gap = await verticalGap(select, checkbox);
+    // A checkbox is shorter than its label's line box, so `items-center`
+    // contributes a couple of pixels of leading even with no margin at all —
+    // the broken build measured within that noise. Require clearly more.
+    expect(gap).toBeGreaterThan(8);
+  });
+
+  test("keeps every setup field group separated", async () => {
+    const { window } = ctx;
+    const setup = window.getByRole("dialog", { name: "Set up project" });
+
+    // Walk the body's own children rather than naming fields: this holds as the
+    // dialog gains or loses groups, and catches a partial regression where only
+    // some pairs collapse.
+    const gaps = await setup.evaluate((root) => {
+      const label = root.querySelector("label[for='git-init-project-name']");
+      const body = label?.parentElement?.parentElement;
+      if (!body) return null;
+      const kids = Array.from(body.children).map((el) => el.getBoundingClientRect());
+      return kids.slice(1).map((box, i) => box.top - (kids[i]!.top + kids[i]!.height));
+    });
+
+    expect(gaps).not.toBeNull();
+    expect(gaps!.length).toBeGreaterThan(1);
+    for (const gap of gaps!) {
+      expect(gap).toBeGreaterThan(8);
+    }
+  });
+});

--- a/src/components/ui/AppDialog.tsx
+++ b/src/components/ui/AppDialog.tsx
@@ -510,7 +510,12 @@ interface AppDialogBodyProps {
 
 AppDialog.Body = function AppDialogBody({ children, className }: AppDialogBodyProps) {
   return (
-    <ScrollShadow className={cn("flex-1 min-h-0", className)} scrollClassName="p-6">
+    // `className` belongs on the padded scroll box, not on ScrollShadow's outer
+    // wrapper — the wrapper's children are the two absolute edge overlays plus
+    // the scroll box, so a caller's `space-y-*` there styled the overlays and
+    // hung a stray margin off the scroll box while the actual fields got no
+    // spacing at all. Matches where `BodyScroll` puts it.
+    <ScrollShadow className="flex-1 min-h-0" scrollClassName={cn("p-6", className)}>
       {children}
     </ScrollShadow>
   );

--- a/src/components/ui/__tests__/AppDialog.test.tsx
+++ b/src/components/ui/__tests__/AppDialog.test.tsx
@@ -1321,3 +1321,48 @@ describe("AppDialog layering over a dock popover", () => {
     expect(renderDialogAt()).not.toBe(promoted);
   });
 });
+
+describe("AppDialog.Body className placement", () => {
+  beforeEach(() => {
+    mockPrevOpen = false;
+    _resetForTests();
+    vi.useRealTimers();
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+  });
+
+  afterEach(() => {
+    _resetForTests();
+  });
+
+  // Callers pass sibling-spacing utilities (`space-y-*`), which only reach the
+  // fields when they land on their direct parent. ScrollShadow's outer wrapper
+  // is two overlays plus the scroll box, so styling it silently spaced nothing.
+  it("puts the caller's class on the element that parents the body content", () => {
+    renderDialog({
+      children: (
+        <AppDialog.Body className="dialog-body-spacing">
+          <span data-testid="field-a">A</span>
+          <span data-testid="field-b">B</span>
+        </AppDialog.Body>
+      ),
+    });
+
+    const parent = screen.getByTestId("field-a").parentElement;
+    expect(parent).toBe(screen.getByTestId("field-b").parentElement);
+    expect(parent?.classList.contains("dialog-body-spacing")).toBe(true);
+  });
+
+  it("leaves the scroll wrapper unstyled by the caller", () => {
+    renderDialog({
+      children: (
+        <AppDialog.Body className="dialog-body-spacing">
+          <span data-testid="field-a">A</span>
+        </AppDialog.Body>
+      ),
+    });
+
+    const wrapper = screen.getByTestId("field-a").parentElement?.parentElement;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.classList.contains("dialog-body-spacing")).toBe(false);
+  });
+});


### PR DESCRIPTION
`AppDialog.Body` was passing its caller's `className` to the wrong element. It went to `ScrollShadow`'s outer wrapper, whose children are the two absolutely-positioned edge overlays plus the scroll box, rather than to the padded scroll box that actually parents the body content.

Callers pass sibling-spacing utilities, and `space-y-*` only reaches the fields when it sits on their immediate parent. So all twelve dialogs using `AppDialog.Body` rendered their field groups flush against each other. Tailwind v4 compiles it to `:where(& > :not(:last-child)) { margin-block-end }`, so the one child that did take a margin was the scroll box, leaving a dead 20px band at the bottom of every dialog body.

The fix moves `className` onto the scroll box. `AppDialog.BodyScroll` already did it this way, so the two are now consistent.

## Affected dialogs

`PluginInputBoxDialog`, `PluginManagerView`, `CloneRepoDialog`, `CreateProjectFolderDialog`, `GitInitDialog`, `NonGitFolderDialog`, `CrashRecoveryDialog`, `AddPresetDialog`, `DiagnosticsReviewDialog`, `ImportEnvDialog`, `RecipeConflictDialog`, `ConfirmDialog`.

All twelve pass spacing-only classes, nothing wrapper-intent, so moving the target is safe. `ConfirmDialog` mostly won't shift in practice: most instances render a description only, and a single child has nothing to space against.

## Measurements

Taken on the reported surface (`GitInitDialog`, reached by opening a folder that isn't a repo):

| | before | after |
|---|---|---|
| gitignore select to "Create initial commit" | 1.96px | 21.56px |
| field-group gaps | 0px, 0px | 19.6px, 19.6px |
| non-git dialog, path caption to explanation | 0px | 12px |

The 1.96px was `items-center` centering a 16px checkbox against a 20px line box. Pure leading, no margin at all, which is why it read as touching.

## Tests

`e2e/full/worktree/dialog-body-spacing.spec.ts` measures rendered geometry rather than class names. jsdom computes no Tailwind styles, and asserting a class exists somewhere in the tree is exactly the check that missed this, so the guard has to run in a real renderer.

Both the unit tests and the E2E spec were confirmed against a reverted build first. Without the fix the E2E assertions fail at 0, 1.96 and 0, and the unit tests fail on the class landing on the wrong node. I dropped a third unit test I'd written that asserted `p-6` was present, since it copied a literal out of the source and passed with the bug in place.

`npm run check` is green. Also spot-checked `preset-tray-default.spec.ts` since `AddPresetDialog` is in the affected set.

Worth noting that PR CI doesn't run E2E, so the new spec won't gate this one. It runs under `full-worktree` in `stabilize` and on release.
