### PR TITLE
fix(window): reject a project view that loaded the wrong document

### DIFF
--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -3271,25 +3271,37 @@ describe("createAppProtocolHandler — direct disk read", () => {
     // bare body with nothing in the log, so a production report could not say
     // which read actually failed — and losing index.html this way still
     // commits a document that looks like a successful navigation.
+    /**
+     * The single diagnostic for the request just served. Asserting there is
+     * exactly one keeps a later branch from quietly adding a second,
+     * contradictory line for the same 404.
+     */
     async function notFoundLog(): Promise<Record<string, unknown> | undefined> {
       const { logWarn } = await import("../../utils/logger.js");
-      const call = vi
+      const calls = vi
         .mocked(logWarn)
-        .mock.calls.find(([event]) => event === "app.protocol.not-found");
-      return call?.[1] as Record<string, unknown> | undefined;
+        .mock.calls.filter(([event]) => event === "app.protocol.not-found");
+      expect(calls).toHaveLength(1);
+      return calls[0]?.[1] as Record<string, unknown> | undefined;
     }
 
     it("distinguishes the stat failure from the other 404 branches", async () => {
       const fs = await import("fs/promises");
-      vi.mocked(fs.stat).mockRejectedValue(Object.assign(new Error("nope"), { code: "ENOENT" }));
+      vi.mocked(fs.stat).mockRejectedValue(
+        Object.assign(new Error("nope"), { code: "ENOENT", errno: -2 })
+      );
 
       const handler = await captureHandler();
-      await handler(makeRequest());
+      await handler(makeRequest("/assets/vanished.js"));
 
       expect(await notFoundLog()).toMatchObject({
         stage: "stat",
+        // The requested URL and the path it resolved to are both needed: the
+        // report has to name the asset that went missing, not just the stage.
+        url: "app://daintree/assets/vanished.js",
         filePath: "/tmp/dist/assets/index-abc123.js",
         code: "ENOENT",
+        errno: -2,
       });
     });
 

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -43,6 +43,12 @@ vi.mock("electron", () => ({
   },
 }));
 
+vi.mock("../../utils/logger.js", () => ({
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+  logError: vi.fn(),
+}));
+
 vi.mock("../../utils/webviewCsp.js", () => ({
   classifyPartition: vi.fn((partition: string) =>
     partition === "persist:daintree" ? "project" : "browser"
@@ -3257,6 +3263,87 @@ describe("createAppProtocolHandler — direct disk read", () => {
     expect(response.status).toBe(200);
     expect(await response.text()).toBe("ok");
     expect(handle.close).toHaveBeenCalledTimes(1);
+  });
+
+  describe("404 diagnostics (#11635)", () => {
+    // Every app:// URL is an application-owned dist asset, so a 404 always
+    // means the packaged tree is damaged. All the branches returned the same
+    // bare body with nothing in the log, so a production report could not say
+    // which read actually failed — and losing index.html this way still
+    // commits a document that looks like a successful navigation.
+    async function notFoundLog(): Promise<Record<string, unknown> | undefined> {
+      const { logWarn } = await import("../../utils/logger.js");
+      const call = vi
+        .mocked(logWarn)
+        .mock.calls.find(([event]) => event === "app.protocol.not-found");
+      return call?.[1] as Record<string, unknown> | undefined;
+    }
+
+    it("distinguishes the stat failure from the other 404 branches", async () => {
+      const fs = await import("fs/promises");
+      vi.mocked(fs.stat).mockRejectedValue(Object.assign(new Error("nope"), { code: "ENOENT" }));
+
+      const handler = await captureHandler();
+      await handler(makeRequest());
+
+      expect(await notFoundLog()).toMatchObject({
+        stage: "stat",
+        filePath: "/tmp/dist/assets/index-abc123.js",
+        code: "ENOENT",
+      });
+    });
+
+    it("reports a directory hit as its own stage rather than an error code", async () => {
+      const fs = await import("fs/promises");
+      vi.mocked(fs.stat).mockResolvedValue({
+        mtime: new Date(0),
+        isFile: () => false,
+      } as Awaited<ReturnType<typeof fs.stat>>);
+
+      const handler = await captureHandler();
+      await handler(makeRequest("/assets/"));
+
+      const logged = await notFoundLog();
+      expect(logged).toMatchObject({ stage: "not-a-file" });
+      // Nothing threw, so there is no errno to invent.
+      expect(logged).not.toHaveProperty("code");
+    });
+
+    it("separates an open failure from a read failure", async () => {
+      const fs = await import("fs/promises");
+      vi.mocked(fs.open).mockRejectedValue(Object.assign(new Error("nope"), { code: "EISDIR" }));
+
+      const handler = await captureHandler();
+      await handler(makeRequest());
+      expect(await notFoundLog()).toMatchObject({ stage: "open", code: "EISDIR" });
+
+      vi.mocked(await import("../../utils/logger.js")).logWarn.mockClear();
+      vi.mocked(fs.open).mockResolvedValue({
+        readFile: vi.fn().mockRejectedValue(Object.assign(new Error("nope"), { code: "EISDIR" })),
+        close: vi.fn().mockResolvedValue(undefined),
+      } as unknown as Awaited<ReturnType<typeof fs.open>>);
+
+      await handler(makeRequest());
+      expect(await notFoundLog()).toMatchObject({ stage: "read", code: "EISDIR" });
+    });
+
+    it("logs the resolver rejection with its reason and never touches disk", async () => {
+      const fs = await import("fs/promises");
+      const appProtocol = await import("../../utils/appProtocol.js");
+      vi.mocked(appProtocol.resolveAppUrlToDistPath).mockReturnValue({
+        filePath: "",
+        error: "path traversal",
+      } as ReturnType<typeof appProtocol.resolveAppUrlToDistPath>);
+
+      const handler = await captureHandler();
+      await handler(makeRequest("/../../etc/passwd"));
+
+      expect(await notFoundLog()).toMatchObject({
+        stage: "resolve",
+        reason: "path traversal",
+      });
+      expect(fs.stat).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -38,6 +38,7 @@ import { stripPluginViewGeneration } from "../../shared/utils/pluginViewUrl.js";
 import { getWebviewDialogService } from "../services/WebviewDialogService.js";
 import { looksLikeOAuthUrl } from "../services/OAuthLoopbackService.js";
 import { CHANNELS } from "../ipc/channels.js";
+import { logWarn } from "../utils/logger.js";
 
 export type GetPluginDir = (pluginId: string) => string | undefined;
 
@@ -49,6 +50,37 @@ let cachedGetPluginDir: GetPluginDir | null = null;
 /**
  * Create the app:// protocol handler function for a given distPath.
  */
+/**
+ * Which read stage produced a 404. Every app:// URL is an application-owned
+ * dist asset, so a miss always means the packaged tree is damaged or
+ * unreadable — never a routine lookup. It matters because losing index.html
+ * this way still commits a document that fires did-finish-load and carries the
+ * preload (#11635), and the stage is the only thing that tells the otherwise
+ * identical branches apart in a production log.
+ */
+type AppNotFoundStage = "resolve" | "stat" | "not-a-file" | "open" | "read";
+
+function appNotFound(
+  stage: AppNotFoundStage,
+  url: string,
+  filePath?: string,
+  cause?: unknown
+): Response {
+  const errno = cause as NodeJS.ErrnoException | undefined;
+  logWarn("app.protocol.not-found", {
+    stage,
+    url,
+    ...(filePath ? { filePath } : {}),
+    ...(typeof cause === "string" ? { reason: cause } : {}),
+    ...(errno?.code ? { code: errno.code } : {}),
+    ...(errno?.errno !== undefined ? { errno: errno.errno } : {}),
+  });
+  return new Response("Not Found", {
+    status: 404,
+    headers: buildHeaders("text/plain"),
+  });
+}
+
 function createAppProtocolHandler(distPath: string) {
   return async (request: GlobalRequest) => {
     if (request.method !== "GET" && request.method !== "HEAD") {
@@ -63,11 +95,7 @@ function createAppProtocolHandler(distPath: string) {
     });
 
     if (error || !filePath) {
-      console.error("[MAIN] App protocol error:", error);
-      return new Response("Not Found", {
-        status: 404,
-        headers: buildHeaders("text/plain"),
-      });
+      return appNotFound("resolve", request.url, undefined, error);
     }
 
     // V8 code cache in Chromium 146 won't persist bytecode without both a
@@ -78,21 +106,15 @@ function createAppProtocolHandler(distPath: string) {
     let stats: Awaited<ReturnType<typeof fs.stat>>;
     try {
       stats = await fs.stat(filePath);
-    } catch {
-      return new Response("Not Found", {
-        status: 404,
-        headers: buildHeaders("text/plain"),
-      });
+    } catch (err) {
+      return appNotFound("stat", request.url, filePath, err);
     }
 
     // stat() succeeds on directories, so guard before the 304 short-circuit:
     // without this a directory URL carrying If-Modified-Since would return 304
     // instead of falling through to the open/read 404 path.
     if (!stats.isFile()) {
-      return new Response("Not Found", {
-        status: 404,
-        headers: buildHeaders("text/plain"),
-      });
+      return appNotFound("not-a-file", request.url, filePath);
     }
 
     const ifModifiedSince = request.headers.get("If-Modified-Since");
@@ -117,10 +139,7 @@ function createAppProtocolHandler(distPath: string) {
     } catch (err) {
       const errCode = (err as NodeJS.ErrnoException).code;
       if (errCode === "ENOENT" || errCode === "EISDIR") {
-        return new Response("Not Found", {
-          status: 404,
-          headers: buildHeaders("text/plain"),
-        });
+        return appNotFound("open", request.url, filePath, err);
       }
       console.error("[MAIN] Error serving file:", filePath, err);
       return new Response("Internal Server Error", {
@@ -140,10 +159,7 @@ function createAppProtocolHandler(distPath: string) {
       // here at readFile. Map it to 404 like the open path so a directory URL
       // never returns a 500.
       if ((err as NodeJS.ErrnoException).code === "EISDIR") {
-        return new Response("Not Found", {
-          status: 404,
-          headers: buildHeaders("text/plain"),
-        });
+        return appNotFound("read", request.url, filePath, err);
       }
       console.error("[MAIN] Error serving file:", filePath, err);
       return new Response("Internal Server Error", {

--- a/electron/window/ProjectViewFactory.ts
+++ b/electron/window/ProjectViewFactory.ts
@@ -313,15 +313,44 @@ export function loadView(
   });
 }
 
+/**
+ * `__DAINTREE_INITIAL_PROJECT__` is contextBridge-exposed by the preload, which
+ * attaches to whatever document the navigation committed — so on its own it
+ * proves the right preload ran, never that the right document rendered. A
+ * `Response` with `status: 404` from the app:// handler is a transport-complete
+ * navigation: it commits, fires did-finish-load, never fires did-fail-load, and
+ * carries the preload intact, so the id probe passed on a bare "Not Found" body
+ * and the switch was accepted (#11635).
+ *
+ * `#root` is the document-owned half of the answer: static markup in
+ * index.html that no other document can produce. It stays in the DOM for the
+ * life of the page, unlike `#startup-skeleton`, which main.tsx removes once
+ * React mounts — probing for that would reject a healthy view whenever React
+ * won the race to did-finish-load.
+ */
+const BOOTSTRAP_PROBE = `({
+  projectId: globalThis.__DAINTREE_INITIAL_PROJECT__?.id ?? null,
+  hasAppRoot: document.getElementById("root") !== null,
+})`;
+
 async function verifyProjectBootstrap(wc: Electron.WebContents, projectId: string): Promise<void> {
-  const loadedProjectId = await wc.executeJavaScript(
-    "globalThis.__DAINTREE_INITIAL_PROJECT__?.id ?? null"
-  );
-  // The production expression above always returns a string or null. Some
-  // unit-test WebContents mocks return undefined for unmodelled scripts;
-  // leave those legacy mocks neutral while still rejecting real missing
-  // bootstrap state (null) and wrong-project bootstraps.
-  if (loadedProjectId === undefined) return;
+  const probe = await wc.executeJavaScript(BOOTSTRAP_PROBE);
+  // The production expression above always returns an object. Some unit-test
+  // WebContents mocks return undefined for unmodelled scripts; leave those
+  // legacy mocks neutral while still rejecting real missing bootstrap state.
+  if (probe === undefined) return;
+  const { projectId: loadedProjectId, hasAppRoot } = (probe ?? {}) as {
+    projectId?: string | null;
+    hasAppRoot?: boolean;
+  };
+  // Checked before the id: a wrong document can still carry the right id, and
+  // reporting it as a bootstrap mismatch would point diagnosis at the project
+  // plumbing instead of at the failed asset read that actually caused it.
+  if (hasAppRoot !== true) {
+    throw new Error(
+      `Project view loaded a non-application document for ${projectId}; app root missing`
+    );
+  }
   if (loadedProjectId !== projectId) {
     throw new Error(
       `Project view loaded without project bootstrap for ${projectId}; got ${String(loadedProjectId)}`

--- a/electron/window/ProjectViewPaintGateController.ts
+++ b/electron/window/ProjectViewPaintGateController.ts
@@ -20,7 +20,9 @@ import type { PaintGate, PaintGateOutcome } from "./ProjectViewManagerTypes.js";
  *   - Soft (`paintGateTimeoutMs`): fires `onSoftTimeout` for observability.
  *     The gate stays open and the outgoing view stays attached.
  *   - Hard (`paintGateHardTimeoutMs`): resolves the gate as
- *     `"hard-timeout"`, prompting the caller to detach the outgoing view.
+ *     `"hard-timeout"`. The caller owns the policy: cold starts abandon the
+ *     switch and roll back (#11635), warm reactivations fall through and
+ *     detach the bridge.
  *
  * Both timer values are captured at gate creation. A later
  * `setPaintGateTimeoutMs` / `setPaintGateHardTimeoutMs` call updates the

--- a/electron/window/ProjectViewSwitchController.ts
+++ b/electron/window/ProjectViewSwitchController.ts
@@ -13,6 +13,7 @@ import {
   registerProjectView,
 } from "./webContentsRegistry.js";
 import { notifyError } from "../ipc/errorHandlers.js";
+import { AppError } from "../utils/errorTypes.js";
 import { logInfo, logWarn } from "../utils/logger.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { unfreezeWebContents } from "../utils/webContentsLifecycle.js";
@@ -364,8 +365,9 @@ export async function performSwitch(
     // (React committed its first structural paint after a double-rAF in
     // `notifyViewPainted`, channel `"painted"`), and `signalViewPainted` is
     // the fallback for both. Two-phase: the soft timeout above is observable
-    // but never user-visible; only the hard timeout below detaches the
-    // outgoing view as a last resort when the renderer is stuck or crashed.
+    // but never user-visible; the hard timeout below abandons the switch and
+    // rolls back to the outgoing view, which is never detached without a
+    // signal.
     const gateResult = await paintGatePromise;
     visibleAt = performance.now();
     if (gateResult === "hard-timeout") {
@@ -373,12 +375,35 @@ export async function performSwitch(
         projectId,
         waitedMs: hardMs,
       });
+      // Abandon rather than commit. Both release signals are document-owned
+      // (APP_SKELETON_PARSED from a script tag in index.html, APP_VIEW_PAINTED
+      // from React), so exhausting the budget without either means this view
+      // gave no evidence it can render — including having committed the wrong
+      // document entirely (#11635). Detaching the outgoing view here strands
+      // the user on that frame with no in-app recovery, while rolling back
+      // keeps a known-good view on screen and stays retryable. Thrown BEFORE
+      // any detach so the rollback restores an attached view. #11462 still
+      // holds where it applies: the soft timeout keeps waiting and "slow but
+      // succeeding" lands via the signal — only "never painted" reaches here.
+      //
+      // Logged here, not in the catch: this is the failure the gate exists to
+      // measure, and the timing locals are only live in this scope.
+      logInfo("projectview.coldstart.rejected", {
+        projectId,
+        durationMs: Math.round(visibleAt - coldStartAt),
+        loadToGateMs: Math.round(visibleAt - loadFinishedAt),
+        paintGateOutcome: gateResult,
+        gateChannel: coldReleaseChannel,
+        rollbackProjectId: previousProjectId,
+      });
+      throw new AppError({
+        code: "INTERNAL",
+        message: "View never painted: project view abandoned after paint gate hard timeout",
+        context: { phase: "paint", projectId, waitedMs: hardMs },
+      });
     }
 
-    // Paint signal received (or hard timeout reached) — detach the
-    // outgoing view. On hard timeout the incoming frame may be blank,
-    // but the renderer has had its full grace period and holding the
-    // outgoing view longer can't recover a stuck renderer.
+    // Paint signal received — detach the outgoing view.
     if (previousEntry && host.activeProjectId === projectId) {
       deactivateEntry(host, previousEntry);
     } else if (unboundOutgoingView && host.activeProjectId === projectId) {
@@ -464,20 +489,19 @@ export async function performSwitch(
 
     host.activeProjectId = previousProjectId;
     if (previousEntry && !previousEntry.view.webContents.isDestroyed()) {
-      // Restore app-view registration so getAppWebContents() resolves back
-      // to the still-visible previous project view instead of falling
-      // through to the bare BrowserWindow's webContents.
-      registerAppView(host.win, previousEntry.view);
-      // If the failure landed after the outgoing view was already
-      // deactivated (which now marks it invisible), restore its visibility
-      // so the rolled-back active view is composited again.
-      try {
-        previousEntry.view.setVisible(true);
-      } catch {
-        // non-critical
-      }
-      previousEntry.state = "active";
-      previousEntry.lastUsed = Date.now();
+      // Full reactivation, not a hand-rolled subset. This previously did only
+      // `registerAppView` + `setVisible(true)`, which is registry bookkeeping
+      // plus a flag: `deactivateEntry` does a real `removeChildView`, and
+      // `setVisible(true)` on a view that is no longer in the tree composites
+      // nothing, so a failure landing after the detach rolled back to a blank
+      // window (#11635). `activateView` owns the matching `addChildView` and
+      // is the path every other reactivation already takes — re-adding a view
+      // whose parent is unchanged reorders it rather than duplicating it, so
+      // this is also correct on the common path where nothing was detached.
+      // Set BEFORE this call as well as inside it: activateView assigns the
+      // same id, but doing it first keeps getActiveView() and the prune sweep
+      // below consistent even if activation throws partway.
+      activateView(host, previousEntry);
       // If the failure landed after deactivateEntry, this view already received
       // APP_VIEW_CACHED and demoted its periodic terminal work (watchdog sweep,
       // reflow heartbeat, activity markers — #11212). It is about to be the

--- a/electron/window/ProjectViewSwitchController.ts
+++ b/electron/window/ProjectViewSwitchController.ts
@@ -279,7 +279,7 @@ export async function performSwitch(
   // value actually used by the in-flight gate even if the setters fire
   // a profile push between gate creation and log emission.
   const softMs = host.paintGateTimeoutMs;
-  const hardMs = Math.max(host.paintGateHardTimeoutMs, softMs);
+  const paintHardMs = Math.max(host.paintGateHardTimeoutMs, softMs);
 
   // Reveal the incoming view as soon as its themed first-paint skeleton
   // (`#startup-skeleton`, injected in createView) is parsed into the DOM —
@@ -312,6 +312,24 @@ export async function performSwitch(
     });
   }
 
+  // The `"painted"` channel holds for the whole React cold boot — ~1.5–4s per
+  // the note above, which the paint-gate hard bound (4s balanced) does not
+  // bracket, and the bound is spent from before `loadView` so it also pays for
+  // renderer spawn, preload eval and navigation. Exhausting it there means
+  // "slow", not "wrong document", and abandoning would turn a cold
+  // focus-next-waiting into an error toast. Stretch it to the view-load soft
+  // bound — the same family's profile-scaled "something is genuinely wrong"
+  // threshold. `"skeleton-painted"` keeps the tight bound: its signal is a
+  // parse-time script tag that lands during the load, so a skeleton gate still
+  // open when the load settles really has seen a document that cannot render.
+  //
+  // Deliberate consequence of pre-arming: on a cold switch this bound, not
+  // `viewLoadHardTimeoutMs`, is the effective ceiling — a load slower than it
+  // expires the gate mid-flight and the switch is abandoned once the load
+  // settles. `viewLoadHardTimeoutMs` still bounds a load that never settles.
+  const hardMs =
+    coldReleaseChannel === "painted" ? Math.max(paintHardMs, host.viewLoadTimeoutMs) : paintHardMs;
+
   const paintGatePromise = host.waitForPaint(
     view.webContents.id,
     outgoingView,
@@ -325,7 +343,7 @@ export async function performSwitch(
         releaseChannel: coldReleaseChannel,
       });
     },
-    { releaseChannel: coldReleaseChannel }
+    { releaseChannel: coldReleaseChannel, softMs, hardMs }
   );
 
   let visibleAt: number;
@@ -436,9 +454,10 @@ export async function performSwitch(
     // drop it (#4670), and consuming-without-delivering would lose it
     // entirely. Leaving it pending lets the queued/next same-project switch
     // deliver it once React is mounted (intents are project-keyed, so an
-    // unrelated switch can't pick it up). On the painted path the intent is
-    // still consumed on every outcome (incl. hard timeout) so a stale focus
-    // can't leak forward.
+    // unrelated switch can't pick it up). A painted-path hard timeout never
+    // reaches here — it throws above — but its intent is still consumed, by the
+    // `consumePendingFocusIntent` call in the catch below, so a stale focus
+    // can't leak forward on that outcome either.
     if (coldReleaseChannel === "painted") {
       const coldIntent = consumePendingFocusIntent(host, projectId);
       if (coldIntent && gateResult === "signal") {

--- a/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
@@ -217,6 +217,10 @@ describe("ProjectViewManager adversarial", () => {
   beforeEach(() => {
     nextWebContentsId = 300;
     wcQueue.length = 0;
+    // Switch-ordering suite, not paint-gate policy: release every gate with a
+    // signal so the zero-length gate can't read as the hard timeout that now
+    // abandons a cold switch (#11635).
+    vi.spyOn(ProjectViewManager.prototype, "waitForPaint").mockResolvedValue("signal");
   });
 
   afterEach(() => {

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -220,6 +220,11 @@ beforeEach(() => {
   resetAppMetricsSnapshotForTesting();
   mockGetAllWebContents.mockReset();
   mockGetAllWebContents.mockReturnValue([]);
+  // This suite tests eviction, not paint-gate policy, and drives cold switches
+  // through a zero-length gate. A cold hard timeout now abandons the switch
+  // (#11635), so release every gate with the signal these fixtures are standing
+  // in for rather than relying on the timeout to wave switches through.
+  vi.spyOn(ProjectViewManager.prototype, "waitForPaint").mockResolvedValue("signal");
 });
 
 const flushImmediates = () => new Promise<void>((resolve) => setImmediate(resolve));

--- a/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
@@ -199,6 +199,10 @@ function createMockWindow() {
     contentView: {
       children,
       addChildView: vi.fn((view: unknown, index?: number) => {
+        // Re-adding a view whose parent is unchanged reorders it rather than
+        // duplicating it — the rollback path re-attaches through activateView.
+        const existing = children.indexOf(view);
+        if (existing >= 0) children.splice(existing, 1);
         if (typeof index === "number") {
           children.splice(index, 0, view);
         } else {
@@ -272,12 +276,20 @@ describe("ProjectViewManager — pending focus intent", () => {
 
       manager.setPendingFocusIntent("proj-b", { intent: "focus-next-waiting" });
       const switchPromise = manager.switchTo("proj-b", "/path/b");
+      // Handler attached in the same tick: the hard timeout abandons the
+      // switch (#11635), so this promise rejects rather than resolving.
+      const rejection = switchPromise.then(
+        () => {
+          throw new Error("Expected the switch to reject");
+        },
+        (err: unknown) => err as Error
+      );
       await vi.advanceTimersByTimeAsync(0);
 
       // Past hard bound (150 ms). The soft bound at 50 ms only warns —
       // intent is dropped on hard fall-through, not on soft warning.
       await vi.advanceTimersByTimeAsync(200);
-      await switchPromise;
+      await rejection;
 
       const focusSends = slowWc.send.mock.calls.filter(
         ([channel]) => channel === CHANNELS.PROJECT_FOCUS_ON_ACTIVATE

--- a/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
@@ -236,6 +236,10 @@ describe("ProjectViewManager — pending focus intent", () => {
       // focus-intent delivery on reactivation, not the warm gate timing (#9679).
       warmPaintGateTimeoutMs: 0,
       warmPaintGateHardTimeoutMs: 0,
+      // Compressed onto the same scale as the paint bounds: the focus-intent
+      // (`painted`) channel stretches its hard bound to this value, and the
+      // hard-timeout test below is written against the 150 ms bound.
+      viewLoadTimeoutMs: 100,
       cachedProjectViews: 3,
     });
 

--- a/electron/window/__tests__/ProjectViewManager.gc.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.gc.test.ts
@@ -145,6 +145,10 @@ describe("ProjectViewManager — GC on deactivate", () => {
 
   beforeEach(() => {
     nextWebContentsId = 100;
+    // GC-on-deactivate suite, not paint-gate policy: release every gate with a
+    // signal so the zero-length gate can't read as the hard timeout that now
+    // abandons a cold switch (#11635).
+    vi.spyOn(ProjectViewManager.prototype, "waitForPaint").mockResolvedValue("signal");
     win = createMockWindow();
     manager = new ProjectViewManager(win as never, {
       dirname: "/test",

--- a/electron/window/__tests__/ProjectViewManager.lifecycle.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.lifecycle.test.ts
@@ -49,7 +49,9 @@ function createMockWebContents(options?: MockWebContentsOptions) {
         // legacy-mock escape hatch, and most of this suite relies on it to keep
         // the bootstrap check neutral.
         return Promise.resolve(
-          bootstrapProjectId === undefined ? undefined : { projectId: bootstrapProjectId, hasAppRoot }
+          bootstrapProjectId === undefined
+            ? undefined
+            : { projectId: bootstrapProjectId, hasAppRoot }
         );
       }
       return Promise.resolve();

--- a/electron/window/__tests__/ProjectViewManager.lifecycle.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.lifecycle.test.ts
@@ -23,12 +23,15 @@ type Handler = (...args: unknown[]) => void;
 interface MockWebContentsOptions {
   autoFinishLoad?: boolean;
   bootstrapProjectId?: string;
+  /** `false` models a committed non-application document (the app:// 404). */
+  hasAppRoot?: boolean;
 }
 
 function createMockWebContents(options?: MockWebContentsOptions) {
   const id = nextWebContentsId++;
   const autoFinishLoad = options?.autoFinishLoad ?? true;
   const bootstrapProjectId = options?.bootstrapProjectId;
+  const hasAppRoot = options?.hasAppRoot ?? true;
   const handlers = new Map<string, Handler[]>();
   const onceHandlers = new Map<string, Handler[]>();
   const ipcOnceHandlers = new Map<string, Handler[]>();
@@ -42,7 +45,12 @@ function createMockWebContents(options?: MockWebContentsOptions) {
     isDestroyed: vi.fn(() => destroyed),
     executeJavaScript: vi.fn((code: string) => {
       if (typeof code === "string" && code.includes("__DAINTREE_INITIAL_PROJECT__")) {
-        return Promise.resolve(bootstrapProjectId);
+        // Undefined when no bootstrap id is configured: that is the probe's
+        // legacy-mock escape hatch, and most of this suite relies on it to keep
+        // the bootstrap check neutral.
+        return Promise.resolve(
+          bootstrapProjectId === undefined ? undefined : { projectId: bootstrapProjectId, hasAppRoot }
+        );
       }
       return Promise.resolve();
     }),
@@ -307,7 +315,11 @@ interface ManagerSetup {
   onViewCached: ReturnType<typeof vi.fn>;
   onViewReady: ReturnType<typeof vi.fn>;
   initialWc: MockWc;
-  initialView: { webContents: MockWc; setBounds: ReturnType<typeof vi.fn> };
+  initialView: {
+    webContents: MockWc;
+    setBounds: ReturnType<typeof vi.fn>;
+    setVisible: ReturnType<typeof vi.fn>;
+  };
 }
 
 /**
@@ -583,6 +595,35 @@ describe("ProjectViewManager — lifecycle invariants", () => {
       // (PTY port, worktree port re-broker) re-binds to what is on screen.
       expect(onViewReady).toHaveBeenCalledTimes(1);
       expect(onViewReady).toHaveBeenCalledWith(initialWc);
+      assertLifecycleInvariants(manager as never, win as never);
+      setup.ledger.assertNoPortsForDeadViews(manager as never);
+    });
+
+    it("rollback re-attaches a previous view that was already detached when the failure landed", async () => {
+      const setup = createManager();
+      const { manager, win, initialView } = setup;
+
+      // Model the state deactivateEntry leaves behind — removed from the view
+      // tree, not merely marked hidden. The old rollback restored only the
+      // app-view registration and the visibility flag, and setVisible(true) on
+      // a view that is no longer in the tree composites nothing, so recovery
+      // landed on a window with no attached view at all (#11635).
+      win.contentView.removeChildView(initialView);
+      expect(win.contentView.children).not.toContain(initialView);
+
+      const failWc = createMockWebContents({ autoFinishLoad: false });
+      wcQueue.push(failWc);
+      const switchPromise = manager.switchTo("proj-b", "/b");
+      await flushMicrotasks();
+      failWc._fire("did-fail-load", {}, -6, "ERR_FILE_NOT_FOUND");
+      await expect(switchPromise).rejects.toThrow("ERR_FILE_NOT_FOUND");
+      await flushImmediates();
+
+      expect(manager.getActiveProjectId()).toBe("proj-a");
+      // Back in the tree, and exactly once — the failed view is gone and the
+      // restored one is not stacked twice.
+      expect(win.contentView.children).toEqual([initialView]);
+      expect(initialView.setVisible).toHaveBeenCalledWith(true);
       assertLifecycleInvariants(manager as never, win as never);
       setup.ledger.assertNoPortsForDeadViews(manager as never);
     });

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -394,9 +394,21 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
       const err = await rejection;
 
       expect(err.message).toContain("View never painted");
-      // The healthy outgoing view is still the attached, active one.
+      expect((err as { context?: Record<string, unknown> }).context).toMatchObject({
+        phase: "paint",
+        projectId: "proj-b",
+      });
+      // The healthy outgoing view is still the attached, active one — and it
+      // was never detached in the first place. Asserting only that it ends up
+      // attached would also pass if the branch detached it and the rollback put
+      // it back, which still fires the cache/throttle/freeze side effects and
+      // flashes the blank frame this whole path exists to prevent.
       expect(manager.getActiveProjectId()).toBe("proj-a");
-      expect(win.contentView.children).toContain(manager.getActiveView());
+      const outgoing = manager.getActiveView();
+      expect(win.contentView.removeChildView).not.toHaveBeenCalledWith(outgoing);
+      expect(initialWc.send).not.toHaveBeenCalledWith(CHANNELS.APP_VIEW_CACHED);
+      // The failed view is gone rather than left stacked behind the outgoing one.
+      expect(win.contentView.children).toEqual([outgoing]);
       expect(slowWc.close).toHaveBeenCalled();
       expect(
         vi
@@ -1169,6 +1181,47 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
     const registerCalls = vi.mocked(registerAppView).mock.calls;
     const lastCall = registerCalls[registerCalls.length - 1];
     expect(lastCall?.[1]).toBe(welcomeView);
+  });
+
+  it("keeps the unbound welcome view when the first project view never paints", async () => {
+    // Same abandon policy on the first-run window, where the outgoing view is
+    // the welcome view rather than a project entry: it is closed for good once
+    // detached, so committing a view that never painted would leave the window
+    // with nothing recoverable on screen.
+    manager.dispose();
+    vi.useFakeTimers();
+    try {
+      win = createMockWindow();
+      manager = new ProjectViewManager(win as never, {
+        dirname: "/test",
+        paintGateTimeoutMs: 50,
+        paintGateHardTimeoutMs: 150,
+        cachedProjectViews: 3,
+      });
+
+      const welcomeWc = createMockWebContents();
+      const welcomeView = { webContents: welcomeWc, setBounds: vi.fn() };
+      win.contentView.addChildView(welcomeView);
+
+      const slowWc = createMockWebContents();
+      wcQueue.push(slowWc);
+      vi.mocked(registerAppView).mockClear();
+
+      const rejection = expectRejection(manager.switchTo("proj-first", "/path/first"));
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(200);
+      await rejection;
+
+      expect(win.contentView.removeChildView).not.toHaveBeenCalledWith(welcomeView);
+      expect(welcomeWc.close).not.toHaveBeenCalled();
+      expect(slowWc.close).toHaveBeenCalled();
+      expect(manager.getActiveProjectId()).toBeNull();
+
+      const registerCalls = vi.mocked(registerAppView).mock.calls;
+      expect(registerCalls[registerCalls.length - 1]?.[1]).toBe(welcomeView);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("dispose() while paint gate is pending settles the wait without throwing", async () => {

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -290,6 +290,10 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
       dirname: "/test",
       paintGateTimeoutMs: 50,
       paintGateHardTimeoutMs: 150,
+      // Compressed onto the same scale: the focus-intent (`painted`) channel
+      // stretches its hard bound to this value, and the hard-timeout tests
+      // below are written against the 150 ms bound.
+      viewLoadTimeoutMs: 100,
       cachedProjectViews: 3,
     });
 
@@ -456,6 +460,53 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
       await rejection;
 
       expect(slowWc.send).not.toHaveBeenCalledWith("project:focus-on-activate", expect.anything());
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("holds the focus-intent gate past the skeleton bound for a slow-but-correct cold boot", async () => {
+    // The `"painted"` channel waits for the full React cold boot, not the
+    // parse-time skeleton, so its budget must outlast a boot that would blow
+    // the skeleton channel's bound — otherwise a cold focus-next-waiting
+    // (agentActions) or focus-panel (projectActions) rejects the whole switch
+    // and shows an error toast. Slow is not the same failure as wrong document;
+    // the abandon tests above still hold for the skeleton channel, whose signal
+    // lands during the load rather than after it.
+    vi.useFakeTimers();
+    try {
+      const slowWc = createMockWebContents();
+      wcQueue.push(slowWc);
+
+      manager.setViewLoadTimeoutMs(1_000);
+      manager.setPendingFocusIntent("proj-b", { intent: "focus-next-waiting" });
+
+      const switchPromise = manager.switchTo("proj-b", "/path/b");
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Well past the skeleton channel's hard bound: this gate is still open
+      // and the outgoing view is still bridging.
+      await vi.advanceTimersByTimeAsync(400);
+      expect(win.contentView.removeChildView).not.toHaveBeenCalled();
+
+      // React finally commits — the switch lands and the intent is delivered.
+      manager.signalViewPainted(slowWc.id);
+      await switchPromise;
+
+      expect(manager.getActiveProjectId()).toBe("proj-b");
+      expect(slowWc.send).toHaveBeenCalledWith(CHANNELS.PROJECT_FOCUS_ON_ACTIVATE, {
+        intent: "focus-next-waiting",
+      });
+      expect(
+        vi
+          .mocked(logWarn)
+          .mock.calls.filter(([event]) => event === "projectview.paintgate.hardtimeout")
+      ).toHaveLength(0);
+      expect(
+        vi
+          .mocked(logInfo)
+          .mock.calls.filter(([event]) => event === "projectview.coldstart.rejected")
+      ).toHaveLength(0);
     } finally {
       vi.useRealTimers();
     }

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -233,6 +233,11 @@ function createMockWindow() {
     contentView: {
       children,
       addChildView: vi.fn((view: unknown, index?: number) => {
+        // Re-adding a view whose parent is unchanged reorders it rather than
+        // duplicating it. Modelled because the rollback path now re-attaches
+        // through activateView, which can land on a still-attached view.
+        const existing = children.indexOf(view);
+        if (existing >= 0) children.splice(existing, 1);
         if (typeof index === "number") {
           children.splice(index, 0, view);
         } else {
@@ -247,6 +252,20 @@ function createMockWindow() {
     webContents: createMockWebContents(),
   };
   return win;
+}
+
+/**
+ * Attach the rejection handler in the same tick the switch is started, so a
+ * fake-timer test can advance past the gate without tripping an unhandled
+ * rejection.
+ */
+function expectRejection(promise: Promise<unknown>): Promise<Error> {
+  return promise.then(
+    () => {
+      throw new Error("Expected the switch to reject");
+    },
+    (err: unknown) => err as Error
+  );
 }
 
 describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
@@ -350,13 +369,18 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
     }
   });
 
-  it("falls through paint gate at hard timeout when signal never arrives", async () => {
+  it("abandons the switch at hard timeout when the signal never arrives", async () => {
+    // Both release signals are document-owned, so exhausting the budget means
+    // the incoming view produced no evidence it can render — including having
+    // committed the wrong document entirely (#11635). Committing here is what
+    // stranded users on a bare "Not Found" frame with no in-app recovery.
     vi.useFakeTimers();
     try {
       const slowWc = createMockWebContents();
       wcQueue.push(slowWc);
 
       const switchPromise = manager.switchTo("proj-b", "/path/b");
+      const rejection = expectRejection(switchPromise);
 
       // Flush microtasks so did-finish-load fires and waitForPaint is armed.
       await vi.advanceTimersByTimeAsync(0);
@@ -365,12 +389,15 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
       await vi.advanceTimersByTimeAsync(60);
       expect(win.contentView.removeChildView).not.toHaveBeenCalled();
 
-      // Cross the hard bound (150 ms total) — outgoing now detached.
+      // Cross the hard bound (150 ms total) — switch abandoned, not committed.
       await vi.advanceTimersByTimeAsync(100);
-      await switchPromise;
+      const err = await rejection;
 
-      expect(win.contentView.removeChildView).toHaveBeenCalledTimes(1);
-      expect(manager.getActiveProjectId()).toBe("proj-b");
+      expect(err.message).toContain("View never painted");
+      // The healthy outgoing view is still the attached, active one.
+      expect(manager.getActiveProjectId()).toBe("proj-a");
+      expect(win.contentView.children).toContain(manager.getActiveView());
+      expect(slowWc.close).toHaveBeenCalled();
       expect(
         vi
           .mocked(logWarn)
@@ -381,6 +408,20 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
           .mocked(logWarn)
           .mock.calls.filter(([event]) => event === "projectview.paintgate.hardtimeout")
       ).toHaveLength(1);
+      // Telemetry must not go dark on the failure the gate exists to measure.
+      const rejected = vi
+        .mocked(logInfo)
+        .mock.calls.filter(([event]) => event === "projectview.coldstart.rejected");
+      expect(rejected).toHaveLength(1);
+      expect(rejected[0]?.[1]).toMatchObject({
+        projectId: "proj-b",
+        paintGateOutcome: "hard-timeout",
+        rollbackProjectId: "proj-a",
+      });
+      // ...and the success event must not also claim this switch landed.
+      expect(
+        vi.mocked(logInfo).mock.calls.filter(([event]) => event === "projectview.coldstart")
+      ).toHaveLength(0);
     } finally {
       vi.useRealTimers();
     }
@@ -395,10 +436,12 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
       manager.setPendingFocusIntent("proj-b", { intent: "focus-next-waiting" });
 
       const switchPromise = manager.switchTo("proj-b", "/path/b");
+      const rejection = expectRejection(switchPromise);
       await vi.advanceTimersByTimeAsync(0);
-      // Past hard bound — fall-through, intent dropped.
+      // Past hard bound — switch abandoned, intent dropped rather than
+      // delivered into a view that never proved it could render.
       await vi.advanceTimersByTimeAsync(200);
-      await switchPromise;
+      await rejection;
 
       expect(slowWc.send).not.toHaveBeenCalledWith("project:focus-on-activate", expect.anything());
     } finally {
@@ -449,6 +492,7 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
       wcQueue.push(slowWc);
 
       const switchPromise = manager.switchTo("proj-b", "/path/b");
+      const rejection = expectRejection(switchPromise);
       await vi.advanceTimersByTimeAsync(0);
 
       // Bump both bounds way up mid-flight — must NOT delay the active gate
@@ -465,10 +509,15 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
           .mock.calls.filter(([event]) => event === "projectview.paintgate.softtimeout")
       ).toHaveLength(1);
 
-      // Cross the original hard bound — fall-through fires using captured value.
+      // Cross the original hard bound — the gate settles on the captured value
+      // rather than the bumped one, so the switch is abandoned here.
       await vi.advanceTimersByTimeAsync(100);
-      await switchPromise;
-      expect(win.contentView.removeChildView).toHaveBeenCalledTimes(1);
+      await rejection;
+      expect(
+        vi
+          .mocked(logWarn)
+          .mock.calls.filter(([event]) => event === "projectview.paintgate.hardtimeout")
+      ).toHaveLength(1);
     } finally {
       vi.useRealTimers();
     }

--- a/electron/window/__tests__/ProjectViewManager.preload.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.preload.test.ts
@@ -206,6 +206,10 @@ describe("ProjectViewManager — preload eval cost (#9770)", () => {
     vi.clearAllMocks();
     mockGetAppMetrics.mockReset();
     mockGetAppMetrics.mockReturnValue([]);
+    // Preload-cost suite, not paint-gate policy: release every gate with a
+    // signal so the zero-length gate can't read as the hard timeout that now
+    // abandons a cold switch (#11635).
+    vi.spyOn(ProjectViewManager.prototype, "waitForPaint").mockResolvedValue("signal");
     win = createMockWindow();
     manager = new ProjectViewManager(win as never, {
       dirname: "/test",

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -47,11 +47,24 @@ function createMockWebContents(opts?: {
   const wc: MockWc = {
     id,
     isDestroyed: vi.fn(() => destroyed),
-    executeJavaScript: vi.fn((code?: string) =>
-      String(code ?? "").includes("__DAINTREE_INITIAL_PROJECT__")
-        ? Promise.resolve({ projectId: bootstrapProjectId, hasAppRoot })
-        : Promise.resolve()
-    ),
+    executeJavaScript: vi.fn((code?: string) => {
+      const script = String(code ?? "");
+      if (!script.includes("__DAINTREE_INITIAL_PROJECT__")) return Promise.resolve();
+      // Evaluate the probe for real against stubbed globals rather than
+      // returning a hand-built result shape. The DOM lookup IS the fix for
+      // #11635, so a fixture that fabricates `hasAppRoot` would keep passing if
+      // production stopped asking the document and hardcoded the answer.
+      const evaluate = new Function("globalThis", "document", `return ${script};`) as (
+        globals: unknown,
+        doc: unknown
+      ) => unknown;
+      return Promise.resolve(
+        evaluate(
+          { __DAINTREE_INITIAL_PROJECT__: bootstrapProjectId ? { id: bootstrapProjectId } : null },
+          { getElementById: (id: string) => (id === "root" && hasAppRoot ? {} : null) }
+        )
+      );
+    }),
     loadURL: vi.fn(() => Promise.resolve()),
     focus: vi.fn(),
     invalidate: vi.fn(),
@@ -243,13 +256,16 @@ function createMockWindow() {
 }
 
 /** Await a promise expected to reject, returning the error. Prevents unhandled-rejection noise. */
-async function expectRejection(promise: Promise<unknown>): Promise<Error> {
-  try {
-    await promise;
-    throw new Error("Expected promise to reject");
-  } catch (err) {
-    return err as Error;
-  }
+function expectRejection(promise: Promise<unknown>): Promise<Error> {
+  // Two-handler form, not try/catch: catching around an `await` also catches
+  // the "expected a rejection" throw itself, so a promise that RESOLVES would
+  // be reported as the rejection the caller asked for.
+  return promise.then(
+    () => {
+      throw new Error("Expected promise to reject");
+    },
+    (err: unknown) => err as Error
+  );
 }
 
 /** The `code` discriminant a load rejection carries, or undefined for an untyped error. */
@@ -901,6 +917,54 @@ describe("ProjectViewManager — switch failure rollback", () => {
       expect.any(Error),
       expect.objectContaining({ source: "project-switch" })
     );
+  });
+
+  it("treats a null probe result as a failure but an undefined one as an unmodelled mock", async () => {
+    // The escape hatch keys on `undefined` ALONE. Widening it to a nullish
+    // check would silently re-open the hole this fix closed, since a frame that
+    // is gone or never ran the expression answers `null`, not `undefined`.
+    const nullProbeWc = createMockWebContents({ autoFinishLoad: false });
+    nullProbeWc.executeJavaScript.mockResolvedValue(null);
+    wcQueue.push(nullProbeWc);
+
+    const nullErr = expectRejection(manager.switchTo("proj-b", "/path/b"));
+    await vi.advanceTimersByTimeAsync(0);
+    nullProbeWc._fireOnce("did-finish-load");
+    expect((await nullErr).message).toContain("non-application document");
+    expect(manager.getActiveProjectId()).toBe("proj-a");
+
+    const legacyMockWc = createMockWebContents({ autoFinishLoad: false });
+    legacyMockWc.executeJavaScript.mockResolvedValue(undefined);
+    wcQueue.push(legacyMockWc);
+
+    const p = manager.switchTo("proj-c", "/path/c");
+    await vi.advanceTimersByTimeAsync(0);
+    legacyMockWc._fireOnce("did-finish-load");
+    await p;
+    expect(manager.getActiveProjectId()).toBe("proj-c");
+  });
+
+  it("blames the document, not the project, when neither the id nor the document matches", async () => {
+    // Both facts are wrong at once, so this pins the precedence rather than
+    // just the message: a wrong document explains a wrong id, and reporting the
+    // id first would send diagnosis to the project plumbing instead of to the
+    // asset read that actually failed.
+    const wrongEverythingWc = createMockWebContents({
+      autoFinishLoad: false,
+      bootstrapProjectId: null,
+      hasAppRoot: false,
+    });
+    wcQueue.push(wrongEverythingWc);
+
+    const p = manager.switchTo("proj-b", "/path/b");
+    const errPromise = expectRejection(p);
+
+    await vi.advanceTimersByTimeAsync(0);
+    wrongEverythingWc._fireOnce("did-finish-load");
+
+    const err = await errPromise;
+    expect(err.message).toContain("non-application document");
+    expect(err.message).not.toContain("without project bootstrap");
   });
 
   it("rejects when the renderer bootstraps a different project than requested", async () => {

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -29,12 +29,15 @@ interface MockWc {
 function createMockWebContents(opts?: {
   autoFinishLoad?: boolean;
   bootstrapProjectId?: string | null;
+  /** `false` models a committed non-application document (the app:// 404). */
+  hasAppRoot?: boolean;
 }): MockWc {
   const id = nextWebContentsId++;
   const handlers = new Map<string, Handler[]>();
   const persistentHandlers = new Map<string, Handler[]>();
   const autoFinish = opts?.autoFinishLoad ?? true;
   const bootstrapProjectId = opts?.bootstrapProjectId ?? null;
+  const hasAppRoot = opts?.hasAppRoot ?? true;
 
   // Electron 42: `close()` tears the native object down synchronously and
   // fires `destroyed` inside the call. Modelled here so teardown-during-load
@@ -46,7 +49,7 @@ function createMockWebContents(opts?: {
     isDestroyed: vi.fn(() => destroyed),
     executeJavaScript: vi.fn((code?: string) =>
       String(code ?? "").includes("__DAINTREE_INITIAL_PROJECT__")
-        ? Promise.resolve(bootstrapProjectId)
+        ? Promise.resolve({ projectId: bootstrapProjectId, hasAppRoot })
         : Promise.resolve()
     ),
     loadURL: vi.fn(() => Promise.resolve()),
@@ -281,6 +284,14 @@ describe("ProjectViewManager — switch failure rollback", () => {
       viewLoadTimeoutMs: LOAD_SOFT_MS,
       viewLoadHardTimeoutMs: LOAD_HARD_MS,
     });
+    // This suite exercises load failure and rollback, not paint-gate policy,
+    // and drives its switches through a zero-length gate. A cold hard timeout
+    // now abandons the switch (#11635), so release the gate with the signal
+    // these fixtures stand in for — otherwise every test that expects the load
+    // to land fails on the gate instead. The managers built inside individual
+    // tests keep their real gates; `startBridgedSwitch` depends on one.
+    (manager as unknown as { waitForPaint: () => Promise<string> }).waitForPaint = () =>
+      Promise.resolve("signal");
 
     initialWc = createMockWebContents();
     const initialView = { webContents: initialWc, setBounds: vi.fn() };
@@ -524,11 +535,16 @@ describe("ProjectViewManager — switch failure rollback", () => {
     // still the painted frame.
     expect(bridgeManager.getOutgoingBridgeProjectId()).toBe(whileGateOpen);
 
-    // Only once the load settles is the bridge genuinely gone.
+    // Only once the load settles is the bridge genuinely gone. The already-
+    // expired gate abandons this switch the moment the load resolves (#11635),
+    // so the bridge clears via the rollback rather than via a commit — either
+    // way no view is left reported as on screen.
+    const rejection = expectRejection(switchPromise);
     slowWc._fireOnce("did-finish-load");
     await vi.advanceTimersByTimeAsync(1);
-    await switchPromise;
+    await rejection;
     expect(bridgeManager.getOutgoingBridgeProjectId()).toBeNull();
+    expect(bridgeManager.getActiveProjectId()).toBe("bridge-a");
   });
 
   it("stops reporting an outgoing bridge once the manager is disposed", async () => {
@@ -851,6 +867,36 @@ describe("ProjectViewManager — switch failure rollback", () => {
     expect(err.message).toContain("Project view loaded without project bootstrap");
     expect(manager.getActiveProjectId()).toBe("proj-a");
     expect(wrongPageWc.close).toHaveBeenCalled();
+    expect(notifyError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ source: "project-switch" })
+    );
+  });
+
+  it("rejects a committed non-application document even when the preload id matches", async () => {
+    // The app:// 404 regression (#11635). A `Response` with status 404 is a
+    // transport-complete navigation: it commits, fires did-finish-load, never
+    // fires did-fail-load, and still carries the preload — so the bootstrap id
+    // is exactly the one requested. Only the document itself can disprove it.
+    const notFoundPageWc = createMockWebContents({
+      autoFinishLoad: false,
+      bootstrapProjectId: "proj-b",
+      hasAppRoot: false,
+    });
+    wcQueue.push(notFoundPageWc);
+
+    const p = manager.switchTo("proj-b", "/path/b");
+    const errPromise = expectRejection(p);
+
+    await vi.advanceTimersByTimeAsync(0);
+    notFoundPageWc._fireOnce("did-finish-load");
+
+    const err = await errPromise;
+    // Attributed to the document, not to the project plumbing — the id matched.
+    expect(err.message).toContain("non-application document");
+    expect(err.message).not.toContain("without project bootstrap");
+    expect(manager.getActiveProjectId()).toBe("proj-a");
+    expect(notFoundPageWc.close).toHaveBeenCalled();
     expect(notifyError).toHaveBeenCalledWith(
       expect.any(Error),
       expect.objectContaining({ source: "project-switch" })


### PR DESCRIPTION
## Summary

- Switching to a project that needed a cold `WebContentsView` could replace the workspace with a raw Not Found page in the packaged app, recoverable only by restarting.
- The bootstrap probe now confirms the actual document rendered, not just that the right preload attached to it. A cold-start hard timeout now abandons the switch instead of committing to a broken view.
- Rollback goes through the real reactivation path, and the four previously-silent 404 branches in the `app://` handler now log enough to diagnose which read failed.

Resolves #11635

## What was wrong

A `Response` with `status: 404` returned from `protocol.handle()` is a transport-complete navigation as far as Chromium is concerned. It commits, `did-finish-load` fires, `did-fail-load` never does, and there's no net-error interstitial. The preload script attaches to that page like any other, so `__DAINTREE_INITIAL_PROJECT__` was present and `verifyProjectBootstrap` read back exactly the id it expected. That check proved the right preload attached. It never proved the right document rendered.

The paint gate was the only thing that got this right, because both of its release signals are document-owned: `APP_SKELETON_PARSED` comes from a script tag in `index.html`, `APP_VIEW_PAINTED` from React. Neither could ever fire on a 404 page, so the gate held its full budget and correctly reported `hard-timeout`. The actual bug was what we did with that answer: logged it, and detached the healthy outgoing view anyway.

## Changes

1. **Bootstrap probe asks the document, not just the id.** Same single `executeJavaScript` round trip, now returning `{ projectId, hasAppRoot }`, where `hasAppRoot` is `document.getElementById("root") !== null`. `#root` is static markup in `index.html` that no other document can produce, and unlike `#startup-skeleton` it survives React mounting, which matters because probing for the skeleton would reject healthy views whenever React wins the race to `did-finish-load`. A wrong document is now reported as a wrong document rather than a bootstrap id mismatch, because blaming the id sends diagnosis toward the project plumbing instead of the asset read that actually failed.

2. **A cold hard timeout now abandons the switch instead of committing to it.** The abandonment is thrown before any detach, so the rollback path restores an already-attached view. The paint gate's permissive design from #11462 still covers everything it was aimed at: the soft timeout keeps waiting, and a switch that's slow but succeeding still lands via the normal paint signal. Only "never painted at all" reaches this rejection path. A new `projectview.coldstart.rejected` telemetry event keeps this failure mode visible instead of going dark.

3. **Rollback re-attaches for real.** It was calling `registerAppView` followed by `setVisible(true)`, which is registry bookkeeping plus a flag. But `deactivateEntry` does a real `removeChildView`, and `setVisible(true)` on a view no longer in the tree composites nothing. Rollback now goes through `activateView`, which owns the matching `addChildView` call and is the same path every other reactivation already takes.

4. **The four silent 404 branches in the `app://` handler now log.** Each carries a stage discriminator (`stat` / `not-a-file` / `open` / `read` / `resolve`) plus the URL, resolved path, and errno, so a production report can say which read failed. Status codes, bodies, headers, the 304/validator shortcut, and containment are all unchanged.

## Not included / follow-up

A maintainer separately pointed out that the `stat` call in the `app://` handler exists only to produce the validator header for the 304 conditional-request shortcut, which is what lets Chromium keep cached V8 bytecode (`#8624`). So a caching optimization is currently failing hard instead of degrading gracefully. That's a real bug, but it's a behavior change, and it doesn't belong in this fix.

## Testing

496 tests across 12 suites, typecheck, eslint, and prettier all clean locally. New coverage: a committed non-application document with a matching preload id; precedence when both the id and the document are wrong; the hard timeout never detaching the outgoing view (asserted as `removeChildView` never being called with it, not just that it ends up attached); the first-run window where the outgoing view is the welcome view; a literal `null` probe result versus the `undefined` legacy-mock escape hatch; and one diagnostic assertion per 404 branch. The bootstrap mock now evaluates the real probe expression against stubbed globals rather than returning a hand-built shape, so a regression that stops querying the DOM fails the test.

Note for reviewers: four suites previously drove cold project switches through a zero-length paint gate as an implicit succeed-instantly shortcut. Since a hard timeout is now a real failure, those suites were updated to release the gate with the signal they were standing in for, via the existing `waitForPaint` test stub. Production behavior wasn't weakened to keep fixtures passing.
