### PR TITLE
fix(file-browser): stop folder navigation from hijacking the viewer

### DIFF
--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -498,10 +498,11 @@ export function FileBrowserPane({
 
   // Point the viewer column at a path — the one write that changes what the
   // right-hand side shows, and the only place `browserSelectedPath` moves for a
-  // user gesture. Every route to the viewer goes through here (a file click, a
-  // folder's Enter, its "Show contents" menu item, any folder-listing row) so
-  // they cannot drift apart. The tree's cursor needs no handling: the
-  // render-time sync above pulls it along with any viewer change.
+  // user gesture. A file click and any folder-listing row land here; the
+  // explicit folder gestures go through `showFolderContents` below, which is
+  // this write plus the one thing they additionally need. The tree's cursor
+  // needs no handling: the render-time sync above pulls it along with any
+  // viewer change.
   //
   // The folder listing hands this straight to its rows, folders included. That
   // surface lives *inside* the viewer, so drilling into a folder there is the
@@ -510,6 +511,22 @@ export function FileBrowserPane({
   const showInViewer = useCallback(
     (path: string) => {
       setFileBrowserView(id, { browserSelectedPath: path });
+    },
+    [id, setFileBrowserView]
+  );
+
+  // The explicit "show me this folder" gestures: Enter, double-click, and the
+  // row menu's "Show contents". They clear a collapsed viewer as well as moving
+  // it, because they are a folder's *only* routes to the listing and the viewer
+  // column unmounts entirely while collapsed — without this the gesture would
+  // write a selection nobody can see, and tree-only mode would lose folder
+  // viewing outright. Deliberately not folded into `showInViewer`: that also
+  // serves plain file clicks and folder-listing rows, where popping the column
+  // back open would fight a collapse the user chose. One patch rather than two
+  // writes, so no intermediate state is rendered or persisted.
+  const showFolderContents = useCallback(
+    (path: string) => {
+      setFileBrowserView(id, { browserSelectedPath: path, browserViewerCollapsed: false });
     },
     [id, setFileBrowserView]
   );
@@ -565,7 +582,7 @@ export function FileBrowserPane({
     (path: string) => {
       const row = rows.find((candidate) => candidate.path === path);
       if (row?.isDirectory === true) {
-        showInViewer(path);
+        showFolderContents(path);
         return;
       }
       // The base-path half is defensive rather than reachable: an unresolved
@@ -594,7 +611,7 @@ export function FileBrowserPane({
         if (location === "dialog") onClose?.();
       })();
     },
-    [location, onClose, basePath, rows, showInViewer]
+    [location, onClose, basePath, rows, showFolderContents]
   );
 
   // The foreground half of the refresh signal, counted apart from the ambient
@@ -983,8 +1000,10 @@ export function FileBrowserPane({
                 only from the keyboard, which would make the whole surface look
                 like it had been removed rather than made deliberate. Carries no
                 shortcut hint — Enter acts on the tree's cursor row, which is not
-                necessarily the row this menu was opened on. */}
-            <ContextMenuItem onSelect={() => showInViewer(row.path)}>
+                necessarily the row this menu was opened on. Routed through the
+                same handler as Enter so the label stays honest with the viewer
+                collapsed: an item that promises contents must not no-op. */}
+            <ContextMenuItem onSelect={() => showFolderContents(row.path)}>
               <PanelRightOpen className="w-3.5 h-3.5 mr-2" />
               Show contents
             </ContextMenuItem>
@@ -1042,7 +1061,7 @@ export function FileBrowserPane({
     ),
     [
       isWorktreeSource,
-      showInViewer,
+      showFolderContents,
       handleSetRoot,
       handleCopyFolderContext,
       handleInsertFileReference,

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -97,6 +97,10 @@ export function FileBrowserPane({
 }: FileBrowserPaneProps) {
   const setFileBrowserView = usePanelStore((state) => state.setFileBrowserView);
 
+  // What the VIEWER column is showing. The name is historical (#11620 named the
+  // persisted field); everything downstream of it — the hook's kind resolution,
+  // the listing target, the file reader — is viewer state, and this is the only
+  // thing that decides what the right-hand column renders.
   const selectedPath = usePanelStore(
     useCallback(
       (state) => {
@@ -106,6 +110,37 @@ export function FileBrowserPane({
       [id]
     )
   );
+
+  // Where the TREE's own highlight sits, which is a different question from
+  // what the viewer shows. Splitting the two is what lets a folder click be
+  // pure navigation: the cursor lands on the folder, and the viewer keeps
+  // whatever it already had open.
+  //
+  // Component state rather than a persisted field. It is ephemeral navigation
+  // position, and on restore the right place for the tree to be pointing is at
+  // the file the viewer is showing — which the sync below produces for free.
+  const [cursorPath, setCursorPath] = useState<string | null>(selectedPath);
+  const [cursorSync, setCursorSync] = useState({ id, viewerPath: selectedPath });
+  // Snap the cursor whenever the viewer target changes from anywhere — a file
+  // click, a folder activation, or an external reveal (`worktree.openFileBrowser`
+  // selects a path this panel never clicked). Adjusting state during render is
+  // React's documented alternative to an effect for exactly this: it re-renders
+  // before paint instead of after, so the tree never flashes the stale row.
+  //
+  // Guarded on the *previous* viewer path rather than on inequality with the
+  // cursor, which is the whole trick: once the user moves the cursor off onto a
+  // folder, the viewer path has not changed, so nothing drags the cursor back.
+  //
+  // The panel id rides the sentinel because this component is not remounted per
+  // panel: a tab group renders one unkeyed `GridPanel` for whichever tab is
+  // active, so switching between two file browsers reuses this instance. Keying
+  // only on the path would let panel A's cursor become panel B's whenever both
+  // happen to have the same viewer target — including the very common case of
+  // both having none.
+  if (cursorSync.id !== id || cursorSync.viewerPath !== selectedPath) {
+    setCursorSync({ id, viewerPath: selectedPath });
+    setCursorPath(selectedPath);
+  }
   const expandedPaths = usePanelStore(
     useCallback(
       (state) => {
@@ -445,17 +480,51 @@ export function FileBrowserPane({
         for (const candidate of current) {
           if (candidate.startsWith(prefix)) current.delete(candidate);
         }
+        // Rehome a cursor that was inside the branch onto the branch itself.
+        // Without this the tree keeps a cursor naming a row that no longer
+        // exists, and every key that reads it goes dead: Enter and the arrows
+        // resolve nothing, ArrowDown restarts at row 0, and the row menu can't
+        // replay. The viewer's own reveal strip can't rescue it — that guards
+        // the viewer path, which collapsing did not touch.
+        //
+        // Functional rather than reading `cursorPath` so this callback doesn't
+        // have to be rebuilt on every cursor move.
+        setCursorPath((cursor) => (cursor?.startsWith(prefix) === true ? path : cursor));
       }
       setFileBrowserView(id, { browserExpandedPaths: [...current].sort() });
     },
     [id, stableExpandedPaths, setFileBrowserView, ensureLoaded]
   );
 
-  const handleSelect = useCallback(
+  // Point the viewer column at a path — the one write that changes what the
+  // right-hand side shows, and the only place `browserSelectedPath` moves for a
+  // user gesture. Every route to the viewer goes through here (a file click, a
+  // folder's Enter, its "Show contents" menu item, any folder-listing row) so
+  // they cannot drift apart. The tree's cursor needs no handling: the
+  // render-time sync above pulls it along with any viewer change.
+  //
+  // The folder listing hands this straight to its rows, folders included. That
+  // surface lives *inside* the viewer, so drilling into a folder there is the
+  // user asking this column to move rather than navigating past it — the exact
+  // opposite of the tree, and the reason the tree gets its own handler below.
+  const showInViewer = useCallback(
     (path: string) => {
       setFileBrowserView(id, { browserSelectedPath: path });
     },
     [id, setFileBrowserView]
+  );
+
+  // The tree's cursor moved. A file re-targets the viewer with it (a leaf has
+  // nothing to navigate into, so opening it is the only thing the gesture can
+  // mean); a folder moves the cursor and stops there, leaving the viewer on
+  // whatever the user last opened. Enter — `handleActivate` — is how a folder
+  // reaches the viewer deliberately.
+  const handleTreeSelect = useCallback(
+    (path: string, isDirectory: boolean) => {
+      setCursorPath(path);
+      if (!isDirectory) showInViewer(path);
+    },
+    [showInViewer]
   );
 
   // Picking a file from the changed-files summary also opens its ancestors, so
@@ -484,13 +553,21 @@ export function FileBrowserPane({
   // already showing the same file, so repeating the gesture activates that panel
   // rather than piling up duplicates.
   //
-  // Positively a file, matching the viewer's own check: the key resolver returns
-  // `activate` for whatever row is selected, so directories arrive here too and
-  // are deliberately dropped — a folder's Enter does nothing, and re-rooting is
-  // the double-click's job.
+  // Enter on a *folder* used to be dead, back when a folder click already sent
+  // it to the viewer and there was nothing left for the key to do. Now that
+  // navigating past a folder deliberately leaves the viewer alone, this is the
+  // gesture that asks for it — the explicit half of the split, and the standard
+  // meaning of Enter on a tree node (WAI-ARIA APG: activate the focused node).
+  // Double-click runs the same command, so the mouse has the natural route and
+  // the row menu's "Show contents" is the redundant accelerator a context menu
+  // is supposed to be, rather than the only way in.
   const handleActivate = useCallback(
     (path: string) => {
       const row = rows.find((candidate) => candidate.path === path);
+      if (row?.isDirectory === true) {
+        showInViewer(path);
+        return;
+      }
       // The base-path half is defensive rather than reachable: an unresolved
       // source renders no tree at all, so nothing can activate a row. It stays
       // because joining against "" would silently produce a wrong absolute path.
@@ -517,7 +594,7 @@ export function FileBrowserPane({
         if (location === "dialog") onClose?.();
       })();
     },
-    [location, onClose, basePath, rows]
+    [location, onClose, basePath, rows, showInViewer]
   );
 
   // The foreground half of the refresh signal, counted apart from the ambient
@@ -900,6 +977,17 @@ export function FileBrowserPane({
       <>
         {row.isDirectory && (
           <>
+            {/* The mouse's way to what Enter does on a tree row. It has to exist
+                as an explicit item now that clicking a folder no longer sends it
+                to the viewer: without it the folder listing would be reachable
+                only from the keyboard, which would make the whole surface look
+                like it had been removed rather than made deliberate. Carries no
+                shortcut hint — Enter acts on the tree's cursor row, which is not
+                necessarily the row this menu was opened on. */}
+            <ContextMenuItem onSelect={() => showInViewer(row.path)}>
+              <PanelRightOpen className="w-3.5 h-3.5 mr-2" />
+              Show contents
+            </ContextMenuItem>
             <ContextMenuItem onSelect={() => handleSetRoot(row.path)}>
               <FolderRoot className="w-3.5 h-3.5 mr-2" />
               Set as root
@@ -954,6 +1042,7 @@ export function FileBrowserPane({
     ),
     [
       isWorktreeSource,
+      showInViewer,
       handleSetRoot,
       handleCopyFolderContext,
       handleInsertFileReference,
@@ -1260,7 +1349,7 @@ export function FileBrowserPane({
               folderStatus={listingStatus}
               folderHasHiddenDotfiles={hideDotfiles && listingHasHiddenDotfiles}
               onShowDotfiles={handleShowDotfiles}
-              onSelectEntry={handleSelect}
+              onSelectEntry={showInViewer}
               rowContextMenu={rowContextMenu}
               basePath={basePath}
               sort={sort}
@@ -1385,11 +1474,13 @@ export function FileBrowserPane({
         )}
         <FileTreeView
           rows={rows}
-          selectedPath={selectedPath}
-          onSelect={handleSelect}
+          cursorPath={cursorPath}
+          // What the other column is showing, so the tree can mark it. Only
+          // meaningful now that it can differ from the cursor.
+          openPath={selectedPath}
+          onSelect={handleTreeSelect}
           onToggleExpanded={handleToggleExpanded}
           onActivate={handleActivate}
-          onRootFolder={handleSetRoot}
           rowContextMenu={rowContextMenu}
           onInsertFileReference={handleInsertFileReference}
           canInsertFileReference={canInsertFileReference}

--- a/src/panels/file-browser/FileTreeView.tsx
+++ b/src/panels/file-browser/FileTreeView.tsx
@@ -20,17 +20,45 @@ export interface FileTreeViewProps {
   // Mutable rather than `readonly`: this is exactly what the tree hook returns,
   // and widening it here would force a cast at the Virtuoso boundary.
   rows: FlatTreeRow[];
-  selectedPath: string | null;
-  onSelect: (path: string) => void;
+  /**
+   * The row the tree itself is on — its highlight, its `aria-activedescendant`
+   * and what its row-scoped commands target. Deliberately NOT "what the viewer
+   * shows": moving through the tree is navigation, and navigation must not
+   * re-target the viewer column behind the user (#11620 follow-up).
+   */
+  cursorPath: string | null;
+  /**
+   * What the viewer column is currently showing, when it is one of these rows.
+   * Marked `aria-current` and given full-strength text — NOT a second selection
+   * highlight. Once the cursor can sit somewhere else, this is the only thing
+   * saying which row the other column belongs to, and without it a screen
+   * reader has no way to perceive that at all.
+   *
+   * Two channels on purpose: the cursor owns the surface lift, the open row
+   * owns text weight. Painting both as fills would just move the confusion the
+   * split was meant to remove — and the accent is spoken for elsewhere.
+   */
+  openPath?: string | null;
+  /**
+   * The cursor landed on `path`. `isDirectory` travels with it because the
+   * caller decides from the row's kind whether this also re-targets the viewer
+   * — files do, folders never do.
+   */
+  onSelect: (path: string, isDirectory: boolean) => void;
   onToggleExpanded: (path: string, expand: boolean) => void;
   /**
-   * Fired by Enter or a double-click on a file row. Directory rows also reach
-   * this on Enter (the key resolver is row-kind agnostic), so the handler owns
-   * the file check.
+   * Fired by Enter and by double-click, on rows of either kind — the tree's one
+   * "act on this" gesture, and the only way a folder reaches the viewer column.
+   *
+   * The two gestures are deliberately the same command. Every platform that
+   * says anything about it (WinUI, GNOME HIG, the ARIA APG's treeitem pattern)
+   * treats Enter and double-click as dual triggers for a row's default action,
+   * and double-click is what people reach for as a faster Enter. Folders used
+   * to re-root the tree here instead (#11496); re-rooting now lives only in the
+   * row menu's "Set as root", which is where Visual Studio ("Scope to This")
+   * and Eclipse ("Go Into") both keep the same command.
    */
   onActivate?: (path: string) => void;
-  /** Fired by double-clicking a directory row: re-root the tree there. */
-  onRootFolder?: (path: string) => void;
   /**
    * Menu items for a row's right-click menu; return null for no menu. The
    * view owns the Radix wiring (and lifts the row while its menu is open so
@@ -101,11 +129,11 @@ const ROW_HEIGHT_PX = 24;
  */
 export function FileTreeView({
   rows,
-  selectedPath,
+  cursorPath,
+  openPath = null,
   onSelect,
   onToggleExpanded,
   onActivate,
-  onRootFolder,
   rowContextMenu,
   onInsertFileReference,
   canInsertFileReference = false,
@@ -120,9 +148,9 @@ export function FileTreeView({
   // `aria-activedescendant` ambiguous.
   const instanceId = useId();
 
-  const selectedIndex = useMemo(
-    () => (selectedPath === null ? -1 : rows.findIndex((row) => row.path === selectedPath)),
-    [rows, selectedPath]
+  const cursorIndex = useMemo(
+    () => (cursorPath === null ? -1 : rows.findIndex((row) => row.path === cursorPath)),
+    [rows, cursorPath]
   );
 
   // The rows array changes identity on every listing update, so the handler is
@@ -132,13 +160,13 @@ export function FileTreeView({
     (event: React.KeyboardEvent<HTMLDivElement>) => {
       // A row's context menu portals out of this container but still bubbles
       // its keys through the React tree, so every branch below would otherwise
-      // act on the *selected* row while the user is driving a menu opened on a
+      // act on the *cursor* row while the user is driving a menu opened on a
       // different one — Enter activating the wrong file, arrows moving the
-      // selection behind the open menu. Radix owns those keys while its menu
+      // cursor behind the open menu. Radix owns those keys while its menu
       // is up; the tree only handles what actually happened inside it.
       if (!isEventInsideTree(event, containerRef.current)) return;
 
-      // Shift+F10 / the ContextMenu key open the selected row's menu — the
+      // Shift+F10 / the ContextMenu key open the cursor row's menu — the
       // rows never take focus, so without this the row menu would be
       // mouse-only. Replayed as a synthetic contextmenu on the row's DOM node
       // because Radix's ContextMenu has no imperative open. preventDefault
@@ -151,8 +179,8 @@ export function FileTreeView({
           !event.ctrlKey &&
           !event.metaKey &&
           !event.altKey);
-      if (isMenuKey && rowContextMenu && selectedPath !== null) {
-        const rowElement = document.getElementById(rowDomId(instanceId, selectedPath));
+      if (isMenuKey && rowContextMenu && cursorPath !== null) {
+        const rowElement = document.getElementById(rowDomId(instanceId, cursorPath));
         if (rowElement) {
           event.preventDefault();
           event.stopPropagation();
@@ -174,11 +202,11 @@ export function FileTreeView({
       // a bare switch over the navigation keys and never claims a letter, so
       // plain `I` (and any future typeahead) stays untouched.
       //
-      // Gated on the selection resolving to a *rendered* row, not merely on a
-      // non-null path: re-rooting the tree leaves `browserSelectedPath` naming
-      // the old root, which no longer appears in `rows`. Firing then would
-      // reference a row the user cannot see and that `aria-activedescendant`
-      // has already disowned.
+      // Gated on the cursor resolving to a *rendered* row, not merely on a
+      // non-null path: re-rooting the tree leaves the cursor naming the old
+      // root, which no longer appears in `rows`. Firing then would reference a
+      // row the user cannot see and that `aria-activedescendant` has already
+      // disowned.
       //
       // Auto-repeat is dropped: holding the combo would append the same token
       // over and over. It also keeps a user-rebound global Cmd+I from turning
@@ -187,25 +215,31 @@ export function FileTreeView({
       if (
         onInsertFileReference &&
         canInsertFileReference &&
-        selectedPath !== null &&
-        selectedIndex >= 0 &&
+        cursorPath !== null &&
+        cursorIndex >= 0 &&
         !event.repeat &&
         matchesInsertFileReferenceCombo(event.nativeEvent, isMac())
       ) {
         event.preventDefault();
         event.stopPropagation();
-        onInsertFileReference(selectedPath);
+        onInsertFileReference(cursorPath);
         return;
       }
 
-      const intent = resolveTreeKey(event.key, rows, selectedPath);
+      const intent = resolveTreeKey(event.key, rows, cursorPath);
       if (!intent) return;
       event.preventDefault();
 
       switch (intent.type) {
-        case "select":
-          onSelect(intent.path);
+        // Arrowing is navigation, so it moves the cursor and nothing else for a
+        // folder. Landing on a *file* still opens it in the viewer — that is
+        // selection-follows-focus for leaves only, the same asymmetry a click
+        // has, and it is what keeps arrow-browsing a set of files useful.
+        case "select": {
+          const target = rows.find((candidate) => candidate.path === intent.path);
+          onSelect(intent.path, target?.isDirectory === true);
           break;
+        }
         case "expand":
           onToggleExpanded(intent.path, true);
           break;
@@ -219,8 +253,8 @@ export function FileTreeView({
     },
     [
       rows,
-      selectedPath,
-      selectedIndex,
+      cursorPath,
+      cursorIndex,
       onSelect,
       onToggleExpanded,
       onActivate,
@@ -231,18 +265,18 @@ export function FileTreeView({
     ]
   );
 
-  // Keep the selection on screen when it moves by keyboard. Runs after commit,
+  // Keep the cursor on screen when it moves by keyboard. Runs after commit,
   // never during render: an abandoned concurrent render would otherwise scroll
   // for state that never committed, and suppress the scroll on the render that
   // did. `auto` only scrolls when the row is actually outside the viewport, so
   // clicking a visible row never yanks the list.
   //
-  // Keyed on the path as well as the index so a restored selection scrolls on
+  // Keyed on the path as well as the index so a restored cursor scrolls on
   // mount, and so a live update that shifts a row's index re-reveals it.
   useEffect(() => {
-    if (selectedIndex < 0) return;
-    virtuosoRef.current?.scrollIntoView({ index: selectedIndex, behavior: "auto" });
-  }, [selectedIndex, selectedPath]);
+    if (cursorIndex < 0) return;
+    virtuosoRef.current?.scrollIntoView({ index: cursorIndex, behavior: "auto" });
+  }, [cursorIndex, cursorPath]);
 
   // Clicking a row selects it but can't focus it — rows are not focusable, by
   // design, because virtualization unmounts them. Pull focus to the container
@@ -257,11 +291,11 @@ export function FileTreeView({
 
   const context: TreeContext = useMemo(
     () => ({
-      selectedPath,
+      cursorPath,
+      openPath,
       onSelect,
       onToggleExpanded,
       onActivate,
-      onRootFolder,
       rowContextMenu,
       hasDirectories,
       instanceId,
@@ -269,11 +303,11 @@ export function FileTreeView({
       gitStatusIndex,
     }),
     [
-      selectedPath,
+      cursorPath,
+      openPath,
       onSelect,
       onToggleExpanded,
       onActivate,
-      onRootFolder,
       rowContextMenu,
       hasDirectories,
       instanceId,
@@ -282,17 +316,17 @@ export function FileTreeView({
     ]
   );
 
-  // Only advertise an active descendant that is actually rendered. A selection
+  // Only advertise an active descendant that is actually rendered. A cursor
   // scrolled out of the virtualized window — or deleted by a live update — has
   // no DOM node, and pointing at a missing id is worse than pointing at none.
   const activeDescendant =
-    selectedPath !== null && selectedIndex >= 0 ? rowDomId(instanceId, selectedPath) : undefined;
+    cursorPath !== null && cursorIndex >= 0 ? rowDomId(instanceId, cursorPath) : undefined;
 
   // Only advertised while the shortcut would actually do something — announcing
-  // Cmd+I with no reachable agent, or with a selection that no longer resolves
+  // Cmd+I with no reachable agent, or with a cursor that no longer resolves
   // to a row, would be promising a no-op. Matches the handler's own gate.
   const insertKeyshortcuts =
-    onInsertFileReference && canInsertFileReference && selectedIndex >= 0
+    onInsertFileReference && canInsertFileReference && cursorIndex >= 0
       ? comboToAriaKeyshortcuts(INSERT_FILE_REFERENCE_COMBO, isMac())
       : undefined;
 
@@ -330,11 +364,11 @@ export function FileTreeView({
 }
 
 interface TreeContext {
-  selectedPath: string | null;
-  onSelect: (path: string) => void;
+  cursorPath: string | null;
+  openPath: string | null;
+  onSelect: (path: string, isDirectory: boolean) => void;
   onToggleExpanded: (path: string, expand: boolean) => void;
   onActivate?: ((path: string) => void) | undefined;
-  onRootFolder?: ((path: string) => void) | undefined;
   rowContextMenu?: ((row: FileEntryLike) => React.ReactNode) | undefined;
   hasDirectories: boolean;
   instanceId: string;
@@ -360,18 +394,20 @@ function rowDomId(instanceId: string, path: string): string {
 }
 
 function renderRow(_index: number, row: FlatTreeRow, context: TreeContext) {
-  const isSelected = context.selectedPath === row.path;
-  return <FileTreeRow row={row} isSelected={isSelected} context={context} />;
+  const isSelected = context.cursorPath === row.path;
+  const isOpen = context.openPath === row.path;
+  return <FileTreeRow row={row} isSelected={isSelected} isOpen={isOpen} context={context} />;
 }
 
 interface FileTreeRowProps {
   row: FlatTreeRow;
   isSelected: boolean;
+  isOpen: boolean;
   context: TreeContext;
 }
 
-function FileTreeRow({ row, isSelected, context }: FileTreeRowProps) {
-  const { onSelect, onToggleExpanded, onActivate, onRootFolder } = context;
+function FileTreeRow({ row, isSelected, isOpen, context }: FileTreeRowProps) {
+  const { onSelect, onToggleExpanded, onActivate } = context;
 
   // Defer the folder-load spinner past the anti-flicker gate so a fast
   // expansion flashes nothing. Drives only the indicator — the tree's content
@@ -380,37 +416,49 @@ function FileTreeRow({ row, isSelected, context }: FileTreeRowProps) {
   // row scrolls out of view and back; harmless (the fetch itself keeps running).
   const showLoadingSpinner = useDeferredLoading(row.isLoading, UI_INLINE_LOADING_GATE_MS);
 
+  // A folder click is navigation and only navigation: it moves the cursor here
+  // and opens the branch. It deliberately does NOT re-target the viewer column,
+  // because expanding a folder to look for something else is the single most
+  // common gesture in this tree, and having it replace whatever file the user
+  // was reading made the viewer unusable as a place to keep something open.
+  //
+  // That rule already existed one handler down — the chevron has always refused
+  // to move the selection — and the row click was the odd one out. Files still
+  // re-target the viewer on a single click: a leaf has nothing to navigate into,
+  // so opening it is the only thing the gesture could mean.
   const handleClick = () => {
-    onSelect(row.path);
+    onSelect(row.path, row.isDirectory);
     if (row.isDirectory) onToggleExpanded(row.path, !row.isExpanded);
   };
 
-  // Double-click re-roots a folder and opens a file in its own panel (#11496) —
-  // the gesture keeps its "go deeper into this" meaning either way. On a folder
-  // the two single clicks it contains toggle expansion twice (a net no-op), and
-  // on a file they only re-select the row, so in both cases the double-click's
-  // own effect is the only observable one.
-  const handleDoubleClick = row.isDirectory
-    ? onRootFolder
-      ? () => {
-          onRootFolder(row.path);
-        }
-      : undefined
-    : onActivate
-      ? () => {
-          onActivate(row.path);
-        }
-      : undefined;
+  // One command for both kinds, and the same one Enter runs: show a folder in
+  // the viewer, open a file as its own panel (#11496). A folder used to re-root
+  // the tree from here, which spent the one gesture everyone reads as "activate
+  // this" on a structural jump nobody else binds to it — Eclipse is the only
+  // IDE that offers re-root-on-double-click at all, and ships it off by default.
+  //
+  // The two single clicks a double-click contains toggle expansion twice (a net
+  // no-op) and leave the viewer alone; on a file they only re-select the row. So
+  // the double-click's own effect is the only observable one either way.
+  const handleDoubleClick = onActivate
+    ? () => {
+        onActivate(row.path);
+      }
+    : undefined;
 
   const handleChevronClick = (event: React.MouseEvent) => {
-    // Toggling from the chevron must not move the selection: it is the
-    // "peek inside without leaving where I am" affordance.
+    // Toggling from the chevron must not move the cursor either: it is the
+    // "peek inside without leaving where I am" affordance. Now that the row
+    // click has stopped re-targeting the viewer, this is the only thing still
+    // separating the two — the chevron leaves the tree's own highlight where it
+    // was, which is what keeps a row-scoped command (Cmd+I, the menu key)
+    // pointed at the file the user picked while they open folders around it.
     event.stopPropagation();
     onToggleExpanded(row.path, !row.isExpanded);
   };
 
-  // The chevron is the double-click's near-miss zone; rooting from it would
-  // punish a fast expand-collapse.
+  // The chevron is the double-click's near-miss zone; activating from it would
+  // punish a fast expand-collapse with a viewer the user never asked to move.
   const handleChevronDoubleClick = (event: React.MouseEvent) => {
     event.stopPropagation();
   };
@@ -479,6 +527,11 @@ function FileTreeRow({ row, isSelected, context }: FileTreeRowProps) {
       {...(gitMarkerId && { "aria-describedby": gitMarkerId })}
       aria-level={row.depth + 1}
       aria-selected={isSelected}
+      // "The viewer is showing this one" — a different question from which row
+      // the tree's cursor is on, and the only channel that answers it once the
+      // two diverge. `true` rather than `page`: the viewer is a companion
+      // column, not a navigation destination.
+      {...(isOpen && { "aria-current": true })}
       {...(row.isDirectory && { "aria-expanded": row.isExpanded })}
       // Deliberately no `cursor-grab`: clicking to select or expand is what
       // nearly every row interaction is, and advertising the drag on all of
@@ -495,7 +548,13 @@ function FileTreeRow({ row, isSelected, context }: FileTreeRowProps) {
         // hover, selection and container focus all live at once, and the accent
         // is reserved for a single load-bearing signal per focus region.
         "transition-colors duration-150 ease-out",
-        isSelected ? "bg-overlay-subtle text-daintree-text" : "text-daintree-text/70",
+        isSelected
+          ? "bg-overlay-subtle text-daintree-text"
+          : // Full-strength text, no fill: enough to find the open row at a
+            // glance without reading as a second selection.
+            isOpen
+            ? "text-daintree-text"
+            : "text-daintree-text/70",
         !isSelected && "hover:bg-tint/5",
         // The row whose context menu is open lifts to a distinct neutral tier
         // (raised, not the selection's subtle) so it reads as "the menu targets

--- a/src/panels/file-browser/FolderListingView.tsx
+++ b/src/panels/file-browser/FolderListingView.tsx
@@ -26,13 +26,19 @@ export interface FolderListingViewProps {
    * Selecting an entry, which is this surface's whole click contract: a folder
    * re-points the listing at itself, a file opens in the viewer.
    *
+   * Unlike the tree's callback, a folder here DOES re-target the viewer, and
+   * that asymmetry is the point: this surface is already inside the viewer, so
+   * drilling into a folder is what the user came here to do. The tree's job is
+   * to navigate without disturbing the viewer; this one's job is to drive it.
+   * `isDirectory` still travels so the caller never has to re-derive the kind.
+   *
    * Deliberately no double-click counterpart to the tree's (#11496). Selecting
    * is what replaces the listing's contents, so the first click of any
    * double-click unmounts the row before the second arrives — a dblclick
    * handler here could never fire. Re-rooting a folder from this surface lives
    * in the row's context menu ("Set as root"), which is reachable.
    */
-  onSelect: (path: string) => void;
+  onSelect: (path: string, isDirectory: boolean) => void;
   /** Same callback the tree uses, so both surfaces offer the identical menu. */
   rowContextMenu?: (row: FileEntryLike) => React.ReactNode;
   /**
@@ -116,7 +122,7 @@ export function FolderListingView({
 }
 
 interface ListingContext {
-  onSelect: (path: string) => void;
+  onSelect: (path: string, isDirectory: boolean) => void;
   rowContextMenu?: ((row: FileEntryLike) => React.ReactNode) | undefined;
   basePath: string;
 }
@@ -148,8 +154,8 @@ function FolderListingRowView({ row, context }: FolderListingRowViewProps) {
   // the listing's contents change, which is why there is no double-click
   // counterpart — see the note on `onSelect` in the props above.
   const handleClick = useCallback(() => {
-    onSelect(row.path);
-  }, [onSelect, row.path]);
+    onSelect(row.path, row.isDirectory);
+  }, [onSelect, row.path, row.isDirectory]);
 
   // Byte-for-byte the tree's drag contract (#11576), down to the single MIME
   // type and the absent `text/plain`: a row dragged from either column has to

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -96,6 +96,9 @@ interface MockPanel {
 }
 
 const mockPanel: MockPanel = { id: "fb-1", kind: "file-browser" };
+// A second browser panel, for the case where a tab group reuses one component
+// instance across two of them.
+const mockPanelTwo: MockPanel = { id: "fb-2", kind: "file-browser" };
 
 // Mutable so a dock test can make this panel the active dock panel (or not) —
 // the pane defers its reveal refresh while parked offscreen (#11588).
@@ -104,7 +107,7 @@ const dockState = { activeDockTerminalId: null as string | null };
 vi.mock("@/store/panelStore", () => ({
   usePanelStore: (selector: (state: unknown) => unknown) =>
     selector({
-      panelsById: { "fb-1": mockPanel },
+      panelsById: { "fb-1": mockPanel, "fb-2": mockPanelTwo },
       setFileBrowserView: setFileBrowserViewMock,
       activeDockTerminalId: dockState.activeDockTerminalId,
     }),
@@ -223,6 +226,10 @@ const { treeProps } = vi.hoisted(() => ({
     onInsertFileReference: undefined as ((path: string) => void) | undefined,
     canInsertFileReference: undefined as boolean | undefined,
     basePath: undefined as string | undefined,
+    onSelect: undefined as ((path: string, isDirectory: boolean) => void) | undefined,
+    onToggleExpanded: undefined as ((path: string, expand: boolean) => void) | undefined,
+    cursorPath: undefined as string | null | undefined,
+    openPath: undefined as string | null | undefined,
     // The derived git model the pane hands the tree. Captured rather than
     // rendered: what this suite owns is the derivation and the join, while how a
     // marker is drawn belongs to FileTreeView's own suite.
@@ -232,19 +239,31 @@ const { treeProps } = vi.hoisted(() => ({
 vi.mock("../FileTreeView", () => ({
   FileTreeView: ({
     rowContextMenu,
+    onSelect,
+    onToggleExpanded,
     onActivate,
     onInsertFileReference,
     canInsertFileReference,
     basePath,
+    cursorPath,
+    openPath,
     gitStatusIndex,
   }: {
     rowContextMenu?: (row: unknown) => React.ReactNode;
+    onSelect?: (path: string, isDirectory: boolean) => void;
+    onToggleExpanded?: (path: string, expand: boolean) => void;
     onActivate?: (path: string) => void;
     onInsertFileReference?: (path: string) => void;
     canInsertFileReference?: boolean;
     basePath?: string;
+    cursorPath?: string | null;
+    openPath?: string | null;
     gitStatusIndex?: FileBrowserGitStatusIndex | null;
   }) => {
+    treeProps.onSelect = onSelect;
+    treeProps.onToggleExpanded = onToggleExpanded;
+    treeProps.cursorPath = cursorPath;
+    treeProps.openPath = openPath;
     treeProps.onActivate = onActivate;
     treeProps.onInsertFileReference = onInsertFileReference;
     treeProps.canInsertFileReference = canInsertFileReference;
@@ -2573,5 +2592,188 @@ describe("a selection the dotfile filter hides (#11620)", () => {
     mockPanel.browserHideDotfiles = true;
     renderPane();
     expect(screen.getByText("Nothing selected")).toBeTruthy();
+  });
+});
+
+// The tree navigates; the viewer only moves when asked. Folder-click used to do
+// both at once, so opening a branch to look for something else threw away the
+// file the user was reading. These pin the split from the pane's side — the
+// tree's own suite proves the row kind reaches this handler at all.
+describe("FileBrowserPane tree navigation vs the viewer", () => {
+  /** Did anything ask the viewer to move? */
+  function viewerWrites(): unknown[] {
+    return setFileBrowserViewMock.mock.calls
+      .filter(([, patch]) => "browserSelectedPath" in (patch as object))
+      .map(([, patch]) => (patch as { browserSelectedPath: string }).browserSelectedPath);
+  }
+
+  it("leaves the viewer alone when the cursor lands on a folder", () => {
+    mockPanel.browserSelectedPath = "src/app.ts";
+    renderPane();
+
+    act(() => {
+      treeProps.onSelect?.("src", true);
+    });
+
+    // The whole point: the open file survives navigating past a folder.
+    expect(viewerWrites()).toEqual([]);
+  });
+
+  it("moves the viewer when the cursor lands on a file", () => {
+    renderPane();
+
+    act(() => {
+      treeProps.onSelect?.("src/app.ts", false);
+    });
+
+    // A leaf has nothing to navigate into, so opening it is the only thing the
+    // gesture could mean — the asymmetry that keeps single-click browsing.
+    expect(viewerWrites()).toEqual(["src/app.ts"]);
+  });
+
+  it("moves the tree cursor for both kinds, viewer or no viewer", () => {
+    renderPane();
+
+    act(() => {
+      treeProps.onSelect?.("src", true);
+    });
+    expect(treeProps.cursorPath).toBe("src");
+
+    act(() => {
+      treeProps.onSelect?.("src/app.ts", false);
+    });
+    expect(treeProps.cursorPath).toBe("src/app.ts");
+  });
+
+  it("opens a folder in the viewer on activate, the deliberate half of the split", () => {
+    renderPane();
+
+    act(() => {
+      treeProps.onActivate?.("src");
+    });
+
+    // Enter is a folder's only keyboard route to the listing now that clicking
+    // one is pure navigation. It must not also try to open a file panel.
+    expect(viewerWrites()).toEqual(["src"]);
+    // Not "wasn't called with these exact options" — a dispatch with slightly
+    // different options would slip through that. Nothing should dispatch here.
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it("gives the mouse the same route through the row menu", () => {
+    // Without this item the folder listing would be keyboard-only, which would
+    // read as the feature having been removed rather than made deliberate.
+    renderPane();
+
+    act(() => {
+      screen.getByText("Show contents").click();
+    });
+
+    expect(viewerWrites()).toEqual([FOLDER_ROW.path]);
+  });
+
+  it("tells the tree which row the viewer is on, so it can be marked", () => {
+    // The cursor and the open row are different questions once they diverge;
+    // the tree needs both to answer either.
+    mockPanel.browserSelectedPath = "src/app.ts";
+    renderPane();
+
+    act(() => {
+      treeProps.onSelect?.("src", true);
+    });
+
+    expect(treeProps.cursorPath).toBe("src");
+    expect(treeProps.openPath).toBe("src/app.ts");
+  });
+
+  it("rehomes a cursor stranded inside a branch the user collapsed", () => {
+    // Collapsing takes every descendant row with it. A cursor left naming one
+    // of them resolves to nothing, and every key that reads it goes dead —
+    // Enter and the arrows included. The viewer's reveal strip can't rescue it
+    // because collapsing never touched the viewer.
+    renderPane();
+    act(() => {
+      treeProps.onSelect?.("src/app.ts", false);
+    });
+    expect(treeProps.cursorPath).toBe("src/app.ts");
+
+    act(() => {
+      treeProps.onToggleExpanded?.("src", false);
+    });
+
+    expect(treeProps.cursorPath).toBe("src");
+  });
+
+  it("leaves a cursor outside the collapsed branch alone", () => {
+    // Prefix matching has to be path-segment honest: collapsing "src" must not
+    // capture a cursor on a sibling that merely starts with the same letters.
+    renderPane();
+    act(() => {
+      treeProps.onSelect?.("srcache/note.md", false);
+    });
+
+    act(() => {
+      treeProps.onToggleExpanded?.("src", false);
+    });
+
+    expect(treeProps.cursorPath).toBe("srcache/note.md");
+  });
+
+  it("does not carry one panel's cursor into another", () => {
+    // A tab group renders one unkeyed GridPanel for whichever tab is active, so
+    // this component is reused rather than remounted when the user switches
+    // between two file browsers. Keying the sync on the path alone would leak
+    // the cursor whenever both panels' viewers agreed — including when both are
+    // empty, which is every freshly opened pair.
+    const { rerender } = render(
+      <TooltipProvider>
+        <FileBrowserPane
+          id="fb-1"
+          title="Files"
+          worktreeId="wt-1"
+          isFocused
+          location="grid"
+          onFocus={vi.fn()}
+          onClose={vi.fn()}
+        />
+      </TooltipProvider>
+    );
+    act(() => {
+      treeProps.onSelect?.("src", true);
+    });
+    expect(treeProps.cursorPath).toBe("src");
+
+    rerender(
+      <TooltipProvider>
+        <FileBrowserPane
+          id="fb-2"
+          title="Files"
+          worktreeId="wt-1"
+          isFocused
+          location="grid"
+          onFocus={vi.fn()}
+          onClose={vi.fn()}
+        />
+      </TooltipProvider>
+    );
+
+    expect(treeProps.cursorPath).toBeNull();
+  });
+
+  it("re-points the cursor when the viewer is moved from outside the tree", () => {
+    // `worktree.openFileBrowser` reveals a path this panel never clicked, and a
+    // restored panel arrives the same way. The tree has to follow, or its
+    // aria-activedescendant names a row that is no longer the subject.
+    mockPanel.browserSelectedPath = "src/app.ts";
+    const { rerender } = renderPane();
+    act(() => {
+      treeProps.onSelect?.("src", true);
+    });
+    expect(treeProps.cursorPath).toBe("src");
+
+    mockPanel.browserSelectedPath = "src/other.ts";
+    rerender(paneJsx({ worktreeId: "wt-1" }));
+
+    expect(treeProps.cursorPath).toBe("src/other.ts");
   });
 });

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -467,6 +467,10 @@ beforeEach(() => {
   treeProps.onInsertFileReference = undefined;
   treeProps.canInsertFileReference = undefined;
   treeProps.basePath = undefined;
+  treeProps.onSelect = undefined;
+  treeProps.onToggleExpanded = undefined;
+  treeProps.cursorPath = undefined;
+  treeProps.openPath = undefined;
   insertFileReferenceMock.mockClear();
   canInsertRef.current = true;
   dispatchMock.mockReset();
@@ -2670,6 +2674,31 @@ describe("FileBrowserPane tree navigation vs the viewer", () => {
     });
 
     expect(viewerWrites()).toEqual([FOLDER_ROW.path]);
+  });
+
+  it("reveals a collapsed viewer for both explicit folder routes", () => {
+    // The viewer column unmounts while collapsed, and these two gestures are a
+    // folder's only routes to the listing — so on their own they would write a
+    // selection nobody can see and tree-only mode would lose folder viewing
+    // outright. One handler serves both, hence one test.
+    mockPanel.browserViewerCollapsed = true;
+    renderPane();
+
+    act(() => {
+      treeProps.onActivate?.("src");
+    });
+    act(() => {
+      screen.getByText("Show contents").click();
+    });
+
+    expect(
+      setFileBrowserViewMock.mock.calls
+        .map(([, patch]) => patch as Record<string, unknown>)
+        .filter((patch) => "browserSelectedPath" in patch)
+    ).toEqual([
+      { browserSelectedPath: "src", browserViewerCollapsed: false },
+      { browserSelectedPath: FOLDER_ROW.path, browserViewerCollapsed: false },
+    ]);
   });
 
   it("tells the tree which row the viewer is on, so it can be marked", () => {

--- a/src/panels/file-browser/__tests__/FileTreeView.test.tsx
+++ b/src/panels/file-browser/__tests__/FileTreeView.test.tsx
@@ -66,7 +66,7 @@ function renderTree(overrides: Partial<Parameters<typeof FileTreeView>[0]> = {})
   const utils = render(
     <FileTreeView
       rows={ROWS}
-      selectedPath={null}
+      cursorPath={null}
       onSelect={onSelect}
       onToggleExpanded={vi.fn()}
       rowContextMenu={() => <div />}
@@ -89,7 +89,7 @@ describe("FileTreeView context-menu interactions", () => {
     const { getByRole, findByRole } = render(
       <FileTreeView
         rows={ROWS}
-        selectedPath="README.md"
+        cursorPath="README.md"
         onSelect={onSelect}
         onToggleExpanded={vi.fn()}
         rowContextMenu={(clicked) => <ContextMenuItem>Act on {clicked.name}</ContextMenuItem>}
@@ -114,11 +114,11 @@ describe("FileTreeView context-menu interactions", () => {
 
     fireEvent.click(getByRole("treeitem", { name: "README.md" }));
 
-    expect(onSelect).toHaveBeenCalledWith("README.md");
+    expect(onSelect).toHaveBeenCalledWith("README.md", false);
   });
 
   it("replays the ContextMenu key as a contextmenu event on the selected row", () => {
-    const { getByRole } = renderTree({ selectedPath: "README.md" });
+    const { getByRole } = renderTree({ cursorPath: "README.md" });
     const contextMenuSpy = vi.fn();
     getByRole("treeitem", { name: "README.md" }).addEventListener("contextmenu", contextMenuSpy);
 
@@ -131,7 +131,7 @@ describe("FileTreeView context-menu interactions", () => {
   });
 
   it("replays Shift+F10 but leaves plain F10 alone", () => {
-    const { getByRole } = renderTree({ selectedPath: "src" });
+    const { getByRole } = renderTree({ cursorPath: "src" });
     const contextMenuSpy = vi.fn();
     getByRole("treeitem", { name: "src" }).addEventListener("contextmenu", contextMenuSpy);
 
@@ -148,7 +148,7 @@ describe("FileTreeView context-menu interactions", () => {
   it("hands the selected row to the agent on the platform's insert shortcut", () => {
     const onInsertFileReference = vi.fn();
     const { getByRole } = renderTree({
-      selectedPath: "README.md",
+      cursorPath: "README.md",
       onInsertFileReference,
       canInsertFileReference: true,
     });
@@ -172,7 +172,7 @@ describe("FileTreeView context-menu interactions", () => {
     isMacMock.mockReturnValue(false);
     const onInsertFileReference = vi.fn();
     const { getByRole } = renderTree({
-      selectedPath: "README.md",
+      cursorPath: "README.md",
       onInsertFileReference,
       canInsertFileReference: true,
     });
@@ -190,7 +190,7 @@ describe("FileTreeView context-menu interactions", () => {
   it("leaves the bare letter and the inject combo to their own handlers", () => {
     const onInsertFileReference = vi.fn();
     const { getByRole } = renderTree({
-      selectedPath: "README.md",
+      cursorPath: "README.md",
       onInsertFileReference,
       canInsertFileReference: true,
     });
@@ -208,7 +208,7 @@ describe("FileTreeView context-menu interactions", () => {
     const { getByRole, rerender } = render(
       <FileTreeView
         rows={ROWS}
-        selectedPath={null}
+        cursorPath={null}
         onSelect={vi.fn()}
         onToggleExpanded={vi.fn()}
         rowContextMenu={() => <div />}
@@ -227,7 +227,7 @@ describe("FileTreeView context-menu interactions", () => {
     rerender(
       <FileTreeView
         rows={ROWS}
-        selectedPath="README.md"
+        cursorPath="README.md"
         onSelect={vi.fn()}
         onToggleExpanded={vi.fn()}
         rowContextMenu={() => <div />}
@@ -248,7 +248,7 @@ describe("FileTreeView context-menu interactions", () => {
     // see and that aria-activedescendant has already disowned.
     const onInsertFileReference = vi.fn();
     const { getByRole } = renderTree({
-      selectedPath: "some/pruned/path",
+      cursorPath: "some/pruned/path",
       onInsertFileReference,
       canInsertFileReference: true,
     });
@@ -265,7 +265,7 @@ describe("FileTreeView context-menu interactions", () => {
     // and let every repeat fall through to here — a genuine wrong action.
     const onInsertFileReference = vi.fn();
     const { getByRole } = renderTree({
-      selectedPath: "README.md",
+      cursorPath: "README.md",
       onInsertFileReference,
       canInsertFileReference: true,
     });
@@ -289,7 +289,7 @@ describe("FileTreeView context-menu interactions", () => {
     const { getByRole, findByRole } = render(
       <FileTreeView
         rows={ROWS}
-        selectedPath="README.md"
+        cursorPath="README.md"
         onSelect={onSelect}
         onToggleExpanded={vi.fn()}
         onActivate={onActivate}
@@ -316,7 +316,7 @@ describe("FileTreeView context-menu interactions", () => {
     const { getByRole, rerender } = render(
       <FileTreeView
         rows={ROWS}
-        selectedPath="README.md"
+        cursorPath="README.md"
         onSelect={vi.fn()}
         onToggleExpanded={vi.fn()}
         onInsertFileReference={vi.fn()}
@@ -330,7 +330,7 @@ describe("FileTreeView context-menu interactions", () => {
     rerender(
       <FileTreeView
         rows={ROWS}
-        selectedPath="README.md"
+        cursorPath="README.md"
         onSelect={vi.fn()}
         onToggleExpanded={vi.fn()}
         onInsertFileReference={vi.fn()}
@@ -342,26 +342,22 @@ describe("FileTreeView context-menu interactions", () => {
     expect(getByRole("tree").hasAttribute("aria-keyshortcuts")).toBe(false);
   });
 
-  it("routes double-click by row kind: folders re-root, files activate", () => {
-    // Both callbacks supplied, so the assertion is that each row picks the right
-    // one — not merely that the unwired branch does nothing (#11496).
-    const onRootFolder = vi.fn();
+  it("routes double-click to activate for both row kinds", () => {
+    // One command for folders and files alike, and the same one Enter runs.
+    // Folders used to re-root from here instead (#11496), which spent the
+    // universal "activate this" gesture on a structural jump.
     const onActivate = vi.fn();
-    const { getByRole } = renderTree({ onRootFolder, onActivate });
+    const { getByRole } = renderTree({ onActivate });
 
     fireEvent.doubleClick(getByRole("treeitem", { name: "src" }));
-    expect(onRootFolder.mock.calls).toEqual([["src"]]);
-    expect(onActivate).not.toHaveBeenCalled();
-
     fireEvent.doubleClick(getByRole("treeitem", { name: "README.md" }));
-    expect(onActivate.mock.calls).toEqual([["README.md"]]);
-    // The folder gesture never re-fires: a file double-click must not re-root.
-    expect(onRootFolder.mock.calls).toEqual([["src"]]);
+
+    expect(onActivate.mock.calls).toEqual([["src"], ["README.md"]]);
   });
 
   it("activates the selected row on Enter and consumes the key", () => {
     const onActivate = vi.fn();
-    const { getByRole } = renderTree({ selectedPath: "README.md", onActivate });
+    const { getByRole } = renderTree({ cursorPath: "README.md", onActivate });
 
     const event = new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true });
     act(() => {
@@ -373,28 +369,96 @@ describe("FileTreeView context-menu interactions", () => {
     expect(event.defaultPrevented).toBe(true);
   });
 
-  it("reports Enter on a folder to the same handler, leaving the file check to it", () => {
+  it("reports Enter on a folder to the same handler, leaving the routing to it", () => {
     // The key resolver is row-kind agnostic, so a directory reaches onActivate
-    // too. Pinned here because the pane's handler is what filters it — if this
-    // ever stopped firing, that guard would look dead and get removed.
+    // too. Pinned here because Enter is now a folder's ONLY keyboard route to
+    // the viewer — clicking one is pure navigation — so if this stopped firing
+    // the folder listing would become unreachable from the keyboard entirely.
     const onActivate = vi.fn();
-    const { getByRole } = renderTree({ selectedPath: "src", onActivate });
+    const { getByRole } = renderTree({ cursorPath: "src", onActivate });
 
     fireEvent.keyDown(getByRole("tree"), { key: "Enter" });
 
     expect(onActivate.mock.calls).toEqual([["src"]]);
   });
 
-  it("does not re-root from a double-click on the chevron", () => {
+  // The tree reports WHICH KIND of row the cursor landed on, and the pane uses
+  // that to decide whether the viewer column moves with it. Without the kind
+  // travelling on the callback the pane would have to re-derive it from a
+  // listings cache that does not answer for every path, which is exactly the
+  // coupling this split removes.
+  it("marks the open row apart from the cursor row", () => {
+    // Once the two can differ, aria-selected alone says nothing about which row
+    // the viewer belongs to — a screen-reader user would have no way to
+    // perceive it. They ride separate attributes on purpose.
+    const { getByRole } = renderTree({ cursorPath: "src", openPath: "README.md" });
+
+    const cursorRow = getByRole("treeitem", { name: "src" });
+    const openRow = getByRole("treeitem", { name: "README.md" });
+
+    expect(cursorRow.getAttribute("aria-selected")).toBe("true");
+    expect(cursorRow.getAttribute("aria-current")).toBeNull();
+    expect(openRow.getAttribute("aria-current")).toBe("true");
+    expect(openRow.getAttribute("aria-selected")).toBe("false");
+  });
+
+  it("marks nothing current when the viewer is showing no row", () => {
+    const { getByRole } = renderTree({ cursorPath: "src" });
+
+    expect(getByRole("treeitem", { name: "src" }).getAttribute("aria-current")).toBeNull();
+    expect(getByRole("treeitem", { name: "README.md" }).getAttribute("aria-current")).toBeNull();
+  });
+
+  it("carries the row kind on a click so the pane can route it", () => {
+    const { onSelect, getByRole } = renderTree();
+
+    fireEvent.click(getByRole("treeitem", { name: "src" }));
+    fireEvent.click(getByRole("treeitem", { name: "README.md" }));
+
+    expect(onSelect.mock.calls).toEqual([
+      ["src", true],
+      ["README.md", false],
+    ]);
+  });
+
+  it("carries the row kind when the cursor moves by keyboard", () => {
+    // Arrowing is navigation too: landing on a folder must be reported as one
+    // so a held ArrowDown cannot walk the viewer through every directory it
+    // passes.
+    const { onSelect, getByRole, rerender } = renderTree();
+
+    fireEvent.keyDown(getByRole("tree"), { key: "ArrowDown" });
+    expect(onSelect.mock.calls).toEqual([["src", true]]);
+
+    rerender(
+      <FileTreeView
+        rows={ROWS}
+        cursorPath="src"
+        onSelect={onSelect}
+        onToggleExpanded={vi.fn()}
+        rowContextMenu={() => <div />}
+        basePath={BASE_PATH}
+        label="Files"
+      />
+    );
+    fireEvent.keyDown(getByRole("tree"), { key: "ArrowDown" });
+
+    expect(onSelect.mock.calls).toEqual([
+      ["src", true],
+      ["README.md", false],
+    ]);
+  });
+
+  it("does not activate from a double-click on the chevron", () => {
     // The chevron is the double-click's near-miss zone: a fast expand-collapse
-    // there must not yank the user into a new root.
-    const onRootFolder = vi.fn();
-    const { getByRole } = renderTree({ onRootFolder });
+    // there must not move the viewer the user never asked to move.
+    const onActivate = vi.fn();
+    const { getByRole } = renderTree({ onActivate });
 
     const chevron = getByRole("treeitem", { name: "src" }).firstElementChild!;
     fireEvent.doubleClick(chevron);
 
-    expect(onRootFolder).not.toHaveBeenCalled();
+    expect(onActivate).not.toHaveBeenCalled();
   });
 
   it("drops the chevron gutter when the listing holds no folders at all", () => {
@@ -551,7 +615,7 @@ describe("FileTreeView folder-load spinner", () => {
     rerender(
       <FileTreeView
         rows={[row("src", true)]}
-        selectedPath={null}
+        cursorPath={null}
         onSelect={vi.fn()}
         onToggleExpanded={vi.fn()}
         basePath={BASE_PATH}
@@ -672,7 +736,7 @@ describe("FileTreeView menu contract", () => {
     const { getByRole } = render(
       <FileTreeView
         rows={ROWS}
-        selectedPath={null}
+        cursorPath={null}
         onSelect={vi.fn()}
         onToggleExpanded={vi.fn()}
         basePath={BASE_PATH}
@@ -776,7 +840,7 @@ describe("FileTreeView git status markers", () => {
     rerender(
       <FileTreeView
         rows={NESTED_ROWS}
-        selectedPath={null}
+        cursorPath={null}
         onSelect={vi.fn()}
         onToggleExpanded={vi.fn()}
         rowContextMenu={() => <div />}

--- a/src/panels/file-browser/__tests__/FolderListingView.test.tsx
+++ b/src/panels/file-browser/__tests__/FolderListingView.test.tsx
@@ -121,7 +121,7 @@ describe("FolderListingView", () => {
     const onSelect = vi.fn();
     renderListing([row("src/a.ts")], { onSelect });
     fireEvent.click(screen.getByLabelText("a.ts"));
-    expect(onSelect).toHaveBeenCalledWith("src/a.ts");
+    expect(onSelect).toHaveBeenCalledWith("src/a.ts", false);
   });
 
   it("makes rows draggable when a base path resolves", () => {
@@ -175,7 +175,10 @@ describe("FolderListingView has no double-click gesture", () => {
     fireEvent.click(rowEl);
     fireEvent.click(rowEl);
     fireEvent.doubleClick(rowEl);
-    expect(onSelect.mock.calls).toEqual([["src/a.ts"], ["src/a.ts"]]);
+    expect(onSelect.mock.calls).toEqual([
+      ["src/a.ts", false],
+      ["src/a.ts", false],
+    ]);
   });
 
   it("re-points on a single click, which is what makes a second click land elsewhere", () => {
@@ -185,7 +188,9 @@ describe("FolderListingView has no double-click gesture", () => {
     // One selection per click; the pane re-points the listing off the back of
     // it, which is the behaviour that rules a double-click out.
     expect(onSelect).toHaveBeenCalledTimes(1);
-    expect(onSelect).toHaveBeenCalledWith("src/pkg");
+    // The kind travels for signature parity with the tree's callback; unlike
+    // the tree, this surface's caller drives the viewer for folders too.
+    expect(onSelect).toHaveBeenCalledWith("src/pkg", true);
   });
 });
 

--- a/src/panels/file-browser/fileBrowserTree.ts
+++ b/src/panels/file-browser/fileBrowserTree.ts
@@ -475,16 +475,16 @@ export type TreeKeyIntent =
 export function resolveTreeKey(
   key: string,
   rows: readonly FlatTreeRow[],
-  selectedPath: string | null
+  cursorPath: string | null
 ): TreeKeyIntent | null {
   if (rows.length === 0) return null;
 
-  const index = selectedPath === null ? -1 : rows.findIndex((row) => row.path === selectedPath);
+  const index = cursorPath === null ? -1 : rows.findIndex((row) => row.path === cursorPath);
   const current = index >= 0 ? rows[index] : undefined;
 
   switch (key) {
     case "ArrowDown": {
-      // No selection yet starts at the top rather than doing nothing, so the
+      // No cursor yet starts at the top rather than doing nothing, so the
       // first arrow press after focusing the tree is never a no-op.
       const next = rows[Math.min(index + 1, rows.length - 1)];
       return next ? { type: "select", path: next.path } : null;


### PR DESCRIPTION
Clicking a folder in the left tree did two things at once: expanded it, and re-targeted the right-hand viewer column. So if you had a file open and clicked a folder just to expand it and look for something else, the file was replaced by that folder's listing. Arrow keys had the same problem, and so did double-click, because the two single clicks inside it each fired a selection on the way past.

The tree already had the right instinct in one place. The chevron handler has always refused to move the selection, with a comment calling it the "peek inside without leaving where I am" affordance. The row click two lines above it did the opposite.

## The split

One piece of state became two:

- `browserSelectedPath` (persisted) keeps its meaning: what the viewer shows. Nothing downstream of it changed, so `useFileBrowserTree.ts` is untouched.
- `cursorPath` (new, component state) is where the tree's own highlight sits. Not persisted. On restore it starts on whatever the viewer has open, which is where you'd want the tree pointing anyway.

The rule is that files re-target the viewer and folders never do, unless you explicitly activate one. A leaf has nothing to navigate into, so opening it is the only thing the gesture could mean. `onSelect` widened to `(path, isDirectory)` so the pane routes on the row's kind instead of re-deriving it from a listings cache that can't answer for every path.

## Gestures on a folder

| Gesture | Before | After |
|---|---|---|
| Click | expand + re-target viewer | expand + move cursor |
| Chevron click | expand only | unchanged |
| Double-click | re-root tree | show contents (same as Enter) |
| Enter | nothing | show contents |
| Menu | Set as root, Copy context | + Show contents |

Double-click moving off re-rooting is the one behaviour change beyond the fix itself. Re-root on double-click turns out to be close to nonexistent as a convention: Eclipse is the only major IDE that offers it and ships it off by default. Every product that has the feature keeps it in a menu, which is where `Set as root` already lives. Visual Studio calls it "Scope to This", Eclipse calls it "Go Into", both right-click only, and both pair it with an up-one-level control that we already have in the toolbar. Meanwhile Enter and double-click are dual triggers for the same default action in WinUI, the GNOME HIG and the ARIA APG, and people reach for double-click as a faster Enter. Spending it on a structural jump was asking for accidental re-roots.

## Two things that fell out of review

The open row now carries `aria-current`. Once the cursor can sit somewhere else, `aria-selected` says nothing about which row the viewer belongs to, and a screen reader had no way to perceive it at all. It rides a separate channel from the cursor visually too: the cursor keeps the surface lift, the open row gets full-strength text. No second fill, no accent.

Collapsing a branch now rehomes a cursor that was inside it onto the branch itself. Otherwise the cursor named a row that no longer existed and every key that reads it went dead, including Enter and the arrows. The viewer's reveal strip can't rescue that because collapsing never touched the viewer.

The cursor sync is also keyed on the panel id, not just the path. A tab group renders one unkeyed `GridPanel` for whichever tab is active, so this component gets reused rather than remounted when you switch between two file browsers, and keying on the path alone leaked one panel's cursor into the other whenever both viewers agreed. Both are empty on a freshly opened pair, so that was most of the time.

## Known gap, not fixed here

Re-rooting resets the tree hook's listing cache, which drops `selectedNode` for the open file, so the viewer blanks anyway. That predates this branch and hits `Set as root` the same way it used to hit double-click. Fixing it means retaining the viewer target's known kind across a listings reset, which is a change to the hook's cache lifecycle and wants its own PR.

## Testing

`npm run check` clean. 1098 unit tests across the file browser, panel registry, serialisers and field-coverage suites. `e2e/full/panels/core-file-browser.spec.ts` passes locally against a fresh build.

The folder-click assertion is mutation-tested: reverting `handleTreeSelect` to write unconditionally fails `leaves the viewer alone when the cursor lands on a folder`, so it's pinning the actual fix rather than restating it.

## Worth a follow-up

With a full tree on the left, a flat file listing on the right is a second navigator over the same hierarchy, which is more or less the definition of Cooper's cognitive excise. Every code-focused editor (VS Code, JetBrains, Sublime, Zed, Nova) has no folder pane at all. The listing earns its place today on Size and Modified with sorting, which the tree has neither of. If it stays it should probably stop being a file list and become a folder dashboard: counts, git rollup, context size for `Copy context`, maybe the README. Happy to open an issue for that.
