### PR TITLE
fix(terminal): move both grids on a background-tier resize

### DIFF
--- a/e2e/full/resilience/background-terminal-bulk-output.spec.ts
+++ b/e2e/full/resilience/background-terminal-bulk-output.spec.ts
@@ -147,15 +147,14 @@ test.describe
     expect(observed!.cols).toBeGreaterThan(2);
     expect(observed!.cols).toBeLessThan(initial!.cols);
 
-    // While still BACKGROUND, xterm's internal grid intentionally stays at
-    // the old geometry — paint is paused and reflow is deferred until wake.
-    // The captured latestCols/latestRows is what matters on the wake path.
+    // The observed geometry is committed to xterm and the PTY together at the
+    // moment it lands, not deferred to wake (#11628) — a hidden pane keeps
+    // parsing output, so a grid that lags the PTY corrupts rows irrecoverably.
     const beforeRestore = await getTerminalDimensions(terminalPanel);
     expect(beforeRestore).not.toBeNull();
 
-    // Restore to FOCUSED. applyDeferredResize on the wake path must reconcile
-    // xterm's grid with the dims captured during background, before refresh
-    // repaints into the buffer.
+    // Restore to FOCUSED. The wake path must leave xterm consistent with the
+    // dims observed during background — reconciling them if anything drifted.
     const restored = await applyTierAndReadDimensions(window, panelId, "FOCUSED");
     expect(restored.applied).toBe(true);
 
@@ -207,8 +206,8 @@ test.describe
     expect(resized).not.toBeNull();
     expect(resized!.cols).toBeLessThan(initial!.cols);
 
-    // Restore visibility — the wake path runs applyDeferredResize before
-    // refresh, so the final repaint targets the narrower grid.
+    // Restore visibility — the narrower grid was already committed to both
+    // xterm and the PTY while hidden, so the repaint targets it directly.
     expect(await applyTier(window, panelId, "FOCUSED")).toBe(true);
     await window.waitForTimeout(T_SETTLE);
 

--- a/e2e/full/resilience/background-terminal-bulk-output.spec.ts
+++ b/e2e/full/resilience/background-terminal-bulk-output.spec.ts
@@ -136,10 +136,12 @@ test.describe
     await window.waitForTimeout(T_SETTLE);
 
     // Simulate a ResizeObserver firing for a substantially smaller container
-    // (e.g. window or split divider shrunk while the panel is in the hidden
-    // tab). Pre-fix, this call was silently dropped by the BACKGROUND guard
-    // in TerminalResizeController.resize() and the dims would never reach
-    // xterm or the PTY.
+    // (e.g. window or split divider shrunk while the panel is in a background
+    // tab). NOTE: applyTier only moves the refresh tier — it does not clear
+    // isFocused/isVisible — so this drives the measured resize path, not
+    // resize()'s hidden-pane branch. The atomicity of that branch is pinned by
+    // the ordering assertions in TerminalResizeController.test.ts; what this
+    // covers is that a tier downgrade never strands the observed geometry.
     const targetWidth = 400;
     const targetHeight = 240;
     const observed = await simulateResize(window, panelId, targetWidth, targetHeight);
@@ -159,9 +161,9 @@ test.describe
     expect(restored.applied).toBe(true);
 
     // The wake transition must leave xterm at a coherent geometry. On Linux
-    // CI, the real foreground ResizeObserver can supersede the deferred
+    // CI, the real foreground ResizeObserver can supersede the observed
     // background size before the test bridge reads dimensions, so accept
-    // either the captured background size or a larger foreground remeasure.
+    // either that size or a larger foreground remeasure.
     expect(restored.dims).not.toBeNull();
     expect(restored.dims!.cols).toBeGreaterThanOrEqual(observed!.cols);
     expect(restored.dims!.rows).toBeGreaterThanOrEqual(observed!.rows);
@@ -215,10 +217,10 @@ test.describe
     // proves the visibility transition didn't drop or corrupt PTY data.
     await waitForTerminalText(terminalPanel, "BG_DONE", T_LONG);
 
-    // The narrower geometry captured during background must have reached the
-    // wake path. A real foreground ResizeObserver can supersede that deferred
-    // size before the test bridge reads dimensions, so accept the captured
-    // size or a larger foreground remeasure.
+    // The narrower geometry observed during background must have survived the
+    // visibility cycle. A real foreground ResizeObserver can supersede it
+    // before the test bridge reads dimensions, so accept that size or a larger
+    // foreground remeasure.
     await expect
       .poll(async () => (await getTerminalDimensions(terminalPanel))?.cols, { timeout: T_LONG })
       .toBeGreaterThanOrEqual(resized!.cols);

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -163,7 +163,6 @@ interface SettledResizeRequest {
   timer: number;
   cols: number;
   rows: number;
-  resizeXterm: boolean;
 }
 
 export class TerminalResizeController {
@@ -307,14 +306,23 @@ export class TerminalResizeController {
     const wasAtBottom = buffer.viewportY >= buffer.baseY;
 
     if (isBackgroundUnfocused) {
-      // Background-tier path: a ResizeObserver fired while the host element
-      // is inside a content-visibility:hidden container. fitAddon.fit() would
-      // read 0x0 from the DOM, so we compute cols/rows from cached cell
-      // metrics instead. Settled agents still coalesce the PTY notification,
-      // but the hidden xterm grid remains untouched until wake reconciliation.
+      // Background-tier path: a ResizeObserver fired while the host element is
+      // inside a content-visibility:hidden container. fitAddon.fit() would read
+      // 0x0 from the DOM, so the ONLY thing this branch changes is where the
+      // grid comes from — cached cell metrics instead of a live measurement.
+      // The commit itself goes through the normal strategy pipeline, so both
+      // grids move together and at the same cadence a visible pane would use.
+      //
+      // It did not always: this branch used to send the PTY resize alone and
+      // leave xterm for wake reconciliation, on the theory that a paused pane
+      // need not pay for a reflow the user cannot see (#7741). Visibility gates
+      // paint, never writes — a hidden pane's xterm parses every byte — so the
+      // app kept emitting cursor-addressed output sized for the new width into
+      // a parser still holding the old grid, and nothing recovered those rows
+      // (#11628). This is the same split #11447 closed for backgrounded views.
       const dims = this.resizeGridFromCachedCellMetrics(managed, width, height, wasAtBottom);
       if (dims) {
-        this.sendPtyOnlyResize(id, dims.cols, dims.rows);
+        this.applyResize(id, dims.cols, dims.rows);
       }
       return dims;
     }
@@ -483,12 +491,13 @@ export class TerminalResizeController {
     return dims;
   }
 
-  // Computes cols/rows from cached cell metrics with no DOM reads — a detached
-  // view has no live layout to measure. Pure computation + state update; the
-  // caller decides whether to apply the grid. `applyBackgroundResize` reflows
-  // xterm and then resizes the PTY; `resize`'s background-unfocused branch
-  // sends the PTY resize only and leaves the content-visibility:hidden pane's
-  // xterm grid for wake reconciliation.
+  // Computes cols/rows from cached cell metrics with no DOM reads — a hidden or
+  // detached view has no live layout to measure. Pure computation + state
+  // update; the caller decides how to apply the grid. Both callers move xterm
+  // and the PTY together and differ only in cadence: `applyBackgroundResize`
+  // commits directly (its burst was already debounced in Main), while
+  // `resize`'s background-unfocused branch goes through `applyResize` to keep
+  // the per-agent resize strategy that the live ResizeObserver path relies on.
   private resizeGridFromCachedCellMetrics(
     managed: ManagedTerminal,
     width: number,
@@ -795,32 +804,16 @@ export class TerminalResizeController {
     managed.latestRows = rows;
 
     if (this.getResizeStrategy(managed) === "settled") {
-      this.scheduleSettledResize(id, cols, rows, true);
+      this.scheduleSettledResize(id, cols, rows);
     } else {
       this.clearSettledTimer(id);
       terminalClient.resize(id, cols, rows);
     }
   }
 
-  private sendPtyOnlyResize(id: string, cols: number, rows: number): void {
-    const managed = this.deps.getInstance(id);
-    this.cancelPendingResize(id);
-    if (managed && this.getResizeStrategy(managed) === "settled") {
-      this.scheduleSettledResize(id, cols, rows, false);
-      return;
-    }
+  private scheduleSettledResize(id: string, cols: number, rows: number): void {
     this.clearSettledTimer(id);
-    terminalClient.resize(id, cols, rows);
-  }
-
-  private scheduleSettledResize(
-    id: string,
-    cols: number,
-    rows: number,
-    resizeXterm: boolean
-  ): void {
-    this.clearSettledTimer(id);
-    const pending: SettledResizeRequest = { timer: 0, cols, rows, resizeXterm };
+    const pending: SettledResizeRequest = { timer: 0, cols, rows };
     const timer = globalThis.setTimeout(() => {
       if (this.settledResizeRequests.get(id) !== pending) return;
       this.settledResizeRequests.delete(id);
@@ -830,13 +823,13 @@ export class TerminalResizeController {
     this.settledResizeRequests.set(id, pending);
   }
 
+  // Every settled request now describes a paired xterm+PTY move. The PTY-only
+  // variant this used to branch on existed solely for hidden panes, and those
+  // move both grids too since #11628 — leaving the flag in place would keep a
+  // state that can no longer be constructed, and invite the split back.
   private commitSettledResize(id: string, pending: SettledResizeRequest): void {
     if (this.isResizeLocked(id)) return;
-    if (pending.resizeXterm) {
-      this.commitResize(id, pending.cols, pending.rows);
-    } else if (this.deps.getInstance(id)) {
-      terminalClient.resize(id, pending.cols, pending.rows);
-    }
+    this.commitResize(id, pending.cols, pending.rows);
   }
 
   private takeSettledResize(id: string): SettledResizeRequest | undefined {

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -286,15 +286,16 @@ export class TerminalResizeController {
 
     const currentTier =
       managed.lastAppliedTier ?? managed.getRefreshTier?.() ?? TerminalRefreshTier.FOCUSED;
-    // Take the no-DOM-measurement path only when the terminal is genuinely
-    // hidden (offscreen / content-visibility:hidden). A freshly prewarmed
-    // terminal carries a stale lastAppliedTier === BACKGROUND — seeded by
-    // prewarmTerminal — until XtermAdapter's applyRendererPolicy effect
-    // promotes it, yet by then it may already be attached and visible. Routing
-    // a *visible* terminal through the hidden path would let it settle for
-    // metric-derived dimensions when it has real layout to measure. isVisible
-    // is set synchronously by setVisible(true) during attach, before the first
-    // fit, so it is a reliable discriminator here.
+    // Take the fallback-free, undeferred path only when the terminal is
+    // genuinely hidden (offscreen / content-visibility:hidden). A freshly
+    // prewarmed terminal carries a stale lastAppliedTier === BACKGROUND —
+    // seeded by prewarmTerminal — until XtermAdapter's applyRendererPolicy
+    // effect promotes it, yet by then it may already be attached and visible.
+    // Routing a *visible* terminal down that branch would strand it whenever
+    // cell metrics are briefly unavailable, since it has no proposeDimensions
+    // fallback to recover with. isVisible is set synchronously by
+    // setVisible(true) during attach, before the first fit, so it is a reliable
+    // discriminator here.
     const isBackgroundUnfocused =
       currentTier === TerminalRefreshTier.BACKGROUND && !managed.isFocused && !managed.isVisible;
 
@@ -307,12 +308,15 @@ export class TerminalResizeController {
 
     if (isBackgroundUnfocused) {
       // Background-tier path: a ResizeObserver fired while the host element is
-      // inside a content-visibility:hidden container, which reports 0x0. The
-      // measured path below would fall back to fitAddon.proposeDimensions() on
-      // that box and bail, so this branch derives the grid from cached cell
-      // metrics alone and commits it without the debounce/idle deferral the
-      // measured path applies. The commit itself is the ordinary one: both
-      // grids move together, at the PTY cadence this path already used.
+      // inside a content-visibility:hidden container. Both paths derive the
+      // grid from cached cell metrics first; what differs is the fallback and
+      // the cadence. The measured path below falls back to
+      // fitAddon.proposeDimensions() when metrics are missing — a DOM read that
+      // returns 0x0 for a hidden box — and defers large-buffer work through
+      // debounce/idle scheduling. This branch has neither: no fallback (a
+      // missing metric bails), and no deferral. The commit itself is the
+      // ordinary one: both grids move together, at the PTY cadence this path
+      // already used.
       //
       // It did not always: this branch used to send the PTY resize alone and
       // leave xterm for wake reconciliation, on the theory that a paused pane

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -286,13 +286,13 @@ export class TerminalResizeController {
 
     const currentTier =
       managed.lastAppliedTier ?? managed.getRefreshTier?.() ?? TerminalRefreshTier.FOCUSED;
-    // Defer the xterm reflow only when the terminal is genuinely hidden
-    // (offscreen / content-visibility:hidden). A freshly prewarmed terminal
-    // carries a stale lastAppliedTier === BACKGROUND — seeded by
+    // Take the no-DOM-measurement path only when the terminal is genuinely
+    // hidden (offscreen / content-visibility:hidden). A freshly prewarmed
+    // terminal carries a stale lastAppliedTier === BACKGROUND — seeded by
     // prewarmTerminal — until XtermAdapter's applyRendererPolicy effect
-    // promotes it, yet by then it may already be attached and visible.
-    // Skipping terminal.resize() for a *visible* terminal strands xterm's grid
-    // at the 80x24 open() default while the PTY runs at the real size. isVisible
+    // promotes it, yet by then it may already be attached and visible. Routing
+    // a *visible* terminal through the hidden path would let it settle for
+    // metric-derived dimensions when it has real layout to measure. isVisible
     // is set synchronously by setVisible(true) during attach, before the first
     // fit, so it is a reliable discriminator here.
     const isBackgroundUnfocused =
@@ -307,11 +307,12 @@ export class TerminalResizeController {
 
     if (isBackgroundUnfocused) {
       // Background-tier path: a ResizeObserver fired while the host element is
-      // inside a content-visibility:hidden container. fitAddon.fit() would read
-      // 0x0 from the DOM, so the ONLY thing this branch changes is where the
-      // grid comes from — cached cell metrics instead of a live measurement.
-      // The commit itself goes through the normal strategy pipeline, so both
-      // grids move together and at the same cadence a visible pane would use.
+      // inside a content-visibility:hidden container, which reports 0x0. The
+      // measured path below would fall back to fitAddon.proposeDimensions() on
+      // that box and bail, so this branch derives the grid from cached cell
+      // metrics alone and commits it without the debounce/idle deferral the
+      // measured path applies. The commit itself is the ordinary one: both
+      // grids move together, at the PTY cadence this path already used.
       //
       // It did not always: this branch used to send the PTY resize alone and
       // leave xterm for wake reconciliation, on the theory that a paused pane
@@ -463,9 +464,13 @@ export class TerminalResizeController {
     if (isRedundantResize(managed, width, height)) {
       // A foreground debounce/settled request updates the pixel and grid
       // caches before it commits. If backgrounding then supplies that same
-      // box, cancelling the queued xterm work must not also discard the PTY
-      // half of the resize. Reassert the cached target directly — the grid
-      // caches already describe this box, so xterm needs no further work.
+      // box, cancelling the queued work must not discard the resize with it.
+      // Commit the cached target rather than asserting it to the PTY alone:
+      // `latestCols`/`latestRows` describe the target the cancelled job was
+      // going to apply, NOT the grid xterm currently holds, so a bare
+      // terminalClient.resize here reproduces the very split this path exists
+      // to prevent (#11628). commitResize is a no-op for the xterm half when
+      // the grid already matches, so the common case costs nothing.
       if (
         hadPendingResize &&
         Number.isInteger(managed.latestCols) &&
@@ -473,7 +478,7 @@ export class TerminalResizeController {
         managed.latestCols > 0 &&
         managed.latestRows > 0
       ) {
-        terminalClient.resize(id, managed.latestCols, managed.latestRows);
+        this.commitResize(id, managed.latestCols, managed.latestRows);
       }
       return null;
     }
@@ -493,11 +498,13 @@ export class TerminalResizeController {
 
   // Computes cols/rows from cached cell metrics with no DOM reads — a hidden or
   // detached view has no live layout to measure. Pure computation + state
-  // update; the caller decides how to apply the grid. Both callers move xterm
-  // and the PTY together and differ only in cadence: `applyBackgroundResize`
-  // commits directly (its burst was already debounced in Main), while
-  // `resize`'s background-unfocused branch goes through `applyResize` to keep
-  // the per-agent resize strategy that the live ResizeObserver path relies on.
+  // update; the caller owns the commit policy, and the two callers differ in
+  // more than timing. `applyBackgroundResize` refuses alt-screen panes, stashes
+  // under a resize lock, and commits directly (its burst was already debounced
+  // in Main); `resize`'s background-unfocused branch has no such exclusions and
+  // goes through `applyResize` to keep the per-agent resize strategy the live
+  // ResizeObserver path relies on. What they share is the invariant that
+  // matters: whenever either applies a grid, xterm adopts it before the PTY.
   private resizeGridFromCachedCellMetrics(
     managed: ManagedTerminal,
     width: number,

--- a/src/services/terminal/__tests__/TerminalResizeController.fitParity.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.fitParity.test.ts
@@ -409,7 +409,7 @@ describe("TerminalResizeController ↔ FitAddon column parity (#11095)", () => {
     });
   });
 
-  it("keeps the PTY-only (backgrounded) path in agreement with FitAddon", () => {
+  it("keeps the backgrounded-view resize path in agreement with FitAddon", () => {
     const { managed, fitAddon } = buildPane();
     const controller = makeController(managed);
 

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -117,6 +117,12 @@ describe("TerminalResizeController", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
+    // clearAllMocks resets calls but NOT implementations, and both of these are
+    // module-hoisted and shared by every test in the file. Without an explicit
+    // reset, one test's `mockImplementation`/`mockReturnValue` silently governs
+    // every test that runs after it, making the suite order-dependent.
+    resizeMock.mockReset();
+    getEffectiveAgentConfigMock.mockReset();
     postTaskCallbacks = [];
 
     vi.stubGlobal("scheduler", {
@@ -216,7 +222,12 @@ describe("TerminalResizeController", () => {
     expect(dataBuffer.resetForTerminal).toHaveBeenCalledWith("term-1");
     // The flush succeeded, so ingest is already drained — no resume needed.
     expect(dataBuffer.resumeFlush).not.toHaveBeenCalled();
+    // Exact counts alongside `order`: the one-shot implementations above only
+    // record the FIRST call each, so a duplicate commit would slip past the
+    // ordering assertion on its own.
+    expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
     expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1600), 40);
+    expect(resizeMock).toHaveBeenCalledTimes(1);
     expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
     // Reflow mutates ybase/ydisp without firing onScroll, so a bottom-following
     // pane needs the explicit re-pin.
@@ -270,8 +281,90 @@ describe("TerminalResizeController", () => {
 
     expect(controller.resize("term-1", 1600, 800)).toEqual({ cols: colsFor(1600), rows: 40 });
     expect(order).toEqual(["xterm", "pty"]);
+    expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
     expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1600), 40);
+    expect(resizeMock).toHaveBeenCalledTimes(1);
     expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
+  });
+
+  it("background-tier resize parks the xterm half while a serialized restore replays", () => {
+    // The one sanctioned exception to the atomicity contract: during a restore
+    // xterm is deliberately held at the snapshot's capture width so the payload
+    // decodes, and live output is deferred for the same window — so the PTY may
+    // lead. The obligation has to be RECORDED though; the old PTY-only path
+    // never did, which is why the grid never caught up.
+    const managed = createManagedTerminal();
+    managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
+    managed.isFocused = false;
+    managed.isVisible = false;
+    managed.isSerializedRestoreInProgress = true;
+    Object.assign(managed.terminal, {
+      _core: { _renderService: { dimensions: { css: { cell: { width: 10, height: 20 } } } } },
+    });
+
+    const controller = new TerminalResizeController({
+      getInstance: vi.fn(() => managed),
+      dataBuffer: {
+        flushForTerminal: vi.fn(),
+        resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
+      } as any,
+    });
+
+    expect(controller.resize("term-1", 1600, 800)).toEqual({ cols: colsFor(1600), rows: 40 });
+    expect(managed.terminal.resize).not.toHaveBeenCalled();
+    expect(managed.pendingRestoreGeometry).toEqual({ cols: colsFor(1600), rows: 40 });
+    // The PTY still gets the real geometry so the agent keeps producing output
+    // sized for the grid the user will see once the replay normalizes.
+    expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
+  });
+
+  it("background-tier resize leaves an over-budget ingest backlog queued and resumes it", () => {
+    // Above RESIZE_FLUSH_SYNC_BUDGET_BYTES the backlog is too big to parse
+    // inline at the outgoing grid, so it stays queued and is resumed after the
+    // commit for watermarked draining — the grids still move together.
+    const managed = createManagedTerminal();
+    managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
+    managed.isFocused = false;
+    managed.isVisible = false;
+    Object.assign(managed.terminal, {
+      _core: { _renderService: { dimensions: { css: { cell: { width: 10, height: 20 } } } } },
+    });
+
+    const order: string[] = [];
+    managed.terminal.resize.mockImplementationOnce(function (
+      this: { cols: number; rows: number },
+      cols: number,
+      rows: number
+    ) {
+      order.push("xterm");
+      this.cols = cols;
+      this.rows = rows;
+    });
+    resizeMock.mockImplementationOnce(() => {
+      order.push("pty");
+    });
+
+    const dataBuffer = {
+      flushForTerminal: vi.fn(),
+      resetForTerminal: vi.fn(),
+      getQueuedBytes: vi.fn(() => RESIZE_FLUSH_SYNC_BUDGET_BYTES + 1),
+      resumeFlush: vi.fn(() => {
+        order.push("resume");
+      }),
+    };
+
+    const controller = new TerminalResizeController({
+      getInstance: vi.fn(() => managed),
+      dataBuffer: dataBuffer as any,
+    });
+
+    expect(controller.resize("term-1", 1600, 800)).toEqual({ cols: colsFor(1600), rows: 40 });
+    // Never flushed at the outgoing grid — that is the whole point of the budget.
+    expect(dataBuffer.flushForTerminal).not.toHaveBeenCalled();
+    expect(dataBuffer.resetForTerminal).not.toHaveBeenCalled();
+    expect(order).toEqual(["xterm", "pty", "resume"]);
   });
 
   it("background-tier resize returns null when cell dims are unavailable", () => {
@@ -856,15 +949,21 @@ describe("TerminalResizeController", () => {
       } as any,
     });
 
-    // Background resize arms the settled timer with dims 120x35.
+    // A resize observed while the pane is genuinely hidden arms the settled
+    // timer. isVisible must be false too, or this takes the measured path and
+    // never exercises the hidden branch the comment claims.
     managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
     managed.isFocused = false;
+    managed.isVisible = false;
     controller.resize("term-1", 1200, 700);
     expect(resizeMock).not.toHaveBeenCalled();
+    expect(managed.terminal.resize).not.toHaveBeenCalled();
 
-    // Wake fires applyDeferredResize before the timer would have run.
+    // Wake fires applyDeferredResize before the timer would have run: the
+    // reveal owns the commit, and the superseded timer must not fire behind it.
     managed.lastAppliedTier = TerminalRefreshTier.FOCUSED;
     managed.isFocused = true;
+    managed.isVisible = true;
     controller.applyDeferredResize("term-1");
 
     expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
@@ -1977,7 +2076,12 @@ describe("TerminalResizeController", () => {
       expect(resizeMock).toHaveBeenCalledTimes(1);
     });
 
-    it("reasserts a pending settled target when the PTY-only box is redundant", () => {
+    it("commits a cancelled settled target to both grids when the box is redundant", () => {
+      // latestCols/latestRows here describe the target the cancelled settled job
+      // was going to apply, NOT the grid xterm currently holds — it is still at
+      // the pre-resize size. Reasserting only the PTY half would background the
+      // pane into exactly the split #11628 is about, so the cancelled work is
+      // committed rather than discarded.
       const managed = createManagedTerminal();
       managed.launchAgentId = "codex";
       managed.runtimeAgentId = "codex";
@@ -1992,14 +2096,33 @@ describe("TerminalResizeController", () => {
       controller.resize("term-1", 1600, 800);
       expect(controller.hasPendingResize("term-1")).toBe(true);
       expect(resizeMock).not.toHaveBeenCalled();
+      // The settled job has not fired, so xterm is still on the old grid.
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+
+      const order: string[] = [];
+      managed.terminal.resize.mockImplementationOnce(function (
+        this: { cols: number; rows: number },
+        cols: number,
+        rows: number
+      ) {
+        order.push("xterm");
+        this.cols = cols;
+        this.rows = rows;
+      });
+      resizeMock.mockImplementationOnce(() => {
+        order.push("pty");
+      });
 
       expect(controller.applyBackgroundResize("term-1", 1600, 800)).toBeNull();
 
       expect(controller.hasPendingResize("term-1")).toBe(false);
-      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(order).toEqual(["xterm", "pty"]);
+      expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
+      expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1600), 40);
       expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
 
       vi.advanceTimersByTime(500);
+      expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
       expect(resizeMock).toHaveBeenCalledTimes(1);
     });
 

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -155,13 +155,107 @@ describe("TerminalResizeController", () => {
     await new Promise<void>((resolve) => queueMicrotask(resolve));
   };
 
-  it("background-tier resize captures dims and notifies PTY without calling fitAddon.fit()", () => {
+  it("background-tier resize flushes held ingest bytes, then moves xterm before the PTY", () => {
+    // The core #11628 contract. A content-visibility:hidden pane still parses
+    // every byte the PTY emits, so moving the PTY alone leaves the app writing
+    // cursor-addressed output sized for the new width into a parser holding the
+    // old grid — damage no later reflow can undo. Both grids move together, and
+    // the order is load-bearing: SIGWINCH must not reach the app for a grid the
+    // parser has not adopted. Held ingest bytes drain first so the backlog
+    // parses at the still-consistent outgoing grid.
     const managed = createManagedTerminal();
     managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
     managed.isFocused = false;
     managed.isVisible = false;
+    // A streaming pane takes the same path: unlike applyDeferredResize's
+    // out-of-band wake reconcile, an observed layout change is never gated on
+    // quiescence — deferring it is what splits the grids in the first place.
+    managed.pendingWrites = 1;
     Object.assign(managed.terminal, {
       _core: { _renderService: { dimensions: { css: { cell: { width: 10, height: 20 } } } } },
+    });
+
+    const order: string[] = [];
+    managed.terminal.resize.mockImplementationOnce(function (
+      this: { cols: number; rows: number },
+      cols: number,
+      rows: number
+    ) {
+      order.push("xterm");
+      this.cols = cols;
+      this.rows = rows;
+    });
+    resizeMock.mockImplementationOnce(() => {
+      order.push("pty");
+    });
+
+    const dataBuffer = {
+      flushForTerminal: vi.fn(() => {
+        order.push("flush");
+      }),
+      resetForTerminal: vi.fn(),
+      // Under RESIZE_FLUSH_SYNC_BUDGET_BYTES, so the backlog is drained inline
+      // rather than left queued for watermarked draining.
+      getQueuedBytes: vi.fn(() => 1024),
+      resumeFlush: vi.fn(),
+    };
+
+    const controller = new TerminalResizeController({
+      getInstance: vi.fn(() => managed),
+      dataBuffer: dataBuffer as any,
+    });
+
+    const result = controller.resize("term-1", 1600, 800);
+    expect(result).toEqual({ cols: colsFor(1600), rows: 40 });
+    // No DOM measurement: a hidden container reports 0x0, which is the whole
+    // reason this branch computes from cached cell metrics.
+    expect(managed.fitAddon.fit).not.toHaveBeenCalled();
+    expect(managed.fitAddon.proposeDimensions).not.toHaveBeenCalled();
+
+    expect(order).toEqual(["flush", "xterm", "pty"]);
+    expect(dataBuffer.resetForTerminal).toHaveBeenCalledWith("term-1");
+    // The flush succeeded, so ingest is already drained — no resume needed.
+    expect(dataBuffer.resumeFlush).not.toHaveBeenCalled();
+    expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1600), 40);
+    expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
+    // Reflow mutates ybase/ydisp without firing onScroll, so a bottom-following
+    // pane needs the explicit re-pin.
+    expect(managed.terminal.scrollToBottom).toHaveBeenCalledOnce();
+    expect(managed.latestCols).toBe(colsFor(1600));
+    expect(managed.latestRows).toBe(40);
+    // The pixel dedup cache still tracks the RAW container width — the scrollbar
+    // is reserved when dividing into columns, never folded into this gate.
+    expect(managed.lastWidth).toBe(1600);
+    expect(managed.lastHeight).toBe(800);
+  });
+
+  it("background-tier resize moves an alt-screen pane's grids together too", () => {
+    // Deliberately the opposite of applyBackgroundResize's alt-screen refusal.
+    // That path can skip BOTH grids because it never sent SIGWINCH; this one
+    // always has, so refusing only the xterm half is exactly the split #11628
+    // reports. Moving xterm first lets the TUI's own redraw land on the grid it
+    // was sized for.
+    const managed = createManagedTerminal();
+    managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
+    managed.isFocused = false;
+    managed.isVisible = false;
+    managed.isAltBuffer = true;
+    Object.assign(managed.terminal, {
+      _core: { _renderService: { dimensions: { css: { cell: { width: 10, height: 20 } } } } },
+    });
+
+    const order: string[] = [];
+    managed.terminal.resize.mockImplementationOnce(function (
+      this: { cols: number; rows: number },
+      cols: number,
+      rows: number
+    ) {
+      order.push("xterm");
+      this.cols = cols;
+      this.rows = rows;
+    });
+    resizeMock.mockImplementationOnce(() => {
+      order.push("pty");
     });
 
     const controller = new TerminalResizeController({
@@ -174,18 +268,10 @@ describe("TerminalResizeController", () => {
       } as any,
     });
 
-    const result = controller.resize("term-1", 1600, 800);
-    expect(result).toEqual({ cols: colsFor(1600), rows: 40 });
-    expect(managed.fitAddon.fit).not.toHaveBeenCalled();
-    // Buffer reflow is deferred to wake — xterm.resize() must NOT fire while paint is paused.
-    expect(managed.terminal.resize).not.toHaveBeenCalled();
+    expect(controller.resize("term-1", 1600, 800)).toEqual({ cols: colsFor(1600), rows: 40 });
+    expect(order).toEqual(["xterm", "pty"]);
+    expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1600), 40);
     expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
-    expect(managed.latestCols).toBe(colsFor(1600));
-    expect(managed.latestRows).toBe(40);
-    // The pixel dedup cache still tracks the RAW container width — the scrollbar
-    // is reserved when dividing into columns, never folded into this gate.
-    expect(managed.lastWidth).toBe(1600);
-    expect(managed.lastHeight).toBe(800);
   });
 
   it("background-tier resize returns null when cell dims are unavailable", () => {
@@ -214,7 +300,7 @@ describe("TerminalResizeController", () => {
     expect(managed.lastHeight).toBe(600);
   });
 
-  it("background-tier resize dedups identical follow-up call without re-notifying PTY", () => {
+  it("background-tier resize dedups an identical follow-up without reapplying either grid", () => {
     const managed = createManagedTerminal();
     managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
     managed.isFocused = false;
@@ -234,15 +320,19 @@ describe("TerminalResizeController", () => {
     });
 
     controller.resize("term-1", 1600, 800);
+    expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
     expect(resizeMock).toHaveBeenCalledTimes(1);
 
-    // Same pixel dims → dedup guard returns null before any side effects.
+    // Same pixel dims → dedup guard returns null before any side effects. Now
+    // that the branch reflows xterm too, the guard has to spare both halves:
+    // a redundant re-reflow is not free on a pane with deep scrollback.
     const second = controller.resize("term-1", 1600, 800);
     expect(second).toBeNull();
+    expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
     expect(resizeMock).toHaveBeenCalledTimes(1);
   });
 
-  it("background-tier settled agents batch the deferred PTY resize", () => {
+  it("background-tier settled agents commit the coalesced target to both grids", () => {
     const managed = createManagedTerminal();
     managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
     managed.isFocused = false;
@@ -267,24 +357,47 @@ describe("TerminalResizeController", () => {
       } as any,
     });
 
+    const order: string[] = [];
+    managed.terminal.resize.mockImplementationOnce(function (
+      this: { cols: number; rows: number },
+      cols: number,
+      rows: number
+    ) {
+      order.push("xterm");
+      this.cols = cols;
+      this.rows = rows;
+    });
+    resizeMock.mockImplementationOnce(() => {
+      order.push("pty");
+    });
+
     controller.resize("term-1", 1600, 800);
     controller.resize("term-1", 1700, 800);
-    // PTY should not fire synchronously — settled 500ms guard owns the resize.
-    expect(resizeMock).not.toHaveBeenCalled();
+    // Neither grid moves synchronously — the settled 500ms guard owns the pair,
+    // which is the whole point of coalescing a drag for these agents.
+    expect(order).toEqual([]);
 
-    vi.advanceTimersByTime(500);
+    vi.advanceTimersByTime(499);
+    expect(order).toEqual([]);
+
+    vi.advanceTimersByTime(1);
+    // One atomic commit at the LATEST target: the superseded 1600px geometry
+    // must never reach either grid, and xterm must adopt it before SIGWINCH.
+    expect(order).toEqual(["xterm", "pty"]);
+    expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
+    expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1700), 40);
     expect(resizeMock).toHaveBeenCalledTimes(1);
     expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1700), 40);
-    expect(managed.terminal.resize).not.toHaveBeenCalled();
   });
 
-  it("background-tier resize reflows xterm when the terminal is visible", () => {
+  it("a stale background tier does not divert a visible terminal off the measured path", () => {
     // A freshly prewarmed terminal carries lastAppliedTier === BACKGROUND until
     // applyRendererPolicy promotes it, but it can already be attached and
-    // visible on screen. A visible terminal must keep xterm's grid in sync with
-    // its container — the deferred-reflow path is only for genuinely hidden
-    // (offscreen / content-visibility:hidden) terminals. Regression guard for
-    // the two-pane split second-panel sizing bug.
+    // visible on screen. Both branches now move xterm and the PTY together, so
+    // what this guards is the measurement source: a visible terminal has real
+    // layout and must use it, never the cached-cell-metric path meant for
+    // containers that report 0x0. Regression guard for the two-pane split
+    // second-panel sizing bug.
     const managed = createManagedTerminal();
     managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
     managed.isFocused = false;
@@ -305,7 +418,6 @@ describe("TerminalResizeController", () => {
 
     const result = controller.resize("term-1", 1600, 800, { immediate: true });
     expect(result).toEqual({ cols: colsFor(1600), rows: 40 });
-    // Visible terminal: xterm's grid is reflowed, not deferred to wake.
     expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1600), 40);
     expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
   });
@@ -1351,7 +1463,10 @@ describe("TerminalResizeController", () => {
       expect(resizeMock).toHaveBeenCalledTimes(1);
     });
 
-    it("flushResize preserves a pending settled PTY-only resize intent", () => {
+    it("flushResize commits a pending background-tier settled pair atomically", () => {
+      // Draining the settled timer early must not resurrect the PTY-only split:
+      // a flushed request carries the same paired commit the timer would have
+      // run, just sooner.
       const managed = createManagedTerminal();
       managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
       managed.isFocused = false;
@@ -1366,15 +1481,36 @@ describe("TerminalResizeController", () => {
         dataBuffer: mockDataBuffer(),
       });
 
+      const order: string[] = [];
+      managed.terminal.resize.mockImplementationOnce(function (
+        this: { cols: number; rows: number },
+        cols: number,
+        rows: number
+      ) {
+        order.push("xterm");
+        this.cols = cols;
+        this.rows = rows;
+      });
+      resizeMock.mockImplementationOnce(() => {
+        order.push("pty");
+      });
+
       controller.resize("term-1", 1200, 800);
       expect(controller.hasPendingResize("term-1")).toBe(true);
+      expect(order).toEqual([]);
+
       controller.flushResize("term-1");
 
       expect(controller.hasPendingResize("term-1")).toBe(false);
-      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(order).toEqual(["xterm", "pty"]);
+      expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
+      expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1200), 40);
       expect(resizeMock).toHaveBeenCalledTimes(1);
       expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1200), 40);
+
+      // The drained timer must not fire a second commit behind the flush.
       vi.advanceTimersByTime(500);
+      expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
       expect(resizeMock).toHaveBeenCalledTimes(1);
     });
 
@@ -1918,7 +2054,7 @@ describe("TerminalResizeController", () => {
       expect(managed.latestCols).toBe(80);
     });
 
-    it("delivers the PTY resize immediately for settled-strategy agents, with no xterm reflow", () => {
+    it("delivers an atomic xterm and PTY resize immediately for settled-strategy agents", () => {
       const managed = createManagedTerminal();
       managed.launchAgentId = "codex";
       managed.runtimeAgentId = "codex";

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -487,17 +487,21 @@ describe("TerminalResizeController", () => {
     // A freshly prewarmed terminal carries lastAppliedTier === BACKGROUND until
     // applyRendererPolicy promotes it, but it can already be attached and
     // visible on screen. Both branches now move xterm and the PTY together, so
-    // what this guards is the measurement source: a visible terminal has real
-    // layout and must use it, never the cached-cell-metric path meant for
-    // containers that report 0x0. Regression guard for the two-pane split
+    // the difference this guards is what happens when cell metrics are absent:
+    // the measured path falls back to fitAddon.proposeDimensions(), while the
+    // hidden branch has no fallback and bails with null (asserted directly by
+    // "background-tier resize returns null when cell dims are unavailable").
+    // Withholding _core is therefore what makes this test able to tell the two
+    // branches apart at all. Regression guard for the two-pane split
     // second-panel sizing bug.
     const managed = createManagedTerminal();
     managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
     managed.isFocused = false;
     managed.isVisible = true;
-    Object.assign(managed.terminal, {
-      _core: { _renderService: { dimensions: { css: { cell: { width: 10, height: 20 } } } } },
-    });
+    // No _core: cell metrics are unavailable, so only the measured path can
+    // produce a grid here.
+    const proposal = { cols: 137, rows: 42 };
+    managed.fitAddon.proposeDimensions = vi.fn(() => proposal);
 
     const controller = new TerminalResizeController({
       getInstance: vi.fn(() => managed),
@@ -510,9 +514,12 @@ describe("TerminalResizeController", () => {
     });
 
     const result = controller.resize("term-1", 1600, 800, { immediate: true });
-    expect(result).toEqual({ cols: colsFor(1600), rows: 40 });
-    expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1600), 40);
-    expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
+    // Had the stale BACKGROUND tier diverted this to the hidden branch, the
+    // missing cell metrics would have produced null and touched nothing.
+    expect(result).toEqual(proposal);
+    expect(managed.fitAddon.proposeDimensions).toHaveBeenCalled();
+    expect(managed.terminal.resize).toHaveBeenCalledWith(proposal.cols, proposal.rows);
+    expect(resizeMock).toHaveBeenCalledWith("term-1", proposal.cols, proposal.rows);
   });
 
   it("flushes and resets ingest buffers before applying resize", () => {


### PR DESCRIPTION
## Summary

- Fixes background-tier terminal resize corruption: a hidden pane's PTY was resized without moving xterm's grid to match, so cursor-addressed output from the agent CLI landed on the wrong rows and reflow could never undo it.
- Routes the hidden-pane resize branch through the existing `applyResize()` / `commitResize()` path instead of a PTY-only path, so xterm moves before the PTY does, and the pre-resize ingest flush plus post-resize bottom-pin both apply.
- Fixes a second instance of the same bug in `applyBackgroundResize()`'s redundant-box early return, found during review, and removes the now-dead `resizeXterm: false` state.

Resolves #11628

## The bug

`TerminalResizeController.resize()` has a branch for hidden panes (`isBackgroundUnfocused`: `BACKGROUND` tier, not focused, not visible) that called `sendPtyOnlyResize()`. The PTY moved, xterm's grid did not, with the reflow deferred to wake reconciliation.

That deferral came from #7741, whose comment reasoned that since paint is paused, deferring the buffer reflow to wake time avoids work the user never sees. The premise is false: visibility gates paint, never writes. A `content-visibility: hidden` pane's xterm keeps parsing every byte, so the CLI emitted cursor-addressed output sized for the new width into a parser still holding the old grid. Reflow cannot undo an erase applied to the wrong line, and the wake-time re-assert dedupes in `TerminalProcess.resize`, so no corrective `SIGWINCH` ever arrives. The rows stay corrupted.

#11447 fixed this same class of bug for backgrounded project views via `applyBackgroundResize()`. This is the sibling entry point that fix didn't reach.

## The fix

Route the branch through the existing `applyResize()` rather than the PTY-only path. That reuses `commitResize()`, so the hidden path now also gets the pre-resize ingest flush (`flushHeldBytesBeforeResize`: background-tier terminals can be holding queued bytes, and resizing without draining risks the xterm parser-drain duplication hazard) and the post-resize bottom-pin (xterm reflow mutates `ybase`/`ydisp` without firing `onScroll`).

Ordering is xterm-then-PTY: the app must never receive `SIGWINCH` for a grid the parser hasn't adopted yet. Per-agent PTY cadence is preserved exactly, default strategy stays immediate, settled strategy stays coalesced over `SETTLED_RESIZE_DELAY_MS`. The only behavioral change is that xterm's grid now moves at the same moment the PTY does.

## Second bug found in review

`applyBackgroundResize()`'s redundant-box early return reasserted `latestCols`/`latestRows` to the PTY alone. Those values describe the target the just-cancelled pending job was going to apply, not the grid xterm currently holds, so backgrounding a pane with a pending foreground resize reproduced the exact split-grid bug this code path exists to prevent. It's now routed through `commitResize`, which is a no-op for the xterm half when the grid already matches.

## Dead state removed

`sendPtyOnlyResize()` was the only producer of `resizeXterm: false` on `SettledResizeRequest`. With that function gone, every settled request is a paired xterm and PTY commit, so the flag and `commitSettledResize`'s branch for it are deleted rather than left in as a state that can no longer be constructed.

## Scope decisions

A few things I deliberately did or didn't do here, worth calling out:

- **Alt-screen panes on this path are resized atomically instead of excluded**, the opposite choice from `applyBackgroundResize`'s alt-buffer refusal. `applyBackgroundResize` can skip both grids because it never sent `SIGWINCH`; this path always has, so refusing only the xterm half would itself be the reported bug. Moving xterm first lets the TUI's own redraw land on the grid it was sized for.
- **The 300ms `hasStreamingWrites()` quiescent gate in `TerminalReconciliationWatchdog.ts` is untouched.** It's a dependency of #10863 and out of scope per the issue. This path stays ungated, symmetric with the already deliberately ungated foreground `ResizeObserver` path.
- **Default-strategy hidden panes now pay an xterm reflow per accepted resize**, giving up part of #7741's optimization. Those same ticks already trigger the agent's redraw via `SIGWINCH` today, so the work was already being created, it was just being parsed into the wrong grid. Settled agents, the majority, including codex and gemini, still reflow once per coalesced burst.
- **Known gap, not fixed here:** the e2e spec `background-terminal-bulk-output.spec.ts` doesn't actually reach this branch, because its `applyTier` bridge moves the refresh tier without clearing `isFocused`/`isVisible`. I corrected its misleading comments to say so. Strengthening that harness is separate work; the branch is pinned by unit tests instead.

## Testing

165 tests pass across 9 suites: the two `TerminalResizeController` suites plus every sibling resize suite and `TerminalSwitchBackRedraw.regression`. `npm run typecheck` is clean across all projects.

Atomicity is proven with ordering assertions, an `order` array pushed from the mocked xterm resize and PTY resize, asserting `["xterm", "pty"]` and `["flush", "xterm", "pty"]`, rather than content equality, which would pass with or without the fix. Five tests that encoded the old split-grid contract were rewritten. New coverage was added for alt-screen panes, serialized-restore parking (the one sanctioned exception, where xterm is held at the snapshot width and the obligation is recorded in `pendingRestoreGeometry`), and the over-budget ingest backlog path. The two module-hoisted mocks are now reset in `beforeEach`, since `clearAllMocks` resets calls but not implementations, which had left the suite order-dependent.
