### PR TITLE
fix(project): let a switch reach the demotion dialog when a project's repository is gone

### DIFF
--- a/electron/ipc/handlers/__tests__/project.switch.test.ts
+++ b/electron/ipc/handlers/__tests__/project.switch.test.ts
@@ -356,16 +356,24 @@ describe("project switch/reopen refuses a row whose repository is gone (#11649)"
       registerProject();
       probeGitMarkerMock.mockResolvedValue("missing");
       projectStoreMock.classifyGitBacking.mockResolvedValue({ gitBacked: false });
+      // A sender with a real outgoing project and a layout to save, so the
+      // persist is genuinely reachable and its absence means something.
+      mockGetProjectForWebContents.mockReturnValue("proj-outgoing");
       const pvm = makePvm();
+      const outgoingState = { terminals: [], draftInputs: { "term-1": "half typed" } };
 
-      await expect(handlerFor(channel, pvm)({ sender: { id: 10 } }, "proj-gone")).rejects.toThrow(
-        expect.objectContaining({ code: "NOT_A_GIT_REPO" })
-      );
+      await expect(
+        handlerFor(channel, pvm)({ sender: { id: 10 } }, "proj-gone", outgoingState)
+      ).rejects.toThrow(expect.objectContaining({ code: "NOT_A_GIT_REPO" }));
 
       // The whole point of rejecting this early: the sender keeps its current
       // project, so declining the dialog is a no-op rather than a half-switch.
       expect(pvm.switchTo).not.toHaveBeenCalled();
       expect(projectStoreMock.setCurrentProject).not.toHaveBeenCalled();
+      expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
+      expect(projectStoreMock.enqueueProjectStateUpdate).not.toHaveBeenCalled();
+      expect(projectStoreMock.saveProjectState).not.toHaveBeenCalled();
+      expect(mockBroadcastProjectSwitchUpdates).not.toHaveBeenCalled();
       expect(refreshProjectMenuStateMock).not.toHaveBeenCalled();
     });
 
@@ -416,6 +424,9 @@ describe("project switch/reopen refuses a row whose repository is gone (#11649)"
 
       await handlerFor(channel, pvm)({ sender: { id: 10 } }, "proj-gone");
 
+      // Asserting the classifier actually ran is what separates this from an
+      // implementation that ignores "missing" and activates regardless.
+      expect(projectStoreMock.classifyGitBacking).toHaveBeenCalledWith("/projects/gone");
       expect(pvm.switchTo).toHaveBeenCalled();
     });
 
@@ -435,6 +446,31 @@ describe("project switch/reopen refuses a row whose repository is gone (#11649)"
       );
       expect(pvm.switchTo).not.toHaveBeenCalled();
     });
+  });
+
+  it.each(CHANNEL_CASES)("guards the legacy non-PVM path too (%s)", async (channel) => {
+    // The legacy branch resumes the workspace host and delegates to
+    // ProjectSwitchService instead of swapping a view, so a guard that only
+    // covered the PVM path would leave it activating a repository-less row.
+    registerProject();
+    probeGitMarkerMock.mockResolvedValue("missing");
+    projectStoreMock.classifyGitBacking.mockResolvedValue({ gitBacked: false });
+    const resumeProject = vi.fn();
+    const ctx = makeWindowContext(1, 10, {});
+    registerProjectCrudHandlers({
+      mainWindow: { id: 1 } as unknown,
+      windowRegistry: makeWindowRegistry([ctx]),
+      worktreeService: { resumeProject, pauseProject: vi.fn() },
+    } as unknown as HandlerDependencies);
+    const call = (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c) => c[0] === channel
+    );
+    const handler = call![1] as (...args: unknown[]) => Promise<unknown>;
+
+    await expect(handler({ sender: { id: 10 } }, "proj-gone")).rejects.toThrow(
+      expect.objectContaining({ code: "NOT_A_GIT_REPO" })
+    );
+    expect(resumeProject).not.toHaveBeenCalled();
   });
 
   it("probes the project's own root", async () => {

--- a/electron/ipc/handlers/__tests__/project.switch.test.ts
+++ b/electron/ipc/handlers/__tests__/project.switch.test.ts
@@ -22,10 +22,28 @@ vi.mock("electron", () => ({
   },
 }));
 
+/**
+ * The `.git` marker probe the switch/reopen guard runs before activating a
+ * git-backed row (#11649). Defaulted to `"present"` so every fixture below —
+ * whose paths don't exist on disk — takes the healthy path it was written for.
+ */
+const probeGitMarkerMock = vi.hoisted(() =>
+  vi.fn<(root: string) => Promise<"present" | "missing" | "unknown">>()
+);
+vi.mock("../../../services/projectOpenPreflight.js", () => ({
+  probeGitMarker: (root: string) => probeGitMarkerMock(root),
+  assertProjectDirectory: vi.fn(),
+  isMissingExecutableError: vi.fn(() => false),
+  PROJECT_DIRECTORY_STAT_TIMEOUT_MS: 5_000,
+  GIT_MARKER_STAT_TIMEOUT_MS: 1_000,
+}));
+
 const projectStoreMock = vi.hoisted(() => {
   const getProjectState = vi.fn<(id: string) => Promise<Record<string, unknown> | null>>();
   const saveProjectState = vi.fn<(id: string, state: unknown) => Promise<void>>();
   return {
+    classifyGitBacking:
+      vi.fn<(path: string) => Promise<{ gitBacked: boolean; gitRoot?: string }>>(),
     getCurrentProjectId: vi.fn<() => string | null>(),
     getProjectById:
       vi.fn<(id: string) => { id: string; name: string; path: string; status?: string } | null>(),
@@ -87,6 +105,11 @@ vi.mock("../../../window/webContentsRegistry.js", () => ({
 // binding. Each test declares the project its sender view is displaying.
 beforeEach(() => {
   mockGetProjectForWebContents.mockReturnValue(null);
+  // Same reason as the binding above: `clearAllMocks` drops call history but not
+  // return values, so the repository-intact guard is re-armed per test rather
+  // than inheriting whichever answer the previous one installed.
+  probeGitMarkerMock.mockResolvedValue("present");
+  projectStoreMock.classifyGitBacking.mockResolvedValue({ gitBacked: true });
 });
 
 vi.mock("../../../window/portDistribution.js", () => ({
@@ -271,6 +294,167 @@ describe("project switch/reopen refreshes the File-menu project gates (#11136)",
     // Once the swap has run, the PVM binding has moved or been rolled back — the
     // gates must reflect where we actually landed, not stay stale.
     expect(refreshProjectMenuStateMock).toHaveBeenCalled();
+  });
+});
+
+// #11649: a row recorded as git-backed whose `.git` is gone used to be
+// unreachable for demotion — every path-based open (Recents, Dock, Cmd+O, CLI)
+// re-runs addProject and lands in the choice dialog, but switch and reopen
+// address a project by id and never re-classified, so the row stayed stuck
+// claiming worktree capability. These handlers now raise the same
+// NOT_A_GIT_REPO the dialog already answers to.
+describe("project switch/reopen refuses a row whose repository is gone (#11649)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetWindowForWebContents.mockReturnValue({ id: 1, isDestroyed: () => false });
+    projectStoreMock.setCurrentProject.mockResolvedValue(undefined);
+  });
+
+  function makePvm() {
+    return {
+      switchTo: vi.fn().mockResolvedValue({
+        view: { webContents: { id: 200, isDestroyed: () => false, send: vi.fn() } },
+        isNew: false,
+      }),
+      getProjectIdForWebContents: vi.fn(),
+      setPendingFocusIntent: vi.fn(),
+    };
+  }
+
+  function handlerFor(channel: string, pvm: unknown) {
+    const ctx = makeWindowContext(1, 10, { projectViewManager: pvm as never });
+    registerProjectCrudHandlers({
+      mainWindow: { id: 1 } as unknown,
+      windowRegistry: makeWindowRegistry([ctx]),
+      projectViewManager: pvm,
+    } as unknown as HandlerDependencies);
+    const call = (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c) => c[0] === channel
+    );
+    expect(call).toBeDefined();
+    return call![1] as (...args: unknown[]) => Promise<unknown>;
+  }
+
+  /** `gitBacked` absent is a git-backed row: NULL predates the column. */
+  function registerProject(overrides: Record<string, unknown> = {}) {
+    projectStoreMock.getProjectById.mockReturnValue({
+      id: "proj-gone",
+      name: "Gone",
+      path: "/projects/gone",
+      status: "background",
+      ...overrides,
+    } as never);
+  }
+
+  const CHANNEL_CASES = [
+    [CHANNELS.PROJECT_SWITCH, "switch"],
+    [CHANNELS.PROJECT_REOPEN, "reopen"],
+  ] as const;
+
+  describe.each(CHANNEL_CASES)("%s", (channel) => {
+    it("rejects with NOT_A_GIT_REPO before anything is swapped or marked active", async () => {
+      registerProject();
+      probeGitMarkerMock.mockResolvedValue("missing");
+      projectStoreMock.classifyGitBacking.mockResolvedValue({ gitBacked: false });
+      const pvm = makePvm();
+
+      await expect(handlerFor(channel, pvm)({ sender: { id: 10 } }, "proj-gone")).rejects.toThrow(
+        expect.objectContaining({ code: "NOT_A_GIT_REPO" })
+      );
+
+      // The whole point of rejecting this early: the sender keeps its current
+      // project, so declining the dialog is a no-op rather than a half-switch.
+      expect(pvm.switchTo).not.toHaveBeenCalled();
+      expect(projectStoreMock.setCurrentProject).not.toHaveBeenCalled();
+      expect(refreshProjectMenuStateMock).not.toHaveBeenCalled();
+    });
+
+    it("activates without consulting git when the marker is there", async () => {
+      registerProject();
+      probeGitMarkerMock.mockResolvedValue("present");
+      const pvm = makePvm();
+
+      await handlerFor(channel, pvm)({ sender: { id: 10 } }, "proj-gone");
+
+      expect(pvm.switchTo).toHaveBeenCalled();
+      // A healthy switch must not pay for a git subprocess.
+      expect(projectStoreMock.classifyGitBacking).not.toHaveBeenCalled();
+    });
+
+    it("activates unchanged when the marker can't be read", async () => {
+      // A dead mount or a permissions blip. Demoting on this would be exactly
+      // the anomaly the refusal-to-auto-demote rule exists to prevent.
+      registerProject();
+      probeGitMarkerMock.mockResolvedValue("unknown");
+      const pvm = makePvm();
+
+      await handlerFor(channel, pvm)({ sender: { id: 10 } }, "proj-gone");
+
+      expect(pvm.switchTo).toHaveBeenCalled();
+      expect(projectStoreMock.classifyGitBacking).not.toHaveBeenCalled();
+    });
+
+    it("never probes a row already opened without git", async () => {
+      // It has no git identity left to lose, so there is nothing to reconcile.
+      registerProject({ gitBacked: false });
+      const pvm = makePvm();
+
+      await handlerFor(channel, pvm)({ sender: { id: 10 } }, "proj-gone");
+
+      expect(pvm.switchTo).toHaveBeenCalled();
+      expect(probeGitMarkerMock).not.toHaveBeenCalled();
+    });
+
+    it("activates when git finds a repository despite the missing marker", async () => {
+      registerProject();
+      probeGitMarkerMock.mockResolvedValue("missing");
+      projectStoreMock.classifyGitBacking.mockResolvedValue({
+        gitBacked: true,
+        gitRoot: "/projects/gone",
+      });
+      const pvm = makePvm();
+
+      await handlerFor(channel, pvm)({ sender: { id: 10 } }, "proj-gone");
+
+      expect(pvm.switchTo).toHaveBeenCalled();
+    });
+
+    it("surfaces an ambiguous classification under its own code", async () => {
+      // Only a positive "not a repository" verdict may reach the demotion
+      // dialog; anything else has to keep its own meaning so the user is told
+      // what actually went wrong.
+      registerProject();
+      probeGitMarkerMock.mockResolvedValue("missing");
+      projectStoreMock.classifyGitBacking.mockRejectedValue(
+        Object.assign(new Error("Permission denied"), { code: "PERMISSION" })
+      );
+      const pvm = makePvm();
+
+      await expect(handlerFor(channel, pvm)({ sender: { id: 10 } }, "proj-gone")).rejects.toThrow(
+        expect.objectContaining({ code: "PERMISSION" })
+      );
+      expect(pvm.switchTo).not.toHaveBeenCalled();
+    });
+  });
+
+  it("probes the project's own root", async () => {
+    registerProject({ path: "/projects/specific" });
+    probeGitMarkerMock.mockResolvedValue("present");
+
+    await handlerFor(CHANNELS.PROJECT_SWITCH, makePvm())({ sender: { id: 10 } }, "proj-gone");
+
+    expect(probeGitMarkerMock).toHaveBeenCalledWith("/projects/specific");
+  });
+
+  it("checks reopen's status precondition before touching the filesystem", async () => {
+    // A closed project can't be reopened at all, so the guard must not spend a
+    // syscall — or blame the repository — for what is a state error.
+    registerProject({ status: "closed" });
+
+    await expect(
+      handlerFor(CHANNELS.PROJECT_REOPEN, makePvm())({ sender: { id: 10 } }, "proj-gone")
+    ).rejects.toThrow(/status/);
+    expect(probeGitMarkerMock).not.toHaveBeenCalled();
   });
 });
 

--- a/electron/ipc/handlers/projectCrud/switch.ts
+++ b/electron/ipc/handlers/projectCrud/switch.ts
@@ -8,6 +8,8 @@ import {
 import { getProjectIdFromSenderUrl } from "../../projectContext.js";
 import { distributePortsToView } from "../../../window/portDistribution.js";
 import { projectStore } from "../../../services/ProjectStore.js";
+import { probeGitMarker } from "../../../services/projectOpenPreflight.js";
+import { AppError } from "../../../utils/errorTypes.js";
 import { scratchStore } from "../../../services/ScratchStore.js";
 import { ProjectSwitchService } from "../../../services/ProjectSwitchService.js";
 import { getProjectHistory } from "../../../services/ProjectHistoryService.js";
@@ -51,6 +53,10 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
     if (!project) {
       throw new Error(`Project not found: ${projectId}`);
     }
+
+    // Ahead of the capture: everything from here on has side effects the sender
+    // can't undo if the target turns out to have lost its repository.
+    await assertProjectRepositoryIntact(project);
 
     const operation = captureSwitchOperation(deps, ctx, projectId, "project:switch");
     const { outgoingProjectId, projectViewManager: pvm } = operation;
@@ -134,6 +140,8 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
       );
     }
 
+    await assertProjectRepositoryIntact(project);
+
     const operation = captureSwitchOperation(deps, ctx, projectId, "project:reopen");
     const { outgoingProjectId, projectViewManager: pvm } = operation;
 
@@ -197,6 +205,45 @@ function trackOutgoingPersist(projectId: string | null, persist: Promise<void>):
     }
   };
   persist.then(cleanup, cleanup);
+}
+
+/**
+ * Refuse to activate a row that claims a repository whose `.git` is provably
+ * gone, surfacing the same `NOT_A_GIT_REPO` the path-based entry points already
+ * raise (#11649).
+ *
+ * Recents, Dock drops, Open With and the CLI all re-run `addProject`, so they
+ * hit that code and land in the choice dialog where demotion is the user's
+ * explicit decision. Switch and reopen address a project by id and never
+ * re-classify, so a row whose repository disappeared stayed stuck claiming
+ * worktree capability forever — which is what let a repository-less folder adopt
+ * the app-global `activeWorktreeId` belonging to some other project. Raising the
+ * same code here routes both to the same dialog instead of inventing a second
+ * consent surface, and it happens before anything is persisted, swapped or
+ * marked active so a declined dialog leaves the sender exactly where it was.
+ *
+ * Deliberately cheap and deliberately timid:
+ * - lightweight rows are skipped — they have nothing left to demote;
+ * - one bounded `.git` stat gates the healthy path, so a normal switch pays no
+ *   git subprocess;
+ * - only a proven-absent marker escalates to the real classifier, and only that
+ *   classifier's "not a repository" verdict throws. A dead mount, a permissions
+ *   blip or a missing git binary answers `"unknown"` or throws its own code, and
+ *   activation proceeds exactly as before rather than prompting to give up a
+ *   project's git identity on the strength of a transient failure.
+ */
+async function assertProjectRepositoryIntact(project: Project): Promise<void> {
+  if (project.gitBacked === false) return;
+  if ((await probeGitMarker(project.path)) !== "missing") return;
+
+  const classification = await projectStore.classifyGitBacking(project.path);
+  if (classification.gitBacked) return;
+
+  throw new AppError({
+    code: "NOT_A_GIT_REPO",
+    message: `Not a git repository: ${project.path}`,
+    context: { projectPath: project.path },
+  });
 }
 
 async function awaitPendingOutgoingPersist(projectId: string): Promise<void> {

--- a/electron/ipc/handlers/projectCrud/switch.ts
+++ b/electron/ipc/handlers/projectCrud/switch.ts
@@ -54,11 +54,15 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
       throw new Error(`Project not found: ${projectId}`);
     }
 
-    // Ahead of the capture: everything from here on has side effects the sender
-    // can't undo if the target turns out to have lost its repository.
+    const operation = captureSwitchOperation(deps, ctx, projectId, "project:switch");
+
+    // After the capture but before anything acts on it. The capture is a pure
+    // synchronous snapshot and has to stay one: read after an await, the
+    // sender's view→project binding can be moved by a concurrent switch in the
+    // same window. Throwing here simply discards it, and everything with a side
+    // effect the sender couldn't undo still lies further down.
     await assertProjectRepositoryIntact(project);
 
-    const operation = captureSwitchOperation(deps, ctx, projectId, "project:switch");
     const { outgoingProjectId, projectViewManager: pvm } = operation;
 
     // Started concurrently with the view swap — the incoming view never reads
@@ -140,9 +144,10 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
       );
     }
 
+    const operation = captureSwitchOperation(deps, ctx, projectId, "project:reopen");
+
     await assertProjectRepositoryIntact(project);
 
-    const operation = captureSwitchOperation(deps, ctx, projectId, "project:reopen");
     const { outgoingProjectId, projectViewManager: pvm } = operation;
 
     // Sender-scoped no-op check: skip the persist only when THIS window is

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -382,27 +382,30 @@ export class ProjectStore {
   }
 
   /**
-   * `options.identity` is the name/emoji chosen in a creation dialog. It is
-   * consulted only where a brand-new row is minted below — every earlier return
-   * (already-registered path, adopted move, lost insert race) keeps the
-   * identity it already has, so re-adding a folder can never rename it.
-   * In-repo `.daintree/project.json` still wins field-wise.
+   * Decide whether a folder is backed by a repository, or throw the classified
+   * reason we couldn't tell.
    *
-   * `options.gitBacked === false` adopts a folder that has no repository at
-   * all; anything else keeps the strict git-root requirement. The two options
-   * are read independently — a lightweight open carries no identity, and an
-   * identity never implies a mode.
+   * The only trustworthy answer to that question in the codebase. `gitBacked:
+   * false` is returned exclusively for a folder git positively reports as "not a
+   * git repository" *and* which still validates as a readable directory —
+   * everything ambiguous (missing binary, dubious ownership, dead mount,
+   * permissions, anything unrecognized) throws its own code instead, because
+   * callers use a negative answer to withdraw a project's git identity and must
+   * never do that off a transient failure. `WorkspaceService.isGitRepository`
+   * deliberately makes the opposite trade (any failure means "no repository")
+   * and is correct for withholding features, but must not drive a stored
+   * classification.
    */
-  async addProject(projectPath: string, options?: ProjectAddOptions): Promise<Project> {
+  async classifyGitBacking(
+    projectPath: string
+  ): Promise<{ gitBacked: true; gitRoot: string } | { gitBacked: false }> {
     // Classify the path before git ever sees it. simple-git's own synchronous
     // baseDir check throws first otherwise, and its error can't distinguish a
     // missing folder from a file — the root cause of #11409.
     await assertProjectDirectory(projectPath);
 
-    const creationIdentity = options?.identity;
-    let gitRoot: string;
     try {
-      gitRoot = await this.getGitRoot(projectPath);
+      return { gitBacked: true, gitRoot: await this.getGitRoot(projectPath) };
     } catch (error) {
       const message = formatErrorMessage(error, "Failed to add project");
 
@@ -436,42 +439,16 @@ export class ProjectStore {
         });
       }
 
-      // Re-check the directory before the guided-init branch: several awaits
+      // Re-check the directory before reporting no-repository: several awaits
       // have passed since the pre-flight, and a folder deleted or swapped for a
       // file in that window reports as "not a git repository" too. Offering to
-      // run `git init` in a folder that no longer exists would be worse than
-      // useless, so a path that stopped validating is reclassified here.
+      // run `git init` in a folder that no longer exists — or demoting a row on
+      // the strength of it — would be worse than useless, so a path that stopped
+      // validating is reclassified here.
       await assertProjectDirectory(projectPath);
 
       if (lower.includes("not a git repository")) {
-        // The folder has no repository. Adopt it as a lightweight workspace when
-        // the caller asked for that explicitly, or when it is already registered
-        // as one — the latter is what lets Recents, Dock drops, Open With and the
-        // CLI reopen it without re-prompting (#11405). Anything else keeps
-        // today's behavior and drives the choice dialog.
-        //
-        // A registered *git-backed* row is deliberately not demoted on its own:
-        // git failing to see a repository at a path we recorded as one is an
-        // anomaly (an unmounted volume, a permissions blip, a `.git` deleted out
-        // from under us), and silently rewriting the row would lose that project's
-        // git identity for good. It falls through to the choice dialog, where
-        // demotion becomes the user's explicit decision.
-        const lightweight = await this.resolveLightweightPath(projectPath);
-        if (lightweight) {
-          const existing = await this.getProjectByPath(lightweight);
-          if (existing) {
-            if (existing.gitBacked === false || options?.gitBacked === false) {
-              return this.touchExistingProject(existing, { gitBacked: false });
-            }
-          } else if (options?.gitBacked === false) {
-            return this.insertLightweightProject(lightweight);
-          }
-        }
-
-        throw new AppError({
-          code: "NOT_A_GIT_REPO",
-          message: `Not a git repository: ${projectPath}`,
-        });
+        return { gitBacked: false };
       }
 
       // Everything unrecognized becomes one opaque code, and the raw text is
@@ -488,12 +465,62 @@ export class ProjectStore {
         cause: error instanceof Error ? error : undefined,
       });
     }
+  }
+
+  /**
+   * `options.identity` is the name/emoji chosen in a creation dialog. It is
+   * consulted only where a brand-new row is minted below — every earlier return
+   * (already-registered path, adopted move, lost insert race) keeps the
+   * identity it already has, so re-adding a folder can never rename it.
+   * In-repo `.daintree/project.json` still wins field-wise.
+   *
+   * `options.gitBacked === false` adopts a folder that has no repository at
+   * all; anything else keeps the strict git-root requirement. The two options
+   * are read independently — a lightweight open carries no identity, and an
+   * identity never implies a mode.
+   */
+  async addProject(projectPath: string, options?: ProjectAddOptions): Promise<Project> {
+    const creationIdentity = options?.identity;
+    const classification = await this.classifyGitBacking(projectPath);
+
+    if (!classification.gitBacked) {
+      // The folder has no repository. Adopt it as a lightweight workspace when
+      // the caller asked for that explicitly, or when it is already registered
+      // as one — the latter is what lets Recents, Dock drops, Open With and the
+      // CLI reopen it without re-prompting (#11405). Anything else keeps
+      // today's behavior and drives the choice dialog.
+      //
+      // A registered *git-backed* row is deliberately not demoted on its own:
+      // git failing to see a repository at a path we recorded as one is an
+      // anomaly (an unmounted volume, a permissions blip, a `.git` deleted out
+      // from under us), and silently rewriting the row would lose that project's
+      // git identity for good. It falls through to the choice dialog, where
+      // demotion becomes the user's explicit decision — which is also how the
+      // switch/reopen handlers reach that dialog, since they surface this same
+      // code rather than activating a row whose repository is gone (#11649).
+      const lightweight = await this.resolveLightweightPath(projectPath);
+      if (lightweight) {
+        const existing = await this.getProjectByPath(lightweight);
+        if (existing) {
+          if (existing.gitBacked === false || options?.gitBacked === false) {
+            return this.touchExistingProject(existing, { gitBacked: false });
+          }
+        } else if (options?.gitBacked === false) {
+          return this.insertLightweightProject(lightweight);
+        }
+      }
+
+      throw new AppError({
+        code: "NOT_A_GIT_REPO",
+        message: `Not a git repository: ${projectPath}`,
+      });
+    }
 
     // NFC-normalize for dedup so a Finder-dragged NFD path and a typed NFC
     // path map to the same project row on macOS. `path.normalize` only
     // handles separator/segment normalization; Unicode normalization is
     // independent.
-    const normalizedPath = path.normalize(gitRoot).normalize("NFC");
+    const normalizedPath = path.normalize(classification.gitRoot).normalize("NFC");
 
     // The registered project is the git ROOT, which is not always the path the
     // caller handed us: creating `/repo/child` inside an existing repository

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -480,8 +480,8 @@ export class ProjectStore {
    * identity never implies a mode.
    */
   async addProject(projectPath: string, options?: ProjectAddOptions): Promise<Project> {
-    const creationIdentity = options?.identity;
     const classification = await this.classifyGitBacking(projectPath);
+    const creationIdentity = options?.identity;
 
     if (!classification.gitBacked) {
       // The folder has no repository. Adopt it as a lightweight workspace when

--- a/electron/services/__tests__/ProjectStore.lightweight.test.ts
+++ b/electron/services/__tests__/ProjectStore.lightweight.test.ts
@@ -221,6 +221,47 @@ describe("opening a folder without git (#11405)", () => {
     expect(store.getProjectById(project.id)?.gitBacked).toBeUndefined();
   });
 
+  it("classifies a repository and a repository-less folder without touching the registry", async () => {
+    const repo = await makeDir("repo");
+    repoPaths.add(repo);
+    const plain = await makeDir("downloads");
+
+    await expect(store.classifyGitBacking(repo)).resolves.toEqual({
+      gitBacked: true,
+      gitRoot: repo,
+    });
+    await expect(store.classifyGitBacking(plain)).resolves.toEqual({ gitBacked: false });
+
+    // Classification answers a question; only addProject may act on the answer.
+    expect(store.getAllProjects()).toHaveLength(0);
+  });
+
+  it("reports a registered repository whose git metadata went missing as not git-backed", async () => {
+    const folder = await makeDir("repo");
+    repoPaths.add(folder);
+    const project = await store.addProject(folder);
+
+    repoPaths.delete(folder);
+
+    // What the switch/reopen guard consults (#11649). It reports the folder's
+    // real state without demoting the row — the demotion stays the user's call.
+    await expect(store.classifyGitBacking(folder)).resolves.toEqual({ gitBacked: false });
+    expect(store.getProjectById(project.id)?.gitBacked).toBeUndefined();
+  });
+
+  it("refuses to call a vanished folder repository-less", async () => {
+    const folder = await makeDir("repo");
+    repoPaths.add(folder);
+    await store.addProject(folder);
+
+    // The row's repository is unreachable rather than proven absent. Answering
+    // `gitBacked: false` here is what would let a yanked volume demote a project.
+    repoPaths.delete(folder);
+    await fs.promises.rm(folder, { recursive: true, force: true });
+
+    await expect(store.classifyGitBacking(folder)).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
   it("demotes a registered repository only when the user explicitly asks", async () => {
     const folder = await makeDir("repo");
     repoPaths.add(folder);

--- a/electron/services/__tests__/projectOpenPreflight.test.ts
+++ b/electron/services/__tests__/projectOpenPreflight.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { constants as fsConstants, type Stats } from "fs";
+import path from "path";
 
 const statMock = vi.hoisted(() => vi.fn<(path: string) => Promise<Stats>>());
 const accessMock = vi.hoisted(() => vi.fn<(path: string, mode?: number) => Promise<void>>());
@@ -10,8 +11,13 @@ vi.mock("fs/promises", () => ({
   access: accessMock,
 }));
 
-const { assertProjectDirectory, isMissingExecutableError, PROJECT_DIRECTORY_STAT_TIMEOUT_MS } =
-  await import("../projectOpenPreflight.js");
+const {
+  assertProjectDirectory,
+  isMissingExecutableError,
+  probeGitMarker,
+  PROJECT_DIRECTORY_STAT_TIMEOUT_MS,
+  GIT_MARKER_STAT_TIMEOUT_MS,
+} = await import("../projectOpenPreflight.js");
 
 const FOLDER = "/repos/alpha";
 
@@ -121,6 +127,107 @@ describe("assertProjectDirectory", () => {
     const mode = accessMock.mock.calls[0]?.[1] ?? 0;
     expect(mode & fsConstants.R_OK).toBe(fsConstants.R_OK);
     expect(mode & fsConstants.X_OK).toBe(fsConstants.X_OK);
+  });
+});
+
+describe("probeGitMarker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reads the .git entry inside the project root", async () => {
+    statMock.mockResolvedValue(statsFor(true));
+
+    await probeGitMarker(FOLDER);
+
+    expect(statMock).toHaveBeenCalledWith(path.join(FOLDER, ".git"));
+  });
+
+  it("accepts a .git file as readily as a .git directory", async () => {
+    // A linked worktree and a submodule both carry `.git` as a file. Requiring a
+    // directory would report every one of them as having lost its repository.
+    statMock.mockResolvedValue(statsFor(false));
+
+    await expect(probeGitMarker(FOLDER)).resolves.toBe("present");
+  });
+
+  it.each([
+    // The only two errnos that prove the entry cannot exist.
+    ["ENOENT", "missing"],
+    ["ENOTDIR", "missing"],
+    // Each proves only that we couldn't look, which must never cost a project
+    // its git identity.
+    ["EACCES", "unknown"],
+    ["EPERM", "unknown"],
+    ["EIO", "unknown"],
+    ["ESTALE", "unknown"],
+    ["ELOOP", "unknown"],
+  ])("answers %s with %s", async (errno, expected) => {
+    statMock.mockRejectedValue(errnoError(errno));
+
+    await expect(probeGitMarker(FOLDER)).resolves.toBe(expected);
+  });
+
+  it("treats an errno-less failure as inconclusive rather than absent", async () => {
+    statMock.mockRejectedValue(new Error("something opaque"));
+
+    await expect(probeGitMarker(FOLDER)).resolves.toBe("unknown");
+  });
+});
+
+describe("probeGitMarker under a hung filesystem", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("gives up on a stat that never settles without claiming the marker is gone", async () => {
+    // A dead mount blocks stat in the kernel. Reporting "missing" here would
+    // route an unplugged drive straight into the demotion prompt.
+    statMock.mockReturnValue(new Promise<Stats>(() => {}));
+
+    const pending = probeGitMarker(FOLDER);
+    const assertion = expect(pending).resolves.toBe("unknown");
+
+    await vi.advanceTimersByTimeAsync(GIT_MARKER_STAT_TIMEOUT_MS + 1);
+    await assertion;
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("bounds the probe far tighter than a user-initiated open", () => {
+    // This one runs on every project switch rather than on an explicit open, so
+    // it has to fail open long before the open flow would.
+    expect(GIT_MARKER_STAT_TIMEOUT_MS).toBeLessThan(PROJECT_DIRECTORY_STAT_TIMEOUT_MS);
+  });
+
+  it("shares one syscall across concurrent probes of the same root", async () => {
+    statMock.mockReturnValue(new Promise<Stats>(() => {}));
+
+    const both = Promise.all([probeGitMarker(FOLDER), probeGitMarker(FOLDER)]);
+
+    await vi.advanceTimersByTimeAsync(GIT_MARKER_STAT_TIMEOUT_MS + 1);
+
+    expect(await both).toEqual(["unknown", "unknown"]);
+    expect(statMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets a remounted drive be probed again after a timeout", async () => {
+    // Holding the timed-out probe would pin every later switch to the same
+    // doomed promise, so remounting the volume would never take effect.
+    statMock.mockReturnValue(new Promise<Stats>(() => {}));
+    const first = probeGitMarker(FOLDER);
+    await vi.advanceTimersByTimeAsync(GIT_MARKER_STAT_TIMEOUT_MS + 1);
+    expect(await first).toBe("unknown");
+
+    statMock.mockResolvedValue(statsFor(true));
+
+    await expect(probeGitMarker(FOLDER)).resolves.toBe("present");
+    expect(statMock).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/electron/services/__tests__/projectOpenPreflight.test.ts
+++ b/electron/services/__tests__/projectOpenPreflight.test.ts
@@ -3,11 +3,13 @@ import { constants as fsConstants, type Stats } from "fs";
 import path from "path";
 
 const statMock = vi.hoisted(() => vi.fn<(path: string) => Promise<Stats>>());
+const lstatMock = vi.hoisted(() => vi.fn<(path: string) => Promise<Stats>>());
 const accessMock = vi.hoisted(() => vi.fn<(path: string, mode?: number) => Promise<void>>());
 
 vi.mock("fs/promises", () => ({
-  default: { stat: statMock, access: accessMock },
+  default: { stat: statMock, lstat: lstatMock, access: accessMock },
   stat: statMock,
+  lstat: lstatMock,
   access: accessMock,
 }));
 
@@ -136,17 +138,27 @@ describe("probeGitMarker", () => {
   });
 
   it("reads the .git entry inside the project root", async () => {
-    statMock.mockResolvedValue(statsFor(true));
+    lstatMock.mockResolvedValue(statsFor(true));
 
     await probeGitMarker(FOLDER);
 
-    expect(statMock).toHaveBeenCalledWith(path.join(FOLDER, ".git"));
+    expect(lstatMock).toHaveBeenCalledWith(path.join(FOLDER, ".git"));
+  });
+
+  it("asks about the entry itself, not what it resolves to", async () => {
+    // `stat` follows symlinks, so a `.git` symlinked onto a detached volume
+    // would answer ENOENT for a marker plainly sitting in the folder — a false
+    // "missing" that would route the project straight at the demotion dialog.
+    lstatMock.mockResolvedValue(statsFor(false));
+
+    await expect(probeGitMarker(FOLDER)).resolves.toBe("present");
+    expect(statMock).not.toHaveBeenCalled();
   });
 
   it("accepts a .git file as readily as a .git directory", async () => {
     // A linked worktree and a submodule both carry `.git` as a file. Requiring a
     // directory would report every one of them as having lost its repository.
-    statMock.mockResolvedValue(statsFor(false));
+    lstatMock.mockResolvedValue(statsFor(false));
 
     await expect(probeGitMarker(FOLDER)).resolves.toBe("present");
   });
@@ -163,15 +175,32 @@ describe("probeGitMarker", () => {
     ["ESTALE", "unknown"],
     ["ELOOP", "unknown"],
   ])("answers %s with %s", async (errno, expected) => {
-    statMock.mockRejectedValue(errnoError(errno));
+    lstatMock.mockRejectedValue(errnoError(errno));
 
     await expect(probeGitMarker(FOLDER)).resolves.toBe(expected);
   });
 
   it("treats an errno-less failure as inconclusive rather than absent", async () => {
-    statMock.mockRejectedValue(new Error("something opaque"));
+    lstatMock.mockRejectedValue(new Error("something opaque"));
 
     await expect(probeGitMarker(FOLDER)).resolves.toBe("unknown");
+  });
+
+  it("re-reads the folder on the next probe rather than caching a verdict", async () => {
+    // The dedup map exists to share one syscall between *concurrent* callers,
+    // never to remember an answer. A cached "present" would recreate the very
+    // bug this guard fixes once `.git` was deleted mid-session; a cached
+    // "missing" would spawn git on every healthy switch thereafter.
+    lstatMock.mockResolvedValue(statsFor(true));
+    await expect(probeGitMarker(FOLDER)).resolves.toBe("present");
+
+    lstatMock.mockRejectedValue(errnoError("ENOENT"));
+    await expect(probeGitMarker(FOLDER)).resolves.toBe("missing");
+
+    lstatMock.mockResolvedValue(statsFor(true));
+    await expect(probeGitMarker(FOLDER)).resolves.toBe("present");
+
+    expect(lstatMock).toHaveBeenCalledTimes(3);
   });
 });
 
@@ -188,7 +217,7 @@ describe("probeGitMarker under a hung filesystem", () => {
   it("gives up on a stat that never settles without claiming the marker is gone", async () => {
     // A dead mount blocks stat in the kernel. Reporting "missing" here would
     // route an unplugged drive straight into the demotion prompt.
-    statMock.mockReturnValue(new Promise<Stats>(() => {}));
+    lstatMock.mockReturnValue(new Promise<Stats>(() => {}));
 
     const pending = probeGitMarker(FOLDER);
     const assertion = expect(pending).resolves.toBe("unknown");
@@ -206,28 +235,28 @@ describe("probeGitMarker under a hung filesystem", () => {
   });
 
   it("shares one syscall across concurrent probes of the same root", async () => {
-    statMock.mockReturnValue(new Promise<Stats>(() => {}));
+    lstatMock.mockReturnValue(new Promise<Stats>(() => {}));
 
     const both = Promise.all([probeGitMarker(FOLDER), probeGitMarker(FOLDER)]);
 
     await vi.advanceTimersByTimeAsync(GIT_MARKER_STAT_TIMEOUT_MS + 1);
 
     expect(await both).toEqual(["unknown", "unknown"]);
-    expect(statMock).toHaveBeenCalledTimes(1);
+    expect(lstatMock).toHaveBeenCalledTimes(1);
   });
 
   it("lets a remounted drive be probed again after a timeout", async () => {
     // Holding the timed-out probe would pin every later switch to the same
     // doomed promise, so remounting the volume would never take effect.
-    statMock.mockReturnValue(new Promise<Stats>(() => {}));
+    lstatMock.mockReturnValue(new Promise<Stats>(() => {}));
     const first = probeGitMarker(FOLDER);
     await vi.advanceTimersByTimeAsync(GIT_MARKER_STAT_TIMEOUT_MS + 1);
     expect(await first).toBe("unknown");
 
-    statMock.mockResolvedValue(statsFor(true));
+    lstatMock.mockResolvedValue(statsFor(true));
 
     await expect(probeGitMarker(FOLDER)).resolves.toBe("present");
-    expect(statMock).toHaveBeenCalledTimes(2);
+    expect(lstatMock).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/electron/services/projectOpenPreflight.ts
+++ b/electron/services/projectOpenPreflight.ts
@@ -147,6 +147,11 @@ const inFlightMarkerProbes = new Map<string, Promise<boolean>>();
  * ENOENT/ENOTDIR are the only proofs of absence; every other errno, and the
  * timeout, answer `"unknown"` so the caller leaves the row alone.
  *
+ * `lstat`, not `stat`: the question is whether the entry is there, not whether
+ * it resolves. `stat` follows symlinks, so a `.git` symlinked onto a detached
+ * volume would report ENOENT — "missing" for a marker plainly sitting in the
+ * folder, which is precisely the false positive this tri-state exists to avoid.
+ *
  * This is a cheap pre-gate, not a classifier: `"missing"` only earns the caller
  * the right to run the real classification, never a decision on its own.
  */
@@ -158,7 +163,7 @@ export async function probeGitMarker(projectRoot: string): Promise<GitMarkerProb
   let pending = inFlightMarkerProbes.get(markerPath);
   if (!pending) {
     const started = fs
-      .stat(markerPath)
+      .lstat(markerPath)
       .then(() => true)
       .finally(() => {
         if (inFlightMarkerProbes.get(markerPath) === started) {

--- a/electron/services/projectOpenPreflight.ts
+++ b/electron/services/projectOpenPreflight.ts
@@ -1,4 +1,5 @@
 import fs from "fs/promises";
+import path from "path";
 import { constants as fsConstants } from "fs";
 import { AppError } from "../utils/errorTypes.js";
 import { TimeoutError, withTimeout } from "../utils/withTimeout.js";
@@ -114,6 +115,73 @@ export async function assertProjectDirectory(directoryPath: string): Promise<voi
       message: `Not a directory: ${directoryPath}`,
       context: { directoryPath },
     });
+  }
+}
+
+/**
+ * Whether a project root still carries a `.git` marker.
+ *
+ * Tri-state on purpose. `"unknown"` is not a soft `"missing"`: only a proven
+ * absence may lead anywhere near demoting a row that claims a repository, so a
+ * dead mount, a permissions blip or a slow first touch all have to be
+ * distinguishable from a folder whose `.git` is genuinely gone.
+ */
+export type GitMarkerProbe = "present" | "missing" | "unknown";
+
+/**
+ * Bounded far tighter than {@link PROJECT_DIRECTORY_STAT_TIMEOUT_MS}: this runs
+ * on every project switch, not on a user-initiated open, so it has to fail open
+ * fast rather than hold a switch behind a dying mount. Overshooting merely
+ * yields `"unknown"`, which preserves today's behavior.
+ */
+export const GIT_MARKER_STAT_TIMEOUT_MS = 1_000;
+
+const inFlightMarkerProbes = new Map<string, Promise<boolean>>();
+
+/**
+ * Report whether `projectRoot` still has a `.git` entry, without ever blocking
+ * a switch on a hung filesystem.
+ *
+ * Existence only — `.git` is a directory in a normal clone and a *file* in a
+ * linked worktree or submodule, and both mean "git still owns this folder".
+ * ENOENT/ENOTDIR are the only proofs of absence; every other errno, and the
+ * timeout, answer `"unknown"` so the caller leaves the row alone.
+ *
+ * This is a cheap pre-gate, not a classifier: `"missing"` only earns the caller
+ * the right to run the real classification, never a decision on its own.
+ */
+export async function probeGitMarker(projectRoot: string): Promise<GitMarkerProbe> {
+  const markerPath = path.join(projectRoot, ".git");
+
+  // Shared for the same reason as `probeOnce`: two windows restoring the same
+  // dead share must not each pin a libuv worker to it.
+  let pending = inFlightMarkerProbes.get(markerPath);
+  if (!pending) {
+    const started = fs
+      .stat(markerPath)
+      .then(() => true)
+      .finally(() => {
+        if (inFlightMarkerProbes.get(markerPath) === started) {
+          inFlightMarkerProbes.delete(markerPath);
+        }
+      });
+    inFlightMarkerProbes.set(markerPath, started);
+    pending = started;
+  }
+
+  try {
+    await withTimeout(pending, GIT_MARKER_STAT_TIMEOUT_MS, `Timed out reading ${markerPath}`);
+    return "present";
+  } catch (error) {
+    if (error instanceof TimeoutError) {
+      // Never settles, so nothing else will clear it.
+      if (inFlightMarkerProbes.get(markerPath) === pending) {
+        inFlightMarkerProbes.delete(markerPath);
+      }
+      return "unknown";
+    }
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    return code === "ENOENT" || code === "ENOTDIR" ? "missing" : "unknown";
   }
 }
 

--- a/src/store/__tests__/projectStore.switching.test.ts
+++ b/src/store/__tests__/projectStore.switching.test.ts
@@ -766,6 +766,147 @@ describe("worktreeLoadError surfacing (#8400)", () => {
   });
 });
 
+describe("switching to a project whose repository is gone (#11649)", () => {
+  /**
+   * How main reports it. The `[AppError|CODE]` prefix is what survives the
+   * contextBridge — `code` as an own property does not — so a fixture that only
+   * set `.code` would pass while the real thing fell through to the toast.
+   */
+  function notAGitRepoRejection(): Error {
+    return new Error("[AppError|NOT_A_GIT_REPO] Not a git repository");
+  }
+
+  /** Settle the fire-and-forget IPC's `.catch()`. */
+  async function flushCatch(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  const TRANSITIONS = [
+    ["switchProject", "switch"],
+    ["reopenProject", "reopen"],
+  ] as const;
+
+  describe.each(TRANSITIONS)("%s", (action, clientMethod) => {
+    async function runRejectedTransition() {
+      projectClientMock[clientMethod].mockRejectedValueOnce(notAGitRepoRejection());
+      const { useProjectStore } = await import("../projectStore");
+      useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
+
+      await useProjectStore.getState()[action](projectB.id);
+      await flushCatch();
+      return useProjectStore;
+    }
+
+    it("opens the choice dialog instead of a dead-end error toast", async () => {
+      const { notify } = await import("@/lib/notify");
+      const useProjectStore = await runRejectedTransition();
+
+      expect(useProjectStore.getState().gitInitDialogOpen).toBe(true);
+      expect(useProjectStore.getState().gitInitDialogStep).toBe("choice");
+      // The dialog IS the recovery, so a toast offering "Try again" would only
+      // re-run the transition that just failed the same way.
+      expect(notify).not.toHaveBeenCalled();
+    });
+
+    it("names the folder from the stored row rather than the error", async () => {
+      // A packaged build strips the error's context and scrubs absolute paths
+      // out of its message, so a path read from the error works in dev and
+      // silently breaks in the builds users run.
+      const useProjectStore = await runRejectedTransition();
+
+      expect(useProjectStore.getState().gitInitDirectoryPath).toBe(projectB.path);
+    });
+
+    it("leaves the sender on its current project with the transition settled", async () => {
+      const useProjectStore = await runRejectedTransition();
+
+      // Main rejected before the swap, so cancelling the dialog has to be a
+      // no-op rather than a half-finished switch.
+      expect(useProjectStore.getState().currentProject).toEqual(projectA);
+      expect(useProjectStore.getState().isSwitching).toBe(false);
+      expect(useProjectStore.getState().switchingToProjectId).toBeNull();
+      expect(useProjectStore.getState().isLoading).toBe(false);
+      // The dialog carries the message; a banner underneath it would be noise.
+      expect(useProjectStore.getState().error).toBeNull();
+    });
+
+    it("still toasts for every other failure", async () => {
+      const { notify } = await import("@/lib/notify");
+      projectClientMock[clientMethod].mockRejectedValueOnce(
+        new Error("[AppError|PERMISSION] Permission denied")
+      );
+      const { useProjectStore } = await import("../projectStore");
+      useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
+
+      await useProjectStore.getState()[action](projectB.id);
+      await flushCatch();
+
+      expect(useProjectStore.getState().gitInitDialogOpen).toBe(false);
+      expect(notify).toHaveBeenCalled();
+    });
+
+    it("falls back to the toast when the row is not in the list", async () => {
+      // Nothing to name in the dialog, and the path can't be recovered from the
+      // sanitized error — so the generic surface is the honest one.
+      const { notify } = await import("@/lib/notify");
+      projectClientMock[clientMethod].mockRejectedValueOnce(notAGitRepoRejection());
+      const { useProjectStore } = await import("../projectStore");
+      useProjectStore.setState({ projects: [projectA], currentProject: projectA });
+
+      await useProjectStore.getState()[action](projectB.id);
+      await flushCatch();
+
+      expect(useProjectStore.getState().gitInitDialogOpen).toBe(false);
+      expect(notify).toHaveBeenCalled();
+    });
+
+    it("lets a superseded transition's rejection pass without stealing the screen", async () => {
+      // The staleness guard runs first, so a losing transition can't pop a modal
+      // over whichever transition actually owns the renderer now.
+      //
+      // The rejection has to be deferred rather than pre-settled: a already-
+      // rejected mock runs its `.catch` on the first await inside the transition
+      // that registered it, so nothing would ever still be in flight to supersede.
+      let rejectFirst: (error: Error) => void = () => {};
+      projectClientMock[clientMethod].mockReturnValueOnce(
+        new Promise((_resolve, reject) => {
+          rejectFirst = reject;
+        })
+      );
+      const { useProjectStore } = await import("../projectStore");
+      useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
+
+      await useProjectStore.getState()[action](projectB.id);
+      // A second click while the first IPC is still open. It targets a project
+      // that isn't the current one, so it really does claim the transition id —
+      // superseding via the *current* project would early-return and supersede
+      // nothing.
+      await useProjectStore.getState().switchProject(projectB.id);
+      rejectFirst(notAGitRepoRejection());
+      await flushCatch();
+
+      expect(useProjectStore.getState().gitInitDialogOpen).toBe(false);
+    });
+  });
+
+  it("adopts the folder without git when the user chooses that", async () => {
+    // The end-to-end point of routing here: the row finally gets demoted, which
+    // is what stops a repository-less folder claiming worktree capability.
+    projectClientMock.switch.mockRejectedValueOnce(notAGitRepoRejection());
+    projectClientMock.add.mockResolvedValue({ ...projectB, gitBacked: false });
+    const { useProjectStore } = await import("../projectStore");
+    useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
+
+    await useProjectStore.getState().switchProject(projectB.id);
+    await flushCatch();
+    await useProjectStore.getState().openWithoutGit();
+
+    expect(projectClientMock.add).toHaveBeenCalledWith(projectB.path, { gitBacked: false });
+    expect(useProjectStore.getState().gitInitDialogOpen).toBe(false);
+  });
+});
+
 describe("switch busy indication (#10736)", () => {
   it("flags isSwitching and the target project id when a switch starts", async () => {
     const { useProjectStore } = await import("../projectStore");

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -448,6 +448,43 @@ function getProjectOpenErrorMessage(error: unknown, directoryPath?: string): str
   return message || "Couldn't open project.";
 }
 
+/**
+ * Route a switch/reopen that failed because the target lost its repository into
+ * the same choice dialog a path-based open would have shown (#11649).
+ *
+ * Main refuses to activate a git-backed row whose `.git` is provably gone, so
+ * the folder can finally be adopted without git — or have a repository
+ * initialized — instead of the row staying stuck claiming worktree capability.
+ * Returns whether it handled the error; `false` falls through to the caller's
+ * generic toast.
+ *
+ * The path comes from the store's own row, never the error: `context` is
+ * stripped and every message is scrubbed of absolute paths before crossing IPC
+ * in a packaged build, so an error-derived path works in dev and silently fails
+ * in the builds users run. Without a row there is nothing to name in the dialog,
+ * so that case falls through too.
+ *
+ * Main rejects before it persists, swaps or marks anything active, so clearing
+ * the transition flags leaves the sender exactly where it was — cancelling the
+ * dialog is a no-op rather than a half-finished switch, and `error` stays null
+ * because the dialog IS the surface for this one.
+ */
+function openNonGitFolderDialogForTransition(
+  set: (partial: Partial<ProjectState>) => void,
+  get: () => ProjectState,
+  projectId: string,
+  error: unknown
+): boolean {
+  if (!isClientAppError(error) || error.code !== "NOT_A_GIT_REPO") return false;
+
+  const targetPath = get().projects.find((project) => project.id === projectId)?.path;
+  if (!targetPath) return false;
+
+  set({ error: null, isLoading: false, isSwitching: false, switchingToProjectId: null });
+  get().openGitInitDialog(targetPath);
+  return true;
+}
+
 function isPersistedProject(value: unknown): value is Project {
   if (!value || typeof value !== "object") return false;
   const candidate = value as Partial<Project>;
@@ -736,6 +773,9 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
       if (requestId !== projectTransitionRequestId) {
         return;
       }
+      if (openNonGitFolderDialogForTransition(set, get, projectId, error)) {
+        return;
+      }
       logErrorWithContext(error, {
         operation: "switch_project",
         component: "projectStore",
@@ -964,6 +1004,9 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     const outgoingState = currentProjectId ? buildOutgoingState(currentProjectId) : undefined;
     projectClient.reopen(projectId, outgoingState).catch((error) => {
       if (requestId !== projectTransitionRequestId) {
+        return;
+      }
+      if (openNonGitFolderDialogForTransition(set, get, projectId, error)) {
         return;
       }
       logErrorWithContext(error, {


### PR DESCRIPTION
## Summary

- A project row recorded as repository backed that loses its `.git` directory could never be demoted to lightweight. Path based entry points (Recents, Dock drop, Cmd+O, CLI) re-run `ProjectStore.addProject`, which throws `NOT_A_GIT_REPO` and lets the renderer route to `NonGitFolderDialog`, where "Open without git" demotes the row. `project:switch` and `project:reopen` instead address a project by id, call `activateProjectView`, and never re-classify, so the in-app project switcher and back/forward history navigation had no route to that dialog at all.
- Once the stored classification and the runtime classification drift apart, they stay apart permanently, and it isn't cosmetic: `src/utils/stateHydration/index.ts:274` gates use of the app-global `activeWorktreeId` on `isGitBackedProject(currentProject)`, so a stuck row lets a folder with no repository adopt whichever worktree the last genuinely git backed project left behind.
- This adds a bounded, tri-state `.git` probe to both switch paths so a provably missing repository reaches the same demotion dialog, while anything short of proof (a dead mount, a permissions error, a stat timeout) leaves activation untouched.

Resolves #11649

## Changes

- `electron/services/projectOpenPreflight.ts`: new `probeGitMarker()`, bounded and deduped, returning a tri-state `present`/`missing`/`unknown`. Uses `lstat` (a `.git` symlink onto a detached volume must read as present, not vanished) with a 1 second timeout, tighter than the 5 second user-open preflight, since this runs on every switch and needs to fail open rather than hold a switch behind a dying mount.
- `electron/services/ProjectStore.ts`: extracted `classifyGitBacking()` out of `addProject` as the single trustworthy answer to whether a folder is repository backed. `addProject`'s own behavior is unchanged.
- `electron/ipc/handlers/projectCrud/switch.ts`: `assertProjectRepositoryIntact()` on both handlers, raising the same `NOT_A_GIT_REPO`. It runs after the pure, synchronous switch-operation capture but before anything acts on it, so a declined dialog leaves the sender exactly where it was.
- `src/store/projectStore.ts`: both transition catches now route into the existing dialog, taking the folder path from the stored row rather than the error, since packaged builds strip `error.context` and scrub absolute paths from messages.

Demotion stays the user's explicit decision through the dialog that already exists: no new consent surface, no new IPC channel, no new microcopy. Only a proven absent `.git` leads to the prompt. A dead mount, `EACCES`, `EIO`, `ESTALE`, a missing git binary, or a stat timeout all leave activation byte identical. The workspace host's own `checkIsRepo().catch(() => false)` is deliberately not used as the trigger, since it can't tell those cases apart. A healthy switch spawns no git subprocess: one `lstat` gates the common path.

## Testing

309 targeted tests passing across `projectOpenPreflight`, `ProjectStore` (lightweight/openFailures/identity/core), `project.switch`, `project.addOptions`, and the renderer `projectStore` suites. New coverage includes the errno taxonomy, the legacy non-PVM handler path, the pre-side-effect boundary, dedup-without-caching, and the renderer dialog routing for both switch and reopen. Typecheck clean, lint ratchet baseline maintained.