### PR TITLE
fix(pilot): gate fleet search on match quality, not bare subsequence

### DIFF
--- a/src/components/Pilot/__tests__/pilotRows.test.ts
+++ b/src/components/Pilot/__tests__/pilotRows.test.ts
@@ -390,12 +390,34 @@ describe("filterPilotGroups", () => {
       ctx()
     );
 
-  it("accepts an ordered subsequence, matching how the switcher searches", () => {
+  it("accepts an acronym spanning words, matching how the switcher searches", () => {
     // Typing "fltsnp" for "fleet snapshot" works in the project switcher, so it
     // has to work here — a palette that accepts a query one way and rejects it
-    // another teaches nothing transferable.
+    // another teaches nothing transferable. The quality floor is for characters
+    // scavenged out of mid-word, not for an acronym landing on word starts.
     const [group] = filterPilotGroups(groups(), "fltsnp");
     expect(group!.rows.map((r) => r.run.runId)).toEqual(["a"]);
+  });
+
+  it("drops a row the query only reaches by scavenging mid-word characters", () => {
+    // "rust" is a legal ordered subsequence of the research title, scraped out
+    // of four unrelated words. Unranked filtering has no bottom of the list to
+    // put that in, so it would read as an answer beside the real one (#11625).
+    const filtered = filterPilotGroups(
+      buildPilotGroups(
+        [
+          run({
+            runId: "loose",
+            agentState: "working",
+            title: "Research file browser folder selection usability",
+          }),
+          run({ runId: "exact", agentState: "working", title: "Rust migration" }),
+        ],
+        ctx()
+      ),
+      "rust"
+    );
+    expect(filtered[0]!.rows.map((r) => r.run.runId)).toEqual(["exact"]);
   });
 
   it("drops a group left with no matching rows", () => {
@@ -404,6 +426,12 @@ describe("filterPilotGroups", () => {
 
   it("keeps every row when the project name itself matches", () => {
     expect(filterPilotGroups(groups(), "daintree")[0]!.rows).toHaveLength(2);
+  });
+
+  it("does not admit a whole project on a loose project-name match", () => {
+    // A match on the group name short-circuits every row beneath it, so "ate"
+    // scraped out of "daintree" would surface the project's entire run list.
+    expect(filterPilotGroups(groups(), "ate")).toEqual([]);
   });
 
   it("recounts demands against the filtered rows", () => {

--- a/src/components/Pilot/__tests__/pilotRows.test.ts
+++ b/src/components/Pilot/__tests__/pilotRows.test.ts
@@ -390,19 +390,20 @@ describe("filterPilotGroups", () => {
       ctx()
     );
 
-  it("accepts an acronym spanning words, matching how the switcher searches", () => {
-    // Typing "fltsnp" for "fleet snapshot" works in the project switcher, so it
-    // has to work here — a palette that accepts a query one way and rejects it
-    // another teaches nothing transferable. The quality floor is for characters
-    // scavenged out of mid-word, not for an acronym landing on word starts.
+  it("accepts an abbreviation anchored to the words it came from", () => {
+    // Typing "fltsnp" for "fleet snapshot" works in the project switcher, and a
+    // query that abbreviates by word has to keep working here too. The floors
+    // themselves differ on purpose — the switcher can afford a weak match
+    // because it ranks one, and this surface cannot because it does not.
     const [group] = filterPilotGroups(groups(), "fltsnp");
     expect(group!.rows.map((r) => r.run.runId)).toEqual(["a"]);
   });
 
-  it("drops a row the query only reaches by scavenging mid-word characters", () => {
-    // "rust" is a legal ordered subsequence of the research title, scraped out
-    // of four unrelated words. Unranked filtering has no bottom of the list to
-    // put that in, so it would read as an answer beside the real one (#11625).
+  it("drops a row the query only reaches as a scattered subsequence", () => {
+    // "rust" is a legal ordered subsequence of the research title, but its
+    // characters are so far apart that the words it does land on cannot pay for
+    // the distance. Unranked filtering has no bottom of the list to put that in,
+    // so it would read as an answer beside the real one (#11625).
     const filtered = filterPilotGroups(
       buildPilotGroups(
         [
@@ -428,10 +429,63 @@ describe("filterPilotGroups", () => {
     expect(filterPilotGroups(groups(), "daintree")[0]!.rows).toHaveLength(2);
   });
 
+  it("keeps every row when the project name matches without being typed whole", () => {
+    // The short-circuit has to survive on match quality, not on the query
+    // happening to be a substring: "fs" is neither contiguous in "fleet
+    // snapshot" nor present in any row's own fields, so these rows are here
+    // only because their project matched.
+    const filtered = filterPilotGroups(
+      buildPilotGroups(
+        [
+          run({ runId: "a", agentState: "working", title: "billing" }),
+          run({ runId: "b", agentState: "working", title: "docs pass" }),
+        ],
+        ctx({
+          workspaces: new Map([["p1", { kind: "project", name: "fleet snapshot", emoji: "🌳" }]]),
+        })
+      ),
+      "fs"
+    );
+    expect(filtered[0]!.rows).toHaveLength(2);
+  });
+
   it("does not admit a whole project on a loose project-name match", () => {
     // A match on the group name short-circuits every row beneath it, so "ate"
     // scraped out of "daintree" would surface the project's entire run list.
-    expect(filterPilotGroups(groups(), "ate")).toEqual([]);
+    // These titles cannot match "ate" themselves, so the group name is the only
+    // thing under test.
+    const filtered = filterPilotGroups(
+      buildPilotGroups(
+        [
+          run({ runId: "a", agentState: "working", title: "billing" }),
+          run({ runId: "b", agentState: "working", title: "docs pass" }),
+        ],
+        ctx()
+      ),
+      "ate"
+    );
+    expect(filtered).toEqual([]);
+  });
+
+  it("matches on the worktree when nothing else on the row does", () => {
+    const filtered = filterPilotGroups(
+      buildPilotGroups([run({ runId: "a", agentState: "working", title: "billing" })], ctx()),
+      "scratch"
+    );
+    expect(filtered[0]!.rows.map((r) => r.run.runId)).toEqual(["a"]);
+  });
+
+  it("matches on the agent when nothing else on the row does", () => {
+    // The agent rides the row as an icon, so its name is only ever reachable
+    // through the query.
+    const filtered = filterPilotGroups(
+      buildPilotGroups(
+        [run({ runId: "a", agentState: "working", agentId: "codex", title: "billing" })],
+        ctx()
+      ),
+      "codex"
+    );
+    expect(filtered[0]!.rows.map((r) => r.run.runId)).toEqual(["a"]);
   });
 
   it("recounts demands against the filtered rows", () => {

--- a/src/components/Pilot/pilotRows.ts
+++ b/src/components/Pilot/pilotRows.ts
@@ -10,7 +10,7 @@ import {
   isDemandBand,
 } from "@/lib/fleetAttention";
 import { formatWaitAge, type ProjectRowTone } from "@/lib/projectRowStatus";
-import { isSubsequenceMatch } from "@/lib/projectSwitcherSearch";
+import { isFilterMatch } from "@/lib/projectSwitcherSearch";
 import { composeTitledPanel } from "@/utils/terminalTitleDisplay";
 import { deriveTerminalChrome, type TerminalChromeDescriptor } from "@/utils/terminalChrome";
 
@@ -227,6 +227,12 @@ export function buildPilotGroups(
  * quality because one of its rows is the destination, whereas here the ranking
  * IS the answer — demoting a blocked agent because a fresher one matched the
  * query better would defeat the surface.
+ *
+ * That is exactly why the fields are gated on {@link isFilterMatch} rather than
+ * a bare subsequence test. Keeping band order means a weak match is not sorted
+ * away from a strong one, it is interleaved with it, so match quality has to be
+ * settled here or not at all — and a loose hit on `group.name` is worse still,
+ * since it admits every row in the project (#11625).
  */
 export function filterPilotGroups(
   groups: readonly PilotProjectGroup[],
@@ -237,15 +243,15 @@ export function filterPilotGroups(
 
   const out: PilotProjectGroup[] = [];
   for (const group of groups) {
-    const projectMatches = isSubsequenceMatch(needle, group.name);
+    const projectMatches = isFilterMatch(needle, group.name);
     const rows = group.rows.filter(
       (row) =>
         projectMatches ||
-        isSubsequenceMatch(needle, row.title) ||
-        (row.worktreeLabel !== null && isSubsequenceMatch(needle, row.worktreeLabel)) ||
+        isFilterMatch(needle, row.title) ||
+        (row.worktreeLabel !== null && isFilterMatch(needle, row.worktreeLabel)) ||
         // The agent's name is on the row as an icon rather than as text, but
         // "codex" is still a plausible thing to type when looking for one.
-        isSubsequenceMatch(needle, row.chrome.label)
+        isFilterMatch(needle, row.chrome.label)
     );
     if (rows.length === 0) continue;
     out.push({

--- a/src/lib/__tests__/projectSwitcherSearch.test.ts
+++ b/src/lib/__tests__/projectSwitcherSearch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  isFilterMatch,
   scoreProjectQuery,
   scoreScratchQuery,
   rankSwitcherMatches,
@@ -47,6 +48,42 @@ function makeProject(
     ...overrides,
   };
 }
+
+describe("isFilterMatch", () => {
+  const RESEARCH_TITLE = "Research file browser folder selection usability";
+
+  it("rejects an empty query rather than matching every field", () => {
+    // An empty string is a substring of anything, so the substring bonus alone
+    // would clear the floor.
+    expect(isFilterMatch("", RESEARCH_TITLE)).toBe(false);
+  });
+
+  it("rejects a subsequence scavenged out of mid-word characters", () => {
+    // The #11625 case: every character is present in order, none of them where
+    // a reader would look for them.
+    expect(isFilterMatch("rust", RESEARCH_TITLE)).toBe(false);
+    expect(isFilterMatch("sv", "fleet snapshot service")).toBe(false);
+    expect(isFilterMatch("ate", "Daintree")).toBe(false);
+  });
+
+  it("accepts an acronym built from word starts", () => {
+    expect(isFilterMatch("fltsnp", "fleet snapshot service")).toBe(true);
+    expect(isFilterMatch("fs", "fleet snapshot service")).toBe(true);
+  });
+
+  it("accepts anything typed contiguously, down to a single character", () => {
+    // Incremental typing is always a substring, so the floor never interrupts
+    // it — including a character sitting mid-word, which scores nothing on its
+    // own and rides the substring bonus alone.
+    expect(isFilterMatch("d", "Daintree")).toBe(true);
+    expect(isFilterMatch("i", "Daintree")).toBe(true);
+    expect(isFilterMatch("brow", RESEARCH_TITLE)).toBe(true);
+  });
+
+  it("rejects a query whose characters are not all present", () => {
+    expect(isFilterMatch("zzzz", "fleet snapshot service")).toBe(false);
+  });
+});
 
 describe("scoreProjectQuery", () => {
   it("returns 0 for empty query", () => {

--- a/src/lib/__tests__/projectSwitcherSearch.test.ts
+++ b/src/lib/__tests__/projectSwitcherSearch.test.ts
@@ -83,10 +83,21 @@ describe("isFilterMatch", () => {
   it("accepts anything typed contiguously, down to a single character", () => {
     // Incremental typing is always a substring, so the floor never interrupts
     // it — including a character sitting mid-word, which earns no boundary or
-    // start bonus and clears the floor on the substring bonus alone.
+    // start bonus and survives on the substring short-circuit alone.
     expect(isFilterMatch("d", "Daintree")).toBe(true);
     expect(isFilterMatch("i", "Daintree")).toBe(true);
     expect(isFilterMatch("brow", RESEARCH_TITLE)).toBe(true);
+  });
+
+  it("accepts a contiguous match in a field long enough to outrun the score", () => {
+    // Short fields hide the problem. The substring bonus feeds the same total
+    // the gap penalties drain, so a short query far enough into a long field
+    // scores under the floor even though it is literally the field's last word
+    // — and agent-set titles, which this length is taken from, have no cap.
+    const LONG_TITLE =
+      "Reviewing the destructive-action safeguard audit and filing the missing confirm dialogs now";
+    expect(LONG_TITLE.length).toBeGreaterThan(85);
+    expect(isFilterMatch("now", LONG_TITLE)).toBe(true);
   });
 
   it("ignores whitespace the caller did not trim", () => {

--- a/src/lib/__tests__/projectSwitcherSearch.test.ts
+++ b/src/lib/__tests__/projectSwitcherSearch.test.ts
@@ -72,13 +72,12 @@ describe("isFilterMatch", () => {
     expect(isFilterMatch("fs", "fleet snapshot service")).toBe(true);
   });
 
-  it("accepts word initials the scorer's greedy walk cannot reach", () => {
-    // The scorer takes the first character it can rather than the best one, so
-    // "sr" spends its "s" inside "issue" and never arrives at "scratch rows".
-    // Initials are one character per word, so reading them costs no looseness.
-    expect(isFilterMatch("sr", "issue-11518-scratch-rows")).toBe(true);
-    expect(isFilterMatch("isr", "issue-11518-scratch-rows")).toBe(true);
-    expect(isFilterMatch("oc", "OpenCode")).toBe(true);
+  it("rejects a query spread across the words of a long title", () => {
+    // Reading word initials instead of characters would let this through: the
+    // initials spell "ctetsf1t2", and a query is free to skip as many words as
+    // it likes on the way through them.
+    expect(isFilterMatch("test", "cut the external tool surface from 100 to 24")).toBe(false);
+    expect(isFilterMatch("ru", RESEARCH_TITLE)).toBe(false);
   });
 
   it("accepts anything typed contiguously, down to a single character", () => {

--- a/src/lib/__tests__/projectSwitcherSearch.test.ts
+++ b/src/lib/__tests__/projectSwitcherSearch.test.ts
@@ -52,32 +52,46 @@ function makeProject(
 describe("isFilterMatch", () => {
   const RESEARCH_TITLE = "Research file browser folder selection usability";
 
-  it("rejects an empty query rather than matching every field", () => {
-    // An empty string is a substring of anything, so the substring bonus alone
-    // would clear the floor.
+  it("rejects a blank query rather than matching every field", () => {
+    // Whitespace is a substring of anything, so the substring bonus alone would
+    // clear the floor.
     expect(isFilterMatch("", RESEARCH_TITLE)).toBe(false);
+    expect(isFilterMatch("   ", RESEARCH_TITLE)).toBe(false);
   });
 
-  it("rejects a subsequence scavenged out of mid-word characters", () => {
-    // The #11625 case: every character is present in order, none of them where
-    // a reader would look for them.
+  it("rejects a subsequence whose characters are too far apart to pay for", () => {
+    // The #11625 case: every character is present in order, none of them near
+    // enough to the words they came from to read as a match.
     expect(isFilterMatch("rust", RESEARCH_TITLE)).toBe(false);
     expect(isFilterMatch("sv", "fleet snapshot service")).toBe(false);
     expect(isFilterMatch("ate", "Daintree")).toBe(false);
   });
 
-  it("accepts an acronym built from word starts", () => {
+  it("accepts an abbreviation anchored to the words it came from", () => {
     expect(isFilterMatch("fltsnp", "fleet snapshot service")).toBe(true);
     expect(isFilterMatch("fs", "fleet snapshot service")).toBe(true);
   });
 
+  it("accepts word initials the scorer's greedy walk cannot reach", () => {
+    // The scorer takes the first character it can rather than the best one, so
+    // "sr" spends its "s" inside "issue" and never arrives at "scratch rows".
+    // Initials are one character per word, so reading them costs no looseness.
+    expect(isFilterMatch("sr", "issue-11518-scratch-rows")).toBe(true);
+    expect(isFilterMatch("isr", "issue-11518-scratch-rows")).toBe(true);
+    expect(isFilterMatch("oc", "OpenCode")).toBe(true);
+  });
+
   it("accepts anything typed contiguously, down to a single character", () => {
     // Incremental typing is always a substring, so the floor never interrupts
-    // it — including a character sitting mid-word, which scores nothing on its
-    // own and rides the substring bonus alone.
+    // it — including a character sitting mid-word, which earns no boundary or
+    // start bonus and clears the floor on the substring bonus alone.
     expect(isFilterMatch("d", "Daintree")).toBe(true);
     expect(isFilterMatch("i", "Daintree")).toBe(true);
     expect(isFilterMatch("brow", RESEARCH_TITLE)).toBe(true);
+  });
+
+  it("ignores whitespace the caller did not trim", () => {
+    expect(isFilterMatch("  fltsnp  ", "fleet snapshot service")).toBe(true);
   });
 
   it("rejects a query whose characters are not all present", () => {

--- a/src/lib/projectSwitcherSearch.ts
+++ b/src/lib/projectSwitcherSearch.ts
@@ -17,36 +17,11 @@ const NAME_WEIGHT = 4;
  */
 const MIN_FILTER_MATCH_SCORE = 100;
 
-const SEPARATOR = /[/\\\-._\s]/;
-
 function isBoundary(str: string, index: number): boolean {
   if (index === 0) return true;
   const prev = str[index - 1] ?? "";
   const curr = str[index] ?? "";
-  return SEPARATOR.test(prev) || (/[a-z]/.test(prev) && /[A-Z]/.test(curr));
-}
-
-/**
- * The first character of every word, in order: "issue-11518-scratch-rows"
- * reduces to "i1sr" and "OpenCode" to "oc". Word starts are {@link isBoundary}'s
- * definition, so this stays in step with what the scorer rewards.
- */
-function fieldInitials(field: string): string {
-  let initials = "";
-  for (let i = 0; i < field.length; i++) {
-    const char = field[i] ?? "";
-    if (SEPARATOR.test(char)) continue;
-    if (isBoundary(field, i)) initials += char;
-  }
-  return initials.toLowerCase();
-}
-
-function isSubsequenceOf(query: string, field: string): boolean {
-  let qi = 0;
-  for (let fi = 0; fi < field.length && qi < query.length; fi++) {
-    if (field[fi] === query[qi]) qi++;
-  }
-  return qi === query.length;
+  return /[/\\\-._\s]/.test(prev) || (/[a-z]/.test(prev) && /[A-Z]/.test(curr));
 }
 
 function scoreField(query: string, field: string): number {
@@ -118,17 +93,20 @@ function scoreField(query: string, field: string): number {
  * usability" (a legal subsequence worth 5 points) reads as a result rather than
  * as noise.
  *
- * Two ways through, because {@link scoreField} alone rejects abbreviations it
- * should keep. Its walk is greedy — it takes the first character it can rather
- * than the best one — so "sr" against "issue-11518-scratch-rows" spends itself
- * on the "s" in "issue" and never reaches "scratch rows", scoring 0 for what a
- * reader would call an obvious hit. Matching {@link fieldInitials} covers that
- * class directly, and is no looser than the score path: initials are one
- * character per word, so there is nothing mid-word left to scavenge.
+ * The floor does not constrain contiguous typing. Anything typed straight
+ * through is a substring and collects that 500-point bonus outright, so
+ * incremental typing — "d", "da", "dai" — never trips it, down to a single
+ * character. What has to clear it is a query assembled from pieces.
  *
- * Neither path constrains contiguous typing. Anything typed straight through is
- * a substring and collects that 500-point bonus outright, so incremental typing
- * — "d", "da", "dai" — never trips the floor, down to a single character.
+ * It inherits one flaw from {@link scoreField}: the walk is greedy, taking the
+ * first character it can rather than the best one, so "sr" against
+ * "issue-11518-scratch-rows" spends its "s" inside "issue", never reaches
+ * "scratch rows", and scores 0. Reading word initials instead would recover
+ * that case, but initials put no bound on the distance between the words they
+ * come from — "test" would match "cut the external tool surface from 100 to
+ * 24" — which is the bug this floor exists to close. Scoring the best
+ * alignment rather than the first is the real fix, and it belongs in
+ * {@link scoreField}, where the switcher's ranking would feel it too.
  */
 export function isFilterMatch(query: string, field: string): boolean {
   // Trimmed here rather than trusted from the caller: whitespace is a substring
@@ -136,8 +114,7 @@ export function isFilterMatch(query: string, field: string): boolean {
   // match everything. Callers that want all rows short-circuit on their own.
   const trimmed = query.trim();
   if (!trimmed) return false;
-  if (scoreField(trimmed, field) >= MIN_FILTER_MATCH_SCORE) return true;
-  return isSubsequenceOf(trimmed.toLowerCase(), fieldInitials(field));
+  return scoreField(trimmed, field) >= MIN_FILTER_MATCH_SCORE;
 }
 
 export function scoreProjectQuery(query: string, name: string, path: string): number {

--- a/src/lib/projectSwitcherSearch.ts
+++ b/src/lib/projectSwitcherSearch.ts
@@ -7,18 +7,46 @@ import type {
 const NAME_WEIGHT = 4;
 
 /**
- * One surviving word boundary: the {@link scoreField} boundary bonus (90) plus
- * the base score for the character that landed on it (10). Below that, a query
- * reached the end of the field without ever anchoring to the start of a word —
- * it scavenged its characters out of the middle of unrelated ones.
+ * What one word boundary is worth in {@link scoreField}: the boundary bonus
+ * (90) plus the base score of the character that landed on it (10).
+ *
+ * It is a floor on the TOTAL, not proof that a boundary was hit — a query can
+ * land on two of them and still come in under, because the gap penalties for
+ * travelling between them outweigh what they paid. That is the intent: a match
+ * has to be anchored to the words it came from AND stay near them.
  */
 const MIN_FILTER_MATCH_SCORE = 100;
+
+const SEPARATOR = /[/\\\-._\s]/;
 
 function isBoundary(str: string, index: number): boolean {
   if (index === 0) return true;
   const prev = str[index - 1] ?? "";
   const curr = str[index] ?? "";
-  return /[/\\\-._\s]/.test(prev) || (/[a-z]/.test(prev) && /[A-Z]/.test(curr));
+  return SEPARATOR.test(prev) || (/[a-z]/.test(prev) && /[A-Z]/.test(curr));
+}
+
+/**
+ * The first character of every word, in order: "issue-11518-scratch-rows"
+ * reduces to "i1sr" and "OpenCode" to "oc". Word starts are {@link isBoundary}'s
+ * definition, so this stays in step with what the scorer rewards.
+ */
+function fieldInitials(field: string): string {
+  let initials = "";
+  for (let i = 0; i < field.length; i++) {
+    const char = field[i] ?? "";
+    if (SEPARATOR.test(char)) continue;
+    if (isBoundary(field, i)) initials += char;
+  }
+  return initials.toLowerCase();
+}
+
+function isSubsequenceOf(query: string, field: string): boolean {
+  let qi = 0;
+  for (let fi = 0; fi < field.length && qi < query.length; fi++) {
+    if (field[fi] === query[qi]) qi++;
+  }
+  return qi === query.length;
 }
 
 function scoreField(query: string, field: string): number {
@@ -83,26 +111,33 @@ function scoreField(query: string, field: string): number {
  * Whether `field` matches `query` well enough to survive a filter that will not
  * rank the result afterwards.
  *
- * The palette can afford a bare subsequence test — "fltsnp" finds "fleet
- * snapshot", and anything scraped together out of unrelated words sinks to the
- * bottom on score. A surface that only filters has no such backstop: every
- * survivor is presented as an equal answer, so "rust" pulling in "Research file
- * browser folder selection usability" (a legal subsequence worth 5 points) reads
- * as a result rather than as noise.
+ * The palette can afford a bare subsequence test — anything scraped together
+ * out of unrelated words still sinks to the bottom on score. A surface that
+ * only filters has no such backstop: every survivor is presented as an equal
+ * answer, so "rust" pulling in "Research file browser folder selection
+ * usability" (a legal subsequence worth 5 points) reads as a result rather than
+ * as noise.
  *
- * The floor applies only to scattered matches. Anything the user typed
- * contiguously is a substring and collects that 500-point bonus outright, so
- * incremental typing — "d", "da", "dai" — never trips it, down to a single
- * character. What has to clear {@link MIN_FILTER_MATCH_SCORE} is a query whose
- * characters came from more than one word, and the ask is modest: land on one
- * word boundary and survive the gap penalties getting there.
+ * Two ways through, because {@link scoreField} alone rejects abbreviations it
+ * should keep. Its walk is greedy — it takes the first character it can rather
+ * than the best one — so "sr" against "issue-11518-scratch-rows" spends itself
+ * on the "s" in "issue" and never reaches "scratch rows", scoring 0 for what a
+ * reader would call an obvious hit. Matching {@link fieldInitials} covers that
+ * class directly, and is no looser than the score path: initials are one
+ * character per word, so there is nothing mid-word left to scavenge.
+ *
+ * Neither path constrains contiguous typing. Anything typed straight through is
+ * a substring and collects that 500-point bonus outright, so incremental typing
+ * — "d", "da", "dai" — never trips the floor, down to a single character.
  */
 export function isFilterMatch(query: string, field: string): boolean {
-  // An empty query is a substring of every field, so it would collect the
-  // substring bonus and match everything. Callers filtering on a blank query
-  // want all rows, but that is their short-circuit to make, not this one's.
-  if (!query) return false;
-  return scoreField(query, field) >= MIN_FILTER_MATCH_SCORE;
+  // Trimmed here rather than trusted from the caller: whitespace is a substring
+  // of every field, so a blank query would collect the substring bonus and
+  // match everything. Callers that want all rows short-circuit on their own.
+  const trimmed = query.trim();
+  if (!trimmed) return false;
+  if (scoreField(trimmed, field) >= MIN_FILTER_MATCH_SCORE) return true;
+  return isSubsequenceOf(trimmed.toLowerCase(), fieldInitials(field));
 }
 
 export function scoreProjectQuery(query: string, name: string, path: string): number {

--- a/src/lib/projectSwitcherSearch.ts
+++ b/src/lib/projectSwitcherSearch.ts
@@ -93,10 +93,14 @@ function scoreField(query: string, field: string): number {
  * usability" (a legal subsequence worth 5 points) reads as a result rather than
  * as noise.
  *
- * The floor does not constrain contiguous typing. Anything typed straight
- * through is a substring and collects that 500-point bonus outright, so
- * incremental typing — "d", "da", "dai" — never trips it, down to a single
- * character. What has to clear it is a query assembled from pieces.
+ * The floor does not constrain contiguous typing: a literal substring is taken
+ * before the score is consulted at all. The 500-point substring bonus cannot
+ * carry that on its own, because {@link scoreField} adds it to the same running
+ * total the greedy walk's gap penalties drain — past roughly 85 characters of
+ * field a query that is literally the field's last word lands under 100, and
+ * agent-set titles do reach that length. So incremental typing — "d", "da",
+ * "dai" — never trips the floor, down to a single character. What has to clear
+ * it is a query assembled from pieces.
  *
  * It inherits one flaw from {@link scoreField}: the walk is greedy, taking the
  * first character it can rather than the best one, so "sr" against
@@ -114,6 +118,9 @@ export function isFilterMatch(query: string, field: string): boolean {
   // match everything. Callers that want all rows short-circuit on their own.
   const trimmed = query.trim();
   if (!trimmed) return false;
+  // Case-folded the way scoreField folds it, so the two agree on what counts as
+  // contiguous.
+  if (field.toLowerCase().includes(trimmed.toLowerCase())) return true;
   return scoreField(trimmed, field) >= MIN_FILTER_MATCH_SCORE;
 }
 

--- a/src/lib/projectSwitcherSearch.ts
+++ b/src/lib/projectSwitcherSearch.ts
@@ -6,30 +6,19 @@ import type {
 
 const NAME_WEIGHT = 4;
 
+/**
+ * One surviving word boundary: the {@link scoreField} boundary bonus (90) plus
+ * the base score for the character that landed on it (10). Below that, a query
+ * reached the end of the field without ever anchoring to the start of a word —
+ * it scavenged its characters out of the middle of unrelated ones.
+ */
+const MIN_FILTER_MATCH_SCORE = 100;
+
 function isBoundary(str: string, index: number): boolean {
   if (index === 0) return true;
   const prev = str[index - 1] ?? "";
   const curr = str[index] ?? "";
   return /[/\\\-._\s]/.test(prev) || (/[a-z]/.test(prev) && /[A-Z]/.test(curr));
-}
-
-/**
- * The palette's matching rule: every query character appears in `field`, in
- * order, not necessarily adjacent. So "fltsnp" finds "fleet snapshot".
- *
- * The same acceptance test {@link scoreField} applies before scoring — it is
- * separated here for surfaces that need to know *whether* something matched
- * without ranking on *how well*. Both must stay in step: a palette that accepts
- * a query one way and rejects it another teaches nothing transferable.
- */
-export function isSubsequenceMatch(query: string, field: string): boolean {
-  const lowerQuery = query.toLowerCase();
-  const lowerField = field.toLowerCase();
-  let qi = 0;
-  for (let fi = 0; fi < lowerField.length && qi < lowerQuery.length; fi++) {
-    if (lowerField[fi] === lowerQuery[qi]) qi++;
-  }
-  return qi === lowerQuery.length;
 }
 
 function scoreField(query: string, field: string): number {
@@ -88,6 +77,32 @@ function scoreField(query: string, field: string): number {
   }
 
   return Math.max(0, score);
+}
+
+/**
+ * Whether `field` matches `query` well enough to survive a filter that will not
+ * rank the result afterwards.
+ *
+ * The palette can afford a bare subsequence test — "fltsnp" finds "fleet
+ * snapshot", and anything scraped together out of unrelated words sinks to the
+ * bottom on score. A surface that only filters has no such backstop: every
+ * survivor is presented as an equal answer, so "rust" pulling in "Research file
+ * browser folder selection usability" (a legal subsequence worth 5 points) reads
+ * as a result rather than as noise.
+ *
+ * The floor applies only to scattered matches. Anything the user typed
+ * contiguously is a substring and collects that 500-point bonus outright, so
+ * incremental typing — "d", "da", "dai" — never trips it, down to a single
+ * character. What has to clear {@link MIN_FILTER_MATCH_SCORE} is a query whose
+ * characters came from more than one word, and the ask is modest: land on one
+ * word boundary and survive the gap penalties getting there.
+ */
+export function isFilterMatch(query: string, field: string): boolean {
+  // An empty query is a substring of every field, so it would collect the
+  // substring bonus and match everything. Callers filtering on a blank query
+  // want all rows, but that is their short-circuit to make, not this one's.
+  if (!query) return false;
+  return scoreField(query, field) >= MIN_FILTER_MATCH_SCORE;
 }
 
 export function scoreProjectQuery(query: string, name: string, path: string): number {


### PR DESCRIPTION
## Summary

- Pilot's fleet-overview search filtered on `isSubsequenceMatch`, a boolean ordered-subsequence test with no quality gate, so any query whose characters showed up in order matched no matter how far apart they landed.
- Typing `rust` matched a run titled `Research file browser folder selection usability`, and typing `ate` matched the project `Daintree`. A project-name match short-circuits, so that admitted every row in the project.
- Replaced it with a new exported `isFilterMatch(query, field)` in `projectSwitcherSearch.ts`, which reuses the switcher's existing scorer and requires a real quality floor before a row is allowed to show up.

Resolves #11625

## What was wrong

The project switcher gets away with a bare acceptance test because it ranks: a 5-point match sinks to the bottom of the list. Pilot deliberately does not re-rank, since band order is the answer there, demoting a blocked agent because a fresher one matched better would defeat the surface. With no bottom of the list for a weak match to sink to, it gets interleaved with the real ones and reads as an answer.

## The fix

`isFilterMatch(query, field)` is `scoreField(query, field) >= 100`, where `scoreField` is the existing private scorer the switcher already uses. All four fields `filterPilotGroups` checks (project name, panel title, worktree label, agent label) now go through it. It only filters, it doesn't reorder anything. `isSubsequenceMatch` is deleted since Pilot was its only caller.

### Why 100

| query | field | score | result |
| --- | --- | --- | --- |
| `rust` | `Research file browser folder selection usability` | 5 | rejected |
| `ate` | `Daintree` | 0 | rejected |
| `sv` | `fleet snapshot service` | 40 | rejected |
| `fs` | `fleet snapshot service` | 180 | kept |
| `fltsnp` | `fleet snapshot service` | 215 | kept |
| any contiguous substring | any | >=500 | always kept |

100 is what one word boundary is worth in `scoreField`: a 90-point boundary bonus plus 10 for the character that landed on it. It's a floor on the total, not proof a boundary was actually hit. `rust` lands on two of them and still only scores 5, because the gap penalties for traveling between them outweigh what they paid.

The floor only ever gates non-contiguous queries. Anything typed straight through is a substring and collects the 500-point bonus outright, so incremental typing (`d`, `da`, `dai`) never trips it, down to a single character. That's what makes a flat threshold safe here.

## Known limitations

These are deliberate, and worth being upfront about:

1. Short real words can still match a short project name. `date` scores 115 against `Daintree` and still admits the group. A threshold can't separate that from a legitimate abbreviation sitting in the same band (`cdx` for Codex scores 100, `crs` for Cursor scores 130). Fixing that needs a structurally different rule for group names, which is a bigger change than this issue calls for.
2. `scoreField` walks greedily, taking the first candidate character rather than the best one, so `sr` against `issue-11518-scratch-rows` spends its `s` inside `issue`, never reaches `scratch-rows`, and scores 0. I tried recovering this class by matching word initials and backed it out: initials put no bound on the distance between the words they come from, so `test` matched `cut the external tool surface from 100 to 24`, the same bug at lower resolution. The real fix is scoring the best alignment instead of the first, and it belongs in `scoreField`, where the switcher's ranking would feel it too. Left a note on this in the code.

## Testing

- New `describe("isFilterMatch")` unit block: scattered-subsequence rejections, a long-title initials false-positive guard, contiguous/single-character acceptance, blank-and-whitespace rejection.
- Pilot integration tests: `rust` now drops the research title while still finding a run called `Rust migration`; `ate` no longer admits the whole project; a genuine non-substring project-name match (`fs` against a group named `fleet snapshot`) still short-circuits and keeps every row; added the first coverage for the worktree-label and agent-label match paths, neither of which had any before.
- No test asserts the threshold constant itself, staying behavioral per the repo's no-tautological-assertions rule. Verified none of it flips if the threshold moves between 90 and 130.
