### PR TITLE
fix(panels): resolve panel kind definitions from the subscribed snapshot

### DIFF
--- a/e2e/full/plugins/core-plugin-panels.spec.ts
+++ b/e2e/full/plugins/core-plugin-panels.spec.ts
@@ -3,6 +3,19 @@ import { closeApp, type AppContext } from "../../helpers/launch";
 import { launchWithSamplePlugin, waitForRichPluginReady } from "../../helpers/plugins";
 import { T_LONG } from "../../helpers/timeouts";
 
+/** Toggle a loaded plugin's enabled state; re-enabling re-registers its contributions. */
+async function setPluginEnabled(page: Page, pluginId: string, enabled: boolean): Promise<void> {
+  await page.evaluate(
+    async (payload) =>
+      (
+        window as unknown as {
+          electron: { plugin: { setEnabled: (id: string, on: boolean) => Promise<unknown> } };
+        }
+      ).electron.plugin.setEnabled(payload.pluginId, payload.enabled),
+    { pluginId, enabled }
+  );
+}
+
 /** Dispatch a renderer action through the E2E-only bridge. */
 async function dispatchAction(page: Page, actionId: string, args?: unknown): Promise<unknown> {
   return page.evaluate(
@@ -236,5 +249,49 @@ test.describe.serial("Core: Plugin panels contribution", () => {
     await expect(ctx.window.getByText("Hook panel view ready")).toBeVisible({
       timeout: T_LONG,
     });
+  });
+
+  // Regression for #11636. `GridPanel` subscribed to the definition registry but
+  // then called `getPanelKindDefinition(kind)` separately, so React Compiler —
+  // which cannot see that the getter reads mutable module state — cached the
+  // result keyed only on `kind`. The subscription still rerendered the panel,
+  // but the cache kept serving the definition resolved on that fiber's FIRST
+  // render, and `ContentGridDefault` keys the wrapper on a stable `group.id` so
+  // the fiber never remounted. A panel restored before its plugin registered its
+  // kind therefore sat on "Plugin unavailable" until closed and reopened.
+  //
+  // Only the compiled bundle can show this: vitest runs uncompiled TSX where the
+  // getter re-runs every render, so a unit test passes with or without the bug.
+  //
+  // Disable/re-enable is the lever because panel contributions register on
+  // plugin LOAD (PluginService.loadPlugin), not on activation — so toggling is
+  // what actually removes and re-registers the definition. Both directions are
+  // asserted on the SAME `data-panel-id`: the panel record is never recreated,
+  // which is what preserves its `extensionState`. Kept last in this serial suite
+  // because it briefly disables the plugin the earlier tests depend on.
+  test("hot-swaps a live panel when its plugin kind is unregistered and registered again", async () => {
+    // Default `reuseExisting` returns the panel opened by the earlier test
+    // rather than spawning a second one.
+    const opened = (await dispatchAction(ctx.window, "panel.openPluginPanel", {
+      kind: "daintree.rich.rich-panel",
+    })) as { panelId: string };
+
+    const panel = ctx.window.locator(`[data-panel-id="${opened.panelId}"]`);
+    const unavailable = panel.getByRole("region", { name: "Plugin unavailable" });
+
+    await expect(panel.getByText("Rich panel view mounted")).toBeVisible({ timeout: T_LONG });
+
+    // Unregistering must reach the mounted panel. Pre-fix the stale cache kept
+    // the real view rendered here and this assertion failed.
+    await setPluginEnabled(ctx.window, "daintree.rich", false);
+    await expect(unavailable).toBeVisible({ timeout: T_LONG });
+
+    // The #11636 direction: the kind returns while the panel is already mounted
+    // and showing the placeholder, and the same panel resolves to the real view.
+    await setPluginEnabled(ctx.window, "daintree.rich", true);
+    await waitForRichPluginReady(ctx.app, ctx.window);
+
+    await expect(panel.getByText("Rich panel view mounted")).toBeVisible({ timeout: T_LONG });
+    await expect(unavailable).toHaveCount(0);
   });
 });

--- a/e2e/full/plugins/core-plugin-panels.spec.ts
+++ b/e2e/full/plugins/core-plugin-panels.spec.ts
@@ -281,14 +281,19 @@ test.describe.serial("Core: Plugin panels contribution", () => {
 
     await expect(panel.getByText("Rich panel view mounted")).toBeVisible({ timeout: T_LONG });
 
-    // Unregistering must reach the mounted panel. Pre-fix the stale cache kept
-    // the real view rendered here and this assertion failed.
-    await setPluginEnabled(ctx.window, "daintree.rich", false);
-    await expect(unavailable).toBeVisible({ timeout: T_LONG });
+    try {
+      // Unregistering must reach the mounted panel. Pre-fix the stale cache kept
+      // the real view rendered here and this assertion failed.
+      await setPluginEnabled(ctx.window, "daintree.rich", false);
+      await expect(unavailable).toBeVisible({ timeout: T_LONG });
+    } finally {
+      // Leave the plugin enabled even if the assertion above fails, so a
+      // failure here can't strand the shared context mid-toggle.
+      await setPluginEnabled(ctx.window, "daintree.rich", true);
+    }
 
     // The #11636 direction: the kind returns while the panel is already mounted
     // and showing the placeholder, and the same panel resolves to the real view.
-    await setPluginEnabled(ctx.window, "daintree.rich", true);
     await waitForRichPluginReady(ctx.app, ctx.window);
 
     await expect(panel.getByText("Rich panel view mounted")).toBeVisible({ timeout: T_LONG });

--- a/src/components/Panel/PanelDialogHost.tsx
+++ b/src/components/Panel/PanelDialogHost.tsx
@@ -1,8 +1,11 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useSyncExternalStore } from "react";
 import { PanelTop } from "lucide-react";
 import { usePanelStore } from "@/store/panelStore";
 import { usePanelDialogStore } from "@/store/panelDialogStore";
-import { getPanelKindDefinition } from "@/panels/registry";
+import {
+  getPanelKindDefinitionsSnapshot,
+  subscribeToPanelKindDefinitions,
+} from "@/panels/registry";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { Button } from "@/components/ui/button";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
@@ -83,9 +86,19 @@ function PanelDialogFrame({
     if (!panel) reconcileRemovedPanel(panelId);
   }, [panelId, panel, reconcileRemovedPanel]);
 
+  // Above the early returns below — hooks cannot be conditional. Subscribing
+  // here is what lets a dialog whose plugin kind registers late resolve to its
+  // real component instead of staying blank forever (#11636); the lookup reads
+  // this snapshot rather than calling `getPanelKindDefinition` separately,
+  // which React Compiler would cache keyed only on the kind.
+  const definitions = useSyncExternalStore(
+    subscribeToPanelKindDefinitions,
+    getPanelKindDefinitionsSnapshot
+  );
+
   if (!panel) return null;
 
-  const definition = getPanelKindDefinition(panel.kind ?? "terminal");
+  const definition = definitions[panel.kind ?? "terminal"];
   if (!definition) return null;
 
   const PanelComponent = definition.component;

--- a/src/components/Panel/__tests__/PanelDialogHost.fullHeight.test.tsx
+++ b/src/components/Panel/__tests__/PanelDialogHost.fullHeight.test.tsx
@@ -22,21 +22,20 @@ const StubPane = vi.hoisted(() => () => null);
 // and the test would pass even without the fix.
 vi.mock("@/panels/registry", async () => {
   const shared = await import("@shared/config/panelKindRegistry");
-  // Snapshot and entries are memoized: `useSyncExternalStore` throws on a
-  // getSnapshot that returns a fresh reference each call.
-  const cache = new Map<string, unknown>();
-  const definitionsSnapshot = new Proxy({} as Record<string, unknown>, {
-    get: (_target, kind: string) => {
-      if (!cache.has(kind)) {
-        const config = shared.getPanelKindConfig(kind);
-        cache.set(kind, config ? { ...config, component: StubPane } : undefined);
-      }
-      return cache.get(kind);
-    },
-  });
+  // Built once and reused: `useSyncExternalStore` throws on a getSnapshot that
+  // returns a fresh reference each call.
+  let snapshot: Record<string, unknown> | undefined;
   return {
     subscribeToPanelKindDefinitions: () => () => {},
-    getPanelKindDefinitionsSnapshot: () => definitionsSnapshot,
+    getPanelKindDefinitionsSnapshot: () => {
+      snapshot ??= Object.fromEntries(
+        shared.getPanelKindIds().flatMap((id) => {
+          const config = shared.getPanelKindConfig(id);
+          return config ? [[id, { ...config, component: StubPane }] as const] : [];
+        })
+      );
+      return snapshot;
+    },
   };
 });
 

--- a/src/components/Panel/__tests__/PanelDialogHost.fullHeight.test.tsx
+++ b/src/components/Panel/__tests__/PanelDialogHost.fullHeight.test.tsx
@@ -22,11 +22,21 @@ const StubPane = vi.hoisted(() => () => null);
 // and the test would pass even without the fix.
 vi.mock("@/panels/registry", async () => {
   const shared = await import("@shared/config/panelKindRegistry");
-  return {
-    getPanelKindDefinition: (kind: string) => {
-      const config = shared.getPanelKindConfig(kind);
-      return config ? { ...config, component: StubPane } : undefined;
+  // Snapshot and entries are memoized: `useSyncExternalStore` throws on a
+  // getSnapshot that returns a fresh reference each call.
+  const cache = new Map<string, unknown>();
+  const definitionsSnapshot = new Proxy({} as Record<string, unknown>, {
+    get: (_target, kind: string) => {
+      if (!cache.has(kind)) {
+        const config = shared.getPanelKindConfig(kind);
+        cache.set(kind, config ? { ...config, component: StubPane } : undefined);
+      }
+      return cache.get(kind);
     },
+  });
+  return {
+    subscribeToPanelKindDefinitions: () => () => {},
+    getPanelKindDefinitionsSnapshot: () => definitionsSnapshot,
   };
 });
 

--- a/src/components/Panel/__tests__/PanelDialogHost.lateRegistration.test.tsx
+++ b/src/components/Panel/__tests__/PanelDialogHost.lateRegistration.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+/**
+ * A dialog-hosted panel whose kind registers after the frame mounted must
+ * resolve to its real component in place (#11636).
+ *
+ * `PanelDialogFrame` used to read the definition registry through the bare
+ * `getPanelKindDefinition` getter with no subscription at all, so a plugin
+ * panel presented as a dialog rendered `null` forever — a definition arriving
+ * later never reached it. Unlike the `GridPanel`/`DockedPanel` half of #11636
+ * (a React Compiler memo, invisible to uncompiled vitest), the missing
+ * subscription is observable here: this fails without the fix regardless of
+ * compilation, because nothing ever schedules the rerender.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+
+const LATE_KIND = "acme.late-panel";
+
+const registry = vi.hoisted(() => {
+  const listeners = new Set<() => void>();
+  const definitions: Record<string, { component: () => unknown }> = {};
+  return {
+    listeners,
+    // Replaced on publish so React's Object.is check sees a change; the same
+    // reference is returned between publishes, as useSyncExternalStore demands.
+    snapshot: { ...definitions } as Record<string, { component: () => unknown }>,
+    publish(kind: string, component: () => unknown) {
+      definitions[kind] = { component };
+      this.notify();
+    },
+    unpublish(kind: string) {
+      delete definitions[kind];
+      this.notify();
+    },
+    notify() {
+      this.snapshot = { ...definitions };
+      for (const listener of listeners) listener();
+    },
+    reset() {
+      for (const key of Object.keys(definitions)) delete definitions[key];
+      this.snapshot = {};
+      listeners.clear();
+    },
+  };
+});
+
+vi.mock("@/panels/registry", () => ({
+  subscribeToPanelKindDefinitions: (listener: () => void) => {
+    registry.listeners.add(listener);
+    return () => registry.listeners.delete(listener);
+  },
+  getPanelKindDefinitionsSnapshot: () => registry.snapshot,
+}));
+
+vi.mock("@/components/ui/AppDialog", () => {
+  const AppDialog = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dialog">{children}</div>
+  );
+  AppDialog.Header = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+  AppDialog.Title = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+  AppDialog.CloseButton = () => <button>close</button>;
+  AppDialog.BodyScroll = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+  return { AppDialog };
+});
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+}));
+
+const panelsById = vi.hoisted(() => ({
+  current: {} as Record<string, { id: string; kind: string; title: string }>,
+}));
+
+vi.mock("@/store/panelStore", async () => {
+  const { useSyncExternalStore } = await import("react");
+  return {
+    usePanelStore: (selector: (s: { panelsById: Record<string, unknown> }) => unknown) =>
+      useSyncExternalStore(
+        () => () => {},
+        () => selector({ panelsById: panelsById.current })
+      ),
+  };
+});
+
+const { usePanelDialogStore } = await import("@/store/panelDialogStore");
+const { PanelDialogHost } = await import("../PanelDialogHost");
+
+describe("PanelDialogHost late kind registration (#11636)", () => {
+  beforeEach(() => {
+    registry.reset();
+    panelsById.current = {};
+    usePanelDialogStore.setState({ dialogStack: [], requestSeq: 0 });
+  });
+
+  it("renders a dialog panel whose kind registers after the frame mounted", () => {
+    panelsById.current = {
+      "late-1": { id: "late-1", kind: LATE_KIND, title: "Late panel" },
+    };
+    render(<PanelDialogHost />);
+
+    act(() => {
+      usePanelDialogStore.setState({ dialogStack: ["late-1"] });
+    });
+
+    // The frame is mounted and subscribed, but its kind has no definition yet.
+    expect(screen.queryByTestId("late-view")).toBeNull();
+
+    act(() => {
+      registry.publish(LATE_KIND, () => <div data-testid="late-view">late view</div>);
+    });
+
+    expect(screen.queryByTestId("late-view")).not.toBeNull();
+  });
+
+  it("drops the view again when the kind is unregistered", () => {
+    panelsById.current = {
+      "late-1": { id: "late-1", kind: LATE_KIND, title: "Late panel" },
+    };
+    render(<PanelDialogHost />);
+
+    act(() => {
+      usePanelDialogStore.setState({ dialogStack: ["late-1"] });
+    });
+    act(() => {
+      registry.publish(LATE_KIND, () => <div data-testid="late-view">late view</div>);
+    });
+    expect(screen.queryByTestId("late-view")).not.toBeNull();
+
+    act(() => {
+      registry.unpublish(LATE_KIND);
+    });
+
+    expect(screen.queryByTestId("late-view")).toBeNull();
+  });
+});

--- a/src/components/Panel/__tests__/PanelDialogHost.stack.test.tsx
+++ b/src/components/Panel/__tests__/PanelDialogHost.stack.test.tsx
@@ -37,8 +37,28 @@ function StatefulPane({ id, isFocused }: { id: string; isFocused?: boolean }) {
   );
 }
 
+// `useSyncExternalStore` throws on a getSnapshot returning a fresh reference
+// each call, so the snapshot and each definition it hands back are stable. The
+// Proxy keeps the previous stub's "every kind resolves to StatefulPane"
+// behaviour without enumerating kinds. Hoisted so the mock factory — which
+// vitest lifts above the module body — cannot observe it in its TDZ.
+const definitionsSnapshot = vi.hoisted(() => {
+  const cache = new Map<string, { component: unknown }>();
+  return new Proxy({} as Record<string, { component: unknown }>, {
+    get: (_target, kind: string) => {
+      let entry = cache.get(kind);
+      if (!entry) {
+        entry = { component: StatefulPane };
+        cache.set(kind, entry);
+      }
+      return entry;
+    },
+  });
+});
+
 vi.mock("@/panels/registry", () => ({
-  getPanelKindDefinition: () => ({ component: StatefulPane }),
+  subscribeToPanelKindDefinitions: () => () => {},
+  getPanelKindDefinitionsSnapshot: () => definitionsSnapshot,
 }));
 
 // The real ErrorBoundary on purpose: every frame's boundary is keyed on the

--- a/src/components/Panel/__tests__/PanelDialogHost.stack.test.tsx
+++ b/src/components/Panel/__tests__/PanelDialogHost.stack.test.tsx
@@ -37,29 +37,22 @@ function StatefulPane({ id, isFocused }: { id: string; isFocused?: boolean }) {
   );
 }
 
-// `useSyncExternalStore` throws on a getSnapshot returning a fresh reference
-// each call, so the snapshot and each definition it hands back are stable. The
-// Proxy keeps the previous stub's "every kind resolves to StatefulPane"
-// behaviour without enumerating kinds. Hoisted so the mock factory — which
-// vitest lifts above the module body — cannot observe it in its TDZ.
-const definitionsSnapshot = vi.hoisted(() => {
-  const cache = new Map<string, { component: unknown }>();
-  return new Proxy({} as Record<string, { component: unknown }>, {
-    get: (_target, kind: string) => {
-      let entry = cache.get(kind);
-      if (!entry) {
-        entry = { component: StatefulPane };
-        cache.set(kind, entry);
-      }
-      return entry;
+// A real object over the shared registry's kinds rather than a Proxy, so `in`
+// and `Object.hasOwn` behave. Built once and reused: `useSyncExternalStore`
+// throws on a getSnapshot that returns a fresh reference each call.
+vi.mock("@/panels/registry", async () => {
+  const shared = await import("@shared/config/panelKindRegistry");
+  let snapshot: Record<string, { component: unknown }> | undefined;
+  return {
+    subscribeToPanelKindDefinitions: () => () => {},
+    getPanelKindDefinitionsSnapshot: () => {
+      snapshot ??= Object.fromEntries(
+        shared.getPanelKindIds().map((id) => [id, { component: StatefulPane }])
+      );
+      return snapshot;
     },
-  });
+  };
 });
-
-vi.mock("@/panels/registry", () => ({
-  subscribeToPanelKindDefinitions: () => () => {},
-  getPanelKindDefinitionsSnapshot: () => definitionsSnapshot,
-}));
 
 // The real ErrorBoundary on purpose: every frame's boundary is keyed on the
 // shared `requestSeq`, which bumps on every push. It only re-keys its children

--- a/src/components/Terminal/DockedPanel.tsx
+++ b/src/components/Terminal/DockedPanel.tsx
@@ -3,7 +3,6 @@ import { usePanelStore } from "@/store";
 import type { PanelInstance } from "@shared/types/panel";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import {
-  getPanelKindDefinition,
   getPanelKindDefinitionsSnapshot,
   subscribeToPanelKindDefinitions,
   type PanelComponentProps,
@@ -56,8 +55,15 @@ export function DockedPanel({
   const kind = terminal.kind ?? "terminal";
   // Subscribe to definition registry mutations so a plugin re-registering its
   // panel kind hot-swaps the PluginMissingPanel placeholder without a reload.
-  useSyncExternalStore(subscribeToPanelKindDefinitions, getPanelKindDefinitionsSnapshot);
-  const definition = getPanelKindDefinition(kind);
+  // The lookup MUST read this snapshot rather than calling
+  // `getPanelKindDefinition(kind)` separately: React Compiler caches that call
+  // keyed only on `kind`, so a definition registered after this fiber first
+  // rendered would never be picked up (#11636).
+  const definitions = useSyncExternalStore(
+    subscribeToPanelKindDefinitions,
+    getPanelKindDefinitionsSnapshot
+  );
+  const definition = definitions[kind];
 
   const panelProps: PanelComponentProps = useMemo(
     () =>

--- a/src/components/Terminal/GridPanel.tsx
+++ b/src/components/Terminal/GridPanel.tsx
@@ -6,7 +6,6 @@ import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { canDuplicatePanelKind } from "@/services/terminal/panelDuplicationService";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import {
-  getPanelKindDefinition,
   getPanelKindDefinitionsSnapshot,
   subscribeToPanelKindDefinitions,
   type PanelComponentProps,
@@ -118,7 +117,14 @@ export const GridPanel = React.memo(function GridPanel({
 
   // Subscribe to definition registry mutations so a plugin re-registering its
   // panel kind hot-swaps the PluginMissingPanel placeholder without a reload.
-  useSyncExternalStore(subscribeToPanelKindDefinitions, getPanelKindDefinitionsSnapshot);
+  // The lookup MUST read this snapshot rather than calling
+  // `getPanelKindDefinition(kind)` separately: React Compiler caches that call
+  // keyed only on `kind`, so a definition registered after this fiber first
+  // rendered would never be picked up (#11636).
+  const definitions = useSyncExternalStore(
+    subscribeToPanelKindDefinitions,
+    getPanelKindDefinitionsSnapshot
+  );
 
   // Compose the effective add-tab handler. Fleet scope disables it (would
   // create a cross-worktree tab group). For single-panel and two-pane callers
@@ -138,7 +144,7 @@ export const GridPanel = React.memo(function GridPanel({
   }, [isFleetScope, onAddTab, onAddTabForPanel, terminal]);
 
   const kind = terminal?.kind ?? "terminal";
-  const definition = getPanelKindDefinition(kind);
+  const definition = definitions[kind];
 
   const panelProps: PanelComponentProps | null = useMemo(() => {
     if (!terminal) return null;

--- a/src/config/__tests__/panelKindDefinitionReads.contract.test.ts
+++ b/src/config/__tests__/panelKindDefinitionReads.contract.test.ts
@@ -2,34 +2,42 @@ import { describe, expect, it } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import ts from "typescript";
 
 const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(TEST_DIR, "../../..");
 const SRC_ROOT = path.join(REPO_ROOT, "src");
 
-// A render path that subscribes to the panel kind definition registry must
-// resolve its definition by indexing the snapshot `useSyncExternalStore`
-// returns. Subscribing and then calling `getPanelKindDefinition(kind)`
-// separately reads mutable module state during render: React Compiler (wired
-// for both `vite dev` and `vite build`, `compilationMode: "infer"`) cannot see
-// that the getter closes over that state, so it caches the call keyed only on
-// `kind`. The subscription still schedules a rerender, but the cache keeps
-// serving the definition resolved on first render — a panel restored before its
-// plugin registered its kind stayed on `PluginMissingPanel` permanently (#11636).
+// `getPanelKindDefinition` reads mutable module state. Calling it during render
+// is unsound under React Compiler (wired for both `vite dev` and `vite build`,
+// `compilationMode: "infer"`): the compiler cannot see the mutable read, so it
+// caches the call keyed only on the arguments. `GridPanel`/`DockedPanel`
+// subscribed to the registry for the rerender but resolved through this getter,
+// so the cache kept serving the definition from the fiber's FIRST render — and
+// `ContentGridDefault` keys the wrapper on a stable `group.id`, so the fiber
+// never remounted. A panel restored before its plugin registered its kind sat on
+// "Plugin unavailable" until it was closed and reopened (#11636).
 //
-// Scanning source rather than asserting behaviour is deliberate: vitest runs
-// uncompiled TSX, where the getter re-runs every render and picks the new value
-// up. A rendering test of this would pass with or without the bug. The compiled
-// bundle is only reachable from E2E, which does not run on PRs — so this
-// contract is what guards the invariant on every change.
+// Render paths must instead index the snapshot `useSyncExternalStore` returns,
+// which the compiler can see and invalidate. This contract bans the getter
+// outside a short imperative allowlist.
+//
+// Source enforcement rather than a rendering assertion is deliberate: vitest
+// runs uncompiled TSX, where the getter re-runs every render and picks the new
+// value up, so a rendering test of this passes with or without the bug. The
+// compiled bundle is only reachable from E2E, which does not run on PRs.
 
+const GETTER = "getPanelKindDefinition";
 const SUBSCRIBE_FN = "subscribeToPanelKindDefinitions";
 const SNAPSHOT_FN = "getPanelKindDefinitionsSnapshot";
-// Matches a call/declaration of the getter but not `getPanelKindDefinitionsSnapshot(`,
-// whose next character after the shared prefix is `s` rather than `(`.
-const GETTER_CALL = /\bgetPanelKindDefinition\s*\(/;
-// The module that declares both symbols necessarily mentions both.
-const DECLARING_MODULE = "panels/registry.tsx";
+
+/** Modules that legitimately call the getter outside a render. */
+const IMPERATIVE_ALLOWLIST = new Set([
+  // Declares it.
+  "panels/registry.tsx",
+  // Imperative filter over both registries; its callers own invalidation.
+  "registry/spawnablePanelKinds.ts",
+]);
 
 /** Render paths that must stay reactive to late plugin kind registration. */
 const REQUIRED_SUBSCRIBERS = [
@@ -37,16 +45,6 @@ const REQUIRED_SUBSCRIBERS = [
   "components/Terminal/DockedPanel.tsx",
   "components/Panel/PanelDialogHost.tsx",
 ];
-
-/**
- * Drop block and line comments so prose naming the banned getter (including the
- * comments explaining this very rule) isn't mistaken for a call. Only trailing
- * text is removed, so a real call can never be hidden — anything after `//` on a
- * line is commented-out code, which is not a call either.
- */
-function stripComments(text: string): string {
-  return text.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
-}
 
 function walk(dir: string, out: string[] = []): string[] {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -61,38 +59,100 @@ function walk(dir: string, out: string[] = []): string[] {
   return out;
 }
 
+function parse(file: string, text: string): ts.SourceFile {
+  return ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+}
+
+function eachNode(node: ts.Node, visit: (node: ts.Node) => void): void {
+  visit(node);
+  node.forEachChild((child) => eachNode(child, visit));
+}
+
+/**
+ * Local binding names the getter was imported under — following aliases, so
+ * `import { getPanelKindDefinition as read }` is still tracked.
+ */
+function importedGetterNames(source: ts.SourceFile): Set<string> {
+  const names = new Set<string>();
+  eachNode(source, (node) => {
+    if (!ts.isImportDeclaration(node)) return;
+    const bindings = node.importClause?.namedBindings;
+    if (!bindings || !ts.isNamedImports(bindings)) return;
+    for (const element of bindings.elements) {
+      const imported = element.propertyName?.text ?? element.name.text;
+      if (imported === GETTER) names.add(element.name.text);
+    }
+  });
+  return names;
+}
+
+/** True when one of `names` appears in call position, including `fn?.(…)`. */
+function callsAny(source: ts.SourceFile, names: Set<string>): boolean {
+  let found = false;
+  eachNode(source, (node) => {
+    if (found || !ts.isCallExpression(node)) return;
+    const callee = node.expression;
+    if (ts.isIdentifier(callee) && names.has(callee.text)) found = true;
+  });
+  return found;
+}
+
+/**
+ * True when the file binds `useSyncExternalStore(subscribe…, …Snapshot)` to a
+ * variable and then indexes that variable. Pinning the *shape* — not just the
+ * presence of two symbol names — is what stops a "fix" that keeps the
+ * subscription for its rerender but resolves the definition some other way.
+ */
+function derivesDefinitionFromSnapshot(source: ts.SourceFile): boolean {
+  const snapshotBindings = new Set<string>();
+  eachNode(source, (node) => {
+    if (!ts.isVariableDeclaration(node) || !node.initializer) return;
+    if (!ts.isCallExpression(node.initializer)) return;
+    const callee = node.initializer.expression;
+    const isStoreHook = ts.isIdentifier(callee) && callee.text === "useSyncExternalStore";
+    if (!isStoreHook) return;
+    const argText = node.initializer.arguments.map((arg) => arg.getText());
+    if (!argText.some((a) => a.includes(SUBSCRIBE_FN))) return;
+    if (!argText.some((a) => a.includes(SNAPSHOT_FN))) return;
+    if (ts.isIdentifier(node.name)) snapshotBindings.add(node.name.text);
+  });
+  if (snapshotBindings.size === 0) return false;
+
+  let indexed = false;
+  eachNode(source, (node) => {
+    if (indexed || !ts.isElementAccessExpression(node)) return;
+    const target = node.expression;
+    if (ts.isIdentifier(target) && snapshotBindings.has(target.text)) indexed = true;
+  });
+  return indexed;
+}
+
 const sourceFiles = walk(SRC_ROOT).map((file) => {
   const text = fs.readFileSync(file, "utf8");
-  return {
-    rel: path.relative(SRC_ROOT, file).split(path.sep).join("/"),
-    text,
-    code: stripComments(text),
-  };
+  const rel = path.relative(SRC_ROOT, file).split(path.sep).join("/");
+  return { rel, source: parse(file, text) };
 });
 
 describe("panel kind definition reads (#11636)", () => {
-  it("resolves definitions from the subscribed snapshot, never a parallel getter call", () => {
+  it("keeps the mutable getter out of every module outside the imperative allowlist", () => {
     const offenders = sourceFiles
-      .filter(
-        (file) =>
-          file.rel !== DECLARING_MODULE &&
-          file.code.includes(SUBSCRIBE_FN) &&
-          GETTER_CALL.test(file.code)
-      )
+      .filter((file) => !IMPERATIVE_ALLOWLIST.has(file.rel))
+      .filter((file) => {
+        const names = importedGetterNames(file.source);
+        return names.size > 0 && callsAny(file.source, names);
+      })
       .map((file) => file.rel);
 
     expect(offenders).toEqual([]);
   });
 
-  it("keeps every panel presentation subscribed to the definition registry", () => {
+  it("resolves every panel presentation's definition from the subscribed snapshot", () => {
     const missing = REQUIRED_SUBSCRIBERS.filter((rel) => {
       const file = sourceFiles.find((candidate) => candidate.rel === rel);
       if (!file) throw new Error(`Contract target no longer exists: src/${rel}`);
-      return !file.code.includes(SUBSCRIBE_FN) || !file.code.includes(SNAPSHOT_FN);
+      return !derivesDefinitionFromSnapshot(file.source);
     });
 
-    // Dropping the subscription would "satisfy" the rule above while
-    // reintroducing the stuck placeholder, so pin the subscription too.
     expect(missing).toEqual([]);
   });
 });

--- a/src/config/__tests__/panelKindDefinitionReads.contract.test.ts
+++ b/src/config/__tests__/panelKindDefinitionReads.contract.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(TEST_DIR, "../../..");
+const SRC_ROOT = path.join(REPO_ROOT, "src");
+
+// A render path that subscribes to the panel kind definition registry must
+// resolve its definition by indexing the snapshot `useSyncExternalStore`
+// returns. Subscribing and then calling `getPanelKindDefinition(kind)`
+// separately reads mutable module state during render: React Compiler (wired
+// for both `vite dev` and `vite build`, `compilationMode: "infer"`) cannot see
+// that the getter closes over that state, so it caches the call keyed only on
+// `kind`. The subscription still schedules a rerender, but the cache keeps
+// serving the definition resolved on first render — a panel restored before its
+// plugin registered its kind stayed on `PluginMissingPanel` permanently (#11636).
+//
+// Scanning source rather than asserting behaviour is deliberate: vitest runs
+// uncompiled TSX, where the getter re-runs every render and picks the new value
+// up. A rendering test of this would pass with or without the bug. The compiled
+// bundle is only reachable from E2E, which does not run on PRs — so this
+// contract is what guards the invariant on every change.
+
+const SUBSCRIBE_FN = "subscribeToPanelKindDefinitions";
+const SNAPSHOT_FN = "getPanelKindDefinitionsSnapshot";
+// Matches a call/declaration of the getter but not `getPanelKindDefinitionsSnapshot(`,
+// whose next character after the shared prefix is `s` rather than `(`.
+const GETTER_CALL = /\bgetPanelKindDefinition\s*\(/;
+// The module that declares both symbols necessarily mentions both.
+const DECLARING_MODULE = "panels/registry.tsx";
+
+/** Render paths that must stay reactive to late plugin kind registration. */
+const REQUIRED_SUBSCRIBERS = [
+  "components/Terminal/GridPanel.tsx",
+  "components/Terminal/DockedPanel.tsx",
+  "components/Panel/PanelDialogHost.tsx",
+];
+
+/**
+ * Drop block and line comments so prose naming the banned getter (including the
+ * comments explaining this very rule) isn't mistaken for a call. Only trailing
+ * text is removed, so a real call can never be hidden — anything after `//` on a
+ * line is commented-out code, which is not a call either.
+ */
+function stripComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "__tests__" || entry.name === "node_modules") continue;
+      walk(full, out);
+    } else if (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const sourceFiles = walk(SRC_ROOT).map((file) => {
+  const text = fs.readFileSync(file, "utf8");
+  return {
+    rel: path.relative(SRC_ROOT, file).split(path.sep).join("/"),
+    text,
+    code: stripComments(text),
+  };
+});
+
+describe("panel kind definition reads (#11636)", () => {
+  it("resolves definitions from the subscribed snapshot, never a parallel getter call", () => {
+    const offenders = sourceFiles
+      .filter(
+        (file) =>
+          file.rel !== DECLARING_MODULE &&
+          file.code.includes(SUBSCRIBE_FN) &&
+          GETTER_CALL.test(file.code)
+      )
+      .map((file) => file.rel);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("keeps every panel presentation subscribed to the definition registry", () => {
+    const missing = REQUIRED_SUBSCRIBERS.filter((rel) => {
+      const file = sourceFiles.find((candidate) => candidate.rel === rel);
+      if (!file) throw new Error(`Contract target no longer exists: src/${rel}`);
+      return !file.code.includes(SUBSCRIBE_FN) || !file.code.includes(SNAPSHOT_FN);
+    });
+
+    // Dropping the subscription would "satisfy" the rule above while
+    // reintroducing the stuck placeholder, so pin the subscription too.
+    expect(missing).toEqual([]);
+  });
+});

--- a/src/panels/registry.tsx
+++ b/src/panels/registry.tsx
@@ -260,9 +260,15 @@ const PANEL_KIND_DEFINITION_REGISTRY: Record<string, PanelKindDefinition> = {
 /**
  * Reactive snapshot for `useSyncExternalStore`. Replaced (not mutated) on
  * every registry change so React's `Object.is` identity check schedules a
- * rerender — components observing this snapshot then re-evaluate
- * `getPanelKindDefinition(kind)` and pick up newly-registered plugin panels
- * without needing a window reload.
+ * rerender — components observing this snapshot then index into it and pick up
+ * newly-registered plugin panels without needing a window reload.
+ *
+ * Render paths MUST resolve a definition as `definitions[kind]` off the value
+ * this hook returns. Subscribing and then calling `getPanelKindDefinition(kind)`
+ * separately looks equivalent but is not: React Compiler cannot see that the
+ * getter closes over mutable module state, so it caches the call keyed only on
+ * `kind` and the panel stays on its placeholder forever (#11636). The getter is
+ * for imperative, non-render callers only.
  */
 let definitionsSnapshot: Readonly<Record<string, PanelKindDefinition>> = {
   ...PANEL_KIND_DEFINITION_REGISTRY,


### PR DESCRIPTION
## Summary
- Persisted panels backed by a plugin panel kind restored stuck on "Plugin unavailable" and never recovered, even after the plugin activated.
- Root cause was a Rules-of-React purity violation in `src/panels/registry.tsx`: three render paths subscribed to the store but read from a getter the compiler couldn't invalidate.
- Fix makes every consumer read the panel kind definition off the subscribed snapshot, so the record can never get stuck.

## Problem
If a persisted panel was backed by a panel kind contributed by a plugin that wasn't active yet, it restored with a "Plugin unavailable" placeholder and never recovered, even after the plugin activated and registered its panel kind. The only way out was to close the panel and launch a fresh one, which loses the panel's extension state.

## Root cause
`src/panels/registry.tsx` exposes both a `useSyncExternalStore` pair (`subscribeToPanelKindDefinitions` / `getPanelKindDefinitionsSnapshot`) and a plain module-level getter, `getPanelKindDefinition(kind)`. Three render paths subscribed to the store for the rerender, but then discarded the snapshot and called the getter separately.

The React Compiler (`compilationMode: "infer"`, wired into `vite.config.ts` for both `vite dev` and `vite build`) can't see that the getter reads mutable module state, so it emits a memo cache keyed only on `kind`:

```js
if ($[14] !== kind) { value = getPanelKindDefinition(kind); $[14] = kind; $[15] = value; }
```

The subscription still rerendered the component, but that cache kept serving the definition resolved on the fiber's first render. `ContentGridDefault.tsx` keys the wrapper on a stable `group.id`, so the fiber never remounted, and the panel stayed stuck permanently.

This is a Rules-of-React purity violation, not a registry-propagation bug. Registration and broadcast were always working correctly.

## Fix
All three consumers now derive `const definition = definitions[kind]` from the value the hook returns, which compiles down to a plain property read the compiler can invalidate:
- `src/components/Terminal/GridPanel.tsx`
- `src/components/Terminal/DockedPanel.tsx`
- `src/components/Panel/PanelDialogHost.tsx` had no subscription at all. One is added above its early returns, so a dialog-hosted plugin panel doesn't render nothing forever.
- `src/panels/registry.tsx` gets a comment fix only. The old doc comment literally prescribed the broken pattern.

No registry-side change, so #7331's invariant (a refused write must not churn the snapshot identity) is untouched.

## Testing
Every new assertion was checked against the pre-fix commit to confirm it fails there and passes after:
- `src/config/__tests__/panelKindDefinitionReads.contract.test.ts` (new): a TypeScript-AST contract that bans the getter outside a documented imperative allowlist and asserts each presentation binds the `useSyncExternalStore` result and indexes it. Source-level enforcement is deliberate: vitest runs uncompiled TSX, where the getter re-runs every render, so a rendering assertion of this would pass with or without the bug, and E2E doesn't run on PRs.
- `src/components/Panel/__tests__/PanelDialogHost.lateRegistration.test.tsx` (new): behavioural, and non-tautological even uncompiled, because `PanelDialogHost` had no subscription before this PR.
- `e2e/full/plugins/core-plugin-panels.spec.ts`: a live panel hot-swaps to the placeholder on plugin disable and back to the real view on re-enable, asserted on the same `data-panel-id`, proving the record is never recreated (which is what preserves extension state).
- Locally: 1094 tests pass across every touched module, prettier is clean, eslint reports 0 errors.

## Follow-up (not in this PR)
Reviewing this with the compiler transform in mind turned up the same defect class elsewhere, in unrelated features. Left out on purpose to keep this bugfix reviewable:
- `src/components/Layout/dockLaunchItems.ts:389-402`: the registry snapshots sit in a manual `useMemo` dep array but are never referenced inside the callback, so the compiler drops them. Late-registered plugin kinds can be missing from the dock `+` menu.
- `src/components/Layout/TrashBinItem.tsx:32` and `TrashGroupItem.tsx:34`: same discard-the-snapshot shape on the plugin agent registry, so names and icons can go stale.
- `src/hooks/usePanelPalette.ts:83` and `src/components/KeyboardShortcuts/ShortcutReferenceDialog.tsx:33`: invalidator-only subscriptions the compiler compiles away.

Resolves #11636