### PR TITLE
fix(worktree): clear an inherited selection in a worktree-less workspace

### DIFF
--- a/src/hooks/__tests__/useAgentLauncher.worktreeResolution.test.ts
+++ b/src/hooks/__tests__/useAgentLauncher.worktreeResolution.test.ts
@@ -6,7 +6,7 @@
  * return must fail a test here, not just at the ActionService boundary.
  */
 import { describe, expect, it } from "vitest";
-import { resolveLaunchWorktree } from "../useAgentLauncher";
+import { resolveLaunchTarget, resolveLaunchWorktree } from "../useAgentLauncher";
 
 function map(ids: string[]): Map<string, { path: string }> {
   return new Map(ids.map((id) => [id, { path: `/repo/${id}` }]));
@@ -46,5 +46,76 @@ describe("resolveLaunchWorktree", () => {
     // the caller's cwd fallbacks rather than failing a launch spuriously.
     expect(resolveLaunchWorktree("main", map([]), false)).toBeNull();
     expect(resolveLaunchWorktree("main", map(["wt-1"]), false)).toBeNull();
+  });
+});
+
+/**
+ * Where the explicit/inherited split lives (#11654). An id the caller named is
+ * an assertion and keeps the #10812 throw; an id inherited from the workspace's
+ * ambient selection is not, and a worktree-less workspace can hold a stale one
+ * from a previous project. The id and worktree are resolved together so a stale
+ * id can never reach panel metadata or preset scoping alongside a null worktree.
+ */
+describe("resolveLaunchTarget", () => {
+  it("keeps throwing for an explicit id that cannot resolve (#10812)", () => {
+    expect(() => resolveLaunchTarget("gone", null, map(["wt-1"]), true)).toThrow(
+      "Worktree 'gone' not found"
+    );
+  });
+
+  it("throws for an explicit bad id even when the inherited id would have resolved", () => {
+    // Proves an explicit request never silently degrades into the ambient one —
+    // an MCP client asking for a specific worktree must hear that it is wrong.
+    expect(() => resolveLaunchTarget("gone", "wt-1", map(["wt-1"]), true)).toThrow(
+      "Worktree 'gone' not found"
+    );
+  });
+
+  it("prefers an explicit id over a different inherited one", () => {
+    expect(resolveLaunchTarget("wt-2", "wt-1", map(["wt-1", "wt-2"]), true)).toEqual({
+      worktreeId: "wt-2",
+      worktree: { path: "/repo/wt-2" },
+    });
+  });
+
+  it("drops an inherited id that the initialized map does not know", () => {
+    // The worktree-less workspace case: launching must proceed without a
+    // worktree rather than failing on state the user never chose.
+    expect(resolveLaunchTarget(undefined, "stale", map([]), true)).toEqual({
+      worktreeId: null,
+      worktree: null,
+    });
+  });
+
+  it("retains an unresolved inherited id until the map is authoritative", () => {
+    // Pre-init the panel is still created with this id, so reporting it stays
+    // accurate — only the worktree is unknown.
+    expect(resolveLaunchTarget(undefined, "stale", map([]), false)).toEqual({
+      worktreeId: "stale",
+      worktree: null,
+    });
+  });
+
+  it("resolves an inherited id that the map knows", () => {
+    expect(resolveLaunchTarget(undefined, "wt-1", map(["wt-1"]), true)).toEqual({
+      worktreeId: "wt-1",
+      worktree: { path: "/repo/wt-1" },
+    });
+  });
+
+  it("yields no target when neither source supplies an id", () => {
+    expect(resolveLaunchTarget(undefined, null, map(["wt-1"]), true)).toEqual({
+      worktreeId: null,
+      worktree: null,
+    });
+  });
+
+  it("normalizes an empty explicit id to no target rather than throwing", () => {
+    // Matches the `id || undefined` the panel options apply downstream, so the
+    // reported id and the panel's own can never disagree.
+    expect(resolveLaunchTarget("", "wt-1", map(["wt-1"]), true)).toEqual({
+      worktreeId: null,
+      worktree: null,
+    });
   });
 });

--- a/src/hooks/__tests__/useAgentLauncher.worktreeResolution.test.ts
+++ b/src/hooks/__tests__/useAgentLauncher.worktreeResolution.test.ts
@@ -138,4 +138,44 @@ describe("resolveLaunchTarget", () => {
       worktree: null,
     });
   });
+
+  /**
+   * A ghost row (#11232) is absent from the live map yet is a legitimate active
+   * selection — `useActiveWorktreeSync` holds the selection on one while its
+   * terminals survive. Dropping the id would put the new panel in the
+   * `__none__` bucket: invisible chrome over a live PTY.
+   */
+  describe("deleted-worktree ghost rows", () => {
+    it("keeps an inherited ghost id so the panel joins the row's surviving terminals", () => {
+      expect(
+        resolveLaunchTarget(undefined, "ghost", map(["wt-1"]), true, new Set(["ghost"]))
+      ).toEqual({ worktreeId: "ghost", worktree: null });
+    });
+
+    it("accepts the store's Map of ghost rows, not just a Set", () => {
+      // The hook passes `deletedWorktrees` straight through, which is a
+      // Map<string, DeletedWorktree>.
+      const deleted = new Map([["ghost", { name: "feature" }]]);
+      expect(resolveLaunchTarget(undefined, "ghost", map([]), true, deleted)).toEqual({
+        worktreeId: "ghost",
+        worktree: null,
+      });
+    });
+
+    it("still drops an inherited id that is neither live nor a ghost row", () => {
+      expect(resolveLaunchTarget(undefined, "stale", map([]), true, new Set(["ghost"]))).toEqual({
+        worktreeId: null,
+        worktree: null,
+      });
+    });
+
+    it("does not rescue an explicit ghost id — a named target still asserts (#10812)", () => {
+      // The caller asked for this worktree by name; a ghost has no path to
+      // launch into, so the failure must surface rather than silently landing
+      // somewhere else.
+      expect(() =>
+        resolveLaunchTarget("ghost", null, map(["wt-1"]), true, new Set(["ghost"]))
+      ).toThrow("Worktree 'ghost' not found");
+    });
+  });
 });

--- a/src/hooks/__tests__/useAgentLauncher.worktreeResolution.test.ts
+++ b/src/hooks/__tests__/useAgentLauncher.worktreeResolution.test.ts
@@ -87,6 +87,25 @@ describe("resolveLaunchTarget", () => {
     });
   });
 
+  it("drops an unknown inherited id against a populated map, not just an empty one", () => {
+    // Switching into a different git-backed project carries the previous
+    // project's id across. Keying the decision off an empty map instead of the
+    // failed lookup would leave that case throwing.
+    expect(resolveLaunchTarget(undefined, "other-project-wt", map(["new-main"]), true)).toEqual({
+      worktreeId: null,
+      worktree: null,
+    });
+  });
+
+  it("retains an unresolved explicit id before initialization instead of throwing", () => {
+    // Symmetric with the inherited pre-init case, and it must not quietly
+    // borrow the inherited id the caller declined to use.
+    expect(resolveLaunchTarget("wt-9", "wt-1", map(["wt-1"]), false)).toEqual({
+      worktreeId: "wt-9",
+      worktree: null,
+    });
+  });
+
   it("retains an unresolved inherited id until the map is authoritative", () => {
     // Pre-init the panel is still created with this id, so reporting it stays
     // accurate — only the worktree is unknown.
@@ -111,8 +130,9 @@ describe("resolveLaunchTarget", () => {
   });
 
   it("normalizes an empty explicit id to no target rather than throwing", () => {
-    // Matches the `id || undefined` the panel options apply downstream, so the
-    // reported id and the panel's own can never disagree.
+    // The MCP launch schema is `z.string().optional()`, so "" reaches here.
+    // Every consumer already reduces it to absent, and it must not fall through
+    // to the inherited id — the caller did supply a value, however useless.
     expect(resolveLaunchTarget("", "wt-1", map(["wt-1"]), true)).toEqual({
       worktreeId: null,
       worktree: null,

--- a/src/hooks/app/__tests__/useActiveWorktreeSync.initialization.test.ts
+++ b/src/hooks/app/__tests__/useActiveWorktreeSync.initialization.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   selectionState: {
     activeWorktreeId: null as string | null,
     selectWorktree: vi.fn(),
+    setActiveWorktree: vi.fn(),
     deletedWorktrees: new Map<string, unknown>(),
   },
   projectState: {
@@ -61,6 +62,7 @@ describe("useActiveWorktreeSync initialization", () => {
   beforeEach(() => {
     mocks.selectionState.activeWorktreeId = null;
     mocks.selectionState.selectWorktree.mockReset();
+    mocks.selectionState.setActiveWorktree.mockReset();
     mocks.selectionState.deletedWorktrees = new Map();
     mocks.useWorktrees.mockReset();
     mocks.projectState.currentProject = { id: "project-1", path: "/repo" };
@@ -110,5 +112,71 @@ describe("useActiveWorktreeSync initialization", () => {
     rerender();
 
     expect(mocks.selectionState.selectWorktree).toHaveBeenCalledExactlyOnceWith(mainWorktree.id);
+  });
+});
+
+/**
+ * A worktree-less workspace (a plain folder, or a repo opened without one) gets
+ * an authoritative empty snapshot, not a pending one. Before #11654 the effect
+ * bailed on the empty list and left whatever id the previous project had
+ * selected, which then failed every agent launch against a worktree that does
+ * not exist here.
+ */
+describe("useActiveWorktreeSync on a worktree-less workspace", () => {
+  beforeEach(() => {
+    mocks.selectionState.activeWorktreeId = null;
+    mocks.selectionState.selectWorktree.mockReset();
+    mocks.selectionState.setActiveWorktree.mockReset();
+    mocks.selectionState.deletedWorktrees = new Map();
+    mocks.useWorktrees.mockReset();
+    mocks.projectState.currentProject = { id: "project-1", path: "/plain-folder" };
+    mocks.scratchState.currentScratch = null;
+  });
+
+  it("clears an inherited selection only once the empty snapshot is authoritative", () => {
+    mocks.selectionState.activeWorktreeId = featureWorktree.id;
+    mocks.useWorktrees.mockReturnValue({ worktrees: [], isInitialized: false });
+
+    const { rerender } = renderHook(() => useActiveWorktreeSync());
+
+    // Empty-and-loading is indistinguishable from empty-and-real without the
+    // flag, so nothing may be cleared yet.
+    expect(mocks.selectionState.setActiveWorktree).not.toHaveBeenCalled();
+
+    mocks.useWorktrees.mockReturnValue({ worktrees: [], isInitialized: true });
+    rerender();
+
+    expect(mocks.selectionState.setActiveWorktree).toHaveBeenCalledExactlyOnceWith(null);
+    // There is no worktree to snap to — reaching for one would read past the
+    // end of the empty list.
+    expect(mocks.selectionState.selectWorktree).not.toHaveBeenCalled();
+  });
+
+  it("leaves an already-cleared selection alone across repeated snapshots", () => {
+    mocks.useWorktrees.mockReturnValue({ worktrees: [], isInitialized: true });
+
+    const { rerender } = renderHook(() => useActiveWorktreeSync());
+    // A fresh array each poll, as the store hands out: the effect re-runs even
+    // though nothing about the workspace changed.
+    mocks.useWorktrees.mockReturnValue({ worktrees: [], isInitialized: true });
+    rerender();
+
+    // setActiveWorktree persists and re-runs terminal policy on every call, so
+    // clearing a selection that is already null is a write for no reason.
+    expect(mocks.selectionState.setActiveWorktree).not.toHaveBeenCalled();
+  });
+
+  it("keeps a deleted row selected when it outlives the last live worktree", () => {
+    // pruneDeletedWorktrees retains a row while it still owns a terminal, so a
+    // deleted row can be the active selection with nothing live left. The user
+    // is looking at its surviving terminals.
+    mocks.selectionState.activeWorktreeId = "ghost";
+    mocks.selectionState.deletedWorktrees = new Map([["ghost", {}]]);
+    mocks.useWorktrees.mockReturnValue({ worktrees: [], isInitialized: true });
+
+    renderHook(() => useActiveWorktreeSync());
+
+    expect(mocks.selectionState.setActiveWorktree).not.toHaveBeenCalled();
+    expect(mocks.selectionState.selectWorktree).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/app/__tests__/useActiveWorktreeSync.initialization.test.ts
+++ b/src/hooks/app/__tests__/useActiveWorktreeSync.initialization.test.ts
@@ -44,6 +44,13 @@ vi.mock("@/hooks/app/useHomeDir", () => ({
   useHomeDir: () => ({ homeDir: "/home" }),
 }));
 
+// Any case that starts from a live selection reaches the sync effect, which
+// pushes the active worktree over the port. jsdom aliases globalThis to window,
+// so stubbing the global satisfies the hook's `window.electron` read.
+vi.stubGlobal("electron", {
+  worktreePort: { request: vi.fn(() => Promise.resolve()) },
+});
+
 const featureWorktree = {
   id: "feature",
   name: "feature/test-branch",
@@ -156,14 +163,33 @@ describe("useActiveWorktreeSync on a worktree-less workspace", () => {
     mocks.useWorktrees.mockReturnValue({ worktrees: [], isInitialized: true });
 
     const { rerender } = renderHook(() => useActiveWorktreeSync());
-    // A fresh array each poll, as the store hands out: the effect re-runs even
-    // though nothing about the workspace changed.
+    // A distinct array, so the dep list changes and the effect genuinely reruns
+    // rather than being skipped.
     mocks.useWorktrees.mockReturnValue({ worktrees: [], isInitialized: true });
     rerender();
 
     // setActiveWorktree persists and re-runs terminal policy on every call, so
     // clearing a selection that is already null is a write for no reason.
     expect(mocks.selectionState.setActiveWorktree).not.toHaveBeenCalled();
+  });
+
+  it("clears the selection when the last live worktree disappears", () => {
+    // The other direction into empty: the workspace was authoritative and
+    // populated all along, so nothing about initialization changes here.
+    mocks.selectionState.activeWorktreeId = featureWorktree.id;
+    mocks.useWorktrees.mockReturnValue({
+      worktrees: [featureWorktree],
+      isInitialized: true,
+    });
+
+    const { rerender } = renderHook(() => useActiveWorktreeSync());
+    expect(mocks.selectionState.setActiveWorktree).not.toHaveBeenCalled();
+
+    mocks.useWorktrees.mockReturnValue({ worktrees: [], isInitialized: true });
+    rerender();
+
+    expect(mocks.selectionState.setActiveWorktree).toHaveBeenCalledExactlyOnceWith(null);
+    expect(mocks.selectionState.selectWorktree).not.toHaveBeenCalled();
   });
 
   it("keeps a deleted row selected when it outlives the last live worktree", () => {

--- a/src/hooks/app/__tests__/useActiveWorktreeSync.initialization.test.ts
+++ b/src/hooks/app/__tests__/useActiveWorktreeSync.initialization.test.ts
@@ -153,7 +153,12 @@ describe("useActiveWorktreeSync on a worktree-less workspace", () => {
     mocks.useWorktrees.mockReturnValue({ worktrees: [], isInitialized: true });
     rerender();
 
-    expect(mocks.selectionState.setActiveWorktree).toHaveBeenCalledExactlyOnceWith(null);
+    // `persist: false` is load-bearing: the persisted `activeWorktreeId` slot is
+    // app-global, so a plain clear here would drop the saved selection of the
+    // git-backed project that left this id behind.
+    expect(mocks.selectionState.setActiveWorktree).toHaveBeenCalledExactlyOnceWith(null, {
+      persist: false,
+    });
     // There is no worktree to snap to — reaching for one would read past the
     // end of the empty list.
     expect(mocks.selectionState.selectWorktree).not.toHaveBeenCalled();
@@ -188,7 +193,9 @@ describe("useActiveWorktreeSync on a worktree-less workspace", () => {
     mocks.useWorktrees.mockReturnValue({ worktrees: [], isInitialized: true });
     rerender();
 
-    expect(mocks.selectionState.setActiveWorktree).toHaveBeenCalledExactlyOnceWith(null);
+    expect(mocks.selectionState.setActiveWorktree).toHaveBeenCalledExactlyOnceWith(null, {
+      persist: false,
+    });
     expect(mocks.selectionState.selectWorktree).not.toHaveBeenCalled();
   });
 

--- a/src/hooks/app/__tests__/useActiveWorktreeSync.test.ts
+++ b/src/hooks/app/__tests__/useActiveWorktreeSync.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   selectionState: {
     activeWorktreeId: null as string | null,
     selectWorktree: vi.fn(),
+    setActiveWorktree: vi.fn(),
     // Only unread today because every active id here is also a live worktree,
     // which short-circuits the `||`. One absent-worktree fixture away from a
     // TypeError without it.

--- a/src/hooks/app/useActiveWorktreeSync.ts
+++ b/src/hooks/app/useActiveWorktreeSync.ts
@@ -44,12 +44,15 @@ export function useActiveWorktreeSync() {
     // pending load — a non-git workspace creates no monitors. Clear the id a
     // previous project left behind rather than snapping to a main worktree that
     // does not exist, or every launch resolves against a phantom target
-    // (#11654). Guarded on a non-null id because `setActiveWorktree` persists
-    // and re-runs terminal policy on every call, and this effect re-runs on each
-    // snapshot.
+    // (#11654). Session-scoped: the persisted `activeWorktreeId` slot is
+    // app-global, so writing null through it would wipe the saved selection of
+    // the git-backed project that left this id behind — the same reasoning that
+    // makes `stateHydration` skip the write rather than clear. Guarded on a
+    // non-null id because `setActiveWorktree` re-runs terminal policy on every
+    // call, and this effect re-runs on each snapshot.
     if (worktrees.length === 0) {
       if (activeWorktreeId !== null) {
-        setActiveWorktree(null);
+        setActiveWorktree(null, { persist: false });
       }
       return;
     }

--- a/src/hooks/app/useActiveWorktreeSync.ts
+++ b/src/hooks/app/useActiveWorktreeSync.ts
@@ -10,6 +10,7 @@ export function useActiveWorktreeSync() {
   const { worktrees, isInitialized } = useWorktrees();
   const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
   const selectWorktree = useWorktreeSelectionStore((s) => s.selectWorktree);
+  const setActiveWorktree = useWorktreeSelectionStore((s) => s.setActiveWorktree);
   const deletedWorktrees = useWorktreeSelectionStore((s) => s.deletedWorktrees);
   const currentProject = useProjectStore((s) => s.currentProject);
   const currentScratch = useScratchStore((s) => s.currentScratch);
@@ -26,20 +27,43 @@ export function useActiveWorktreeSync() {
   );
 
   useEffect(() => {
-    if (!isInitialized || worktrees.length === 0) return;
+    if (!isInitialized) return;
 
     // A deleted-worktree row (directory gone, terminals surviving) is a valid
     // active selection — the user clicked it to view its terminals. Only snap
     // back to main once the id is neither live nor a deleted row (e.g. its
-    // last terminal closed and the row was pruned).
-    const worktreeExists =
-      activeWorktreeId &&
+    // last terminal closed and the row was pruned). Checked before the empty
+    // branch: a deleted row outlives the last live worktree while it still owns
+    // a terminal, so an empty list does not invalidate it.
+    const activeSelectionIsValid =
+      activeWorktreeId !== null &&
       (worktrees.some((w) => w.id === activeWorktreeId) || deletedWorktrees.has(activeWorktreeId));
-    if (!worktreeExists) {
-      const mainWorktree = worktrees.find((w) => w.isMainWorktree) ?? worktrees[0]!;
-      selectWorktree(mainWorktree.id);
+    if (activeSelectionIsValid) return;
+
+    // Past `isInitialized`, an empty list is the workspace's real answer, not a
+    // pending load — a non-git workspace creates no monitors. Clear the id a
+    // previous project left behind rather than snapping to a main worktree that
+    // does not exist, or every launch resolves against a phantom target
+    // (#11654). Guarded on a non-null id because `setActiveWorktree` persists
+    // and re-runs terminal policy on every call, and this effect re-runs on each
+    // snapshot.
+    if (worktrees.length === 0) {
+      if (activeWorktreeId !== null) {
+        setActiveWorktree(null);
+      }
+      return;
     }
-  }, [worktrees, activeWorktreeId, isInitialized, selectWorktree, deletedWorktrees]);
+
+    const mainWorktree = worktrees.find((w) => w.isMainWorktree) ?? worktrees[0]!;
+    selectWorktree(mainWorktree.id);
+  }, [
+    worktrees,
+    activeWorktreeId,
+    isInitialized,
+    selectWorktree,
+    setActiveWorktree,
+    deletedWorktrees,
+  ]);
 
   useEffect(() => {
     const projectId = currentProject?.id ?? null;

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -62,6 +62,10 @@ const CLIPBOARD_DIR_NAME = "daintree-clipboard";
  * loops (#10812). The thrown message lists the available IDs so a model client
  * can self-correct. Before the map is initialized we cannot assert "not found",
  * so we fall through and let the caller use its cwd fallbacks.
+ *
+ * Only ever reached with an id the caller asked for by name — an inherited
+ * ambient selection goes through `resolveLaunchTarget` instead, which must not
+ * throw. See that function for why the two are treated differently.
  */
 export function resolveLaunchWorktree<T>(
   targetWorktreeId: string | null | undefined,
@@ -77,6 +81,47 @@ export function resolveLaunchWorktree<T>(
     );
   }
   return targetWorktree ?? null;
+}
+
+/**
+ * Pick the worktree a launch actually targets, and the id that describes it.
+ *
+ * The two sources of a target are not equivalent. An explicit
+ * `launchOptions.worktreeId` is the caller naming a destination, so an id that
+ * does not resolve is their error and must surface as one (#10812) — it goes
+ * straight to `resolveLaunchWorktree` and keeps the throw. An inherited id is
+ * whatever the workspace happened to have selected; the user never chose it for
+ * this launch. A worktree-less workspace can hold one left behind by a previous
+ * project, and failing every launch over it is the bug in #11654 — so once the
+ * map is authoritative and the id is absent, the launch simply proceeds without
+ * a worktree.
+ *
+ * Before the map initializes, absent is unknowable rather than false, so an
+ * inherited id survives with a null worktree — the panel is still created with
+ * it, which is what `buildLaunchIdentity` reports.
+ *
+ * The id and the worktree are returned together because they must agree: a
+ * caller holding the raw inherited id alongside a normalized worktree would tag
+ * panels and scope presets to a worktree that does not exist.
+ */
+export function resolveLaunchTarget<T>(
+  explicitWorktreeId: string | undefined,
+  inheritedWorktreeId: string | null,
+  worktreeMap: Map<string, T>,
+  isInitialized: boolean
+): { worktreeId: string | null; worktree: T | null } {
+  if (explicitWorktreeId !== undefined) {
+    return {
+      worktreeId: explicitWorktreeId || null,
+      worktree: resolveLaunchWorktree(explicitWorktreeId, worktreeMap, isInitialized),
+    };
+  }
+
+  const worktree = inheritedWorktreeId ? (worktreeMap.get(inheritedWorktreeId) ?? null) : null;
+  if (inheritedWorktreeId && !worktree && isInitialized) {
+    return { worktreeId: null, worktree: null };
+  }
+  return { worktreeId: inheritedWorktreeId, worktree };
 }
 
 export interface LaunchAgentOptions {
@@ -297,8 +342,12 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
         // Inside the try: a throw between the add above and the `finally` would
         // strand the entry and leave this agentId unlaunchable for the session.
         markRendererPerformance("agentlaunch.begin", { agentId });
-        const targetWorktreeId = launchOptions?.worktreeId ?? activeWorktreeId;
-        const targetWorktree = resolveLaunchWorktree(targetWorktreeId, worktreeMap, isInitialized);
+        const { worktreeId: effectiveWorktreeId, worktree: targetWorktree } = resolveLaunchTarget(
+          launchOptions?.worktreeId,
+          activeWorktreeId,
+          worktreeMap,
+          isInitialized
+        );
 
         const cwd =
           launchOptions?.cwd ??
@@ -311,7 +360,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
 
         // Resolved once, spread into every success return so a caller learns
         // where the launch landed without re-deriving it.
-        const launchIdentity = buildLaunchIdentity(targetWorktreeId, targetWorktree, cwd);
+        const launchIdentity = buildLaunchIdentity(effectiveWorktreeId, targetWorktree, cwd);
 
         // Handle browser pane specially
         if (agentId === "browser") {
@@ -319,7 +368,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
             const terminalId = await addPanel({
               kind: "browser",
               cwd,
-              worktreeId: targetWorktreeId || undefined,
+              worktreeId: effectiveWorktreeId || undefined,
               location: launchOptions?.location,
               activateDockOnCreate: launchOptions?.activateDockOnCreate,
               spawnedBy: launchOptions?.spawnedBy,
@@ -341,7 +390,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               kind: "dev-preview",
               title: "Dev Server",
               cwd,
-              worktreeId: targetWorktreeId || undefined,
+              worktreeId: effectiveWorktreeId || undefined,
               location: launchOptions?.location,
               activateDockOnCreate: launchOptions?.activateDockOnCreate,
               spawnedBy: launchOptions?.spawnedBy,
@@ -388,7 +437,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
           //   agent-level `presetId` so switching worktrees doesn't silently
           //   surface another worktree's pick.
           const explicitDefault = launchOptions?.presetId === null;
-          const savedPresetId = resolveEffectivePresetId(entry, targetWorktreeId);
+          const savedPresetId = resolveEffectivePresetId(entry, effectiveWorktreeId);
           const resolvedPresetId = explicitDefault
             ? undefined
             : (launchOptions?.presetId ?? savedPresetId);
@@ -412,8 +461,8 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
           // when a valid global fallback exists. The stale scoped slot is still
           // cleared below so the next launch resolves directly against global.
           const scopedId =
-            targetWorktreeId && entry.worktreePresets
-              ? entry.worktreePresets[targetWorktreeId]
+            effectiveWorktreeId && entry.worktreePresets
+              ? entry.worktreePresets[effectiveWorktreeId]
               : undefined;
           if (
             !primaryPreset &&
@@ -440,10 +489,10 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
           if (resolvedPresetId && !primaryPreset) {
             const { useAgentSettingsStore: settingsStore } =
               await import("@/store/agentSettingsStore");
-            if (scopedId && scopedId === resolvedPresetId && targetWorktreeId) {
+            if (scopedId && scopedId === resolvedPresetId && effectiveWorktreeId) {
               void settingsStore
                 .getState()
-                .updateWorktreePreset(agentId, targetWorktreeId, undefined);
+                .updateWorktreePreset(agentId, effectiveWorktreeId, undefined);
             } else if (entry.presetId && entry.presetId === resolvedPresetId) {
               void settingsStore.getState().updateAgent(agentId, { presetId: undefined });
             }
@@ -572,7 +621,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               title: trimmedName || presetTitle,
               ...customTitle,
               cwd,
-              worktreeId: targetWorktreeId || undefined,
+              worktreeId: effectiveWorktreeId || undefined,
               location: launchOptions?.location,
               agentLaunchFlags: launchFlags,
               agentModelId: launchOptions?.modelId,
@@ -591,7 +640,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               title: trimmedName || title,
               ...customTitle,
               cwd,
-              worktreeId: targetWorktreeId || undefined,
+              worktreeId: effectiveWorktreeId || undefined,
               command,
               location: launchOptions?.location,
               activateDockOnCreate: launchOptions?.activateDockOnCreate,
@@ -620,7 +669,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               launchAgentId: agentId,
               title: trimmedName || presetTitle,
               ...customTitle,
-              worktreeId: targetWorktreeId || undefined,
+              worktreeId: effectiveWorktreeId || undefined,
               cwd,
               cols: 80,
               rows: 24,

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -103,6 +103,12 @@ export function resolveLaunchWorktree<T>(
  * The id and the worktree are returned together because they must agree: a
  * caller holding the raw inherited id alongside a normalized worktree would tag
  * panels and scope presets to a worktree that does not exist.
+ *
+ * An explicit `""` normalizes to null rather than travelling as an empty
+ * string. Every consumer already reduces it the same way — `|| undefined` for
+ * panel options, `|| null` in `buildLaunchIdentity`, a falsy guard in
+ * `resolveEffectivePresetId` — so nothing observable changes, and the returned
+ * id is then always either a real id or null.
  */
 export function resolveLaunchTarget<T>(
   explicitWorktreeId: string | undefined,

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -109,12 +109,21 @@ export function resolveLaunchWorktree<T>(
  * panel options, `|| null` in `buildLaunchIdentity`, a falsy guard in
  * `resolveEffectivePresetId` — so nothing observable changes, and the returned
  * id is then always either a real id or null.
+ *
+ * `deletedWorktreeIds` carries the ghost rows (#11232): a deleted worktree
+ * whose terminals outlived it is absent from the live map but is still a valid
+ * active selection — `useActiveWorktreeSync` deliberately holds the selection
+ * on one. Dropping it here would land the new panel in the `__none__` bucket
+ * (invisible, with a live PTY) instead of alongside the row's surviving
+ * terminals, so a ghost id survives the same way a live one does, with a null
+ * worktree because it has no path or branch left to report.
  */
 export function resolveLaunchTarget<T>(
   explicitWorktreeId: string | undefined,
   inheritedWorktreeId: string | null,
   worktreeMap: Map<string, T>,
-  isInitialized: boolean
+  isInitialized: boolean,
+  deletedWorktreeIds?: { has: (id: string) => boolean }
 ): { worktreeId: string | null; worktree: T | null } {
   if (explicitWorktreeId !== undefined) {
     return {
@@ -124,7 +133,12 @@ export function resolveLaunchTarget<T>(
   }
 
   const worktree = inheritedWorktreeId ? (worktreeMap.get(inheritedWorktreeId) ?? null) : null;
-  if (inheritedWorktreeId && !worktree && isInitialized) {
+  if (
+    inheritedWorktreeId &&
+    !worktree &&
+    isInitialized &&
+    !deletedWorktreeIds?.has(inheritedWorktreeId)
+  ) {
     return { worktreeId: null, worktree: null };
   }
   return { worktreeId: inheritedWorktreeId, worktree };
@@ -263,6 +277,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
   const addPanel = usePanelStore((state) => state.addPanel);
   const { worktreeMap, isInitialized } = useWorktrees();
   const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
+  const deletedWorktrees = useWorktreeSelectionStore((state) => state.deletedWorktrees);
   const currentProject = useProjectStore((state) => state.currentProject);
   const currentScratch = useScratchStore((state) => state.currentScratch);
   const { homeDir } = useHomeDir();
@@ -352,7 +367,8 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
           launchOptions?.worktreeId,
           activeWorktreeId,
           worktreeMap,
-          isInitialized
+          isInitialized,
+          deletedWorktrees
         );
 
         const cwd =
@@ -751,6 +767,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
     },
     [
       activeWorktreeId,
+      deletedWorktrees,
       worktreeMap,
       isInitialized,
       addPanel,

--- a/src/store/__tests__/worktreeStore.test.ts
+++ b/src/store/__tests__/worktreeStore.test.ts
@@ -792,6 +792,30 @@ describe("worktreeStore", () => {
       expect(useWorktreeSelectionStore.getState().restoreWorktreeId).toBeNull();
     });
 
+    // A worktree-less workspace clearing its inherited selection must not touch
+    // the app-global slot, which is shared with the git-backed project that owns
+    // the saved id (#11654).
+    it("setActiveWorktree(null, { persist: false }) clears the session selection only", async () => {
+      useWorktreeSelectionStore.getState().setActiveWorktree("wt-feature");
+      // persistActiveWorktree defers its setState through a dynamic import, so
+      // the seed's write must land before the mock is cleared.
+      await vi.waitFor(() =>
+        expect(appSetStateMock).toHaveBeenCalledWith({ activeWorktreeId: "wt-feature" })
+      );
+      appSetStateMock.mockClear();
+
+      useWorktreeSelectionStore.getState().setActiveWorktree(null, { persist: false });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const state = useWorktreeSelectionStore.getState();
+      expect(state.activeWorktreeId).toBeNull();
+      // The durable pick and the persisted slot both survive, so returning to
+      // the project that owns it still lands on wt-feature.
+      expect(state.restoreWorktreeId).toBe("wt-feature");
+      expect(appSetStateMock).not.toHaveBeenCalled();
+    });
+
     it("reset clears the restore target", () => {
       useWorktreeSelectionStore.getState().selectWorktree("wt-x");
       expect(useWorktreeSelectionStore.getState().restoreWorktreeId).toBe("wt-x");

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -249,7 +249,15 @@ interface WorktreeSelectionState {
   _previousRestoreWorktreeId: string | null;
   _fleetScopeToken: FleetScopeToken | null;
 
-  setActiveWorktree: (id: string | null) => void;
+  /**
+   * `persist: false` makes the activation session-scoped: the in-memory
+   * selection moves, but neither `restoreWorktreeId` nor the main-process
+   * `activeWorktreeId` slot is written. That slot is app-global — shared by
+   * every project — so a worktree-less workspace clearing it would wipe the
+   * saved selection of the git-backed project that owns it. `stateHydration`
+   * makes the same call by skipping the write outright (#11654).
+   */
+  setActiveWorktree: (id: string | null, options?: { persist?: boolean }) => void;
   setFocusedWorktree: (id: string | null) => void;
   selectWorktree: (id: string, options?: { source?: "user" | "focus" }) => void;
   setPendingWorktree: (id: string | null) => void;
@@ -644,7 +652,12 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
   _previousRestoreWorktreeId: null,
   _fleetScopeToken: null,
 
-  setActiveWorktree: (id) => {
+  setActiveWorktree: (id, options) => {
+    // Both the durable slot and the persisted one ride this flag together: the
+    // restore target is the in-memory half of the same app-global selection, so
+    // a session-scoped activation that nulled it would still lose the durable
+    // pick the moment anything else re-persisted from it (#11654).
+    const persist = options?.persist ?? true;
     const previousId = get().activeWorktreeId;
     const generation = get()._policyGeneration + 1;
     const switchStartedAt = Date.now();
@@ -660,7 +673,9 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       _policyGeneration: generation,
     };
 
-    if (id !== null) {
+    if (!persist) {
+      // Leave the durable selection exactly as it was.
+    } else if (id !== null) {
       // An explicit activation is a durable selection — make it the restore
       // target so switching projects round-trips back to it (#9512).
       updates.restoreWorktreeId = id;
@@ -704,7 +719,9 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     }
     scheduleWorktreeSwitchPaintedMark(previousId ?? null, id ?? null, switchStartedAt);
 
-    persistActiveWorktree(id);
+    if (persist) {
+      persistActiveWorktree(id);
+    }
 
     applyWorktreeTerminalPolicy(get, set, id, generation, () => {
       markRendererPerformance(PERF_MARKS.WORKTREE_SWITCH_END, {


### PR DESCRIPTION
## Summary

- In a workspace with no git worktrees, an `activeWorktreeId` inherited from a previous git-backed project was never reconciled away. Once the worktree map finished loading empty, every agent launch failed with nothing visible to the user (reported on `0.29.0` as "it won't let me launch a codex").
- Two coupled causes, both fixed: the reconcile effect in `useActiveWorktreeSync.ts` read an empty worktree list as "not loaded yet," and `useAgentLauncher.ts` collapsed an explicit worktree id and an inherited ambient default into one variable before the resolver could tell them apart.
- No new user-facing notification. The reconcile is automatic and needs no recovery action, so it stays T0.

Resolves #11654

## Changes

**`src/hooks/app/useActiveWorktreeSync.ts`**

The reconcile effect bailed on `if (!isInitialized || worktrees.length === 0) return;`. That was correct before folders could be opened without git, but a non-git workspace host deliberately creates no monitors and returns an authoritative empty snapshot, so empty is now a real answer, not a loading state.

Restructured into four stages: keep the `isInitialized` guard (it's there for #4894, terminals opening in `$HOME` before hydration), check the active selection's validity (live worktree or a soft-deleted row) before checking emptiness, then branch. The deleted-row check has to come first because a deleted row can outlive the last live worktree while it still owns a terminal. The empty branch clears via `setActiveWorktree(null)`, guarded on a non-null id, since `setActiveWorktree` persists and re-runs terminal policy on every call and the effect re-runs per snapshot. Splitting the branches also means `worktrees[0]!` is only reached once the list is proven non-empty.

**`src/hooks/useAgentLauncher.ts`**

`const targetWorktreeId = launchOptions?.worktreeId ?? activeWorktreeId;` collapsed the two sources before `resolveLaunchWorktree` could tell them apart, so a stale ambient id hit the same throw as a bad explicit one. That throw has to stay for explicit ids (#10812: a silent null used to get serialized as a terminal-less success and drove MCP client retry loops), but it's wrong for a default the user never chose.

Added a pure `resolveLaunchTarget` that keeps the two sources apart and returns the id and worktree together so they can't disagree. `resolveLaunchWorktree` itself is untouched, so the #10812 contract is still guarded where it always was.

The resolved id replaces the raw one at all nine downstream consumers (panel `worktreeId` at five sites, `buildLaunchIdentity`, `resolveEffectivePresetId`, the scoped-preset lookup, and the scoped-preset cleanup). Without that, a stale id would still tag the new panel and scope its preset to a worktree that no longer exists.

Pre-init behavior is deliberately unchanged: an unresolved id still survives with a null worktree, because before the map loads, "absent" is unknowable, and the panel really is created with that id, which is what `buildLaunchIdentity` already documents.

**Out of scope**

`cleanupOrphanedTerminals` in `src/store/createWorktreeStore.ts` has a similar-looking `!isInitialized || size === 0` bail, but that guard fronts a destructive PTY-kill path. Dropping it would kill every worktree-tagged panel in a non-git workspace. It's protective, not a bug, so it's untouched here.

Related: #11650 covers why a non-git workspace inherits the id in the first place.

## Testing

186 tests pass across the 9 affected files. New coverage: authoritative-empty clears only after init, an already-null selection is left alone across repeated snapshots, a deleted row survives an empty live list, the last live worktree disappearing clears the selection, an unknown inherited id drops against a populated map (not just an empty one, so keying off map size alone would've missed it), an unresolved explicit id survives pre-init without borrowing the inherited one, and explicit bad ids still throw even when a valid inherited id exists.

Known gap: no test renders `useAgentLauncher` itself, so the nine downstream substitutions are guarded structurally (no raw id variable remains in the callback scope) rather than behaviorally. A full `renderHook` harness would need around ten store mocks, and this repo has a history of partial `vi.mock` factories silently breaking suites, so it wasn't worth it for this fix.
