### PR TITLE
fix(terminal): retry worktree-switch reveal from component mount

### DIFF
--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -64,6 +64,7 @@ import { errorsClient } from "@/clients";
 import type { AgentState } from "@/types";
 import { isBuiltInAgentId, type BuiltInAgentId } from "@shared/config/agentIds";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import { notifyWorktreeTerminalAttached } from "@/services/terminal/worktreeRevealCoordinator";
 import { actionService } from "@/services/ActionService";
 import { useReviewDialogOpenForWorktree } from "./useReviewDialogOpenForWorktree";
 import { InputTracker } from "@/services/clearCommandDetection";
@@ -677,6 +678,18 @@ function TerminalPaneComponent({
   // (#11445). `useReducer`'s dispatch identity is stable, so handing it
   // straight to XtermAdapter can't churn its attach effect.
   const [attachEpoch, bumpAttachEpoch] = useReducer((epoch: number) => epoch + 1, 0);
+
+  // This mount is also what discharges the worktree-switch reveal obligation
+  // (#11640): the switch's policy pass ran before React re-rendered, so its wake
+  // could not paint a host that was still parked offscreen. The coordinator
+  // waits for attach to settle before repainting — `onAttached` fires while
+  // `isAttaching` can still be true, so it is a re-arm signal, not a paint
+  // trigger. `bumpAttachEpoch` has a stable identity, so this callback's
+  // identity is stable too and can't churn XtermAdapter's attach effect.
+  const handleAttached = useCallback(() => {
+    bumpAttachEpoch();
+    notifyWorktreeTerminalAttached(id);
+  }, [id]);
 
   useTerminalVisibilityObserver({
     id,
@@ -1429,7 +1442,7 @@ function TerminalPaneComponent({
                     onReady={handleReady}
                     onExit={handleExit}
                     onInput={handleInput}
-                    onAttached={bumpAttachEpoch}
+                    onAttached={handleAttached}
                     className="absolute inset-0"
                     getRefreshTier={getRefreshTierCallback}
                     cwd={cwd}

--- a/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
+++ b/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
@@ -296,6 +296,26 @@ describe("XtermAdapter lifecycle", () => {
     expect(attachedOrder).toBeGreaterThan(visibleOrder);
   });
 
+  it("announces the attach before it has settled, so consumers must gate on settle (#11640)", async () => {
+    // attach() defers clearing isAttaching into a rAF for a reparented terminal,
+    // so onAttached can land while the attach is still in flight. The worktree
+    // reveal coordinator relies on this being a re-arm signal rather than a
+    // paint trigger: repaintForReveal has no isAttaching guard, so painting
+    // straight from this callback would race the terminal's own post-attach fit.
+    mocks.terminalInstanceService.attach.mockImplementation(() => {
+      mocks.managed.isAttaching = true;
+    });
+    let attachingAtAnnounce: boolean | undefined;
+    const onAttached = vi.fn(() => {
+      attachingAtAnnounce = mocks.managed.isAttaching;
+    });
+
+    renderAdapter({ onAttached });
+
+    await waitFor(() => expect(onAttached).toHaveBeenCalledTimes(1));
+    expect(attachingAtAnnounce).toBe(true);
+  });
+
   it("does not re-announce an attach when only hot callbacks change (#11445)", async () => {
     const onAttached = vi.fn();
 

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -748,8 +748,8 @@ class TerminalInstanceService {
     this.resizeController.lockResize(id, false);
   }
 
-  wake(id: string): void {
-    this.revealController.wake(id);
+  wake(id: string): boolean {
+    return this.revealController.wake(id);
   }
 
   wakeForFocus(id: string): void {

--- a/src/services/terminal/TerminalRevealController.ts
+++ b/src/services/terminal/TerminalRevealController.ts
@@ -168,9 +168,16 @@ export class TerminalRevealController {
     }
   }
 
-  wake(id: string): void {
+  /**
+   * @returns `true` only when the repaint actually landed. Callers that own a
+   * durable obligation (the worktree-switch policy, #11640) treat `false` as
+   * "not paintable yet — retry once the host is mounted" rather than discarding
+   * it. The unopened branch reports `false` because its restore is
+   * fire-and-forget: it can defer on an unmeasurable host without telling us.
+   */
+  wake(id: string): boolean {
     const managed = this.deps.getInstance(id);
-    if (!managed) return;
+    if (!managed) return false;
     // A click/focus/reveal of a live pane is a PLAIN REPAINT. The pane stayed
     // fully live in the background (no suspend/resync anymore), so
     // repaintForReveal (WebGL reacquire + atlas/refresh + geometry re-fit) is
@@ -178,9 +185,9 @@ export class TerminalRevealController {
     // reveal) takes the visibility-restore path, which opens it then repaints.
     if (!managed.isOpened) {
       void this.fullWakeForVisibilityRestore(id);
-      return;
+      return false;
     }
-    this.repaintForReveal(id);
+    return this.repaintForReveal(id);
   }
 
   /**

--- a/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
@@ -118,6 +118,7 @@ type FullWakeTestService = {
   fullWakeForVisibilityRestore: (id: string) => Promise<void>;
   repaintForReveal: (id: string, opts?: { trustDomVisibility?: boolean }) => boolean;
   revealTerminal: (id: string) => Promise<boolean>;
+  wake: (id: string) => boolean;
   revealController: {
     fullWakeForVisibilityRestore: (id: string) => Promise<void>;
     repaintForReveal: (id: string, opts?: { trustDomVisibility?: boolean }) => boolean;
@@ -780,6 +781,66 @@ describe("TerminalInstanceService.revealTerminal (foreground reveal routing)", (
 
     expect(fullWake).not.toHaveBeenCalled();
     expect(repaint).not.toHaveBeenCalled();
+  });
+});
+
+describe("TerminalInstanceService.wake verdict (#11640)", () => {
+  let service: FullWakeTestService;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const imported = await import("../TerminalInstanceService");
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    service = imported.terminalInstanceService as unknown as FullWakeTestService;
+    service.instances.clear();
+  });
+
+  afterEach(() => {
+    if (service) service.instances.clear();
+  });
+
+  it("reports the repaint verdict for an opened terminal", () => {
+    const id = "wake-1";
+    service.instances.set(id, makeInstance({ isOpened: true }));
+    const repaint = vi
+      .spyOn(service.revealController, "repaintForReveal")
+      .mockImplementation(() => true);
+
+    expect(service.wake(id)).toBe(true);
+    expect(repaint).toHaveBeenCalledWith(id);
+  });
+
+  it("propagates a repaint that could not paint", () => {
+    const id = "wake-2";
+    service.instances.set(id, makeInstance({ isOpened: true }));
+    // The worktree-switch case: the host is still parked under
+    // content-visibility:hidden, so there is nothing paintable yet. The caller
+    // turns this false into a retry obligation instead of discarding it.
+    vi.spyOn(service.revealController, "repaintForReveal").mockImplementation(() => false);
+
+    expect(service.wake(id)).toBe(false);
+  });
+
+  it("reports false for a missing instance without repainting", () => {
+    const repaint = vi
+      .spyOn(service.revealController, "repaintForReveal")
+      .mockImplementation(() => true);
+
+    expect(service.wake("missing")).toBe(false);
+    expect(repaint).not.toHaveBeenCalled();
+  });
+
+  it("reports false for an unopened terminal and takes the restore path", () => {
+    const id = "wake-3";
+    service.instances.set(id, makeInstance({ isOpened: false }));
+    const fullWake = vi
+      .spyOn(service.revealController, "fullWakeForVisibilityRestore")
+      .mockResolvedValue(undefined);
+
+    // The restore is fire-and-forget and can defer on an unmeasurable host
+    // without reporting back, so the verdict is conservatively false.
+    expect(service.wake(id)).toBe(false);
+    expect(fullWake).toHaveBeenCalledWith(id);
   });
 });
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
@@ -664,7 +664,7 @@ describe("TerminalInstanceService - Activity Tier", () => {
 type InputWakeService = {
   instances: Map<string, Record<string, unknown>>;
   onUserInput: (id: string, data: string) => void;
-  wake: (id: string) => void;
+  wake: (id: string) => boolean;
 };
 
 type PanelStoreModule = {

--- a/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
@@ -691,10 +691,11 @@ describe("TerminalInstanceService - onUserInput wake for paused-backpressure", (
     ({ usePanelStore: panelStore } =
       (await import("@/store/panelStore")) as unknown as PanelStoreModule);
 
-    // wake() is now a plain repaint (no host snapshot wake). Spy it as a no-op so
-    // these tests assert the onUserInput ROUTING decision (which panes get an
-    // unstick reveal on type) without driving the real geometry/repaint path.
-    wakeSpy = vi.spyOn(service, "wake").mockImplementation(() => {});
+    // wake() is now a plain repaint (no host snapshot wake) reporting whether it
+    // painted. Stub it as a landed repaint so these tests assert the onUserInput
+    // ROUTING decision (which panes get an unstick reveal on type) without
+    // driving the real geometry/repaint path.
+    wakeSpy = vi.spyOn(service, "wake").mockImplementation(() => true);
 
     service.instances.clear();
   });

--- a/src/services/terminal/__tests__/worktreeRevealCoordinator.test.ts
+++ b/src/services/terminal/__tests__/worktreeRevealCoordinator.test.ts
@@ -179,13 +179,9 @@ describe("worktreeRevealCoordinator", () => {
   });
 
   it("does not stack parallel loops for duplicate attach notifications", async () => {
-    let releaseAttach: (() => void) | undefined;
-    waitForAttachSettledMock.mockImplementation(
-      () =>
-        new Promise<void>((resolve) => {
-          releaseAttach = resolve;
-        })
-    );
+    // Park every discharge on an attach wait that never resolves, so a second
+    // loop would have to show up as a second waitForAttachSettled call.
+    waitForAttachSettledMock.mockImplementation(() => new Promise<void>(() => {}));
 
     const coordinator = createWorktreeRevealCoordinator();
     coordinator.replace(1, ["a"]);

--- a/src/services/terminal/__tests__/worktreeRevealCoordinator.test.ts
+++ b/src/services/terminal/__tests__/worktreeRevealCoordinator.test.ts
@@ -136,8 +136,27 @@ describe("worktreeRevealCoordinator", () => {
     coordinator.notifyAttached("a");
     await settle();
 
-    // REVEAL_CONFIRM_PAINTS — a single unstuck paint must not retire it.
+    // Drives the full revealUntilStable loop, not a single bare repaint: one
+    // unstuck paint can be undone by the compositor swap or xterm's own
+    // observers re-firing, which is why the confirm pass exists. Swapping the
+    // loop for a lone repaintForReveal call would land exactly one.
     expect(repaintForRevealMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("keeps the obligation armed when the document hides mid-reveal", async () => {
+    const visibility = vi.spyOn(document, "visibilityState", "get");
+    visibility.mockReturnValue("hidden");
+
+    const coordinator = createWorktreeRevealCoordinator();
+    coordinator.replace(1, ["a"]);
+    coordinator.notifyAttached("a");
+    await settle();
+
+    // Repainting a hidden surface is pointless, but abandoning the obligation
+    // would strand the pane garbled once the window comes back.
+    expect(coordinator.pendingIds()).toEqual(["a"]);
+
+    visibility.mockRestore();
   });
 
   it("never routes through revealTerminal, which reports true for a missing instance", async () => {
@@ -212,6 +231,30 @@ describe("worktreeRevealCoordinator", () => {
 
     expect(repaintForRevealMock).toHaveBeenCalledWith("a");
     expect(coordinator.pendingIds()).toEqual([]);
+  });
+
+  it("keeps the obligation when a remount lands after the final confirm paint", async () => {
+    // revealUntilStable yields one more frame AFTER its last confirm paint and
+    // returns without another abort check. A remount arriving in that gap has
+    // its notification swallowed by the inFlight guard, so retiring the
+    // obligation on object identity alone would lose it permanently.
+    let paints = 0;
+    const coordinator = createWorktreeRevealCoordinator();
+    repaintForRevealMock.mockImplementation(() => {
+      paints++;
+      // Fire the remount as the second (final) confirm paint lands, so the
+      // notification falls inside revealUntilStable's trailing frame yield.
+      if (paints === 2) coordinator.notifyAttached("a");
+      return true;
+    });
+
+    coordinator.replace(1, ["a"]);
+    coordinator.notifyAttached("a");
+    await settle();
+
+    // The newer mount still owes a reveal, so the entry must survive and be
+    // re-driven rather than retired by the superseded pass.
+    expect(waitForAttachSettledMock.mock.calls.length).toBeGreaterThan(1);
   });
 
   it("drops obligations for terminals the next policy pass no longer targets", () => {

--- a/src/services/terminal/__tests__/worktreeRevealCoordinator.test.ts
+++ b/src/services/terminal/__tests__/worktreeRevealCoordinator.test.ts
@@ -1,0 +1,316 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const waitForAttachSettledMock =
+  vi.fn<(id: string, opts?: { timeoutMs?: number }) => Promise<void>>();
+const repaintForRevealMock = vi.fn<(id: string) => boolean>();
+const revealTerminalMock = vi.fn<(id: string) => Promise<boolean>>();
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    waitForAttachSettled: waitForAttachSettledMock,
+    repaintForReveal: repaintForRevealMock,
+    revealTerminal: revealTerminalMock,
+  },
+}));
+
+const { createWorktreeRevealCoordinator } = await import("../worktreeRevealCoordinator");
+
+/** Drain the microtask queue without letting a frame pass. */
+async function drainMicrotasks(ticks = 12): Promise<void> {
+  for (let i = 0; i < ticks; i++) await Promise.resolve();
+}
+
+/**
+ * `revealUntilStable` yields a real frame between attempts, so the coordinator's
+ * chain needs frames as well as microtasks to quiesce. MAX_REVEAL_FRAMES is 10,
+ * so 16 covers a full budget plus the attach-wait retries.
+ */
+async function settle(frames = 16): Promise<void> {
+  for (let i = 0; i < frames; i++) {
+    await drainMicrotasks(4);
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  }
+  await drainMicrotasks();
+}
+
+beforeEach(() => {
+  waitForAttachSettledMock.mockReset();
+  waitForAttachSettledMock.mockResolvedValue(undefined);
+  repaintForRevealMock.mockReset();
+  repaintForRevealMock.mockReturnValue(true);
+  revealTerminalMock.mockReset();
+});
+
+describe("worktreeRevealCoordinator", () => {
+  it("does not repaint at arm time — the mount is the trigger", async () => {
+    const coordinator = createWorktreeRevealCoordinator();
+    coordinator.replace(1, ["a", "b"]);
+
+    await settle(2);
+
+    // A warm parked terminal already satisfies isAttachSettled, so an eager
+    // discharge would burn the whole frame budget against a still-hidden host.
+    expect(waitForAttachSettledMock).not.toHaveBeenCalled();
+    expect(repaintForRevealMock).not.toHaveBeenCalled();
+    expect(coordinator.pendingIds()).toEqual(["a", "b"]);
+  });
+
+  it("repaints and clears the obligation once the attach settles", async () => {
+    const coordinator = createWorktreeRevealCoordinator();
+    coordinator.replace(1, ["a"]);
+
+    coordinator.notifyAttached("a");
+    await settle();
+
+    expect(waitForAttachSettledMock).toHaveBeenCalledWith("a", expect.anything());
+    expect(repaintForRevealMock).toHaveBeenCalledWith("a");
+    expect(coordinator.pendingIds()).toEqual([]);
+  });
+
+  it("waits for the attach to settle before repainting", async () => {
+    let releaseAttach: (() => void) | undefined;
+    waitForAttachSettledMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseAttach = resolve;
+        })
+    );
+
+    const coordinator = createWorktreeRevealCoordinator();
+    coordinator.replace(1, ["a"]);
+    coordinator.notifyAttached("a");
+    await settle(2);
+
+    expect(repaintForRevealMock).not.toHaveBeenCalled();
+
+    releaseAttach?.();
+    await settle();
+
+    expect(repaintForRevealMock).toHaveBeenCalledWith("a");
+  });
+
+  it("re-arms the attach wait after a timeout instead of abandoning the obligation", async () => {
+    waitForAttachSettledMock
+      .mockRejectedValueOnce(new Error("attach settle timeout"))
+      .mockResolvedValue(undefined);
+
+    const coordinator = createWorktreeRevealCoordinator();
+    coordinator.replace(1, ["a"]);
+    coordinator.notifyAttached("a");
+    await settle();
+
+    expect(waitForAttachSettledMock).toHaveBeenCalledTimes(2);
+    expect(coordinator.pendingIds()).toEqual([]);
+  });
+
+  it("keeps the obligation armed when every attach wait times out", async () => {
+    waitForAttachSettledMock.mockRejectedValue(new Error("attach settle timeout"));
+
+    const coordinator = createWorktreeRevealCoordinator();
+    coordinator.replace(1, ["a"]);
+    coordinator.notifyAttached("a");
+    await settle();
+
+    expect(repaintForRevealMock).not.toHaveBeenCalled();
+    expect(coordinator.pendingIds()).toEqual(["a"]);
+  });
+
+  it("requires a confirmed paint — an unpaintable host stays armed", async () => {
+    repaintForRevealMock.mockReturnValue(false);
+
+    const coordinator = createWorktreeRevealCoordinator();
+    coordinator.replace(1, ["a"]);
+    coordinator.notifyAttached("a");
+    await settle();
+
+    expect(repaintForRevealMock).toHaveBeenCalled();
+    expect(coordinator.pendingIds()).toEqual(["a"]);
+  });
+
+  it("banks two separate confirm paints before discharging", async () => {
+    const coordinator = createWorktreeRevealCoordinator();
+    coordinator.replace(1, ["a"]);
+    coordinator.notifyAttached("a");
+    await settle();
+
+    // REVEAL_CONFIRM_PAINTS — a single unstuck paint must not retire it.
+    expect(repaintForRevealMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("never routes through revealTerminal, which reports true for a missing instance", async () => {
+    const coordinator = createWorktreeRevealCoordinator();
+    coordinator.replace(1, ["a"]);
+    coordinator.notifyAttached("a");
+    await settle();
+
+    expect(revealTerminalMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores an attach notification for a terminal it is not tracking", async () => {
+    const coordinator = createWorktreeRevealCoordinator();
+    coordinator.replace(1, ["a"]);
+
+    coordinator.notifyAttached("someone-else");
+    await settle(2);
+
+    expect(waitForAttachSettledMock).not.toHaveBeenCalled();
+  });
+
+  it("does not stack parallel loops for duplicate attach notifications", async () => {
+    let releaseAttach: (() => void) | undefined;
+    waitForAttachSettledMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseAttach = resolve;
+        })
+    );
+
+    const coordinator = createWorktreeRevealCoordinator();
+    coordinator.replace(1, ["a"]);
+    coordinator.notifyAttached("a");
+    coordinator.notifyAttached("a");
+    coordinator.notifyAttached("a");
+    await settle(2);
+
+    expect(waitForAttachSettledMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-drives a remount that lands while a discharge is in flight", async () => {
+    // The remount re-attaches, so the re-drive legitimately re-awaits the settle.
+    // Hold every resolver so the second wait can be released independently.
+    const resolvers: Array<() => void> = [];
+    waitForAttachSettledMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvers.push(resolve);
+        })
+    );
+    const releaseAll = (): void => {
+      resolvers.splice(0).forEach((resolve) => resolve());
+    };
+
+    const coordinator = createWorktreeRevealCoordinator();
+    coordinator.replace(1, ["a"]);
+    coordinator.notifyAttached("a");
+    await settle(2);
+
+    // Second mount lands while the first discharge is parked on its attach wait.
+    coordinator.notifyAttached("a");
+    releaseAll();
+    await settle(2);
+
+    // The superseded pass bailed without painting, and the re-drive is now
+    // parked on its own attach wait.
+    expect(waitForAttachSettledMock).toHaveBeenCalledTimes(2);
+    expect(coordinator.pendingIds()).toEqual(["a"]);
+
+    releaseAll();
+    await settle();
+
+    expect(repaintForRevealMock).toHaveBeenCalledWith("a");
+    expect(coordinator.pendingIds()).toEqual([]);
+  });
+
+  it("drops obligations for terminals the next policy pass no longer targets", () => {
+    const coordinator = createWorktreeRevealCoordinator();
+    coordinator.replace(1, ["a", "b"]);
+    coordinator.replace(2, ["b", "c"]);
+
+    // Wholesale replacement is what bounds the map — "a" never mounted and is gone.
+    expect(coordinator.pendingIds()).toEqual(["b", "c"]);
+  });
+
+  it("carries a live obligation across a same-generation replay", async () => {
+    let releaseAttach: (() => void) | undefined;
+    waitForAttachSettledMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseAttach = resolve;
+        })
+    );
+
+    const coordinator = createWorktreeRevealCoordinator();
+    coordinator.replace(1, ["a"]);
+    coordinator.notifyAttached("a");
+    await settle(2);
+
+    // applyPendingWorktreeSelection replays the CURRENT generation; swapping the
+    // entry here would strand the in-flight discharge as permanently stale.
+    coordinator.replace(1, ["a"]);
+    releaseAttach?.();
+    await settle();
+
+    expect(repaintForRevealMock).toHaveBeenCalledWith("a");
+    expect(coordinator.pendingIds()).toEqual([]);
+  });
+
+  it("does not let a superseded generation's discharge clear a newer obligation", async () => {
+    let releaseAttach: (() => void) | undefined;
+    waitForAttachSettledMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseAttach = resolve;
+        })
+    );
+
+    const coordinator = createWorktreeRevealCoordinator();
+    // A -> B -> A: generation 1's in-flight pass must not discharge generation 3.
+    coordinator.replace(1, ["a"]);
+    coordinator.notifyAttached("a");
+    await settle(2);
+    coordinator.replace(2, ["b"]);
+    coordinator.replace(3, ["a"]);
+
+    releaseAttach?.();
+    await settle();
+
+    expect(coordinator.pendingIds()).toEqual(["a"]);
+  });
+
+  it("clear() drops every obligation and stops an in-flight discharge", async () => {
+    let releaseAttach: (() => void) | undefined;
+    waitForAttachSettledMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseAttach = resolve;
+        })
+    );
+
+    const coordinator = createWorktreeRevealCoordinator();
+    coordinator.replace(1, ["a"]);
+    coordinator.notifyAttached("a");
+    await settle(2);
+
+    coordinator.clear();
+    releaseAttach?.();
+    await settle();
+
+    expect(coordinator.pendingIds()).toEqual([]);
+    expect(repaintForRevealMock).not.toHaveBeenCalled();
+  });
+
+  it("caps how many terminals repaint concurrently", async () => {
+    const painted = new Set<string>();
+    repaintForRevealMock.mockImplementation((id: string) => {
+      painted.add(id);
+      return true;
+    });
+
+    const coordinator = createWorktreeRevealCoordinator();
+    const ids = ["a", "b", "c", "d", "e", "f"];
+    coordinator.replace(1, ids);
+    for (const id of ids) coordinator.notifyAttached(id);
+
+    // Before any frame elapses only the slot holders can have painted — every
+    // panel in the incoming worktree mounts in the same commit, so without the
+    // gate all six would repaint on one frame.
+    await drainMicrotasks();
+    expect(painted.size).toBeLessThanOrEqual(2);
+
+    await settle(40);
+    expect(coordinator.pendingIds()).toEqual([]);
+  });
+});

--- a/src/services/terminal/paintFabric/PaintFabricCompositor.ts
+++ b/src/services/terminal/paintFabric/PaintFabricCompositor.ts
@@ -661,8 +661,8 @@ export class PaintFabricCompositor implements TerminalPaintPlane {
     this.plane(id).clearResizeSuppression(id);
   }
 
-  wake(id: string): void {
-    this.plane(id).wake(id);
+  wake(id: string): boolean {
+    return this.plane(id).wake(id);
   }
 
   wakeForFocus(id: string): void {

--- a/src/services/terminal/worktreeRevealCoordinator.ts
+++ b/src/services/terminal/worktreeRevealCoordinator.ts
@@ -1,0 +1,213 @@
+import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import { isDocumentHidden, revealUntilStable } from "./revealUntilStable";
+
+// Per-attempt budget for the attach-settle wait. Matches the registry's own
+// default; a warm terminal resolves immediately, a cold one parks on the attach
+// notification.
+const ATTACH_SETTLE_TIMEOUT_MS = 1500;
+// waitForAttachSettled REJECTS on timeout and deregisters its waiter, so a
+// terminal that settles just after the deadline would never wake us again
+// (#11070). Re-arm the wait instead of abandoning the obligation.
+const ATTACH_WAIT_ATTEMPTS = 3;
+// Cap concurrent reveal loops so a large grid never turns the switch into a
+// single long task — every panel in the incoming worktree mounts in the same
+// commit, so their attach notifications all land on one tick. Mirrors
+// REVEAL_CONCURRENCY in repaintActiveWorktreeTerminals.
+const REVEAL_CONCURRENCY = 2;
+
+interface Obligation {
+  id: string;
+  /** The `_policyGeneration` stamp of the policy pass that armed this. */
+  generation: number;
+  /**
+   * Bumped by every attach notification. An in-flight discharge captures the
+   * stamp it started on, so a remount that lands mid-discharge supersedes it
+   * rather than letting the older pass clear a newer obligation.
+   */
+  attachStamp: number;
+  inFlight: boolean;
+}
+
+export interface WorktreeRevealCoordinator {
+  /**
+   * Replace the tracked set wholesale with the terminals whose policy wake just
+   * reported "not paintable". Wholesale replacement is what bounds the map: a
+   * terminal that never mounts is dropped by the next policy pass rather than
+   * accumulating.
+   */
+  replace: (generation: number, ids: Iterable<string>) => void;
+  /** A terminal's XtermAdapter just completed a live `attach()`. */
+  notifyAttached: (id: string) => void;
+  /** Drop every obligation (store reset). */
+  clear: () => void;
+  /** Introspection for tests. */
+  pendingIds: () => string[];
+}
+
+/**
+ * Owns the retry-until-paintable repaint that a worktree switch needs and the
+ * store action cannot deliver (#11640).
+ *
+ * `applyWorktreeTerminalPolicy` runs synchronously inside `selectWorktree` /
+ * `setActiveWorktree`, i.e. BEFORE React re-renders. The incoming worktree's
+ * terminals are still unmounted at that point, their hosts parked in
+ * `TerminalOffscreenManager`'s `content-visibility: hidden` container, so
+ * `wake()` bottoms out in `hostHasRenderableDims()` → `checkVisibility()` →
+ * false and returns without repainting. That verdict used to be discarded, so
+ * the WebGL reacquire, atlas repair, refresh, reflow and fresh geometry
+ * reconcile were all silently skipped on every switch and correctness rested
+ * entirely on `attach()`'s single geometry pass landing on a settled box.
+ *
+ * This turns that false return into a tracked obligation discharged from the
+ * component mount instead: the panel remounts into the live grid, XtermAdapter
+ * fires `onAttached`, and the obligation runs through the same
+ * {@link revealUntilStable} loop the project-view switch has used since #10362.
+ *
+ * Discharge is driven ONLY by the attach notification, never eagerly at arm
+ * time. A warm parked terminal already satisfies `isAttachSettled` (its host
+ * sits in the offscreen container, which is connected), so an eager pass would
+ * resolve instantly and then burn the whole frame budget against a host that is
+ * still `content-visibility: hidden` — on the switch's critical path. The mount
+ * is the event that makes the host paintable, so the mount is the trigger.
+ */
+export function createWorktreeRevealCoordinator(): WorktreeRevealCoordinator {
+  let pending = new Map<string, Obligation>();
+  let active = 0;
+  const slotWaiters: Array<() => void> = [];
+
+  const acquireSlot = (): Promise<void> => {
+    if (active < REVEAL_CONCURRENCY) {
+      active++;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      slotWaiters.push(() => {
+        active++;
+        resolve();
+      });
+    });
+  };
+
+  const releaseSlot = (): void => {
+    active--;
+    slotWaiters.shift()?.();
+  };
+
+  const discharge = (obligation: Obligation): void => {
+    // Already chasing this obligation. A notification that arrives mid-flight
+    // bumps attachStamp, which the in-flight pass detects as stale and re-drives
+    // from its own finally — so the newer mount is never dropped.
+    if (obligation.inFlight) return;
+    obligation.inFlight = true;
+
+    const stamp = obligation.attachStamp;
+    const isStale = (): boolean =>
+      pending.get(obligation.id) !== obligation || obligation.attachStamp !== stamp;
+
+    void (async () => {
+      let holdsSlot = false;
+      try {
+        let attached = false;
+        for (let attempt = 0; attempt < ATTACH_WAIT_ATTEMPTS; attempt++) {
+          if (isStale()) return;
+          try {
+            await terminalInstanceService.waitForAttachSettled(obligation.id, {
+              timeoutMs: ATTACH_SETTLE_TIMEOUT_MS,
+            });
+            attached = true;
+            break;
+          } catch {
+            // Timed out — fall through and re-arm the wait (it resolves at once
+            // if the attach landed in the gap).
+          }
+        }
+        // Out of patience. Leave the obligation armed so a later remount, or the
+        // next policy pass, can still pick it up.
+        if (!attached || isStale()) return;
+
+        // The slot is taken AFTER the attach wait so a terminal parked on a slow
+        // attach can't starve one that is ready to paint.
+        await acquireSlot();
+        holdsSlot = true;
+        if (isStale()) return;
+
+        // repaintForReveal, NOT revealTerminal: revealTerminal reports `true` for
+        // a MISSING instance ("gone, nothing to retry"), which would instantly
+        // bank both confirm paints against a terminal that is still registering.
+        // repaintForReveal reports false, so the loop keeps retrying.
+        const painted = await revealUntilStable(
+          obligation.id,
+          (target) => terminalInstanceService.repaintForReveal(target),
+          () => isStale() || isDocumentHidden(),
+          "[worktreeReveal]"
+        );
+        // Discharge only on a confirmed paint. A false return (frame budget spent
+        // on an unpaintable host, or the document went hidden) leaves the
+        // obligation armed for the next mount.
+        if (painted && pending.get(obligation.id) === obligation) {
+          pending.delete(obligation.id);
+        }
+      } finally {
+        if (holdsSlot) releaseSlot();
+        obligation.inFlight = false;
+        // A remount landed while this pass was running: it was superseded, so
+        // re-drive against the newer stamp.
+        if (pending.get(obligation.id) === obligation && obligation.attachStamp !== stamp) {
+          discharge(obligation);
+        }
+      }
+    })();
+  };
+
+  return {
+    replace(generation, ids) {
+      const next = new Map<string, Obligation>();
+      for (const id of ids) {
+        const existing = pending.get(id);
+        // Carry a live entry across a same-generation replay rather than
+        // replacing it: `applyPendingWorktreeSelection` re-runs the policy with
+        // the CURRENT generation, and swapping the object there would strand an
+        // in-flight discharge as permanently stale.
+        if (existing && existing.generation === generation) {
+          next.set(id, existing);
+          continue;
+        }
+        next.set(id, { id, generation, attachStamp: 0, inFlight: false });
+      }
+      pending = next;
+    },
+
+    notifyAttached(id) {
+      const obligation = pending.get(id);
+      if (!obligation) return;
+      obligation.attachStamp++;
+      discharge(obligation);
+    },
+
+    clear() {
+      pending = new Map<string, Obligation>();
+    },
+
+    pendingIds() {
+      return Array.from(pending.keys());
+    },
+  };
+}
+
+const coordinator = createWorktreeRevealCoordinator();
+
+export function replaceWorktreeRevealObligations(generation: number, ids: Iterable<string>): void {
+  coordinator.replace(generation, ids);
+}
+
+export function notifyWorktreeTerminalAttached(id: string): void {
+  coordinator.notifyAttached(id);
+}
+
+export function clearWorktreeRevealObligations(): void {
+  coordinator.clear();
+}
+
+export function pendingWorktreeRevealIds(): string[] {
+  return coordinator.pendingIds();
+}

--- a/src/services/terminal/worktreeRevealCoordinator.ts
+++ b/src/services/terminal/worktreeRevealCoordinator.ts
@@ -144,7 +144,15 @@ export function createWorktreeRevealCoordinator(): WorktreeRevealCoordinator {
         // Discharge only on a confirmed paint. A false return (frame budget spent
         // on an unpaintable host, or the document went hidden) leaves the
         // obligation armed for the next mount.
-        if (painted && pending.get(obligation.id) === obligation) {
+        //
+        // Re-check staleness rather than object identity alone: revealUntilStable
+        // yields one more frame AFTER its final confirm paint and returns without
+        // another abort check, so a remount can land in that gap. Its
+        // notification is swallowed by the inFlight guard, so deleting here on
+        // identity alone would retire an obligation the newer mount still needs
+        // and leave `finally` with nothing to re-drive. Nothing can interleave
+        // between this synchronous check and the delete.
+        if (painted && !isStale()) {
           pending.delete(obligation.id);
         }
       } finally {

--- a/src/store/__tests__/worktreeStore.test.ts
+++ b/src/store/__tests__/worktreeStore.test.ts
@@ -53,10 +53,16 @@ const {
   clearSidebarGestureMock,
   subscribeMock,
   panelSetStateMock,
+  replaceWorktreeRevealObligationsMock,
+  clearWorktreeRevealObligationsMock,
 } = vi.hoisted(() => ({
   appSetStateMock: vi.fn().mockResolvedValue(undefined),
   applyRendererPolicyMock: vi.fn(),
-  wakeMock: vi.fn(),
+  // Typed so a bare `vi.fn()` can't silently reintroduce the `undefined` return
+  // that the policy's strict `=== false` obligation check exists to reject.
+  wakeMock: vi.fn<(id: string) => boolean>(),
+  replaceWorktreeRevealObligationsMock: vi.fn<(generation: number, ids: string[]) => void>(),
+  clearWorktreeRevealObligationsMock: vi.fn<() => void>(),
   recordMruMock: vi.fn(),
   setFocusedMock: vi.fn(),
   logErrorWithContextMock: vi.fn(),
@@ -128,6 +134,11 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   },
 }));
 
+vi.mock("@/services/terminal/worktreeRevealCoordinator", () => ({
+  replaceWorktreeRevealObligations: replaceWorktreeRevealObligationsMock,
+  clearWorktreeRevealObligations: clearWorktreeRevealObligationsMock,
+}));
+
 vi.mock("@/utils/errorContext", () => ({
   logErrorWithContext: logErrorWithContextMock,
 }));
@@ -157,6 +168,10 @@ setFleetLastArmedIdAccessor(() => lastArmedIdForFleet);
 describe("worktreeStore", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default to a wake that actually painted (an already-mounted terminal), so
+    // only tests that opt in exercise the reveal-obligation path. clearAllMocks
+    // drops calls but keeps implementations, hence the reinstall here.
+    wakeMock.mockReturnValue(true);
     useWorktreeSelectionStore.getState().reset();
     terminalStoreState.panelsById = {};
     terminalStoreState.panelIds = [];
@@ -398,6 +413,154 @@ describe("worktreeStore", () => {
     expect(applyRendererPolicyMock).toHaveBeenCalledTimes(5);
 
     expect(wakeMock.mock.calls).toEqual([["agent-a"], ["plain-a"]]);
+  });
+
+  describe("reveal obligations (#11640)", () => {
+    it("arms an obligation for every wake that could not paint", () => {
+      setMockTerminals([
+        { id: "term-a", worktreeId: "wt-a", location: "grid", kind: "terminal" },
+        { id: "term-b", worktreeId: "wt-a", location: "grid", kind: "terminal" },
+      ]);
+      // The switch runs before React re-renders, so both hosts are still parked
+      // offscreen and neither wake can paint.
+      wakeMock.mockReturnValue(false);
+
+      useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+
+      const generation = useWorktreeSelectionStore.getState()._policyGeneration;
+      expect(replaceWorktreeRevealObligationsMock).toHaveBeenCalledTimes(1);
+      expect(replaceWorktreeRevealObligationsMock).toHaveBeenCalledWith(generation, [
+        "term-a",
+        "term-b",
+      ]);
+    });
+
+    it("does not arm an obligation for a wake that painted", () => {
+      setMockTerminals([{ id: "term-a", worktreeId: "wt-a", location: "grid", kind: "terminal" }]);
+      wakeMock.mockReturnValue(true);
+
+      useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+
+      expect(replaceWorktreeRevealObligationsMock).toHaveBeenCalledWith(expect.any(Number), []);
+    });
+
+    it("treats only an explicit false as a failed wake", () => {
+      setMockTerminals([{ id: "term-a", worktreeId: "wt-a", location: "grid", kind: "terminal" }]);
+      // A bare `vi.fn()` service mock returns undefined. Arming on that would
+      // start coordinator work across every suite that stubs the service.
+      wakeMock.mockReturnValue(undefined as unknown as boolean);
+
+      useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+
+      expect(replaceWorktreeRevealObligationsMock).toHaveBeenCalledWith(expect.any(Number), []);
+    });
+
+    it("arms an obligation when the wake throws", () => {
+      setMockTerminals([{ id: "term-a", worktreeId: "wt-a", location: "grid", kind: "terminal" }]);
+      wakeMock.mockImplementation(() => {
+        throw new Error("wake boom");
+      });
+
+      useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+
+      expect(logErrorWithContextMock).toHaveBeenCalled();
+      expect(replaceWorktreeRevealObligationsMock).toHaveBeenCalledWith(expect.any(Number), [
+        "term-a",
+      ]);
+    });
+
+    it("never arms non-grid surfaces, which have their own reveal owners", () => {
+      setMockTerminals([
+        { id: "grid-a", worktreeId: "wt-a", location: "grid", kind: "terminal" },
+        // The Assistant is overlay-hosted and owned by its own reveal
+        // coordinator; dock/trash manage their own visibility. None of them
+        // route through TerminalPane's onAttached, so an obligation for one
+        // could never be discharged.
+        { id: "assistant", worktreeId: "wt-a", location: "overlay", kind: "terminal" },
+        { id: "docked", worktreeId: "wt-a", location: "dock", kind: "terminal" },
+        { id: "trashed", worktreeId: "wt-a", location: "trash", kind: "terminal" },
+      ]);
+      wakeMock.mockReturnValue(false);
+
+      useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+
+      expect(replaceWorktreeRevealObligationsMock).toHaveBeenCalledWith(expect.any(Number), [
+        "grid-a",
+      ]);
+    });
+
+    it("replaces the tracked set on every policy pass so stale generations drop", () => {
+      setMockTerminals([
+        { id: "term-a", worktreeId: "wt-a", location: "grid", kind: "terminal" },
+        { id: "term-b", worktreeId: "wt-b", location: "grid", kind: "terminal" },
+      ]);
+      wakeMock.mockReturnValue(false);
+
+      useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+      useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+
+      // wt-a's obligation is not carried forward — the second pass replaces it.
+      expect(replaceWorktreeRevealObligationsMock.mock.calls.map(([, ids]) => ids)).toEqual([
+        ["term-a"],
+        ["term-b"],
+      ]);
+    });
+
+    it("does not touch obligations when the policy generation guard bails", () => {
+      setMockTerminals([{ id: "term-a", worktreeId: "wt-a", location: "grid", kind: "terminal" }]);
+      useWorktreeSelectionStore.setState({
+        activeWorktreeId: "wt-b",
+        pendingWorktreeId: "wt-a",
+      });
+
+      useWorktreeSelectionStore.getState().applyPendingWorktreeSelection("wt-a");
+
+      expect(replaceWorktreeRevealObligationsMock).not.toHaveBeenCalled();
+    });
+
+    it("replays the CURRENT generation for a pending selection", () => {
+      setMockTerminals([{ id: "term-a", worktreeId: "wt-a", location: "grid", kind: "terminal" }]);
+      wakeMock.mockReturnValue(false);
+      useWorktreeSelectionStore.setState({
+        activeWorktreeId: "wt-a",
+        pendingWorktreeId: "wt-a",
+        _policyGeneration: 7,
+      });
+
+      useWorktreeSelectionStore.getState().applyPendingWorktreeSelection("wt-a");
+
+      // Not a bump — the coordinator relies on this to carry a live obligation
+      // across the replay rather than superseding it.
+      expect(replaceWorktreeRevealObligationsMock).toHaveBeenCalledWith(7, ["term-a"]);
+    });
+
+    it("arms fleet-scope armed terminals from other worktrees", () => {
+      setMockTerminals([
+        { id: "term-a", worktreeId: "wt-a", location: "grid", kind: "terminal" },
+        { id: "term-b", worktreeId: "wt-b", location: "grid", kind: "terminal" },
+      ]);
+      wakeMock.mockReturnValue(false);
+      armedIdsForFleet = new Set(["term-b"]);
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-a" });
+
+      useWorktreeSelectionStore.getState().enterFleetScope();
+
+      // term-b mounts fresh into the fleet grid, so it needs the same treatment
+      // as the active worktree's own panes.
+      expect(replaceWorktreeRevealObligationsMock).toHaveBeenCalledWith(expect.any(Number), [
+        "term-a",
+        "term-b",
+      ]);
+      armedIdsForFleet = new Set<string>();
+    });
+
+    it("clears obligations on reset — the generation bump can't reach them", () => {
+      const before = clearWorktreeRevealObligationsMock.mock.calls.length;
+
+      useWorktreeSelectionStore.getState().reset();
+
+      expect(clearWorktreeRevealObligationsMock.mock.calls.length).toBe(before + 1);
+    });
   });
 
   it("setActiveWorktree syncs focusedWorktreeId to clear stale focus", () => {

--- a/src/store/__tests__/worktreeStore.test.ts
+++ b/src/store/__tests__/worktreeStore.test.ts
@@ -81,7 +81,7 @@ type MockTerminal = {
   id: string;
   kind?: "terminal" | "browser" | "dev-preview" | "notes";
   worktreeId?: string;
-  location?: "grid" | "dock" | "trash" | "background";
+  location?: "grid" | "dock" | "trash" | "background" | "overlay" | "dialog";
   hasPty?: boolean;
 };
 type MockTabGroup = {

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -1,5 +1,9 @@
 import { create, type StateCreator } from "zustand";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import {
+  clearWorktreeRevealObligations,
+  replaceWorktreeRevealObligations,
+} from "@/services/terminal/worktreeRevealCoordinator";
 import { TerminalRefreshTier, isGridPanelLocation, isPtyPanel } from "@shared/types/panel";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import type { Issue, PR } from "@shared/types/forge";
@@ -1281,7 +1285,10 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     applyWorktreeTerminalPolicy(get, set, restoreId, generation);
   },
 
-  reset: () =>
+  reset: () => {
+    // Reveal obligations are keyed by policy generation but held outside the
+    // store, so the generation bump below cannot invalidate them on its own.
+    clearWorktreeRevealObligations();
     set({
       activeWorktreeId: null,
       restoreWorktreeId: null,
@@ -1321,7 +1328,8 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       // post-reset token is null and the exit-side guard compares against
       // null.
       _policyGeneration: get()._policyGeneration + 1,
-    }),
+    });
+  },
 });
 
 export const useWorktreeSelectionStore = create<WorktreeSelectionState>()(
@@ -1358,6 +1366,12 @@ function applyWorktreeTerminalPolicy(
   const fleetActive = get().isFleetScopeActive;
   const armedIds = fleetActive ? getFleetArmedIds() : null;
 
+  // Terminals whose wake could not paint because this runs BEFORE React
+  // re-renders — their hosts are still parked in the offscreen container under
+  // `content-visibility: hidden`. Handed to the reveal coordinator, which
+  // discharges each one from its XtermAdapter mount (#11640).
+  const revealObligations: string[] = [];
+
   for (const id of panelIds) {
     const terminal = panelsById[id];
     if (!terminal) continue;
@@ -1391,9 +1405,19 @@ function applyWorktreeTerminalPolicy(
       (!isPtyPanel(terminal) || terminal.hasPty !== false) &&
       panelKindHasPty(terminal.kind ?? "terminal")
     ) {
+      // The wake still runs first: for a terminal that IS already mounted and
+      // paintable (fleet-scope re-entry, a re-selected worktree) it is the
+      // cheapest correct correction and settles in-tick.
+      //
+      // Only an EXPLICIT false (or a throw) becomes an obligation. `wake` is
+      // typed boolean, so in production this is identical to `!wake(...)` — but
+      // a bare `vi.fn()` service mock returns `undefined`, and the loose test
+      // would arm the coordinator across every suite that stubs the service.
+      let wakeVerdict: boolean | undefined;
       try {
-        terminalInstanceService.wake(terminal.id);
+        wakeVerdict = terminalInstanceService.wake(terminal.id);
       } catch (error) {
+        wakeVerdict = false;
         logErrorWithContext(error, {
           operation: "wake_visible_worktree_terminal",
           component: "worktreeStore",
@@ -1401,8 +1425,21 @@ function applyWorktreeTerminalPolicy(
           details: { terminalId: terminal.id, targetWorktreeId, generation },
         });
       }
+      // Only grid-owned panels are tracked. Dock/trash manage their own
+      // visibility, and the overlay-hosted Assistant already has a dedicated
+      // reveal owner (createAssistantRevealCoordinator) that must not be
+      // double-driven — neither surface routes through TerminalPane's
+      // `onAttached`, so an obligation for one could never be discharged.
+      if (wakeVerdict === false && isGridPanelLocation(location)) {
+        revealObligations.push(terminal.id);
+      }
     }
   }
+
+  // Replace wholesale, even when empty: this is what drops a previous
+  // generation's obligations for terminals that never mounted, so the tracked
+  // set can never outgrow the last policy pass's targets.
+  replaceWorktreeRevealObligations(generation, revealObligations);
 
   onComplete?.();
 }


### PR DESCRIPTION
## Summary

`applyWorktreeTerminalPolicy()` runs synchronously inside `selectWorktree` / `setActiveWorktree`, before React re-renders. It calls `wake()` on the incoming worktree's terminals while their hosts are still parked in `TerminalOffscreenManager`'s `content-visibility: hidden` container, so `wake()` bottoms out in `hostHasRenderableDims()` -> `checkVisibility()` -> `false`. That verdict gets discarded and nothing retries, so the WebGL reacquire, atlas repair, refresh, `forceXtermReflow()`, and `reconcileGeometryFresh()` are all silently skipped on every worktree switch. Correctness rested entirely on `attach()`'s single geometry pass landing on an already-settled box.

The project-view switch already solved this exact problem with `repaintActiveWorktreeTerminals()` + `revealUntilStable()`, a retry-until-paintable loop with a confirm paint. The worktree switch had no equivalent.

Resolves #11640

## Changes

1. **Widen `wake()` to report whether the repaint actually landed**, threaded through `TerminalInstanceService` and `PaintFabricCompositor`.
2. **New `src/services/terminal/worktreeRevealCoordinator.ts`**, holding a generation-stamped, per-terminal obligation. It's discharged from `XtermAdapter`'s existing `onAttached` callback via `waitForAttachSettled` + `revealUntilStable(repaintForReveal)`, the same retry-until-paintable-and-confirm-paint loop the project-view sweep uses.
3. **The policy arms an obligation only on an explicit `false` (or a throw)**, restricted to grid-owned PTY panels, and replaces the tracked set wholesale each pass so it stays bounded.
4. **`reset()` clears obligations**, since a generation bump can't reach state held outside the store.

### Design notes

- Discharge is driven only by the mount notification, never eagerly at arm time. A warm, parked terminal already satisfies `isAttachSettled` (the offscreen container is still connected), so an eager pass would burn the frame budget against a still-hidden host, right on the switch's critical path.
- The sweep injects `repaintForReveal`, not `revealTerminal`. `revealTerminal` reports `true` for a missing instance, which would instantly bank both confirm paints against a terminal that's still registering.
- The issue's second defect (`XtermAdapter.handleResizeEntry` dropping a `ResizeObserver` entry during `isAttaching`) is fixed by the same sweep rather than a separate replay path. A `performFit()` replay routes through `resize()`, which returns `null` under the project-switch resize lock (`TerminalResizeController.ts:277`), whereas `repaintForReveal` ends in the lock-exempt `reconcileGeometryFresh`, the correction that actually lands.

## Testing

288 tests pass across 10 suites. ESLint and Prettier are clean on all 11 changed files.

No E2E coverage added: Playwright forces `DAINTREE_DISABLE_WEBGL=1`, so the DOM renderer paints regardless and a spec here would stay green even if this fix were reverted. Unit tests are the real gate. The remount-races-the-confirm-paint regression test was verified failing before the fix and passing after.

An adversarial Codex review pass caught and led to fixing one real defect during development: `revealUntilStable` yielded one extra frame after its final confirm paint and returned without another abort check, so a remount landing in that gap had its notification swallowed by the in-flight guard and its obligation permanently retired. Fixed before landing.