### PR TITLE
feat(terminal): echo applied PTY dimensions and detect grid divergence

### DIFF
--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -86,6 +86,7 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
   "plugin:archive-install-intent": "external",
   "terminal:exit": "external",
   "terminal:spawn-result": "external",
+  "terminal:resize-result": "external",
 } as const satisfies Record<keyof IpcEventBusMap, "bus" | "external">;
 
 const EVENT_BUS_RELAYED_EVENTS = (

--- a/electron/ipc/handlers/terminal/__tests__/events.resizeResult.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/events.resizeResult.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+import type { TerminalResizeResult } from "../../../../../shared/types/pty-host.js";
+
+const { broadcastToRenderer, broadcastToProjectRenderers } = vi.hoisted(() => ({
+  broadcastToRenderer: vi.fn(),
+  broadcastToProjectRenderers: vi.fn(),
+}));
+
+vi.mock("../../../utils.js", () => ({ broadcastToRenderer, broadcastToProjectRenderers }));
+vi.mock("../../../../services/McpPaneConfigService.js", () => ({
+  mcpPaneConfigService: { revokePaneConfig: vi.fn().mockResolvedValue(undefined) },
+}));
+vi.mock("../../../../services/pty/agentSessionJournal.js", () => ({
+  journalAgentSession: vi.fn(),
+}));
+// The real bus's `on()` returns an unsubscribe function, which the handler
+// pushes straight onto its cleanup list — a bare EventEmitter returns itself
+// and the teardown then throws.
+vi.mock("../../../../services/events.js", () => ({
+  events: { on: vi.fn(() => vi.fn()), emit: vi.fn() },
+}));
+
+import { CHANNELS } from "../../../channels.js";
+import { registerTerminalEventHandlers } from "../events.js";
+import type { HandlerDependencies } from "../../../types.js";
+
+function makeResult(overrides: Partial<TerminalResizeResult> = {}): TerminalResizeResult {
+  return {
+    launchGeneration: 3,
+    requestedCols: 120,
+    requestedRows: 40,
+    appliedCols: 120,
+    appliedRows: 40,
+    outcome: "applied",
+    ...overrides,
+  };
+}
+
+describe("terminal event handlers — resize-result forwarding (#11641)", () => {
+  let ptyClient: EventEmitter;
+  let dispose: () => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ptyClient = new EventEmitter();
+    dispose = registerTerminalEventHandlers({
+      ptyClient,
+    } as unknown as HandlerDependencies);
+  });
+
+  afterEach(() => {
+    dispose();
+  });
+
+  function resizeEnvelopes() {
+    return broadcastToRenderer.mock.calls.filter(
+      (call) => call[0] === CHANNELS.EVENTS_PUSH && call[1]?.name === "terminal:resize-result"
+    );
+  }
+
+  it("forwards a resize result as an events-push envelope carrying id and result", () => {
+    const result = makeResult();
+
+    ptyClient.emit("resize-result", "t1", result);
+
+    const envelopes = resizeEnvelopes();
+    expect(envelopes).toHaveLength(1);
+    // The payload is a tuple the preload destructures as `([id, result])` —
+    // an object payload here would silently deliver `undefined` to callers.
+    expect(envelopes[0]?.[1]).toEqual({
+      name: "terminal:resize-result",
+      payload: ["t1", result],
+    });
+  });
+
+  it("forwards a result with no confirmed geometry without inventing one", () => {
+    ptyClient.emit(
+      "resize-result",
+      "t1",
+      makeResult({ outcome: "deferred", appliedCols: null, appliedRows: null })
+    );
+
+    const payload = resizeEnvelopes()[0]?.[1]?.payload as [string, TerminalResizeResult];
+    expect(payload[1].appliedCols).toBeNull();
+    expect(payload[1].appliedRows).toBeNull();
+  });
+
+  it("stops forwarding once the handlers are disposed", () => {
+    dispose();
+
+    ptyClient.emit("resize-result", "t1", makeResult());
+
+    expect(resizeEnvelopes()).toHaveLength(0);
+    expect(ptyClient.listenerCount("resize-result")).toBe(0);
+  });
+});

--- a/electron/ipc/handlers/terminal/__tests__/events.resizeResult.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/events.resizeResult.test.ts
@@ -38,12 +38,14 @@ function makeResult(overrides: Partial<TerminalResizeResult> = {}): TerminalResi
 }
 
 describe("terminal event handlers — resize-result forwarding (#11641)", () => {
-  let ptyClient: EventEmitter;
+  let ptyClient: EventEmitter & { getTerminalProjectId: ReturnType<typeof vi.fn> };
   let dispose: () => void;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    ptyClient = new EventEmitter();
+    ptyClient = Object.assign(new EventEmitter(), {
+      getTerminalProjectId: vi.fn((id: string) => `project-for-${id}`),
+    });
     dispose = registerTerminalEventHandlers({
       ptyClient,
     } as unknown as HandlerDependencies);
@@ -54,8 +56,8 @@ describe("terminal event handlers — resize-result forwarding (#11641)", () => 
   });
 
   function resizeEnvelopes() {
-    return broadcastToRenderer.mock.calls.filter(
-      (call) => call[0] === CHANNELS.EVENTS_PUSH && call[1]?.name === "terminal:resize-result"
+    return broadcastToProjectRenderers.mock.calls.filter(
+      (call) => call[1] === CHANNELS.EVENTS_PUSH && call[2]?.name === "terminal:resize-result"
     );
   }
 
@@ -68,10 +70,30 @@ describe("terminal event handlers — resize-result forwarding (#11641)", () => 
     expect(envelopes).toHaveLength(1);
     // The payload is a tuple the preload destructures as `([id, result])` —
     // an object payload here would silently deliver `undefined` to callers.
-    expect(envelopes[0]?.[1]).toEqual({
+    expect(envelopes[0]?.[2]).toEqual({
       name: "terminal:resize-result",
       payload: ["t1", result],
     });
+  });
+
+  it("scopes the echo to the owning project instead of fanning out to every view", () => {
+    ptyClient.emit("resize-result", "t1", makeResult());
+
+    expect(ptyClient.getTerminalProjectId).toHaveBeenCalledWith("t1");
+    expect(resizeEnvelopes()[0]?.[0]).toBe("project-for-t1");
+    // Every non-owning view drops the echo in `recordPtyResizeResult` anyway, so
+    // a global broadcast would be a structured clone + IPC task per unrelated view.
+    expect(
+      broadcastToRenderer.mock.calls.some((call) => call[1]?.name === "terminal:resize-result")
+    ).toBe(false);
+  });
+
+  it("passes an unknown project through so the util can fall back to a full broadcast", () => {
+    ptyClient.getTerminalProjectId.mockReturnValue(null);
+
+    ptyClient.emit("resize-result", "t1", makeResult());
+
+    expect(resizeEnvelopes()[0]?.[0]).toBeNull();
   });
 
   it("forwards a result with no confirmed geometry without inventing one", () => {
@@ -81,7 +103,7 @@ describe("terminal event handlers — resize-result forwarding (#11641)", () => 
       makeResult({ outcome: "deferred", appliedCols: null, appliedRows: null })
     );
 
-    const payload = resizeEnvelopes()[0]?.[1]?.payload as [string, TerminalResizeResult];
+    const payload = resizeEnvelopes()[0]?.[2]?.payload as [string, TerminalResizeResult];
     expect(payload[1].appliedCols).toBeNull();
     expect(payload[1].appliedRows).toBeNull();
   });

--- a/electron/ipc/handlers/terminal/events.ts
+++ b/electron/ipc/handlers/terminal/events.ts
@@ -9,6 +9,7 @@ import { mcpPaneConfigService } from "../../../services/McpPaneConfigService.js"
 import { journalAgentSession } from "../../../services/pty/agentSessionJournal.js";
 import type {
   SpawnResult,
+  TerminalResizeResult,
   BroadcastWriteResultPayload,
   FdLeakWarningPayload,
 } from "../../../../shared/types/pty-host.js";
@@ -67,6 +68,18 @@ export function registerTerminalEventHandlers(deps: HandlerDependencies): () => 
   };
   ptyClient.on("spawn-result", handleSpawnResult);
   handlers.push(() => ptyClient.off("spawn-result", handleSpawnResult));
+
+  // Geometry the PTY actually holds after a resize. The renderer compares it
+  // against its own xterm grid to detect a split the two sides cannot otherwise
+  // see (#11641). Already generation-filtered by the router.
+  const handleResizeResult = (id: string, result: TerminalResizeResult) => {
+    broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
+      name: "terminal:resize-result",
+      payload: [id, result],
+    });
+  };
+  ptyClient.on("resize-result", handleResizeResult);
+  handlers.push(() => ptyClient.off("resize-result", handleResizeResult));
 
   // Terminal status for flow control visibility. Per-terminal pulses are
   // inherently project-scoped — only views of the owning project host panels

--- a/electron/ipc/handlers/terminal/events.ts
+++ b/electron/ipc/handlers/terminal/events.ts
@@ -71,9 +71,12 @@ export function registerTerminalEventHandlers(deps: HandlerDependencies): () => 
 
   // Geometry the PTY actually holds after a resize. The renderer compares it
   // against its own xterm grid to detect a split the two sides cannot otherwise
-  // see (#11641). Already generation-filtered by the router.
+  // see (#11641). Already generation-filtered by the router. Project-scoped for
+  // the same reason as `terminal:status` below — only views of the owning
+  // project host panels for the terminal, and every other view drops the echo
+  // in `recordPtyResizeResult` after paying for the clone.
   const handleResizeResult = (id: string, result: TerminalResizeResult) => {
-    broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
+    broadcastToProjectRenderers(ptyClient.getTerminalProjectId(id), CHANNELS.EVENTS_PUSH, {
       name: "terminal:resize-result",
       payload: [id, result],
     });

--- a/electron/ipc/handlers/terminal/io.ts
+++ b/electron/ipc/handlers/terminal/io.ts
@@ -13,6 +13,7 @@ import {
 import type { TerminalResizePayload } from "../../../types/index.js";
 import { TerminalResizePayloadSchema } from "../../../schemas/ipc.js";
 import type { PtyHostActivityTier } from "../../../../shared/types/pty-host.js";
+import { normalizeTerminalGridDimension } from "../../../../shared/types/terminal.js";
 import { normalizeObservedTitle } from "../../../../shared/utils/isUselessTitle.js";
 import { defineIpcNamespace, op } from "../../define.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
@@ -153,10 +154,15 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
       }
 
       const { id, cols, rows } = parseResult.data;
-      const clampedCols = Math.max(1, Math.min(500, Math.floor(cols)));
-      const clampedRows = Math.max(1, Math.min(500, Math.floor(rows)));
-
-      ptyClient.resize(id, clampedCols, clampedRows);
+      // Defensive backstop at the shared ceiling. The renderer already
+      // normalized to the same bound before choosing a transport, so this
+      // agrees with what the MessagePort path (which bypasses Main entirely)
+      // delivers rather than imposing a second, lower limit.
+      ptyClient.resize(
+        id,
+        normalizeTerminalGridDimension(cols),
+        normalizeTerminalGridDimension(rows)
+      );
     } catch (error) {
       console.error("Error resizing terminal:", error);
     }

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -29,6 +29,7 @@ import type {
   AgentSessionRetentionDays,
 } from "../../../../shared/types/ipc/agentSessionHistory.js";
 import { resolveDaintreeMcpTier } from "../../../../shared/types/project.js";
+import { normalizeTerminalGridDimension } from "../../../../shared/types/terminal.js";
 import { DEFAULT_DANGEROUS_ARGS } from "../../../../shared/types/agentSettings.js";
 import {
   getAssistantWiredAgentIds,
@@ -195,8 +196,8 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       await waitForTerminalSpawnAdmission(validatedOptions);
     }
 
-    const cols = Math.max(1, Math.min(500, Math.floor(validatedOptions.cols) || 80));
-    const rows = Math.max(1, Math.min(500, Math.floor(validatedOptions.rows) || 30));
+    const cols = normalizeTerminalGridDimension(Math.floor(validatedOptions.cols) || 80);
+    const rows = normalizeTerminalGridDimension(Math.floor(validatedOptions.rows) || 30);
 
     const kind = "terminal";
     const launchAgentId = validatedOptions.launchAgentId;

--- a/electron/ipc/handlers/terminalLayout.ts
+++ b/electron/ipc/handlers/terminalLayout.ts
@@ -1,4 +1,5 @@
 import { projectStore } from "../../services/ProjectStore.js";
+import { isValidTerminalGeometry } from "../../../shared/types/terminal.js";
 import {
   TerminalSnapshotSchema,
   filterValidTerminalEntries,
@@ -76,7 +77,8 @@ export function sanitizeFieldEdits(value: unknown): IdArrayFieldEdit[] | undefin
 
 /**
  * Validate and sanitize terminal size records.
- * Entries with invalid dimensions (non-finite, non-integer, out of 1–500 range) are dropped.
+ * Entries whose geometry a terminal could not actually have been captured at
+ * are dropped.
  */
 export function sanitizeTerminalSizes(
   sizes: Record<string, unknown>
@@ -92,16 +94,7 @@ export function sanitizeTerminalSizes(
       typeof (size as { rows: unknown }).rows === "number"
     ) {
       const { cols, rows } = size as { cols: number; rows: number };
-      if (
-        Number.isFinite(cols) &&
-        Number.isFinite(rows) &&
-        Number.isInteger(cols) &&
-        Number.isInteger(rows) &&
-        cols > 0 &&
-        cols <= 500 &&
-        rows > 0 &&
-        rows <= 500
-      ) {
+      if (isValidTerminalGeometry({ cols, rows })) {
         sanitized[terminalId] = { cols, rows };
       }
     }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -148,6 +148,7 @@ import type {
   BroadcastWriteResultPayload,
   FdLeakWarningPayload,
   TerminalReliabilityMetricPayload,
+  TerminalResizeResult,
 } from "../shared/types/pty-host.js";
 
 type SpawnResultPayload = SpawnResult;
@@ -1286,6 +1287,11 @@ function buildElectronApi(): ElectronAPI {
       onReliabilityMetric: (
         callback: (data: TerminalReliabilityMetricPayload) => void
       ): (() => void) => _eventBusOn("terminal:reliability-metric", callback),
+
+      onResizeResult: (
+        callback: (id: string, result: TerminalResizeResult) => void
+      ): (() => void) =>
+        _eventBusOn("terminal:resize-result", ([id, result]) => callback(id, result)),
 
       onResourceMetrics: (
         callback: (data: { metrics: TerminalResourceBatchPayload; timestamp: number }) => void

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -1294,6 +1294,13 @@ ptyManager.on("error", (id: string, error: string) => {
   sendEvent({ type: "error", id, error });
 });
 
+ptyManager.on(
+  "resize-result",
+  (id: string, result: import("../shared/types/pty-host.js").TerminalResizeResult) => {
+    sendEvent({ type: "resize-result", id, result });
+  }
+);
+
 // Forward internal event bus events to Main
 events.on("agent:state-changed", (payload) => {
   // Only forward if terminalId is defined

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -5,6 +5,7 @@
 import { z } from "zod";
 import { BUILT_IN_PANEL_KINDS, panelKindHasPty } from "../../shared/config/panelKindRegistry.js";
 import { BUILT_IN_AGENT_IDS } from "../../shared/config/agentIds.js";
+import { MAX_TERMINAL_GRID_DIMENSION } from "../../shared/types/terminal.js";
 import {
   ASSISTANT_HOST_PROTOCOL_VERSION,
   type AssistantHostEvent,
@@ -338,8 +339,8 @@ export const TerminalSpawnOptionsSchema = z.object({
   projectId: z.string().optional(),
   cwd: z.string().optional(),
   shell: z.string().optional(),
-  cols: z.number().int().positive().max(500),
-  rows: z.number().int().positive().max(500),
+  cols: z.number().int().positive().max(MAX_TERMINAL_GRID_DIMENSION),
+  rows: z.number().int().positive().max(MAX_TERMINAL_GRID_DIMENSION),
   // `command` is interpolated raw into a shell startup script in
   // buildCommandLaunchShell — shell metacharacters are intentional (pipes,
   // redirects, env vars), but control characters are never legitimate and

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -552,6 +552,19 @@ export class PtyClient extends EventEmitter {
             ledger.recordClose(id, generation, `spawn-failed:${result.error?.code ?? "UNKNOWN"}`);
           }
         },
+        // Resize is a live-state op: only the current incarnation's geometry is
+        // meaningful. `recordResize` rejects anything but the current
+        // generation, so an echo that crossed the kill/respawn boundary is
+        // dropped here instead of overwriting the successor's applied dims.
+        acceptResizeResult: (id, result) => {
+          if (result.launchGeneration === null) return false;
+          return getLifecycleLedger().recordResize(
+            id,
+            result.launchGeneration,
+            result.requestedCols,
+            result.requestedRows
+          ).accepted;
+        },
       },
       logWarn: (message) => console.warn(message),
     };

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -556,14 +556,13 @@ export class PtyClient extends EventEmitter {
         // meaningful. `recordResize` rejects anything but the current
         // generation, so an echo that crossed the kill/respawn boundary is
         // dropped here instead of overwriting the successor's applied dims.
+        // `isCurrent` rather than `recordResize`: routing must not have a side
+        // effect. The echo now fires on every resize, and a burst after a
+        // kill/respawn would otherwise push one anomaly per rejected echo,
+        // evicting genuinely useful lifecycle anomalies from the bounded ring.
         acceptResizeResult: (id, result) => {
           if (result.launchGeneration === null) return false;
-          return getLifecycleLedger().recordResize(
-            id,
-            result.launchGeneration,
-            result.requestedCols,
-            result.requestedRows
-          ).accepted;
+          return getLifecycleLedger().isCurrent(id, result.launchGeneration);
         },
       },
       logWarn: (message) => console.warn(message),

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -37,7 +37,7 @@ import { ledgerFactsFromSpawnOptions } from "./pty/lifecycleLedger.js";
 import { AgentTerminalLifecycleLedger } from "../../shared/utils/agentLifecycleLedger.js";
 import { events } from "./events.js";
 import { getGitBranch } from "../utils/gitUtils.js";
-import type { GracefulKillResult } from "../../shared/types/pty-host.js";
+import type { GracefulKillResult, TerminalResizeResult } from "../../shared/types/pty-host.js";
 import type { SerializedTerminalSnapshot } from "../../shared/types/terminal.js";
 import { SCROLLBACK_MIN } from "../../shared/config/scrollback.js";
 import { shouldTrimAnalysisSession } from "../../shared/utils/workerGovernancePolicy.js";
@@ -528,15 +528,33 @@ export class PtyManager extends EventEmitter {
 
   /**
    * Resize terminal.
+   *
+   * Emits `resize-result` for every request that reached a live terminal so the
+   * renderer can compare the geometry the PTY actually holds against its own
+   * xterm grid (#11641). Both resize transports — the Main IPC handler and the
+   * renderer's direct MessagePort — funnel through here, so this is the one
+   * place that sees every resize.
+   *
+   * The buffering branch emits nothing: an unlaunched id has no generation to
+   * stamp, and the spawn that consumes the buffered dims reports them itself.
    */
   resize(id: string, cols: number, rows: number): void {
+    const terminal = this.registry.get(id);
     if (!Number.isFinite(cols) || !Number.isFinite(rows) || cols <= 0 || rows <= 0) {
       logWarn(`Terminal ${id} resize rejected: invalid dims ${cols}x${rows}`);
+      if (terminal) {
+        this.emitResizeResult(id, {
+          requestedCols: cols,
+          requestedRows: rows,
+          appliedCols: null,
+          appliedRows: null,
+          outcome: "rejected",
+        });
+      }
       return;
     }
-    const terminal = this.registry.get(id);
     if (terminal) {
-      terminal.resize(cols, rows);
+      this.emitResizeResult(id, terminal.resize(cols, rows));
     } else {
       // Buffer the dims and apply them at spawn time. Coalesces last-write-wins.
       // Stamp the current ledger generation (null = never launched) so a
@@ -549,6 +567,21 @@ export class PtyManager extends EventEmitter {
       });
       logDebug(`Terminal ${id} not yet registered, buffering resize ${cols}x${rows}`);
     }
+  }
+
+  /**
+   * Stamp a resize outcome with the incarnation that produced it. Main drops
+   * results whose generation is no longer current, so a late echo from a killed
+   * terminal can never be attributed to a same-id successor (#10950).
+   */
+  private emitResizeResult(
+    id: string,
+    result: Omit<TerminalResizeResult, "launchGeneration">
+  ): void {
+    this.emit("resize-result", id, {
+      ...result,
+      launchGeneration: this.lifecycleLedger.currentGeneration(id) ?? null,
+    } satisfies TerminalResizeResult);
   }
 
   /**

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -477,12 +477,18 @@ export class PtyManager extends EventEmitter {
       // very first grid came from the buffer — and if that geometry disagrees
       // with xterm, the divergence goes unseen until some later resize happens
       // to occur (#11641).
+      //
+      // Read back rather than echoing the request: claiming `applied` for
+      // dimensions nobody confirmed is the exact failure this echo exists to
+      // expose, and ConPTY can still be queueing the boot geometry here.
+      const applied = terminalProcess.readPtyGeometry();
+      const confirmed = applied.cols === options.cols && applied.rows === options.rows;
       this.emitResizeResult(id, {
         requestedCols: options.cols,
         requestedRows: options.rows,
-        appliedCols: options.cols,
-        appliedRows: options.rows,
-        outcome: "applied",
+        appliedCols: confirmed ? applied.cols : null,
+        appliedRows: confirmed ? applied.rows : null,
+        outcome: confirmed ? "applied" : "deferred",
       });
     }
   }

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -38,7 +38,10 @@ import { AgentTerminalLifecycleLedger } from "../../shared/utils/agentLifecycleL
 import { events } from "./events.js";
 import { getGitBranch } from "../utils/gitUtils.js";
 import type { GracefulKillResult, TerminalResizeResult } from "../../shared/types/pty-host.js";
-import type { SerializedTerminalSnapshot } from "../../shared/types/terminal.js";
+import {
+  isValidTerminalGeometry,
+  type SerializedTerminalSnapshot,
+} from "../../shared/types/terminal.js";
 import { SCROLLBACK_MIN } from "../../shared/config/scrollback.js";
 import { shouldTrimAnalysisSession } from "../../shared/utils/workerGovernancePolicy.js";
 
@@ -463,8 +466,25 @@ export class PtyManager extends EventEmitter {
       throw error;
     }
 
+    const consumedPendingResize = this.pendingResizes.has(id);
     this.pendingResizes.delete(id);
     this.registry.add(id, terminalProcess);
+
+    if (consumedPendingResize) {
+      // A resize that beat the spawn became this PTY's boot geometry without
+      // ever passing through `resize()`, so nothing has reported it. Without
+      // this the renderer holds no applied geometry at all for a terminal whose
+      // very first grid came from the buffer — and if that geometry disagrees
+      // with xterm, the divergence goes unseen until some later resize happens
+      // to occur (#11641).
+      this.emitResizeResult(id, {
+        requestedCols: options.cols,
+        requestedRows: options.rows,
+        appliedCols: options.cols,
+        appliedRows: options.rows,
+        outcome: "applied",
+      });
+    }
   }
 
   /**
@@ -535,12 +555,19 @@ export class PtyManager extends EventEmitter {
    * renderer's direct MessagePort — funnel through here, so this is the one
    * place that sees every resize.
    *
-   * The buffering branch emits nothing: an unlaunched id has no generation to
-   * stamp, and the spawn that consumes the buffered dims reports them itself.
+   * The buffering branch emits nothing here: an unlaunched id has no generation
+   * to stamp. `spawn()` emits the result when it consumes those buffered dims,
+   * once an incarnation exists to attribute them to.
+   *
+   * This is also the geometry trust boundary. The renderer's MessagePort talks
+   * to the host directly and its handler only checks `typeof number`, so bounds
+   * enforcement cannot live in the Main IPC handler alone — a fractional or
+   * absurd grid arriving there would otherwise be buffered as spawn dims,
+   * skipping `TerminalProcess.resize`'s own validation entirely.
    */
   resize(id: string, cols: number, rows: number): void {
     const terminal = this.registry.get(id);
-    if (!Number.isFinite(cols) || !Number.isFinite(rows) || cols <= 0 || rows <= 0) {
+    if (!isValidTerminalGeometry({ cols, rows })) {
       logWarn(`Terminal ${id} resize rejected: invalid dims ${cols}x${rows}`);
       if (terminal) {
         this.emitResizeResult(id, {

--- a/electron/services/__tests__/PtyClient.lifecycleLedger.test.ts
+++ b/electron/services/__tests__/PtyClient.lifecycleLedger.test.ts
@@ -326,4 +326,53 @@ describe("PtyClient lifecycle ledger", () => {
     });
     expect(getLifecycleLedger().getEntry("t1")?.spawnOk).toBe(true);
   });
+
+  describe("resize-result generation filtering (#11641)", () => {
+    function emitResizeResult(
+      client: import("../PtyClient.js").PtyClient,
+      launchGeneration: number | null
+    ): Array<[string, unknown]> {
+      const seen: Array<[string, unknown]> = [];
+      client.on("resize-result", (id: string, result: unknown) => seen.push([id, result]));
+      mockChild.emit("message", {
+        type: "resize-result",
+        id: "t1",
+        result: {
+          launchGeneration,
+          requestedCols: 120,
+          requestedRows: 40,
+          appliedCols: 120,
+          appliedRows: 40,
+          outcome: "applied",
+        },
+      });
+      return seen;
+    }
+
+    it("forwards a result stamped with the live incarnation", () => {
+      const client = createReadyClient();
+      client.spawn("t1", baseOptions);
+
+      expect(emitResizeResult(client, 1)).toHaveLength(1);
+    });
+
+    it("drops a result from an incarnation that was already replaced", () => {
+      const client = createReadyClient();
+      client.spawn("t1", baseOptions);
+      client.kill("t1");
+      client.spawn("t1", baseOptions);
+
+      // Generation 1's echo lands after the same id respawned. Applying it
+      // would report the dead PTY's geometry as the successor's.
+      expect(emitResizeResult(client, 1)).toHaveLength(0);
+      expect(emitResizeResult(client, 2)).toHaveLength(1);
+    });
+
+    it("drops a result that carries no incarnation at all", () => {
+      const client = createReadyClient();
+      client.spawn("t1", baseOptions);
+
+      expect(emitResizeResult(client, null)).toHaveLength(0);
+    });
+  });
 });

--- a/electron/services/__tests__/PtyManager.adversarial.test.ts
+++ b/electron/services/__tests__/PtyManager.adversarial.test.ts
@@ -77,6 +77,7 @@ class MockTerminalProcess {
       outcome: unchanged ? ("unchanged" as const) : ("applied" as const),
     };
   });
+  readPtyGeometry = vi.fn(() => ({ cols: this.info.cols, rows: this.info.rows }));
   setSabModeEnabled = vi.fn();
   setActivityMonitorTier = vi.fn();
   startProcessDetector = vi.fn();

--- a/electron/services/__tests__/PtyManager.adversarial.test.ts
+++ b/electron/services/__tests__/PtyManager.adversarial.test.ts
@@ -66,8 +66,16 @@ class MockTerminalProcess {
     this.info.wasKilled = true;
   });
   resize = vi.fn((cols: number, rows: number) => {
+    const unchanged = this.info.cols === cols && this.info.rows === rows;
     this.info.cols = cols;
     this.info.rows = rows;
+    return {
+      requestedCols: cols,
+      requestedRows: rows,
+      appliedCols: cols,
+      appliedRows: rows,
+      outcome: unchanged ? ("unchanged" as const) : ("applied" as const),
+    };
   });
   setSabModeEnabled = vi.fn();
   setActivityMonitorTier = vi.fn();

--- a/electron/services/__tests__/PtyManager.lifecycleLedger.test.ts
+++ b/electron/services/__tests__/PtyManager.lifecycleLedger.test.ts
@@ -54,8 +54,16 @@ class MockTerminalProcess {
     this.info.wasKilled = true;
   });
   resize = vi.fn((cols: number, rows: number) => {
+    const unchanged = this.info.cols === cols && this.info.rows === rows;
     this.info.cols = cols;
     this.info.rows = rows;
+    return {
+      requestedCols: cols,
+      requestedRows: rows,
+      appliedCols: cols,
+      appliedRows: rows,
+      outcome: unchanged ? ("unchanged" as const) : ("applied" as const),
+    };
   });
   setSabModeEnabled = vi.fn();
   dispose = vi.fn();
@@ -242,6 +250,40 @@ describe("PtyManager lifecycle ledger", () => {
 
     expect(shared.created[0]?.options.cols).toBe(132);
     expect(shared.created[0]?.options.rows).toBe(43);
+  });
+
+  it("stamps a resize result with the incarnation that applied it (#11641)", () => {
+    const manager = new PtyManager();
+    const results: Array<{ id: string; launchGeneration: number | null }> = [];
+    manager.on("resize-result", (id: string, result: { launchGeneration: number | null }) => {
+      results.push({ id, launchGeneration: result.launchGeneration });
+    });
+
+    manager.spawn("t1", spawnOptions({ launchGeneration: 1 }));
+    manager.resize("t1", 120, 40);
+    manager.kill("t1");
+    shared.created[0]!.callbacks.onExit("t1", 0);
+    manager.spawn("t1", spawnOptions({ launchGeneration: 2 }));
+    manager.resize("t1", 130, 45);
+
+    // Main filters stale echoes by generation, so a result that reports the
+    // wrong incarnation would be attributed to the successor.
+    expect(results).toEqual([
+      { id: "t1", launchGeneration: 1 },
+      { id: "t1", launchGeneration: 2 },
+    ]);
+  });
+
+  it("emits no resize result while the terminal is only buffered (#11641)", () => {
+    const manager = new PtyManager();
+    const results: unknown[] = [];
+    manager.on("resize-result", (...args: unknown[]) => results.push(args));
+
+    // Nothing has launched, so there is no incarnation to attribute geometry
+    // to — the spawn that consumes these dims reports them itself.
+    manager.resize("t1", 132, 43);
+
+    expect(results).toEqual([]);
   });
 
   it("drops a buffered resize stamped by a previous incarnation", () => {

--- a/electron/services/__tests__/PtyManager.lifecycleLedger.test.ts
+++ b/electron/services/__tests__/PtyManager.lifecycleLedger.test.ts
@@ -5,6 +5,10 @@ import type { PtyHostSpawnOptions } from "../../../shared/types/pty-host.js";
 const shared = vi.hoisted(() => ({
   terminals: new Map<string, MockTerminalProcess>(),
   created: [] as MockTerminalProcess[],
+  // Geometry the fake node-pty reports back, when it must differ from the dims
+  // it was asked for (ConPTY queues a pre-ready resize and keeps reporting the
+  // old grid). `null` = the PTY holds exactly what it was spawned with.
+  ptyGeometryOverride: null as { cols: number | null; rows: number | null } | null,
   trashCallbacks: new Map<string, (id: string) => void>(),
   eventsEmit: vi.fn(),
   computeSpawnContext: vi.fn(),
@@ -65,6 +69,10 @@ class MockTerminalProcess {
       outcome: unchanged ? ("unchanged" as const) : ("applied" as const),
     };
   });
+  readPtyGeometry = vi.fn(
+    (): { cols: number | null; rows: number | null } =>
+      shared.ptyGeometryOverride ?? { cols: this.info.cols, rows: this.info.rows }
+  );
   setSabModeEnabled = vi.fn();
   dispose = vi.fn();
   getActivityTier = vi.fn(() => "active" as const);
@@ -226,6 +234,7 @@ describe("PtyManager lifecycle ledger", () => {
     shared.terminals.clear();
     shared.created.length = 0;
     shared.trashCallbacks.clear();
+    shared.ptyGeometryOverride = null;
     shared.computeSpawnContext.mockReturnValue({
       env: {},
       shell: "/bin/zsh",
@@ -298,6 +307,29 @@ describe("PtyManager lifecycle ledger", () => {
     // buffer, so a divergence at boot would go unseen.
     manager.spawn("t1", spawnOptions({ launchGeneration: 1 }));
     expect(results).toEqual([{ launchGeneration: 1, appliedCols: 132 }]);
+  });
+
+  it("reads the boot geometry back instead of echoing the request (#11641)", () => {
+    const manager = new PtyManager();
+    const results: unknown[] = [];
+    manager.on("resize-result", (_id: string, result: unknown) => results.push(result));
+
+    // The backend queued the boot geometry and still reports the old grid.
+    // Claiming `applied` here would manufacture agreement with xterm and hide
+    // the very split the echo exists to expose.
+    shared.ptyGeometryOverride = { cols: 80, rows: 24 };
+    manager.resize("t1", 132, 43);
+    manager.spawn("t1", spawnOptions({ launchGeneration: 1 }));
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        outcome: "deferred",
+        requestedCols: 132,
+        requestedRows: 43,
+        appliedCols: null,
+        appliedRows: null,
+      }),
+    ]);
   });
 
   it("emits no echo for a spawn that did not consume a buffered resize (#11641)", () => {

--- a/electron/services/__tests__/PtyManager.lifecycleLedger.test.ts
+++ b/electron/services/__tests__/PtyManager.lifecycleLedger.test.ts
@@ -274,16 +274,62 @@ describe("PtyManager lifecycle ledger", () => {
     ]);
   });
 
-  it("emits no resize result while the terminal is only buffered (#11641)", () => {
+  it("defers a buffered resize's echo until spawn gives it an incarnation (#11641)", () => {
+    const manager = new PtyManager();
+    const results: Array<{ launchGeneration: number | null; appliedCols: number | null }> = [];
+    manager.on(
+      "resize-result",
+      (_id: string, result: { launchGeneration: number | null; appliedCols: number | null }) => {
+        results.push({
+          launchGeneration: result.launchGeneration,
+          appliedCols: result.appliedCols,
+        });
+      }
+    );
+
+    // Nothing has launched yet, so there is no incarnation to attribute the
+    // geometry to.
+    manager.resize("t1", 132, 43);
+    expect(results).toEqual([]);
+
+    // These buffered dims BECOME the PTY's boot geometry without passing
+    // through resize(). Staying silent here would leave the renderer with no
+    // applied geometry at all for a terminal whose first grid came from the
+    // buffer, so a divergence at boot would go unseen.
+    manager.spawn("t1", spawnOptions({ launchGeneration: 1 }));
+    expect(results).toEqual([{ launchGeneration: 1, appliedCols: 132 }]);
+  });
+
+  it("emits no echo for a spawn that did not consume a buffered resize (#11641)", () => {
     const manager = new PtyManager();
     const results: unknown[] = [];
     manager.on("resize-result", (...args: unknown[]) => results.push(args));
 
-    // Nothing has launched, so there is no incarnation to attribute geometry
-    // to — the spawn that consumes these dims reports them itself.
-    manager.resize("t1", 132, 43);
+    manager.spawn("t1", spawnOptions({ launchGeneration: 1 }));
 
     expect(results).toEqual([]);
+  });
+
+  it("forwards the outcome and applied geometry, not just the generation (#11641)", () => {
+    const manager = new PtyManager();
+    const results: unknown[] = [];
+    manager.on("resize-result", (_id: string, result: unknown) => results.push(result));
+
+    manager.spawn("t1", spawnOptions({ launchGeneration: 1 }));
+    manager.resize("t1", 120, 40);
+    // Re-asserting the geometry the PTY already holds must still report it —
+    // the dedup shortcut emits no SIGWINCH, so silence here is what would let a
+    // stuck PTY go undetected.
+    manager.resize("t1", 120, 40);
+    // Out of range at the trust boundary: the direct MessagePort transport
+    // reaches this method without passing through any other validation.
+    manager.resize("t1", 40.5, 10);
+
+    expect(results).toEqual([
+      expect.objectContaining({ outcome: "applied", appliedCols: 120, requestedCols: 120 }),
+      expect.objectContaining({ outcome: "unchanged", appliedCols: 120 }),
+      expect.objectContaining({ outcome: "rejected", appliedCols: null, requestedCols: 40.5 }),
+    ]);
   });
 
   it("drops a buffered resize stamped by a previous incarnation", () => {

--- a/electron/services/pty/PtyEventRouter.ts
+++ b/electron/services/pty/PtyEventRouter.ts
@@ -26,6 +26,7 @@ import type {
   PtyHostEvent,
   PtyHostSpawnOptions,
   SpawnResult,
+  TerminalResizeResult,
   TerminalResourceBatchPayload,
   TerminalStatusPayload,
 } from "../../../shared/types/pty-host.js";
@@ -77,6 +78,14 @@ export interface PtyEventRouterCallbacks {
    * effect.
    */
   onSpawnResult?: (id: string, result: SpawnResult) => void;
+  /**
+   * Optional gate for `resize-result`. Returns false when the echo belongs to a
+   * superseded incarnation of `id`, so a resize completing after a kill/respawn
+   * never reports a dead PTY's geometry as the successor's (#10950). PtyClient
+   * implements it against the lifecycle ledger; when unwired the router forwards
+   * every result.
+   */
+  acceptResizeResult?: (id: string, result: TerminalResizeResult) => boolean;
 }
 
 export interface PtyEventRouterDeps {
@@ -320,6 +329,23 @@ export function routeHostEvent(event: PtyHostEvent, deps: PtyEventRouterDeps): b
         }
       }
       emitter.emit("spawn-result", spawnResultEvent.id, spawnResultEvent.result);
+      return true;
+    }
+
+    case "resize-result": {
+      const resizeEvent: { id: string; result: TerminalResizeResult } = event;
+      if (callbacks.acceptResizeResult) {
+        let accepted = false;
+        try {
+          accepted = callbacks.acceptResizeResult(resizeEvent.id, resizeEvent.result);
+        } catch (err) {
+          deps.logWarn(
+            `[PtyClient] acceptResizeResult threw for ${resizeEvent.id}: ${String(err)}`
+          );
+        }
+        if (!accepted) return true;
+      }
+      emitter.emit("resize-result", resizeEvent.id, resizeEvent.result);
       return true;
     }
 

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1116,6 +1116,22 @@ export class TerminalProcess {
   }
 
   /**
+   * Geometry node-pty holds right now, without touching it. Lets a caller that
+   * sized the PTY outside {@link resize} — spawn adopting a buffered resize as
+   * its boot geometry — report the same read-back rather than echoing back the
+   * dimensions it asked for (#11641). A dimension reads `null` when the getter
+   * throws or reports nonsense.
+   */
+  readPtyGeometry(): { cols: number | null; rows: number | null } {
+    const terminal = this.terminalInfo;
+    if (terminal.isExited) return { cols: null, rows: null };
+    return {
+      cols: readPtyDimension(() => terminal.ptyProcess.cols, null),
+      rows: readPtyDimension(() => terminal.ptyProcess.rows, null),
+    };
+  }
+
+  /**
    * Apply a resize and report what the PTY ended up holding. Every path returns
    * a result — including the no-op shortcut and the throwing path — because the
    * caller cannot otherwise distinguish "the PTY is at the geometry you asked

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -130,10 +130,11 @@ export interface TerminalProcessDependencies {
 }
 
 /**
- * Read one dimension node-pty holds, falling back to `fallback` if the getter
- * throws (the pty can be torn down between the resize and the read-back).
+ * Read one dimension node-pty holds. Returns null when the getter throws or
+ * reports nonsense (the pty can be torn down between the resize and the
+ * read-back) — an unknown geometry must never be reported as a known one.
  */
-function readPtyDimension(read: () => number, fallback: number): number {
+function readPtyDimension(read: () => number, fallback: number | null): number | null {
   try {
     const value = read();
     return Number.isFinite(value) ? value : fallback;
@@ -1193,8 +1194,16 @@ export class TerminalProcess {
 
     // Read back before the analysis resize: a throw from analysis must not
     // relabel a PTY resize that genuinely landed.
-    const appliedCols = readPtyDimension(() => terminal.ptyProcess.cols, cols);
-    const appliedRows = readPtyDimension(() => terminal.ptyProcess.rows, rows);
+    const appliedCols = readPtyDimension(() => terminal.ptyProcess.cols, null);
+    const appliedRows = readPtyDimension(() => terminal.ptyProcess.rows, null);
+    // node-pty's Windows backend QUEUES resize until ConPTY signals ready and
+    // only updates its cached dims inside that deferred callback, so a
+    // pre-ready resize leaves the getters reporting the OLD grid. Reporting
+    // that as `applied` would be a lie in the dangerous direction: the watchdog
+    // would compare a stale geometry against xterm, see agreement, and miss the
+    // split once the queued resize finally lands. Confirm the read-back matches
+    // what we asked for; when it doesn't, say we don't know rather than guess.
+    const confirmed = appliedCols === cols && appliedRows === rows;
 
     try {
       this.analysis.resize(cols, rows);
@@ -1208,9 +1217,9 @@ export class TerminalProcess {
     return {
       requestedCols: cols,
       requestedRows: rows,
-      appliedCols,
-      appliedRows,
-      outcome: "applied",
+      appliedCols: confirmed ? appliedCols : null,
+      appliedRows: confirmed ? appliedRows : null,
+      outcome: confirmed ? "applied" : "deferred",
     };
   }
 

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -8,8 +8,10 @@ import serialize, { type SerializeAddon as SerializeAddonType } from "@xterm/add
 const { SerializeAddon } = serialize;
 import unicode11 from "@xterm/addon-unicode11";
 const { Unicode11Addon } = unicode11;
+import type { TerminalResizeResult } from "../../../shared/types/pty-host.js";
 import { getEffectiveAgentConfig } from "../../../shared/config/agentRegistry.js";
 import { applyXtermReflowFastpath } from "../../../shared/utils/xtermReflowFastpath.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import { ProcessDetector, type DetectionResult } from "../ProcessDetector.js";
 import type { ProcessTreeCache } from "../ProcessTreeCache.js";
 import type { ImagePathProbe } from "./ImagePathProbe.js";
@@ -125,6 +127,19 @@ export interface TerminalProcessDependencies {
    * legacy in-thread path (the DAINTREE_DISABLE_ANALYSIS_WORKERS fallback).
    */
   analysisWorkerPool?: AnalysisWorkerPool | null;
+}
+
+/**
+ * Read one dimension node-pty holds, falling back to `fallback` if the getter
+ * throws (the pty can be torn down between the resize and the read-back).
+ */
+function readPtyDimension(read: () => number, fallback: number): number {
+  try {
+    const value = read();
+    return Number.isFinite(value) ? value : fallback;
+  } catch {
+    return fallback;
+  }
 }
 
 export class TerminalProcess {
@@ -1099,7 +1114,13 @@ export class TerminalProcess {
     await this.inputController.performSubmit(text);
   }
 
-  resize(cols: number, rows: number): void {
+  /**
+   * Apply a resize and report what the PTY ended up holding. Every path returns
+   * a result — including the no-op shortcut and the throwing path — because the
+   * caller cannot otherwise distinguish "the PTY is at the geometry you asked
+   * for" from "the PTY never moved" (#11641).
+   */
+  resize(cols: number, rows: number): Omit<TerminalResizeResult, "launchGeneration"> {
     if (
       !Number.isFinite(cols) ||
       !Number.isFinite(rows) ||
@@ -1109,7 +1130,13 @@ export class TerminalProcess {
       rows !== Math.floor(rows)
     ) {
       console.warn(`Invalid terminal dimensions for ${this.id}: ${cols}x${rows}`);
-      return;
+      return {
+        requestedCols: cols,
+        requestedRows: rows,
+        appliedCols: null,
+        appliedRows: null,
+        outcome: "rejected",
+      };
     }
 
     const terminal = this.terminalInfo;
@@ -1124,18 +1151,52 @@ export class TerminalProcess {
       } catch (error) {
         console.error(`Failed to resize terminal ${this.id}:`, error);
       }
-      return;
+      return {
+        requestedCols: cols,
+        requestedRows: rows,
+        appliedCols: null,
+        appliedRows: null,
+        outcome: "exited",
+      };
     }
+
+    let currentCols: number | null = null;
+    let currentRows: number | null = null;
     try {
-      const currentCols = terminal.ptyProcess.cols;
-      const currentRows = terminal.ptyProcess.rows;
+      currentCols = terminal.ptyProcess.cols;
+      currentRows = terminal.ptyProcess.rows;
 
       if (currentCols === cols && currentRows === rows) {
-        return;
+        return {
+          requestedCols: cols,
+          requestedRows: rows,
+          appliedCols: currentCols,
+          appliedRows: currentRows,
+          outcome: "unchanged",
+        };
       }
 
       terminal.ptyProcess.resize(cols, rows);
+    } catch (error) {
+      // A throw here means the PTY did NOT move — report the geometry it still
+      // holds so the renderer sees the real split rather than the request.
+      console.error(`Failed to resize terminal ${this.id}:`, error);
+      return {
+        requestedCols: cols,
+        requestedRows: rows,
+        appliedCols: currentCols,
+        appliedRows: currentRows,
+        outcome: "failed",
+        error: formatErrorMessage(error, "pty resize failed"),
+      };
+    }
 
+    // Read back before the analysis resize: a throw from analysis must not
+    // relabel a PTY resize that genuinely landed.
+    const appliedCols = readPtyDimension(() => terminal.ptyProcess.cols, cols);
+    const appliedRows = readPtyDimension(() => terminal.ptyProcess.rows, rows);
+
+    try {
       this.analysis.resize(cols, rows);
       if (this.analysis.kind === "worker") {
         terminal.contentEpoch++;
@@ -1143,6 +1204,14 @@ export class TerminalProcess {
     } catch (error) {
       console.error(`Failed to resize terminal ${this.id}:`, error);
     }
+
+    return {
+      requestedCols: cols,
+      requestedRows: rows,
+      appliedCols,
+      appliedRows,
+      outcome: "applied",
+    };
   }
 
   gracefulShutdown(): Promise<string | null> {

--- a/electron/services/pty/__tests__/TerminalProcess.lifecycle.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.lifecycle.test.ts
@@ -1203,22 +1203,61 @@ describe("TerminalProcess — resize result echo (#11641)", () => {
     return { pty, resizeSpy };
   }
 
-  it("reports the geometry the pty ended up holding, not the geometry requested", () => {
-    // The pty accepts a narrower grid than asked for. Echoing the request would
-    // hide exactly the split the caller needs to see.
-    const { pty } = createResizablePty(80, 24, (cols, rows) => ({
-      cols: Math.min(cols, 550),
-      rows,
-    }));
+  it("reports the geometry the pty holds once it adopts the request", () => {
+    const { pty } = createResizablePty(80, 24);
     const terminal = createTerminal(pty, undefined, undefined, "t-resize-applied");
     try {
       const result = terminal.resize(700, 40);
 
       expect(result.outcome).toBe("applied");
-      expect(result.requestedCols).toBe(700);
-      expect(result.appliedCols).toBe(550);
-      expect(result.appliedCols).not.toBe(result.requestedCols);
+      expect(result.appliedCols).toBe(700);
       expect(result.appliedRows).toBe(40);
+    } finally {
+      terminal.dispose();
+    }
+  });
+
+  it("reports no geometry when the backend has not adopted the resize yet", () => {
+    // node-pty on Windows QUEUES resize until ConPTY is ready and updates its
+    // cached dims only inside that deferred callback, so the getters still
+    // report the pre-resize grid. Claiming the OLD grid as applied is the
+    // dangerous answer: the watchdog would compare it against xterm, see
+    // agreement, and miss the split once the queued resize lands.
+    const { pty, resizeSpy } = createResizablePty(80, 24, (_cols, _rows) => ({
+      cols: 80,
+      rows: 24,
+    }));
+    const terminal = createTerminal(pty, undefined, undefined, "t-resize-deferred");
+    try {
+      const result = terminal.resize(700, 40);
+
+      expect(resizeSpy).toHaveBeenCalledWith(700, 40);
+      expect(result.outcome).toBe("deferred");
+      // Neither the request nor the stale grid — the geometry is unknown.
+      expect(result.appliedCols).toBeNull();
+      expect(result.appliedRows).toBeNull();
+    } finally {
+      terminal.dispose();
+    }
+  });
+
+  it("reports no geometry when the dimensions cannot be read at all", () => {
+    const { pty } = createResizablePty(80, 24);
+    const terminal = createTerminal(pty, undefined, undefined, "t-resize-getter-throws");
+    try {
+      Object.defineProperty(pty, "cols", {
+        get: (): number => {
+          throw new Error("pty destroyed");
+        },
+        configurable: true,
+      });
+
+      const result = terminal.resize(120, 40);
+
+      // An unreadable grid must never fall back to the request — that would
+      // manufacture agreement with xterm out of a measurement failure.
+      expect(result.appliedCols).toBeNull();
+      expect(result.appliedCols).not.toBe(result.requestedCols);
     } finally {
       terminal.dispose();
     }

--- a/electron/services/pty/__tests__/TerminalProcess.lifecycle.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.lifecycle.test.ts
@@ -1172,3 +1172,124 @@ describe("TerminalProcess — agent startup instrumentation (Issue #7616)", () =
     }
   });
 });
+
+describe("TerminalProcess — resize result echo (#11641)", () => {
+  /**
+   * A pty whose `cols`/`rows` track what `resize()` accepted, and which can
+   * accept something other than what it was asked for. Real node-pty reports
+   * its own cached view rather than a kernel read-back, so the distinction the
+   * echo has to preserve is "what the pty ended up holding" vs "what we asked
+   * for" — a fake that always stores the argument can't tell those apart.
+   */
+  function createResizablePty(
+    initialCols: number,
+    initialRows: number,
+    accept: (cols: number, rows: number) => { cols: number; rows: number } = (cols, rows) => ({
+      cols,
+      rows,
+    })
+  ) {
+    const pty = createControllablePty();
+    let currentCols = initialCols;
+    let currentRows = initialRows;
+    Object.defineProperty(pty, "cols", { get: () => currentCols, configurable: true });
+    Object.defineProperty(pty, "rows", { get: () => currentRows, configurable: true });
+    const resizeSpy = vi.fn<(cols: number, rows: number) => void>((cols, rows) => {
+      const accepted = accept(cols, rows);
+      currentCols = accepted.cols;
+      currentRows = accepted.rows;
+    });
+    pty.resize = resizeSpy;
+    return { pty, resizeSpy };
+  }
+
+  it("reports the geometry the pty ended up holding, not the geometry requested", () => {
+    // The pty accepts a narrower grid than asked for. Echoing the request would
+    // hide exactly the split the caller needs to see.
+    const { pty } = createResizablePty(80, 24, (cols, rows) => ({
+      cols: Math.min(cols, 550),
+      rows,
+    }));
+    const terminal = createTerminal(pty, undefined, undefined, "t-resize-applied");
+    try {
+      const result = terminal.resize(700, 40);
+
+      expect(result.outcome).toBe("applied");
+      expect(result.requestedCols).toBe(700);
+      expect(result.appliedCols).toBe(550);
+      expect(result.appliedCols).not.toBe(result.requestedCols);
+      expect(result.appliedRows).toBe(40);
+    } finally {
+      terminal.dispose();
+    }
+  });
+
+  it("still reports the pty's geometry when the request is a no-op", () => {
+    // The dedup shortcut skips ptyProcess.resize (and therefore SIGWINCH). A
+    // caller that learns nothing here cannot distinguish "the pty is where you
+    // asked" from "the pty never moved", which is the split this echo exists
+    // to surface.
+    const { pty, resizeSpy } = createResizablePty(120, 30);
+    const terminal = createTerminal(pty, undefined, undefined, "t-resize-noop");
+    try {
+      const result = terminal.resize(120, 30);
+
+      expect(result.outcome).toBe("unchanged");
+      expect(result.appliedCols).toBe(120);
+      expect(result.appliedRows).toBe(30);
+      expect(resizeSpy).not.toHaveBeenCalled();
+    } finally {
+      terminal.dispose();
+    }
+  });
+
+  it("reports the pre-existing geometry when the pty rejects the resize", () => {
+    const { pty } = createResizablePty(100, 30);
+    pty.resize = () => {
+      throw new Error("ioctl failed");
+    };
+    const terminal = createTerminal(pty, undefined, undefined, "t-resize-throw");
+    try {
+      const result = terminal.resize(200, 50);
+
+      expect(result.outcome).toBe("failed");
+      expect(result.error).toContain("ioctl failed");
+      // The grid did NOT move — reporting the request here would claim a
+      // resize that never happened.
+      expect(result.appliedCols).toBe(100);
+      expect(result.appliedRows).toBe(30);
+    } finally {
+      terminal.dispose();
+    }
+  });
+
+  it("rejects non-integral geometry without touching the pty", () => {
+    const { pty, resizeSpy } = createResizablePty(80, 24);
+    const terminal = createTerminal(pty, undefined, undefined, "t-resize-invalid");
+    try {
+      const result = terminal.resize(80.5, 24);
+
+      expect(result.outcome).toBe("rejected");
+      expect(result.appliedCols).toBeNull();
+      expect(result.appliedRows).toBeNull();
+      expect(resizeSpy).not.toHaveBeenCalled();
+    } finally {
+      terminal.dispose();
+    }
+  });
+
+  it("reports no applied geometry once the pty has exited", () => {
+    const { pty, resizeSpy } = createResizablePty(80, 24);
+    const terminal = createTerminal(pty, undefined, undefined, "t-resize-exited");
+    try {
+      pty.emitExit(0);
+      const result = terminal.resize(120, 40);
+
+      expect(result.outcome).toBe("exited");
+      expect(result.appliedCols).toBeNull();
+      expect(resizeSpy).not.toHaveBeenCalled();
+    } finally {
+      terminal.dispose();
+    }
+  });
+});

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -5,7 +5,7 @@ import type { AgentState, AgentId, WaitingReason } from "../../../shared/types/a
 import type { TerminalCheckResult } from "../../../shared/types/checkResult.js";
 import type { PanelKind, PanelTitleMode } from "../../../shared/types/panel.js";
 import type { BuiltInAgentId } from "../../../shared/config/agentIds.js";
-import type { PtyHostSpawnOptions } from "../../../shared/types/pty-host.js";
+import type { PtyHostSpawnOptions, TerminalResizeResult } from "../../../shared/types/pty-host.js";
 import type { SerializedTerminalSnapshot } from "../../../shared/types/terminal.js";
 import type { ProcessDetector } from "../ProcessDetector.js";
 
@@ -204,6 +204,7 @@ export interface PtyManagerEvents {
   data: (id: string, data: string | Uint8Array) => void;
   exit: (id: string, exitCode: number, signal?: number, launchGeneration?: number) => void;
   error: (id: string, error: string) => void;
+  "resize-result": (id: string, result: TerminalResizeResult) => void;
 }
 
 /**

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -435,7 +435,11 @@ export type {
   TerminalGeometry,
   SerializedTerminalSnapshot,
 } from "./terminal.js";
-export { isValidTerminalGeometry, MAX_TERMINAL_GRID_DIMENSION } from "./terminal.js";
+export {
+  isValidTerminalGeometry,
+  normalizeTerminalGridDimension,
+  MAX_TERMINAL_GRID_DIMENSION,
+} from "./terminal.js";
 
 // Pty Host types - IPC protocol for terminal management
 export type {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -161,6 +161,7 @@ import type {
   BroadcastWriteResultPayload,
   FdLeakWarningPayload,
   TerminalReliabilityMetricPayload,
+  TerminalResizeResult,
 } from "../pty-host.js";
 import type {
   FileSearchPayload,
@@ -304,6 +305,11 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     releaseWorkerIngestPort(id: string): Promise<void>;
     onStatus(callback: (data: TerminalStatusPayload) => void): () => void;
     onReliabilityMetric(callback: (data: TerminalReliabilityMetricPayload) => void): () => void;
+    /**
+     * Geometry the PTY actually holds after each resize it processed. Compare
+     * against the live xterm grid to detect a split neither side can see alone.
+     */
+    onResizeResult(callback: (id: string, result: TerminalResizeResult) => void): () => void;
     onResourceMetrics(
       callback: (data: { metrics: TerminalResourceBatchPayload; timestamp: number }) => void
     ): () => void;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -100,6 +100,7 @@ import type { GitCommitListOptions, GitCommitListResponse } from "../git.js";
 import type {
   SpawnResult,
   TerminalReliabilityMetricPayload,
+  TerminalResizeResult,
   TerminalStatusPayload,
   TerminalResourceBatchPayload,
   BroadcastWriteResultPayload,
@@ -1391,6 +1392,7 @@ export interface IpcEventMap {
   "terminal:broadcast-write-result": BroadcastWriteResultPayload;
   "terminal:send-key": [id: string, key: string];
   "terminal:spawn-result": [id: string, result: SpawnResult];
+  "terminal:resize-result": [id: string, result: TerminalResizeResult];
   "terminal:backend-crashed": {
     crashType: string;
     code: number | null;
@@ -2076,6 +2078,7 @@ export type IpcEventBusMap = Pick<
   | "terminal:backend-ready"
   | "terminal:spawn-result"
   // Terminal observability
+  | "terminal:resize-result"
   | "terminal:reliability-metric"
   | "terminal:status"
   // Agent session journaled — resume surfaces refetch (global broadcast)

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -936,8 +936,16 @@ export interface HostThrottlePayload {
  * while the renderer keeps re-asserting that same wrong geometry is exactly the
  * split this echo exists to expose (#11447, #11641), so the no-op path must
  * still report the dimensions the PTY actually holds.
+ *
+ * `deferred` means the call was accepted but the backend has not adopted it
+ * yet, so the applied geometry is genuinely unknown. node-pty's Windows backend
+ * queues resizes until ConPTY signals ready and updates its cached dimensions
+ * only inside that deferred callback — reporting the pre-resize grid as
+ * `applied` there would manufacture false agreement with xterm and hide the
+ * very split this echo exists to catch.
  */
-export type TerminalResizeOutcome = "applied" | "unchanged" | "failed" | "rejected" | "exited";
+export type TerminalResizeOutcome =
+  "applied" | "unchanged" | "deferred" | "failed" | "rejected" | "exited";
 
 /**
  * What the pty-host did with a resize request, and the geometry node-pty holds

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -502,6 +502,7 @@ export type PtyHostEvent =
   | { type: "exit"; id: string; exitCode: number; signal?: number; launchGeneration?: number }
   | { type: "error"; id: string; error: string }
   | { type: "spawn-result"; id: string; result: SpawnResult }
+  | { type: "resize-result"; id: string; result: TerminalResizeResult }
   | { type: "kill-by-project-result"; requestId: string; killed: number }
   | {
       type: "project-stats";
@@ -926,6 +927,41 @@ export interface HostThrottlePayload {
 }
 
 /** Payload for terminal reliability metrics (backpressure/suspend) */
+/**
+ * How the pty-host disposed of one resize request.
+ *
+ * `unchanged` is deliberately reported rather than swallowed: `TerminalProcess`
+ * skips `IPty.resize()` when node-pty already holds the requested dimensions,
+ * and that shortcut emits no SIGWINCH. A PTY sitting at the wrong geometry
+ * while the renderer keeps re-asserting that same wrong geometry is exactly the
+ * split this echo exists to expose (#11447, #11641), so the no-op path must
+ * still report the dimensions the PTY actually holds.
+ */
+export type TerminalResizeOutcome = "applied" | "unchanged" | "failed" | "rejected" | "exited";
+
+/**
+ * What the pty-host did with a resize request, and the geometry node-pty holds
+ * afterwards.
+ *
+ * The applied dimensions are node-pty's own cached view of the request it
+ * accepted — NOT a kernel read-back. `IPty.cols`/`rows` never round-trip a query
+ * to the tty or ConPTY, so this cannot detect silent OS-level clamping. What it
+ * does detect is application-level divergence: geometry a layer of ours dropped,
+ * clamped, or failed to apply while xterm moved on without it.
+ */
+export interface TerminalResizeResult {
+  /** Incarnation the host actually touched; `null` when the id was never launched. */
+  launchGeneration: number | null;
+  requestedCols: number;
+  requestedRows: number;
+  /** Geometry node-pty holds after the attempt; `null` when no live PTY was resized. */
+  appliedCols: number | null;
+  appliedRows: number | null;
+  outcome: TerminalResizeOutcome;
+  /** Present only for `failed` — the message `IPty.resize()` threw. */
+  error?: string;
+}
+
 export interface TerminalReliabilityMetricPayload {
   terminalId: string;
   metricType:

--- a/shared/types/terminal.ts
+++ b/shared/types/terminal.ts
@@ -83,6 +83,17 @@ export interface SerializedTerminalSnapshot extends TerminalGeometry {
 export const MAX_TERMINAL_GRID_DIMENSION = 2000;
 
 /**
+ * Round `value` into the grid range every terminal layer agrees on. Callers that
+ * drive BOTH grids (xterm and the PTY) must normalize once and pass the same
+ * number to each — clamping independently per layer is what lets the two sides
+ * settle at different widths and never reconcile (#11641).
+ */
+export function normalizeTerminalGridDimension(value: number): number {
+  if (!Number.isFinite(value)) return 1;
+  return Math.max(1, Math.min(MAX_TERMINAL_GRID_DIMENSION, Math.floor(value)));
+}
+
+/**
  * True when `value` is a grid a terminal could actually have been captured at.
  * Replay sizes a real xterm to these numbers, so anything non-integral, zero,
  * negative or absurd must degrade to "no geometry" (replay verbatim) rather

--- a/src/clients/__tests__/terminalClient.test.ts
+++ b/src/clients/__tests__/terminalClient.test.ts
@@ -58,6 +58,18 @@ let windowMessageListeners: Array<(e: MessageEvent) => void> = [];
 
 const typedGlobal = globalThis as unknown as Record<string, unknown>;
 
+function fireWindowMessage(data: Record<string, unknown>, ports?: MessagePort[]) {
+  const event = {
+    data,
+    ports: ports || [],
+    source: typedGlobal.window,
+    origin: "http://localhost",
+  } as unknown as MessageEvent;
+  for (const listener of windowMessageListeners) {
+    listener(event);
+  }
+}
+
 describe("terminalClient MessagePort data routing", () => {
   beforeEach(async () => {
     vi.resetModules();
@@ -99,18 +111,6 @@ describe("terminalClient MessagePort data routing", () => {
     fireWindowMessage({ type: "terminal-port", token }, [mc.port2]);
 
     return port;
-  }
-
-  function fireWindowMessage(data: Record<string, unknown>, ports?: MessagePort[]) {
-    const event = {
-      data,
-      ports: ports || [],
-      source: typedGlobal.window,
-      origin: "http://localhost",
-    } as unknown as MessageEvent;
-    for (const listener of windowMessageListeners) {
-      listener(event);
-    }
   }
 
   it("announces readiness after installing the MessagePort listener", () => {
@@ -787,5 +787,74 @@ describe("terminalClient MessagePort data routing", () => {
         resolve();
       }, 100);
     });
+  });
+});
+
+describe("terminalClient resize normalization (#11641)", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    windowMessageListeners = [];
+
+    const windowMock = {
+      top: null as unknown,
+      electron: { terminal: mockElectronTerminal },
+      location: { origin: "http://localhost", protocol: "http:" },
+      postMessage: vi.fn(),
+      addEventListener: vi.fn((type: string, handler: (e: MessageEvent) => void) => {
+        if (type === "message") windowMessageListeners.push(handler);
+      }),
+    };
+    windowMock.top = windowMock;
+    typedGlobal.window = windowMock;
+
+    vi.clearAllMocks();
+
+    const mod = await import("../terminalClient");
+    terminalClient = mod.terminalClient;
+  });
+
+  afterEach(() => {
+    delete typedGlobal.window;
+  });
+
+  it("sends a wide grid through IPC without a legacy column cap", async () => {
+    // An ultrawide display at a small font legitimately exceeds the old 500
+    // ceiling. Capping only this transport left the PTY narrower than xterm.
+    terminalClient.resize("t1", 640, 60);
+
+    expect(mockElectronTerminal.resize).toHaveBeenCalledWith("t1", 640, 60);
+  });
+
+  it("normalizes identically on the MessagePort and IPC transports", async () => {
+    const mc = new MessageChannel();
+    const token = "resize-token";
+    fireWindowMessage({ type: "terminal-port-token", token });
+    fireWindowMessage({ type: "terminal-port", token }, [mc.port2]);
+
+    const viaPort: Array<Record<string, unknown>> = [];
+    mc.port1.addEventListener("message", (event: MessageEvent) => {
+      const msg = event.data as Record<string, unknown>;
+      if (msg?.type === "resize") viaPort.push(msg);
+    });
+    mc.port1.start();
+
+    // Far past the shared ceiling: the two transports must agree on what the
+    // PTY is told, otherwise which grid the backend adopts depends on whether a
+    // port happened to be live.
+    terminalClient.resize("t1", 9000, 9000);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(viaPort).toHaveLength(1);
+    const portDims = { cols: viaPort[0]?.cols, rows: viaPort[0]?.rows };
+
+    // Drop the port so the same request takes the IPC fallback.
+    mc.port1.close();
+    mc.port2.close();
+    vi.resetModules();
+    const mod = await import("../terminalClient");
+    mod.terminalClient.resize("t1", 9000, 9000);
+
+    const ipcCall = mockElectronTerminal.resize.mock.calls.at(-1);
+    expect({ cols: ipcCall?.[1], rows: ipcCall?.[2] }).toEqual(portDims);
   });
 });

--- a/src/clients/__tests__/terminalClient.test.ts
+++ b/src/clients/__tests__/terminalClient.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MAX_TERMINAL_GRID_DIMENSION } from "@shared/types/terminal";
 
 // Track IPC onData subscriptions so we can simulate IPC data delivery
 const ipcOnDataHandlers: Array<{ id: string; cb: (data: string | Uint8Array) => void }> = [];
@@ -846,6 +847,13 @@ describe("terminalClient resize normalization (#11641)", () => {
 
     expect(viaPort).toHaveLength(1);
     const portDims = { cols: viaPort[0]?.cols, rows: viaPort[0]?.rows };
+    // Both transports agreeing is necessary but not sufficient — with no
+    // normalization at all they would agree on 9000. Pin them to the bound the
+    // xterm half is also normalized to, which is what makes the grids match.
+    expect(portDims).toEqual({
+      cols: MAX_TERMINAL_GRID_DIMENSION,
+      rows: MAX_TERMINAL_GRID_DIMENSION,
+    });
 
     // Drop the port so the same request takes the IPC fallback.
     mc.port1.close();

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -15,7 +15,9 @@ import type {
 import type {
   PtyHostToRendererMessage,
   TerminalReliabilityMetricPayload,
+  TerminalResizeResult,
 } from "@shared/types/pty-host";
+import { normalizeTerminalGridDimension } from "@shared/types/terminal";
 import { PERF_MARKS } from "@shared/perf/marks";
 import { logDebug, logWarn } from "@/utils/logger";
 import { isRendererPerfCaptureEnabled, markRendererPerformance } from "@/utils/performance";
@@ -400,18 +402,38 @@ export const terminalClient = {
     return window.electron.terminal.onBroadcastWriteResult(callback);
   },
 
+  /**
+   * Geometry the PTY actually holds after each resize. Guarded because older
+   * preload surfaces (and partial test doubles) predate the channel.
+   */
+  onResizeResult: (callback: (id: string, result: TerminalResizeResult) => void): (() => void) => {
+    if (typeof window.electron?.terminal?.onResizeResult !== "function") return () => {};
+    return window.electron.terminal.onResizeResult(callback);
+  },
+
   resize: (id: string, cols: number, rows: number): void => {
+    // Normalized here rather than downstream: the MessagePort path reaches the
+    // pty-host without passing through Main, so a clamp applied only in the IPC
+    // handler would bound the fallback transport and not the primary one —
+    // leaving the PTY at a width xterm never adopts (#11641).
+    const normalizedCols = normalizeTerminalGridDimension(cols);
+    const normalizedRows = normalizeTerminalGridDimension(rows);
     if (messagePort) {
       try {
-        messagePort.postMessage({ type: "resize", id, cols, rows });
+        messagePort.postMessage({
+          type: "resize",
+          id,
+          cols: normalizedCols,
+          rows: normalizedRows,
+        });
       } catch (error) {
         logWarn("[TerminalClient] MessagePort resize failed, clearing port", { error });
         messagePort = null;
 
-        window.electron.terminal.resize(id, cols, rows);
+        window.electron.terminal.resize(id, normalizedCols, normalizedRows);
       }
     } else {
-      window.electron.terminal.resize(id, cols, rows);
+      window.electron.terminal.resize(id, normalizedCols, normalizedRows);
     }
   },
 

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -403,11 +403,9 @@ export const terminalClient = {
   },
 
   /**
-   * Geometry the PTY actually holds after each resize. Guarded because older
-   * preload surfaces (and partial test doubles) predate the channel.
+   * Geometry the PTY actually holds after each resize.
    */
   onResizeResult: (callback: (id: string, result: TerminalResizeResult) => void): (() => void) => {
-    if (typeof window.electron?.terminal?.onResizeResult !== "function") return () => {};
     return window.electron.terminal.onResizeResult(callback);
   },
 

--- a/src/config/xtermConfig.ts
+++ b/src/config/xtermConfig.ts
@@ -14,6 +14,7 @@
 import type { ITerminalOptions, ITheme } from "@xterm/xterm";
 import { getTerminalThemeFromCSS } from "@/utils/terminalTheme";
 import { DEFAULT_TERMINAL_FONT_FAMILY } from "@/config/terminalFont";
+import { normalizeTerminalGridDimension } from "@shared/types/terminal";
 
 /**
  * Configuration for terminal appearance.
@@ -179,7 +180,13 @@ export function calculateTerminalDimensions(
   const metrics = getTerminalMetrics(fontSize);
   const availableWidth = widthPx - TERMINAL_SCROLLBAR_WIDTH;
   return {
-    cols: Math.max(20, Math.min(500, Math.floor(availableWidth / metrics.cellWidth))),
-    rows: Math.max(10, Math.min(200, Math.floor(heightPx / metrics.cellHeight))),
+    // Bounded by the shared ceiling rather than a local cap: an ultrawide
+    // display legitimately exceeds 500 columns, and booting xterm narrower than
+    // the container starts the pane already split from the PTY (#11641).
+    cols: Math.max(
+      20,
+      normalizeTerminalGridDimension(Math.floor(availableWidth / metrics.cellWidth))
+    ),
+    rows: Math.max(10, normalizeTerminalGridDimension(Math.floor(heightPx / metrics.cellHeight))),
   };
 }

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -748,6 +748,30 @@ class TerminalInstanceService {
     managed.lastPtyResizeResult = result;
   }
 
+  /**
+   * Drop the echo when the backend that produced it is gone. The renderer keeps
+   * resizing a pane whose PTY has exited (or whose host has crashed) and no new
+   * echo can arrive to correct the record, so the watchdog would otherwise
+   * compare a dead process's geometry against a live xterm grid and blame the
+   * split on a PTY that no longer exists — precisely when the log is the
+   * diagnostic surface. Unknown geometry, not stale geometry.
+   */
+  private clearPtyGeometryEcho(managed: ManagedTerminal): void {
+    managed.lastPtyResizeResult = undefined;
+    managed.ptyGeometryDivergenceSignature = undefined;
+  }
+
+  /**
+   * Every live pane loses its geometry echo when the pty-host dies: no PTY
+   * survives the crash, and the recovered host re-spawns under fresh launch
+   * generations. Called on the crash, not on recovery — the renderer keeps
+   * resizing panes for the whole outage, which is the window the stale echo
+   * would be misread in.
+   */
+  handleBackendCrash(): void {
+    this.instances.forEach((managed) => this.clearPtyGeometryEcho(managed));
+  }
+
   setTargetSize(id: string, cols: number, rows: number): void {
     const instance = this.instances.get(id);
     if (!instance) return;
@@ -1010,10 +1034,16 @@ class TerminalInstanceService {
 
     const unsubExit = terminalClient.onExit((termId, exitCode) => {
       if (termId !== id) return;
+      const current = this.instances.get(id);
+      // Ahead of the suppression gate: the PTY is gone either way, and a
+      // suppressed exit (trash/restore churn) is exactly the case where the pane
+      // outlives its backend long enough for the stale echo to be compared.
+      if (current) {
+        this.clearPtyGeometryEcho(current);
+      }
       if (this.shouldSuppressExit(id)) {
         return;
       }
-      const current = this.instances.get(id);
       if (current) {
         current.terminal.write(`\r\n\x1b[90m[Process exited with code ${exitCode}]\x1b[0m\r\n`);
       }

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -46,7 +46,8 @@ import {
 import { reduceScrollback, restoreScrollback } from "./TerminalScrollbackController";
 import { DEFAULT_TERMINAL_FONT_FAMILY, onTerminalFontArrivedLate } from "@/config/terminalFont";
 import { isPtyPanel } from "@shared/types/panel";
-import type { TerminalGeometry } from "@shared/types/terminal";
+import { isValidTerminalGeometry, type TerminalGeometry } from "@shared/types/terminal";
+import type { TerminalResizeResult } from "@shared/types/pty-host";
 import { applyXtermReflowFastpath } from "@shared/utils/xtermReflowFastpath";
 import { usePanelStore } from "@/store/panelStore";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
@@ -127,6 +128,7 @@ class TerminalInstanceService {
   private workerIngestController: TerminalWorkerIngestController;
   private revealController: TerminalRevealController;
   private unsubTierChanged: (() => void) | null = null;
+  private unsubResizeResult: (() => void) | null = null;
 
   constructor() {
     if (canAutoInitializeTerminalIngest()) {
@@ -716,20 +718,44 @@ class TerminalInstanceService {
     });
   }
 
+  /**
+   * One process-wide listener for PTY resize echoes, armed on the first
+   * terminal rather than in the constructor: the service is built at module
+   * scope, where `window.electron` does not exist yet under Node test
+   * environments.
+   */
+  private ensureResizeResultSubscription(): void {
+    if (this.unsubResizeResult) return;
+    this.unsubResizeResult = terminalClient.onResizeResult((id, result) => {
+      this.recordPtyResizeResult(id, result);
+    });
+  }
+
+  /**
+   * Store the geometry the PTY reports holding. A new PTY incarnation retires
+   * the previous one's divergence history — the counter describes one live
+   * backend process, not the pane.
+   */
+  private recordPtyResizeResult(id: string, result: TerminalResizeResult): void {
+    const managed = this.instances.get(id);
+    if (!managed) return;
+
+    if (managed.ptyGeometryDivergenceGeneration !== result.launchGeneration) {
+      managed.ptyGeometryDivergenceGeneration = result.launchGeneration ?? undefined;
+      managed.ptyGeometryDivergenceCount = 0;
+      managed.ptyGeometryDivergenceSignature = undefined;
+    }
+    managed.lastPtyResizeResult = result;
+  }
+
   setTargetSize(id: string, cols: number, rows: number): void {
     const instance = this.instances.get(id);
     if (!instance) return;
 
-    if (
-      Number.isFinite(cols) &&
-      Number.isFinite(rows) &&
-      Number.isInteger(cols) &&
-      Number.isInteger(rows) &&
-      cols > 0 &&
-      cols <= 500 &&
-      rows > 0 &&
-      rows <= 500
-    ) {
+    // Shared ceiling, not a local 500: a restored pane that legitimately
+    // exceeds it must not silently keep the previous target and boot the PTY at
+    // a geometry xterm never adopts (#11641).
+    if (isValidTerminalGeometry({ cols, rows })) {
       instance.targetCols = cols;
       instance.targetRows = rows;
     }
@@ -1051,6 +1077,7 @@ class TerminalInstanceService {
     installTerminalBoundListeners(terminal, managed, id, this.makeListenerInstallDeps());
 
     this.instances.set(id, managed);
+    this.ensureResizeResultSubscription();
 
     const initialTier = getRefreshTier ? getRefreshTier() : TerminalRefreshTier.FOCUSED;
     this.rendererPolicy.applyRendererPolicy(id, initialTier);
@@ -2723,6 +2750,8 @@ class TerminalInstanceService {
     this.stopPolling();
     this.unsubTierChanged?.();
     this.unsubTierChanged = null;
+    this.unsubResizeResult?.();
+    this.unsubResizeResult = null;
     this.workerIngestController.dispose();
     this.resizePassScheduler.dispose();
     this.reflowController.dispose();

--- a/src/services/terminal/TerminalReconciliationWatchdog.ts
+++ b/src/services/terminal/TerminalReconciliationWatchdog.ts
@@ -3,6 +3,7 @@ import { TerminalRefreshTier } from "@/types";
 import { isSidebarMeasurementLocked } from "@/lib/layoutTransitionLock";
 import { isProjectViewCached, subscribeProjectViewLifecycle } from "@/lib/viewCacheState";
 import { logDebug, logWarn } from "@/utils/logger";
+import { normalizeTerminalGridDimension } from "@shared/types/terminal";
 import { hasStreamingWrites } from "./TerminalResizeController";
 import type { ManagedTerminal } from "./types";
 
@@ -248,38 +249,95 @@ export class TerminalReconciliationWatchdog {
   }
 
   /**
-   * Dev-only diagnostic for the project-switch garble bug: an on-screen,
-   * settled terminal whose xterm grid (`terminal.cols/rows`) disagrees with the
+   * Diagnostic for the project-switch garble bug: an on-screen, settled
+   * terminal whose xterm grid (`terminal.cols/rows`) disagrees with the
    * dimensions the container can actually hold (`fitAddon.proposeDimensions()`)
    * is rendering its buffer at the wrong width — the exact "garbled line flow"
    * users see after switching back to a project. The watchdog already gated out
    * drags, layout transitions, and resize-suppressed/attaching terminals, so a
-   * divergence reaching here is real, not transient. This call itself only
-   * logs (DEV) — the actual repair is the geometry-convergence branch in
-   * {@link reconcile} (#10632) — so a silently-wrong grid is both loud during
-   * local development and reconciled on the same tick.
+   * divergence reaching here is real, not transient. This call only logs — the
+   * actual repair is the geometry-convergence branch in {@link reconcile}
+   * (#10632).
+   *
+   * Runs in production (#11641). The sweep is interval-driven, so both checks
+   * report once per divergence EPISODE rather than once per tick: a signature
+   * of the disagreeing geometries gates the warning, and only an observed
+   * agreement clears it. A missing proposal or a thrown measurement proves
+   * nothing about convergence and must leave the signature standing.
    */
   private diagnoseGeometryDivergence(id: string, managed: ManagedTerminal): void {
-    if (!import.meta.env?.DEV) return;
+    this.diagnosePtyGeometryDivergence(id, managed);
     try {
       const proposal = managed.fitAddon.proposeDimensions?.();
       if (!proposal || proposal.cols <= 1 || proposal.rows <= 1) return;
       const { cols, rows } = managed.terminal;
-      if (proposal.cols !== cols || proposal.rows !== rows) {
-        logWarn(
-          "[TerminalReconciliationWatchdog] geometry divergence: xterm grid disagrees with container (garble risk)",
-          {
-            id,
-            xtermCols: cols,
-            xtermRows: rows,
-            proposedCols: proposal.cols,
-            proposedRows: proposal.rows,
-          }
-        );
+      // Normalize before comparing: xterm is capped at the shared ceiling, so an
+      // uncapped proposal past it would read as a permanent divergence.
+      const proposedCols = normalizeTerminalGridDimension(proposal.cols);
+      const proposedRows = normalizeTerminalGridDimension(proposal.rows);
+      if (proposedCols === cols && proposedRows === rows) {
+        managed.fitGeometryDivergenceSignature = undefined;
+        return;
       }
+      const signature = `${managed.attachGeneration}:${cols}x${rows}:${proposedCols}x${proposedRows}`;
+      if (managed.fitGeometryDivergenceSignature === signature) return;
+      managed.fitGeometryDivergenceSignature = signature;
+      logWarn(
+        "[TerminalReconciliationWatchdog] geometry divergence: xterm grid disagrees with container (garble risk)",
+        {
+          id,
+          xtermCols: cols,
+          xtermRows: rows,
+          proposedCols,
+          proposedRows,
+        }
+      );
     } catch {
       // Diagnostic only — never let a measurement throw break the sweep.
     }
+  }
+
+  /**
+   * Compare the geometry the PTY reported holding against xterm's live grid.
+   * These are the two halves that must never move independently: the PTY wraps
+   * the agent's output at its width while xterm parses it at its own, and once
+   * they disagree, cursor-addressed output lands on the wrong rows with nothing
+   * to recover it (#11447).
+   *
+   * Compares `managed.terminal.cols/rows` directly — never `latestCols/Rows`,
+   * which name the target of a QUEUED resize, not the grid xterm holds.
+   */
+  private diagnosePtyGeometryDivergence(id: string, managed: ManagedTerminal): void {
+    const result = managed.lastPtyResizeResult;
+    if (!result || result.appliedCols === null || result.appliedRows === null) return;
+
+    const { cols, rows } = managed.terminal;
+    if (result.appliedCols === cols && result.appliedRows === rows) {
+      managed.ptyGeometryDivergenceSignature = undefined;
+      return;
+    }
+
+    const signature = `${result.launchGeneration ?? "none"}:${result.appliedCols}x${result.appliedRows}:${cols}x${rows}`;
+    if (managed.ptyGeometryDivergenceSignature === signature) return;
+    managed.ptyGeometryDivergenceSignature = signature;
+    managed.ptyGeometryDivergenceCount = (managed.ptyGeometryDivergenceCount ?? 0) + 1;
+
+    logWarn(
+      "[TerminalReconciliationWatchdog] geometry divergence: PTY grid disagrees with xterm (output wraps at the wrong width)",
+      {
+        id,
+        launchGeneration: result.launchGeneration,
+        outcome: result.outcome,
+        requestedCols: result.requestedCols,
+        requestedRows: result.requestedRows,
+        appliedCols: result.appliedCols,
+        appliedRows: result.appliedRows,
+        xtermCols: cols,
+        xtermRows: rows,
+        divergenceCount: managed.ptyGeometryDivergenceCount,
+        ...(result.error ? { error: result.error } : {}),
+      }
+    );
   }
 
   /**

--- a/src/services/terminal/TerminalReconciliationWatchdog.ts
+++ b/src/services/terminal/TerminalReconciliationWatchdog.ts
@@ -692,6 +692,15 @@ export class TerminalReconciliationWatchdog {
       isAttaching: managed.isAttaching === true,
       isDetached: managed.isDetached === true,
       isResizeSuppressed: managed.isResizeSuppressed === true,
+      // The backend half of the chain (#11641): a pane wrapping at the wrong
+      // width is a broken layer like any other, and the click is the only
+      // moment the two grids are captured side by side.
+      xtermCols: managed.terminal.cols,
+      xtermRows: managed.terminal.rows,
+      ptyResizeOutcome: managed.lastPtyResizeResult?.outcome,
+      ptyAppliedCols: managed.lastPtyResizeResult?.appliedCols,
+      ptyAppliedRows: managed.lastPtyResizeResult?.appliedRows,
+      ptyGeometryDivergenceCount: managed.ptyGeometryDivergenceCount,
     });
   }
 

--- a/src/services/terminal/TerminalReconciliationWatchdog.ts
+++ b/src/services/terminal/TerminalReconciliationWatchdog.ts
@@ -531,8 +531,15 @@ export class TerminalReconciliationWatchdog {
     if (!managed.isAltBuffer && !inSynchronizedBlock && !resizeTransitioning) {
       const proposal = managed.fitAddon.proposeDimensions?.();
       if (proposal && proposal.cols > 1 && proposal.rows > 1) {
+        // Normalize before comparing, exactly as the diagnostic does. Both
+        // resize primitives clamp to the shared ceiling, so an above-ceiling
+        // proposal can never be reached: comparing it raw would read as a
+        // permanent divergence, burn every breaker attempt on repairs that are
+        // no-ops, and latch `geometryRepairGaveUp` for the pane's whole life.
+        const proposedCols = normalizeTerminalGridDimension(proposal.cols);
+        const proposedRows = normalizeTerminalGridDimension(proposal.rows);
         const diverged =
-          proposal.cols !== managed.terminal.cols || proposal.rows !== managed.terminal.rows;
+          proposedCols !== managed.terminal.cols || proposedRows !== managed.terminal.rows;
         if (!diverged) {
           // Converged: the grid now matches what the container can hold. Re-arm the
           // circuit breaker (#10909) so a pane that self-corrected — e.g. a resize

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -96,18 +96,36 @@ function toFitPx(px: number): number {
  *
  * `Math.max(2, …)` matches FitAddon's floor and absorbs a container narrower
  * than the gutter itself.
+ *
+ * Clamped here rather than only where the number is applied: a measurement is
+ * copied into `latestCols`/`latestRows` AND handed to `resizeTerminal`, and a
+ * value that only the latter clamps leaves the target cache describing a grid
+ * xterm can never reach — every `terminal.cols === latestCols` convergence
+ * check then fails forever (#11641).
  */
 function colsForWidth(terminal: Terminal, widthPx: number, cellWidth: number): number {
   const availableWidth = toFitPx(widthPx) - getEffectiveScrollbarWidth(terminal.options);
-  return Math.max(2, Math.floor(availableWidth / cellWidth));
+  return Math.max(2, normalizeTerminalGridDimension(availableWidth / cellWidth));
 }
 
 /**
  * Rows a container of `heightPx` can hold. The scrollbar is never reserved
- * against height — FitAddon subtracts it from width alone.
+ * against height — FitAddon subtracts it from width alone. Clamped for the same
+ * reason as {@link colsForWidth}.
  */
 function rowsForHeight(heightPx: number, cellHeight: number): number {
-  return Math.max(1, Math.floor(toFitPx(heightPx) / cellHeight));
+  return normalizeTerminalGridDimension(toFitPx(heightPx) / cellHeight);
+}
+
+/** FitAddon's own measurement, clamped for the same reason {@link colsForWidth} is. */
+function normalizeProposal(proposal: { cols: number; rows: number }): {
+  cols: number;
+  rows: number;
+} {
+  return {
+    cols: normalizeTerminalGridDimension(proposal.cols),
+    rows: normalizeTerminalGridDimension(proposal.rows),
+  };
 }
 
 /**
@@ -242,7 +260,7 @@ export class TerminalResizeController {
         return null;
       }
 
-      const { cols, rows } = proposal;
+      const { cols, rows } = normalizeProposal(proposal);
       const buffer = managed.terminal.buffer.active;
       const wasAtBottom = buffer.viewportY >= buffer.baseY;
       managed.lastWidth = rect.width;
@@ -380,7 +398,7 @@ export class TerminalResizeController {
           return null;
         }
 
-        const { cols, rows } = proposal;
+        const { cols, rows } = normalizeProposal(proposal);
         managed.lastWidth = width;
         managed.lastHeight = height;
         managed.latestCols = cols;
@@ -626,7 +644,9 @@ export class TerminalResizeController {
     // Normalize here and in `terminalClient.resize` with the same function, so
     // xterm and the PTY land on identical dimensions no matter which call site
     // or transport carried them. Clamping per-layer instead is what let the two
-    // grids settle at different widths and never reconcile (#11641).
+    // grids settle at different widths and never reconcile (#11641). Idempotent
+    // for the internal callers — the measurement helpers above already clamp, so
+    // this only bites geometry handed in from outside the controller.
     const normalizedCols = normalizeTerminalGridDimension(cols);
     const normalizedRows = normalizeTerminalGridDimension(rows);
     if (managed.isSerializedRestoreInProgress) {
@@ -752,8 +772,7 @@ export class TerminalResizeController {
     let rows: number;
     const proposal = managed.fitAddon.proposeDimensions?.();
     if (proposal && proposal.cols > 1 && proposal.rows > 1) {
-      cols = proposal.cols;
-      rows = proposal.rows;
+      ({ cols, rows } = normalizeProposal(proposal));
     } else {
       const cellDims = getXtermCellDimensions(managed.terminal);
       if (!cellDims) return false;

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -2,6 +2,7 @@ import { Terminal } from "@xterm/xterm";
 import { terminalClient } from "@/clients";
 import { TerminalRefreshTier } from "@/types";
 import { getEffectiveAgentConfig } from "@shared/config/agentRegistry";
+import { normalizeTerminalGridDimension } from "@shared/types/terminal";
 import { getEffectiveScrollbarWidth } from "@/config/xtermConfig";
 import { logError, logWarn } from "@/utils/logger";
 import type { ManagedTerminal, TerminalResyncOptions } from "./types";
@@ -622,11 +623,17 @@ export class TerminalResizeController {
    * agent keeps producing output sized for the grid the user can see.
    */
   resizeTerminal(managed: ManagedTerminal, cols: number, rows: number): void {
+    // Normalize here and in `terminalClient.resize` with the same function, so
+    // xterm and the PTY land on identical dimensions no matter which call site
+    // or transport carried them. Clamping per-layer instead is what let the two
+    // grids settle at different widths and never reconcile (#11641).
+    const normalizedCols = normalizeTerminalGridDimension(cols);
+    const normalizedRows = normalizeTerminalGridDimension(rows);
     if (managed.isSerializedRestoreInProgress) {
-      managed.pendingRestoreGeometry = { cols, rows };
+      managed.pendingRestoreGeometry = { cols: normalizedCols, rows: normalizedRows };
       return;
     }
-    managed.terminal.resize(cols, rows);
+    managed.terminal.resize(normalizedCols, normalizedRows);
   }
 
   /**

--- a/src/services/terminal/__tests__/TerminalInstanceService.captureBufferText.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.captureBufferText.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/clients", () => ({
     resize: vi.fn(),
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onResizeResult: vi.fn(() => vi.fn()),
     onTierChanged: vi.fn(() => vi.fn()),
     write: vi.fn(),
     setActivityTier: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.concurrentCreate.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.concurrentCreate.test.ts
@@ -31,6 +31,7 @@ vi.mock("@/clients", () => ({
     resize: vi.fn(),
     onData: onDataMock,
     onExit: vi.fn(() => vi.fn()),
+    onResizeResult: vi.fn(() => vi.fn()),
     onTierChanged: vi.fn(() => vi.fn()),
     write: vi.fn(),
     setActivityTier: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.dataLoss.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.dataLoss.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/clients", () => ({
     resize: vi.fn(),
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onResizeResult: vi.fn(() => vi.fn()),
     onTierChanged: vi.fn(() => vi.fn()),
     write: vi.fn(),
     setActivityTier: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.fontGrid.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.fontGrid.test.ts
@@ -30,6 +30,7 @@ vi.mock("@/clients", () => ({
   terminalClient: {
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onResizeResult: vi.fn(() => vi.fn()),
     onTierChanged: vi.fn(() => vi.fn()),
     setActivityTier: vi.fn(),
     wake: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.installerCallSite.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.installerCallSite.test.ts
@@ -15,6 +15,7 @@ vi.mock("../TerminalListenerInstaller", () => ({
 const mockTerminalClient = {
   onData: vi.fn(() => vi.fn()),
   onExit: vi.fn(() => vi.fn()),
+  onResizeResult: vi.fn(() => vi.fn()),
   onTierChanged: vi.fn(() => vi.fn()),
   setActivityTier: vi.fn(),
   wake: vi.fn().mockResolvedValue({ state: null }),

--- a/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/clients", () => ({
   terminalClient: {
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onResizeResult: vi.fn(() => vi.fn()),
     onTierChanged: vi.fn(() => vi.fn()),
     setActivityTier: vi.fn(),
     wake: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.paintFabric.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.paintFabric.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/clients", () => ({
     resize: vi.fn(),
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onResizeResult: vi.fn(() => vi.fn()),
     onTierChanged: vi.fn(() => vi.fn()),
     write: vi.fn(),
     setActivityTier: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.paintFabricGpu.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.paintFabricGpu.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/clients", () => ({
     resize: vi.fn(),
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onResizeResult: vi.fn(() => vi.fn()),
     onTierChanged: vi.fn(() => vi.fn()),
     write: vi.fn(),
     setActivityTier: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.resizeResult.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.resizeResult.test.ts
@@ -12,11 +12,17 @@ const onResizeResult = vi.fn((cb: (id: string, result: TerminalResizeResult) => 
   return vi.fn();
 });
 
+// Per-terminal exit listeners, in registration order.
+const capturedExitCbs: Array<(id: string, exitCode: number) => void> = [];
+
 vi.mock("@/clients", () => ({
   terminalClient: {
     onResizeResult,
     onData: vi.fn(() => vi.fn()),
-    onExit: vi.fn(() => vi.fn()),
+    onExit: vi.fn((cb: (id: string, exitCode: number) => void) => {
+      capturedExitCbs.push(cb);
+      return vi.fn();
+    }),
     onTierChanged: vi.fn(() => vi.fn()),
     resize: vi.fn(),
     write: vi.fn(),
@@ -64,6 +70,7 @@ type ResizeResultTestService = {
     type: string,
     options: Record<string, unknown>
   ) => Record<string, unknown>;
+  handleBackendCrash: () => void;
 };
 
 function makeResult(overrides: Partial<TerminalResizeResult> = {}): TerminalResizeResult {
@@ -94,6 +101,7 @@ describe("TerminalInstanceService — PTY resize-result intake (#11641)", () => 
     vi.resetModules();
     vi.clearAllMocks();
     capturedResizeResultCb = null;
+    capturedExitCbs.length = 0;
 
     ({ terminalInstanceService: service } =
       (await import("../TerminalInstanceService")) as unknown as {
@@ -160,5 +168,54 @@ describe("TerminalInstanceService — PTY resize-result intake (#11641)", () => 
     capturedResizeResultCb?.("t1", makeResult({ appliedCols: 130 }));
 
     expect(managed.ptyGeometryDivergenceCount).toBe(4);
+  });
+
+  it("drops the echo when the PTY behind it exits", async () => {
+    await service.prewarmTerminal("t1", "terminal", {});
+    const managed = service.instances.get("t1")!;
+
+    capturedResizeResultCb?.("t1", makeResult());
+    managed.ptyGeometryDivergenceSignature = "1:120x40:80x40";
+
+    // The pane outlives its process and keeps being resized, but no echo can
+    // arrive to correct the record — comparing a dead PTY's grid against a live
+    // xterm blames a process that no longer exists.
+    capturedExitCbs.forEach((cb) => cb("t1", 0));
+
+    expect(managed.lastPtyResizeResult).toBeUndefined();
+    expect(managed.ptyGeometryDivergenceSignature).toBeUndefined();
+  });
+
+  it("leaves other terminals' echoes alone when one PTY exits", async () => {
+    await service.prewarmTerminal("t1", "terminal", {});
+    await service.prewarmTerminal("t2", "terminal", {});
+
+    capturedResizeResultCb?.("t1", makeResult());
+    capturedResizeResultCb?.("t2", makeResult());
+
+    capturedExitCbs.forEach((cb) => cb("t1", 0));
+
+    expect(service.instances.get("t1")?.lastPtyResizeResult).toBeUndefined();
+    expect(service.instances.get("t2")?.lastPtyResizeResult).toMatchObject({ appliedCols: 120 });
+  });
+
+  it("drops every echo when the pty-host crashes", async () => {
+    await service.prewarmTerminal("warm", "terminal", {});
+    const a = makeManaged();
+    const b = makeManaged();
+    service.instances.set("t1", a);
+    service.instances.set("t2", b);
+
+    capturedResizeResultCb?.("t1", makeResult());
+    capturedResizeResultCb?.("t2", makeResult());
+    a.ptyGeometryDivergenceSignature = "1:120x40:80x40";
+
+    // No PTY survives the host, and the renderer keeps resizing panes for the
+    // whole outage.
+    service.handleBackendCrash();
+
+    expect(a.lastPtyResizeResult).toBeUndefined();
+    expect(a.ptyGeometryDivergenceSignature).toBeUndefined();
+    expect(b.lastPtyResizeResult).toBeUndefined();
   });
 });

--- a/src/services/terminal/__tests__/TerminalInstanceService.resizeResult.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.resizeResult.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TerminalResizeResult } from "@shared/types/pty-host";
+import type { ManagedTerminal } from "../types";
+
+// Captured when the service installs its lazy subscription. Not reset between
+// tests — `vi.resetModules()` gives each test a fresh service that re-subscribes.
+let capturedResizeResultCb: ((id: string, result: TerminalResizeResult) => void) | null = null;
+
+const onResizeResult = vi.fn((cb: (id: string, result: TerminalResizeResult) => void) => {
+  capturedResizeResultCb = cb;
+  return vi.fn();
+});
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    onResizeResult,
+    onData: vi.fn(() => vi.fn()),
+    onExit: vi.fn(() => vi.fn()),
+    onTierChanged: vi.fn(() => vi.fn()),
+    resize: vi.fn(),
+    write: vi.fn(),
+    setActivityTier: vi.fn(),
+    wake: vi.fn(),
+    getSerializedState: vi.fn(),
+    getSharedBuffers: vi.fn(async () => ({ visualBuffers: [], signalBuffer: null })),
+    acknowledgeData: vi.fn(),
+    acknowledgePortData: vi.fn(),
+    discardPortAcks: vi.fn(),
+  },
+  systemClient: { openExternal: vi.fn() },
+  appClient: { getHydrationState: vi.fn() },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(() => ({
+    dispose: vi.fn(),
+    onContextLoss: vi.fn(() => ({ dispose: vi.fn() })),
+  })),
+}));
+
+vi.mock("../TerminalAddonManager", () => ({
+  setupTerminalAddons: vi.fn(() => ({
+    fitAddon: { fit: vi.fn() },
+    serializeAddon: { serialize: vi.fn() },
+    imageAddon: { dispose: vi.fn() },
+    searchAddon: {},
+    fileLinksDisposable: { dispose: vi.fn() },
+    webLinksAddon: { dispose: vi.fn() },
+  })),
+  createImageAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createFileLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createWebLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+}));
+
+type ResizeResultTestService = {
+  instances: Map<string, ManagedTerminal>;
+  prewarmTerminal: (
+    id: string,
+    type: string,
+    options: Record<string, unknown>
+  ) => Record<string, unknown>;
+};
+
+function makeResult(overrides: Partial<TerminalResizeResult> = {}): TerminalResizeResult {
+  return {
+    launchGeneration: 1,
+    requestedCols: 120,
+    requestedRows: 40,
+    appliedCols: 120,
+    appliedRows: 40,
+    outcome: "applied",
+    ...overrides,
+  };
+}
+
+function makeManaged(): ManagedTerminal {
+  return {
+    terminal: { cols: 120, rows: 40 },
+    latestCols: 120,
+    latestRows: 40,
+  } as unknown as ManagedTerminal;
+}
+
+describe("TerminalInstanceService — PTY resize-result intake (#11641)", () => {
+  let service: ResizeResultTestService;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    vi.clearAllMocks();
+    capturedResizeResultCb = null;
+
+    ({ terminalInstanceService: service } =
+      (await import("../TerminalInstanceService")) as unknown as {
+        terminalInstanceService: ResizeResultTestService;
+      });
+    service.instances.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("subscribes lazily on first terminal creation, once per process", async () => {
+    // Constructing the singleton must not reach into terminalClient — the
+    // service is built at module scope, where window.electron does not exist
+    // under Node test environments.
+    expect(onResizeResult).not.toHaveBeenCalled();
+
+    await service.prewarmTerminal("warm-a", "terminal", {});
+    await service.prewarmTerminal("warm-b", "terminal", {});
+
+    // One listener routed by id, not one per terminal.
+    expect(onResizeResult).toHaveBeenCalledTimes(1);
+    expect(capturedResizeResultCb).toBeTypeOf("function");
+  });
+
+  it("stores the reported geometry on the addressed terminal only", async () => {
+    await service.prewarmTerminal("warm", "terminal", {});
+    const managed = makeManaged();
+    service.instances.set("t1", managed);
+
+    capturedResizeResultCb?.("t1", makeResult());
+    expect(managed.lastPtyResizeResult).toMatchObject({ appliedCols: 120 });
+
+    // An echo for a terminal this renderer does not host must not throw.
+    expect(() => capturedResizeResultCb?.("unknown", makeResult())).not.toThrow();
+  });
+
+  it("retires the divergence history when a new PTY incarnation reports in", async () => {
+    await service.prewarmTerminal("warm", "terminal", {});
+    const managed = makeManaged();
+    service.instances.set("t1", managed);
+
+    capturedResizeResultCb?.("t1", makeResult());
+    managed.ptyGeometryDivergenceCount = 4;
+    managed.ptyGeometryDivergenceSignature = "1:120x40:80x40";
+
+    // A respawn reuses the terminal id; the dead PTY's divergence tally says
+    // nothing about the successor's grid.
+    capturedResizeResultCb?.("t1", makeResult({ launchGeneration: 2 }));
+
+    expect(managed.ptyGeometryDivergenceCount).toBe(0);
+    expect(managed.ptyGeometryDivergenceSignature).toBeUndefined();
+  });
+
+  it("keeps the divergence tally across echoes from the same incarnation", async () => {
+    await service.prewarmTerminal("warm", "terminal", {});
+    const managed = makeManaged();
+    service.instances.set("t1", managed);
+
+    capturedResizeResultCb?.("t1", makeResult());
+    managed.ptyGeometryDivergenceCount = 4;
+
+    capturedResizeResultCb?.("t1", makeResult({ appliedCols: 130 }));
+
+    expect(managed.ptyGeometryDivergenceCount).toBe(4);
+  });
+});

--- a/src/services/terminal/__tests__/TerminalInstanceService.restore.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.restore.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/clients", () => ({
   terminalClient: {
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onResizeResult: vi.fn(() => vi.fn()),
     onTierChanged: vi.fn(() => vi.fn()),
     setActivityTier: vi.fn(),
     wake: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
@@ -9,6 +9,7 @@ let capturedTierChangedCb: ((id: string, tier: "active" | "background") => void)
 const mockTerminalClient = {
   onData: vi.fn(() => vi.fn()),
   onExit: vi.fn(() => vi.fn()),
+  onResizeResult: vi.fn(() => vi.fn()),
   onTierChanged: vi.fn((cb: (id: string, tier: "active" | "background") => void) => {
     capturedTierChangedCb = cb;
     return vi.fn();

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -1700,6 +1700,11 @@ describe("TerminalReconciliationWatchdog — fit diagnostic in production (#1164
 
   beforeEach(() => {
     vi.useFakeTimers();
+    // Vitest runs with import.meta.env.DEV === true, so without forcing it off
+    // these tests would pass just as happily against the old
+    // `if (!import.meta.env?.DEV) return;` gate — i.e. they would not actually
+    // prove the diagnostic was promoted.
+    vi.stubEnv("DEV", false);
     instances = new Map();
     setDocumentVisibility("visible");
     __resetSidebarLayoutTransitionLockForTests();
@@ -1713,6 +1718,7 @@ describe("TerminalReconciliationWatchdog — fit diagnostic in production (#1164
     document.body.innerHTML = "";
     __resetSidebarLayoutTransitionLockForTests();
     __resetSidebarHydrationLockForTests();
+    vi.unstubAllEnvs();
     vi.useRealTimers();
     vi.clearAllMocks();
   });

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -18,6 +18,7 @@ import {
   type ReconciliationWatchdogDeps,
 } from "../TerminalReconciliationWatchdog";
 import type { ManagedTerminal } from "../types";
+import { MAX_TERMINAL_GRID_DIMENSION } from "@shared/types/terminal";
 
 vi.mock("@/utils/logger", () => ({
   logDebug: vi.fn(),
@@ -1532,5 +1533,254 @@ describe("TerminalReconciliationWatchdog — cached project view (#11212)", () =
     vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 5);
 
     expect(deps.setVisible).not.toHaveBeenCalled();
+  });
+});
+
+describe("TerminalReconciliationWatchdog — applied-PTY geometry divergence (#11641)", () => {
+  let watchdog: TerminalReconciliationWatchdog | undefined;
+  let instances: Map<string, ManagedTerminal>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    instances = new Map();
+    setDocumentVisibility("visible");
+    __resetSidebarLayoutTransitionLockForTests();
+    __resetSidebarHydrationLockForTests();
+    unlockSidebarHydration();
+  });
+
+  afterEach(() => {
+    watchdog?.dispose();
+    watchdog = undefined;
+    document.body.innerHTML = "";
+    __resetSidebarLayoutTransitionLockForTests();
+    __resetSidebarHydrationLockForTests();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  function ptyDivergenceWarnings() {
+    return vi
+      .mocked(logWarn)
+      .mock.calls.filter((call) => String(call[0]).includes("PTY grid disagrees with xterm"));
+  }
+
+  function makeResult(
+    overrides: Partial<ManagedTerminal["lastPtyResizeResult"] & object> = {}
+  ): NonNullable<ManagedTerminal["lastPtyResizeResult"]> {
+    return {
+      launchGeneration: 1,
+      requestedCols: 120,
+      requestedRows: 40,
+      appliedCols: 120,
+      appliedRows: 40,
+      outcome: "applied",
+      ...overrides,
+    };
+  }
+
+  it("reports a PTY grid that disagrees with the live xterm grid", () => {
+    const managed = makeManaged();
+    // The PTY wraps at 120 while xterm parses at 80 — cursor-addressed output
+    // lands on the wrong rows and nothing recovers it.
+    setGrid(managed, { cols: 80, rows: 40 }, { cols: 80, rows: 40 });
+    managed.lastPtyResizeResult = makeResult();
+    instances.set("t1", managed);
+    watchdog = new TerminalReconciliationWatchdog(makeDeps(instances));
+
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+
+    const warnings = ptyDivergenceWarnings();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.[1]).toMatchObject({ appliedCols: 120, xtermCols: 80 });
+    expect(managed.ptyGeometryDivergenceCount).toBe(1);
+  });
+
+  it("reports a persistent divergence once per episode, not once per sweep", () => {
+    const managed = makeManaged();
+    setGrid(managed, { cols: 80, rows: 40 }, { cols: 80, rows: 40 });
+    managed.lastPtyResizeResult = makeResult();
+    instances.set("t1", managed);
+    watchdog = new TerminalReconciliationWatchdog(makeDeps(instances));
+
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 5);
+
+    // An interval-driven sweep that logged every tick would flood the log
+    // buffer for the entire life of a split pane.
+    expect(ptyDivergenceWarnings()).toHaveLength(1);
+    expect(managed.ptyGeometryDivergenceCount).toBe(1);
+  });
+
+  it("counts a new episode when the divergence changes shape", () => {
+    const managed = makeManaged();
+    setGrid(managed, { cols: 80, rows: 40 }, { cols: 80, rows: 40 });
+    managed.lastPtyResizeResult = makeResult();
+    instances.set("t1", managed);
+    watchdog = new TerminalReconciliationWatchdog(makeDeps(instances));
+
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+    managed.lastPtyResizeResult = makeResult({ appliedCols: 200, requestedCols: 200 });
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+
+    expect(ptyDivergenceWarnings()).toHaveLength(2);
+    expect(managed.ptyGeometryDivergenceCount).toBe(2);
+  });
+
+  it("re-reports a divergence that recurs after the grids agreed", () => {
+    const managed = makeManaged();
+    setGrid(managed, { cols: 80, rows: 40 }, { cols: 80, rows: 40 });
+    managed.lastPtyResizeResult = makeResult();
+    instances.set("t1", managed);
+    watchdog = new TerminalReconciliationWatchdog(makeDeps(instances));
+
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+    // Converged: the signature must clear so a recurrence is a fresh episode
+    // rather than being swallowed as a duplicate forever.
+    managed.lastPtyResizeResult = makeResult({ appliedCols: 80, requestedCols: 80 });
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+    expect(ptyDivergenceWarnings()).toHaveLength(1);
+
+    managed.lastPtyResizeResult = makeResult();
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+    expect(ptyDivergenceWarnings()).toHaveLength(2);
+    expect(managed.ptyGeometryDivergenceCount).toBe(2);
+  });
+
+  it("stays silent when the PTY and xterm grids agree", () => {
+    const managed = makeManaged();
+    setGrid(managed, { cols: 120, rows: 40 }, { cols: 120, rows: 40 });
+    managed.lastPtyResizeResult = makeResult();
+    instances.set("t1", managed);
+    watchdog = new TerminalReconciliationWatchdog(makeDeps(instances));
+
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 3);
+
+    expect(ptyDivergenceWarnings()).toHaveLength(0);
+    expect(managed.ptyGeometryDivergenceCount).toBeUndefined();
+  });
+
+  it("stays silent when no live PTY geometry was reported", () => {
+    const managed = makeManaged();
+    setGrid(managed, { cols: 80, rows: 40 }, { cols: 80, rows: 40 });
+    // An exited/rejected resize carries no applied geometry — there is nothing
+    // to compare, so it must not be read as a divergence against 80x40.
+    managed.lastPtyResizeResult = makeResult({
+      outcome: "exited",
+      appliedCols: null,
+      appliedRows: null,
+    });
+    instances.set("t1", managed);
+    watchdog = new TerminalReconciliationWatchdog(makeDeps(instances));
+
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+
+    expect(ptyDivergenceWarnings()).toHaveLength(0);
+  });
+
+  it("compares against the live xterm grid, not a queued resize target", () => {
+    const managed = makeManaged();
+    setGrid(managed, { cols: 80, rows: 40 }, { cols: 80, rows: 40 });
+    // latestCols names the target of a resize that has not committed. Reading
+    // it as xterm's geometry would call a real split converged.
+    managed.latestCols = 120;
+    managed.latestRows = 40;
+    managed.lastPtyResizeResult = makeResult();
+    instances.set("t1", managed);
+    watchdog = new TerminalReconciliationWatchdog(makeDeps(instances));
+
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+
+    expect(ptyDivergenceWarnings()).toHaveLength(1);
+  });
+});
+
+describe("TerminalReconciliationWatchdog — fit diagnostic in production (#11641)", () => {
+  let watchdog: TerminalReconciliationWatchdog | undefined;
+  let instances: Map<string, ManagedTerminal>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    instances = new Map();
+    setDocumentVisibility("visible");
+    __resetSidebarLayoutTransitionLockForTests();
+    __resetSidebarHydrationLockForTests();
+    unlockSidebarHydration();
+  });
+
+  afterEach(() => {
+    watchdog?.dispose();
+    watchdog = undefined;
+    document.body.innerHTML = "";
+    __resetSidebarLayoutTransitionLockForTests();
+    __resetSidebarHydrationLockForTests();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  function fitWarnings() {
+    return vi
+      .mocked(logWarn)
+      .mock.calls.filter((call) => String(call[0]).includes("disagrees with container"));
+  }
+
+  it("reports a container/xterm divergence once per episode", () => {
+    const managed = makeManaged();
+    setGrid(managed, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
+    instances.set("t1", managed);
+    watchdog = new TerminalReconciliationWatchdog(
+      makeDeps(instances, { reconcileRevealGeometry: vi.fn() })
+    );
+
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 4);
+
+    expect(fitWarnings()).toHaveLength(1);
+  });
+
+  it("does not treat a proposal past the shared ceiling as a divergence", () => {
+    const managed = makeManaged();
+    // xterm cannot exceed the shared ceiling, so an unbounded proposal above it
+    // would otherwise read as a permanent, unfixable disagreement.
+    setGrid(
+      managed,
+      { cols: MAX_TERMINAL_GRID_DIMENSION, rows: 40 },
+      { cols: MAX_TERMINAL_GRID_DIMENSION + 500, rows: 40 }
+    );
+    instances.set("t1", managed);
+    watchdog = new TerminalReconciliationWatchdog(makeDeps(instances));
+
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+
+    expect(fitWarnings()).toHaveLength(0);
+  });
+
+  it("keeps reporting after a measurement failure rather than treating it as convergence", () => {
+    const managed = makeManaged();
+    setGrid(managed, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
+    instances.set("t1", managed);
+    watchdog = new TerminalReconciliationWatchdog(
+      makeDeps(instances, { reconcileRevealGeometry: vi.fn() })
+    );
+
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+    expect(fitWarnings()).toHaveLength(1);
+
+    // A throwing measurement proves nothing about the grid. Clearing the
+    // signature here would make the next tick re-report the same episode.
+    // Models a detached element: the proposal resolves, reading it throws.
+    setGrid(
+      managed,
+      { cols: 137, rows: 40 },
+      {
+        get cols(): number {
+          throw new Error("element detached");
+        },
+        rows: 40,
+      }
+    );
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+
+    setGrid(managed, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+    expect(fitWarnings()).toHaveLength(1);
   });
 });

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -1130,6 +1130,41 @@ describe("TerminalReconciliationWatchdog", () => {
       expect(deps.resumeFlush).not.toHaveBeenCalled();
     });
 
+    it("records the PTY half of the chain alongside xterm's grid (#11641)", () => {
+      const managed = makeManaged();
+      setGrid(managed, { cols: 80, rows: 24 }, { cols: 80, rows: 24 });
+      managed.lastPtyResizeResult = {
+        launchGeneration: 2,
+        requestedCols: 120,
+        requestedRows: 40,
+        appliedCols: 120,
+        appliedRows: 40,
+        outcome: "applied",
+      };
+      managed.ptyGeometryDivergenceCount = 3;
+      instances.set("t1", managed);
+      watchdog = new TerminalReconciliationWatchdog(makeDeps(instances));
+
+      (managed.terminal.element as HTMLElement).dispatchEvent(
+        new Event("pointerdown", { bubbles: true })
+      );
+
+      // A pane wrapping at the wrong width is a broken layer like any other,
+      // and the click is the only moment both grids are captured together —
+      // `setFocused`'s wake destroys the evidence right after.
+      expect(logDebug).toHaveBeenCalledWith(
+        expect.stringContaining("pointerdown chain snapshot"),
+        expect.objectContaining({
+          xtermCols: 80,
+          xtermRows: 24,
+          ptyResizeOutcome: "applied",
+          ptyAppliedCols: 120,
+          ptyAppliedRows: 40,
+          ptyGeometryDivergenceCount: 3,
+        })
+      );
+    });
+
     it("ignores pointerdowns outside any terminal host element", () => {
       instances.set("t1", makeManaged());
       const deps = makeDeps(instances);

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -28,6 +28,7 @@ import {
   type ResizeControllerDeps,
 } from "../TerminalResizeController";
 import { TERMINAL_SCROLLBAR_WIDTH } from "@/config/xtermConfig";
+import { MAX_TERMINAL_GRID_DIMENSION } from "@shared/types/terminal";
 
 /**
  * The scrollbar gutter the controller reserves before dividing a container width
@@ -2626,6 +2627,33 @@ describe("TerminalResizeController", () => {
       // The reveal-path reflow re-pins a bottom-following pane — the missing
       // pin that left docked terminals parked above the bottom (#11316).
       expect(managed.terminal.scrollToBottom).toHaveBeenCalledOnce();
+    });
+
+    it("clamps the measurement itself so the target cache stays reachable", () => {
+      const managed = createManagedTerminal();
+      // An absurd box (hostile serialized geometry, a compositor reporting a
+      // nonsense rect). Clamping only where the number is APPLIED would leave
+      // latestCols at the raw measurement while xterm and the PTY both landed
+      // on the ceiling — and every `terminal.cols === latestCols` convergence
+      // check (forceGeometryResync's circuit-breaker re-arm, the reveal
+      // controller's drift probe) would then be unsatisfiable forever (#11641).
+      managed.fitAddon.proposeDimensions = vi.fn(() => ({
+        cols: MAX_TERMINAL_GRID_DIMENSION + 500,
+        rows: MAX_TERMINAL_GRID_DIMENSION + 500,
+      }));
+
+      const controller = makeController(managed);
+      expect(controller.reconcileGeometryFresh("term-1")).toBe(true);
+
+      expect(managed.terminal.cols).toBeLessThanOrEqual(MAX_TERMINAL_GRID_DIMENSION);
+      expect(managed.terminal.rows).toBeLessThanOrEqual(MAX_TERMINAL_GRID_DIMENSION);
+      expect(managed.latestCols).toBe(managed.terminal.cols);
+      expect(managed.latestRows).toBe(managed.terminal.rows);
+      expect(resizeMock).toHaveBeenCalledWith(
+        "term-1",
+        managed.terminal.cols,
+        managed.terminal.rows
+      );
     });
 
     it("preserves a deliberately user-scrolled viewport across a fresh reflow", () => {

--- a/src/services/terminal/paintFabric/PaintFabricCompositor.ts
+++ b/src/services/terminal/paintFabric/PaintFabricCompositor.ts
@@ -1023,6 +1023,10 @@ export class PaintFabricCompositor implements TerminalPaintPlane {
     this.planes().forEach((plane) => plane.handleBackendRecovery());
   }
 
+  handleBackendCrash(): void {
+    this.planes().forEach((plane) => plane.handleBackendCrash());
+  }
+
   // Option updates fold into the captured create-args so a later transfer
   // rebuilds the terminal with its CURRENT options, not its original ones.
   updateOptions(id: string, options: Partial<Terminal["options"]>): void {

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -8,6 +8,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { TerminalRefreshTier, PanelKind, AgentState } from "@/types";
 import type { TerminalScrollbackRestoreError } from "@shared/types/panel";
 import type { TerminalGeometry } from "@shared/types/terminal";
+import type { TerminalResizeResult } from "@shared/types/pty-host";
 
 export type RefreshTierProvider = () => TerminalRefreshTier;
 
@@ -111,6 +112,24 @@ export interface ManagedTerminal {
   // the same id must not inherit a prior instance's give-up state (mirrors the
   // revealPendingGeneration guard).
   geometryRepairGeneration?: number;
+  // Geometry the PTY reported holding after its last resize (#11641). The only
+  // view the renderer has of the backend grid — everything else here describes
+  // xterm's side.
+  lastPtyResizeResult?: TerminalResizeResult;
+  // Divergence episodes seen between the applied PTY grid and xterm's grid.
+  // Counts episodes, not watchdog ticks: it advances only when the divergence
+  // signature changes, so it stays in step with what was logged.
+  ptyGeometryDivergenceCount?: number;
+  // The PTY launchGeneration the count accrued under. Scoped to the PTY
+  // incarnation, NOT attachGeneration — detaching and reattaching a pane leaves
+  // the same PTY running, so its divergence history is still the pane's own.
+  ptyGeometryDivergenceGeneration?: number;
+  // Signature of the divergence currently being reported, so a persistently
+  // split pane logs once per episode instead of once per sweep. Cleared only on
+  // observed agreement.
+  ptyGeometryDivergenceSignature?: string;
+  // Same episode-dedup for the container-vs-xterm fit diagnostic.
+  fitGeometryDivergenceSignature?: string;
   // Visibility tracking
   isVisible: boolean;
   lastActiveTime: number;

--- a/src/store/listeners/panel/__tests__/backendHealth.test.ts
+++ b/src/store/listeners/panel/__tests__/backendHealth.test.ts
@@ -10,18 +10,25 @@ vi.mock("@/utils/logger", () => ({
   logWarn: vi.fn(),
 }));
 
+const { handleBackendCrash, handleBackendRecovery } = vi.hoisted(() => ({
+  handleBackendCrash: vi.fn(),
+  handleBackendRecovery: vi.fn(),
+}));
+
 vi.mock("@/services/TerminalInstanceService", () => ({
-  terminalInstanceService: {
-    handleBackendRecovery: vi.fn(),
-  },
+  terminalInstanceService: { handleBackendCrash, handleBackendRecovery },
 }));
 
 const backendReadyHandlers = vi.hoisted(() => [] as Array<() => void>);
+const backendCrashedHandlers = vi.hoisted(() => [] as Array<(details: unknown) => void>);
 vi.mock("@/controllers", () => {
   const noopSub = () => () => {};
   return {
     terminalRegistryController: {
-      onBackendCrashed: vi.fn(noopSub),
+      onBackendCrashed: vi.fn((handler: (details: unknown) => void) => {
+        backendCrashedHandlers.push(handler);
+        return () => {};
+      }),
       onBackendRecovering: vi.fn(noopSub),
       onBackendReady: vi.fn((handler: () => void) => {
         backendReadyHandlers.push(handler);
@@ -38,6 +45,14 @@ function getBackendReadyHandler(): () => void {
   setupBackendHealthListeners();
   const handler = backendReadyHandlers.at(-1);
   if (!handler) throw new Error("onBackendReady handler was not registered");
+  return handler;
+}
+
+function getBackendCrashedHandler(): (details: unknown) => void {
+  backendCrashedHandlers.length = 0;
+  setupBackendHealthListeners();
+  const handler = backendCrashedHandlers.at(-1);
+  if (!handler) throw new Error("onBackendCrashed handler was not registered");
   return handler;
 }
 
@@ -58,7 +73,21 @@ const ptyBase = {
 
 beforeEach(() => {
   usePanelStore.setState({ panelsById: {}, panelIds: [] });
+  vi.clearAllMocks();
   vi.useFakeTimers();
+});
+
+describe("onBackendCrashed — stale PTY geometry echoes dropped (#11641)", () => {
+  it("invalidates every pane's echo at crash time, not at recovery", () => {
+    getBackendCrashedHandler()({ crashType: "SIGNAL_TERMINATED" });
+
+    // The renderer keeps resizing panes for the whole outage, so waiting for
+    // onBackendReady would leave a dead PTY's geometry comparable against a
+    // live xterm grid for exactly the window the logs matter in.
+    expect(handleBackendCrash).toHaveBeenCalledTimes(1);
+    expect(handleBackendRecovery).not.toHaveBeenCalled();
+    expect(usePanelStore.getState().backendStatus).toBe("disconnected");
+  });
 });
 
 describe("onBackendReady — stale flow state cleared on host recovery (#9899)", () => {

--- a/src/store/listeners/panel/backendHealth.ts
+++ b/src/store/listeners/panel/backendHealth.ts
@@ -92,6 +92,11 @@ export function setupBackendHealthListeners(): DisposableStore {
           recoveryTimer = null;
         }
 
+        // The PTYs died with the host, so the geometry each pane last echoed
+        // describes a process that no longer exists. Panes keep resizing for the
+        // whole outage and no echo can arrive to correct the record (#11641).
+        terminalInstanceService.handleBackendCrash();
+
         usePanelStore.setState({
           backendStatus: "disconnected",
           lastCrashType: normalizeCrashType(details?.crashType),


### PR DESCRIPTION
## What
The pty-host applied resize requests but never reported what it actually applied, so nothing could detect the PTY's real grid drifting from xterm's. This adds an applied-dimensions echo (pty-host → Main → renderer), a divergence counter, promotes the dev-only geometry diagnostic to production, and fixes a column-clamp asymmetry.

- `TerminalProcess.resize` now returns a `TerminalResizeResult` on every path — including the dedup shortcut and the throwing path, so a caller can tell "the PTY is where you asked" from "the PTY never moved" (the #11447 no-SIGWINCH case).
- `PtyManager` emits `resize-result` stamped with the launch generation. Both resize transports funnel through it, so one emit point covers the Main IPC handler and the renderer's direct MessagePort.
- Main drops echoes from a superseded incarnation via the lifecycle ledger's `isCurrent` (#10950), so a late result can't land on a same-id successor.
- `ManagedTerminal` carries the applied geometry; the reconciliation watchdog compares it against `terminal.cols/rows` directly (never `latestCols`, which names a queued target) and counts divergence episodes.
- `diagnoseGeometryDivergence` is out of its `import.meta.env.DEV` gate, deduped by divergence signature so the interval sweep reports once per episode rather than once per tick.

## Honest scope of the signal
node-pty's `IPty.cols/rows` are its own cached copy of the request, not a kernel read-back, so this cannot detect OS/ConPTY clamping — that is structurally unobservable through node-pty's API. What it does detect is application-level divergence: our own clamps, the pre-spawn buffering path, and a resize throw that was previously swallowed into a bare `console.error`.

## Column-clamp asymmetry
`terminalClient.resize` posts straight to the pty-host over a MessagePort and only falls back to Main IPC when no port exists — so the old 500-column clamp bounded the *fallback* transport and not the primary one, letting the two grids split permanently above 500 columns on an ultrawide display. Both halves now normalize through the existing shared `MAX_TERMINAL_GRID_DIMENSION` (2000), and `PtyManager.resize` enforces it at the real trust boundary.

## Windows note (found in review)
node-pty's Windows backend queues `resize()` until ConPTY signals ready and updates its cached dimensions only inside that deferred callback. Reporting the pre-resize grid as `applied` there would manufacture agreement with xterm and hide the exact split this feature exists to catch — so an unconfirmed read-back reports `deferred` with null dimensions instead of guessing.

## Known limitation
If a spawn is rejected with `TERMINAL_ALREADY_LIVE`, Main has already minted generation N+1 while the host keeps stamping echoes with the still-live generation N, so Main drops them and the echo goes quiet for that terminal. The clean fix is an active-owner generation, which restructures a primitive that also guards journal/close exactly-once dedup — deliberately left out of this PR. Follow-on work in #11638's area also covers the pre-spawn PTY-only resize in `addPanel.ts`, which predates this branch.

## Testing
848 tests across 44 suites pass locally, including new coverage for: the read-back vs echo-of-request distinction, the no-op/deferred/failed/rejected/exited outcomes, generation filtering across kill/respawn, the Main broadcast envelope, the service's lazy subscription and per-incarnation counter reset, and transport parity for the clamp fix. The promoted-diagnostic tests force `import.meta.env.DEV` false — vitest runs with it true, so they would otherwise have passed against the old gate.

Resolves #11641