### PR TITLE
feat(sidebar): make the worktree refresh button a true full refresh

### DIFF
--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -182,6 +182,7 @@ class PullRequestService {
   // "unknown" (undefined), never success (#6240). Initialized at field-
   // declaration time so it's correct before the singleton's first checkForPRs.
   private ciEnrichmentEnabled: boolean = process.env.DAINTREE_INSTANCE_ROLE !== "worker";
+  private refreshInFlight: Promise<void> | null = null;
   private lastCheckAt: number = Number.NEGATIVE_INFINITY;
   // Separate from `lastCheckAt`: that one throttles PR *detection*, and reusing
   // it would let a recent detection poll suppress the focus CI catch-up (they
@@ -772,7 +773,27 @@ class PullRequestService {
     logDebug("PullRequestService stopped");
   }
 
-  public async refresh(): Promise<void> {
+  /**
+   * Manual "give me fresh data now" pass. One sidebar click reaches this same
+   * host twice — once via the view's worktree port (WorkspaceService.refresh)
+   * and once via the pool-wide `refresh-prs` fan-out — so the two are coalesced
+   * onto a single pass. Without that, the second caller's `invalidateProvider()`
+   * disposes the first's in-flight coalescers mid-cycle and
+   * `resolvePRsForBranches()` absorbs the disposal as `null`, silently skipping
+   * those branches on the very click that promised fresh data.
+   */
+  public refresh(): Promise<void> {
+    const existing = this.refreshInFlight;
+    if (existing) return existing;
+    const run = this.performRefresh().finally(() => {
+      // Identity-guarded so a settled older pass can't clear a newer one.
+      if (this.refreshInFlight === run) this.refreshInFlight = null;
+    });
+    this.refreshInFlight = run;
+    return run;
+  }
+
+  private async performRefresh(): Promise<void> {
     if (!this.cwd) {
       return;
     }
@@ -810,7 +831,13 @@ class PullRequestService {
     // Manual refresh is an explicit "I want fresh data now" — bypass the 5s
     // floor by clearing the throttle clock before the direct checkForPRs().
     this.lastCheckAt = Number.NEGATIVE_INFINITY;
-    await this.checkForPRs();
+    // Force CI enrichment for this pass. `ciEnrichmentEnabled` tracks window
+    // focus (and is clamped off for worker instances), so an unforced refresh
+    // dispatched while blurred completes with no CI fetched at all and the
+    // badges never move. The force rides the call rather than the shared flag:
+    // flipping the flag would run the disable sweep on restore and discard the
+    // very result this pass fetched.
+    await this.checkForPRs({ forceCiEnrichment: true });
 
     if (this.isPolling) {
       if (this.hasUnresolvedCandidates()) {
@@ -1174,9 +1201,13 @@ class PullRequestService {
   // a failed batch leaves the prior state alone so a transient error doesn't
   // accidentally cancel a live boost.
   private updateBoostFromDetectedPRs(): void {
-    const hasPendingCi = Array.from(this.detectedPRs.values()).some(
-      (pr) => pr.ciStatus === "pending"
-    );
+    // Gated on ambient enrichment: a forced (manual-refresh) `pending` result
+    // can land while the flag is off, and arming the 30s boost then would keep
+    // re-arming a revalidation cadence with no ambient CI fetch behind it
+    // (#6149) — exactly what the disable sweep exists to collapse.
+    const hasPendingCi =
+      this.ciEnrichmentEnabled &&
+      Array.from(this.detectedPRs.values()).some((pr) => pr.ciStatus === "pending");
     this.boostExpiresAt = hasPendingCi
       ? Date.now() + RESOLVED_REVALIDATION_BOOST_DURATION_MS
       : null;
@@ -1602,7 +1633,17 @@ class PullRequestService {
     }
   }
 
-  private async checkForPRs(): Promise<void> {
+  private async checkForPRs(options?: { forceCiEnrichment?: boolean }): Promise<void> {
+    // A forced pass (manual refresh) fetches CI regardless of the ambient
+    // focus-driven flag, and awaits the result so the refresh resolves only
+    // once the badges have actually been re-emitted.
+    // The force overrides the focus-driven flag only. A worker instance still
+    // never fetches CI: the env role is the authoritative quota invariant, and
+    // there is no user at the keyboard there to have asked for a refresh.
+    const forceCi =
+      options?.forceCiEnrichment === true && process.env.DAINTREE_INSTANCE_ROLE !== "worker";
+    const shouldEnrichCi = forceCi || this.ciEnrichmentEnabled;
+    const forcedCiEnrichments: Array<Promise<void>> = [];
     const activeCandidates: Array<{
       worktreeId: string;
       issueNumber?: number;
@@ -1859,7 +1900,7 @@ class PullRequestService {
             // enrichment is disabled there is no phase-2 emit coming, so omit
             // the flag entirely (`|| undefined` → absent, not false) — a held
             // "loading" with no resolution would spin forever (#6240).
-            isCiStatusLoading: this.ciEnrichmentEnabled || undefined,
+            isCiStatusLoading: shouldEnrichCi || undefined,
             prTitle: pr.title,
             issueNumber,
             branchName: lookupBranch,
@@ -1874,9 +1915,17 @@ class PullRequestService {
         // Fire-and-forget CI status enrichment (skipped on unattended
         // instances; enrichPRWithCIStatus also self-guards, but skipping here
         // avoids the needless call).
-        if (this.ciEnrichmentEnabled) {
-          this.enrichPRWithCIStatus(internalPR, repo);
+        if (shouldEnrichCi) {
+          const enrichment = this.enrichPRWithCIStatus(internalPR, repo, forceCi);
+          if (forceCi) forcedCiEnrichments.push(enrichment);
         }
+      }
+
+      // Every load enqueued above coalesced into one getCIStatuses batch in the
+      // same tick; only now is it safe to await. Draining before the boost
+      // update also lets it read the freshly-landed CI status.
+      if (forcedCiEnrichments.length > 0) {
+        await Promise.allSettled(forcedCiEnrichments);
       }
 
       this.updateBoostFromDetectedPRs();
@@ -1956,11 +2005,18 @@ class PullRequestService {
    * Fire CI status lookup as a non-blocking tail after PR detection.
    * On success, updates the detectedPRs entry and re-emits sys:pr:detected
    * with the enriched CI status so the renderer can update the badge.
+   *
+   * `force` marks an explicitly user-initiated pass (manual refresh). It rides
+   * the call instead of the shared `ciEnrichmentEnabled` flag so a blurred or
+   * worker-role instance can still serve one deliberate refresh without the
+   * disable sweep tearing down the result. Returned promise is best-effort and
+   * never rejects; forced callers await it, ambient ones drop it on the floor
+   * to keep the batch coalescing described below.
    */
-  private enrichPRWithCIStatus(pr: InternalLinkedPR, repo: RepoRef): void {
-    if (!this.ciEnrichmentEnabled) return;
+  private enrichPRWithCIStatus(pr: InternalLinkedPR, repo: RepoRef, force = false): Promise<void> {
+    if (!force && !this.ciEnrichmentEnabled) return Promise.resolve();
     const loader = this.ciStatusLoader;
-    if (!loader) return;
+    if (!loader) return Promise.resolve();
     // Synchronous `load()` here: enrichPRWithCIStatus is called fire-and-forget
     // in a `for` loop per detected PR, so all loads enqueue in the same tick and
     // coalesce into one `getCIStatuses` batch. Do NOT add an `await` before this
@@ -1970,13 +2026,15 @@ class PullRequestService {
     // pace the slow terminal re-check, and pacing on resolve would retry every
     // tick for as long as the provider keeps rejecting.
     pr.lastCiCheckAt = Date.now();
-    loader
+    return loader
       .load(pr.number)
       .then((ciStatus) => {
         // Enrichment may have been disabled (window blur) while this batch was
         // in flight — discard the result rather than write a CI status back and
-        // re-arm the boost the sweep just collapsed.
-        if (!this.ciEnrichmentEnabled) return;
+        // re-arm the boost the sweep just collapsed. A forced pass keeps its
+        // result: the user asked for it, and the boost stays collapsed because
+        // updateBoostFromDetectedPRs only arms while ambient enrichment is on.
+        if (!force && !this.ciEnrichmentEnabled) return;
         const prevCiStatus = pr.ciStatus;
         // A resolved value is authoritative: the batch contract surfaces a
         // transient miss as a rejection (→ .catch below), so a `null` here is a

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -183,6 +183,12 @@ class PullRequestService {
   // declaration time so it's correct before the singleton's first checkForPRs.
   private ciEnrichmentEnabled: boolean = process.env.DAINTREE_INSTANCE_ROLE !== "worker";
   private refreshInFlight: Promise<void> | null = null;
+  // Bumped when something a refresh depends on changes underneath it (forge
+  // settings, a service reset). An in-flight pass stamped with an older epoch
+  // resolved against the previous configuration, so a caller arriving after the
+  // change must not be handed its result.
+  private refreshEpoch = 0;
+  private refreshInFlightEpoch = -1;
   private lastCheckAt: number = Number.NEGATIVE_INFINITY;
   // Separate from `lastCheckAt`: that one throttles PR *detection*, and reusing
   // it would let a recent detection poll suppress the focus CI catch-up (they
@@ -433,6 +439,9 @@ class PullRequestService {
     this.forgeProviderOverride = args.forgeProviderOverride;
     this.globalDefaultProviderId = args.forgeDefaultProviderId;
     this.forgeRemote = args.forgeRemote ?? null;
+    // Supersede any in-flight refresh: it resolved the provider these settings
+    // just replaced, so the caller that follows this change needs its own pass.
+    this.refreshEpoch += 1;
     this.invalidateProvider();
   }
 
@@ -784,12 +793,23 @@ class PullRequestService {
    */
   public refresh(): Promise<void> {
     const existing = this.refreshInFlight;
-    if (existing) return existing;
-    const run = this.performRefresh().finally(() => {
-      // Identity-guarded so a settled older pass can't clear a newer one.
-      if (this.refreshInFlight === run) this.refreshInFlight = null;
-    });
+    // Join only a pass that still reflects the current configuration. Without
+    // the epoch check, `updateForgeSettings()`'s follow-up refresh would be
+    // handed a pass that resolved the PREVIOUS provider, and the new one would
+    // never get a detection cycle.
+    if (existing && this.refreshInFlightEpoch === this.refreshEpoch) return existing;
+    const epoch = this.refreshEpoch;
+    // A superseded pass is chained after, not run alongside: two overlapping
+    // passes are exactly the disposal race this single-flight exists to remove.
+    const run = (existing ?? Promise.resolve())
+      .catch(() => {})
+      .then(() => this.performRefresh())
+      .finally(() => {
+        // Identity-guarded so a settled older pass can't clear a newer one.
+        if (this.refreshInFlight === run) this.refreshInFlight = null;
+      });
     this.refreshInFlight = run;
+    this.refreshInFlightEpoch = epoch;
     return run;
   }
 
@@ -855,6 +875,9 @@ class PullRequestService {
     this.detectedPRs.clear();
     this.consecutiveErrors = 0;
     this.nextRetryAt = 0;
+    // A pass from the previous project/token must not satisfy a refresh
+    // requested after the reset.
+    this.refreshEpoch += 1;
     // reset() runs on project switch, service teardown, and token removal
     // (updateToken(null) → reset()). Token removal does NOT re-attach the
     // worktree port, so a silent clear would strand a tripped glyph in the
@@ -2007,11 +2030,12 @@ class PullRequestService {
    * with the enriched CI status so the renderer can update the badge.
    *
    * `force` marks an explicitly user-initiated pass (manual refresh). It rides
-   * the call instead of the shared `ciEnrichmentEnabled` flag so a blurred or
-   * worker-role instance can still serve one deliberate refresh without the
-   * disable sweep tearing down the result. Returned promise is best-effort and
-   * never rejects; forced callers await it, ambient ones drop it on the floor
-   * to keep the batch coalescing described below.
+   * the call instead of the shared `ciEnrichmentEnabled` flag so a blurred
+   * instance can still serve one deliberate refresh without the disable sweep
+   * tearing down the result. It overrides window focus only — worker-role
+   * instances stay clamped off, gated by the caller in `checkForPRs`. Returned
+   * promise is best-effort and never rejects; forced callers await it, ambient
+   * ones drop it on the floor to keep the batch coalescing described below.
    */
   private enrichPRWithCIStatus(pr: InternalLinkedPR, repo: RepoRef, force = false): Promise<void> {
     if (!force && !this.ciEnrichmentEnabled) return Promise.resolve();

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -40,6 +40,12 @@ import type { GitFileDiffResult } from "../../shared/types/ipc/git.js";
 
 const STATES_INFLIGHT_COALESCE_WINDOW_MS = 150;
 
+// Manual PR refresh re-resolves the forge provider, re-detects every PR, and
+// now awaits the CI-status batch on top, so it needs more than the host's 30s
+// default per-request budget. Raised only for this request type — the default
+// still governs every other call.
+const REFRESH_PRS_TIMEOUT_MS = 45_000;
+
 // Upper bound on how long a worktree-state read waits for the host to finish
 // (re)populating its monitor map before giving up and reporting "unknown" ([]).
 //
@@ -220,17 +226,29 @@ export class WorkspaceClient extends EventEmitter {
   }
 
   async refreshPullRequests(): Promise<void> {
-    for (const entry of this.pool.entries.values()) {
-      try {
-        const requestId = entry.host.generateRequestId();
-        await entry.host.sendWithResponse({
-          type: "refresh-prs",
-          requestId,
-        });
-      } catch {
-        // Host may be crashed
-      }
-    }
+    // Fan out concurrently (matching refreshOnWake above): hosts are
+    // independent projects, so awaiting them in sequence made a multi-project
+    // refresh walk them one at a time for no quota benefit — each provider
+    // owns its own transport limits.
+    await Promise.allSettled(
+      Array.from(this.pool.entries.values()).map(async (entry) => {
+        try {
+          const requestId = entry.host.generateRequestId();
+          // A manual refresh now awaits CI enrichment on top of provider
+          // re-resolution and PR re-detection, so the default 30s response
+          // budget is tight for the extra round trip.
+          await entry.host.sendWithResponse(
+            {
+              type: "refresh-prs",
+              requestId,
+            },
+            REFRESH_PRS_TIMEOUT_MS
+          );
+        } catch {
+          // Host may be crashed
+        }
+      })
+    );
   }
 
   // ── Fan-out: PR / polling / config ──

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -42,8 +42,10 @@ const STATES_INFLIGHT_COALESCE_WINDOW_MS = 150;
 
 // Manual PR refresh re-resolves the forge provider, re-detects every PR, and
 // now awaits the CI-status batch on top, so it needs more than the host's 30s
-// default per-request budget. Raised only for this request type — the default
-// still governs every other call.
+// default per-request budget. Matches HOST_REFRESH_TIMEOUT_MS (WorkspaceService),
+// the watchdog the port-driven refresh already bounds the same work with, so
+// both entry points give up at the same point instead of one reporting failure
+// while the other is still waiting. Raised only for this request type.
 const REFRESH_PRS_TIMEOUT_MS = 45_000;
 
 // Upper bound on how long a worktree-state read waits for the host to finish

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -2695,6 +2695,57 @@ describe("PullRequestService", () => {
       });
     });
 
+    it("does not hand a post-settings-change refresh a pass that resolved the old provider", async () => {
+      await withRole(undefined, async () => {
+        let releaseFirst: () => void = () => {};
+        const gate = new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+        let batchCalls = 0;
+        const batchSpy = vi.fn(async (_repo: RepoRef, branches: string[]) => {
+          batchCalls += 1;
+          // Hold the first pass open so the settings change lands mid-flight.
+          if (batchCalls === 1) await gate;
+          const map = new Map<string, ForgePR | null>();
+          for (const branch of branches)
+            map.set(branch, makeMockForgePR({ number: 7, headRef: branch }));
+          return map;
+        });
+        mockForgeProviderResolved(undefined, batchSpy);
+
+        const { pullRequestService } = await import("../PullRequestService.js");
+        const { events } = await import("../events.js");
+
+        pullRequestService.initialize("/repo", "test-project-id");
+        events.emit(
+          "sys:worktree:update",
+          makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+        );
+
+        const first = pullRequestService.refresh();
+
+        // updateForgeSettings() does exactly this: change the settings, then
+        // refresh. Joining the in-flight pass would resolve the provider the
+        // settings just replaced, and the new one would never get a cycle.
+        pullRequestService.setForgeSettings({
+          forgeProviderOverride: "other.forge",
+          forgeDefaultProviderId: null,
+          forgeRemote: null,
+        });
+        const second = pullRequestService.refresh();
+        expect(second).not.toBe(first);
+
+        releaseFirst();
+        await Promise.all([first, second]);
+
+        // The superseded pass is chained, not run alongside, so the second
+        // caller still gets its own detection cycle.
+        expect(batchSpy).toHaveBeenCalledTimes(2);
+
+        pullRequestService.destroy();
+      });
+    });
+
     it("clears in-flight CI and collapses the boost when enrichment is disabled", async () => {
       await withRole(undefined, async () => {
         mockForgeProviderResolved();
@@ -2870,12 +2921,17 @@ describe("PullRequestService", () => {
         expect(getCIStatuses).toHaveBeenCalledTimes(1);
 
         pullRequestService.setCIEnrichmentEnabled(false);
-        resolveCi(new Map([[7, makeMockCIStatus()]]));
+        // Resolve as PENDING specifically: a terminal state would leave the
+        // boost null no matter what, so only a pending result actually
+        // exercises the ambient gate on updateBoostFromDetectedPRs.
+        resolveCi(
+          new Map([[7, { state: "pending", total: 1, passed: 0, failed: 0, pending: 1, rawData: null }]])
+        );
         await refresh;
 
-        expect(svc.detectedPRs.get("wt-1")?.ciStatus).toBe("success");
-        // …but the collapsed boost stays collapsed: there is no ambient fetch
-        // behind it to resolve a pending state (#6149).
+        expect(svc.detectedPRs.get("wt-1")?.ciStatus).toBe("pending");
+        // …but the collapsed boost stays collapsed: arming the 30s cadence here
+        // would keep re-arming with no ambient fetch behind it (#6149).
         expect(svc.boostExpiresAt).toBeNull();
 
         pullRequestService.destroy();

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -2925,7 +2925,9 @@ describe("PullRequestService", () => {
         // boost null no matter what, so only a pending result actually
         // exercises the ambient gate on updateBoostFromDetectedPRs.
         resolveCi(
-          new Map([[7, { state: "pending", total: 1, passed: 0, failed: 0, pending: 1, rawData: null }]])
+          new Map([
+            [7, { state: "pending", total: 1, passed: 0, failed: 0, pending: 1, rawData: null }],
+          ])
         );
         await refresh;
 

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -286,7 +286,10 @@ describe("PullRequestService", () => {
       "feature/no-issue"
     );
 
-    expect(detected).toHaveLength(1);
+    // A manual refresh awaits CI enrichment, so the phase-2 re-emit lands
+    // inside the await too. The invariant is one PR bound per worktree, not a
+    // raw emit count.
+    expect(new Set(detected.map((d) => d.worktreeId))).toEqual(new Set(["wt-1"]));
     expect(detected[0]).toMatchObject({
       worktreeId: "wt-1",
       prNumber: 42,
@@ -686,7 +689,7 @@ describe("PullRequestService", () => {
     );
     // Per-branch path must NOT be used when the batch capability is present and succeeds.
     expect(mockImpl.findPRByBranch).not.toHaveBeenCalled();
-    expect(detected).toHaveLength(2);
+    expect(new Set(detected.map((d) => d.worktreeId))).toEqual(new Set(["wt-1", "wt-2"]));
 
     const byWorktree = new Map(detected.map((d) => [d.worktreeId, d]));
     expect(byWorktree.get("wt-1")).toMatchObject({
@@ -738,8 +741,7 @@ describe("PullRequestService", () => {
       expect.arrayContaining(["shared/branch"])
     );
     // Both worktrees get a detection event from the single PR
-    expect(detected).toHaveLength(2);
-    const worktreeIds = detected.map((d) => d.worktreeId).sort();
+    const worktreeIds = [...new Set(detected.map((d) => d.worktreeId))].sort();
     expect(worktreeIds).toEqual(["wt-a", "wt-b"]);
     expect(detected.every((d) => d.prNumber === 99)).toBe(true);
 
@@ -1293,7 +1295,7 @@ describe("PullRequestService", () => {
     // Per-branch fallback fires for each unique branch on batch failure.
     expect(mockImpl.findPRByBranch).toHaveBeenCalledTimes(2);
     // Detection still completes — a single transient batch error must not blank every row.
-    expect(detected).toHaveLength(2);
+    expect(new Set(detected.map((d) => d.worktreeId))).toEqual(new Set(["wt-1", "wt-2"]));
 
     unsubscribe();
     pullRequestService.destroy();
@@ -2612,6 +2614,87 @@ describe("PullRequestService", () => {
       });
     });
 
+    it("fetches and commits CI on a manual refresh while ambient enrichment is off", async () => {
+      await withRole(undefined, async () => {
+        const batchSpy = vi.fn(async (_repo: RepoRef, branches: string[]) => {
+          const map = new Map<string, ForgePR | null>();
+          for (const branch of branches)
+            map.set(branch, makeMockForgePR({ number: 7, headRef: branch }));
+          return map;
+        });
+        const mockImpl = mockForgeProviderResolved(undefined, batchSpy);
+        const getCIStatuses = vi.fn(async (_repo: RepoRef, prNumbers: number[]) => {
+          const map = new Map<number, CIStatus | null>();
+          for (const n of prNumbers) map.set(n, makeMockCIStatus());
+          return map;
+        });
+        mockImpl.batchLookups = { getCIStatuses };
+
+        const { pullRequestService } = await import("../PullRequestService.js");
+        const { events } = await import("../events.js");
+        const svc = pullRequestService as any;
+
+        pullRequestService.initialize("/repo", "test-project-id");
+        events.emit(
+          "sys:worktree:update",
+          makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+        );
+
+        // Window is blurred, so ambient enrichment is off — the state in which
+        // a refresh used to complete with no CI fetched at all (#11633).
+        pullRequestService.setCIEnrichmentEnabled(false);
+
+        await pullRequestService.refresh();
+
+        expect(getCIStatuses).toHaveBeenCalledTimes(1);
+        expect(svc.detectedPRs.get("wt-1")?.ciStatus).toBe("success");
+        // The forced pass rides the call, so the ambient flag is untouched —
+        // no restore step, and nothing for the disable sweep to tear down.
+        expect(svc.ciEnrichmentEnabled).toBe(false);
+
+        pullRequestService.destroy();
+      });
+    });
+
+    it("coalesces concurrent refreshes into a single detection cycle", async () => {
+      await withRole(undefined, async () => {
+        const batchSpy = vi.fn(async (_repo: RepoRef, branches: string[]) => {
+          const map = new Map<string, ForgePR | null>();
+          for (const branch of branches)
+            map.set(branch, makeMockForgePR({ number: 7, headRef: branch }));
+          return map;
+        });
+        mockForgeProviderResolved(undefined, batchSpy);
+
+        const { pullRequestService } = await import("../PullRequestService.js");
+        const { events } = await import("../events.js");
+
+        pullRequestService.initialize("/repo", "test-project-id");
+        events.emit(
+          "sys:worktree:update",
+          makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+        );
+
+        // One sidebar click reaches this host twice — via the view's worktree
+        // port and via the pool-wide refresh-prs fan-out. Unjoined, the second
+        // caller's invalidateProvider() disposes the first's in-flight
+        // coalescers and those branches resolve to null for the cycle.
+        const [a, b] = [pullRequestService.refresh(), pullRequestService.refresh()];
+        expect(a).toBe(b);
+        await Promise.all([a, b]);
+
+        expect(batchSpy).toHaveBeenCalledTimes(1);
+        // The PR still bound despite the concurrent second trigger.
+        expect((pullRequestService as any).detectedPRs.get("wt-1")?.number).toBe(7);
+
+        // A later refresh is a new cycle, not a joined one.
+        await pullRequestService.refresh();
+        expect(batchSpy).toHaveBeenCalledTimes(2);
+
+        pullRequestService.destroy();
+      });
+    });
+
     it("clears in-flight CI and collapses the boost when enrichment is disabled", async () => {
       await withRole(undefined, async () => {
         mockForgeProviderResolved();
@@ -2732,7 +2815,9 @@ describe("PullRequestService", () => {
           "sys:worktree:update",
           makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
         );
-        await pullRequestService.refresh();
+        // Ambient detection, not a manual refresh: an ambient enrichment is
+        // fire-and-forget, so it is still in flight when the blur lands.
+        await svc.checkForPRs();
         await flushLoaders();
 
         // Enrichment is dispatched but still pending. Disable, then let it land.
@@ -2744,6 +2829,54 @@ describe("PullRequestService", () => {
         // The stale in-flight result is discarded — the PR keeps no CI status.
         const pr = svc.detectedPRs.get("wt-1");
         expect(pr?.ciStatus).toBeUndefined();
+
+        pullRequestService.destroy();
+      });
+    });
+
+    it("keeps a manual refresh's CI result when the window blurs mid-flight", async () => {
+      await withRole(undefined, async () => {
+        let resolveCi: (m: Map<number, CIStatus | null>) => void = () => {};
+        const batchSpy = vi.fn(async (_repo: RepoRef, branches: string[]) => {
+          const map = new Map<string, ForgePR | null>();
+          for (const branch of branches)
+            map.set(branch, makeMockForgePR({ number: 7, headRef: branch }));
+          return map;
+        });
+        const mockImpl = mockForgeProviderResolved(undefined, batchSpy);
+        const getCIStatuses = vi.fn(
+          (_repo: RepoRef, _prNumbers: number[]) =>
+            new Promise<Map<number, CIStatus | null>>((resolve) => {
+              resolveCi = resolve;
+            })
+        );
+        mockImpl.batchLookups = { getCIStatuses };
+
+        const { pullRequestService } = await import("../PullRequestService.js");
+        const { events } = await import("../events.js");
+        const svc = pullRequestService as any;
+
+        pullRequestService.initialize("/repo", "test-project-id");
+        events.emit(
+          "sys:worktree:update",
+          makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+        );
+
+        // The user asked for this data explicitly, so a blur arriving while the
+        // batch is in flight must not throw the answer away — the opposite of
+        // the ambient case above.
+        const refresh = pullRequestService.refresh();
+        await flushLoaders();
+        expect(getCIStatuses).toHaveBeenCalledTimes(1);
+
+        pullRequestService.setCIEnrichmentEnabled(false);
+        resolveCi(new Map([[7, makeMockCIStatus()]]));
+        await refresh;
+
+        expect(svc.detectedPRs.get("wt-1")?.ciStatus).toBe("success");
+        // …but the collapsed boost stays collapsed: there is no ambient fetch
+        // behind it to resolve a pending state (#6149).
+        expect(svc.boostExpiresAt).toBeNull();
 
         pullRequestService.destroy();
       });

--- a/electron/services/__tests__/WorkspaceClient.rateLimit.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.rateLimit.test.ts
@@ -164,3 +164,91 @@ describe("WorkspaceClient.relayFetchThrottle", () => {
     expect(() => client.relayFetchThrottle(2)).not.toThrow();
   });
 });
+
+describe("WorkspaceClient.refreshPullRequests", () => {
+  let client: WorkspaceClient;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockHosts.length = 0;
+    client = new WorkspaceClient({
+      maxRestartAttempts: 3,
+      showCrashDialog: false,
+      healthCheckIntervalMs: 1000,
+    });
+  });
+
+  afterEach(() => {
+    client.dispose();
+    vi.useRealTimers();
+  });
+
+  function h(index: number): MockHost {
+    return mockHosts[index];
+  }
+
+  async function loadProject(projectPath: string, hostIndex: number, windowId: number) {
+    const load = client.loadProject(projectPath, windowId);
+    h(hostIndex).simulateReady();
+    await vi.advanceTimersByTimeAsync(0);
+    const req = h(hostIndex).getLastRequest()!;
+    h(hostIndex).resolveRequest(req.requestId);
+    await vi.advanceTimersByTimeAsync(0);
+    await load;
+  }
+
+  it("dispatches to every pooled host before any of them has responded", async () => {
+    await loadProject("/project-a", 0, 1);
+    await loadProject("/project-b", 1, 2);
+    h(0).sendWithResponse.mockClear();
+    h(1).sendWithResponse.mockClear();
+
+    const refresh = client.refreshPullRequests();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Neither host has responded yet. A sequential fan-out would leave the
+    // second host untouched until the first resolved, so both requests being
+    // in flight at once is what proves the walk is concurrent.
+    expect(h(0).getLastRequest()?.type).toBe("refresh-prs");
+    expect(h(1).getLastRequest()?.type).toBe("refresh-prs");
+
+    h(0).resolveRequest(h(0).getLastRequest()!.requestId);
+    h(1).resolveRequest(h(1).getLastRequest()!.requestId);
+    await refresh;
+  });
+
+  it("gives the refresh more response headroom than the host default", async () => {
+    await loadProject("/project-a", 0, 1);
+    h(0).sendWithResponse.mockClear();
+
+    const refresh = client.refreshPullRequests();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // A manual refresh now awaits CI enrichment on top of provider
+    // re-resolution and PR re-detection, so it must not inherit the host's
+    // default per-request budget.
+    const timeoutMs = h(0).sendWithResponse.mock.calls[0][1] as number | undefined;
+    expect(timeoutMs).toBeDefined();
+    expect(timeoutMs).toBeGreaterThan(30_000);
+
+    h(0).resolveRequest(h(0).getLastRequest()!.requestId);
+    await refresh;
+  });
+
+  it("refreshes the surviving host when another host fails", async () => {
+    await loadProject("/project-a", 0, 1);
+    await loadProject("/project-b", 1, 2);
+    h(0).sendWithResponse.mockClear();
+    h(1).sendWithResponse.mockClear();
+    h(0).sendWithResponse.mockRejectedValueOnce(new Error("host crashed"));
+
+    const refresh = client.refreshPullRequests();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(h(1).getLastRequest()?.type).toBe("refresh-prs");
+    h(1).resolveRequest(h(1).getLastRequest()!.requestId);
+
+    // A crashed host must not reject the whole fan-out.
+    await expect(refresh).resolves.toBeUndefined();
+  });
+});

--- a/electron/services/__tests__/WorkspaceClient.rateLimit.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.rateLimit.test.ts
@@ -38,11 +38,15 @@ const { mockHosts, MockWorkspaceHostProcess } = vi.hoisted(() => {
 
     send = vi.fn(() => true);
 
-    sendWithResponse = vi.fn(<T>(request: { requestId: string; type: string }): Promise<T> => {
-      return new Promise<T>((resolve) => {
-        this.responseHandlers.set(request.requestId, resolve);
-      });
-    });
+    // Second parameter mirrors the real sendWithResponse(request, timeoutMs?)
+    // so callers passing an explicit timeout type-check against this double.
+    sendWithResponse = vi.fn(
+      <T>(request: { requestId: string; type: string }, _timeoutMs?: number): Promise<T> => {
+        return new Promise<T>((resolve) => {
+          this.responseHandlers.set(request.requestId, resolve);
+        });
+      }
+    );
 
     pauseHealthCheck = vi.fn();
     resumeHealthCheck = vi.fn();
@@ -227,7 +231,7 @@ describe("WorkspaceClient.refreshPullRequests", () => {
     // A manual refresh now awaits CI enrichment on top of provider
     // re-resolution and PR re-detection, so it must not inherit the host's
     // default per-request budget.
-    const timeoutMs = h(0).sendWithResponse.mock.calls[0][1] as number | undefined;
+    const timeoutMs = h(0).sendWithResponse.mock.calls[0][1];
     expect(timeoutMs).toBeDefined();
     expect(timeoutMs).toBeGreaterThan(30_000);
 

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -39,6 +39,7 @@ import { useBuiltinView } from "@/registry/builtinRendererRegistry";
 import type { ForgeBulkCreateWorktreeDialogProps } from "@/types/forgeSlotProps";
 import { useResolvedForgeProvider } from "@/hooks/useResolvedForgeProvider";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { createTooltipContent } from "@/lib/tooltipShortcut";
 import { SpinningIcon } from "@/components/ui/SpinningIcon";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
@@ -1695,17 +1696,23 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
             >
               <Zap className="w-3.5 h-3.5" />
             </button>
-            <button
-              type="button"
-              onClick={handleRefreshAll}
-              aria-disabled={isRefreshing || undefined}
-              className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent aria-disabled:opacity-40 aria-disabled:cursor-not-allowed aria-disabled:hover:bg-transparent aria-disabled:hover:text-daintree-text/40"
-              aria-label="Refresh sidebar"
-              aria-keyshortcuts={refreshAriaShortcut}
-              title={formatButtonTitle("Refresh sidebar", refreshShortcut)}
-            >
-              <SpinningIcon icon={RefreshCw} active={isRefreshing} className="w-3.5 h-3.5" />
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={handleRefreshAll}
+                  aria-disabled={isRefreshing || undefined}
+                  className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent aria-disabled:opacity-40 aria-disabled:cursor-not-allowed aria-disabled:hover:bg-transparent aria-disabled:hover:text-daintree-text/40"
+                  aria-label="Refresh sidebar"
+                  aria-keyshortcuts={refreshAriaShortcut}
+                >
+                  <SpinningIcon icon={RefreshCw} active={isRefreshing} className="w-3.5 h-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {createTooltipContent("Refresh sidebar", refreshShortcut)}
+              </TooltipContent>
+            </Tooltip>
           </div>
           <button
             type="button"

--- a/src/components/Sidebar/__tests__/SidebarContent.shortcuts.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.shortcuts.test.ts
@@ -78,17 +78,22 @@ describe("SidebarContent shortcut labels — issue #5843", () => {
       // appears without the native title's delay (#11633). The shortcut still
       // has to reach the user, so it rides createTooltipContent's chord pill
       // rather than a string suffix.
-      // Scoped to the button's own opening tag: a wider window would sweep in
-      // the sibling controls, which still carry native titles of their own.
-      const refreshButton = source.match(/<button[^>]*onClick=\{handleRefreshAll\}[^>]*>/);
-      expect(refreshButton).not.toBeNull();
-      // A leftover native title would double up with the tooltip.
-      expect(refreshButton![0]).not.toMatch(/\btitle=/);
+      // One contiguous Tooltip block that contains the refresh handler, with no
+      // nested <Tooltip> opening in between — so the content below is proven to
+      // belong to THIS button rather than matching a sibling control elsewhere
+      // in the header (several still carry native titles of their own).
+      const refreshTooltip = source.match(
+        /<Tooltip>(?:(?!<Tooltip>)[\s\S])*?onClick=\{handleRefreshAll\}[\s\S]*?<\/Tooltip>/
+      );
+      expect(refreshTooltip).not.toBeNull();
+      const block = refreshTooltip![0];
 
+      // A leftover native title would double up with the tooltip.
+      expect(block.match(/<button[^>]*>/)![0]).not.toMatch(/\btitle=/);
       // The shortcut still has to reach the user — it rides createTooltipContent's
       // chord pill instead of formatButtonTitle's string suffix.
-      expect(source).toMatch(
-        /<TooltipContent side="bottom">\s*\{createTooltipContent\("Refresh sidebar", refreshShortcut\)\}\s*<\/TooltipContent>/
+      expect(block).toMatch(
+        /<TooltipContent side="bottom">\s*\{createTooltipContent\("Refresh sidebar", refreshShortcut\)\}/
       );
     });
 

--- a/src/components/Sidebar/__tests__/SidebarContent.shortcuts.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.shortcuts.test.ts
@@ -73,8 +73,23 @@ describe("SidebarContent shortcut labels — issue #5843", () => {
       expect(source).not.toMatch(/formatButtonTitle\("Select terminals to arm",/);
     });
 
-    it("uses formatButtonTitle for Refresh sidebar title", () => {
-      expect(source).toContain('formatButtonTitle("Refresh sidebar", refreshShortcut)');
+    it("renders the Refresh sidebar label through the app Tooltip, not a native title", () => {
+      // The refresh control uses the shared Tooltip so the label is styled and
+      // appears without the native title's delay (#11633). The shortcut still
+      // has to reach the user, so it rides createTooltipContent's chord pill
+      // rather than a string suffix.
+      // Scoped to the button's own opening tag: a wider window would sweep in
+      // the sibling controls, which still carry native titles of their own.
+      const refreshButton = source.match(/<button[^>]*onClick=\{handleRefreshAll\}[^>]*>/);
+      expect(refreshButton).not.toBeNull();
+      // A leftover native title would double up with the tooltip.
+      expect(refreshButton![0]).not.toMatch(/\btitle=/);
+
+      // The shortcut still has to reach the user — it rides createTooltipContent's
+      // chord pill instead of formatButtonTitle's string suffix.
+      expect(source).toMatch(
+        /<TooltipContent side="bottom">\s*\{createTooltipContent\("Refresh sidebar", refreshShortcut\)\}\s*<\/TooltipContent>/
+      );
     });
 
     it("uses formatButtonTitle for Create new worktree title", () => {

--- a/src/hooks/__tests__/useForgeTooltip.test.tsx
+++ b/src/hooks/__tests__/useForgeTooltip.test.tsx
@@ -37,11 +37,30 @@ import { usePRTooltip, useIssueTooltip, invalidateForgeTooltipCaches } from "../
 const CWD = "/repo/worktree";
 
 function makePR(title: string): PRTooltipData {
-  return { title, state: "open", author: "octocat" } as PRTooltipData;
+  return {
+    number: 42,
+    title,
+    bodyExcerpt: "",
+    state: "open",
+    rawState: "OPEN",
+    isDraft: false,
+    createdAt: 0,
+    assignees: [],
+    labels: [],
+  };
 }
 
 function makeIssue(title: string): IssueTooltipData {
-  return { title, state: "open" } as IssueTooltipData;
+  return {
+    number: 7,
+    title,
+    bodyExcerpt: "",
+    state: "open",
+    rawState: "OPEN",
+    createdAt: 0,
+    assignees: [],
+    labels: [],
+  };
 }
 
 beforeEach(() => {

--- a/src/hooks/__tests__/useForgeTooltip.test.tsx
+++ b/src/hooks/__tests__/useForgeTooltip.test.tsx
@@ -134,6 +134,43 @@ describe("usePRTooltip caching", () => {
     expect(getPRTooltipMock).toHaveBeenCalledTimes(2);
     await waitFor(() => expect(result.current.data?.title).toBe("Fresh title"));
   });
+
+  it("does not let a pre-refresh response overwrite a newer one that already resolved", async () => {
+    // Ordering matters: the stale request resolves LAST. Fencing only the cache
+    // write would still let its setState repaint the open tooltip over the
+    // fresh data — and forge badge tooltips do not auto-dismiss, so it would
+    // stay wrong on screen.
+    let resolveStale: (value: PRTooltipData) => void = () => {};
+    getPRTooltipMock.mockReturnValueOnce(
+      new Promise<PRTooltipData>((resolve) => {
+        resolveStale = resolve;
+      })
+    );
+
+    const { result } = renderHook(() => usePRTooltip(CWD, 42));
+
+    let stalePending: Promise<void> = Promise.resolve();
+    act(() => {
+      stalePending = result.current.fetchTooltip();
+    });
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("daintree:refresh-sidebar"));
+    });
+
+    getPRTooltipMock.mockResolvedValue(makePR("Fresh title"));
+    await act(async () => {
+      await result.current.fetchTooltip();
+    });
+    await waitFor(() => expect(result.current.data?.title).toBe("Fresh title"));
+
+    await act(async () => {
+      resolveStale(makePR("Stale title"));
+      await stalePending;
+    });
+
+    expect(result.current.data?.title).toBe("Fresh title");
+  });
 });
 
 describe("useIssueTooltip caching", () => {

--- a/src/hooks/__tests__/useForgeTooltip.test.tsx
+++ b/src/hooks/__tests__/useForgeTooltip.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PRTooltipData, IssueTooltipData } from "@shared/types/forge";
+
+const { getPRTooltipMock, getIssueTooltipMock, getCredentialStatusMock } = vi.hoisted(() => ({
+  getPRTooltipMock: vi.fn<(cwd: string, prNumber: number) => Promise<PRTooltipData | null>>(),
+  getIssueTooltipMock:
+    vi.fn<(cwd: string, issueNumber: number) => Promise<IssueTooltipData | null>>(),
+  getCredentialStatusMock: vi.fn<(providerId: string) => Promise<{ hasCredential: boolean }>>(),
+}));
+
+vi.mock("@/clients", () => ({
+  forgeClient: {
+    getPRTooltip: getPRTooltipMock,
+    getIssueTooltip: getIssueTooltipMock,
+  },
+}));
+
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: (selector: (s: { currentProject: { id: string } | null }) => unknown) =>
+    selector({ currentProject: { id: "test-project" } }),
+}));
+
+vi.mock("@/hooks/useResolvedForgeProvider", () => ({
+  useResolvedForgeProvider: () => ({
+    entry: { pluginId: "test.forge", contribution: { id: "provider", name: "Test Forge" } },
+    providerId: "test.forge.provider",
+    resolvedVia: "hostname",
+    loading: false,
+    refresh: () => {},
+  }),
+}));
+
+import { usePRTooltip, useIssueTooltip, invalidateForgeTooltipCaches } from "../useForgeTooltip";
+
+const CWD = "/repo/worktree";
+
+function makePR(title: string): PRTooltipData {
+  return { title, state: "open", author: "octocat" } as PRTooltipData;
+}
+
+function makeIssue(title: string): IssueTooltipData {
+  return { title, state: "open" } as IssueTooltipData;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Each test starts from an empty cache so a previous test's entries can't
+  // satisfy a fetch this one expects to reach the client.
+  invalidateForgeTooltipCaches();
+  getCredentialStatusMock.mockResolvedValue({ hasCredential: true });
+  Object.defineProperty(window, "electron", {
+    value: { forge: { getCredentialStatus: getCredentialStatusMock } },
+    writable: true,
+    configurable: true,
+  });
+});
+
+describe("usePRTooltip caching", () => {
+  it("serves a repeat fetch for the same PR from cache without re-hitting the client", async () => {
+    getPRTooltipMock.mockResolvedValue(makePR("Original title"));
+
+    const { result } = renderHook(() => usePRTooltip(CWD, 42));
+
+    await act(async () => {
+      await result.current.fetchTooltip();
+    });
+    await act(async () => {
+      await result.current.fetchTooltip();
+    });
+
+    expect(getPRTooltipMock).toHaveBeenCalledTimes(1);
+    expect(result.current.data?.title).toBe("Original title");
+  });
+
+  it("re-reads from the provider after a sidebar refresh instead of serving the cached copy", async () => {
+    getPRTooltipMock.mockResolvedValue(makePR("Original title"));
+
+    const { result } = renderHook(() => usePRTooltip(CWD, 42));
+    await act(async () => {
+      await result.current.fetchTooltip();
+    });
+    expect(getPRTooltipMock).toHaveBeenCalledTimes(1);
+
+    getPRTooltipMock.mockResolvedValue(makePR("Updated title"));
+    act(() => {
+      window.dispatchEvent(new CustomEvent("daintree:refresh-sidebar"));
+    });
+
+    await act(async () => {
+      await result.current.fetchTooltip();
+    });
+
+    expect(getPRTooltipMock).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(result.current.data?.title).toBe("Updated title"));
+  });
+
+  it("does not let a response that predates the refresh repopulate the cleared cache", async () => {
+    // The user hovers (fetch starts), then clicks refresh before the response
+    // lands. Writing that pre-refresh response into the cache would make the
+    // NEXT hover serve stale data with no request — the exact staleness the
+    // refresh was supposed to clear.
+    let resolveFirst: (value: PRTooltipData) => void = () => {};
+    getPRTooltipMock.mockReturnValueOnce(
+      new Promise<PRTooltipData>((resolve) => {
+        resolveFirst = resolve;
+      })
+    );
+
+    const { result } = renderHook(() => usePRTooltip(CWD, 42));
+
+    let pending: Promise<void> = Promise.resolve();
+    act(() => {
+      pending = result.current.fetchTooltip();
+    });
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("daintree:refresh-sidebar"));
+    });
+
+    await act(async () => {
+      resolveFirst(makePR("Stale title"));
+      await pending;
+    });
+
+    getPRTooltipMock.mockResolvedValue(makePR("Fresh title"));
+    await act(async () => {
+      await result.current.fetchTooltip();
+    });
+
+    // Two client calls total: the cache must not have been satisfied by the
+    // in-flight response that resolved after the invalidation.
+    expect(getPRTooltipMock).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(result.current.data?.title).toBe("Fresh title"));
+  });
+});
+
+describe("useIssueTooltip caching", () => {
+  it("re-reads issue detail from the provider after a sidebar refresh", async () => {
+    getIssueTooltipMock.mockResolvedValue(makeIssue("Original issue"));
+
+    const { result } = renderHook(() => useIssueTooltip(CWD, 7));
+    await act(async () => {
+      await result.current.fetchTooltip();
+    });
+    await act(async () => {
+      await result.current.fetchTooltip();
+    });
+    expect(getIssueTooltipMock).toHaveBeenCalledTimes(1);
+
+    getIssueTooltipMock.mockResolvedValue(makeIssue("Updated issue"));
+    act(() => {
+      window.dispatchEvent(new CustomEvent("daintree:refresh-sidebar"));
+    });
+
+    await act(async () => {
+      await result.current.fetchTooltip();
+    });
+
+    expect(getIssueTooltipMock).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(result.current.data?.title).toBe("Updated issue"));
+  });
+});

--- a/src/hooks/useForgeTooltip.ts
+++ b/src/hooks/useForgeTooltip.ts
@@ -105,17 +105,18 @@ export function useIssueTooltip(cwd: string | undefined, issueNumber: number | u
 
     const inFlight = inFlightIssues.get(cacheKey);
     if (inFlight) {
+      const joinedGeneration = cacheGeneration;
       setState((prev) => ({ ...prev, loading: true, error: false }));
       try {
         const data = await inFlight;
-        if (!mountedRef.current) return;
+        if (!mountedRef.current || joinedGeneration !== cacheGeneration) return;
         if (data) {
           setState({ data, loading: false, error: false });
         } else {
           setState({ data: null, loading: false, error: true });
         }
       } catch {
-        if (!mountedRef.current) return;
+        if (!mountedRef.current || joinedGeneration !== cacheGeneration) return;
         setState({ data: null, loading: false, error: true });
       }
       return;
@@ -145,14 +146,18 @@ export function useIssueTooltip(cwd: string | undefined, issueNumber: number | u
 
     try {
       const data = await promise;
-      if (!mountedRef.current) return;
+      // Same fence as the cache write: a response from before the refresh must
+      // not paint pre-refresh detail into an open tooltip, and must not
+      // overwrite a newer request that already resolved. The tooltip re-fetches
+      // on its next open rather than committing data the refresh invalidated.
+      if (!mountedRef.current || generation !== cacheGeneration) return;
       if (data) {
         setState({ data, loading: false, error: false });
       } else {
         setState({ data: null, loading: false, error: true });
       }
     } catch {
-      if (!mountedRef.current) return;
+      if (!mountedRef.current || generation !== cacheGeneration) return;
       setState({ data: null, loading: false, error: true });
     }
   }, [cwd, issueNumber, providerResolved, missingCredential]);
@@ -194,17 +199,18 @@ export function usePRTooltip(cwd: string | undefined, prNumber: number | undefin
 
     const inFlight = inFlightPRs.get(cacheKey);
     if (inFlight) {
+      const joinedGeneration = cacheGeneration;
       setState((prev) => ({ ...prev, loading: true, error: false }));
       try {
         const data = await inFlight;
-        if (!mountedRef.current) return;
+        if (!mountedRef.current || joinedGeneration !== cacheGeneration) return;
         if (data) {
           setState({ data, loading: false, error: false });
         } else {
           setState({ data: null, loading: false, error: true });
         }
       } catch {
-        if (!mountedRef.current) return;
+        if (!mountedRef.current || joinedGeneration !== cacheGeneration) return;
         setState({ data: null, loading: false, error: true });
       }
       return;
@@ -231,14 +237,16 @@ export function usePRTooltip(cwd: string | undefined, prNumber: number | undefin
 
     try {
       const data = await promise;
-      if (!mountedRef.current) return;
+      // See useIssueTooltip: a pre-refresh response neither paints nor
+      // overwrites a newer one.
+      if (!mountedRef.current || generation !== cacheGeneration) return;
       if (data) {
         setState({ data, loading: false, error: false });
       } else {
         setState({ data: null, loading: false, error: true });
       }
     } catch {
-      if (!mountedRef.current) return;
+      if (!mountedRef.current || generation !== cacheGeneration) return;
       setState({ data: null, loading: false, error: true });
     }
   }, [cwd, prNumber, providerResolved, missingCredential]);

--- a/src/hooks/useForgeTooltip.ts
+++ b/src/hooks/useForgeTooltip.ts
@@ -17,6 +17,11 @@ const TOOLTIP_CACHE_TTL = 300_000; // 5 minutes, matching backend TTL
 const issueCache = new TtlCache<string, IssueTooltipData>(TOOLTIP_CACHE_MAX, TOOLTIP_CACHE_TTL);
 const prCache = new TtlCache<string, PRTooltipData>(TOOLTIP_CACHE_MAX, TOOLTIP_CACHE_TTL);
 
+// Bumped by invalidateForgeTooltipCaches (see bottom of file). Each fetch
+// captures the generation it started in so a response that predates a refresh
+// can't repopulate a cache that refresh just cleared.
+let cacheGeneration = 0;
+
 // Per-provider credential presence. Short TTL: a token saved in Settings
 // becomes visible to badges within this window (the forge credential surface
 // has no push event, so a bounded poll-on-mount is the trade-off).
@@ -118,23 +123,25 @@ export function useIssueTooltip(cwd: string | undefined, issueNumber: number | u
 
     setState((prev) => ({ ...prev, loading: true, error: false }));
 
+    const generation = cacheGeneration;
     const promise = (async () => {
       const data = await forgeClient.getIssueTooltip(cwd, issueNumber);
-      if (data) {
+      // A sidebar refresh landed while this was in flight: the response predates
+      // the invalidation, so writing it back would re-poison the cache the
+      // refresh just cleared and the next hover would serve pre-refresh data.
+      if (data && generation === cacheGeneration) {
         issueCache.set(cacheKey, data);
       }
       return data;
     })();
 
     inFlightIssues.set(cacheKey, promise);
-    promise.then(
-      () => {
-        inFlightIssues.delete(cacheKey);
-      },
-      () => {
-        inFlightIssues.delete(cacheKey);
-      }
-    );
+    // Identity-checked so a settled pre-refresh promise can't evict the newer
+    // request that replaced it under the same key.
+    const clearInFlight = () => {
+      if (inFlightIssues.get(cacheKey) === promise) inFlightIssues.delete(cacheKey);
+    };
+    promise.then(clearInFlight, clearInFlight);
 
     try {
       const data = await promise;
@@ -205,23 +212,22 @@ export function usePRTooltip(cwd: string | undefined, prNumber: number | undefin
 
     setState((prev) => ({ ...prev, loading: true, error: false }));
 
+    const generation = cacheGeneration;
     const promise = (async () => {
       const data = await forgeClient.getPRTooltip(cwd, prNumber);
-      if (data) {
+      // See useIssueTooltip: a response that predates a refresh must not
+      // repopulate the cache the refresh cleared.
+      if (data && generation === cacheGeneration) {
         prCache.set(cacheKey, data);
       }
       return data;
     })();
 
     inFlightPRs.set(cacheKey, promise);
-    promise.then(
-      () => {
-        inFlightPRs.delete(cacheKey);
-      },
-      () => {
-        inFlightPRs.delete(cacheKey);
-      }
-    );
+    const clearInFlight = () => {
+      if (inFlightPRs.get(cacheKey) === promise) inFlightPRs.delete(cacheKey);
+    };
+    promise.then(clearInFlight, clearInFlight);
 
     try {
       const data = await promise;
@@ -242,4 +248,32 @@ export function usePRTooltip(cwd: string | undefined, prNumber: number | undefin
   }, []);
 
   return { ...state, missingCredential, providerId, fetchTooltip, reset };
+}
+
+/**
+ * Drop the hover-detail caches so a manual sidebar refresh re-reads PR and issue
+ * metadata from the provider instead of serving pre-refresh data until the 5min
+ * TTL lapses. Registered once at module scope because the caches themselves are
+ * module-level: clearing has to happen even when no badge is mounted, which is
+ * the common case (the user clicks refresh first, then hovers).
+ *
+ * The credential cache is deliberately left alone — a refresh is not a
+ * credential change, and its 30s TTL already re-reads promptly.
+ */
+export function invalidateForgeTooltipCaches(): void {
+  cacheGeneration += 1;
+  issueCache.clear();
+  prCache.clear();
+  // In-flight entries resolve into the previous generation and are fenced out of
+  // the caches, so leaving them mapped would make the next hover await a promise
+  // whose result is already discarded.
+  inFlightIssues.clear();
+  inFlightPRs.clear();
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("daintree:refresh-sidebar", invalidateForgeTooltipCaches);
+  import.meta.hot?.dispose(() => {
+    window.removeEventListener("daintree:refresh-sidebar", invalidateForgeTooltipCaches);
+  });
 }

--- a/src/services/actions/definitions/__tests__/worktreeServiceActions.test.ts
+++ b/src/services/actions/definitions/__tests__/worktreeServiceActions.test.ts
@@ -94,6 +94,19 @@ describe("worktree service action definitions", () => {
     expect(payload.message).toBe("Refresh watchdog tripped");
   });
 
+  it("worktree.refresh drives both the active host and the pool-wide PR fan-out", async () => {
+    const def = registry.get("worktree.refresh")!();
+    await def.run!(undefined as never, undefined as never);
+
+    // These reach different hosts and are NOT interchangeable: the worktree
+    // port is bound to this view's project alone, while refreshPullRequests
+    // fans out across every pooled project. Dropping either as a "duplicate"
+    // silently narrows what a refresh actually covers — the duplicate work it
+    // used to cause is coalesced host-side instead (#11633).
+    expect(mockRequest).toHaveBeenCalledWith("refresh");
+    expect(mockRefreshPullRequests).toHaveBeenCalledTimes(1);
+  });
+
   it("worktree.refresh does not let a PR-refresh failure surface as a refresh error", async () => {
     mockRefreshPullRequests.mockRejectedValueOnce(new Error("rate limited"));
 


### PR DESCRIPTION
## Summary

- The sidebar's refresh button now uses the app's `Tooltip` component instead of a native HTML `title`, matching the sibling controls in the same header.
- A click is now a true full refresh: worktree titles, pull requests, and CI badges all re-resolve through the forge provider abstraction instead of quietly no-opping in several cases.

Resolves #11633

## Changes

The issue listed four concrete holes. All four are addressed:

**CI status never moved.** `ciEnrichmentEnabled` gates every CI fetch and tracks window focus, but `refresh()` never touched it, so a refresh dispatched while the window was blurred (or from MCP or agent automation) completed with no CI fetched at all. The fix forces enrichment for the manual pass. It rides the call rather than the shared flag on purpose: flipping the flag and restoring it would run the disable sweep on restore and discard the very result the pass had just fetched, since enrichment is fire-and-forget. `refresh()` now awaits the forced batch, so it resolves once the badges have actually been re-emitted, and same-tick `BatchLoader` coalescing is preserved. The revalidation boost stays gated on ambient enrichment, so a forced `pending` result can't re-arm the 30s cadence with no ambient fetch behind it. Worker-role instances stay clamped too: the force overrides window focus only, never the environment role.

**Duplicate refresh round trip.** One click was reaching a host twice: once via the view's worktree port, once via the pool-wide `refresh-prs` fan-out. Both are kept, since they aren't interchangeable (the port is bound to a single host, the client fans out to every pooled project), so the duplication is now coalesced host-side with a single-flight. That also closes a real data-loss race: the second caller's `invalidateProvider()` was disposing the first caller's in-flight coalescers, and `resolvePRsForBranches()` absorbs a disposal as `null`, silently skipping those branches on the very click that promised fresh data. The single-flight is epoch-gated, so a config change (`updateForgeSettings`) still gets its own pass rather than inheriting a result resolved against the previous provider.

**Sequential host walk.** `refreshPullRequests()` now fans out with `Promise.allSettled`, matching the sibling `refreshOnWake` right above it in the file, with extra response headroom for the added CI phase.

**Stale hover data.** The renderer's module-level tooltip caches had no invalidation at all, so hovering a badge after a refresh kept serving pre-refresh PR and CI detail until the 5 minute TTL lapsed. They now clear on `daintree:refresh-sidebar`, fenced by a generation counter so an in-flight response can't repopulate a cache the refresh just cleared, or repaint an open tooltip over newer data.

**Known limitations (deliberate, flagging for reviewers):** the GitHub plugin's `issueTooltipCache` isn't cleared by `clearPullRequestCaches`. Clearing it needs a broader provider cache-invalidation capability, and doing that now would mean overloading a PR-named capability, so it's deferred. Separately, a worktree discovered by topology discovery *during* a refresh can be omitted from that pass; it self-heals within ~5s via the existing debounced check.

## Testing

133 tests across 6 files pass locally: `PullRequestService.test.ts`, `WorkspaceClient.rateLimit.test.ts`, `useForgeTooltip.test.tsx` (new), `SidebarContent.shortcuts.test.ts`, `SidebarContent.a11y.test.ts`, `worktreeServiceActions.test.ts`. Own-file prettier/eslint are clean.
