### PR TITLE
fix(sidebar): scope the worktree filter bulk arm to agent terminals

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -1071,9 +1071,10 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     };
   }, []);
 
-  // Fleet-eligible terminals inside the currently visible worktrees, split so an
-  // arm/disarm elsewhere only re-walks the unarmed tally rather than re-scanning
-  // every panel. Drives the QuickStateFilterBar arm affordance.
+  // Arm-eligible agent terminals inside the currently visible worktrees, split
+  // so an arm/disarm elsewhere only re-walks the unarmed tally rather than
+  // re-scanning every panel. Drives the QuickStateFilterBar arm affordance,
+  // which is agent-scoped like the state-filter presets beside it (#11637).
   const filterArmEligibleIds = useMemo(() => {
     const worktreeIdSet = new Set(filteredWorktrees.map((w) => w.id));
     if (worktreeIdSet.size === 0) return EMPTY_ELIGIBLE_IDS;
@@ -1597,9 +1598,11 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
 
   // Compact arm affordance pinned to the QuickStateFilterBar's trailing edge —
   // replaces the former full-width banner button. Enabled whenever the visible
-  // worktrees still hold unarmed fleet-eligible terminals; with "All" selected
-  // and no filters that means "arm everything". Otherwise it rests dimmed and
+  // worktrees still hold unarmed agent terminals; with "All" selected and no
+  // filters that means "arm every agent". Otherwise it rests dimmed and
   // disabled so the layout stays stable and the affordance stays discoverable.
+  // Plain shells are excluded here (#11637) — they stay armable individually
+  // and via the header fleet picker's broad "arm all".
   const filterArmEligibleCount = filterArmEligibleIds.length;
   const canArmMatching = filterArmUnarmedCount > 0;
   const armNoun = filterArmUnarmedCount === 1 ? "terminal" : "terminals";

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -1605,7 +1605,10 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   // and via the header fleet picker's broad "arm all".
   const filterArmEligibleCount = filterArmEligibleIds.length;
   const canArmMatching = filterArmUnarmedCount > 0;
-  const armNoun = filterArmUnarmedCount === 1 ? "terminal" : "terminals";
+  // Agent-scoped nouns: this affordance no longer addresses plain shells, so
+  // "terminals" would overstate what a click arms and the exhausted states
+  // would read as false whenever an unarmed shell is in scope (#11637).
+  const armNoun = filterArmUnarmedCount === 1 ? "agent" : "agents";
   const armMatchingLabel = canArmMatching
     ? hasFilters
       ? armedSize > 0
@@ -1616,11 +1619,11 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         : `Arm all ${filterArmUnarmedCount} ${armNoun}`
     : filterArmEligibleCount === 0
       ? hasFilters
-        ? "No arm-eligible terminals match the filter"
-        : "No arm-eligible terminals"
+        ? "No agents match the filter"
+        : "No agents to arm"
       : hasFilters
-        ? "All matching terminals are armed"
-        : "All terminals are armed";
+        ? "All matching agents are armed"
+        : "All agents are armed";
   const armMatchingButton = (
     <Tooltip>
       <TooltipTrigger asChild>

--- a/src/components/Sidebar/__tests__/sidebarPanelDerivation.test.ts
+++ b/src/components/Sidebar/__tests__/sidebarPanelDerivation.test.ts
@@ -130,13 +130,15 @@ describe("sidebarPanelDerivation selectors", () => {
     expect(eligible.shell).toBeUndefined();
   });
 
-  it("fleet eligibility excludes ex-agent shells whose live detection was cleared", () => {
+  it("fleet eligibility excludes demoted ex-agent shells", () => {
+    // Launch affinity survives but detection, runtime identity, and agentState
+    // are gone — the demotion branch, distinct from the plain shell above.
     const state = makeState({
       exAgent: agentPanel({
         id: "exAgent",
         worktreeId: "wt-1",
         runtimeStatus: "running",
-        launchAgentId: undefined,
+        launchAgentId: "claude",
         detectedAgentId: undefined,
         runtimeIdentity: undefined,
         agentState: undefined,
@@ -145,6 +147,23 @@ describe("sidebarPanelDerivation selectors", () => {
     });
 
     expect(selectSidebarFleetEligibleWorktreeById(state).exAgent).toBeUndefined();
+  });
+
+  it("fleet eligibility counts plugin-contributed agents, not just built-in ids", () => {
+    // The arm count must not gate on built-in agent capability — plugin and user
+    // agent ids are non-built-in by construction, and arming only adds the
+    // terminal to the broadcast set (#11637).
+    const state = makeState({
+      plugin: agentPanel({
+        id: "plugin",
+        worktreeId: "wt-1",
+        runtimeStatus: "running",
+        launchAgentId: "acme-plugin-agent",
+        detectedAgentId: undefined,
+      }),
+    });
+
+    expect(selectSidebarFleetEligibleWorktreeById(state).plugin).toBe("wt-1");
   });
 });
 

--- a/src/components/Sidebar/__tests__/sidebarPanelDerivation.test.ts
+++ b/src/components/Sidebar/__tests__/sidebarPanelDerivation.test.ts
@@ -106,6 +106,46 @@ describe("sidebarPanelDerivation selectors", () => {
     // A panel whose runtimeStatus has crossed into "exited" is not arm-eligible.
     expect(eligible.exited).toBeUndefined();
   });
+
+  it("fleet eligibility excludes plain shells so the sidebar arm count is agent-scoped", () => {
+    // #11637: the count behind the quick-filter arm affordance fed on the broad
+    // terminal predicate, so shells inflated "Arm all N terminals" and got armed.
+    // `agentPanel` defaults launchAgentId to "claude", so the shell must clear
+    // every identity source or it stays agent-capable and proves nothing.
+    const state = makeState({
+      agent: agentPanel({ id: "agent", worktreeId: "wt-1", runtimeStatus: "running" }),
+      shell: agentPanel({
+        id: "shell",
+        worktreeId: "wt-1",
+        runtimeStatus: "running",
+        launchAgentId: undefined,
+        detectedAgentId: undefined,
+        runtimeIdentity: undefined,
+        agentState: undefined,
+      }),
+    });
+
+    const eligible = selectSidebarFleetEligibleWorktreeById(state);
+    expect(eligible.agent).toBe("wt-1");
+    expect(eligible.shell).toBeUndefined();
+  });
+
+  it("fleet eligibility excludes ex-agent shells whose live detection was cleared", () => {
+    const state = makeState({
+      exAgent: agentPanel({
+        id: "exAgent",
+        worktreeId: "wt-1",
+        runtimeStatus: "running",
+        launchAgentId: undefined,
+        detectedAgentId: undefined,
+        runtimeIdentity: undefined,
+        agentState: undefined,
+        everDetectedAgent: true,
+      }),
+    });
+
+    expect(selectSidebarFleetEligibleWorktreeById(state).exAgent).toBeUndefined();
+  });
 });
 
 describe("computePanelStateByWorktree", () => {

--- a/src/components/Sidebar/sidebarPanelDerivation.ts
+++ b/src/components/Sidebar/sidebarPanelDerivation.ts
@@ -2,7 +2,7 @@ import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
 import type { AgentState } from "@shared/types/agent";
 import { isAgentTerminal } from "@/utils/terminalType";
 import { isTerminalVisible } from "@/lib/terminalVisibility";
-import { isFleetArmEligible } from "@/store/fleetArmingStore";
+import { isAgentFleetActionEligible } from "@/store/fleetEligibility";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 
 // Per-worktree rollups consumed by the sidebar (terminal counts + agent-state
@@ -75,10 +75,17 @@ export function selectSidebarAgentStateByPanelId(
 }
 
 /**
- * Fleet-arm-eligible panels → their worktree id. `isFleetArmEligible` reads
- * `runtimeStatus`, which the buffer writes, but only its exited/error transition
- * flips eligibility and the buffer never sets those on the flow path
- * (`panelStatusBuffer.ts`) — so the eligible set is stable across flushes.
+ * Agent panels eligible for the sidebar's filter-scoped bulk arm → their
+ * worktree id. Agent-scoped rather than terminal-scoped so the quick-filter
+ * arm affordance matches the state-filter presets it sits beside; plain shells
+ * stay armable individually (#11637). `collectFilterArmEligibleIds` applies the
+ * same predicate at dispatch time.
+ *
+ * `isAgentFleetActionEligible` reads `runtimeStatus`, which the buffer writes,
+ * but only its exited/error transition flips eligibility and the buffer never
+ * sets those on the flow path (`panelStatusBuffer.ts`) — so the eligible set is
+ * stable across flushes. The agent-identity fields it adds are not buffer-written
+ * either, so the churn-safety invariant above still holds.
  */
 export function selectSidebarFleetEligibleWorktreeById(
   state: SidebarPanelDerivationState
@@ -86,7 +93,7 @@ export function selectSidebarFleetEligibleWorktreeById(
   const result: Record<string, string> = {};
   for (const id of state.panelIds) {
     const panel = getNarrowPanel(state.panelsById, id);
-    if (!isFleetArmEligible(panel)) continue;
+    if (!isAgentFleetActionEligible(panel)) continue;
     result[id] = panel.worktreeId ?? "";
   }
   return result;

--- a/src/components/Sidebar/sidebarPanelDerivation.ts
+++ b/src/components/Sidebar/sidebarPanelDerivation.ts
@@ -2,7 +2,7 @@ import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
 import type { AgentState } from "@shared/types/agent";
 import { isAgentTerminal } from "@/utils/terminalType";
 import { isTerminalVisible } from "@/lib/terminalVisibility";
-import { isAgentFleetActionEligible } from "@/store/fleetEligibility";
+import { isAgentTerminalFleetEligible } from "@/store/fleetEligibility";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 
 // Per-worktree rollups consumed by the sidebar (terminal counts + agent-state
@@ -77,11 +77,15 @@ export function selectSidebarAgentStateByPanelId(
 /**
  * Agent panels eligible for the sidebar's filter-scoped bulk arm → their
  * worktree id. Agent-scoped rather than terminal-scoped so the quick-filter
- * arm affordance matches the state-filter presets it sits beside; plain shells
- * stay armable individually (#11637). `collectFilterArmEligibleIds` applies the
- * same predicate at dispatch time.
+ * arm affordance addresses the same terminals as the state filters beside it;
+ * plain shells stay armable individually (#11637). `collectFilterArmEligibleIds`
+ * applies the same predicate at dispatch time.
  *
- * `isAgentFleetActionEligible` reads `runtimeStatus`, which the buffer writes,
+ * Shares `isAgentTerminal` with `selectSidebarAgentStateByPanelId` above, so the
+ * arm count and the working/waiting chips agree on what counts as an agent —
+ * including plugin-contributed ones.
+ *
+ * `isAgentTerminalFleetEligible` reads `runtimeStatus`, which the buffer writes,
  * but only its exited/error transition flips eligibility and the buffer never
  * sets those on the flow path (`panelStatusBuffer.ts`) — so the eligible set is
  * stable across flushes. The agent-identity fields it adds are not buffer-written
@@ -93,7 +97,7 @@ export function selectSidebarFleetEligibleWorktreeById(
   const result: Record<string, string> = {};
   for (const id of state.panelIds) {
     const panel = getNarrowPanel(state.panelsById, id);
-    if (!isAgentFleetActionEligible(panel)) continue;
+    if (!isAgentTerminalFleetEligible(panel)) continue;
     result[id] = panel.worktreeId ?? "";
   }
   return result;

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -1509,7 +1509,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "keywords": undefined,
     "kind": "command",
     "requiresArgs": true,
-    "title": "Fleet: Arm Terminals Matching Filter",
+    "title": "Fleet: Arm Agents Matching Filter",
   },
   {
     "category": "terminal",

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -1503,7 +1503,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "terminal",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Arm all eligible terminals whose worktree is in the provided set — sidebar 'Arm N matching' affordance",
+    "description": "Arm all eligible agent terminals whose worktree is in the provided set — sidebar 'Arm N matching' affordance",
     "examples": undefined,
     "id": "fleet.armMatchingFilter",
     "keywords": undefined,

--- a/src/services/actions/definitions/__tests__/fleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/fleetActions.test.ts
@@ -354,7 +354,14 @@ describe("fleet.armMatchingFilter", () => {
       makeAgent("a1", { worktreeId: "wt-1" }),
       makeAgent("a2", { worktreeId: "wt-2" }),
       makeAgent("a3", { worktreeId: "wt-3" }),
-      makeAgent("p1", { worktreeId: "wt-3", detectedAgentId: undefined, everDetectedAgent: false }),
+      makeAgent("p1", {
+        worktreeId: "wt-3",
+        detectedAgentId: undefined,
+        launchAgentId: undefined,
+        runtimeIdentity: undefined,
+        agentState: undefined,
+        everDetectedAgent: false,
+      }),
     ]);
     const registry = await buildRegistry();
     await run(registry, "fleet.armMatchingFilter", { worktreeIds: ["wt-1", "wt-3"] });

--- a/src/services/actions/definitions/__tests__/fleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/fleetActions.test.ts
@@ -347,7 +347,9 @@ describe("fleet.armMatchingFilter", () => {
     vi.clearAllMocks();
   });
 
-  it("arms eligible terminals in the provided worktree ids", async () => {
+  it("arms agent terminals in the provided worktree ids and skips plain shells", async () => {
+    // p1 is a plain shell sharing wt-3 with an agent. The sidebar affordance
+    // this action backs is agent-scoped (#11637), so p1 must stay unarmed.
     seedPanels([
       makeAgent("a1", { worktreeId: "wt-1" }),
       makeAgent("a2", { worktreeId: "wt-2" }),
@@ -356,7 +358,7 @@ describe("fleet.armMatchingFilter", () => {
     ]);
     const registry = await buildRegistry();
     await run(registry, "fleet.armMatchingFilter", { worktreeIds: ["wt-1", "wt-3"] });
-    expect([...useFleetArmingStore.getState().armedIds].sort()).toEqual(["a1", "a3", "p1"]);
+    expect([...useFleetArmingStore.getState().armedIds].sort()).toEqual(["a1", "a3"]);
   });
 
   it("is a no-op when worktreeIds is empty (does not clobber existing armed set)", async () => {

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -402,7 +402,7 @@ export function registerFleetActions(actions: ActionRegistry): void {
     id: "fleet.armMatchingFilter",
     title: "Fleet: Arm Terminals Matching Filter",
     description:
-      "Arm all eligible terminals whose worktree is in the provided set — sidebar 'Arm N matching' affordance",
+      "Arm all eligible agent terminals whose worktree is in the provided set — sidebar 'Arm N matching' affordance",
     category: "terminal",
     kind: "command",
     danger: "safe",

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -400,7 +400,7 @@ export function registerFleetActions(actions: ActionRegistry): void {
 
   actions.set("fleet.armMatchingFilter", () => ({
     id: "fleet.armMatchingFilter",
-    title: "Fleet: Arm Terminals Matching Filter",
+    title: "Fleet: Arm Agents Matching Filter",
     description:
       "Arm all eligible agent terminals whose worktree is in the provided set — sidebar 'Arm N matching' affordance",
     category: "terminal",

--- a/src/store/__tests__/fleetArmingStore.test.ts
+++ b/src/store/__tests__/fleetArmingStore.test.ts
@@ -556,21 +556,70 @@ describe("fleetArmingStore", () => {
       expect(useFleetArmingStore.getState().armOrder).toEqual(["a1", "a2"]);
     });
 
-    it("excludes ex-agent terminals — filter-scoped arming needs live agent capability", () => {
-      // `armAll` still takes ex-agents and plain shells (broadcast membership is
-      // PTY-based). The sidebar's filter-scoped arm is agent-scoped instead, so
-      // it matches the state-filter presets it sits beside (#11637).
+    it("excludes demoted ex-agent terminals — filter-scoped arming needs a live agent", () => {
+      // A real demoted record: launch affinity survives but detection, runtime
+      // identity, and agentState are all gone, so `isDemotedExAgent` fires.
+      // `armAll` still takes these (broadcast membership is PTY-based); the
+      // sidebar's filter-scoped arm is agent-scoped instead (#11637).
       seedPanels([
         makeAgentTerminal("a1", { worktreeId: "wt-1" }),
         makeAgentTerminal("p1", {
           worktreeId: "wt-1",
           kind: "terminal",
           detectedAgentId: undefined,
+          runtimeIdentity: undefined,
+          launchAgentId: "claude",
+          agentState: undefined,
           everDetectedAgent: true,
         }),
       ]);
       useFleetArmingStore.getState().armMatchingFilter(["wt-1"]);
       expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1"]);
+    });
+
+    it("arms plugin-contributed agents whose id is not a built-in", () => {
+      // Arming only adds a terminal to the broadcast set, so it must not gate on
+      // built-in agent capability the way accept/interrupt/restart do — plugin
+      // and user agent ids are non-built-in by construction (#11637).
+      seedPanels([
+        makeAgentTerminal("plugin", {
+          worktreeId: "wt-1",
+          detectedAgentId: undefined,
+          launchAgentId: "acme-plugin-agent",
+          everDetectedAgent: false,
+        }),
+      ]);
+      useFleetArmingStore.getState().armMatchingFilter(["wt-1"]);
+      expect([...useFleetArmingStore.getState().armedIds]).toEqual(["plugin"]);
+    });
+
+    it("preserves the prior fleet when the matched worktree holds only shells", () => {
+      // Newly reachable after #11637: the worktree matches the filter and has
+      // live terminals, but none are agents, so the collector returns empty and
+      // the early return must leave the user's existing selection intact.
+      seedPanels([
+        makeAgentTerminal("agent-elsewhere", { worktreeId: "wt-2" }),
+        makeAgentTerminal("shell", {
+          worktreeId: "wt-1",
+          kind: "terminal",
+          detectedAgentId: undefined,
+          launchAgentId: undefined,
+          runtimeIdentity: undefined,
+          agentState: undefined,
+          everDetectedAgent: false,
+        }),
+      ]);
+      useFleetArmingStore.getState().armIds(["agent-elsewhere"]);
+      const before = useFleetArmingStore.getState();
+      const beforeOrder = [...before.armOrder];
+      const beforeLast = before.lastArmedId;
+
+      useFleetArmingStore.getState().armMatchingFilter(["wt-1"]);
+
+      const after = useFleetArmingStore.getState();
+      expect([...after.armedIds]).toEqual(["agent-elsewhere"]);
+      expect(after.armOrder).toEqual(beforeOrder);
+      expect(after.lastArmedId).toBe(beforeLast);
     });
 
     it("excludes plain shells but still arms agents in the same worktree", () => {

--- a/src/store/__tests__/fleetArmingStore.test.ts
+++ b/src/store/__tests__/fleetArmingStore.test.ts
@@ -411,22 +411,28 @@ describe("fleetArmingStore", () => {
       expect([...useFleetArmingStore.getState().armedIds].sort()).toEqual(["a1", "a3"]);
     });
 
-    it("skips structurally ineligible panels even when worktree matches", () => {
+    it("skips structurally ineligible and non-agent panels even when worktree matches", () => {
       seedPanels([
         makeAgentTerminal("a1", { worktreeId: "wt-1" }),
         makeAgentTerminal("a2", { worktreeId: "wt-1", location: "trash" }),
         makeAgentTerminal("a3", { worktreeId: "wt-1", location: "background" }),
         makeAgentTerminal("a4", { worktreeId: "wt-1", hasPty: false }),
+        // a5 is a plain shell: no live detection, no launch affinity, no
+        // runtime identity. Filter-scoped bulk arming is agent-scoped (#11637),
+        // so it is excluded on capability rather than structure.
         makeAgentTerminal("a5", {
           worktreeId: "wt-1",
           kind: "terminal",
           detectedAgentId: undefined,
+          launchAgentId: undefined,
+          runtimeIdentity: undefined,
+          agentState: undefined,
           everDetectedAgent: false,
         }),
         makeAgentTerminal("a6", { worktreeId: "wt-1", location: "dock" }),
       ]);
       useFleetArmingStore.getState().armMatchingFilter(["wt-1"]);
-      expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1", "a5"]);
+      expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1"]);
     });
 
     it("skips non-PTY panel kinds (browser, dev-preview, review) (#8957 batch B)", () => {
@@ -550,7 +556,10 @@ describe("fleetArmingStore", () => {
       expect(useFleetArmingStore.getState().armOrder).toEqual(["a1", "a2"]);
     });
 
-    it("includes ex-agent terminals because broadcast membership is PTY-based", () => {
+    it("excludes ex-agent terminals — filter-scoped arming needs live agent capability", () => {
+      // `armAll` still takes ex-agents and plain shells (broadcast membership is
+      // PTY-based). The sidebar's filter-scoped arm is agent-scoped instead, so
+      // it matches the state-filter presets it sits beside (#11637).
       seedPanels([
         makeAgentTerminal("a1", { worktreeId: "wt-1" }),
         makeAgentTerminal("p1", {
@@ -561,7 +570,53 @@ describe("fleetArmingStore", () => {
         }),
       ]);
       useFleetArmingStore.getState().armMatchingFilter(["wt-1"]);
-      expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1", "p1"]);
+      expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1"]);
+    });
+
+    it("excludes plain shells but still arms agents in the same worktree", () => {
+      // Direct regression for #11637: the zap affordance next to the quick
+      // state filter bar must not sweep up shells sharing a worktree.
+      seedPanels([
+        makeAgentTerminal("a1", { worktreeId: "wt-1" }),
+        makeAgentTerminal("shell", {
+          worktreeId: "wt-1",
+          kind: "terminal",
+          detectedAgentId: undefined,
+          launchAgentId: undefined,
+          runtimeIdentity: undefined,
+          agentState: undefined,
+          everDetectedAgent: false,
+        }),
+        makeAgentTerminal("a2", { worktreeId: "wt-1" }),
+      ]);
+      useFleetArmingStore.getState().armMatchingFilter(["wt-1"]);
+      expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1", "a2"]);
+    });
+
+    it("arms terminals whose agent identity comes from launchAgentId or runtimeIdentity", () => {
+      // The agent predicate resolves identity from more than `detectedAgentId`;
+      // narrowing the sidebar arm must not drop restored or toolbar-launched
+      // agent terminals that have not re-detected yet.
+      seedPanels([
+        makeAgentTerminal("launched", {
+          worktreeId: "wt-1",
+          detectedAgentId: undefined,
+          launchAgentId: "claude",
+          everDetectedAgent: false,
+        }),
+        makeAgentTerminal("runtime", {
+          worktreeId: "wt-1",
+          detectedAgentId: undefined,
+          runtimeIdentity: {
+            kind: "agent",
+            id: "claude",
+            iconId: "claude",
+            agentId: "claude",
+          },
+        }),
+      ]);
+      useFleetArmingStore.getState().armMatchingFilter(["wt-1"]);
+      expect([...useFleetArmingStore.getState().armedIds]).toEqual(["launched", "runtime"]);
     });
 
     it("is fully idempotent — repeated calls preserve armOrder, armOrderById, and lastArmedId", () => {

--- a/src/store/fleetArmingStore.ts
+++ b/src/store/fleetArmingStore.ts
@@ -4,7 +4,11 @@ import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import type { PanelInstance, PtyPanelData } from "@shared/types/panel";
 import type { AgentState } from "@/types";
-import { isAgentFleetActionEligible, isTerminalFleetEligible } from "./fleetEligibility";
+import {
+  isAgentFleetActionEligible,
+  isAgentTerminalFleetEligible,
+  isTerminalFleetEligible,
+} from "./fleetEligibility";
 
 // Carrier shape sourced from `getNarrowPanel`'s parameter so this file doesn't
 // have to name the legacy carrier type directly — auto-tracks the carrier flip
@@ -130,9 +134,11 @@ export function computeArmByStateIds(
  * Pure collector: agent terminal ids whose worktree is in `worktreeIds`, in
  * panelIds (sidebar) order. Backs `armMatchingFilter` (the store mutation)
  * behind the sidebar's arm-matching affordance. Agent-scoped, not
- * terminal-scoped, so bulk arming from the quick-filter bar matches the
- * state-filter presets beside it and leaves plain shells alone (#11637) —
- * shells stay armable one at a time, and `armAll` still takes everything live.
+ * terminal-scoped, so bulk arming from the quick-filter bar addresses the same
+ * terminals as the state filters beside it and leaves plain shells alone
+ * (#11637) — shells stay armable one at a time, and `armAll` still takes
+ * everything live. Uses the `isAgentTerminal`-based predicate rather than the
+ * built-in-capability one so plugin-contributed agents are not dropped.
  *
  * The sidebar derives its own count reactively via
  * `selectSidebarFleetEligibleWorktreeById` rather than calling this; the two
@@ -150,7 +156,7 @@ export function collectFilterArmEligibleIds(
   const ids: string[] = [];
   for (const id of panelIds) {
     const t = getNarrowPanel(panelsById, id);
-    if (!isAgentFleetActionEligible(t)) continue;
+    if (!isAgentTerminalFleetEligible(t)) continue;
     if (!t.worktreeId || !worktreeIdSet.has(t.worktreeId)) continue;
     ids.push(id);
   }

--- a/src/store/fleetArmingStore.ts
+++ b/src/store/fleetArmingStore.ts
@@ -127,12 +127,18 @@ export function computeArmByStateIds(
 }
 
 /**
- * Pure collector: arm-eligible terminal ids whose worktree is in `worktreeIds`,
- * in panelIds (sidebar) order. Shared by `armMatchingFilter` (the store
- * mutation) and the sidebar's arm-matching affordance, which needs the same
- * set to decide whether anything is still unarmed. Takes `panelIds`/`panelsById`
- * explicitly so callers can pass reactive selector values rather than reaching
- * into `usePanelStore.getState()`.
+ * Pure collector: agent terminal ids whose worktree is in `worktreeIds`, in
+ * panelIds (sidebar) order. Backs `armMatchingFilter` (the store mutation)
+ * behind the sidebar's arm-matching affordance. Agent-scoped, not
+ * terminal-scoped, so bulk arming from the quick-filter bar matches the
+ * state-filter presets beside it and leaves plain shells alone (#11637) —
+ * shells stay armable one at a time, and `armAll` still takes everything live.
+ *
+ * The sidebar derives its own count reactively via
+ * `selectSidebarFleetEligibleWorktreeById` rather than calling this; the two
+ * must apply the same predicate or the tooltip count drifts from what a click
+ * actually arms. Takes `panelIds`/`panelsById` explicitly so callers can pass
+ * reactive selector values rather than reaching into `usePanelStore.getState()`.
  */
 export function collectFilterArmEligibleIds(
   worktreeIds: readonly string[],
@@ -144,7 +150,7 @@ export function collectFilterArmEligibleIds(
   const ids: string[] = [];
   for (const id of panelIds) {
     const t = getNarrowPanel(panelsById, id);
-    if (!isFleetArmEligible(t)) continue;
+    if (!isAgentFleetActionEligible(t)) continue;
     if (!t.worktreeId || !worktreeIdSet.has(t.worktreeId)) continue;
     ids.push(id);
   }

--- a/src/store/fleetEligibility.ts
+++ b/src/store/fleetEligibility.ts
@@ -6,7 +6,7 @@ import {
   type PtyPanelData,
 } from "@shared/types/panel";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
-import { getBuiltInRuntimeAgentId } from "@/utils/terminalType";
+import { getBuiltInRuntimeAgentId, isAgentTerminal } from "@/utils/terminalType";
 
 // Carrier element from the legacy `panelsById` shape, sourced through
 // `getNarrowPanel`'s parameter so this file doesn't import the deprecated
@@ -69,6 +69,23 @@ export function isAgentFleetActionEligible(
   t: PanelInstance | CarrierPanel | undefined
 ): t is PtyPanelData {
   return isTerminalFleetEligible(t) && resolveFleetAgentCapabilityId(t) !== undefined;
+}
+
+/**
+ * Bulk-arming predicate for surfaces that address agents rather than terminals.
+ *
+ * Deliberately NOT `isAgentFleetActionEligible`: that one resolves a *built-in*
+ * capability id because accept/reject/interrupt/restart drive built-in agent
+ * protocols. Arming just adds a terminal to the broadcast set, so any agent
+ * qualifies — gating on built-ins would silently drop plugin- and
+ * user-contributed agents, whose ids are non-built-in by construction (#11637).
+ * Matches `isAgentTerminal`, which the sidebar already uses for the agent-state
+ * rollups behind the quick state filters this sits beside.
+ */
+export function isAgentTerminalFleetEligible(
+  t: PanelInstance | CarrierPanel | undefined
+): t is PtyPanelData {
+  return isTerminalFleetEligible(t) && isAgentTerminal(t);
 }
 
 export function isFleetWaitingAgentEligible(

--- a/src/store/fleetEligibility.ts
+++ b/src/store/fleetEligibility.ts
@@ -72,7 +72,9 @@ export function isAgentFleetActionEligible(
 }
 
 /**
- * Bulk-arming predicate for surfaces that address agents rather than terminals.
+ * Predicate for the sidebar's filter-scoped bulk arm, which addresses agents
+ * rather than terminals. (The ribbon's state presets still run on the built-in
+ * predicate below — a separate, pre-existing gap, not this one.)
  *
  * Deliberately NOT `isAgentFleetActionEligible`: that one resolves a *built-in*
  * capability id because accept/reject/interrupt/restart drive built-in agent


### PR DESCRIPTION
## Summary

- The worktree sidebar's bulk arm button (the zap icon next to the quick state filter bar) armed every live terminal in the visible worktrees, including plain shells, and its "Arm all N terminals" count included non-agents.
- It now addresses only agent terminals, matching the state filters it sits beside. Individual arming and the header fleet picker's `armAll` stay broad on purpose: a plain shell is still armable one at a time.

Resolves #11637

## Changes

- Added `isAgentTerminalFleetEligible` (`src/store/fleetEligibility.ts`), defined as `isTerminalFleetEligible` AND `isAgentTerminal`, and used it at both sidebar bulk-arm call sites: the reactive count (`selectSidebarFleetEligibleWorktreeById` in `src/components/Sidebar/sidebarPanelDerivation.ts`) and the mutation (`collectFilterArmEligibleIds` in `src/store/fleetArmingStore.ts`). Both paths need to share a predicate or the tooltip count drifts from what a click actually arms.
- Deliberately did not reuse `isAgentFleetActionEligible`. That one resolves a built-in capability id, because accept/reject/interrupt/restart drive built-in agent protocols. Arming only adds a terminal to the broadcast set, so gating it on a built-in capability id would silently drop plugin-contributed and user-contributed agents, whose ids are non-built-in by construction. This also lines the arm count up with `selectSidebarAgentStateByPanelId`, which already uses `isAgentTerminal` to drive the state-filter chips the button sits next to.
- Fixed the button's affordance copy to be agent-scoped. The exhausted state previously read "All terminals are armed" even with an unarmed shell in scope, which was misleading.
- Left `isFleetArmEligible`, `isTerminalFleetEligible`, `collectEligibleIds`, `armAll`, and `terminal.arm` untouched. Broadcast membership is intentionally terminal-based, not agent-based.

## Testing

- Flipped the two `armMatchingFilter` cases that had locked in shell and ex-agent inclusion as correct behavior, and fixed the action-layer expectation that assumed the same.
- Added coverage for the sidebar count path (previously no agent-vs-shell coverage), the real `isDemotedExAgent` demotion branch, non-built-in agent ids, and the newly reachable shell-only early return that preserves a prior fleet selection.
- 2,261 targeted tests pass across the fleet, sidebar, and actions suites. Typecheck is clean. Own files are formatted and lint-clean.

Known gap, not addressed here: the ribbon's state presets (`computeArmByStateIds`) still use the built-in-only predicate, so plugin agents are excluded there too. That predates this issue and is worth a separate follow-up fix.
