### PR TITLE
fix(terminal): make Redraw force a full geometry resync

### DIFF
--- a/src/services/actions/definitions/__tests__/terminalLifecycleActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalLifecycleActions.test.ts
@@ -767,13 +767,27 @@ describe("agent dispatch target binding (#11532)", () => {
 
     await run("terminal.redraw", { terminalId: "explicit-panel" }, { dispatchSource: "agent" });
 
-    expect(spies.resetRenderer).toHaveBeenCalledWith("explicit-panel", { force: true });
+    // Agent dispatch is not foreground, so it redraws without the bypass.
+    expect(spies.resetRenderer).toHaveBeenCalledWith("explicit-panel", { force: false });
     // The old `not.toHaveBeenCalledWith("focused-panel")` would now pass even if
     // the focused pane WERE redrawn, since the real call carries a second
     // argument and never matches that shape. Pin the call count and the target
     // instead, so the negative can't rot into a false positive (#11638).
     expect(spies.resetRenderer).toHaveBeenCalledTimes(1);
     expect(spies.resetRenderer.mock.calls[0]?.[0]).toBe("explicit-panel");
+  });
+
+  it("withholds the streaming-write bypass from non-foreground dispatch", async () => {
+    const spies = setGuardState();
+    const run = setupActions();
+
+    // A plugin can reach this safe action through host.dispatch() on a timer.
+    // That IS the automatic out-of-band writer #10863's deferral was written
+    // for, so it must not inherit the human's bypass (#11638) — it still gets
+    // the renderer repair, just with the guard intact.
+    await run("terminal.redraw", { terminalId: "explicit-panel" }, { dispatchSource: "plugin" });
+
+    expect(spies.resetRenderer).toHaveBeenCalledWith("explicit-panel", { force: false });
   });
 
   it("treats an empty terminalId as naming nothing", async () => {

--- a/src/services/actions/definitions/__tests__/terminalLifecycleActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalLifecycleActions.test.ts
@@ -680,7 +680,10 @@ describe("agent dispatch target binding (#11532)", () => {
       id: "terminal.redraw",
       noTarget: OPTIONAL_SCHEMA,
       blocked: (s) => s.resetRenderer,
-      hitFocused: (s) => expect(s.resetRenderer).toHaveBeenCalledWith("focused-panel"),
+      // #11638: the explicit user path forces past the streaming-write
+      // deferral. An unforced call here would be the bug this action shipped.
+      hitFocused: (s) =>
+        expect(s.resetRenderer).toHaveBeenCalledWith("focused-panel", { force: true }),
     },
     {
       id: "terminal.rename",
@@ -764,8 +767,13 @@ describe("agent dispatch target binding (#11532)", () => {
 
     await run("terminal.redraw", { terminalId: "explicit-panel" }, { dispatchSource: "agent" });
 
-    expect(spies.resetRenderer).toHaveBeenCalledWith("explicit-panel");
-    expect(spies.resetRenderer).not.toHaveBeenCalledWith("focused-panel");
+    expect(spies.resetRenderer).toHaveBeenCalledWith("explicit-panel", { force: true });
+    // The old `not.toHaveBeenCalledWith("focused-panel")` would now pass even if
+    // the focused pane WERE redrawn, since the real call carries a second
+    // argument and never matches that shape. Pin the call count and the target
+    // instead, so the negative can't rot into a false positive (#11638).
+    expect(spies.resetRenderer).toHaveBeenCalledTimes(1);
+    expect(spies.resetRenderer.mock.calls[0]?.[0]).toBe("explicit-panel");
   });
 
   it("treats an empty terminalId as naming nothing", async () => {

--- a/src/services/actions/definitions/__tests__/worktreeSessionActions.test.ts
+++ b/src/services/actions/definitions/__tests__/worktreeSessionActions.test.ts
@@ -40,6 +40,7 @@ type Panel = {
   id: string;
   location: "grid" | "dock" | "trash" | "overlay" | "background" | "dialog";
   worktreeId?: string;
+  kind?: string;
   detectedAgentId?: string;
   agentState?: string;
 };
@@ -470,34 +471,58 @@ describe("worktree.sessions confirmed flag survives arg validation (schema regre
 });
 
 describe("worktree.sessions.resetRenderers", () => {
-  // Enough panes to span several chunks of the frame-spread loop, so a bug that
-  // dropped everything past the first chunk would show up as a short call list.
+  // Mixed kinds and worktrees: only the PTY panels of the target worktree may
+  // be swept. A browser/review panel has no renderer to reset, and letting one
+  // hold a frame slot would delay a genuinely garbled terminal behind it.
   const PANES: Panel[] = [
-    { id: "a1", location: "grid", worktreeId: "wt-1" },
-    { id: "b1", location: "grid", worktreeId: "wt-2" },
-    { id: "a2", location: "grid", worktreeId: "wt-1" },
-    { id: "a3", location: "dock", worktreeId: "wt-1" },
+    { id: "a1", location: "grid", worktreeId: "wt-1", kind: "terminal" },
+    { id: "b1", location: "grid", worktreeId: "wt-2", kind: "terminal" },
+    { id: "a2", location: "grid", worktreeId: "wt-1", kind: "terminal" },
+    { id: "web1", location: "grid", worktreeId: "wt-1", kind: "browser" },
+    { id: "a3", location: "dock", worktreeId: "wt-1", kind: "terminal" },
+    { id: "rev1", location: "grid", worktreeId: "wt-1", kind: "review" },
+    // A legacy panel with no recorded kind still sweeps — absence is not proof
+    // it lacks a PTY, and skipping it would silently drop a real terminal.
     { id: "a4", location: "grid", worktreeId: "wt-1" },
-    { id: "a5", location: "grid", worktreeId: "wt-1" },
   ];
 
-  it("forces every pane in the target worktree and no others", async () => {
+  const ptyTargets = ["a1", "a2", "a3", "a4"];
+
+  it("forces every PTY pane in the target worktree and no others", async () => {
     setPanelState(PANES);
     const run = setupActions();
 
-    await run("worktree.sessions.resetRenderers", { worktreeId: "wt-1" });
+    await run(
+      "worktree.sessions.resetRenderers",
+      { worktreeId: "wt-1" },
+      { dispatchSource: "menu" }
+    );
 
-    const expected = PANES.filter((p) => p.worktreeId === "wt-1").map((p) => p.id);
     const called = terminalInstanceServiceMock.resetRenderer.mock.calls.map(([id]) => id);
-    // Order-insensitive set equality: the chunking is an implementation detail,
-    // but the COVERAGE is the contract — awaiting the action must leave no pane
-    // of the worktree un-redrawn.
-    expect([...called].sort()).toEqual([...expected].sort());
+    // Order-insensitive set equality: the frame pacing is an implementation
+    // detail, but the COVERAGE is the contract — awaiting the action must leave
+    // no PTY pane of the worktree un-redrawn, and no non-PTY pane touched.
+    expect([...called].sort()).toEqual([...ptyTargets].sort());
     // Bulk Redraw is the same explicit user intent as the per-pane one, so it
-    // takes the same bypass (#11638). Without this it stays broken for exactly
-    // the busy panes it is pressed on.
+    // takes the same bypass (#11638).
     for (const call of terminalInstanceServiceMock.resetRenderer.mock.calls) {
       expect(call[1]).toEqual({ force: true });
+    }
+  });
+
+  it("withholds the bypass from non-foreground dispatch", async () => {
+    setPanelState(PANES);
+    const run = setupActions();
+
+    await run(
+      "worktree.sessions.resetRenderers",
+      { worktreeId: "wt-1" },
+      { dispatchSource: "plugin" }
+    );
+
+    expect(terminalInstanceServiceMock.resetRenderer).toHaveBeenCalled();
+    for (const call of terminalInstanceServiceMock.resetRenderer.mock.calls) {
+      expect(call[1]).toEqual({ force: false });
     }
   });
 
@@ -505,7 +530,11 @@ describe("worktree.sessions.resetRenderers", () => {
     setPanelState(PANES);
     const run = setupActions();
 
-    await run("worktree.sessions.resetRenderers", {}, { activeWorktreeId: "wt-2" });
+    await run(
+      "worktree.sessions.resetRenderers",
+      {},
+      { activeWorktreeId: "wt-2", dispatchSource: "menu" }
+    );
 
     const called = terminalInstanceServiceMock.resetRenderer.mock.calls.map(([id]) => id);
     expect(called).toEqual(["b1"]);
@@ -515,7 +544,7 @@ describe("worktree.sessions.resetRenderers", () => {
     setPanelState(PANES);
     const run = setupActions();
 
-    await run("worktree.sessions.resetRenderers", {});
+    await run("worktree.sessions.resetRenderers", {}, { dispatchSource: "menu" });
 
     expect(terminalInstanceServiceMock.resetRenderer).not.toHaveBeenCalled();
   });

--- a/src/services/actions/definitions/__tests__/worktreeSessionActions.test.ts
+++ b/src/services/actions/definitions/__tests__/worktreeSessionActions.test.ts
@@ -468,3 +468,55 @@ describe("worktree.sessions confirmed flag survives arg validation (schema regre
     }
   );
 });
+
+describe("worktree.sessions.resetRenderers", () => {
+  // Enough panes to span several chunks of the frame-spread loop, so a bug that
+  // dropped everything past the first chunk would show up as a short call list.
+  const PANES: Panel[] = [
+    { id: "a1", location: "grid", worktreeId: "wt-1" },
+    { id: "b1", location: "grid", worktreeId: "wt-2" },
+    { id: "a2", location: "grid", worktreeId: "wt-1" },
+    { id: "a3", location: "dock", worktreeId: "wt-1" },
+    { id: "a4", location: "grid", worktreeId: "wt-1" },
+    { id: "a5", location: "grid", worktreeId: "wt-1" },
+  ];
+
+  it("forces every pane in the target worktree and no others", async () => {
+    setPanelState(PANES);
+    const run = setupActions();
+
+    await run("worktree.sessions.resetRenderers", { worktreeId: "wt-1" });
+
+    const expected = PANES.filter((p) => p.worktreeId === "wt-1").map((p) => p.id);
+    const called = terminalInstanceServiceMock.resetRenderer.mock.calls.map(([id]) => id);
+    // Order-insensitive set equality: the chunking is an implementation detail,
+    // but the COVERAGE is the contract — awaiting the action must leave no pane
+    // of the worktree un-redrawn.
+    expect([...called].sort()).toEqual([...expected].sort());
+    // Bulk Redraw is the same explicit user intent as the per-pane one, so it
+    // takes the same bypass (#11638). Without this it stays broken for exactly
+    // the busy panes it is pressed on.
+    for (const call of terminalInstanceServiceMock.resetRenderer.mock.calls) {
+      expect(call[1]).toEqual({ force: true });
+    }
+  });
+
+  it("falls back to the ambient worktree when the caller names none", async () => {
+    setPanelState(PANES);
+    const run = setupActions();
+
+    await run("worktree.sessions.resetRenderers", {}, { activeWorktreeId: "wt-2" });
+
+    const called = terminalInstanceServiceMock.resetRenderer.mock.calls.map(([id]) => id);
+    expect(called).toEqual(["b1"]);
+  });
+
+  it("is a no-op when no worktree can be resolved", async () => {
+    setPanelState(PANES);
+    const run = setupActions();
+
+    await run("worktree.sessions.resetRenderers", {});
+
+    expect(terminalInstanceServiceMock.resetRenderer).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/actions/definitions/__tests__/worktreeSessionActions.test.ts
+++ b/src/services/actions/definitions/__tests__/worktreeSessionActions.test.ts
@@ -548,4 +548,31 @@ describe("worktree.sessions.resetRenderers", () => {
 
     expect(terminalInstanceServiceMock.resetRenderer).not.toHaveBeenCalled();
   });
+
+  it("serializes overlapping sweeps instead of interleaving them", async () => {
+    setPanelState(PANES);
+    const run = setupActions();
+
+    // Two dispatches in flight at once. Each paces itself at one synchronous
+    // reflow per frame, but if their loops interleave, several land in the same
+    // frame — the pile-up the pacing exists to prevent. Queueing (not
+    // superseding) also means neither worktree is left half-repaired.
+    const first = run(
+      "worktree.sessions.resetRenderers",
+      { worktreeId: "wt-1" },
+      { dispatchSource: "menu" }
+    );
+    const second = run(
+      "worktree.sessions.resetRenderers",
+      { worktreeId: "wt-2" },
+      { dispatchSource: "menu" }
+    );
+    await Promise.all([first, second]);
+
+    const called = terminalInstanceServiceMock.resetRenderer.mock.calls.map(([id]) => id);
+    // Every target of BOTH sweeps ran, and wt-2's single pane comes after all
+    // of wt-1's rather than being spliced between them.
+    expect([...called].sort()).toEqual([...ptyTargets, "b1"].sort());
+    expect(called.indexOf("b1")).toBe(called.length - 1);
+  });
 });

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -16,6 +16,7 @@ import {
 } from "@/utils/destructiveSessionConfirm";
 import { isEphemeralPanel } from "@/store/slices/panelRegistry/panelCount";
 import { requireExplicitTerminalIdForAgentDispatch } from "./terminalTargetBinding";
+import { isForegroundDispatch } from "./dispatchSource";
 
 function parseConfirmed(args: unknown): boolean {
   if (!args || typeof args !== "object") return false;
@@ -229,12 +230,17 @@ export function registerTerminalLifecycleActions(
       const state = usePanelStore.getState();
       const targetId = terminalId ?? state.focusedId;
       if (targetId) {
-        // force: the user is looking at a broken pane and has asked for it to
-        // be fixed. #10863's write-quiescence deferral is for AUTOMATIC
-        // geometry writers, and a busy agent never opens the 300ms gap it waits
-        // for — leaving Redraw a no-op on exactly the terminals it exists for
-        // (#11638).
-        terminalInstanceService.resetRenderer(targetId, { force: true });
+        // Only a PERSON gets the bypass (#11638). #10863's write-quiescence
+        // deferral exists to stop an automatic out-of-band re-wrap landing
+        // under a live cursor-relative repaint, and a busy agent never opens
+        // the 300ms gap it waits for — so a human staring at a garbled pane
+        // needs to skip it, but a plugin or agent driving this action on a
+        // timer IS the automatic writer the guard was written for. Non-
+        // foreground dispatch still gets the renderer repair, just with the
+        // deferral intact.
+        terminalInstanceService.resetRenderer(targetId, {
+          force: isForegroundDispatch(ctx?.dispatchSource),
+        });
       }
     },
   }));

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -229,7 +229,12 @@ export function registerTerminalLifecycleActions(
       const state = usePanelStore.getState();
       const targetId = terminalId ?? state.focusedId;
       if (targetId) {
-        terminalInstanceService.resetRenderer(targetId);
+        // force: the user is looking at a broken pane and has asked for it to
+        // be fixed. #10863's write-quiescence deferral is for AUTOMATIC
+        // geometry writers, and a busy agent never opens the 300ms gap it waits
+        // for — leaving Redraw a no-op on exactly the terminals it exists for
+        // (#11638).
+        terminalInstanceService.resetRenderer(targetId, { force: true });
       }
     },
   }));

--- a/src/services/actions/definitions/worktreeSessionActions.ts
+++ b/src/services/actions/definitions/worktreeSessionActions.ts
@@ -16,6 +16,14 @@ const clearHistoryArgsSchema = z.object({
   confirmed: z.boolean().optional(),
 });
 
+// Serializes renderer sweeps across dispatches. Each sweep paces itself at one
+// synchronous reflow per frame, but two overlapping dispatches — a double press,
+// or two worktrees — would interleave their loops and put several back in the
+// same frame, which is the pile-up the pacing exists to prevent. Queue instead
+// of superseding: a sweep of another worktree must still finish, not be
+// abandoned half-repaired.
+let rendererSweepChain: Promise<void> = Promise.resolve();
+
 export function registerWorktreeSessionActions(
   actions: ActionRegistry,
   _callbacks: ActionCallbacks
@@ -143,10 +151,14 @@ export function registerWorktreeSessionActions(
       // precisely when a whole worktree looks garbled, so an unchunked loop
       // would pile every reflow into one long task. The id list is snapshotted
       // above; a pane closed mid-sweep just no-ops in the service.
-      for (const [index, id] of targets.entries()) {
-        if (index > 0) await nextFrame();
-        terminalInstanceService.resetRenderer(id, { force });
-      }
+      const sweep = rendererSweepChain.then(async () => {
+        for (const [index, id] of targets.entries()) {
+          if (index > 0) await nextFrame();
+          terminalInstanceService.resetRenderer(id, { force });
+        }
+      });
+      rendererSweepChain = sweep.catch(() => undefined);
+      await sweep;
     },
   }));
 

--- a/src/services/actions/definitions/worktreeSessionActions.ts
+++ b/src/services/actions/definitions/worktreeSessionActions.ts
@@ -3,9 +3,11 @@ import { z } from "zod";
 import type { ActionContext } from "@shared/types/actions";
 import { terminalInstanceService } from "@/services/terminal/TerminalInstanceService";
 import { nextFrame } from "@/services/terminal/revealUntilStable";
+import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { usePanelStore } from "@/store/panelStore";
 import { useTerminalPendingDestructiveActionStore } from "@/store/terminalPendingDestructiveActionStore";
 import { collectRunningAgentTerminals } from "@/utils/destructiveSessionConfirm";
+import { isForegroundDispatch } from "./dispatchSource";
 
 // Shared by argsSchema + run() so the worktree id is extracted via a validated
 // parse rather than an unchecked `as` cast (keeps the lint ratchet green).
@@ -13,11 +15,6 @@ const clearHistoryArgsSchema = z.object({
   worktreeId: z.string().optional(),
   confirmed: z.boolean().optional(),
 });
-
-// Forced renderer resets applied per animation frame by
-// `worktree.sessions.resetRenderers`. Each one can reflow a pane's full
-// scrollback synchronously, so they are chunked rather than run in one task.
-const RESET_RENDERERS_PER_FRAME = 2;
 
 export function registerWorktreeSessionActions(
   actions: ActionRegistry,
@@ -126,22 +123,29 @@ export function registerWorktreeSessionActions(
       const targetWorktreeId = worktreeId ?? ctx.activeWorktreeId;
       if (!targetWorktreeId) return;
       const { panelsById, panelIds } = usePanelStore.getState();
-      const targets = panelIds.filter(
-        (id) => panelsById[id]?.worktreeId === targetWorktreeId
-      );
+      // PTY panels only: a browser/review/preview panel in the worktree has no
+      // renderer to reset, and letting one occupy a frame slot would delay a
+      // genuinely garbled terminal behind it.
+      const targets = panelIds.filter((id) => {
+        const panel = panelsById[id];
+        return (
+          panel?.worktreeId === targetWorktreeId &&
+          (!panel.kind || panelKindHasPty(panel.kind))
+        );
+      });
+      // Same explicit-repair intent as the per-pane Redraw, so the same
+      // foreground-only force (#11638).
+      const force = isForegroundDispatch(ctx.dispatchSource);
 
-      // Same explicit-repair intent as the per-pane Redraw, so the same force
-      // (#11638) — but spread across frames. Forcing turns each pane's geometry
-      // step into a synchronous xterm reflow of its whole scrollback, and this
-      // action is pressed precisely when a whole worktree looks garbled, so an
-      // unchunked loop would pile every reflow into one long task. Two per
-      // frame mirrors the watchdog's heavy-repair budget. The id list is
-      // snapshotted above; a pane closed mid-sweep just no-ops in the service.
-      for (let index = 0; index < targets.length; index += RESET_RENDERERS_PER_FRAME) {
+      // One pane per frame. Forcing turns each pane's geometry step into a
+      // synchronous xterm reflow of its whole scrollback — the resize-pass
+      // scheduler budgets 15-40ms for exactly that — and this action is pressed
+      // precisely when a whole worktree looks garbled, so an unchunked loop
+      // would pile every reflow into one long task. The id list is snapshotted
+      // above; a pane closed mid-sweep just no-ops in the service.
+      for (const [index, id] of targets.entries()) {
         if (index > 0) await nextFrame();
-        for (const id of targets.slice(index, index + RESET_RENDERERS_PER_FRAME)) {
-          terminalInstanceService.resetRenderer(id, { force: true });
-        }
+        terminalInstanceService.resetRenderer(id, { force });
       }
     },
   }));

--- a/src/services/actions/definitions/worktreeSessionActions.ts
+++ b/src/services/actions/definitions/worktreeSessionActions.ts
@@ -137,8 +137,7 @@ export function registerWorktreeSessionActions(
       const targets = panelIds.filter((id) => {
         const panel = panelsById[id];
         return (
-          panel?.worktreeId === targetWorktreeId &&
-          (!panel.kind || panelKindHasPty(panel.kind))
+          panel?.worktreeId === targetWorktreeId && (!panel.kind || panelKindHasPty(panel.kind))
         );
       });
       // Same explicit-repair intent as the per-pane Redraw, so the same

--- a/src/services/actions/definitions/worktreeSessionActions.ts
+++ b/src/services/actions/definitions/worktreeSessionActions.ts
@@ -2,6 +2,7 @@ import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import { z } from "zod";
 import type { ActionContext } from "@shared/types/actions";
 import { terminalInstanceService } from "@/services/terminal/TerminalInstanceService";
+import { nextFrame } from "@/services/terminal/revealUntilStable";
 import { usePanelStore } from "@/store/panelStore";
 import { useTerminalPendingDestructiveActionStore } from "@/store/terminalPendingDestructiveActionStore";
 import { collectRunningAgentTerminals } from "@/utils/destructiveSessionConfirm";
@@ -12,6 +13,11 @@ const clearHistoryArgsSchema = z.object({
   worktreeId: z.string().optional(),
   confirmed: z.boolean().optional(),
 });
+
+// Forced renderer resets applied per animation frame by
+// `worktree.sessions.resetRenderers`. Each one can reflow a pane's full
+// scrollback synchronously, so they are chunked rather than run in one task.
+const RESET_RENDERERS_PER_FRAME = 2;
 
 export function registerWorktreeSessionActions(
   actions: ActionRegistry,
@@ -120,10 +126,21 @@ export function registerWorktreeSessionActions(
       const targetWorktreeId = worktreeId ?? ctx.activeWorktreeId;
       if (!targetWorktreeId) return;
       const { panelsById, panelIds } = usePanelStore.getState();
-      for (const id of panelIds) {
-        const t = panelsById[id];
-        if (t && t.worktreeId === targetWorktreeId) {
-          terminalInstanceService.resetRenderer(t.id);
+      const targets = panelIds.filter(
+        (id) => panelsById[id]?.worktreeId === targetWorktreeId
+      );
+
+      // Same explicit-repair intent as the per-pane Redraw, so the same force
+      // (#11638) — but spread across frames. Forcing turns each pane's geometry
+      // step into a synchronous xterm reflow of its whole scrollback, and this
+      // action is pressed precisely when a whole worktree looks garbled, so an
+      // unchunked loop would pile every reflow into one long task. Two per
+      // frame mirrors the watchdog's heavy-repair budget. The id list is
+      // snapshotted above; a pane closed mid-sweep just no-ops in the service.
+      for (let index = 0; index < targets.length; index += RESET_RENDERERS_PER_FRAME) {
+        if (index > 0) await nextFrame();
+        for (const id of targets.slice(index, index + RESET_RENDERERS_PER_FRAME)) {
+          terminalInstanceService.resetRenderer(id, { force: true });
         }
       }
     },

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -2257,12 +2257,14 @@ class TerminalInstanceService {
       return;
     }
 
-    // The explicit repair discharged any obligation an earlier automatic
-    // deferral (handlePostWake / applyDeferredResize) armed. Leaving it set
-    // would spend a watchdog heavy-budget slot and stamp the repair cooldown on
-    // a reconcile that is already a no-op.
-    managed.revealPendingRepair = false;
-    managed.revealPendingGeneration = undefined;
+    // Deliberately does NOT clear `revealPendingRepair`. That flag is
+    // multiplexed: the reveal controller also arms it when an open DEC 2026
+    // synchronized-output block forced it to defer the atlas repair / refresh /
+    // unpause (TerminalRevealController, #10632), which a geometry step does
+    // not discharge. Clearing it here to save the watchdog one near-no-op tick
+    // would drop that unrelated obligation on the floor and leave the pane
+    // stale until the next click or heartbeat. The redundant tick is cheap;
+    // the lost repair is not.
 
     // Re-arm the geometry circuit breaker only on DEMONSTRATED main-buffer
     // convergence. reconcileGeometryFresh's boolean is measurability, not
@@ -2344,6 +2346,11 @@ class TerminalInstanceService {
           this.forceGeometryResync(id, managed);
         } catch (error) {
           logError(`resetRenderer forced resync failed for ${id}`, error);
+          // Same obligation the unmeasurable-box branch arms: a throw is no
+          // more converged than a false, and dropping it here would leave the
+          // pane with no path back to a correct grid.
+          managed.revealPendingRepair = true;
+          managed.revealPendingGeneration = managed.attachGeneration;
         }
       } else if (!this.deferGridChangeForStream(managed, this.proposalDivergesFromGrid(managed))) {
         try {

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -10,6 +10,7 @@ import {
   AgentStateCallback,
   PostCompleteHook,
   TerminalLink,
+  TerminalResyncOptions,
 } from "./types";
 import { tallyScrollbackRestoreStates } from "./scrollbackRestoreAggregate";
 import {
@@ -2196,13 +2197,6 @@ class TerminalInstanceService {
   }
 
   /**
-   * Recover a terminal's renderer the way the manual "Redraw" action does.
-   * Returns whether the repair ACTUALLY ran: false when it self-skipped on its
-   * own guards (gone/hibernated/disconnected/sub-50px box). Callers that must
-   * guarantee a redraw (the project-switch suppression-clear, #10632) use the
-   * return value to know whether the obligation still needs to be carried.
-   */
-  /**
    * True when the container proposes a grid DIFFERENT from the live xterm grid
    * — i.e. a fit() here would actually re-wrap the buffer, not just re-assert.
    * Shared divergence probe for the out-of-band geometry writers below.
@@ -2228,6 +2222,11 @@ class TerminalInstanceService {
    * and returns true so the caller skips its geometry step. The
    * ResizeObserver-driven applyResize path is NOT gated here — user-visible
    * layout changes must keep flowing to the PTY.
+   *
+   * An explicitly-forced `resetRenderer` (#11638) does not consult this at all
+   * — it takes {@link forceGeometryResync} instead. The hazard this guards is
+   * the AUTOMATIC out-of-band re-wrap; a user who pressed Redraw has already
+   * decided the pane is broken.
    */
   private deferGridChangeForStream(managed: ManagedTerminal, gridWouldChange: boolean): boolean {
     if (!gridWouldChange || managed.isAltBuffer || !hasStreamingWrites(managed, Date.now())) {
@@ -2238,7 +2237,64 @@ class TerminalInstanceService {
     return true;
   }
 
-  resetRenderer(id: string): boolean {
+  /**
+   * The explicit-Redraw geometry step (#11638). Runs INSTEAD of the guarded
+   * `fit()` below, never in addition to it: `reconcileGeometryFresh` is
+   * lock-exempt, measures fresh from the live DOM box, and moves xterm and the
+   * PTY together in one synchronous step — `fit()` would re-introduce the
+   * resize lock and, for a settled-strategy agent, split the two grids across
+   * ~500ms. There is deliberately no `fit()` fallback when this returns false:
+   * every reason it can fail (occluded host, sub-50px box, no cell metrics) is
+   * a reason `fit()` would fail too.
+   */
+  private forceGeometryResync(id: string, managed: ManagedTerminal): void {
+    if (!this.resizeController.reconcileGeometryFresh(id, { force: true })) {
+      // Unmeasurable/transitional box — hand the obligation to the watchdog
+      // exactly as the suppression-clear path does, so a pane that becomes
+      // measurable later still converges.
+      managed.revealPendingRepair = true;
+      managed.revealPendingGeneration = managed.attachGeneration;
+      return;
+    }
+
+    // The explicit repair discharged any obligation an earlier automatic
+    // deferral (handlePostWake / applyDeferredResize) armed. Leaving it set
+    // would spend a watchdog heavy-budget slot and stamp the repair cooldown on
+    // a reconcile that is already a no-op.
+    managed.revealPendingRepair = false;
+    managed.revealPendingGeneration = undefined;
+
+    // Re-arm the geometry circuit breaker only on DEMONSTRATED main-buffer
+    // convergence. reconcileGeometryFresh's boolean is measurability, not
+    // convergence: an alt-buffer pane returns true without touching geometry,
+    // and `resizeTerminal` parks the xterm resize during a serialized restore.
+    // Comparing the live grid against the geometry just measured is the only
+    // real signal, and it mirrors what the watchdog's converged branch does.
+    if (
+      !managed.isAltBuffer &&
+      managed.terminal.cols === managed.latestCols &&
+      managed.terminal.rows === managed.latestRows
+    ) {
+      managed.geometryRepairAttempts = 0;
+      managed.geometryRepairGaveUp = false;
+      managed.geometryRepairGeneration = managed.attachGeneration;
+    }
+  }
+
+  /**
+   * Recover a terminal's renderer the way the manual "Redraw" action does.
+   * Returns whether the repair ACTUALLY ran: false when it self-skipped on its
+   * own guards (gone/hibernated/disconnected/sub-50px box). Callers that must
+   * guarantee a redraw (the project-switch suppression-clear, #10632) use the
+   * return value to know whether the obligation still needs to be carried — a
+   * geometry sub-step that could not converge does NOT flip it, since the
+   * renderer repair itself still ran.
+   *
+   * `options.force` (#11638) marks an explicit user Redraw and takes the
+   * ungated atomic geometry path; every automatic caller omits it and keeps
+   * #10863's streaming deferral.
+   */
+  resetRenderer(id: string, options: TerminalResyncOptions = {}): boolean {
     const managed = this.instances.get(id);
     if (!managed) return false;
 
@@ -2267,12 +2323,29 @@ class TerminalInstanceService {
         managed.terminal.refresh(0, managed.terminal.rows - 1);
       }
 
-      // Same #10863 guard as handlePostWake: never fit-rewrap a streaming
-      // main-buffer pane. The suppression-clear timer that drives this on
-      // project switch-back lands exactly in the assistant's cold-resume boot
-      // window; the atlas/refresh recovery above already ran, and the armed
-      // watchdog obligation converges the grid once the stream quiesces.
-      if (!this.deferGridChangeForStream(managed, this.proposalDivergesFromGrid(managed))) {
+      // The geometry step. Two exclusive branches (#11638):
+      //
+      // force — an explicit user Redraw. Runs the lock-exempt atomic reconcile
+      // unconditionally. The stream gate below can never open for a busy agent
+      // (Claude Code repaints several times a second, so `lastWriteAt` is never
+      // 300ms stale), and the watchdog backstop the gate defers to tests the
+      // same predicate — so without this branch the ONLY step that can correct
+      // a wrong grid is dead on exactly the panes Redraw exists for.
+      //
+      // default — every automatic caller (handleBackendRecovery, the
+      // project-switch suppression clear, the post-drag reparent). Same #10863
+      // guard as handlePostWake: never fit-rewrap a streaming main-buffer pane.
+      // The suppression-clear timer that drives this on project switch-back
+      // lands exactly in the assistant's cold-resume boot window; the
+      // atlas/refresh recovery above already ran, and the armed watchdog
+      // obligation converges the grid once the stream quiesces.
+      if (options.force) {
+        try {
+          this.forceGeometryResync(id, managed);
+        } catch (error) {
+          logError(`resetRenderer forced resync failed for ${id}`, error);
+        }
+      } else if (!this.deferGridChangeForStream(managed, this.proposalDivergesFromGrid(managed))) {
         try {
           this.resizeController.fit(id);
         } catch (error) {

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -718,6 +718,19 @@ export class TerminalResizeController {
     // always (re)assert the PTY size so the two agree.
     this.cancelPendingResize(id);
     if (managed.terminal.cols !== cols || managed.terminal.rows !== rows) {
+      // Drain held ingest bytes at the OUTGOING grid before re-wrapping, the
+      // same invariant commitResize enforces at the other choke point. Bytes
+      // held by ingest backpressure were emitted for the current grid; parsing
+      // them after xterm adopts a new one lands their cursor moves and erases
+      // on the wrong rows, which no later reflow can undo. The automatic
+      // callers never met this hazard because the streaming gate above already
+      // turned them away — a forced resync (#11638) runs precisely when a
+      // backlog is most likely, so the flush has to be explicit here.
+      if (!this.flushHeldBytesBeforeResize(id)) {
+        // Backlog exceeded the sync-flush budget and stayed queued; let it
+        // drain against the new grid rather than stall ingest behind it.
+        this.deps.dataBuffer.resumeFlush(id);
+      }
       this.resizeTerminal(managed, cols, rows);
     }
     terminalClient.resize(id, cols, rows);

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -717,23 +717,28 @@ export class TerminalResizeController {
     // apply atomically: resize xterm only when its grid actually drifted, and
     // always (re)assert the PTY size so the two agree.
     this.cancelPendingResize(id);
+    // Drain held ingest bytes at the OUTGOING grid before re-wrapping, the same
+    // invariant commitResize enforces at the other choke point. Bytes held by
+    // ingest backpressure were emitted for the current grid; parsing them after
+    // xterm adopts a new one lands their cursor moves and erases on the wrong
+    // rows, which no later reflow can undo. The automatic callers never met
+    // this hazard because the streaming gate above already turned them away —
+    // a forced resync (#11638) runs precisely when a backlog is most likely,
+    // so the flush has to be explicit here.
+    let heldBytesFlushed = true;
     if (managed.terminal.cols !== cols || managed.terminal.rows !== rows) {
-      // Drain held ingest bytes at the OUTGOING grid before re-wrapping, the
-      // same invariant commitResize enforces at the other choke point. Bytes
-      // held by ingest backpressure were emitted for the current grid; parsing
-      // them after xterm adopts a new one lands their cursor moves and erases
-      // on the wrong rows, which no later reflow can undo. The automatic
-      // callers never met this hazard because the streaming gate above already
-      // turned them away — a forced resync (#11638) runs precisely when a
-      // backlog is most likely, so the flush has to be explicit here.
-      if (!this.flushHeldBytesBeforeResize(id)) {
-        // Backlog exceeded the sync-flush budget and stayed queued; let it
-        // drain against the new grid rather than stall ingest behind it.
-        this.deps.dataBuffer.resumeFlush(id);
-      }
+      heldBytesFlushed = this.flushHeldBytesBeforeResize(id);
       this.resizeTerminal(managed, cols, rows);
     }
     terminalClient.resize(id, cols, rows);
+    // An over-budget backlog resumes only AFTER the resize, exactly as
+    // commitResize orders it. Resuming first would drain it inline into xterm
+    // and then let resize()'s synchronous flushSync keep consuming whatever
+    // notifyWriteComplete appends behind it — one unyielding task that defeats
+    // the sync-flush budget the over-budget branch exists to enforce.
+    if (!heldBytesFlushed) {
+      this.deps.dataBuffer.resumeFlush(id);
+    }
     this.pinToBottomAfterResize(managed);
     return true;
   }

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -4,7 +4,7 @@ import { TerminalRefreshTier } from "@/types";
 import { getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 import { getEffectiveScrollbarWidth } from "@/config/xtermConfig";
 import { logError, logWarn } from "@/utils/logger";
-import type { ManagedTerminal } from "./types";
+import type { ManagedTerminal, TerminalResyncOptions } from "./types";
 import type { TerminalOutputIngestService } from "./TerminalOutputIngestService";
 
 const START_DEBOUNCING_THRESHOLD = 200;
@@ -633,14 +633,18 @@ export class TerminalResizeController {
    * cached dims can equal the now-stale xterm grid), which applyDeferredResize's
    * cache==current early-return would miss.
    *
+   * @param options `force: true` skips ONLY the streaming-quiescence gate below
+   * (#11638) — the explicit user Redraw path. Every other guard here still
+   * applies. Automatic callers must omit it.
+   *
    * @returns true once a fresh measurement landed (whether or not a resize was
    * needed); false when the box is not measurable yet (zero/occluded/transitional
    * layout) so the reveal sweep retries on a later frame. The boolean is
    * measurability, NOT convergence — an alt-buffer pane reports true without
-   * touching geometry at all, so no caller may treat it as proof the grid now
-   * matches the container.
+   * touching geometry at all, and a serialized restore parks the xterm resize,
+   * so no caller may treat it as proof the grid now matches the container.
    */
-  reconcileGeometryFresh(id: string): boolean {
+  reconcileGeometryFresh(id: string, options: TerminalResyncOptions = {}): boolean {
     const managed = this.deps.getInstance(id);
     if (!managed) return false;
     if (!managed.hostElement.checkVisibility()) return false;
@@ -687,7 +691,17 @@ export class TerminalResizeController {
     // watchdog picks up a pane that outlasts the sweep at its first quiet
     // tick. A no-drift pass falls through: the PTY re-assert below is
     // dedupe-safe and never re-wraps.
+    //
+    // `force` (#11638) is the one exemption: an explicit user Redraw. A busy
+    // agent repaints its status line several times a second and never opens the
+    // 300ms window this gate waits for, so deferring an explicitly-requested
+    // repair defers it forever — and the watchdog backstop tests the same
+    // predicate, so nothing converges the pane either. The re-wrap hazard the
+    // gate protects against is real but it is the AUTOMATIC case; a user who
+    // pressed Redraw has already judged the pane broken and accepts a frame of
+    // churn to fix it.
     if (
+      !options.force &&
       (managed.terminal.cols !== cols || managed.terminal.rows !== rows) &&
       hasStreamingWrites(managed, Date.now())
     ) {

--- a/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
@@ -52,12 +52,65 @@ vi.mock("../TerminalAddonManager", () => ({
 type ReflowTestService = {
   instances: Map<string, ManagedTerminal>;
   maybeReflowTerminal: (managed: ManagedTerminal) => void;
-  resetRenderer: (id: string) => void;
+  resetRenderer: (id: string, options?: { force?: boolean }) => boolean;
   handleBackendRecovery: () => void;
-  resizeController: { fit: (id: string) => unknown };
+  resizeController: {
+    fit: (id: string) => unknown;
+    reconcileGeometryFresh: (id: string, options?: { force?: boolean }) => boolean;
+  };
   getSynchronizedOutputMode: (id: string) => boolean | null;
   webGLManager: { repairAtlasForReactivation: (id: string) => boolean };
 };
+
+/**
+ * Upgrades a {@link makeManaged} fixture into one the REAL
+ * `resizeController.reconcileGeometryFresh` can drive end to end: a measurable
+ * host box, a live grid, and a fit proposal that diverges from it. Used by the
+ * #11638 regression, which has to observe an actual grid change rather than a
+ * spy call.
+ */
+function makeDivergedPane(
+  managed: ManagedTerminal,
+  proposal: { cols: number; rows: number }
+): { resize: ReturnType<typeof vi.fn>; scrollToBottom: ReturnType<typeof vi.fn> } {
+  for (const [prop, value] of [
+    ["clientWidth", 800],
+    ["clientHeight", 600],
+  ] as const) {
+    Object.defineProperty(managed.hostElement, prop, { value, configurable: true });
+  }
+  managed.hostElement.checkVisibility = vi.fn(() => true);
+  managed.hostElement.getBoundingClientRect = vi.fn(() => ({
+    left: 0,
+    width: 800,
+    height: 600,
+  })) as unknown as HTMLElement["getBoundingClientRect"];
+
+  const resize = vi.fn((cols: number, rows: number) => {
+    term.cols = cols;
+    term.rows = rows;
+  });
+  const scrollToBottom = vi.fn();
+  const term = managed.terminal as unknown as {
+    cols: number;
+    rows: number;
+    resize: typeof resize;
+    refresh: ReturnType<typeof vi.fn>;
+    scrollToBottom: typeof scrollToBottom;
+  };
+  term.cols = 80;
+  term.rows = 24;
+  term.resize = resize;
+  term.refresh = vi.fn();
+  term.scrollToBottom = scrollToBottom;
+
+  managed.fitAddon = {
+    fit: vi.fn(),
+    proposeDimensions: vi.fn(() => proposal),
+  } as unknown as ManagedTerminal["fitAddon"];
+
+  return { resize, scrollToBottom };
+}
 
 function makeManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal {
   const hostElement = document.createElement("div");
@@ -157,6 +210,7 @@ function clearSyncModes(managed: ManagedTerminal): void {
 
 describe("TerminalInstanceService maybeReflowTerminal", () => {
   let service: ReflowTestService;
+  let terminalClient: { resize: ReturnType<typeof vi.fn> };
 
   beforeEach(async () => {
     vi.resetModules();
@@ -164,6 +218,13 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
       (await import("../TerminalInstanceService")) as unknown as {
         terminalInstanceService: ReflowTestService;
       });
+    // Read the client out of the SAME post-reset module registry the service
+    // just bound to — a static top-level import would hold the pre-reset
+    // instance and never observe these calls.
+    ({ terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { resize: ReturnType<typeof vi.fn> };
+    });
+    terminalClient.resize.mockClear();
     service.instances.clear();
   });
 
@@ -382,6 +443,91 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     expect(managed.lastReflowAt).toBe(0);
     // Even on the error path, Redraw never flushes the shared atlas.
     expect(term.clearTextureAtlas).not.toHaveBeenCalled();
+  });
+
+  it("forced resetRenderer converges a streaming, diverged pane that the default path defers (#11638)", () => {
+    const managed = makeManaged();
+    const { resize } = makeDivergedPane(managed, { cols: 120, rows: 40 });
+    // A working agent's steady state: a batch is always in flight, so the
+    // 300ms write-quiescence window the guard waits for never opens.
+    managed.pendingWrites = 2;
+    service.instances.set("t1", managed);
+    vi.spyOn(service.webGLManager, "repairAtlasForReactivation").mockReturnValue(true);
+    const fit = vi.spyOn(service.resizeController, "fit");
+
+    const term = managed.terminal as unknown as { cols: number; rows: number };
+    const staleGrid = { cols: term.cols, rows: term.rows };
+    const proposal = managed.fitAddon.proposeDimensions();
+
+    // The bug: the default path defers its one grid-correcting step and hands
+    // the repair to the watchdog, which tests the same predicate and so never
+    // runs it either. Nothing about the pane changes.
+    expect(service.resetRenderer("t1")).toBe(true);
+    expect(term.cols).toBe(staleGrid.cols);
+    expect(term.rows).toBe(staleGrid.rows);
+    expect(managed.revealPendingRepair).toBe(true);
+
+    // Same pane, same instant, no timer advance — only the explicit intent
+    // differs. This is the assertion the issue asked for.
+    expect(service.resetRenderer("t1", { force: true })).toBe(true);
+
+    expect(term.cols).toBe(proposal?.cols);
+    expect(term.rows).toBe(proposal?.rows);
+    expect(resize).toHaveBeenCalledWith(proposal?.cols, proposal?.rows);
+    // The PTY moved with xterm in the same step; a settled-strategy agent must
+    // never see the two grids disagree across a 500ms debounce.
+    expect(terminalClient.resize).toHaveBeenCalledWith("t1", proposal?.cols, proposal?.rows);
+    // Routed through the lock-exempt atomic reconcile, NOT the lock-aware fit()
+    // that the default branch uses.
+    expect(fit).not.toHaveBeenCalled();
+    // The explicit repair discharged the obligation the deferral armed, so the
+    // next watchdog tick doesn't spend a heavy-budget slot on a no-op.
+    expect(managed.revealPendingRepair).toBe(false);
+    expect(managed.revealPendingGeneration).toBeUndefined();
+  });
+
+  it("forced resetRenderer re-arms the geometry circuit breaker once the grid converges", () => {
+    const managed = makeManaged();
+    makeDivergedPane(managed, { cols: 120, rows: 40 });
+    managed.pendingWrites = 2;
+    // A pane the watchdog gave up on (#10909): its automatic geometry repairs
+    // are latched off, and only genuine convergence or a re-attach re-arms it.
+    // An explicit Redraw that DOES converge is exactly that kind of boundary —
+    // leaving it barred would strand the pane's future automatic repairs.
+    managed.geometryRepairAttempts = 5;
+    managed.geometryRepairGaveUp = true;
+    managed.attachGeneration = 7;
+    service.instances.set("t1", managed);
+    vi.spyOn(service.webGLManager, "repairAtlasForReactivation").mockReturnValue(true);
+
+    service.resetRenderer("t1", { force: true });
+
+    expect(managed.geometryRepairGaveUp).toBe(false);
+    expect(managed.geometryRepairAttempts).toBe(0);
+    // Re-armed under the CURRENT incarnation, so a later re-attach still
+    // supersedes it rather than inheriting this counter.
+    expect(managed.geometryRepairGeneration).toBe(managed.attachGeneration);
+  });
+
+  it("forced resetRenderer keeps the breaker latched when the grid could not converge", () => {
+    const managed = makeManaged();
+    makeDivergedPane(managed, { cols: 120, rows: 40 });
+    managed.pendingWrites = 2;
+    managed.geometryRepairAttempts = 5;
+    managed.geometryRepairGaveUp = true;
+    // A serialized restore parks the xterm resize (#11552) — reconcile reports
+    // a successful measurement, but the live grid never moved. Trusting that
+    // boolean would re-arm the breaker on no evidence at all.
+    managed.isSerializedRestoreInProgress = true;
+    service.instances.set("t1", managed);
+    vi.spyOn(service.webGLManager, "repairAtlasForReactivation").mockReturnValue(true);
+
+    service.resetRenderer("t1", { force: true });
+
+    const term = managed.terminal as unknown as { cols: number; rows: number };
+    expect(term.cols).toBe(80);
+    expect(managed.geometryRepairGaveUp).toBe(true);
+    expect(managed.geometryRepairAttempts).toBe(5);
   });
 
   it("resetRenderer leaves sibling panes untouched (#9701 isolation)", () => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
@@ -480,10 +480,6 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     // Routed through the lock-exempt atomic reconcile, NOT the lock-aware fit()
     // that the default branch uses.
     expect(fit).not.toHaveBeenCalled();
-    // The explicit repair discharged the obligation the deferral armed, so the
-    // next watchdog tick doesn't spend a heavy-budget slot on a no-op.
-    expect(managed.revealPendingRepair).toBe(false);
-    expect(managed.revealPendingGeneration).toBeUndefined();
   });
 
   it("forced resetRenderer re-arms the geometry circuit breaker once the grid converges", () => {
@@ -528,6 +524,102 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     expect(term.cols).toBe(80);
     expect(managed.geometryRepairGaveUp).toBe(true);
     expect(managed.geometryRepairAttempts).toBe(5);
+  });
+
+  it("forced resetRenderer arms the watchdog obligation when the box is unmeasurable", () => {
+    const managed = makeManaged();
+    makeDivergedPane(managed, { cols: 120, rows: 40 });
+    managed.pendingWrites = 2;
+    managed.attachGeneration = 4;
+    // Passes resetRenderer's own clientWidth/Height floor, but the LIVE rect is
+    // mid-transition — reconcileGeometryFresh can't measure it. The repair must
+    // not be silently spent: hand it to the watchdog for a later frame.
+    managed.hostElement.getBoundingClientRect = vi.fn(() => ({
+      left: 0,
+      width: 10,
+      height: 10,
+    })) as unknown as HTMLElement["getBoundingClientRect"];
+    service.instances.set("t1", managed);
+    vi.spyOn(service.webGLManager, "repairAtlasForReactivation").mockReturnValue(true);
+    const fit = vi.spyOn(service.resizeController, "fit");
+
+    // Still true: the renderer repair itself ran. The #10632 suppression-clear
+    // reads this boolean to decide whether its one-shot was spent, so a failed
+    // geometry sub-step must not flip it.
+    expect(service.resetRenderer("t1", { force: true })).toBe(true);
+
+    expect(managed.revealPendingRepair).toBe(true);
+    expect(managed.revealPendingGeneration).toBe(managed.attachGeneration);
+    // No fit() fallback — every reason the fresh reconcile failed is a reason
+    // fit() would fail too, and fit() would reintroduce the lock and the
+    // settled-strategy split.
+    expect(fit).not.toHaveBeenCalled();
+    // The escape hatch still runs so a paused renderer resumes drawing.
+    expect(paddingHistory(managed)).toContain("0.01px");
+  });
+
+  it("forced resetRenderer still runs forceXtermReflow when the reconcile throws", () => {
+    const managed = makeManaged();
+    makeDivergedPane(managed, { cols: 120, rows: 40 });
+    managed.pendingWrites = 2;
+    managed.attachGeneration = 9;
+    service.instances.set("t1", managed);
+    vi.spyOn(service.webGLManager, "repairAtlasForReactivation").mockReturnValue(true);
+    vi.spyOn(service.resizeController, "reconcileGeometryFresh").mockImplementation(() => {
+      throw new Error("reconcile boom");
+    });
+
+    expect(() => service.resetRenderer("t1", { force: true })).not.toThrow();
+
+    // A throw is no more converged than a false — the obligation is armed
+    // either way rather than dropped.
+    expect(managed.revealPendingRepair).toBe(true);
+    expect(managed.revealPendingGeneration).toBe(managed.attachGeneration);
+    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(managed.lastReflowAt).toBe(0);
+  });
+
+  it("forced resetRenderer never reflows a live alt-screen pane or re-arms its breaker", () => {
+    const managed = makeManaged();
+    const { resize } = makeDivergedPane(managed, { cols: 120, rows: 40 });
+    managed.pendingWrites = 2;
+    managed.isAltBuffer = true;
+    managed.geometryRepairAttempts = 5;
+    managed.geometryRepairGaveUp = true;
+    service.instances.set("t1", managed);
+    vi.spyOn(service.webGLManager, "repairAtlasForReactivation").mockReturnValue(true);
+    const fit = vi.spyOn(service.resizeController, "fit");
+
+    service.resetRenderer("t1", { force: true });
+
+    // End-to-end through the action's entry point: a full-screen TUI's frame is
+    // never mangled out from under its own SIGWINCH redraw (#10805), and the
+    // alt-buffer "success" (measurable, but no geometry touched) is not
+    // evidence of convergence, so the breaker stays latched.
+    expect(resize).not.toHaveBeenCalled();
+    expect(fit).not.toHaveBeenCalled();
+    expect(managed.geometryRepairGaveUp).toBe(true);
+    expect(managed.geometryRepairAttempts).toBe(5);
+  });
+
+  it("forced resetRenderer preserves a reveal obligation it did not discharge", () => {
+    const managed = makeManaged();
+    makeDivergedPane(managed, { cols: 120, rows: 40 });
+    managed.pendingWrites = 2;
+    // Armed by the reveal controller because an open synchronized-output block
+    // blocked its atlas repair / unpause — NOT a geometry deferral. A geometry
+    // step cannot discharge it, so clearing it here would strand the pane.
+    managed.revealPendingRepair = true;
+    managed.revealPendingGeneration = 3;
+    service.instances.set("t1", managed);
+    vi.spyOn(service.webGLManager, "repairAtlasForReactivation").mockReturnValue(true);
+
+    service.resetRenderer("t1", { force: true });
+
+    const term = managed.terminal as unknown as { cols: number };
+    expect(term.cols).toBe(120);
+    expect(managed.revealPendingRepair).toBe(true);
+    expect(managed.revealPendingGeneration).toBe(3);
   });
 
   it("resetRenderer leaves sibling panes untouched (#9701 isolation)", () => {
@@ -577,10 +669,12 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
       } as unknown as ManagedTerminal["terminal"],
     });
     service.instances.set("t1", managed);
-    const resetRenderer = vi.spyOn(service, "resetRenderer").mockImplementation(() => undefined);
+    const resetRenderer = vi.spyOn(service, "resetRenderer").mockImplementation(() => true);
 
     service.handleBackendRecovery();
 
+    // Automatic recovery must stay UNforced — a single-arg call is the assertion
+    // that #10863's deferral still shields this sweep (#11638).
     expect(resetRenderer).toHaveBeenCalledWith("t1");
     expect(managed.fitAddon.fit).not.toHaveBeenCalled();
     expect(write).toHaveBeenCalledTimes(2);

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -2370,6 +2370,73 @@ describe("TerminalResizeController", () => {
       expect(resizeMock).toHaveBeenCalledWith("term-1", 100, 30);
     });
 
+    it("converges a still-streaming diverged grid when the caller forces it (#11638)", () => {
+      const managed = createManagedTerminal();
+      managed.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 100, rows: 30 }));
+      // Both streaming signals live at once — a busy agent's steady state. The
+      // point of the force flag is that no amount of waiting would clear this.
+      (managed as { lastWriteAt?: number }).lastWriteAt = Date.now();
+      (managed as { pendingWrites?: number }).pendingWrites = 3;
+
+      const controller = makeController(managed);
+
+      // Same pane, same instant: the unforced call is the deferral this issue
+      // is about, and the forced call is the fix. Asserting both against one
+      // fixture is what proves force is doing the work, not the clock.
+      expect(controller.reconcileGeometryFresh("term-1")).toBe(false);
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+
+      const ok = controller.reconcileGeometryFresh("term-1", { force: true });
+
+      expect(ok).toBe(true);
+      // xterm and the PTY land on the SAME freshly proposed geometry — the
+      // atomicity that makes this safe for a settled-strategy agent.
+      const proposal = managed.fitAddon.proposeDimensions();
+      expect(managed.terminal.resize).toHaveBeenCalledWith(proposal.cols, proposal.rows);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", proposal.cols, proposal.rows);
+      expect(managed.latestCols).toBe(proposal.cols);
+      expect(managed.latestRows).toBe(proposal.rows);
+      // Never via fitAddon.fit() — that resizes xterm ahead of the PTY.
+      expect(managed.fitAddon.fit).not.toHaveBeenCalled();
+    });
+
+    it("force does not reflow a live alt-screen TUI (#10805 survives the bypass)", () => {
+      const managed = createManagedTerminal();
+      managed.isAltBuffer = true;
+      managed.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 100, rows: 30 }));
+      (managed as { pendingWrites?: number }).pendingWrites = 3;
+
+      const controller = makeController(managed);
+      const ok = controller.reconcileGeometryFresh("term-1", { force: true });
+
+      // force buys past write-quiescence and nothing else: the alt-buffer early
+      // return sits ABOVE the streaming gate, so a full-screen TUI's frame is
+      // still never mangled out from under its own SIGWINCH redraw.
+      expect(ok).toBe(true);
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).not.toHaveBeenCalled();
+      expect(managed.terminal.scrollToBottom).not.toHaveBeenCalled();
+    });
+
+    it("force still reports failure on an unmeasurable host box", () => {
+      const managed = createManagedTerminal();
+      managed.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 100, rows: 30 }));
+      (managed as { pendingWrites?: number }).pendingWrites = 3;
+      // Transitional/occluded layout: below the >=50px floor the fresh
+      // measurement is meaningless, and forcing must not fabricate one.
+      managed.hostElement.getBoundingClientRect = vi.fn(() => ({
+        left: 0,
+        width: 10,
+        height: 10,
+      })) as any;
+
+      const controller = makeController(managed);
+
+      expect(controller.reconcileGeometryFresh("term-1", { force: true })).toBe(false);
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).not.toHaveBeenCalled();
+    });
+
     it("still re-asserts the PTY during streaming when the grid has not drifted", () => {
       const managed = createManagedTerminal();
       managed.terminal.cols = 100;

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -2400,6 +2400,66 @@ describe("TerminalResizeController", () => {
       expect(managed.fitAddon.fit).not.toHaveBeenCalled();
     });
 
+    it("drains held ingest bytes at the OUTGOING grid before a forced re-wrap", () => {
+      const managed = createManagedTerminal();
+      managed.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 100, rows: 30 }));
+      (managed as { pendingWrites?: number }).pendingWrites = 3;
+
+      const order: string[] = [];
+      const dataBuffer = {
+        flushForTerminal: vi.fn(() => order.push("flush")),
+        resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 1024),
+        resumeFlush: vi.fn(() => order.push("resume")),
+      };
+      const controller = new TerminalResizeController({
+        getInstance: vi.fn(() => managed),
+        dataBuffer: dataBuffer as any,
+      });
+      (managed.terminal.resize as ReturnType<typeof vi.fn>).mockImplementation(() =>
+        order.push("resize")
+      );
+
+      expect(controller.reconcileGeometryFresh("term-1", { force: true })).toBe(true);
+
+      // Bytes held by backpressure were emitted for the OLD grid. Parsing them
+      // after xterm adopts the new one puts their cursor moves and erases on
+      // the wrong rows, and no later reflow undoes that.
+      expect(order).toEqual(["flush", "resize"]);
+    });
+
+    it("resumes an over-budget backlog only AFTER the forced resize", () => {
+      const managed = createManagedTerminal();
+      managed.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 100, rows: 30 }));
+      (managed as { pendingWrites?: number }).pendingWrites = 3;
+
+      const order: string[] = [];
+      const dataBuffer = {
+        flushForTerminal: vi.fn(() => order.push("flush")),
+        resetForTerminal: vi.fn(),
+        // Past the sync-flush budget: the backlog stays queued rather than
+        // being drained inline.
+        getQueuedBytes: vi.fn(() => 64 * 1024 * 1024),
+        resumeFlush: vi.fn(() => order.push("resume")),
+      };
+      const controller = new TerminalResizeController({
+        getInstance: vi.fn(() => managed),
+        dataBuffer: dataBuffer as any,
+      });
+      (managed.terminal.resize as ReturnType<typeof vi.fn>).mockImplementation(() =>
+        order.push("resize")
+      );
+
+      expect(controller.reconcileGeometryFresh("term-1", { force: true })).toBe(true);
+
+      // Never flushed inline (that is what the budget is for), and resumed only
+      // after the resize. Resuming first would drain the backlog into xterm and
+      // then let resize()'s synchronous flushSync keep consuming what
+      // notifyWriteComplete appends behind it — one unyielding task.
+      expect(dataBuffer.flushForTerminal).not.toHaveBeenCalled();
+      expect(order).toEqual(["resize", "resume"]);
+    });
+
     it("force does not reflow a live alt-screen TUI (#10805 survives the bypass)", () => {
       const managed = createManagedTerminal();
       managed.isAltBuffer = true;

--- a/src/services/terminal/paintFabric/PaintFabricCompositor.ts
+++ b/src/services/terminal/paintFabric/PaintFabricCompositor.ts
@@ -5,6 +5,7 @@ import type {
   RefreshTierProvider,
   AgentStateCallback,
   PostCompleteHook,
+  TerminalResyncOptions,
 } from "../types";
 import { GRID_RESIZE_COALESCE_MS } from "../types";
 import type { UnseenOutputSnapshot } from "../TerminalUnseenOutputTracker";
@@ -1014,8 +1015,8 @@ export class PaintFabricCompositor implements TerminalPaintPlane {
     this.plane(id).focus(id);
   }
 
-  resetRenderer(id: string): boolean {
-    return this.plane(id).resetRenderer(id);
+  resetRenderer(id: string, options: TerminalResyncOptions = {}): boolean {
+    return this.plane(id).resetRenderer(id, options);
   }
 
   handleBackendRecovery(): void {

--- a/src/services/terminal/paintFabric/__tests__/PaintFabricCompositor.test.ts
+++ b/src/services/terminal/paintFabric/__tests__/PaintFabricCompositor.test.ts
@@ -35,6 +35,19 @@ describe("PaintFabricCompositor", () => {
     expect(a.focus).not.toHaveBeenCalled();
   });
 
+  it("carries the resync options through to the owning plane and returns its verdict", async () => {
+    const { compositor, a, b } = makeCompositor();
+    await compositor.getOrCreate("t1-b", undefined, {});
+    b.resetRenderer.mockReturnValue(true);
+
+    // The delegation seam forwards only what it names. Dropping the options
+    // here would silently downgrade an explicit Redraw back to the deferring
+    // path with nothing failing to notice (#11638).
+    expect(compositor.resetRenderer("t1-b", { force: true })).toBe(true);
+    expect(b.resetRenderer).toHaveBeenCalledWith("t1-b", { force: true });
+    expect(a.resetRenderer).not.toHaveBeenCalled();
+  });
+
   it("routes unplaced terminals to the default surface", () => {
     const { compositor, a, b } = makeCompositor();
     compositor.focus("never-created");

--- a/src/services/terminal/paintFabric/__tests__/PaintFabricCompositor.test.ts
+++ b/src/services/terminal/paintFabric/__tests__/PaintFabricCompositor.test.ts
@@ -35,18 +35,23 @@ describe("PaintFabricCompositor", () => {
     expect(a.focus).not.toHaveBeenCalled();
   });
 
-  it("carries the resync options through to the owning plane and returns its verdict", async () => {
-    const { compositor, a, b } = makeCompositor();
-    await compositor.getOrCreate("t1-b", undefined, {});
-    b.resetRenderer.mockReturnValue(true);
+  it.each([true, false])(
+    "carries the resync options through to the owning plane and returns its verdict (%s)",
+    async (verdict) => {
+      const { compositor, a, b } = makeCompositor();
+      await compositor.getOrCreate("t1-b", undefined, {});
+      b.resetRenderer.mockReturnValue(verdict);
 
-    // The delegation seam forwards only what it names. Dropping the options
-    // here would silently downgrade an explicit Redraw back to the deferring
-    // path with nothing failing to notice (#11638).
-    expect(compositor.resetRenderer("t1-b", { force: true })).toBe(true);
-    expect(b.resetRenderer).toHaveBeenCalledWith("t1-b", { force: true });
-    expect(a.resetRenderer).not.toHaveBeenCalled();
-  });
+      // The delegation seam forwards only what it names. Dropping the options
+      // here would silently downgrade an explicit Redraw back to the deferring
+      // path with nothing failing to notice (#11638). Both verdicts are pinned
+      // so a hardcoded `return true` can't satisfy the contract either — the
+      // #10632 suppression-clear reads this boolean.
+      expect(compositor.resetRenderer("t1-b", { force: true })).toBe(verdict);
+      expect(b.resetRenderer).toHaveBeenCalledWith("t1-b", { force: true });
+      expect(a.resetRenderer).not.toHaveBeenCalled();
+    }
+  );
 
   it("routes unplaced terminals to the default surface", () => {
     const { compositor, a, b } = makeCompositor();

--- a/src/services/terminal/paintFabric/__tests__/fakePaintPlane.ts
+++ b/src/services/terminal/paintFabric/__tests__/fakePaintPlane.ts
@@ -64,6 +64,7 @@ export function makeFakePlane() {
     detach: vi.fn(),
     fit: vi.fn((): { cols: number; rows: number } | null => null),
     resize: vi.fn((): { cols: number; rows: number } | null => null),
+    resetRenderer: vi.fn((): boolean => false),
   };
 }
 

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -29,6 +29,26 @@ export type AgentStateCallback = (state: AgentState) => void;
 
 export type PostCompleteHook = (output: string) => void | Promise<void>;
 
+/**
+ * Intent marker for a renderer/geometry resync (#11638). `force` means the user
+ * explicitly asked for this repair — the Redraw action or its bulk per-worktree
+ * variant — and it bypasses EXACTLY ONE guard: #10863's write-quiescence
+ * deferral ({@link https://github.com/daintreehq/daintree/issues/10863}), which
+ * exists to stop an AUTOMATIC out-of-band re-wrap from landing under a live
+ * cursor-relative repaint. A user staring at a garbled pane has already made
+ * that call, and a busy agent never opens the 300ms gap the guard waits for, so
+ * without the bypass the one load-bearing step of Redraw is dead on exactly the
+ * terminals it exists for.
+ *
+ * It bypasses NOTHING else: the alt-screen exclusion (#10805), host visibility,
+ * the >=50px box floor, cell-metric availability, and the serialized-restore
+ * parking all still apply. Deliberately absent from `TerminalRevealController`
+ * and the watchdog's dep signatures so no automatic path can even ask for it.
+ */
+export interface TerminalResyncOptions {
+  force?: boolean;
+}
+
 export interface ManagedTerminal {
   /** Stable terminal id — the key this instance is registered under. */
   id: string;

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -40,10 +40,21 @@ export type PostCompleteHook = (output: string) => void | Promise<void>;
  * without the bypass the one load-bearing step of Redraw is dead on exactly the
  * terminals it exists for.
  *
- * It bypasses NOTHING else: the alt-screen exclusion (#10805), host visibility,
- * the >=50px box floor, cell-metric availability, and the serialized-restore
- * parking all still apply. Deliberately absent from `TerminalRevealController`
- * and the watchdog's dep signatures so no automatic path can even ask for it.
+ * Still enforced under `force`: the alt-screen exclusion (#10805), host
+ * visibility, the >=50px box floor, cell-metric availability, the
+ * serialized-restore parking, and the pre-resize drain of held ingest bytes.
+ *
+ * Also note what `force` implies beyond the stream gate: it routes the repair
+ * through the lock-exempt atomic reconcile rather than `fit()`, so it can land
+ * during a resize lock (a divider drag, DnD, the project-switch suppression
+ * window). That is deliberate — the lock is how the pane got stale in the
+ * first place, and deferring to the end-of-transition pass is the same
+ * hand-off-to-something-that-never-runs that made Redraw a no-op.
+ *
+ * Deliberately absent from `TerminalRevealController` and the watchdog's dep
+ * signatures so no automatic path can even ask for it. The two actions that do
+ * ask gate it on `isForegroundDispatch` — an agent or plugin driving Redraw on
+ * a timer IS the automatic writer #10863 was written for.
  */
 export interface TerminalResyncOptions {
   force?: boolean;


### PR DESCRIPTION
## Summary

- Redraw does nothing on a busy agent terminal. The only grid-correcting step inside `resetRenderer()` is wrapped in `deferGridChangeForStream()`, which skips the fit whenever the grid has diverged from its container *and* the pane has had a write in the last 300ms. A busy coding agent repaints its status line several times a second, so that gap never opens: the fit only ever runs when the grid was already correct, i.e. a no-op.
- The deferred repair is supposed to fall back to `TerminalReconciliationWatchdog`, but that watchdog checks the exact same divergence-plus-recent-write condition on both its reveal-pending and geometry-convergence branches, so the backstop never fires either. The one thing Redraw is supposed to fix, it could never fix on the terminals people actually press it on.
- Fixed by threading a `force` option through `resetRenderer()` that skips only the streaming-quiescence guard and routes the resize through a lock-exempt atomic path, gated to foreground (human-triggered) dispatch only.

Resolves #11638

## Changes

- Added `TerminalResyncOptions { force?: boolean }`, threaded from `resetRenderer()` through the internal reconcile-geometry step and down into `PaintFabricCompositor`. `force: true` skips only the 300ms streaming-quiescence gate and moves the xterm buffer and the underlying pty size together in one atomic step, instead of the normal lock-aware `fit()` path that splits the update across a 500ms settled-strategy window.
- Everything else stays intact: alt-screen handling (#10805), visibility checks, the 50px minimum size floor, cell metrics, serialized-restore parking, and the pre-resize held-bytes drain. The pty process, its output buffer, and the agent session are untouched, only the rendering/geometry layer is touched.
- The force bypass is gated on `isForegroundDispatch`. An agent or plugin driving Redraw on a timer is exactly the automatic background writer the original guard (#10863) was built to protect against, so those paths keep the deferral. `TerminalReconciliationWatchdog` and the reveal controller both keep single-argument call signatures, so neither can request the bypass.
- Considered remounting the terminal component with a fresh React key instead (what the issue proposed), matching what happens on a worktree switch. Ruled it out: `attach()`'s own fit is skipped by a dimension-match early return, and the post-attach resize is separately deduplicated as redundant. Both compare the container box, which is unchanged in the broken state, only the internal grid is stale, so a remount would also be a no-op. It's destructive too: a fresh key kills and restarts the terminal process, and even a plain detach blurs focus off the pane.
- Gave `worktree.sessions.resetRenderers` the same force-resync treatment, scoped to panes with a live pty, at most one synchronous reflow per animation frame, with overlapping sweep requests queued so they can't interleave.

## Testing

- Added the convergence test the issue asked for: a streaming, diverged pane converges immediately after Redraw, in the same instant, with no timer advance, while confirming the default (non-forced) path still defers as before.
- Added tests for the preserved guards (alt-buffer, unmeasurable box, serialized-restore parking), the foreground-only gate, pending-repair bookkeeping, buffer flush ordering, and that the compositor receives the right options.
- Locally: 1612 tests passing across `src/services/terminal/__tests__/`, `src/services/terminal/paintFabric/__tests__/`, and the two related action suites. `npm run typecheck` clean, Prettier clean, lint ratchet clean with no per-rule regressions.
