### PR TITLE
feat(pilot): rebuild the fleet overview's visual hierarchy

### DIFF
--- a/src/components/Pilot/PilotFilterBar.tsx
+++ b/src/components/Pilot/PilotFilterBar.tsx
@@ -3,11 +3,17 @@ import type { ComponentType, KeyboardEvent } from "react";
 import { cn } from "@/lib/utils";
 import { BAND_GLYPH } from "./PilotRunState";
 import {
+  bandFilterHasDemand,
   PILOT_BAND_FILTER_LABEL,
   PILOT_BAND_FILTERS,
   type PilotBandFilter,
   type PilotBandFilterCounts,
 } from "./pilotRows";
+import type { FleetBandCounts } from "@/lib/fleetAttention";
+
+/** The tone a segment falls back to when it holds no demand. */
+const NEUTRAL_TONE = "text-text-secondary";
+const NEUTRAL_TONE_FADED = "text-text-secondary/40";
 
 /**
  * Tone per segment, in complete class literals.
@@ -16,10 +22,11 @@ import {
  * the faded variant is spelled out rather than derived — the same constraint
  * `QuickStateFilterBar` documents.
  *
- * `working` is neutral because its rows are: colour is spent only where there
- * is a demand, and a hued Working segment would put back one of the competing
- * signals this surface exists to remove. The other two keep the hue of the
- * worst band they admit, which is what ties a segment to the rows it reveals.
+ * `working` has no demand tone at all because its rows have none: colour is
+ * spent only where there is something to act on, and a hued Working segment
+ * would put back one of the competing signals this surface exists to remove.
+ * The other two carry the hue of the demand they can reveal, and only while
+ * they are actually holding one — see `bandFilterHasDemand`.
  */
 const SEGMENT_TONE: Record<
   Exclude<PilotBandFilter, "all">,
@@ -32,8 +39,8 @@ const SEGMENT_TONE: Record<
   },
   working: {
     Icon: BAND_GLYPH.running,
-    tone: "text-text-secondary",
-    toneFaded: "text-text-secondary/40",
+    tone: NEUTRAL_TONE,
+    toneFaded: NEUTRAL_TONE_FADED,
   },
   finished: {
     Icon: BAND_GLYPH.review,
@@ -48,7 +55,19 @@ export interface PilotFilterBarProps {
   value: PilotBandFilter;
   /** Rows per segment in the query-filtered fleet, so a count matches the list. */
   counts: Readonly<PilotBandFilterCounts>;
+  /**
+   * Per-band counts over the same population, which is what decides whether a
+   * mixed segment has earned its hue. A count alone can't: "Finished" holding
+   * three acknowledged runs and "Finished" holding three waiting to be reviewed
+   * are the same number and opposite situations.
+   */
+  bands: Readonly<FleetBandCounts>;
   onChange: (value: PilotBandFilter) => void;
+  /**
+   * Fired as real focus enters and leaves the bar, so the palette can stop
+   * advertising the list's keys while they belong to these segments instead.
+   */
+  onFocusChange?: (focused: boolean) => void;
 }
 
 /**
@@ -74,7 +93,13 @@ export interface PilotFilterBarProps {
  * and reversible, so making the user arrow then confirm would charge two
  * keystrokes for a decision they can see the result of.
  */
-export function PilotFilterBar({ value, counts, onChange }: PilotFilterBarProps) {
+export function PilotFilterBar({
+  value,
+  counts,
+  bands,
+  onChange,
+  onFocusChange,
+}: PilotFilterBarProps) {
   const refs = useRef(new Map<PilotBandFilter, HTMLButtonElement | null>());
 
   const move = useCallback(
@@ -126,6 +151,13 @@ export function PilotFilterBar({ value, counts, onChange }: PilotFilterBarProps)
       aria-label="Filter agents by state"
       data-testid="pilot-filter-bar"
       onKeyDown={handleKeyDown}
+      onFocus={() => onFocusChange?.(true)}
+      // Arrowing between segments blurs one and focuses the next, so a bare
+      // handler would report the bar as vacated for a moment on every keypress.
+      // Only a move that leaves the group entirely counts as leaving it.
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) onFocusChange?.(false);
+      }}
       className="flex"
     >
       {SEGMENTS.map((segment, idx) => {
@@ -133,10 +165,16 @@ export function PilotFilterBar({ value, counts, onChange }: PilotFilterBarProps)
         const count = counts[segment];
         const visual = segment === "all" ? null : SEGMENT_TONE[segment];
         const label = PILOT_BAND_FILTER_LABEL[segment];
-        // An empty bucket keeps its glyph and its "0" but mutes the glyph, so
-        // the zero registers without having to be read.
         const Icon = visual?.Icon;
         const isSpinning = segment === "working" && count > 0;
+        // Hued only while the segment actually holds a demand; otherwise it
+        // falls back to neutral like the rows it would reveal.
+        const tone = bandFilterHasDemand(bands, segment) ? visual?.tone : NEUTRAL_TONE;
+        // An empty bucket keeps its glyph and its "0" but mutes the glyph, so
+        // the zero registers without having to be read.
+        const fadedTone = bandFilterHasDemand(bands, segment)
+          ? visual?.toneFaded
+          : NEUTRAL_TONE_FADED;
 
         return (
           <button
@@ -170,7 +208,7 @@ export function PilotFilterBar({ value, counts, onChange }: PilotFilterBarProps)
                 aria-hidden="true"
                 className={cn(
                   "h-3 w-3 shrink-0 transition-colors",
-                  count === 0 ? visual.toneFaded : visual.tone,
+                  count === 0 ? fadedTone : tone,
                   isSpinning && "animate-spin-slow motion-reduce:animate-none"
                 )}
               />

--- a/src/components/Pilot/PilotFilterBar.tsx
+++ b/src/components/Pilot/PilotFilterBar.tsx
@@ -1,0 +1,203 @@
+import { useCallback, useRef } from "react";
+import type { ComponentType, KeyboardEvent } from "react";
+import { cn } from "@/lib/utils";
+import { BAND_GLYPH } from "./PilotRunState";
+import {
+  PILOT_BAND_FILTER_LABEL,
+  PILOT_BAND_FILTERS,
+  type PilotBandFilter,
+  type PilotBandFilterCounts,
+} from "./pilotRows";
+
+/**
+ * Tone per segment, in complete class literals.
+ *
+ * Assembled strings like `${color}/40` are invisible to Tailwind's scanner, so
+ * the faded variant is spelled out rather than derived — the same constraint
+ * `QuickStateFilterBar` documents.
+ *
+ * `working` is neutral because its rows are: colour is spent only where there
+ * is a demand, and a hued Working segment would put back one of the competing
+ * signals this surface exists to remove. The other two keep the hue of the
+ * worst band they admit, which is what ties a segment to the rows it reveals.
+ */
+const SEGMENT_TONE: Record<
+  Exclude<PilotBandFilter, "all">,
+  { Icon: ComponentType<{ className?: string }>; tone: string; toneFaded: string }
+> = {
+  "needs-you": {
+    Icon: BAND_GLYPH["needs-you"],
+    tone: "text-state-waiting",
+    toneFaded: "text-state-waiting/40",
+  },
+  working: {
+    Icon: BAND_GLYPH.running,
+    tone: "text-text-secondary",
+    toneFaded: "text-text-secondary/40",
+  },
+  finished: {
+    Icon: BAND_GLYPH.review,
+    tone: "text-activity-completed",
+    toneFaded: "text-activity-completed/40",
+  },
+};
+
+const SEGMENTS: readonly PilotBandFilter[] = ["all", ...PILOT_BAND_FILTERS];
+
+export interface PilotFilterBarProps {
+  value: PilotBandFilter;
+  /** Rows per segment in the query-filtered fleet, so a count matches the list. */
+  counts: Readonly<PilotBandFilterCounts>;
+  onChange: (value: PilotBandFilter) => void;
+}
+
+/**
+ * The state filter under the search box.
+ *
+ * A radiogroup rather than the worktree sidebar's toolbar-of-toggles: these
+ * segments are mutually exclusive with All as the null option, which is what a
+ * radiogroup IS. (The sidebar's own `QuickStateFilterBar` is roled as a toolbar
+ * with `aria-pressed` for the same single-select behaviour, which is arguably
+ * wrong, but realigning it is a separate change.) Visually the two are the same
+ * control — same segment box, dividers, active treatment and
+ * muted-icon-on-zero rule — so the fleet overview and the sidebar don't teach
+ * two spellings of one idea.
+ *
+ * Physical focus lives in the search input, which drives the list through
+ * `aria-activedescendant`; Tab hands real focus to this bar, and from that
+ * moment the input's virtual focus is simply inert rather than contradicted.
+ * Arrow keys are bound HERE and nowhere else — `usePaletteTreeNavigation` owns
+ * Home/End/←/→ as structural keys, but only while focus is physically in the
+ * input, so the two never contend.
+ *
+ * Selection follows focus, per the radiogroup pattern: the filter is instant
+ * and reversible, so making the user arrow then confirm would charge two
+ * keystrokes for a decision they can see the result of.
+ */
+export function PilotFilterBar({ value, counts, onChange }: PilotFilterBarProps) {
+  const refs = useRef(new Map<PilotBandFilter, HTMLButtonElement | null>());
+
+  const move = useCallback(
+    (to: PilotBandFilter) => {
+      onChange(to);
+      refs.current.get(to)?.focus();
+    },
+    [onChange]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      const index = SEGMENTS.indexOf(value);
+      if (index === -1) return;
+
+      let next: PilotBandFilter | undefined;
+      switch (event.key) {
+        case "ArrowRight":
+        case "ArrowDown":
+          next = SEGMENTS[(index + 1) % SEGMENTS.length];
+          break;
+        case "ArrowLeft":
+        case "ArrowUp":
+          next = SEGMENTS[(index - 1 + SEGMENTS.length) % SEGMENTS.length];
+          break;
+        case "Home":
+          next = SEGMENTS[0];
+          break;
+        case "End":
+          next = SEGMENTS[SEGMENTS.length - 1];
+          break;
+        default:
+          return;
+      }
+
+      if (next === undefined) return;
+      // Only once a key is known to belong to this bar. Cancelling earlier
+      // would eat keys the dialog and the browser still have a use for.
+      event.preventDefault();
+      event.stopPropagation();
+      move(next);
+    },
+    [value, move]
+  );
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Filter agents by state"
+      data-testid="pilot-filter-bar"
+      onKeyDown={handleKeyDown}
+      className="flex"
+    >
+      {SEGMENTS.map((segment, idx) => {
+        const isActive = segment === value;
+        const count = counts[segment];
+        const visual = segment === "all" ? null : SEGMENT_TONE[segment];
+        const label = PILOT_BAND_FILTER_LABEL[segment];
+        // An empty bucket keeps its glyph and its "0" but mutes the glyph, so
+        // the zero registers without having to be read.
+        const Icon = visual?.Icon;
+        const isSpinning = segment === "working" && count > 0;
+
+        return (
+          <button
+            key={segment}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            // Roving tabindex: the checked segment is the bar's single tab
+            // stop, so Tab from the search box lands on the active filter
+            // rather than walking four controls to reach the list.
+            tabIndex={isActive ? 0 : -1}
+            aria-label={`${label}, ${count} ${count === 1 ? "agent" : "agents"}`}
+            ref={(el) => {
+              refs.current.set(segment, el);
+            }}
+            onClick={() => {
+              onChange(segment);
+            }}
+            className={cn(
+              "inline-flex min-w-0 flex-1 items-center justify-center gap-1 px-2 py-1.5 transition-colors",
+              "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent",
+              idx > 0 && "border-l border-border-default",
+              isActive
+                ? // Fallback keeps themes without the var byte-identical.
+                  "bg-[var(--worktree-quick-state-active-bg,var(--color-overlay-subtle))] shadow-[inset_0_-2px_0_0_var(--color-text-secondary)]"
+                : "hover:bg-tint/[0.04]"
+            )}
+          >
+            {Icon && visual && (
+              <Icon
+                aria-hidden="true"
+                className={cn(
+                  "h-3 w-3 shrink-0 transition-colors",
+                  count === 0 ? visual.toneFaded : visual.tone,
+                  isSpinning && "animate-spin-slow motion-reduce:animate-none"
+                )}
+              />
+            )}
+            {/* The accessible name above carries both halves; exposing them
+                again would read the segment twice. */}
+            <span
+              aria-hidden="true"
+              className={cn(
+                "truncate text-xs",
+                isActive ? "font-medium text-daintree-text" : "text-daintree-text/60"
+              )}
+            >
+              {label}
+            </span>
+            <span
+              aria-hidden="true"
+              className={cn(
+                "text-xs tabular-nums",
+                isActive ? "text-daintree-text" : "text-daintree-text/60"
+              )}
+            >
+              {count}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/Pilot/PilotRunState.tsx
+++ b/src/components/Pilot/PilotRunState.tsx
@@ -1,3 +1,4 @@
+import type { ComponentType } from "react";
 import {
   SpinnerCircle,
   HollowCircle,
@@ -14,46 +15,88 @@ interface PilotRunStateProps {
 }
 
 /**
+ * The neutral tone every non-demand state now carries.
+ *
+ * Colour is spent only where there is a demand, so `running`, `done` and `idle`
+ * give theirs up and read as ordinary text. Deliberately `text-text-secondary`
+ * rather than `text-muted`: muted sits below the contrast floor against the
+ * palette's raised surface in the dark themes, and a state glyph nobody can see
+ * is worse than a loud one.
+ */
+const NEUTRAL_TONE = "text-text-secondary";
+
+/**
+ * One glyph per band, shared by every surface that speaks about bands.
+ *
+ * The filter bar's segments and a collapsed group's pip cluster both draw from
+ * here, so "the amber hollow circle" means the same thing in the list, in the
+ * header and in the control that filters on it. A second set for any one of
+ * them would teach the reader two vocabularies for one fact.
+ *
+ * These are the BAND's representative shapes. `PilotRunState` refines two of
+ * them where the row knows more than the band does — directing inside
+ * `running`, and exited inside `idle`.
+ */
+export const BAND_GLYPH: Record<FleetBand, ComponentType<{ className?: string }>> = {
+  blocked: HollowCircle,
+  "needs-you": HollowCircle,
+  review: CircleCheck,
+  running: SpinnerCircle,
+  done: CircleCheck,
+  idle: HollowCircle,
+};
+
+/**
+ * Colour per band, and the one place the "only a demand is hued" rule lives.
+ *
+ * Exported alongside the glyphs so a collapsed group's pips and a run's own
+ * state mark cannot end up differently coloured for the same band — the two
+ * read as one signal only if they agree by construction rather than by two
+ * lists someone has to keep in step.
+ */
+export const BAND_GLYPH_TONE: Record<FleetBand, string> = {
+  blocked: "text-status-danger",
+  "needs-you": "text-state-waiting",
+  review: "text-activity-completed",
+  running: NEUTRAL_TONE,
+  done: NEUTRAL_TONE,
+  idle: NEUTRAL_TONE,
+};
+
+/**
  * A run's state, in the app's existing agent vocabulary.
  *
- * Deliberately the same glyphs and tokens the assistant header and the dock
- * already use — the green spinner and the amber hollow circle ARE the identity
- * of "working" and "waiting" in this product. Inventing a second set for one
- * surface would teach the user two languages for one fact.
+ * Deliberately the same glyphs the assistant header and the dock already use —
+ * the spinner and the hollow circle ARE the identity of "working" and "waiting"
+ * in this product. Inventing a second set for one surface would teach the user
+ * two languages for one fact.
  *
- * Keyed on the BAND, not the raw state, so the glyph cannot contradict the label
- * and tone beside it: an acknowledged completion has to stop looking like a
+ * Keyed on the BAND, not the raw state, so the glyph cannot contradict the
+ * ordering beside it: an acknowledged completion has to stop looking like a
  * hand-back at the same moment it stops being counted as one.
  *
- * Redundant by design. Every state here is also written out in words on the row,
- * because the two states a supervisor most needs to tell apart — waiting and
- * idle — are both hollow circles, and hue is the only thing separating them.
+ * Only the three demand bands are hued. Shape still carries the state as a
+ * second channel for all six — spinner, hollow circle, check and exited stay
+ * distinct — and the row keeps the state in text either way, visibly for a
+ * demand and in its accessible name otherwise. Never colour alone, and now
+ * never colour where there is nothing to act on.
  */
 export function PilotRunState({ band, agentState }: PilotRunStateProps) {
-  const size = "size-3.5 shrink-0";
+  const className = `size-3.5 shrink-0 ${BAND_GLYPH_TONE[band]}`;
 
-  switch (band) {
-    case "blocked":
-      return <HollowCircle className={`${size} text-status-danger`} />;
-    case "needs-you":
-      return <HollowCircle className={`${size} text-state-waiting`} />;
-    case "review":
-      return <CircleCheck className={`${size} text-activity-completed`} />;
-    case "running":
-      return agentState === "directing" ? (
-        <InteractingCircle className={`${size} text-category-blue`} />
-      ) : (
-        <SpinnerCircle
-          className={`${size} text-state-working animate-spin-slow motion-reduce:animate-none`}
-        />
-      );
-    case "done":
-      return <CircleCheck className={`${size} text-daintree-text/40`} />;
-    default:
-      return agentState === "exited" ? (
-        <ExitedCircle className={`${size} text-daintree-text/40`} />
-      ) : (
-        <HollowCircle className={`${size} text-daintree-text/30`} />
-      );
+  // The two refinements the row can make that the band alone cannot. Everything
+  // else takes the band's own shape, so there is no second list to drift.
+  if (band === "running") {
+    return agentState === "directing" ? (
+      <InteractingCircle className={className} />
+    ) : (
+      <SpinnerCircle className={`${className} animate-spin-slow motion-reduce:animate-none`} />
+    );
   }
+  if (band === "idle" && agentState === "exited") {
+    return <ExitedCircle className={className} />;
+  }
+
+  const Glyph = BAND_GLYPH[band];
+  return <Glyph className={className} />;
 }

--- a/src/components/Pilot/PilotView.tsx
+++ b/src/components/Pilot/PilotView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getProjectGradient } from "@/lib/colorUtils";
@@ -305,11 +305,30 @@ function RunRow({
   // text, so it moves into the option's accessible name instead of vanishing.
   const isDemand = isDemandBand(row.band);
 
+  /**
+   * Spelled out rather than left to the name-from-content computation.
+   *
+   * Those spans are inline, so a computed name concatenates them with no
+   * separators at all: "Fix authWorkingfeature-x2m". Naming the parts here is
+   * what turns the row back into a sentence, and it lets the age be announced
+   * as an age ("2m ago") instead of a bare token a screen reader reads as
+   * "two em".
+   */
+  const accessibleName = [
+    row.title,
+    row.statusLabel,
+    row.worktreeLabel,
+    row.age !== null ? agoPhrase(row.age) : null,
+  ]
+    .filter((part): part is string => part !== null)
+    .join(", ");
+
   return (
     <div
       id={domId}
       role="option"
       aria-selected={isSelected}
+      aria-label={accessibleName}
       data-testid="pilot-row"
       onClick={onActivate}
       // One line, ~32px. Two-line rows made 8 agents into 16 lines of identical
@@ -350,15 +369,22 @@ function RunRow({
         {row.title}
       </span>
 
-      {/* Never truncates and never wraps: this is the column the eye runs down. */}
-      <span className="flex shrink-0 items-center gap-2 text-[11px] leading-none">
-        {isDemand ? (
-          <span className={ROW_TONE_CLASS[row.tone]}>{row.statusLabel}</span>
-        ) : (
-          <span className="sr-only">{row.statusLabel}</span>
+      {/*
+        The scan column. Everything here is `aria-hidden` — the row's own label
+        above says all of it, in order and with separators, so announcing these
+        as well would read each row's facts twice.
+
+        The group may shrink, but only into the worktree: the status word and
+        the age are short and bounded, while an untruncatable 10rem worktree
+        beside a 3.5rem age floor could push the title out of a narrow palette
+        entirely and give the list a horizontal scrollbar.
+      */}
+      <span aria-hidden="true" className="flex min-w-0 items-center gap-2 text-[11px] leading-none">
+        {isDemand && (
+          <span className={cn("shrink-0", ROW_TONE_CLASS[row.tone])}>{row.statusLabel}</span>
         )}
         {row.worktreeLabel !== null && (
-          <span className="max-w-[10rem] truncate text-daintree-text/40">{row.worktreeLabel}</span>
+          <span className="max-w-[8rem] truncate text-daintree-text/40">{row.worktreeLabel}</span>
         )}
         {/*
           Right-aligned, tabular, and given a floor width so "just now" and
@@ -367,7 +393,7 @@ function RunRow({
           being eight separate reads instead of one scan.
         */}
         {row.age !== null && (
-          <span className="min-w-[3.5rem] text-right tabular-nums text-daintree-text/50">
+          <span className="min-w-[3.5rem] shrink-0 text-right tabular-nums text-daintree-text/50">
             {row.age}
           </span>
         )}
@@ -420,10 +446,12 @@ function PilotFooter({
             type="button"
             onClick={onShowDemand}
             data-testid="pilot-demand-action"
-            // The visible text stays the sentence; the accessible name says
-            // what pressing it does, because "2 agents need you" names a
-            // situation rather than an action.
-            aria-label={`Show ${demandCount} ${demandCount === 1 ? "agent" : "agents"} that need you`}
+            // No `aria-label`. An action-phrased one ("Show 2 agents that need
+            // you") would not contain the visible sentence, which is a
+            // label-in-name failure for anyone driving the app by voice — and
+            // its singular came out as "Show 1 agent that need you". The
+            // button role already says it is actionable; the sentence says
+            // what it is about.
             className={cn(
               "truncate rounded-[var(--radius-sm)] px-1.5 py-0.5 text-daintree-text/70 transition-colors",
               "hover:bg-overlay-subtle hover:text-daintree-text",
@@ -474,6 +502,17 @@ export function PilotView() {
    * when the query cleared.
    */
   const [narrowingCollapsed, setNarrowingCollapsed] = useState<readonly string[]>([]);
+  /**
+   * True while real focus sits on a filter segment.
+   *
+   * The footer advertises the LIST's keys, and on a segment those keys mean
+   * something else entirely — Enter reselects the filter, the arrows move
+   * between segments. Leaving "↵ Open" up while focus is there is the same
+   * false promise the footer already drops over an empty list.
+   */
+  const [isFilterFocused, setIsFilterFocused] = useState(false);
+  /** So a control that removes itself can hand focus back somewhere useful. */
+  const searchRef = useRef<HTMLInputElement>(null);
 
   // The clock is state, not a bare tick counter, and it is a real dependency of
   // the row build below. A `setTick(n => n + 1)` that nothing reads is a no-op
@@ -830,7 +869,10 @@ export function PilotView() {
               : "";
 
   // Every selectable row is an agent now, so the verb never changes.
-  const actionLabel = selectedRow === null ? null : "Open";
+  // Dropped while a filter segment holds focus: on a segment those keys drive
+  // the filter, not the list, so the hints would be naming keys that do
+  // something else.
+  const actionLabel = selectedRow === null || isFilterFocused ? null : "Open";
 
   const hasTree = renderGroups.length > 0;
   // Stale counts as well as live: retained runs are real rows, so a query that
@@ -857,6 +899,7 @@ export function PilotView() {
     <AppPaletteDialog isOpen={isOpen} onClose={close} ariaLabel="All agents">
       <AppPaletteDialog.Header label="All agents" shortcut={pilotShortcut}>
         <AppPaletteDialog.Input
+          inputRef={searchRef}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={navigation.handleInputKeyDown}
@@ -884,7 +927,13 @@ export function PilotView() {
         */}
         {showFilterBar && (
           <div className="-mx-3 -mb-2 mt-2 border-t border-border-default">
-            <PilotFilterBar value={bandFilter} counts={filterCounts} onChange={setBandFilter} />
+            <PilotFilterBar
+              value={bandFilter}
+              counts={filterCounts}
+              bands={fleet.bands}
+              onChange={setBandFilter}
+              onFocusChange={setIsFilterFocused}
+            />
           </div>
         )}
       </AppPaletteDialog.Header>
@@ -972,6 +1021,11 @@ export function PilotView() {
                   data-testid="pilot-clear-filter"
                   onClick={() => {
                     setBandFilter("all");
+                    // This button is about to unmount itself. Without handing
+                    // focus back, a keyboard user is left on the document body
+                    // — and if the retained query still matches nothing there
+                    // is no row to arrow to either.
+                    searchRef.current?.focus();
                   }}
                   className={cn(
                     "rounded-[var(--radius-sm)] px-2 py-1 text-xs text-daintree-text/70 transition-colors",
@@ -1046,6 +1100,12 @@ export function PilotView() {
             demandCount={needsYou}
             onShowDemand={() => {
               setBandFilter("needs-you");
+              // Cleared explicitly, not left to the narrowing effect. With the
+              // filter ALREADY on needs-you the state set is a no-op, the
+              // effect never re-runs, and a group the user had collapsed stays
+              // collapsed — leaving the button advertising agents it then
+              // failed to put on screen.
+              setNarrowingCollapsed([]);
             }}
           />
         </AppPaletteDialog.Footer>

--- a/src/components/Pilot/PilotView.tsx
+++ b/src/components/Pilot/PilotView.tsx
@@ -9,22 +9,27 @@ import { useProjectStore } from "@/store/projectStore";
 import { useScratchStore } from "@/store/scratchStore";
 import { getViewWorkspaceId } from "@/store/viewWorkspaceId";
 import { actionService } from "@/services/ActionService";
-import { BAND_TONE, type FleetBand } from "@/lib/fleetAttention";
+import { FLEET_BANDS, isDemandBand, type FleetBand } from "@/lib/fleetAttention";
 import { UI_ANIMATION_DURATION, UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { useDeferredLoading } from "@/hooks/useDeferredLoading";
 import { agoPhrase, formatWaitAge, ROW_TONE_CLASS } from "@/lib/projectRowStatus";
 import {
   buildPilotGroups,
+  countPilotBands,
+  filterPilotBands,
   filterPilotGroups,
   summarizePilotGroups,
+  PILOT_BAND_FILTER_LABEL,
+  type PilotBandFilter,
   type PilotProjectGroup,
   type PilotRow,
   type PilotWorkspaceMeta,
 } from "./pilotRows";
-import { PilotRunState } from "./PilotRunState";
+import { BAND_GLYPH, BAND_GLYPH_TONE, PilotRunState } from "./PilotRunState";
+import { PilotFilterBar } from "./PilotFilterBar";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { AppPaletteDialog, KBD_CLASS } from "@/components/ui/AppPaletteDialog";
-import { PALETTE_ROW_CLASS } from "@/components/ui/paletteRowStyles";
+import { PALETTE_ROW_CLASS, PALETTE_SECTION_LABEL_CLASS } from "@/components/ui/paletteRowStyles";
 import {
   usePaletteTreeNavigation,
   type NavigablePaletteTreeRow,
@@ -115,11 +120,19 @@ function groupSummary(group: PilotProjectGroup): string {
 /** The resting tone. Selected is the shared row class's to own, off the attribute. */
 const ROW_TONE = "text-daintree-text/70 hover:bg-overlay-subtle hover:text-daintree-text";
 
+/**
+ * 16px, down from the switcher's 32px.
+ *
+ * At half the size the tile stops being an avatar competing with the rows and
+ * becomes a coloured bullet in front of a section label, which is what a
+ * project heading actually is here. The colour still identifies the project;
+ * it just no longer outweighs the agents it organises.
+ */
 const TILE_BASE =
-  "flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-lg)] text-base";
+  "flex h-4 w-4 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-[9px]";
 
 /**
- * The workspace's identity tile, at the switcher's size and radius.
+ * The workspace's identity tile, at the switcher's colour and a heading's size.
  *
  * Only a project carries an emoji and a colour. A scratch is an app-managed
  * folder with neither, so the switcher gives it a neutral tile and a glyph —
@@ -132,7 +145,7 @@ function WorkspaceTile({ group }: { group: PilotProjectGroup }) {
     const Glyph = group.kind === "scratch" ? FileText : CircleHelp;
     return (
       <div className={cn(TILE_BASE, "bg-tint/[0.04] text-muted-foreground")}>
-        <Glyph className="h-4 w-4" aria-hidden="true" />
+        <Glyph className="h-2.5 w-2.5" aria-hidden="true" />
       </div>
     );
   }
@@ -150,6 +163,42 @@ function WorkspaceTile({ group }: { group: PilotProjectGroup }) {
     >
       <span className="leading-none select-none filter drop-shadow-sm">{group.emoji}</span>
     </div>
+  );
+}
+
+/**
+ * What a collapsed project is still holding, as one pip per band present.
+ *
+ * Expanded, the rows ARE the summary and a sentence restating them in prose is
+ * a third thing to read for facts already on screen. Collapsed, the rows are
+ * gone and something has to stop a project hiding a blocked agent behind a
+ * chevron — so the summary earns its place at exactly the moment the rows stop
+ * being visible, and nowhere else.
+ *
+ * Glyphs, not words, and the same glyphs the filter bar uses, so the cluster
+ * reads as a compressed version of the list rather than a new notation.
+ * `aria-hidden` throughout: the toggle's own label already carries
+ * `groupSummary()` in both states, and announcing four glyph-count fragments
+ * beside it would be the same fact twice, less intelligibly the second time.
+ */
+function CollapsedBandPips({ group }: { group: PilotProjectGroup }) {
+  const counts = new Map<FleetBand, number>();
+  for (const row of group.rows) counts.set(row.band, (counts.get(row.band) ?? 0) + 1);
+
+  return (
+    <span aria-hidden="true" className="flex shrink-0 items-center gap-2">
+      {FLEET_BANDS.filter((band) => counts.has(band)).map((band) => {
+        const Glyph = BAND_GLYPH[band];
+        return (
+          <span key={band} className="flex items-center gap-1">
+            <Glyph className={cn("size-2.5 shrink-0", BAND_GLYPH_TONE[band])} />
+            <span className="text-[10px] leading-none tabular-nums text-daintree-text/50">
+              {counts.get(band)}
+            </span>
+          </span>
+        );
+      })}
+    </span>
   );
 }
 
@@ -185,13 +234,16 @@ function GroupHeader({
   return (
     <div
       data-testid="pilot-group-header"
-      className={cn("flex w-full items-center gap-2 py-2 pr-3 pl-3 select-none", className)}
+      className={cn("flex w-full items-center gap-2 py-1 pr-3 pl-3 select-none", className)}
     >
       <button
         type="button"
         tabIndex={-1}
         aria-expanded={!isCollapsed}
         aria-controls={groupId}
+        // The summary rides the label in BOTH states. Collapsed it is the only
+        // account of what is inside; expanded it saves a screen-reader user
+        // walking the rows to learn what walking them would cost.
         aria-label={`${group.name}, ${summary}`}
         data-testid="pilot-group-toggle"
         onClick={onToggle}
@@ -200,7 +252,7 @@ function GroupHeader({
         <ChevronRight
           aria-hidden="true"
           className={cn(
-            "size-3.5 transition-transform ease-out motion-reduce:transition-none",
+            "size-3 transition-transform ease-out motion-reduce:transition-none",
             !isCollapsed && "rotate-90"
           )}
           style={{ transitionDuration: `${UI_ANIMATION_DURATION}ms` }}
@@ -209,39 +261,29 @@ function GroupHeader({
 
       <WorkspaceTile group={group} />
 
-      {/* The toggle's label already carries both lines; exposing them twice
-          would read the project name and its summary back-to-back. */}
-      <div aria-hidden="true" className="min-w-0 flex-1">
-        <div className="flex min-w-0 items-center">
-          <span className="truncate text-sm leading-tight font-semibold text-daintree-text">
-            {group.name}
-          </span>
-          {/*
-            Which workspace you are already in decides whether opening a run is
-            instant or swaps the whole view, so it is worth a word. Muted and
-            textual — membership is never an accent signal.
-          */}
-          {group.isCurrent && (
-            <span
-              aria-hidden="true"
-              className="ml-1.5 shrink-0 text-[11px] leading-none text-daintree-text/40"
-            >
-              Current
-            </span>
-          )}
-        </div>
-        <div className="mt-0.5 flex min-w-0 items-center">
-          <span
-            aria-hidden="true"
-            className={cn(
-              "truncate text-[11px] leading-none",
-              ROW_TONE_CLASS[BAND_TONE[group.topBand]]
-            )}
-          >
-            {summary}
-          </span>
-        </div>
+      {/*
+        The shared section-label treatment every other palette gives this
+        element — 10px, tracked, uppercase, muted. A project is structure, and
+        structure has to weigh less than the content it organises; the 14px
+        semibold name plus a second coloured line outweighed the very rows it
+        was meant to be filing.
+
+        The toggle's label already carries the name and the summary, so this is
+        hidden rather than announced a second time.
+      */}
+      <div aria-hidden="true" className="flex min-w-0 flex-1 items-center gap-1.5">
+        <span className={cn(PALETTE_SECTION_LABEL_CLASS, "truncate")}>{group.name}</span>
+        {/*
+          Which workspace you are already in decides whether opening a run is
+          instant or swaps the whole view, so it is worth a word. Muted and
+          textual — membership is never an accent signal.
+        */}
+        {group.isCurrent && (
+          <span className="shrink-0 text-[10px] leading-none text-daintree-text/30">Current</span>
+        )}
       </div>
+
+      {isCollapsed && <CollapsedBandPips group={group} />}
     </div>
   );
 }
@@ -257,12 +299,11 @@ function RunRow({
   domId: string;
   onActivate: () => void;
 }) {
-  // State first, then how long it has been that way, then where it is running.
-  // The age sat on the trailing edge before, where a bare "2h" beside a title
-  // named no quantity — runtime, wait, and time-since-finish all read the same.
-  // The agent's name is deliberately absent: the brand icon carries identity,
-  // which is the same reason the tab strip's `compact` title drops it.
-  const detail = [row.age, row.worktreeLabel].filter(Boolean).join(" · ");
+  // Only a demand gets a visible word. The other three states are neutral by
+  // design now, and a status word for each of them was half of what made every
+  // row look equally important — but the state still has to be readable as
+  // text, so it moves into the option's accessible name instead of vanishing.
+  const isDemand = isDemandBand(row.band);
 
   return (
     <div
@@ -271,30 +312,27 @@ function RunRow({
       aria-selected={isSelected}
       data-testid="pilot-row"
       onClick={onActivate}
-      // The header's own column structure — same padding, the chevron column,
-      // then a tile-width column — rather than a hand-computed indent, so
-      // titles line up with the project title above them by construction.
-      className={cn(ROW_BASE, ROW_TONE, "gap-2 py-1.5 pr-3 pl-3")}
+      // One line, ~32px. Two-line rows made 8 agents into 16 lines of identical
+      // shape with nothing to scan down; the trailing group below puts the
+      // facts into columns instead.
+      className={cn(ROW_BASE, ROW_TONE, "gap-2 py-1 pr-3 pl-3")}
     >
       {/*
-        State rides the chevron column, so every agent's spinner or amber circle
-        sits in one vertical line down the left edge and the whole fleet's
-        working-vs-waiting split can be read in a single glance without tracking
-        across each row. Redundant with the status word below it by design —
-        never colour alone.
+        State rides the chevron column, so every agent's mark sits in one
+        vertical line down the left edge and the fleet's working-vs-waiting
+        split reads in a single glance without tracking across each row.
       */}
       <span className="flex size-3.5 shrink-0 items-center justify-center">
         <PilotRunState band={row.band} agentState={row.run.agentState} />
       </span>
 
       {/*
-        The panel's own brand mark, in a tile-width column so run titles line up
-        with the project title above them. Same component, chrome and preset
-        colour the panel header and dock render, so one agent looks like itself
-        everywhere — a generic glyph here would make the row the only surface
-        that cannot tell Claude from Codex.
+        The panel's own brand mark. Same component, chrome and preset colour the
+        panel header and dock render, so one agent looks like itself everywhere
+        — a generic glyph here would make the row the only surface that cannot
+        tell Claude from Codex.
       */}
-      <span className="flex w-8 shrink-0 items-center justify-center">
+      <span className="flex size-4 shrink-0 items-center justify-center">
         <TerminalIcon
           chrome={row.chrome}
           className="h-4 w-4"
@@ -303,19 +341,36 @@ function RunRow({
         />
       </span>
 
-      <span className="min-w-0 flex-1">
-        <span
-          className={cn(
-            "block truncate text-sm leading-tight",
-            isSelected ? "text-daintree-text" : "text-daintree-text/85"
-          )}
-        >
-          {row.title}
-        </span>
-        <span className="mt-0.5 block truncate text-[11px] leading-none">
+      <span
+        className={cn(
+          "min-w-0 flex-1 truncate text-sm leading-tight",
+          isSelected ? "text-daintree-text" : "text-daintree-text/85"
+        )}
+      >
+        {row.title}
+      </span>
+
+      {/* Never truncates and never wraps: this is the column the eye runs down. */}
+      <span className="flex shrink-0 items-center gap-2 text-[11px] leading-none">
+        {isDemand ? (
           <span className={ROW_TONE_CLASS[row.tone]}>{row.statusLabel}</span>
-          {detail && <span className="text-daintree-text/50">{` · ${detail}`}</span>}
-        </span>
+        ) : (
+          <span className="sr-only">{row.statusLabel}</span>
+        )}
+        {row.worktreeLabel !== null && (
+          <span className="max-w-[10rem] truncate text-daintree-text/40">{row.worktreeLabel}</span>
+        )}
+        {/*
+          Right-aligned, tabular, and given a floor width so "just now" and
+          "2h 15m" start at the same x. Without that the ages sit at eight
+          different offsets and "how long has this been stuck" goes back to
+          being eight separate reads instead of one scan.
+        */}
+        {row.age !== null && (
+          <span className="min-w-[3.5rem] text-right tabular-nums text-daintree-text/50">
+            {row.age}
+          </span>
+        )}
       </span>
     </div>
   );
@@ -325,10 +380,26 @@ function RunRow({
  * `actionLabel` is null when nothing is listed, and the key hints go with it —
  * a footer offering "↵ Open" over a loading or empty list is chrome promising
  * a key that visibly does nothing.
+ *
+ * `onShowDemand` turns the demand sentence into the control it was already
+ * implying. "2 agents need you" stated a fact the surface gave no way to act
+ * on; as a button it isolates exactly the two agents it counted. Present only
+ * when there is a demand to isolate, so the footer never grows a control that
+ * would filter to nothing.
  */
-function PilotFooter({ actionLabel, summary }: { actionLabel: string | null; summary: string }) {
+function PilotFooter({
+  actionLabel,
+  summary,
+  demandCount,
+  onShowDemand,
+}: {
+  actionLabel: string | null;
+  summary: string;
+  demandCount: number;
+  onShowDemand: () => void;
+}) {
   return (
-    <div className="flex w-full items-center justify-between">
+    <div className="flex w-full items-center justify-between gap-3">
       <div className="flex items-center gap-3">
         {actionLabel !== null && (
           <>
@@ -343,7 +414,29 @@ function PilotFooter({ actionLabel, summary }: { actionLabel: string | null; sum
           </>
         )}
       </div>
-      {summary && <span className="truncate text-daintree-text/50">{summary}</span>}
+      {summary &&
+        (demandCount > 0 ? (
+          <button
+            type="button"
+            onClick={onShowDemand}
+            data-testid="pilot-demand-action"
+            // The visible text stays the sentence; the accessible name says
+            // what pressing it does, because "2 agents need you" names a
+            // situation rather than an action.
+            aria-label={`Show ${demandCount} ${demandCount === 1 ? "agent" : "agents"} that need you`}
+            className={cn(
+              "truncate rounded-[var(--radius-sm)] px-1.5 py-0.5 text-daintree-text/70 transition-colors",
+              "hover:bg-overlay-subtle hover:text-daintree-text",
+              "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent"
+            )}
+          >
+            {summary}
+          </button>
+        ) : (
+          <span data-testid="pilot-summary" className="truncate text-daintree-text/50">
+            {summary}
+          </span>
+        ))}
     </div>
   );
 }
@@ -362,14 +455,25 @@ export function PilotView() {
 
   const [query, setQuery] = useState("");
   /**
-   * Collapse overrides that apply only while a search is active.
+   * The state segment, held locally beside the query rather than in
+   * `pilotStore`.
    *
-   * Searching force-expands every matching group, so without a separate set the
+   * Both are narrowing state for one opening of the dialog and both reset when
+   * it closes. `collapsedWorkspaceIds` lives in the store because it is the
+   * opposite thing — a durable preference about a project that should survive
+   * closing — and a filter that persisted would reopen the surface already
+   * hiding agents, with the reason two openings in the past.
+   */
+  const [bandFilter, setBandFilter] = useState<PilotBandFilter>("all");
+  /**
+   * Collapse overrides that apply only while the list is narrowed.
+   *
+   * Narrowing force-expands every matching group, so without a separate set the
    * header toggle would be a dead control: `aria-expanded` pinned open while the
    * click silently edited the persisted set, collapsing the group minutes later
    * when the query cleared.
    */
-  const [searchCollapsed, setSearchCollapsed] = useState<readonly string[]>([]);
+  const [narrowingCollapsed, setNarrowingCollapsed] = useState<readonly string[]>([]);
 
   // The clock is state, not a bare tick counter, and it is a real dependency of
   // the row build below. A `setTick(n => n + 1)` that nothing reads is a no-op
@@ -535,12 +639,33 @@ export function PilotView() {
     });
   }, [liveGroups, frozenOrder]);
 
+  /**
+   * The narrowing pipeline, in the one order that makes the counts honest.
+   *
+   * Query first, then count, then the band filter. Counting between the two is
+   * what makes each segment report the query-intersected population: count
+   * after the band filter and every segment reads its own filtered total, which
+   * is always the length of the list already on screen and therefore tells the
+   * user nothing. The two narrowings intersect with AND, so "the blocked agents
+   * in this repo" is one question.
+   */
+  const queryGroups = useMemo(() => filterPilotGroups(stableGroups, query), [stableGroups, query]);
+
+  const filterCounts = useMemo(() => countPilotBands(queryGroups), [queryGroups]);
+
   const visibleGroups = useMemo(
-    () => filterPilotGroups(stableGroups, query),
-    [stableGroups, query]
+    () => filterPilotBands(queryGroups, bandFilter),
+    [queryGroups, bandFilter]
   );
 
-  const isSearching = query.trim().length > 0;
+  /**
+   * Either narrowing is in play, so a group holding a match must open itself.
+   *
+   * The filter has exactly the same claim on this as the query does: finding
+   * the blocked agent you filtered for still collapsed behind a chevron is the
+   * same "narrowing failing to do its job" the query path already solves.
+   */
+  const isNarrowing = query.trim().length > 0 || bandFilter !== "all";
 
   /**
    * The tree, in the shared model's shape.
@@ -568,10 +693,10 @@ export function PilotView() {
           navigable: false,
         },
         // A collapsed group that contains a match opens itself — making someone
-        // click to reveal the thing they just searched for is the search
+        // click to reveal the thing they just narrowed to is the narrowing
         // failing to do its job.
-        isCollapsed: isSearching
-          ? searchCollapsed.includes(group.workspaceId)
+        isCollapsed: isNarrowing
+          ? narrowingCollapsed.includes(group.workspaceId)
           : collapsedIds.includes(group.workspaceId),
         items: group.rows.map((row) => ({
           rowId: row.run.runId,
@@ -580,24 +705,29 @@ export function PilotView() {
           item: row,
         })),
       })),
-    [visibleGroups, isSearching, searchCollapsed, collapsedIds]
+    [visibleGroups, isNarrowing, narrowingCollapsed, collapsedIds]
   );
 
-  // The search-scoped collapses belong to the query that produced them, and
-  // closing drops them so a reopen doesn't restore state from a fleet that has
-  // moved on. The selection resets alongside, inside the navigation model.
+  // The narrowing-scoped collapses belong to the query AND the filter that
+  // produced them — a collapse made while looking at blocked agents has no
+  // claim on the list once the segment changes. Closing drops them too, so a
+  // reopen doesn't restore state from a fleet that has moved on. The selection
+  // resets alongside, inside the navigation model.
   useEffect(() => {
-    setSearchCollapsed([]);
-  }, [query, isOpen]);
+    setNarrowingCollapsed([]);
+  }, [query, bandFilter, isOpen]);
 
   useEffect(() => {
-    if (!isOpen) setQuery("");
+    if (!isOpen) {
+      setQuery("");
+      setBandFilter("all");
+    }
   }, [isOpen]);
 
   const setGroupCollapsed = useCallback(
     (workspaceId: string, collapsed: boolean) => {
-      if (isSearching) {
-        setSearchCollapsed((ids) => {
+      if (isNarrowing) {
+        setNarrowingCollapsed((ids) => {
           const has = ids.includes(workspaceId);
           if (collapsed === has) return ids;
           return collapsed ? [...ids, workspaceId] : ids.filter((id) => id !== workspaceId);
@@ -606,7 +736,7 @@ export function PilotView() {
         toggleCollapsed(workspaceId);
       }
     },
-    [isSearching, collapsedIds, toggleCollapsed]
+    [isNarrowing, collapsedIds, toggleCollapsed]
   );
 
   const activate = useCallback((row: NavigablePaletteTreeRow<PilotProjectGroup, PilotRow>) => {
@@ -626,11 +756,19 @@ export function PilotView() {
    * non-empty they stay with the caret; an empty box has nothing to edit, so
    * they navigate. Search force-expands every matching group anyway, which is
    * where collapse would matter least.
+   *
+   * Deliberately keyed on the query alone and not on the band filter: an active
+   * filter with an empty box still leaves nothing to edit, and handing the
+   * caret keys over then would take collapse and expand away from a keyboard
+   * user for no gain. The filter bar binds its own arrows, but only while it
+   * physically holds focus, so the two never contend.
    */
   const navigation = usePaletteTreeNavigation<PilotProjectGroup, PilotRow>({
     groups: paletteGroups,
     isActive: isOpen,
-    selectionScopeKey: query,
+    // Both narrowings scope the selection. Keyed on the query alone, the
+    // highlight would survive on a row the filter had just removed.
+    selectionScopeKey: `${query}|${bandFilter}`,
     onActivate: activate,
     onGroupCollapsedChange: setGroupCollapsed,
     shouldPreserveInputCaretKey: () => query.length > 0,
@@ -654,7 +792,26 @@ export function PilotView() {
       : ({ kind: "stale", since: snapshot.lastSuccessfulAt } as const);
   }, [snapshot]);
 
-  const fleet = useMemo(() => summarizePilotGroups(stableGroups), [stableGroups]);
+  /**
+   * Summarised over the QUERY-filtered fleet, not the raw one.
+   *
+   * The footer's sentence is now a control that applies a filter, and a control
+   * has to deliver what it advertises: counted over the whole fleet it would
+   * promise five agents and reveal the two that also match the query.
+   */
+  const fleet = useMemo(() => summarizePilotGroups(queryGroups), [queryGroups]);
+
+  /**
+   * The demand the footer can actually isolate.
+   *
+   * NOT `fleet.demand`, which counts `review` as a demand — correct for the
+   * band vocabulary, wrong here, because the Needs-you segment covers only
+   * `blocked` and `needs-you`. A footer counting review would state a number
+   * its own button then failed to produce. Review keeps its own sentence
+   * instead of being folded into somebody else's.
+   */
+  const needsYou = filterCounts["needs-you"];
+  const review = fleet.bands.review;
 
   // Counted by band, never off the raw row total: a fleet holding two working
   // agents and six exited ones is not "8 agents running".
@@ -662,13 +819,15 @@ export function PilotView() {
   const summary =
     status.kind === "loading" || status.kind === "unavailable"
       ? ""
-      : fleet.demand > 0
-        ? demandPhrase(fleet.demand)
-        : live > 0
-          ? `Nothing needs you · ${live} ${live === 1 ? "agent" : "agents"} working`
-          : fleet.total > 0
-            ? `Nothing needs you · ${agentCount(fleet.total)}`
-            : "";
+      : needsYou > 0
+        ? demandPhrase(needsYou)
+        : review > 0
+          ? bandPhrase("review", review)
+          : live > 0
+            ? `Nothing needs you · ${live} ${live === 1 ? "agent" : "agents"} working`
+            : fleet.total > 0
+              ? `Nothing needs you · ${agentCount(fleet.total)}`
+              : "";
 
   // Every selectable row is an agent now, so the verb never changes.
   const actionLabel = selectedRow === null ? null : "Open";
@@ -681,6 +840,18 @@ export function PilotView() {
   const showEmpty =
     (status.kind === "live" || status.kind === "stale") && renderGroups.length === 0;
   const showSkeleton = useDeferredLoading(status.kind === "loading", UI_DOHERTY_THRESHOLD);
+
+  /**
+   * The bar rides the un-narrowed fleet, not the visible one.
+   *
+   * Four zero segments over a fleet that hasn't been read yet would be a claim
+   * the surface can't support, and over a genuinely empty one they are chrome
+   * competing with the sentence telling the user to start an agent. But once
+   * there ARE runs the bar has to stay, even when the current query and segment
+   * leave nothing on screen — that is precisely when it is the way back.
+   */
+  const showFilterBar =
+    (status.kind === "live" || status.kind === "stale") && stableGroups.length > 0;
 
   return (
     <AppPaletteDialog isOpen={isOpen} onClose={close} ariaLabel="All agents">
@@ -703,6 +874,19 @@ export function PilotView() {
           aria-activedescendant={activeDescendantId}
           data-testid="pilot-search"
         />
+
+        {/*
+          Inside the header, under the input, so the two narrowing controls read
+          as one unit and the header's own rule closes the block. Full-bleed
+          against the header's padding, matching the sidebar's bar exactly.
+          After the input in DOM order, which is also the tab order: input →
+          active segment → results.
+        */}
+        {showFilterBar && (
+          <div className="-mx-3 -mb-2 mt-2 border-t border-border-default">
+            <PilotFilterBar value={bandFilter} counts={filterCounts} onChange={setBandFilter} />
+          </div>
+        )}
       </AppPaletteDialog.Header>
 
       <AppPaletteDialog.Body
@@ -720,11 +904,11 @@ export function PilotView() {
            */
           <>
             <Skeleton className="flex flex-col gap-1 p-2" data-testid="pilot-skeleton">
-              {/* Shaped like what is coming: a group header, then its runs. */}
-              <SkeletonBone className="h-12 w-full" />
-              <SkeletonBone className="h-10 w-full" />
-              <SkeletonBone className="h-10 w-full" />
-              <SkeletonBone className="h-12 w-full" />
+              {/* Shaped like what is coming: a section label, then its runs. */}
+              <SkeletonBone className="h-6 w-full" />
+              <SkeletonBone className="h-8 w-full" />
+              <SkeletonBone className="h-8 w-full" />
+              <SkeletonBone className="h-6 w-full" />
             </Skeleton>
             <SkeletonHint firstThreshold={LOADING_HINT_MS} message="Still reading the fleet…" />
           </>
@@ -767,11 +951,39 @@ export function PilotView() {
            * the fleet as a `review` or `done` row, and an exited one as `idle`,
            * so an empty snapshot means no agent terminals exist at all.
            *
-           * No button — launching is per-project and this surface spans them
-           * all, so a CTA here would name an action it cannot perform. The
-           * sentence is the affordance.
+           * No button on the zero-data branch — launching is per-project and
+           * this surface spans them all, so a CTA there would name an action it
+           * cannot perform. The sentence is the affordance.
+           *
+           * A filtered empty IS actionable, though, and gets the one control
+           * that undoes the constraint the user can't otherwise see: the filter
+           * is named in the title, and clearing it keeps the query, because
+           * throwing away both would make the button a reset rather than the
+           * targeted correction it says it is.
            */
-          <AppPaletteDialog.Empty query={query} emptyMessage="Start an agent in any project" />
+          <AppPaletteDialog.Empty
+            query={query}
+            emptyMessage="Start an agent in any project"
+            {...(bandFilter !== "all" ? { filterLabel: PILOT_BAND_FILTER_LABEL[bandFilter] } : {})}
+            noMatchContent={
+              bandFilter === "all" ? undefined : (
+                <button
+                  type="button"
+                  data-testid="pilot-clear-filter"
+                  onClick={() => {
+                    setBandFilter("all");
+                  }}
+                  className={cn(
+                    "rounded-[var(--radius-sm)] px-2 py-1 text-xs text-daintree-text/70 transition-colors",
+                    "hover:bg-overlay-subtle hover:text-daintree-text",
+                    "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent"
+                  )}
+                >
+                  Clear filter
+                </button>
+              )
+            }
+          />
         )}
 
         {/*
@@ -828,7 +1040,14 @@ export function PilotView() {
       */}
       {(actionLabel !== null || summary !== "") && (
         <AppPaletteDialog.Footer>
-          <PilotFooter actionLabel={actionLabel} summary={summary} />
+          <PilotFooter
+            actionLabel={actionLabel}
+            summary={summary}
+            demandCount={needsYou}
+            onShowDemand={() => {
+              setBandFilter("needs-you");
+            }}
+          />
         </AppPaletteDialog.Footer>
       )}
     </AppPaletteDialog>

--- a/src/components/Pilot/PilotView.tsx
+++ b/src/components/Pilot/PilotView.tsx
@@ -760,6 +760,8 @@ export function PilotView() {
     if (!isOpen) {
       setQuery("");
       setBandFilter("all");
+      // Closing takes focus with it without a blur ever reaching the bar.
+      setIsFilterFocused(false);
     }
   }, [isOpen]);
 
@@ -868,12 +870,6 @@ export function PilotView() {
               ? `Nothing needs you · ${agentCount(fleet.total)}`
               : "";
 
-  // Every selectable row is an agent now, so the verb never changes.
-  // Dropped while a filter segment holds focus: on a segment those keys drive
-  // the filter, not the list, so the hints would be naming keys that do
-  // something else.
-  const actionLabel = selectedRow === null || isFilterFocused ? null : "Open";
-
   const hasTree = renderGroups.length > 0;
   // Stale counts as well as live: retained runs are real rows, so a query that
   // matches none of them is a true statement about the query rather than a claim
@@ -894,6 +890,23 @@ export function PilotView() {
    */
   const showFilterBar =
     (status.kind === "live" || status.kind === "stale") && stableGroups.length > 0;
+
+  // Removing a focused element does not reliably fire a blur, so a bar that
+  // vanishes under the cursor — the fleet drains, or the host stops answering
+  // — would leave the flag stuck true and the footer's hints suppressed for
+  // the rest of the opening, including after the fleet comes back.
+  useEffect(() => {
+    if (!showFilterBar) setIsFilterFocused(false);
+  }, [showFilterBar]);
+
+  // Every selectable row is an agent now, so the verb never changes.
+  //
+  // Dropped while a filter segment holds focus: on a segment those keys drive
+  // the filter, not the list, so the hints would be naming keys that do
+  // something else. Gated on the bar still being here as well, because a bar
+  // that unmounts while focused — the fleet drains, or the dialog closes —
+  // never gets its blur, and the flag alone would suppress the hints for good.
+  const actionLabel = selectedRow === null || (isFilterFocused && showFilterBar) ? null : "Open";
 
   return (
     <AppPaletteDialog isOpen={isOpen} onClose={close} ariaLabel="All agents">

--- a/src/components/Pilot/__tests__/PilotFilterBar.test.tsx
+++ b/src/components/Pilot/__tests__/PilotFilterBar.test.tsx
@@ -1,20 +1,57 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
 import { PilotFilterBar } from "../PilotFilterBar";
 import type { PilotBandFilter, PilotBandFilterCounts } from "../pilotRows";
+import { emptyBandCounts, type FleetBandCounts } from "@/lib/fleetAttention";
 
 function counts(overrides: Partial<PilotBandFilterCounts> = {}): PilotBandFilterCounts {
   return { all: 0, "needs-you": 0, working: 0, finished: 0, ...overrides };
 }
 
+function bands(overrides: Partial<FleetBandCounts> = {}): FleetBandCounts {
+  return { ...emptyBandCounts(), ...overrides };
+}
+
 function renderBar(
   value: PilotBandFilter = "all",
-  bandCounts: PilotBandFilterCounts = counts({ all: 3, "needs-you": 1, working: 2 })
+  bandCounts: PilotBandFilterCounts = counts({ all: 3, "needs-you": 1, working: 2 }),
+  perBand: FleetBandCounts = bands({ "needs-you": 1, running: 2 })
 ) {
   const onChange = vi.fn();
-  render(<PilotFilterBar value={value} counts={bandCounts} onChange={onChange} />);
+  render(<PilotFilterBar value={value} counts={bandCounts} bands={perBand} onChange={onChange} />);
   return { onChange };
+}
+
+/**
+ * The bar wired to real state, which is what a keyboard test actually needs.
+ *
+ * With a fixed `value` prop, pressing an arrow calls `onChange` and nothing
+ * moves — so the NEXT key is still computed from the original segment, and a
+ * component that never called `.focus()` at all would look identical.
+ */
+function StatefulBar({ initial = "all" }: { initial?: PilotBandFilter }) {
+  const [value, setValue] = useState<PilotBandFilter>(initial);
+  return (
+    <PilotFilterBar
+      value={value}
+      counts={counts({ all: 3, "needs-you": 1, working: 2 })}
+      bands={bands({ "needs-you": 1, running: 2 })}
+      onChange={setValue}
+    />
+  );
+}
+
+/** Checked segment, its tab stop and where focus actually is, as one reading. */
+function liveState(): { checked: string; tabbable: string; focused: string } {
+  const radios = screen.getAllByRole("radio");
+  const name = (el: Element | null) => el?.getAttribute("aria-label")?.split(",")[0] ?? "none";
+  return {
+    checked: name(radios.find((el) => el.getAttribute("aria-checked") === "true") ?? null),
+    tabbable: name(radios.find((el) => el.getAttribute("tabindex") === "0") ?? null),
+    focused: name(document.activeElement),
+  };
 }
 
 /** The bar's segments, in rendered order, by accessible name. */
@@ -90,54 +127,85 @@ describe("PilotFilterBar", () => {
       fireEvent.keyDown(screen.getByRole("radiogroup"), { key });
     }
 
-    it("moves selection with the arrows, in both directions", () => {
+    it("moves the checked segment, its tab stop and focus together", () => {
       // Selection follows focus: the filter is instant and reversible, so
       // charging a second keystroke to confirm would be a toll for nothing.
-      const { onChange } = renderBar("needs-you");
+      // All three have to move as one, or Tab returns somewhere unexpected.
+      render(<StatefulBar initial="needs-you" />);
 
       press("ArrowRight");
-      expect(onChange).toHaveBeenLastCalledWith("working");
+      expect(liveState()).toEqual({
+        checked: "Working",
+        tabbable: "Working",
+        focused: "Working",
+      });
 
       press("ArrowLeft");
-      expect(onChange).toHaveBeenLastCalledWith("all");
+      expect(liveState()).toEqual({
+        checked: "Needs you",
+        tabbable: "Needs you",
+        focused: "Needs you",
+      });
     });
 
     it("wraps backwards off the first segment", () => {
-      const { onChange } = renderBar("all");
+      render(<StatefulBar initial="all" />);
 
       press("ArrowLeft");
 
-      expect(onChange).toHaveBeenLastCalledWith("finished");
+      expect(liveState().checked).toBe("Finished");
     });
 
     it("wraps forwards off the last segment", () => {
-      const { onChange } = renderBar("finished");
+      render(<StatefulBar initial="finished" />);
 
       press("ArrowRight");
 
-      expect(onChange).toHaveBeenLastCalledWith("all");
+      expect(liveState().checked).toBe("All");
     });
 
     it("jumps to the ends with Home and End", () => {
-      const { onChange } = renderBar("working");
+      render(<StatefulBar initial="working" />);
 
       press("Home");
-      expect(onChange).toHaveBeenLastCalledWith("all");
+      expect(liveState().checked).toBe("All");
 
       press("End");
-      expect(onChange).toHaveBeenLastCalledWith("finished");
+      expect(liveState().checked).toBe("Finished");
     });
 
-    it("claims only the keys it handles", () => {
+    it("keeps exactly one tab stop through every move", () => {
+      render(<StatefulBar initial="all" />);
+
+      for (const key of ["ArrowRight", "ArrowRight", "End", "Home", "ArrowLeft"]) {
+        press(key);
+        const tabbable = screen
+          .getAllByRole("radio")
+          .filter((el) => el.getAttribute("tabindex") === "0");
+        expect(tabbable).toHaveLength(1);
+      }
+    });
+
+    it("claims only the keys it handles, and keeps them off the palette", () => {
       // The dialog and the browser still have a use for everything else —
       // cancelling indiscriminately from a control inside a palette is how a
       // surface eats Escape or Enter from the components around it.
-      renderBar();
+      const outer = vi.fn();
+      render(
+        <div onKeyDown={outer}>
+          <StatefulBar />
+        </div>
+      );
       const group = screen.getByRole("radiogroup");
 
       expect(fireEvent.keyDown(group, { key: "ArrowRight" })).toBe(false);
+      // Its own arrows must not also reach the palette's tree navigation.
+      expect(outer).not.toHaveBeenCalled();
+
       expect(fireEvent.keyDown(group, { key: "Escape" })).toBe(true);
       expect(fireEvent.keyDown(group, { key: "a" })).toBe(true);
+      // ...but everything else still bubbles, so Escape still closes.
+      expect(outer).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -160,17 +228,37 @@ describe("PilotFilterBar", () => {
     });
 
     it("mutes the glyph of an empty bucket and not of a populated one", () => {
-      // The zero has to register without being read. Compared against the
-      // populated segment rather than asserted as a colour literal — the
-      // invariant is that the two differ, not what either one spells.
-      renderBar("all", counts({ all: 2, working: 2 }));
-
+      // The SAME segment at zero and at one. Comparing two different segments
+      // proved nothing — their base tones already differ, so deleting the fade
+      // rule entirely would still have passed.
+      renderBar("all", counts({ all: 0 }), bands());
       const empty = glyphOf(/Needs you/)?.getAttribute("class") ?? "";
-      const populated = glyphOf(/Working/)?.getAttribute("class") ?? "";
+
+      cleanup();
+
+      renderBar("all", counts({ all: 1, "needs-you": 1 }), bands({ "needs-you": 1 }));
+      const populated = glyphOf(/Needs you/)?.getAttribute("class") ?? "";
 
       expect(empty).not.toBe("");
-      expect(populated).not.toBe("");
       expect(empty).not.toBe(populated);
+    });
+
+    it("keeps a mixed segment neutral until it actually holds a demand", () => {
+      // Finished admits `review`, which is a demand, alongside `done`, which
+      // is not. A count alone can't tell them apart, so hueing on membership
+      // would paint a project whose completions have all been acknowledged in
+      // the colour reserved for work still waiting to be looked at.
+      renderBar("all", counts({ all: 2, finished: 2 }), bands({ done: 2 }));
+      const acknowledged = glyphOf(/Finished/)?.getAttribute("class") ?? "";
+
+      cleanup();
+
+      renderBar("all", counts({ all: 2, finished: 2 }), bands({ review: 2 }));
+      const awaitingReview = glyphOf(/Finished/)?.getAttribute("class") ?? "";
+
+      // Same segment, same count — only the bands underneath differ.
+      expect(acknowledged).not.toBe("");
+      expect(acknowledged).not.toBe(awaitingReview);
     });
 
     it("only spins the working glyph when something is actually working", () => {

--- a/src/components/Pilot/__tests__/PilotFilterBar.test.tsx
+++ b/src/components/Pilot/__tests__/PilotFilterBar.test.tsx
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { PilotFilterBar } from "../PilotFilterBar";
+import type { PilotBandFilter, PilotBandFilterCounts } from "../pilotRows";
+
+function counts(overrides: Partial<PilotBandFilterCounts> = {}): PilotBandFilterCounts {
+  return { all: 0, "needs-you": 0, working: 0, finished: 0, ...overrides };
+}
+
+function renderBar(
+  value: PilotBandFilter = "all",
+  bandCounts: PilotBandFilterCounts = counts({ all: 3, "needs-you": 1, working: 2 })
+) {
+  const onChange = vi.fn();
+  render(<PilotFilterBar value={value} counts={bandCounts} onChange={onChange} />);
+  return { onChange };
+}
+
+/** The bar's segments, in rendered order, by accessible name. */
+function segmentNames(): string[] {
+  return screen.getAllByRole("radio").map((el) => el.getAttribute("aria-label") ?? "");
+}
+
+describe("PilotFilterBar", () => {
+  it("offers the four states as one mutually exclusive choice", () => {
+    // A radiogroup, not the sidebar's toolbar of toggles: these segments are
+    // exclusive with All as the null option, which is what a radiogroup IS.
+    renderBar();
+
+    expect(screen.getByRole("radiogroup")).toBeTruthy();
+    expect(screen.getAllByRole("radio")).toHaveLength(4);
+  });
+
+  it("reports exactly one checked segment", () => {
+    renderBar("working");
+
+    const checked = screen.getAllByRole("radio", { checked: true });
+    expect(checked).toHaveLength(1);
+    expect(checked[0]!.getAttribute("aria-label")).toContain("Working");
+  });
+
+  it("gives the group a single tab stop, on the checked segment", () => {
+    // Roving tabindex: Tab from the search box lands on the active filter
+    // rather than walking four controls on the way to the list.
+    renderBar("finished");
+
+    const tabbable = screen
+      .getAllByRole("radio")
+      .filter((el) => el.getAttribute("tabindex") === "0");
+
+    expect(tabbable).toHaveLength(1);
+    expect(tabbable[0]!.getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("carries the count in each segment's name, so it is never colour-and-digit alone", () => {
+    renderBar("all", counts({ all: 7, "needs-you": 2, working: 4, finished: 1 }));
+
+    expect(segmentNames()).toEqual([
+      "All, 7 agents",
+      "Needs you, 2 agents",
+      "Working, 4 agents",
+      "Finished, 1 agent",
+    ]);
+  });
+
+  it("selects a segment on click", () => {
+    const { onChange } = renderBar();
+
+    fireEvent.click(screen.getByRole("radio", { name: /Needs you/ }));
+
+    expect(onChange).toHaveBeenCalledWith("needs-you");
+  });
+
+  it("does not toggle the checked segment back to All", () => {
+    // The sidebar's toolbar toggles because its segments are independent
+    // presses. Re-selecting the checked radio in a radiogroup is a no-op, not
+    // an escape hatch — All is a segment of its own and is how you get back.
+    const { onChange } = renderBar("working");
+
+    fireEvent.click(screen.getByRole("radio", { name: /Working/ }));
+
+    expect(onChange).toHaveBeenCalledWith("working");
+    expect(onChange).not.toHaveBeenCalledWith("all");
+  });
+
+  describe("keyboard", () => {
+    /** Arrows are bound on the group, so they are dispatched there. */
+    function press(key: string): void {
+      fireEvent.keyDown(screen.getByRole("radiogroup"), { key });
+    }
+
+    it("moves selection with the arrows, in both directions", () => {
+      // Selection follows focus: the filter is instant and reversible, so
+      // charging a second keystroke to confirm would be a toll for nothing.
+      const { onChange } = renderBar("needs-you");
+
+      press("ArrowRight");
+      expect(onChange).toHaveBeenLastCalledWith("working");
+
+      press("ArrowLeft");
+      expect(onChange).toHaveBeenLastCalledWith("all");
+    });
+
+    it("wraps backwards off the first segment", () => {
+      const { onChange } = renderBar("all");
+
+      press("ArrowLeft");
+
+      expect(onChange).toHaveBeenLastCalledWith("finished");
+    });
+
+    it("wraps forwards off the last segment", () => {
+      const { onChange } = renderBar("finished");
+
+      press("ArrowRight");
+
+      expect(onChange).toHaveBeenLastCalledWith("all");
+    });
+
+    it("jumps to the ends with Home and End", () => {
+      const { onChange } = renderBar("working");
+
+      press("Home");
+      expect(onChange).toHaveBeenLastCalledWith("all");
+
+      press("End");
+      expect(onChange).toHaveBeenLastCalledWith("finished");
+    });
+
+    it("claims only the keys it handles", () => {
+      // The dialog and the browser still have a use for everything else —
+      // cancelling indiscriminately from a control inside a palette is how a
+      // surface eats Escape or Enter from the components around it.
+      renderBar();
+      const group = screen.getByRole("radiogroup");
+
+      expect(fireEvent.keyDown(group, { key: "ArrowRight" })).toBe(false);
+      expect(fireEvent.keyDown(group, { key: "Escape" })).toBe(true);
+      expect(fireEvent.keyDown(group, { key: "a" })).toBe(true);
+    });
+  });
+
+  describe("empty buckets", () => {
+    /** The glyph a segment renders, if it has one. */
+    function glyphOf(name: RegExp): Element | null {
+      return screen.getByRole("radio", { name }).querySelector("svg");
+    }
+
+    it("keeps a zero segment selectable and still counted", () => {
+      // Hiding an empty segment would make the bar's own shape change as the
+      // fleet moved, and take away the control that proves the bucket is empty.
+      const { onChange } = renderBar("all", counts({ all: 2, working: 2 }));
+
+      const empty = screen.getByRole("radio", { name: /Needs you/ });
+      expect(empty.getAttribute("aria-label")).toBe("Needs you, 0 agents");
+
+      fireEvent.click(empty);
+      expect(onChange).toHaveBeenCalledWith("needs-you");
+    });
+
+    it("mutes the glyph of an empty bucket and not of a populated one", () => {
+      // The zero has to register without being read. Compared against the
+      // populated segment rather than asserted as a colour literal — the
+      // invariant is that the two differ, not what either one spells.
+      renderBar("all", counts({ all: 2, working: 2 }));
+
+      const empty = glyphOf(/Needs you/)?.getAttribute("class") ?? "";
+      const populated = glyphOf(/Working/)?.getAttribute("class") ?? "";
+
+      expect(empty).not.toBe("");
+      expect(populated).not.toBe("");
+      expect(empty).not.toBe(populated);
+    });
+
+    it("only spins the working glyph when something is actually working", () => {
+      // A spinner over a count of zero animates a claim that nothing is
+      // happening, which is motion with no information in it.
+      renderBar("all", counts({ all: 1, "needs-you": 1 }));
+      expect(glyphOf(/Working/)?.getAttribute("class")).not.toContain("animate-spin");
+
+      cleanup();
+
+      renderBar("all", counts({ all: 1, working: 1 }));
+      expect(glyphOf(/Working/)?.getAttribute("class")).toContain("animate-spin");
+    });
+  });
+
+  it("hides the decorative label and digit from the accessible name", () => {
+    // The name above already carries both halves; exposing the visible text as
+    // well would read every segment twice.
+    renderBar("all", counts({ all: 5 }));
+    const all = screen.getByRole("radio", { name: /All/ });
+
+    for (const child of Array.from(all.children)) {
+      expect(child.getAttribute("aria-hidden")).toBe("true");
+    }
+  });
+});

--- a/src/components/Pilot/__tests__/PilotRunState.test.tsx
+++ b/src/components/Pilot/__tests__/PilotRunState.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { BAND_GLYPH, PilotRunState } from "../PilotRunState";
+import { FLEET_BANDS, isDemandBand, type FleetBand } from "@/lib/fleetAttention";
+import type { AgentState } from "@shared/types/agent";
+
+/**
+ * The colour utilities on a band's rendered glyph.
+ *
+ * Deliberately extracted rather than compared to a literal: the invariants
+ * below are about which bands share a tone and which shapes stay distinct, so
+ * changing a token should not have to be typed out twice.
+ */
+function toneOf(band: FleetBand, agentState?: AgentState): string {
+  const { container, unmount } = render(<PilotRunState band={band} agentState={agentState} />);
+  const svg = container.querySelector("svg");
+  const tones = (svg?.getAttribute("class") ?? "")
+    .split(/\s+/)
+    .filter((cls) => cls.startsWith("text-"))
+    .sort()
+    .join(" ");
+  unmount();
+  return tones;
+}
+
+/**
+ * The glyph's own geometry, which is what makes a state readable without hue.
+ *
+ * The whole child markup, not a chosen attribute or two: the spinner and the
+ * hollow circle are the same `<circle r="6">` and separate only on
+ * `strokeDasharray` — a 270° arc against a closed ring. Sampling attributes by
+ * hand reported them identical, which would have let a genuinely
+ * indistinguishable pair through unnoticed. Tone stays out of this by
+ * construction, since the class rides the `<svg>` root rather than its children.
+ */
+function shapeOf(band: FleetBand, agentState?: AgentState): string {
+  const { container, unmount } = render(<PilotRunState band={band} agentState={agentState} />);
+  const shape = container.querySelector("svg")?.innerHTML ?? "";
+  unmount();
+  return shape;
+}
+
+const DEMAND_BANDS = FLEET_BANDS.filter(isDemandBand);
+const NEUTRAL_BANDS = FLEET_BANDS.filter((band) => !isDemandBand(band));
+
+describe("PilotRunState", () => {
+  it("gives every band a glyph", () => {
+    // A band with no entry would render nothing at all, leaving the row's left
+    // scan column empty for exactly the state nobody thought about.
+    for (const band of FLEET_BANDS) {
+      expect(BAND_GLYPH[band]).toBeTruthy();
+    }
+  });
+
+  it("paints one shared neutral tone across every state without a demand", () => {
+    // Running, done and idle gave up their hue: colour is the signal that
+    // something needs the user, and three more hues competing with it is what
+    // made two waiting agents invisible among five working ones.
+    const tones = new Set(NEUTRAL_BANDS.map((band) => toneOf(band)));
+    expect(tones.size).toBe(1);
+  });
+
+  it("keeps the directing and exited refinements inside that neutral tone", () => {
+    // Both used to carry a colour of their own — `directing` a category blue,
+    // `exited` a dimmer grey. Neither is a demand.
+    const neutral = toneOf("done");
+    expect(toneOf("running", "directing")).toBe(neutral);
+    expect(toneOf("idle", "exited")).toBe(neutral);
+  });
+
+  it("hues every band that is a demand, and none that isn't", () => {
+    const neutral = toneOf("done");
+    for (const band of DEMAND_BANDS) {
+      expect(toneOf(band)).not.toBe(neutral);
+    }
+    expect(new Set(DEMAND_BANDS.map((band) => toneOf(band))).size).toBe(DEMAND_BANDS.length);
+  });
+
+  it("keeps shape as a second channel, so the neutral states stay tellable apart", () => {
+    // Working, finished and exited are all neutral now, so geometry is the only
+    // thing left separating them — never colour alone, and never its absence.
+    const shapes = [
+      shapeOf("running"),
+      shapeOf("running", "directing"),
+      shapeOf("done"),
+      shapeOf("idle"),
+      shapeOf("idle", "exited"),
+    ];
+
+    expect(new Set(shapes).size).toBe(shapes.length);
+  });
+
+  it("spins only the run that is actually working", () => {
+    const spinning = (band: FleetBand, agentState?: AgentState) => {
+      const { container, unmount } = render(<PilotRunState band={band} agentState={agentState} />);
+      const cls = container.querySelector("svg")?.getAttribute("class") ?? "";
+      unmount();
+      return cls.includes("animate-spin");
+    };
+
+    expect(spinning("running")).toBe(true);
+    // Directing is a person typing, not a process grinding.
+    expect(spinning("running", "directing")).toBe(false);
+    expect(spinning("idle")).toBe(false);
+  });
+});

--- a/src/components/Pilot/__tests__/PilotRunState.test.tsx
+++ b/src/components/Pilot/__tests__/PilotRunState.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 import { render } from "@testing-library/react";
-import { BAND_GLYPH, PilotRunState } from "../PilotRunState";
+import { PilotRunState } from "../PilotRunState";
 import { FLEET_BANDS, isDemandBand, type FleetBand } from "@/lib/fleetAttention";
 import type { AgentState } from "@shared/types/agent";
 
@@ -45,20 +45,16 @@ const DEMAND_BANDS = FLEET_BANDS.filter(isDemandBand);
 const NEUTRAL_BANDS = FLEET_BANDS.filter((band) => !isDemandBand(band));
 
 describe("PilotRunState", () => {
-  it("gives every band a glyph", () => {
-    // A band with no entry would render nothing at all, leaving the row's left
-    // scan column empty for exactly the state nobody thought about.
-    for (const band of FLEET_BANDS) {
-      expect(BAND_GLYPH[band]).toBeTruthy();
-    }
-  });
-
   it("paints one shared neutral tone across every state without a demand", () => {
     // Running, done and idle gave up their hue: colour is the signal that
     // something needs the user, and three more hues competing with it is what
     // made two waiting agents invisible among five working ones.
     const tones = new Set(NEUTRAL_BANDS.map((band) => toneOf(band)));
+
     expect(tones.size).toBe(1);
+    // A set of one is also what "no tone at all" produces, and an uncoloured
+    // glyph would fall through to whatever the row happens to be painted.
+    expect([...tones][0]).not.toBe("");
   });
 
   it("keeps the directing and exited refinements inside that neutral tone", () => {

--- a/src/components/Pilot/__tests__/PilotView.test.tsx
+++ b/src/components/Pilot/__tests__/PilotView.test.tsx
@@ -183,19 +183,53 @@ describe("PilotView", () => {
     expect(new Set(iconIds).size).toBe(2);
   });
 
-  it("writes the run's state out in words, not just a coloured glyph", () => {
-    // Waiting and idle are both hollow circles; hue is the only thing between
-    // them. The switcher never encodes status by colour alone and neither may
-    // this — the sentence beside the glyph carries the meaning.
+  it("makes every run's state available as text, not just as a glyph", () => {
+    // Waiting and idle are both hollow circles; shape alone cannot separate
+    // them. The neutral states gave up their visible word, so the word has to
+    // survive in the option's accessible name — never colour or shape alone.
     seed([
       run({ runId: "a", agentState: "waiting", title: "one", since: NOW - 60_000 }),
       run({ runId: "b", agentState: "idle", title: "two", since: NOW - 60_000 }),
     ]);
     render(<PilotView />);
 
-    const rows = screen.getAllByTestId("pilot-row").map((r) => r.textContent ?? "");
-    expect(rows[0]).toContain("Needs you");
-    expect(rows[1]).toContain("Idle");
+    expect(screen.getByRole("option", { name: /Needs you/ }).textContent).toContain("one");
+    expect(screen.getByRole("option", { name: /Idle/ }).textContent).toContain("two");
+  });
+
+  it("spends colour only on the agents that are actually asking for something", () => {
+    // The whole point of the surface. One blocked agent among six working ones
+    // has to be the only status word on screen — six green labels beside one
+    // amber one is the wall this replaced, where nothing stood out because
+    // everything was shouting.
+    seed([
+      run({
+        runId: "blocked",
+        agentState: "waiting",
+        waitingReason: "error",
+        title: "stuck",
+        since: NOW - 60_000,
+      }),
+      ...Array.from({ length: 6 }, (_, i) =>
+        run({ runId: `w${i}`, agentState: "working", title: `work ${i}`, since: NOW - 60_000 })
+      ),
+    ]);
+    render(<PilotView />);
+
+    const rows = screen.getAllByTestId("pilot-row");
+    expect(rows).toHaveLength(7);
+
+    // A status word the eye can see is one that isn't screen-reader-only.
+    const visibleStatuses = rows.flatMap((row) =>
+      Array.from(row.querySelectorAll("span")).filter(
+        (el) => el.textContent === "Blocked" && !el.classList.contains("sr-only")
+      )
+    );
+    expect(visibleStatuses).toHaveLength(1);
+
+    // ...and every one of the seven still says what it is doing, in text.
+    expect(screen.getAllByRole("option", { name: /Working/ })).toHaveLength(6);
+    expect(screen.getAllByRole("option", { name: /Blocked/ })).toHaveLength(1);
   });
 
   it("marks the workspace this view already owns", () => {
@@ -738,6 +772,343 @@ describe("PilotView", () => {
       await vi.advanceTimersByTimeAsync(0);
 
       expect(selected().text).toContain("bravo");
+    });
+  });
+
+  describe("state filter", () => {
+    /** Blocked + needs-you in one project, working + done in another. */
+    function seedMixedFleet(): void {
+      seed([
+        run({
+          runId: "blocked",
+          workspaceId: "p1",
+          agentState: "waiting",
+          waitingReason: "error",
+          title: "auth blocked",
+          since: NOW - 60_000,
+        }),
+        run({
+          runId: "asking",
+          workspaceId: "p1",
+          agentState: "waiting",
+          title: "docs asking",
+          since: NOW - 30_000,
+        }),
+        run({
+          runId: "working",
+          workspaceId: "s1",
+          agentState: "working",
+          title: "auth working",
+          since: NOW - 10_000,
+        }),
+        run({
+          runId: "idle",
+          workspaceId: "s1",
+          agentState: "exited",
+          title: "old shell",
+          since: NOW - 10_000,
+        }),
+      ]);
+    }
+
+    function segment(name: RegExp): HTMLElement {
+      return screen.getByRole("radio", { name });
+    }
+
+    function rowTitles(): string[] {
+      return screen.queryAllByTestId("pilot-row").map((r) => r.textContent ?? "");
+    }
+
+    it("narrows the list to one band without touching the query", () => {
+      seedMixedFleet();
+      render(<PilotView />);
+      expect(rowTitles()).toHaveLength(4);
+
+      fireEvent.click(segment(/Needs you/));
+
+      expect(rowTitles()).toHaveLength(2);
+      expect(rowTitles().join(" ")).toContain("auth blocked");
+      expect(rowTitles().join(" ")).not.toContain("auth working");
+    });
+
+    it("intersects with the query instead of replacing it", () => {
+      // Two constraints, one question — "the blocked agents in this repo".
+      seedMixedFleet();
+      render(<PilotView />);
+
+      fireEvent.change(screen.getByTestId("pilot-search"), { target: { value: "auth" } });
+      expect(rowTitles()).toHaveLength(2);
+
+      fireEvent.click(segment(/Needs you/));
+
+      expect(rowTitles()).toHaveLength(1);
+      expect(rowTitles()[0]).toContain("auth blocked");
+    });
+
+    it("counts the query-filtered population, not the whole fleet", () => {
+      // Counted after the query and before the segment. Count the other way and
+      // every segment reports the length of the list already on screen.
+      seedMixedFleet();
+      render(<PilotView />);
+      expect(segment(/^All/).getAttribute("aria-label")).toBe("All, 4 agents");
+
+      fireEvent.change(screen.getByTestId("pilot-search"), { target: { value: "auth" } });
+
+      expect(segment(/^All/).getAttribute("aria-label")).toBe("All, 2 agents");
+      expect(segment(/Needs you/).getAttribute("aria-label")).toBe("Needs you, 1 agent");
+      expect(segment(/Working/).getAttribute("aria-label")).toBe("Working, 1 agent");
+    });
+
+    it("holds the counts still while the segment changes", () => {
+      // Selecting a segment must not rewrite the numbers next to the others, or
+      // the bar stops being a map of the fleet and becomes a mirror of itself.
+      seedMixedFleet();
+      render(<PilotView />);
+      const before = screen.getAllByRole("radio").map((el) => el.getAttribute("aria-label"));
+
+      fireEvent.click(segment(/Needs you/));
+
+      expect(screen.getAllByRole("radio").map((el) => el.getAttribute("aria-label"))).toEqual(
+        before
+      );
+    });
+
+    it("leaves an exited run in All and in nothing else", () => {
+      seedMixedFleet();
+      render(<PilotView />);
+
+      expect(segment(/Finished/).getAttribute("aria-label")).toBe("Finished, 0 agents");
+      fireEvent.click(segment(/Working/));
+
+      expect(rowTitles().join(" ")).not.toContain("old shell");
+    });
+
+    it("moves the highlight off a row the filter removes", () => {
+      seedMixedFleet();
+      render(<PilotView />);
+      expect(document.querySelector('[aria-selected="true"]')?.textContent).toContain(
+        "auth blocked"
+      );
+
+      fireEvent.click(segment(/Working/));
+
+      // Enter committing a row that is no longer listed is the bug this guards.
+      const selected = document.querySelector('[aria-selected="true"]');
+      expect(selected?.textContent).toContain("auth working");
+    });
+
+    it("opens a persistently collapsed group that the filter matches", () => {
+      seedMixedFleet();
+      usePilotStore.setState({ isOpen: true, collapsedWorkspaceIds: ["p1"] });
+      render(<PilotView />);
+      expect(rowTitles().join(" ")).not.toContain("auth blocked");
+
+      fireEvent.click(segment(/Needs you/));
+
+      // Same rule the query already follows: making someone click to reveal
+      // what they just filtered for is the narrowing failing to do its job.
+      expect(rowTitles().join(" ")).toContain("auth blocked");
+    });
+
+    it("scopes a collapse made under a filter to that filter", () => {
+      seedMixedFleet();
+      render(<PilotView />);
+      fireEvent.click(segment(/Needs you/));
+
+      fireEvent.click(screen.getAllByTestId("pilot-group-toggle")[0]!);
+      expect(rowTitles()).toHaveLength(0);
+      // It must not leak into the persisted set, or the group would stay
+      // collapsed long after the filter was cleared.
+      expect(usePilotStore.getState().collapsedWorkspaceIds).toEqual([]);
+
+      fireEvent.click(segment(/^All/));
+      expect(rowTitles()).toHaveLength(4);
+    });
+
+    it("keeps the bar reachable when the narrowing leaves nothing", () => {
+      seedMixedFleet();
+      render(<PilotView />);
+
+      fireEvent.change(screen.getByTestId("pilot-search"), { target: { value: "zzzz" } });
+
+      // The moment the list is empty is exactly when the bar is the way back.
+      expect(screen.getByTestId("pilot-filter-bar")).toBeTruthy();
+    });
+
+    it("says nothing about states before the fleet has been read", () => {
+      // Four zero segments over an unknown fleet is a claim the surface cannot
+      // support, and over a genuinely empty one it is chrome competing with the
+      // sentence telling the user what to do.
+      seed(null);
+      const view = render(<PilotView />);
+      expect(screen.queryByTestId("pilot-filter-bar")).toBeNull();
+
+      seed([]);
+      view.rerender(<PilotView />);
+      expect(screen.queryByTestId("pilot-filter-bar")).toBeNull();
+    });
+
+    it("names both constraints when the two of them empty the list", () => {
+      // The ghost-filter dead end: hitting zero results with no way to see that
+      // a filter you set is the reason.
+      seedMixedFleet();
+      render(<PilotView />);
+
+      fireEvent.click(segment(/Working/));
+      fireEvent.change(screen.getByTestId("pilot-search"), { target: { value: "docs" } });
+
+      expect(screen.getByText('No matches for "docs" in Working')).toBeTruthy();
+      expect(screen.getByTestId("pilot-clear-filter")).toBeTruthy();
+    });
+
+    it("names the filter alone when it is the only thing excluding rows", () => {
+      seedMixedFleet();
+      render(<PilotView />);
+
+      fireEvent.click(segment(/Finished/));
+
+      expect(screen.getByText("No matches in Finished")).toBeTruthy();
+    });
+
+    it("clears the filter without discarding the query", () => {
+      // A targeted correction, not a reset — throwing away the typing as well
+      // would make the user retype what was never the problem.
+      seedMixedFleet();
+      render(<PilotView />);
+      fireEvent.click(segment(/Working/));
+      fireEvent.change(screen.getByTestId("pilot-search"), { target: { value: "docs" } });
+
+      fireEvent.click(screen.getByTestId("pilot-clear-filter"));
+
+      expect(screen.getByDisplayValue("docs")).toBeTruthy();
+      expect(rowTitles()).toHaveLength(1);
+      expect(rowTitles()[0]).toContain("docs asking");
+    });
+
+    it("starts every opening back at All", () => {
+      seedMixedFleet();
+      const view = render(<PilotView />);
+      fireEvent.click(segment(/Needs you/));
+      expect(rowTitles()).toHaveLength(2);
+
+      usePilotStore.setState({ isOpen: false });
+      view.rerender(<PilotView />);
+      usePilotStore.setState({ isOpen: true });
+      view.rerender(<PilotView />);
+
+      // A filter that persisted would reopen the surface already hiding agents,
+      // with the reason two openings in the past.
+      expect(rowTitles()).toHaveLength(4);
+    });
+  });
+
+  describe("footer demand", () => {
+    it("isolates exactly the agents it counted", () => {
+      seed([
+        run({
+          runId: "a",
+          agentState: "waiting",
+          waitingReason: "error",
+          title: "one",
+          since: NOW - 60_000,
+        }),
+        run({ runId: "b", agentState: "waiting", title: "two", since: NOW - 30_000 }),
+        run({ runId: "c", agentState: "working", title: "three", since: NOW - 10_000 }),
+      ]);
+      render(<PilotView />);
+
+      const action = screen.getByTestId("pilot-demand-action");
+      expect(action.textContent).toBe("2 agents need you");
+
+      fireEvent.click(action);
+
+      // The sentence stated a demand the surface gave no way to act on. As a
+      // control it has to deliver the number it advertised.
+      expect(screen.getAllByTestId("pilot-row")).toHaveLength(2);
+    });
+
+    it("does not count work awaiting review as a demand it can isolate", () => {
+      // `review` is a demand band but NOT part of the Needs-you segment, so
+      // counting it here would promise agents the button then failed to show.
+      seed([
+        run({ runId: "a", agentState: "waiting", title: "one", since: NOW - 60_000 }),
+        run({ runId: "b", agentState: "completed", title: "two", since: NOW - 30_000 }),
+      ]);
+      render(<PilotView />);
+
+      expect(screen.getByTestId("pilot-demand-action").textContent).toBe("Agent needs you");
+
+      fireEvent.click(screen.getByTestId("pilot-demand-action"));
+      expect(screen.getAllByTestId("pilot-row")).toHaveLength(1);
+    });
+
+    it("still reports finished work when nothing else is asking", () => {
+      // Dropping review from the demand count must not make a hand-back
+      // disappear into "nothing needs you".
+      seed([run({ runId: "a", agentState: "completed", title: "one", since: NOW - 30_000 })]);
+      render(<PilotView />);
+
+      expect(screen.getByTestId("pilot-summary").textContent).toBe("Ready for review");
+      expect(screen.queryByTestId("pilot-demand-action")).toBeNull();
+    });
+
+    it("leaves the summary inert when there is no demand to isolate", () => {
+      seed([run({ agentState: "working", since: NOW - 60_000 })]);
+      render(<PilotView />);
+
+      expect(screen.getByText(/Nothing needs you/)).toBeTruthy();
+      expect(screen.queryByTestId("pilot-demand-action")).toBeNull();
+    });
+  });
+
+  describe("group headers", () => {
+    it("summarises a project only once its rows are gone", () => {
+      // Expanded, the rows ARE the summary; a sentence restating them is a
+      // third thing to read for facts already on screen.
+      seed([
+        run({
+          runId: "a",
+          agentState: "waiting",
+          waitingReason: "error",
+          title: "one",
+          since: NOW - 60_000,
+        }),
+        run({ runId: "b", agentState: "working", title: "two", since: NOW - 60_000 }),
+      ]);
+      render(<PilotView />);
+
+      const header = () => screen.getByTestId("pilot-group-header").textContent ?? "";
+      // Expanded, the header is structure and nothing else — no prose summary,
+      // no counts.
+      expect(header()).not.toContain("Agent blocked");
+      expect(header()).not.toMatch(/\d/);
+
+      fireEvent.click(screen.getByTestId("pilot-group-toggle"));
+
+      // Collapsed, something has to stop a project hiding a blocked agent
+      // behind a chevron — one pip per band present, each with its count.
+      expect(header()).toMatch(/\d/);
+    });
+
+    it("reports a collapsed project's blocked agent through the toggle's name", () => {
+      seed([
+        run({
+          runId: "a",
+          agentState: "waiting",
+          waitingReason: "error",
+          title: "one",
+          since: NOW - 60_000,
+        }),
+        run({ runId: "b", agentState: "working", title: "two", since: NOW - 60_000 }),
+      ]);
+      usePilotStore.setState({ isOpen: true, collapsedWorkspaceIds: ["p1"] });
+      render(<PilotView />);
+
+      // The pips are decorative; the accessible account is the toggle's label,
+      // and it has to carry the demand in both states.
+      const label = screen.getByTestId("pilot-group-toggle").getAttribute("aria-label") ?? "";
+      expect(label).toContain("daintree");
+      expect(label).toContain("Agent blocked");
     });
   });
 

--- a/src/components/Pilot/__tests__/PilotView.test.tsx
+++ b/src/components/Pilot/__tests__/PilotView.test.tsx
@@ -1029,6 +1029,58 @@ describe("PilotView", () => {
       fireEvent.change(screen.getByTestId("pilot-search"), { target: { value: "" } });
 
       expect(screen.getByText("No matches with Finished selected")).toBeTruthy();
+      // Not merely "the new title exists" — the quoted one must no longer be
+      // PRESENTED, or a deleted query goes on being quoted back at the user.
+      // `EmptyState` cross-fades, so the old title may still be in the DOM;
+      // what it may not be is visible to anyone, which is what its exit cell's
+      // `aria-hidden` + `inert` pair guarantees.
+      for (const stale of screen.queryAllByText(/No matches for/)) {
+        expect(stale.closest('[aria-hidden="true"],[inert]')).not.toBeNull();
+      }
+    });
+
+    it("keeps the footer honest about whose keys are whose", () => {
+      // The hints describe the LIST's keys. On a filter segment those keys move
+      // between segments instead, so leaving "↵ Open" up is the same false
+      // promise the footer already drops over an empty list.
+      seedMixedFleet();
+      render(<PilotView />);
+      expect(screen.getByText("Open")).toBeTruthy();
+
+      act(() => {
+        segment(/^All/).focus();
+      });
+      expect(screen.queryByText("Open")).toBeNull();
+
+      act(() => {
+        screen.getByTestId("pilot-search").focus();
+      });
+      expect(screen.getByText("Open")).toBeTruthy();
+    });
+
+    it("restores the hints after the bar disappears under the cursor", () => {
+      // Removing a focused element fires no reliable blur, so a fleet that
+      // drains while a segment holds focus would leave the flag stuck and the
+      // hints suppressed for the rest of the opening.
+      seedMixedFleet();
+      const view = render(<PilotView />);
+      act(() => {
+        segment(/^All/).focus();
+      });
+      expect(screen.queryByText("Open")).toBeNull();
+
+      act(() => {
+        seed([]);
+      });
+      view.rerender(<PilotView />);
+      expect(screen.queryByTestId("pilot-filter-bar")).toBeNull();
+
+      act(() => {
+        seedMixedFleet();
+      });
+      view.rerender(<PilotView />);
+
+      expect(screen.getByText("Open")).toBeTruthy();
     });
 
     it("hands focus back when the clear control removes itself", () => {
@@ -1074,8 +1126,12 @@ describe("PilotView", () => {
         ]);
       });
       fireEvent.click(screen.getByRole("radio", { name: /Needs you/ }));
-      fireEvent.click(screen.getByRole("radio", { name: /^All/ }));
+      // Asserted WHILE narrowed, not only after returning to All: a filter that
+      // re-derived the order would be invisible if the check waited until the
+      // pinned order had been restored anyway.
+      expect(titles()).toEqual(opening);
 
+      fireEvent.click(screen.getByRole("radio", { name: /^All/ }));
       expect(titles()).toEqual(opening);
     });
 
@@ -1178,6 +1234,21 @@ describe("PilotView", () => {
 
       expect(screen.getByTestId("pilot-summary").textContent).toBe("Ready for review");
       expect(screen.queryByTestId("pilot-demand-action")).toBeNull();
+    });
+
+    it("is named by the sentence it shows, not by a second phrasing of it", () => {
+      // An action-phrased label ("Show 2 agents that need you") does not
+      // contain the visible text, which is a label-in-name failure for anyone
+      // driving the app by voice — and its singular read "1 agent that need
+      // you". The visible sentence has to BE the name.
+      seed([
+        run({ runId: "a", agentState: "waiting", title: "one", since: NOW - 60_000 }),
+        run({ runId: "b", agentState: "waiting", title: "two", since: NOW - 30_000 }),
+      ]);
+      render(<PilotView />);
+
+      const action = screen.getByTestId("pilot-demand-action");
+      expect(screen.getByRole("button", { name: action.textContent ?? "" })).toBe(action);
     });
 
     it("leaves the summary inert when there is no demand to isolate", () => {

--- a/src/components/Pilot/__tests__/PilotView.test.tsx
+++ b/src/components/Pilot/__tests__/PilotView.test.tsx
@@ -197,6 +197,35 @@ describe("PilotView", () => {
     expect(screen.getByRole("option", { name: /Idle/ }).textContent).toContain("two");
   });
 
+  it("names a row as a sentence rather than a run of jammed-together facts", () => {
+    // Left to the name-from-content computation these inline spans concatenate
+    // with no separators — "Fix authWorkingfeature-x2m". Naming the parts is
+    // what keeps the row a phrase, and what lets the age be read as an age.
+    seed([
+      run({
+        runId: "a",
+        agentState: "waiting",
+        title: "Fix auth",
+        cwd: "/repo/feature-x",
+        since: NOW - 120_000,
+      }),
+    ]);
+    render(<PilotView />);
+
+    expect(screen.getByTestId("pilot-row").getAttribute("aria-label")).toBe(
+      "Fix auth, Needs you, feature-x, 2m ago"
+    );
+  });
+
+  it("leaves no dangling separator when a run has no age to report", () => {
+    seed([run({ runId: "a", agentState: "working", title: "Fix auth", cwd: "/repo/feature-x" })]);
+    render(<PilotView />);
+
+    expect(screen.getByTestId("pilot-row").getAttribute("aria-label")).toBe(
+      "Fix auth, Working, feature-x"
+    );
+  });
+
   it("spends colour only on the agents that are actually asking for something", () => {
     // The whole point of the surface. One blocked agent among six working ones
     // has to be the only status word on screen — six green labels beside one
@@ -219,13 +248,12 @@ describe("PilotView", () => {
     const rows = screen.getAllByTestId("pilot-row");
     expect(rows).toHaveLength(7);
 
-    // A status word the eye can see is one that isn't screen-reader-only.
-    const visibleStatuses = rows.flatMap((row) =>
-      Array.from(row.querySelectorAll("span")).filter(
-        (el) => el.textContent === "Blocked" && !el.classList.contains("sr-only")
-      )
-    );
-    expect(visibleStatuses).toHaveLength(1);
+    // Rendered text is what the eye sees, and only the demand row spends a
+    // word on its state — the six working rows say nothing visible about
+    // theirs.
+    const withVisibleStatus = rows.filter((row) => /Blocked|Working/.test(row.textContent ?? ""));
+    expect(withVisibleStatus).toHaveLength(1);
+    expect(withVisibleStatus[0]!.textContent).toContain("Blocked");
 
     // ...and every one of the seven still says what it is doing, in text.
     expect(screen.getAllByRole("option", { name: /Working/ })).toHaveLength(6);
@@ -776,7 +804,7 @@ describe("PilotView", () => {
   });
 
   describe("state filter", () => {
-    /** Blocked + needs-you in one project, working + done in another. */
+    /** Blocked + needs-you in one project, working + an exited shell in another. */
     function seedMixedFleet(): void {
       seed([
         run({
@@ -873,6 +901,24 @@ describe("PilotView", () => {
       );
     });
 
+    it("sorts review into Finished and out of Needs you", () => {
+      // The asymmetry worth pinning: `review` IS a demand band, so it counts
+      // toward `demandCount`, but the Needs-you segment is blocked + needs-you
+      // only. A review row must land in exactly one of the two segments.
+      seed([
+        run({ runId: "r", agentState: "completed", title: "handed back", since: NOW - 30_000 }),
+        run({ runId: "w", agentState: "waiting", title: "asking", since: NOW - 30_000 }),
+      ]);
+      render(<PilotView />);
+
+      expect(segment(/Needs you/).getAttribute("aria-label")).toBe("Needs you, 1 agent");
+      expect(segment(/Finished/).getAttribute("aria-label")).toBe("Finished, 1 agent");
+
+      fireEvent.click(segment(/Finished/));
+      expect(rowTitles()).toHaveLength(1);
+      expect(rowTitles()[0]).toContain("handed back");
+    });
+
     it("leaves an exited run in All and in nothing else", () => {
       seedMixedFleet();
       render(<PilotView />);
@@ -957,7 +1003,7 @@ describe("PilotView", () => {
       fireEvent.click(segment(/Working/));
       fireEvent.change(screen.getByTestId("pilot-search"), { target: { value: "docs" } });
 
-      expect(screen.getByText('No matches for "docs" in Working')).toBeTruthy();
+      expect(screen.getByText('No matches for "docs" with Working selected')).toBeTruthy();
       expect(screen.getByTestId("pilot-clear-filter")).toBeTruthy();
     });
 
@@ -967,7 +1013,70 @@ describe("PilotView", () => {
 
       fireEvent.click(segment(/Finished/));
 
-      expect(screen.getByText("No matches in Finished")).toBeTruthy();
+      expect(screen.getByText("No matches with Finished selected")).toBeTruthy();
+    });
+
+    it("stops naming a query the moment it is cleared", () => {
+      // The filter keeps the narrowed branch mounted after the box empties, so
+      // a deferred query value would go on being quoted over text the user has
+      // already deleted.
+      seedMixedFleet();
+      render(<PilotView />);
+      fireEvent.click(segment(/Finished/));
+      fireEvent.change(screen.getByTestId("pilot-search"), { target: { value: "docs" } });
+      expect(screen.getByText('No matches for "docs" with Finished selected')).toBeTruthy();
+
+      fireEvent.change(screen.getByTestId("pilot-search"), { target: { value: "" } });
+
+      expect(screen.getByText("No matches with Finished selected")).toBeTruthy();
+    });
+
+    it("hands focus back when the clear control removes itself", () => {
+      // The button unmounts on click, and with an unmatched query left behind
+      // there is no row to arrow to either — so focus has to be placed, not
+      // dropped on the document.
+      seedMixedFleet();
+      render(<PilotView />);
+      fireEvent.click(segment(/Working/));
+      fireEvent.change(screen.getByTestId("pilot-search"), { target: { value: "zzzz" } });
+
+      fireEvent.click(screen.getByTestId("pilot-clear-filter"));
+
+      expect(document.activeElement).toBe(screen.getByTestId("pilot-search"));
+    });
+
+    it("holds the opening order while a filter comes and goes", () => {
+      // `frozenOrder` pins position for the whole opening. A filter must narrow
+      // that order, never re-derive one — every row here is a click target.
+      seed([
+        run({ runId: "a", agentState: "waiting", title: "alpha", since: NOW - 10_000 }),
+        run({ runId: "b", agentState: "waiting", title: "bravo", since: NOW - 5_000 }),
+      ]);
+      render(<PilotView />);
+      // Titles, not full text: "bravo" changes band below, so its visible
+      // status word legitimately changes. Position is what must not.
+      const titles = () =>
+        screen.getAllByTestId("pilot-row").map((r) => r.getAttribute("aria-label")?.split(",")[0]);
+      const opening = titles();
+
+      // "bravo" becomes the more urgent of the two, which would reorder them
+      // on a fresh sort.
+      act(() => {
+        seed([
+          run({ runId: "a", agentState: "waiting", title: "alpha", since: NOW - 10_000 }),
+          run({
+            runId: "b",
+            agentState: "waiting",
+            waitingReason: "error",
+            title: "bravo",
+            since: NOW,
+          }),
+        ]);
+      });
+      fireEvent.click(screen.getByRole("radio", { name: /Needs you/ }));
+      fireEvent.click(screen.getByRole("radio", { name: /^All/ }));
+
+      expect(titles()).toEqual(opening);
     });
 
     it("clears the filter without discarding the query", () => {
@@ -1024,6 +1133,25 @@ describe("PilotView", () => {
 
       // The sentence stated a demand the surface gave no way to act on. As a
       // control it has to deliver the number it advertised.
+      expect(screen.getAllByTestId("pilot-row")).toHaveLength(2);
+    });
+
+    it("delivers its count even when its filter is already the active one", () => {
+      // With the filter already on Needs you, setting it again is a no-op, so
+      // nothing clears a collapse the user made — and the button would go on
+      // advertising agents while showing none of them.
+      seed([
+        run({ runId: "a", agentState: "waiting", title: "one", since: NOW - 60_000 }),
+        run({ runId: "b", agentState: "waiting", title: "two", since: NOW - 30_000 }),
+      ]);
+      render(<PilotView />);
+
+      fireEvent.click(screen.getByRole("radio", { name: /Needs you/ }));
+      fireEvent.click(screen.getByTestId("pilot-group-toggle"));
+      expect(screen.queryAllByTestId("pilot-row")).toHaveLength(0);
+
+      fireEvent.click(screen.getByTestId("pilot-demand-action"));
+
       expect(screen.getAllByTestId("pilot-row")).toHaveLength(2);
     });
 

--- a/src/components/Pilot/__tests__/pilotRows.test.ts
+++ b/src/components/Pilot/__tests__/pilotRows.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   buildPilotGroups,
+  countPilotBands,
+  filterPilotBands,
   filterPilotGroups,
   summarizePilotGroups,
   type PilotRowContext,
@@ -242,6 +244,188 @@ describe("buildPilotGroups", () => {
     );
 
     expect(groups.map((g) => g.name)).toEqual(["alpha", "beta"]);
+  });
+
+  it("does not let activity times reorder two equally quiet projects", () => {
+    // The tiebreak used to be recency, so the order changed between every
+    // opening and spatial memory never formed. Same fleet, only the timestamps
+    // swapped: the order has to be the same both times.
+    const quiet = (aSince: number, bSince: number) =>
+      buildPilotGroups(
+        [
+          run({ runId: "a", workspaceId: "p1", agentState: "working", since: aSince }),
+          run({ runId: "b", workspaceId: "p2", agentState: "working", since: bSince }),
+        ],
+        ctx({
+          workspaces: new Map([
+            ["p1", { kind: "project", name: "beta" }],
+            ["p2", { kind: "project", name: "alpha" }],
+          ]),
+        })
+      ).map((g) => g.name);
+
+    expect(quiet(NOW - 600_000, NOW)).toEqual(quiet(NOW, NOW - 600_000));
+  });
+
+  it("puts the longest-standing demand first among equally urgent projects", () => {
+    // The anti-starvation rule the rows already follow, now applied a level up:
+    // a stream of fresh blocks must never bury the one stuck for forty minutes.
+    const groups = buildPilotGroups(
+      [
+        run({
+          runId: "fresh",
+          workspaceId: "p1",
+          agentState: "waiting",
+          waitingReason: "error",
+          since: NOW - 60_000,
+        }),
+        run({
+          runId: "stale",
+          workspaceId: "p2",
+          agentState: "waiting",
+          waitingReason: "error",
+          since: NOW - 40 * 60_000,
+        }),
+      ],
+      ctx({
+        workspaces: new Map([
+          // Named so alphabetical order would give the opposite answer.
+          ["p1", { kind: "project", name: "aaa" }],
+          ["p2", { kind: "project", name: "zzz" }],
+        ]),
+      })
+    );
+
+    expect(groups.map((g) => g.name)).toEqual(["zzz", "aaa"]);
+  });
+
+  it("dates a project by its oldest demand, not by its oldest run", () => {
+    // A project whose blocked agent is fresh must not inherit urgency from a
+    // long-running working agent sitting beside it.
+    const groups = buildPilotGroups(
+      [
+        run({
+          runId: "old-work",
+          workspaceId: "p1",
+          agentState: "working",
+          since: NOW - 3_600_000,
+        }),
+        run({
+          runId: "fresh-block",
+          workspaceId: "p1",
+          agentState: "waiting",
+          waitingReason: "error",
+          since: NOW - 1_000,
+        }),
+        run({
+          runId: "older-block",
+          workspaceId: "p2",
+          agentState: "waiting",
+          waitingReason: "error",
+          since: NOW - 60_000,
+        }),
+      ],
+      ctx({
+        workspaces: new Map([
+          ["p1", { kind: "project", name: "aaa" }],
+          ["p2", { kind: "project", name: "zzz" }],
+        ]),
+      })
+    );
+
+    expect(groups.map((g) => g.name)).toEqual(["zzz", "aaa"]);
+  });
+
+  it("sorts a demand of unknown age behind one it can actually date", () => {
+    // An unknown age is not evidence of urgency — treating it as infinitely old
+    // would let a pre-detection boot window outrank a genuine wait.
+    const groups = buildPilotGroups(
+      [
+        run({ runId: "undated", workspaceId: "p1", agentState: "waiting" }),
+        run({ runId: "dated", workspaceId: "p2", agentState: "waiting", since: NOW - 1_000 }),
+      ],
+      ctx({
+        workspaces: new Map([
+          ["p1", { kind: "project", name: "aaa" }],
+          ["p2", { kind: "project", name: "zzz" }],
+        ]),
+      })
+    );
+
+    expect(groups.map((g) => g.name)).toEqual(["zzz", "aaa"]);
+  });
+
+  it("gives the current workspace primacy only among equally quiet projects", () => {
+    const groups = buildPilotGroups(
+      [
+        run({ runId: "a", workspaceId: "p1", agentState: "working", since: NOW }),
+        run({ runId: "b", workspaceId: "p2", agentState: "working", since: NOW }),
+      ],
+      ctx({
+        currentWorkspaceId: "p2",
+        workspaces: new Map([
+          ["p1", { kind: "project", name: "alpha" }],
+          ["p2", { kind: "project", name: "zeta" }],
+        ]),
+      })
+    );
+
+    // Alphabetically last, but it is the workspace this view already owns and
+    // neither project has anything urgent to say.
+    expect(groups.map((g) => g.name)).toEqual(["zeta", "alpha"]);
+  });
+
+  it("never lets the current workspace outrank another project's demand", () => {
+    // Context above severity would bury a blocked agent somewhere else, which is
+    // the exact failure the band ordering exists to prevent.
+    const groups = buildPilotGroups(
+      [
+        run({ runId: "a", workspaceId: "p1", agentState: "working", since: NOW }),
+        run({
+          runId: "b",
+          workspaceId: "p2",
+          agentState: "waiting",
+          waitingReason: "error",
+          since: NOW,
+        }),
+      ],
+      ctx({
+        currentWorkspaceId: "p1",
+        workspaces: new Map([
+          ["p1", { kind: "project", name: "here" }],
+          ["p2", { kind: "project", name: "elsewhere" }],
+        ]),
+      })
+    );
+
+    expect(groups.map((g) => g.name)).toEqual(["elsewhere", "here"]);
+  });
+
+  it("orders two identically named projects the same way whatever order they arrive in", () => {
+    // Two checkouts of one repo, or a scratch sharing a project's name, is
+    // ordinary. Without a final tiebreak the comparator stops being a total
+    // order and "the same fleet opens the same way" quietly becomes false.
+    const named = (runs: Parameters<typeof buildPilotGroups>[0]) =>
+      buildPilotGroups(
+        runs,
+        ctx({
+          workspaces: new Map([
+            ["p1", { kind: "project", name: "same" }],
+            ["p2", { kind: "project", name: "same" }],
+          ]),
+        })
+      ).map((g) => g.workspaceId);
+
+    const forward = named([
+      run({ runId: "a", workspaceId: "p1", agentState: "working", since: NOW }),
+      run({ runId: "b", workspaceId: "p2", agentState: "working", since: NOW }),
+    ]);
+    const backward = named([
+      run({ runId: "b", workspaceId: "p2", agentState: "working", since: NOW }),
+      run({ runId: "a", workspaceId: "p1", agentState: "working", since: NOW }),
+    ]);
+
+    expect(forward).toEqual(backward);
   });
 
   it("orders rows inside a project worst-first, then oldest-first", () => {
@@ -525,6 +709,163 @@ describe("filterPilotGroups", () => {
     expect(severity(filtered!.topBand)).toBeGreaterThan(severity(unfiltered[0]!.topBand));
     // The band is whatever the worst surviving row is, never a remembered one.
     expect(filtered!.topBand).toBe(filtered!.rows[0]!.band);
+  });
+});
+
+describe("countPilotBands", () => {
+  /** One run in each of the six bands, spread over two projects. */
+  const wholeFleet = () =>
+    buildPilotGroups(
+      [
+        run({
+          runId: "blocked",
+          workspaceId: "p1",
+          agentState: "waiting",
+          waitingReason: "error",
+          since: NOW,
+        }),
+        run({ runId: "needs", workspaceId: "p1", agentState: "waiting", since: NOW }),
+        run({ runId: "review", workspaceId: "p1", agentState: "completed", since: NOW }),
+        run({ runId: "running", workspaceId: "p2", agentState: "working", since: NOW }),
+        run({
+          runId: "done",
+          workspaceId: "p2",
+          agentState: "completed",
+          since: NOW - 120_000,
+        }),
+        run({ runId: "idle", workspaceId: "p2", agentState: "exited", since: NOW }),
+      ],
+      ctx({
+        workspaces: new Map([
+          ["p1", { kind: "project", name: "one" }],
+          // Acknowledged after `done` finished but before `review` did, so the
+          // two completions land in different bands.
+          ["p2", { kind: "project", name: "two", lastCompletionSeenAt: NOW - 60_000 }],
+        ]),
+      })
+    );
+
+  it("maps all six bands onto the four segments", () => {
+    const counts = countPilotBands(wholeFleet());
+
+    expect(counts.all).toBe(6);
+    // Blocked and needs-you are one demand; review is a hand-back, not a block.
+    expect(counts["needs-you"]).toBe(2);
+    expect(counts.working).toBe(1);
+    expect(counts.finished).toBe(2);
+  });
+
+  it("leaves an exited run out of every segment but All", () => {
+    // An exited terminal isn't working, isn't finished, and isn't asking for
+    // anything — putting it in a bucket would make that bucket lie.
+    const counts = countPilotBands(
+      buildPilotGroups([run({ runId: "gone", agentState: "exited", since: NOW })], ctx())
+    );
+
+    expect(counts.all).toBe(1);
+    expect(counts["needs-you"] + counts.working + counts.finished).toBe(0);
+  });
+
+  it("counts the population it was handed, so a query narrows the segments", () => {
+    const built = buildPilotGroups(
+      [
+        run({ runId: "a", agentState: "waiting", title: "auth refactor", since: NOW }),
+        run({ runId: "b", agentState: "waiting", title: "docs pass", since: NOW }),
+      ],
+      ctx()
+    );
+
+    expect(countPilotBands(built)["needs-you"]).toBe(2);
+    expect(countPilotBands(filterPilotGroups(built, "auth"))["needs-you"]).toBe(1);
+  });
+});
+
+describe("filterPilotBands", () => {
+  const mixed = () =>
+    buildPilotGroups(
+      [
+        run({
+          runId: "blocked",
+          workspaceId: "p1",
+          agentState: "waiting",
+          waitingReason: "error",
+          since: NOW,
+        }),
+        run({ runId: "working", workspaceId: "p1", agentState: "working", since: NOW }),
+        run({ runId: "idle", workspaceId: "p2", agentState: "exited", since: NOW }),
+      ],
+      ctx({
+        workspaces: new Map([
+          ["p1", { kind: "project", name: "one" }],
+          ["p2", { kind: "project", name: "two" }],
+        ]),
+      })
+    );
+
+  it("returns every row untouched for All", () => {
+    const all = filterPilotBands(mixed(), "all");
+    expect(all.flatMap((g) => g.rows.map((r) => r.run.runId))).toEqual([
+      "blocked",
+      "working",
+      "idle",
+    ]);
+  });
+
+  it("drops a group the segment leaves empty", () => {
+    const filtered = filterPilotBands(mixed(), "needs-you");
+
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]!.rows.map((r) => r.run.runId)).toEqual(["blocked"]);
+  });
+
+  it("recounts the demand tally against the surviving rows", () => {
+    const [group] = filterPilotBands(mixed(), "working");
+
+    // "working" survives in a project whose blocked run the segment removed —
+    // an inherited tally would report a demand no longer on screen.
+    expect(group!.demandCount).toBe(0);
+    expect(group!.topBand).toBe("running");
+  });
+
+  it("finds the worst surviving band by rank, not by whichever row is first", () => {
+    // Rows reaching a filter have been through `frozenOrder`, which pins the
+    // order captured when the dialog opened — so once a run changes state the
+    // first row is no longer the worst one present. Reading the band off row
+    // zero would put a header's summary and its pip cluster at odds with the
+    // rows directly underneath.
+    const [built] = buildPilotGroups(
+      [
+        run({ runId: "urgent", agentState: "waiting", waitingReason: "error", since: NOW }),
+        run({ runId: "asking", agentState: "waiting", since: NOW }),
+        run({ runId: "calm", agentState: "working", since: NOW }),
+      ],
+      ctx()
+    );
+    const frozen = { ...built!, rows: [...built!.rows].reverse() };
+
+    const [narrowed] = filterPilotBands([frozen], "needs-you");
+
+    // Both demand rows survive, in the pinned order that puts the milder one
+    // first — the band still has to come back as the worse of the two.
+    expect(narrowed!.rows.map((r) => r.run.runId)).toEqual(["asking", "urgent"]);
+    expect(narrowed!.rows[0]!.band).toBe("needs-you");
+    expect(narrowed!.topBand).toBe("blocked");
+  });
+
+  it("intersects with a query rather than replacing it", () => {
+    const built = buildPilotGroups(
+      [
+        run({ runId: "a", agentState: "waiting", title: "auth refactor", since: NOW }),
+        run({ runId: "b", agentState: "working", title: "auth rewrite", since: NOW }),
+        run({ runId: "c", agentState: "waiting", title: "docs pass", since: NOW }),
+      ],
+      ctx()
+    );
+
+    const both = filterPilotBands(filterPilotGroups(built, "auth"), "needs-you");
+
+    // Only the row satisfying BOTH constraints survives.
+    expect(both.flatMap((g) => g.rows.map((r) => r.run.runId))).toEqual(["a"]);
   });
 });
 

--- a/src/components/Pilot/__tests__/pilotRows.test.ts
+++ b/src/components/Pilot/__tests__/pilotRows.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  bandFilterHasDemand,
   buildPilotGroups,
   countPilotBands,
   filterPilotBands,
@@ -8,7 +9,7 @@ import {
   type PilotRowContext,
 } from "../pilotRows";
 import type { FleetRunRow } from "@shared/types/ipc/fleet";
-import { FLEET_BANDS, type FleetBand } from "@/lib/fleetAttention";
+import { emptyBandCounts, FLEET_BANDS, type FleetBand } from "@/lib/fleetAttention";
 
 const NOW = 1_700_000_000_000;
 
@@ -777,6 +778,34 @@ describe("countPilotBands", () => {
 
     expect(countPilotBands(built)["needs-you"]).toBe(2);
     expect(countPilotBands(filterPilotGroups(built, "auth"))["needs-you"]).toBe(1);
+  });
+});
+
+describe("bandFilterHasDemand", () => {
+  const bands = (overrides: Partial<Record<FleetBand, number>> = {}) => ({
+    ...emptyBandCounts(),
+    ...overrides,
+  });
+
+  it("separates a Finished segment awaiting review from one already acknowledged", () => {
+    // The whole reason this exists: both are "2 finished", and only one of them
+    // is still asking to be looked at.
+    expect(bandFilterHasDemand(bands({ review: 2 }), "finished")).toBe(true);
+    expect(bandFilterHasDemand(bands({ done: 2 }), "finished")).toBe(false);
+  });
+
+  it("treats any populated Needs-you segment as a demand", () => {
+    // Every band it admits is a demand, so membership alone settles it.
+    expect(bandFilterHasDemand(bands({ blocked: 1 }), "needs-you")).toBe(true);
+    expect(bandFilterHasDemand(bands({ "needs-you": 1 }), "needs-you")).toBe(true);
+    expect(bandFilterHasDemand(bands(), "needs-you")).toBe(false);
+  });
+
+  it("never reports a demand for Working or All", () => {
+    // Working holds none by definition; All is the null option and colouring it
+    // would hue the bar whenever the fleet held anything at all.
+    expect(bandFilterHasDemand(bands({ running: 5 }), "working")).toBe(false);
+    expect(bandFilterHasDemand(bands({ blocked: 5 }), "all")).toBe(false);
   });
 });
 

--- a/src/components/Pilot/pilotRows.ts
+++ b/src/components/Pilot/pilotRows.ts
@@ -100,11 +100,54 @@ function rank(band: FleetBand): number {
   return BAND_RANK.get(band) ?? FLEET_BANDS.length;
 }
 
-/** Most recent state transition in a project, for the severity tiebreak. */
-function latestActivity(runs: readonly FleetRunRow[]): number {
-  let latest = 0;
-  for (const run of runs) if (run.since !== undefined && run.since > latest) latest = run.since;
-  return latest;
+/**
+ * A group restricted to a subset of its own rows, with both derived fields
+ * recomputed rather than inherited.
+ *
+ * `topBand` is found by RANK across the survivors rather than read off
+ * `rows[0]`. Rows reaching a filter have already been through `frozenOrder`,
+ * which pins the order captured when the dialog opened — so once a run changes
+ * state the first row is no longer guaranteed to be the worst one present.
+ * Inheriting either field would put a header's summary and its collapsed pip
+ * cluster at odds with the rows directly underneath it.
+ */
+function narrowGroup(group: PilotProjectGroup, rows: PilotRow[]): PilotProjectGroup {
+  let topBand: FleetBand = "idle";
+  // Annotated: `FLEET_BANDS` is a const tuple, so its `length` narrows to the
+  // literal 6 and the accumulator would refuse every rank assigned below it.
+  let best: number = FLEET_BANDS.length;
+  let demandCount = 0;
+  for (const row of rows) {
+    const rowRank = rank(row.band);
+    if (rowRank < best) {
+      best = rowRank;
+      topBand = row.band;
+    }
+    if (isDemandBand(row.band)) demandCount++;
+  }
+  return { ...group, rows, demandCount, topBand };
+}
+
+/**
+ * Oldest still-outstanding demand in a project, or undefined when it has none.
+ *
+ * This is the group-level twin of {@link compareWithinBand}'s row rule, which
+ * is the point: the two levels finally agree about what "most urgent" means,
+ * and a project whose block has been standing for forty minutes stops being
+ * displaced by one that only just started asking.
+ *
+ * A demand with no `since` contributes nothing rather than counting as
+ * infinitely old — an unknown age is not evidence of urgency.
+ */
+function oldestDemand(rows: readonly PilotRow[]): number | undefined {
+  let oldest: number | undefined;
+  for (const row of rows) {
+    if (!isDemandBand(row.band)) continue;
+    const since = row.run.since;
+    if (since === undefined) continue;
+    if (oldest === undefined || since < oldest) oldest = since;
+  }
+  return oldest;
 }
 
 /**
@@ -115,8 +158,19 @@ function latestActivity(runs: readonly FleetRunRow[]): number {
  * running eight idle agents would otherwise bury one holding a single blocked
  * agent, which is the documented failure mode of count-based ranking in
  * operator tools. Volume is reported as a count on the header instead, where it
- * informs without competing for position. Projects tied on severity fall back
- * to most-recent activity, then to name, so the order is always explainable.
+ * informs without competing for position.
+ *
+ * Ties break on the oldest outstanding demand, NOT on recency. Recency changed
+ * between every single opening, so the group order was never the same twice and
+ * spatial memory never formed — and it inverted the anti-starvation rule the
+ * rows themselves already follow. Quiet projects, which have no demand to date,
+ * fall back to the workspace this view already owns and then to name, so their
+ * order is fixed for as long as they stay quiet and only genuinely demanding
+ * projects float.
+ *
+ * The current workspace is deliberately NOT pinned above severity: putting
+ * context first would bury a blocked agent in another project, which is the
+ * exact failure the band ordering exists to prevent.
  */
 export function buildPilotGroups(
   runs: readonly FleetRunRow[],
@@ -129,7 +183,7 @@ export function buildPilotGroups(
     else byWorkspace.set(run.workspaceId, [run]);
   }
 
-  const groups: Array<PilotProjectGroup & { latestActivity: number }> = [];
+  const groups: Array<PilotProjectGroup & { oldestDemand: number | undefined }> = [];
   for (const [workspaceId, workspaceRuns] of byWorkspace) {
     const meta = ctx.workspaces.get(workspaceId);
     // A run whose workspace has been removed from the store still has to render
@@ -198,19 +252,39 @@ export function buildPilotGroups(
       rows,
       demandCount: rows.filter((r) => isDemandBand(r.band)).length,
       topBand: rows[0]?.band ?? "idle",
-      latestActivity: latestActivity(workspaceRuns),
+      oldestDemand: oldestDemand(rows),
     });
   }
 
   groups.sort((a, b) => {
     const byBand = rank(a.topBand) - rank(b.topBand);
     if (byBand !== 0) return byBand;
-    const byRecency = b.latestActivity - a.latestActivity;
-    if (byRecency !== 0) return byRecency;
-    return a.name.localeCompare(b.name);
+
+    // Both sides share a top band here, so testing either one answers for the
+    // pair. A demand band ranks by how long it has been outstanding; anything
+    // else has no urgency to compare and gives primacy to the workspace this
+    // view is already in, where opening a run costs no switch.
+    if (isDemandBand(a.topBand)) {
+      const ao = a.oldestDemand;
+      const bo = b.oldestDemand;
+      if (ao !== undefined && bo !== undefined && ao !== bo) return ao - bo;
+      if (ao === undefined && bo !== undefined) return 1;
+      if (bo === undefined && ao !== undefined) return -1;
+    } else if (a.isCurrent !== b.isCurrent) {
+      return a.isCurrent ? -1 : 1;
+    }
+
+    const byName = a.name.localeCompare(b.name);
+    if (byName !== 0) return byName;
+    // Workspace id last, so the comparator is a TRUE total order. Two projects
+    // sharing a name is ordinary (a scratch and a project, or two checkouts),
+    // and leaving them to `sort`'s arbitrary decision would make "the same
+    // fleet opens in the same order" false exactly where it is hardest to see.
+    if (a.workspaceId === b.workspaceId) return 0;
+    return a.workspaceId < b.workspaceId ? -1 : 1;
   });
 
-  return groups.map(({ latestActivity: _latest, ...group }) => group);
+  return groups.map(({ oldestDemand: _oldest, ...group }) => group);
 }
 
 /**
@@ -254,17 +328,102 @@ export function filterPilotGroups(
         isFilterMatch(needle, row.chrome.label)
     );
     if (rows.length === 0) continue;
-    out.push({
-      ...group,
-      rows,
-      demandCount: rows.filter((r) => isDemandBand(r.band)).length,
-      // Recomputed, never inherited: a query that filters the blocked run out of
-      // a project leaves a group whose header would otherwise still announce
-      // "0 agents blocked" in danger red over a row that is merely running.
-      // `filter` preserves the band-sorted order, so the first survivor is still
-      // the worst one left.
-      topBand: rows[0]?.band ?? "idle",
-    });
+    // Recomputed, never inherited: a query that filters the blocked run out of
+    // a project leaves a group whose header would otherwise still announce
+    // "0 agents blocked" over a row that is merely running.
+    out.push(narrowGroup(group, rows));
+  }
+  return out;
+}
+
+/**
+ * The state filter's vocabulary, declared beside the bands so a segment and the
+ * count under it can never drift apart.
+ */
+export type PilotBandFilter = "all" | "needs-you" | "working" | "finished";
+
+/**
+ * Which bands each segment admits.
+ *
+ * `idle` is deliberately in no bucket but All: an exited terminal isn't
+ * working, isn't finished, and isn't asking for anything, so putting it
+ * anywhere else would make that segment lie about what it holds.
+ *
+ * "Needs you" is `blocked` + `needs-you` and NOT `review`, even though
+ * `isDemandBand` counts review as a demand. Review is a hand-back, not a
+ * block — folding it in would make the footer's demand count promise more
+ * agents than applying the filter actually reveals.
+ */
+const BAND_FILTER_SETS: Record<Exclude<PilotBandFilter, "all">, ReadonlySet<FleetBand>> = {
+  "needs-you": new Set<FleetBand>(["blocked", "needs-you"]),
+  working: new Set<FleetBand>(["running"]),
+  finished: new Set<FleetBand>(["review", "done"]),
+};
+
+/** The narrowing segments, in the order the bar renders them after All. */
+export const PILOT_BAND_FILTERS: readonly Exclude<PilotBandFilter, "all">[] = [
+  "needs-you",
+  "working",
+  "finished",
+];
+
+/**
+ * A segment's name, declared here rather than in the bar because two surfaces
+ * say it: the segment itself, and the empty state that has to name which filter
+ * produced no rows.
+ */
+export const PILOT_BAND_FILTER_LABEL: Record<PilotBandFilter, string> = {
+  all: "All",
+  "needs-you": "Needs you",
+  working: "Working",
+  finished: "Finished",
+};
+
+export type PilotBandFilterCounts = Record<PilotBandFilter, number>;
+
+/**
+ * Rows per segment.
+ *
+ * Counted BEFORE the band filter runs, which is the whole reason this is a
+ * separate pass: each segment has to report the query-intersected population.
+ * Counting afterwards would give every segment its own filtered total, which is
+ * always the length of the list already on screen and therefore tells the user
+ * nothing they can't see.
+ */
+export function countPilotBands(groups: readonly PilotProjectGroup[]): PilotBandFilterCounts {
+  const counts: PilotBandFilterCounts = { all: 0, "needs-you": 0, working: 0, finished: 0 };
+  for (const group of groups) {
+    for (const row of group.rows) {
+      counts.all++;
+      for (const filter of PILOT_BAND_FILTERS) {
+        if (BAND_FILTER_SETS[filter].has(row.band)) counts[filter]++;
+      }
+    }
+  }
+  return counts;
+}
+
+/**
+ * Filter groups to the rows one segment admits, dropping groups left empty.
+ *
+ * Composes with {@link filterPilotGroups} rather than replacing it — the query
+ * and the segment intersect with AND, so "show me the blocked agents in this
+ * repo" is one question rather than two mutually exclusive ones. Input order is
+ * preserved: ordering is decided once, upstream, and a filter that re-sorted
+ * would move rows under the cursor.
+ */
+export function filterPilotBands(
+  groups: readonly PilotProjectGroup[],
+  filter: PilotBandFilter
+): PilotProjectGroup[] {
+  if (filter === "all") return [...groups];
+
+  const bands = BAND_FILTER_SETS[filter];
+  const out: PilotProjectGroup[] = [];
+  for (const group of groups) {
+    const rows = group.rows.filter((row) => bands.has(row.band));
+    if (rows.length === 0) continue;
+    out.push(narrowGroup(group, rows));
   }
   return out;
 }

--- a/src/components/Pilot/pilotRows.ts
+++ b/src/components/Pilot/pilotRows.ts
@@ -131,10 +131,15 @@ function narrowGroup(group: PilotProjectGroup, rows: PilotRow[]): PilotProjectGr
 /**
  * Oldest still-outstanding demand in a project, or undefined when it has none.
  *
- * This is the group-level twin of {@link compareWithinBand}'s row rule, which
- * is the point: the two levels finally agree about what "most urgent" means,
- * and a project whose block has been standing for forty minutes stops being
- * displaced by one that only just started asking.
+ * The group-level counterpart of {@link compareWithinBand}'s anti-starvation
+ * rule, which is the point: a project whose block has been standing for forty
+ * minutes stops being displaced by one that only just started asking.
+ *
+ * Not identical to it, deliberately. `compareWithinBand` ranks rows inside ONE
+ * band; this takes the oldest demand of ANY kind, so a long-unread completion
+ * can date a project whose worst band is a fresh question. That is the right
+ * reading of "oldest outstanding demand" — a review nobody has looked at in two
+ * hours is outstanding — but it does mean the two are not the same function.
  *
  * A demand with no `since` contributes nothing rather than counting as
  * infinitely old — an unknown age is not evidence of urgency.
@@ -404,6 +409,27 @@ export function countPilotBands(groups: readonly PilotProjectGroup[]): PilotBand
 }
 
 /**
+ * Whether a segment currently holds anything that is a demand on the user.
+ *
+ * "Finished" is the reason this exists: it admits `review`, which is a demand,
+ * alongside `done`, which is not. Colouring the segment on membership alone
+ * would paint a project whose every completion has been acknowledged in the
+ * hue reserved for work still waiting to be looked at — putting back one of the
+ * false signals this surface exists to remove. "Needs you" holds only demands,
+ * so it is hued whenever it holds anything at all, which this returns for free.
+ */
+export function bandFilterHasDemand(
+  bands: Readonly<FleetBandCounts>,
+  filter: PilotBandFilter
+): boolean {
+  if (filter === "all") return false;
+  for (const band of BAND_FILTER_SETS[filter]) {
+    if (isDemandBand(band) && bands[band] > 0) return true;
+  }
+  return false;
+}
+
+/**
  * Filter groups to the rows one segment admits, dropping groups left empty.
  *
  * Composes with {@link filterPilotGroups} rather than replacing it — the query
@@ -435,8 +461,13 @@ export interface PilotSummary {
 }
 
 /**
- * Fleet totals for the footer, counted from the same rows the list renders so
- * the summary and the group chips can never disagree.
+ * Fleet totals for the footer.
+ *
+ * Counted over whatever population the caller hands it. The fleet overview
+ * passes the QUERY-filtered groups — before the band filter — so the footer
+ * describes, and its demand control acts on, the same set the segment counts
+ * report. Passing the band-filtered groups instead would make the footer
+ * describe only what the current segment already shows.
  */
 export function summarizePilotGroups(groups: readonly PilotProjectGroup[]): PilotSummary {
   const bands = emptyBandCounts();

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -634,12 +634,24 @@ interface AppPaletteEmptyProps {
   noMatchMessage?: string;
   noMatchContent?: React.ReactNode;
   children?: React.ReactNode;
+  /**
+   * Name of a narrowing control, other than the query, that is also excluding
+   * rows — supplied only while that control is actually active.
+   *
+   * Without it the zero-data branch claims the surface itself is empty when a
+   * filter the user set is what emptied it: the ghost-filter dead end, where
+   * someone hits no results and cannot see why. Naming BOTH constraints is the
+   * point, so the default title states the filter and the query together rather
+   * than whichever one the caller happened to think of. Pair it with a
+   * `noMatchContent` action that clears the filter.
+   */
+  filterLabel?: string;
 }
 
 const NO_MATCH_QUERY_MAX = 40;
 const EMPTY_ANNOUNCEMENT_DEBOUNCE_MS = 600;
 
-function defaultNoMatchTitle(trimmedQuery: string) {
+function defaultNoMatchTitle(trimmedQuery: string, filterLabel: string | undefined) {
   // Iterate by codepoint (Array.from handles surrogate pairs) so we never
   // truncate inside an astral-plane character like an emoji.
   const codepoints = Array.from(trimmedQuery);
@@ -647,7 +659,13 @@ function defaultNoMatchTitle(trimmedQuery: string) {
     codepoints.length > NO_MATCH_QUERY_MAX
       ? `${codepoints.slice(0, NO_MATCH_QUERY_MAX).join("")}…`
       : trimmedQuery;
-  return `No matches for "${display}"`;
+
+  // Generic noun: this component serves every palette, and only the caller
+  // knows whether its rows are agents, projects or commands.
+  if (!trimmedQuery) return `No matches in ${filterLabel}`;
+  return filterLabel === undefined
+    ? `No matches for "${display}"`
+    : `No matches for "${display}" in ${filterLabel}`;
 }
 
 AppPaletteDialog.Empty = function AppPaletteEmpty({
@@ -656,6 +674,7 @@ AppPaletteDialog.Empty = function AppPaletteEmpty({
   noMatchMessage,
   noMatchContent,
   children,
+  filterLabel,
 }: AppPaletteEmptyProps) {
   const trimmedQuery = query.trim();
   // Defer the *displayed* query so the title doesn't redraw every keystroke
@@ -676,7 +695,13 @@ AppPaletteDialog.Empty = function AppPaletteEmpty({
   const srTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [srAnnouncement, setSrAnnouncement] = useState("");
   const displayQuery = deferredTrimmedQuery || trimmedQuery;
-  const title = trimmedQuery ? (noMatchMessage ?? defaultNoMatchTitle(displayQuery)) : emptyMessage;
+  // A filter narrows the population exactly as a query does, so it takes the
+  // same branch. The branch decision stays on the immediate values; only the
+  // rendered query text is deferred.
+  const isNarrowed = trimmedQuery.length > 0 || filterLabel !== undefined;
+  const title = isNarrowed
+    ? (noMatchMessage ?? defaultNoMatchTitle(displayQuery, filterLabel))
+    : emptyMessage;
 
   useEffect(() => {
     return () => {
@@ -695,7 +720,7 @@ AppPaletteDialog.Empty = function AppPaletteEmpty({
     };
   }, [title, trimmedQuery]);
 
-  if (trimmedQuery) {
+  if (isNarrowed) {
     return (
       <>
         <EmptyState

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -660,12 +660,14 @@ function defaultNoMatchTitle(trimmedQuery: string, filterLabel: string | undefin
       ? `${codepoints.slice(0, NO_MATCH_QUERY_MAX).join("")}…`
       : trimmedQuery;
 
-  // Generic noun: this component serves every palette, and only the caller
-  // knows whether its rows are agents, projects or commands.
-  if (!trimmedQuery) return `No matches in ${filterLabel}`;
+  // "with X selected" rather than "in X": the point of naming the filter is to
+  // explain why the list is empty, and only the causal phrasing does that.
+  // Generic noun throughout — this component serves every palette, and only the
+  // caller knows whether its rows are agents, projects or commands.
+  if (!trimmedQuery) return `No matches with ${filterLabel} selected`;
   return filterLabel === undefined
     ? `No matches for "${display}"`
-    : `No matches for "${display}" in ${filterLabel}`;
+    : `No matches for "${display}" with ${filterLabel} selected`;
 }
 
 AppPaletteDialog.Empty = function AppPaletteEmpty({
@@ -694,7 +696,12 @@ AppPaletteDialog.Empty = function AppPaletteEmpty({
   // doesn't suppress repeated identical announcements.
   const srTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [srAnnouncement, setSrAnnouncement] = useState("");
-  const displayQuery = deferredTrimmedQuery || trimmedQuery;
+  // Forced empty the instant the real query is, never merely deferred to it.
+  // A filter keeps the narrowed branch mounted after the box is cleared, so a
+  // lagging deferred value would go on rendering `No matches for "docs"` over a
+  // query the user had already deleted — the stale flash the immediate-branch
+  // decision above exists to prevent.
+  const displayQuery = trimmedQuery ? deferredTrimmedQuery || trimmedQuery : "";
   // A filter narrows the population exactly as a query does, so it takes the
   // same branch. The branch decision stays on the immediate values; only the
   // rendered query text is deferred.

--- a/src/components/ui/__tests__/PaletteEmptyStates.test.tsx
+++ b/src/components/ui/__tests__/PaletteEmptyStates.test.tsx
@@ -46,6 +46,60 @@ describe("AppPaletteDialog.Empty", () => {
     expect(screen.getByText('No matches for "foo"')).toBeTruthy();
   });
 
+  describe("filterLabel", () => {
+    it("names the filter when it is the only thing excluding rows", () => {
+      // Without this the zero-data branch claims the surface is empty while a
+      // filter the user set is what emptied it — the ghost-filter dead end.
+      render(
+        <AppPaletteDialog.Empty query="" emptyMessage="No items available" filterLabel="Needs you">
+          <span data-testid="cta">Create a terminal</span>
+        </AppPaletteDialog.Empty>
+      );
+
+      expect(screen.getByText("No matches in Needs you")).toBeTruthy();
+      expect(screen.queryByText("No items available")).toBeNull();
+      // A narrowed empty is not a zero-data empty, so the zero-data CTA has no
+      // business being the action offered for it.
+      expect(screen.queryByTestId("cta")).toBeNull();
+    });
+
+    it("names both constraints when a query and a filter are active together", () => {
+      render(
+        <AppPaletteDialog.Empty
+          query="auth"
+          emptyMessage="No items available"
+          filterLabel="Working"
+        />
+      );
+
+      expect(screen.getByText('No matches for "auth" in Working')).toBeTruthy();
+    });
+
+    it("offers the filtered action once a filter is active without a query", () => {
+      render(
+        <AppPaletteDialog.Empty
+          query=""
+          emptyMessage="No items available"
+          filterLabel="Working"
+          noMatchContent={<span data-testid="clear">Clear filter</span>}
+        />
+      );
+
+      expect(screen.getByTestId("clear")).toBeTruthy();
+    });
+
+    it("leaves the zero-data branch alone when no filter is active", () => {
+      render(
+        <AppPaletteDialog.Empty query="" emptyMessage="No items available">
+          <span data-testid="cta">Create a terminal</span>
+        </AppPaletteDialog.Empty>
+      );
+
+      expect(screen.getByText("No items available")).toBeTruthy();
+      expect(screen.getByTestId("cta")).toBeTruthy();
+    });
+  });
+
   it("renders noMatchContent when query has text (no-match state)", () => {
     render(
       <AppPaletteDialog.Empty

--- a/src/components/ui/__tests__/PaletteEmptyStates.test.tsx
+++ b/src/components/ui/__tests__/PaletteEmptyStates.test.tsx
@@ -56,7 +56,7 @@ describe("AppPaletteDialog.Empty", () => {
         </AppPaletteDialog.Empty>
       );
 
-      expect(screen.getByText("No matches in Needs you")).toBeTruthy();
+      expect(screen.getByText("No matches with Needs you selected")).toBeTruthy();
       expect(screen.queryByText("No items available")).toBeNull();
       // A narrowed empty is not a zero-data empty, so the zero-data CTA has no
       // business being the action offered for it.
@@ -72,7 +72,7 @@ describe("AppPaletteDialog.Empty", () => {
         />
       );
 
-      expect(screen.getByText('No matches for "auth" in Working')).toBeTruthy();
+      expect(screen.getByText('No matches for "auth" with Working selected')).toBeTruthy();
     });
 
     it("offers the filtered action once a filter is active without a query", () => {
@@ -86,17 +86,6 @@ describe("AppPaletteDialog.Empty", () => {
       );
 
       expect(screen.getByTestId("clear")).toBeTruthy();
-    });
-
-    it("leaves the zero-data branch alone when no filter is active", () => {
-      render(
-        <AppPaletteDialog.Empty query="" emptyMessage="No items available">
-          <span data-testid="cta">Create a terminal</span>
-        </AppPaletteDialog.Empty>
-      );
-
-      expect(screen.getByText("No items available")).toBeTruthy();
-      expect(screen.getByTestId("cta")).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
## Summary

Rebuilds the fleet overview palette (`⌥⌘O`) so colour carries a single meaning: only rows with an active demand (`blocked`, `needs-you`, `review`) keep a hue, everything else goes fully neutral. Rows drop to a single line, group headers become real section labels, and a new filter bar lets you isolate what actually needs you instead of scanning a wall of colour.

Resolves #11626

## Changes

- **Colour with one job**: `running`, `done` and `idle` go fully neutral, glyph and label both. Only the three demand states keep a hue. Shape stays a second channel, and every row's state is still readable as text via its accessible name.
- **Single-line rows**, ~32px (down from ~44px): glyph, brand mark, title, then a trailing group of status (demand bands only), worktree, and a right-aligned tabular age column with a fixed floor width so the age reads as one vertical scan.
- **Headers as section labels**, ~24px (down from ~48px), reusing the existing `PALETTE_SECTION_LABEL_CLASS`; identity tile shrinks 32px → 16px. The prose summary disappears while a group is expanded and comes back as a glyph+count pip cluster only when collapsed, so a collapsed project still can't hide a blocked agent.
- **New `PilotFilterBar`**: All / Needs you / Working / Finished, visually matched to the worktree sidebar's `QuickStateFilterBar` but implemented as a radiogroup with roving tabindex. Filter and search query intersect with AND; segment counts reflect the query-filtered population.
- **Ordering**: the `latestActivity` tiebreak is replaced by the group's oldest outstanding demand, so quiet projects hold a fixed order across openings instead of reshuffling every time. Severity-first ordering and `frozenOrder` are unchanged, and the current project is deliberately not pinned above severity.
- The footer's "N agents need you" is now a control that applies the Needs-you filter.
- `AppPaletteDialog.Empty` gained an optional `filterLabel` so an empty result names both the filter and the query, with one action that clears the filter.

Three bugs turned up along the way:

- `filterPilotGroups` derived a group's `topBand` from `rows[0]`, but once `frozenOrder` pins row order that index isn't actually the worst band. Both filters now scan for the worst surviving band by rank.
- The footer counted `review` into "N agents need you" via an `isDemandBand` check, but the Needs-you segment is only `blocked` + `needs-you`. As a clickable control it would have advertised agents it then failed to show. Review now gets its own sentence.
- A row's accessible name was built by concatenating adjacent inline spans, producing run-ons like "Fix authWorkingfeature-x2m". It's now composed explicitly.

Known deferrals: `blocked` and `needs-you` still share a `HollowCircle` glyph in the collapsed pip cluster, differing only by hue. That's pre-existing in `PilotRunState`, the glyph vocabulary itself is explicitly out of scope for this change, and the toggle's accessible name already carries the band in words. `PilotProjectGroup.demandCount` and `PilotSummary.demand` are now unused in production code but are kept because tests reading them cover the acknowledgement-watermark semantics.

## Testing

- 2092 tests across 128 files pass locally, covering the whole Pilot, palette and hooks surface, including the CI-only accent-guard and colour-system contract suites.
- Project-wide `tsc --noEmit`: 0 errors.
- `eslint` on all 10 changed files: 0 errors, 0 warnings. Prettier clean.
- No relevant e2e coverage change: the only Pilot spec is `e2e/screenshots/palette-review.spec.ts`, a visual-review tool outside the CI tiers, and it selects by `[role="dialog"][aria-label="All agents"]`, which is unchanged.
