### PR TITLE
fix(terminal): dedupe background grid resizes against the live grid, not the target cache

### DIFF
--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -165,6 +165,22 @@ interface SettledResizeRequest {
   rows: number;
 }
 
+/**
+ * A grid derived from cached cell metrics, plus what the caller needs to decide
+ * how much of it to commit. `null` from
+ * {@link TerminalResizeController.resizeGridFromCachedCellMetrics} means the
+ * metrics were unavailable and nothing was computed — it never means "no work",
+ * which is what `converged` says.
+ */
+interface CachedMetricGrid {
+  cols: number;
+  rows: number;
+  /** xterm already holds this grid, so there is no reflow to apply. */
+  converged: boolean;
+  /** The target cache pointed elsewhere before this call re-pointed it. */
+  cacheWasStale: boolean;
+}
+
 export class TerminalResizeController {
   private resizeLocks = new Map<string, number>();
   private settledResizeRequests = new Map<string, SettledResizeRequest>();
@@ -325,11 +341,24 @@ export class TerminalResizeController {
       // app kept emitting cursor-addressed output sized for the new width into
       // a parser still holding the old grid, and nothing recovered those rows
       // (#11628). This is the same split #11447 closed for backgrounded views.
-      const dims = this.resizeGridFromCachedCellMetrics(managed, width, height, wasAtBottom);
-      if (dims) {
-        this.applyResize(id, dims.cols, dims.rows);
+      const grid = this.resizeGridFromCachedCellMetrics(managed, width, height, wasAtBottom);
+      if (!grid) return null;
+      if (grid.converged) {
+        // xterm is already on this grid, so nothing reflows — but the branch
+        // that used to handle this case ran through `applyResize`, which
+        // cancels older queued work on the way past. Returning early drops
+        // that, so supersede explicitly or a debounce/idle/settled job holding
+        // an older box fires later and drags BOTH grids to it (#11095). The
+        // same send re-asserts the PTY when the cache ran ahead of the grid:
+        // it was told that other target and nothing else here will correct it.
+        if (grid.cacheWasStale || this.hasPendingResize(id)) {
+          this.clearResizeJob(managed);
+          this.sendPtyResize(id, grid.cols, grid.rows);
+        }
+        return null;
       }
-      return dims;
+      this.applyResize(id, grid.cols, grid.rows);
+      return { cols: grid.cols, rows: grid.rows };
     }
 
     try {
@@ -488,16 +517,29 @@ export class TerminalResizeController {
     }
     const buffer = managed.terminal.buffer.active;
     const wasAtBottom = buffer.viewportY >= buffer.baseY;
-    const dims = this.resizeGridFromCachedCellMetrics(managed, width, height, wasAtBottom);
-    if (dims) {
-      this.clearSettledTimer(id);
-      // xterm first, then the PTY: the app must never receive SIGWINCH for a
-      // grid the parser has not adopted yet.
-      this.resizeTerminal(managed, dims.cols, dims.rows);
-      terminalClient.resize(id, dims.cols, dims.rows);
-      this.pinToBottomAfterResize(managed);
+    const grid = this.resizeGridFromCachedCellMetrics(managed, width, height, wasAtBottom);
+    if (!grid) return null;
+    if (grid.converged) {
+      // Nothing to reflow, but a cache that ran ahead means the PTY was told a
+      // different grid — panel spawn sizes it directly, before xterm has ever
+      // been fit — and the pixel box is stamped processed on the way out of the
+      // helper, so no later resize revisits it. Re-assert the truth to the PTY
+      // alone: xterm is already correct, and routing through `sendPtyResize`
+      // here would hand a settled-strategy agent's commit to a timer that
+      // reflows a hidden, possibly frozen renderer — the delivery this path
+      // exists to bypass. Queued work was already cancelled above.
+      if (grid.cacheWasStale) {
+        terminalClient.resize(id, grid.cols, grid.rows);
+      }
+      return null;
     }
-    return dims;
+    this.clearSettledTimer(id);
+    // xterm first, then the PTY: the app must never receive SIGWINCH for a
+    // grid the parser has not adopted yet.
+    this.resizeTerminal(managed, grid.cols, grid.rows);
+    terminalClient.resize(id, grid.cols, grid.rows);
+    this.pinToBottomAfterResize(managed);
+    return { cols: grid.cols, rows: grid.rows };
   }
 
   // Computes cols/rows from cached cell metrics with no DOM reads — a hidden or
@@ -514,24 +556,55 @@ export class TerminalResizeController {
     width: number,
     height: number,
     wasAtBottom: boolean
-  ): { cols: number; rows: number } | null {
+  ): CachedMetricGrid | null {
     const cellDims = getXtermCellDimensions(managed.terminal);
     if (!cellDims) {
       return null;
     }
     const cols = colsForWidth(managed.terminal, width, cellDims.width);
     const rows = rowsForHeight(height, cellDims.height);
-    if (managed.latestCols === cols && managed.latestRows === rows) {
-      managed.lastWidth = width;
-      managed.lastHeight = height;
-      return null;
-    }
+    // Convergence is a claim about the grid xterm actually holds, never about
+    // the target cache. `latestCols`/`latestRows` are written AHEAD of the
+    // commit — by `applyResize`'s settled branch, by `sendPtyResize`, and by the
+    // PTY-only sizing panel spawn does before xterm has ever been fit — so a box
+    // that computes to the cached target proves nothing about the parser. Trust
+    // it and a target stranded ahead of the grid (a settled timer dropped by
+    // `lockResize`, a spawn-time PTY resize xterm never adopted) reads as
+    // "already resolved": this returns null, stamps the pixel box as processed,
+    // and `isRedundantResize` then skips that box for good — leaving xterm
+    // narrower than the PTY until something forces a full re-measure (#11639).
+    // Same distinction `isRedundantResize` and `resize`'s own dedup draw:
+    // redundant and stale are not the same, and only redundant is safe to drop
+    // (#7762, #11095).
+    //
+    // A serialized restore never converges. xterm is parked at the snapshot's
+    // CAPTURE grid while the payload replays, so `terminal.cols` describes the
+    // replay, not the pane; the box has to reach `resizeTerminal` to be recorded
+    // into `pendingRestoreGeometry`, which is what the replay normalizes to when
+    // it closes. Calling the capture grid "converged" drops the box on the floor
+    // AND stamps it redundant — the very stranding above, one layer down
+    // (#11552).
+    const converged =
+      !managed.isSerializedRestoreInProgress &&
+      managed.terminal.cols === cols &&
+      managed.terminal.rows === rows;
+    // Whether the target the PTY was last told differs from the grid xterm
+    // holds. Only meaningful alongside `converged`: there is no reflow to apply,
+    // but the PTY is still sized for that other target, so a caller that just
+    // returns leaves the two halves split.
+    const cacheWasStale = managed.latestCols !== cols || managed.latestRows !== rows;
+
     managed.lastWidth = width;
     managed.lastHeight = height;
+    // Re-point the target at the truth either way. Left alone, a stale
+    // ahead-of-grid target is what `applyDeferredResize`, `forceImmediateResize`
+    // and `TerminalRevealController` push to the PTY later (#11095).
     managed.latestCols = cols;
     managed.latestRows = rows;
-    managed.latestWasAtBottom = wasAtBottom;
-    return { cols, rows };
+    if (!converged) {
+      managed.latestWasAtBottom = wasAtBottom;
+    }
+    return { cols, rows, converged, cacheWasStale };
   }
 
   /**

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -483,6 +483,147 @@ describe("TerminalResizeController", () => {
     expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1700), 40);
   });
 
+  it("background-tier resize applies a box whose grid equals a stranded target", () => {
+    // The #11639 split. `latestCols`/`latestRows` are written ahead of the
+    // commit, so a target can outlive the work that was going to apply it —
+    // here a settled timer `lockResize` drops. Deduping the next box against
+    // that cache calls the resize resolved while xterm is still on the old
+    // grid, and the pixel stamp that goes with it makes the box redundant for
+    // good. Only the grid xterm actually holds can answer "is there work?".
+    const managed = createManagedTerminal();
+    managed.launchAgentId = "codex";
+    managed.runtimeAgentId = "codex";
+    Object.assign(managed.terminal, {
+      _core: { _renderService: { dimensions: { css: { cell: CELL } } } },
+    });
+    getEffectiveAgentConfigMock.mockReturnValue({
+      capabilities: { resizeStrategy: "settled" },
+    });
+
+    const controller = new TerminalResizeController({
+      getInstance: vi.fn(() => managed),
+      dataBuffer: {
+        flushForTerminal: vi.fn(),
+        resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
+      } as any,
+    });
+
+    // Arm the write-ahead, then strand it: the lock cancels the settled timer,
+    // so the target survives with nothing left to commit it.
+    controller.resize("term-1", 1600, 800);
+    expect(controller.hasPendingResize("term-1")).toBe(true);
+    controller.lockResize("term-1", true);
+    controller.lockResize("term-1", false);
+    expect(controller.hasPendingResize("term-1")).toBe(false);
+    expect(managed.terminal.resize).not.toHaveBeenCalled();
+    expect(managed.terminal.cols).toBe(80);
+
+    managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
+    managed.isFocused = false;
+    managed.isVisible = false;
+
+    // A different pixel box — so the pixel gate lets it through — that lands on
+    // the same grid the stranded target already names.
+    expect(colsFor(1604)).toBe(colsFor(1600));
+    expect(controller.resize("term-1", 1604, 819)).toEqual({ cols: colsFor(1604), rows: 40 });
+
+    vi.advanceTimersByTime(500);
+    expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1604), 40);
+    expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1604), 40);
+  });
+
+  it("background-tier convergence supersedes a queued target instead of letting it fire", () => {
+    // Deduping on the live grid returns before `applyResize`, and `applyResize`
+    // is what used to cancel older queued work on the way past. Without an
+    // explicit supersede the dropped job still fires and drags both grids to a
+    // box that is no longer the container (#11095).
+    const managed = createManagedTerminal();
+    managed.launchAgentId = "codex";
+    managed.runtimeAgentId = "codex";
+    Object.assign(managed.terminal, {
+      _core: { _renderService: { dimensions: { css: { cell: CELL } } } },
+    });
+    getEffectiveAgentConfigMock.mockReturnValue({
+      capabilities: { resizeStrategy: "settled" },
+    });
+
+    const controller = new TerminalResizeController({
+      getInstance: vi.fn(() => managed),
+      dataBuffer: {
+        flushForTerminal: vi.fn(),
+        resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
+      } as any,
+    });
+
+    // xterm is settled on the 1600px grid; a later 1700px box queued behind it.
+    managed.terminal.cols = colsFor(1600);
+    managed.terminal.rows = 40;
+    managed.latestCols = colsFor(1600);
+    managed.latestRows = 40;
+    managed.lastWidth = 1600;
+    managed.lastHeight = 800;
+    controller.resize("term-1", 1700, 800);
+    expect(controller.hasPendingResize("term-1")).toBe(true);
+
+    managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
+    managed.isFocused = false;
+    managed.isVisible = false;
+
+    // Back to a box on the grid xterm already holds — no reflow to do.
+    expect(controller.resize("term-1", 1604, 819)).toBeNull();
+    expect(managed.latestCols).toBe(colsFor(1604));
+    expect(managed.latestRows).toBe(40);
+
+    vi.advanceTimersByTime(500);
+    expect(managed.terminal.resize).not.toHaveBeenCalledWith(colsFor(1700), 40);
+    expect(resizeMock).not.toHaveBeenCalledWith("term-1", colsFor(1700), 40);
+    expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1604), 40);
+  });
+
+  it("background-tier resize records a restore target when the replay grid already matches", () => {
+    // While a snapshot replays, xterm is parked at the CAPTURE grid, so
+    // `terminal.cols` describes the payload rather than the pane. A box that
+    // happens to match it has not converged on anything: it still has to reach
+    // resizeTerminal to be recorded as the geometry the replay normalizes to
+    // when it closes (#11552).
+    const managed = createManagedTerminal();
+    managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
+    managed.isFocused = false;
+    managed.isVisible = false;
+    managed.isSerializedRestoreInProgress = true;
+    managed.pendingRestoreGeometry = { cols: 100, rows: 30 };
+    managed.latestCols = 100;
+    managed.latestRows = 30;
+    Object.assign(managed.terminal, {
+      _core: { _renderService: { dimensions: { css: { cell: CELL } } } },
+    });
+
+    const controller = new TerminalResizeController({
+      getInstance: vi.fn(() => managed),
+      dataBuffer: {
+        flushForTerminal: vi.fn(),
+        resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
+      } as any,
+    });
+
+    // 820x480 computes to 80x24 — exactly the replay grid the terminal is
+    // parked on.
+    expect(colsFor(820)).toBe(managed.terminal.cols);
+    expect(controller.resize("term-1", 820, 480)).toEqual({ cols: colsFor(820), rows: 24 });
+
+    expect(managed.terminal.resize).not.toHaveBeenCalled();
+    expect(managed.pendingRestoreGeometry).toEqual({ cols: colsFor(820), rows: 24 });
+    expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(820), 24);
+    expect(managed.lastWidth).toBe(820);
+    expect(managed.lastHeight).toBe(480);
+  });
+
   it("a stale background tier does not divert a visible terminal off the measured path", () => {
     // A freshly prewarmed terminal carries lastAppliedTier === BACKGROUND until
     // applyRendererPolicy promotes it, but it can already be attached and
@@ -2209,6 +2350,104 @@ describe("TerminalResizeController", () => {
       vi.advanceTimersByTime(500);
       expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
       expect(resizeMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("applies a box whose grid equals a stranded settled target", () => {
+      // The #11639 split through the direct-commit caller. The settled request
+      // stamped `latestCols`/`latestRows` before anything committed, and
+      // `lockResize` then dropped the timer — so the target names a grid xterm
+      // never adopted. Deduping the next box against it returns null and stamps
+      // the pixel box processed, which `isRedundantResize` honours from then on:
+      // the pane stays on the old grid permanently.
+      const managed = createManagedTerminal();
+      managed.launchAgentId = "codex";
+      managed.runtimeAgentId = "codex";
+      Object.assign(managed.terminal, {
+        _core: { _renderService: { dimensions: { css: { cell: CELL } } } },
+      });
+      getEffectiveAgentConfigMock.mockReturnValue({
+        capabilities: { resizeStrategy: "settled" },
+      });
+      const controller = makeController(managed);
+
+      controller.resize("term-1", 1600, 800);
+      expect(controller.hasPendingResize("term-1")).toBe(true);
+      controller.lockResize("term-1", true);
+      controller.lockResize("term-1", false);
+
+      expect(controller.hasPendingResize("term-1")).toBe(false);
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(managed.terminal.cols).toBe(80);
+      expect(managed.latestCols).toBe(colsFor(1600));
+
+      // A new pixel box — past the pixel gate — landing on the grid the
+      // stranded target already names.
+      expect(colsFor(1604)).toBe(colsFor(1600));
+      const order: string[] = [];
+      managed.terminal.resize.mockImplementationOnce(function (
+        this: { cols: number; rows: number },
+        cols: number,
+        rows: number
+      ) {
+        order.push("xterm");
+        this.cols = cols;
+        this.rows = rows;
+      });
+      resizeMock.mockImplementationOnce(() => {
+        order.push("pty");
+      });
+
+      expect(controller.applyBackgroundResize("term-1", 1604, 819)).toEqual({
+        cols: colsFor(1604),
+        rows: 40,
+      });
+
+      expect(order).toEqual(["xterm", "pty"]);
+      expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1604), 40);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1604), 40);
+      expect(managed.lastWidth).toBe(1604);
+      expect(managed.lastHeight).toBe(819);
+
+      vi.advanceTimersByTime(500);
+      expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
+      expect(resizeMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-asserts the PTY when the grid already converged but the cache ran ahead", () => {
+      // Panel spawn sizes the PTY directly, before xterm has ever been fit, so
+      // `latestCols`/`latestRows` can name a grid only the PTY is on. Finding
+      // xterm already correct means there is no reflow to run — it does NOT
+      // mean the two halves agree, and the pixel box is stamped processed on
+      // the way out, so nothing revisits it. The PTY half gets re-asserted
+      // alone; sending it through the settled timer would reflow a hidden
+      // renderer, which is what this path exists to avoid.
+      const managed = createManagedTerminal();
+      Object.assign(managed.terminal, {
+        _core: { _renderService: { dimensions: { css: { cell: CELL } } } },
+      });
+      const controller = makeController(managed);
+
+      controller.sendPtyResize("term-1", 100, 30);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 100, 30);
+      expect(managed.terminal.cols).toBe(80);
+      expect(managed.terminal.rows).toBe(24);
+      resizeMock.mockClear();
+
+      // 820x480 computes to 80x24 — the grid xterm holds, not the 100x30 the
+      // PTY was told.
+      expect(colsFor(820)).toBe(80);
+      expect(controller.applyBackgroundResize("term-1", 820, 480)).toBeNull();
+
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 80, 24);
+      expect(managed.latestCols).toBe(80);
+      expect(managed.latestRows).toBe(24);
+
+      // A second delivery of the same box is genuinely redundant now: both
+      // halves agree, so nothing is re-sent.
+      resizeMock.mockClear();
+      expect(controller.applyBackgroundResize("term-1", 820, 480)).toBeNull();
+      expect(resizeMock).not.toHaveBeenCalled();
     });
 
     it("supersedes a pending settled timer scheduled before backgrounding", () => {

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -51,6 +51,21 @@ const CELL = { width: 10, height: 20 };
 const colsFor = (widthPx: number): number =>
   Math.max(2, Math.floor((widthPx - SCROLLBAR_PX) / CELL.width));
 
+/**
+ * The widest and tallest pixel box that still resolves to the same grid as
+ * `widthPx`/`heightPx` — a box the pixel dedup treats as new while the column
+ * and row math lands exactly where it did before.
+ *
+ * Derived from the gutter and cell size rather than hardcoded: now that the
+ * scrollbar is reserved before the division (#11095), a fixed "+4px" would
+ * cross a cell boundary and silently stop testing the collision it was written
+ * for.
+ */
+const sameGridBox = (widthPx: number, heightPx: number): [number, number] => [
+  widthPx + (CELL.width - 1 - ((widthPx - SCROLLBAR_PX) % CELL.width)),
+  heightPx + (CELL.height - 1 - (heightPx % CELL.height)),
+];
+
 function createManagedTerminal() {
   const terminal = {
     cols: 80,
@@ -525,13 +540,20 @@ describe("TerminalResizeController", () => {
     managed.isVisible = false;
 
     // A different pixel box — so the pixel gate lets it through — that lands on
-    // the same grid the stranded target already names.
-    expect(colsFor(1604)).toBe(colsFor(1600));
-    expect(controller.resize("term-1", 1604, 819)).toEqual({ cols: colsFor(1604), rows: 40 });
+    // the same grid the stranded target already names. Grown to the widest and
+    // tallest pixel still inside the same cell rather than hardcoded, so a
+    // change to the gutter or cell size cannot quietly move it onto a different
+    // grid and stop testing the collision it was written for.
+    const [retryWidth, retryHeight] = sameGridBox(1600, 800);
+    expect(colsFor(retryWidth)).toBe(colsFor(1600));
+    expect(controller.resize("term-1", retryWidth, retryHeight)).toEqual({
+      cols: colsFor(1600),
+      rows: 40,
+    });
 
     vi.advanceTimersByTime(500);
-    expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1604), 40);
-    expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1604), 40);
+    expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1600), 40);
+    expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
   });
 
   it("background-tier convergence supersedes a queued target instead of letting it fire", () => {
@@ -612,16 +634,73 @@ describe("TerminalResizeController", () => {
       } as any,
     });
 
-    // 820x480 computes to 80x24 — exactly the replay grid the terminal is
-    // parked on.
-    expect(colsFor(820)).toBe(managed.terminal.cols);
-    expect(controller.resize("term-1", 820, 480)).toEqual({ cols: colsFor(820), rows: 24 });
+    // A box landing on exactly the replay grid, derived from that grid on BOTH
+    // axes — a hardcoded pair would keep passing against a naive live-grid
+    // guard if the fixture's rows ever stopped matching by accident.
+    const parkedCols = managed.terminal.cols;
+    const parkedRows = managed.terminal.rows;
+    const parkedWidth = SCROLLBAR_PX + parkedCols * CELL.width;
+    const parkedHeight = parkedRows * CELL.height;
+
+    expect(controller.resize("term-1", parkedWidth, parkedHeight)).toEqual({
+      cols: parkedCols,
+      rows: parkedRows,
+    });
 
     expect(managed.terminal.resize).not.toHaveBeenCalled();
-    expect(managed.pendingRestoreGeometry).toEqual({ cols: colsFor(820), rows: 24 });
-    expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(820), 24);
-    expect(managed.lastWidth).toBe(820);
-    expect(managed.lastHeight).toBe(480);
+    expect(managed.pendingRestoreGeometry).toEqual({ cols: parkedCols, rows: parkedRows });
+    expect(resizeMock).toHaveBeenCalledWith("term-1", parkedCols, parkedRows);
+    expect(managed.lastWidth).toBe(parkedWidth);
+    expect(managed.lastHeight).toBe(parkedHeight);
+  });
+
+  it("background-tier convergence re-asserts a PTY the cache left ahead of the grid", () => {
+    // Isolates the cache half of the supersede gate: panel spawn sizes the PTY
+    // directly and stamps the target, leaving NO queued work behind it, so
+    // `hasPendingResize` cannot carry this case. Finding xterm already correct
+    // is not the same as the two halves agreeing.
+    const managed = createManagedTerminal();
+    managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
+    managed.isFocused = false;
+    managed.isVisible = false;
+    Object.assign(managed.terminal, {
+      _core: { _renderService: { dimensions: { css: { cell: CELL } } } },
+    });
+
+    const controller = new TerminalResizeController({
+      getInstance: vi.fn(() => managed),
+      dataBuffer: {
+        flushForTerminal: vi.fn(),
+        resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
+      } as any,
+    });
+
+    controller.sendPtyResize("term-1", 100, 30);
+    expect(controller.hasPendingResize("term-1")).toBe(false);
+    resizeMock.mockClear();
+
+    // A sentinel the converged branch must leave alone: no grid moves, so the
+    // auto-follow intent recorded with the last real change still stands. The
+    // fixture's buffer reads as at-bottom, so an unconditional assignment here
+    // would flip this to true.
+    managed.latestWasAtBottom = false;
+
+    const liveCols = managed.terminal.cols;
+    const liveRows = managed.terminal.rows;
+    const result = controller.resize(
+      "term-1",
+      SCROLLBAR_PX + liveCols * CELL.width,
+      liveRows * CELL.height
+    );
+
+    expect(result).toBeNull();
+    expect(managed.terminal.resize).not.toHaveBeenCalled();
+    expect(resizeMock).toHaveBeenCalledWith("term-1", liveCols, liveRows);
+    expect(managed.latestCols).toBe(liveCols);
+    expect(managed.latestRows).toBe(liveRows);
+    expect(managed.latestWasAtBottom).toBe(false);
   });
 
   it("a stale background tier does not divert a visible terminal off the measured path", () => {
@@ -2382,7 +2461,8 @@ describe("TerminalResizeController", () => {
 
       // A new pixel box — past the pixel gate — landing on the grid the
       // stranded target already names.
-      expect(colsFor(1604)).toBe(colsFor(1600));
+      const [retryWidth, retryHeight] = sameGridBox(1600, 800);
+      expect(colsFor(retryWidth)).toBe(colsFor(1600));
       const order: string[] = [];
       managed.terminal.resize.mockImplementationOnce(function (
         this: { cols: number; rows: number },
@@ -2397,16 +2477,16 @@ describe("TerminalResizeController", () => {
         order.push("pty");
       });
 
-      expect(controller.applyBackgroundResize("term-1", 1604, 819)).toEqual({
-        cols: colsFor(1604),
+      expect(controller.applyBackgroundResize("term-1", retryWidth, retryHeight)).toEqual({
+        cols: colsFor(1600),
         rows: 40,
       });
 
       expect(order).toEqual(["xterm", "pty"]);
-      expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1604), 40);
-      expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1604), 40);
-      expect(managed.lastWidth).toBe(1604);
-      expect(managed.lastHeight).toBe(819);
+      expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1600), 40);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
+      expect(managed.lastWidth).toBe(retryWidth);
+      expect(managed.lastHeight).toBe(retryHeight);
 
       vi.advanceTimersByTime(500);
       expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
@@ -2443,11 +2523,48 @@ describe("TerminalResizeController", () => {
       expect(managed.latestCols).toBe(80);
       expect(managed.latestRows).toBe(24);
 
-      // A second delivery of the same box is genuinely redundant now: both
-      // halves agree, so nothing is re-sent.
+      // Now that both halves agree, a fresh box on the same grid converges with
+      // nothing to re-assert — neither half is touched. Widened past the pixel
+      // gate deliberately: an identical box would exit at `isRedundantResize`
+      // and prove only that pixel dedup works.
+      const [sameGridWidth, sameGridHeight] = sameGridBox(820, 480);
+      expect(colsFor(sameGridWidth)).toBe(colsFor(820));
       resizeMock.mockClear();
-      expect(controller.applyBackgroundResize("term-1", 820, 480)).toBeNull();
+
+      expect(controller.applyBackgroundResize("term-1", sameGridWidth, sameGridHeight)).toBeNull();
       expect(resizeMock).not.toHaveBeenCalled();
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+    });
+
+    it("records a restore target rather than converging on the replay grid", () => {
+      // The direct-commit twin of the measured path's restore case: xterm is
+      // parked at the capture grid, so matching it is not convergence — the box
+      // still has to reach resizeTerminal to become the geometry the replay
+      // normalizes to (#11552).
+      const managed = createManagedTerminal();
+      managed.isSerializedRestoreInProgress = true;
+      managed.pendingRestoreGeometry = { cols: 100, rows: 30 };
+      managed.latestCols = 100;
+      managed.latestRows = 30;
+      Object.assign(managed.terminal, {
+        _core: { _renderService: { dimensions: { css: { cell: CELL } } } },
+      });
+      const controller = makeController(managed);
+
+      // Derived from the parked grid on both axes, so neither the column nor
+      // the row half can drift into a coincidence if the fixture changes.
+      const parkedCols = managed.terminal.cols;
+      const parkedRows = managed.terminal.rows;
+      const parkedWidth = SCROLLBAR_PX + parkedCols * CELL.width;
+      const parkedHeight = parkedRows * CELL.height;
+
+      expect(controller.applyBackgroundResize("term-1", parkedWidth, parkedHeight)).toEqual({
+        cols: parkedCols,
+        rows: parkedRows,
+      });
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(managed.pendingRestoreGeometry).toEqual({ cols: parkedCols, rows: parkedRows });
+      expect(resizeMock).toHaveBeenCalledWith("term-1", parkedCols, parkedRows);
     });
 
     it("supersedes a pending settled timer scheduled before backgrounding", () => {


### PR DESCRIPTION
Resolves #11639

## The bug

`resizeGridFromCachedCellMetrics()` deduped a newly computed grid against `managed.latestCols`/`latestRows` — the *target cache*, which is written **ahead** of the commit by `applyResize()`'s settled branch, by `sendPtyResize()`, and by the PTY-only sizing panel spawn does before xterm has ever been fit.

So a target that outlived the work meant to apply it — a settled timer `lockResize()` drops, a spawn-time PTY resize xterm never adopted — read as convergence. The helper returned `null` **and** stamped `lastWidth`/`lastHeight`, after which `isRedundantResize()` skipped that pixel box for good: xterm stayed narrower than the PTY permanently, producing mid-phrase wrapping or a squashed sticky-region repaint until something forced a full re-measure.

Its sibling in `resize()` already had this right, and says why (#11095): redundant and stale are not the same thing, and only redundant is safe to drop.

## The fix

Compare against `managed.terminal.cols`/`rows` — the grid xterm actually holds — and re-point `latestCols`/`latestRows` at that truth either way, so `applyDeferredResize`, `forceImmediateResize` and `TerminalRevealController` stop inheriting a stale ahead-of-grid target.

Three things convergence has to keep doing, which a bare guard swap would have dropped:

- **Never converge during a serialized restore.** xterm is parked at the snapshot's *capture* grid while a payload replays, so `terminal.cols` describes the replay, not the pane. The box has to reach `resizeTerminal` to be recorded into `pendingRestoreGeometry` — which is what `closeRestoreWindow` normalizes to. Calling the capture grid "converged" drops the box *and* stamps it redundant: the same permanent stranding, one layer down (#11552).
- **Supersede queued work.** Before, a box matching the live grid but not the cache took the non-converged path into `applyResize()`, which cancels older jobs on the way past. Returning early loses that, so a debounce/idle/settled job holding an older box would fire later and drag both grids to it (#11095).
- **Re-assert the PTY when the cache ran ahead.** Panel spawn (`addPanel.ts`, `TerminalRegistryController.ts`) sizes the PTY alone, so the two halves can already disagree when xterm turns out to be correct. Convergence means "no reflow to run", not "the halves agree" — without the re-assert this would have traded one permanent split for another on the most common path in the app.

`applyBackgroundResize` re-asserts via `terminalClient.resize` directly rather than `sendPtyResize`: for a settled-strategy agent the latter hands the commit to a timer that reflows a hidden, possibly frozen renderer — the delivery this path exists to bypass.

## Verification

7 regression tests across **both** callers of the helper (`applyBackgroundResize` and `resize()`'s background-unfocused branch). Each was mutation-verified rather than assumed:

| Mutant | Tests that fail |
|---|---|
| Original target-cache guard | 4 |
| Naive live-grid guard (no restore exclusion) | 2 |
| Supersede gate without `cacheWasStale` | 1 |
| `latestWasAtBottom` assigned unconditionally | 1 |

328 tests pass across the 16 suites covering the changed module, including `TerminalInstanceService.backgroundResize` and `TerminalSwitchBackRedraw.regression`.

## Noted, not fixed (pre-existing, out of scope)

Two adjacent holes surfaced during review. Both predate this change and behave identically before and after it, so they are left alone rather than widening this PR:

- `isRedundantResize()`'s pixel gate short-circuits *before* this helper, so re-delivering an **identical** pixel box after `lockResize()` cancelled uncommitted work still strands the target. Fixing it means invalidating the pixel cache inside `lockResize` — a hot project-switch path this PR doesn't otherwise touch.
- `resize()`'s own measured-path dedupe lacks the `isSerializedRestoreInProgress` exclusion added here. Lower severity there because it doesn't stamp `lastWidth`, so the next resize tick, the reveal-time `terminal.cols !== latestCols` repair, and the watchdog each recover it.