### PR TITLE
fix(hydration): key the worktree guard on the host's verdict, not git_backed

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -1,5 +1,6 @@
 export const CHANNELS = {
   WORKTREE_GET_ALL: "worktree:get-all",
+  WORKTREE_GET_ALL_WITH_STATUS: "worktree:get-all-with-status",
   WORKTREE_REFRESH: "worktree:refresh",
   WORKTREE_SET_ACTIVE: "worktree:set-active",
   WORKTREE_REMOVE: "worktree:remove",

--- a/electron/ipc/handlers/worktree/lifecycle.ts
+++ b/electron/ipc/handlers/worktree/lifecycle.ts
@@ -7,7 +7,7 @@ import { projectStore } from "../../../services/ProjectStore.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import type { HandlerDependencies, IpcContext } from "../../types.js";
 import type { WorktreeDeletePayload } from "../../../types/index.js";
-import type { WorktreeState } from "../../../../shared/types/worktree.js";
+import type { WorktreeState, WorktreeListResult } from "../../../../shared/types/worktree.js";
 import { fileSearchService } from "../../../services/FileSearchService.js";
 import { gitServiceCache } from "../../../services/GitServiceCache.js";
 import { getSoundService } from "../../../services/getSoundService.js";
@@ -80,6 +80,39 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
       project.path,
       senderProjectId
     )) as WorktreeState[];
+  };
+
+  /**
+   * `get-all` plus the host's own "is there a repository here" verdict (#11650).
+   *
+   * Hydration needs both in one round trip: the list alone cannot say whether
+   * an empty answer means "folder with no repository" or "host still
+   * registering", and the project row's `gitBacked` column cannot either
+   * (NULL there means both "real repository" and "never classified"). Every
+   * unresolved case below answers `gitBacked: null` — the same "unknown, keep
+   * saved state" sentinel `[]` carries — because a `false` would tell the
+   * renderer to discard a real repository's worktree state during the very
+   * boot race these guards exist for.
+   */
+  const handleWorktreeGetAllWithStatus = async (ctx: IpcContext): Promise<WorktreeListResult> => {
+    const unknown: WorktreeListResult = { worktrees: [], gitBacked: null };
+    if (!deps.worktreeService) {
+      return unknown;
+    }
+    const senderProjectId = ctx.projectId;
+    if (senderProjectId === null) {
+      return unknown;
+    }
+    const project = projectStore.getProjectById(senderProjectId);
+    if (!project) {
+      return unknown;
+    }
+    const { states, gitBacked } =
+      await deps.worktreeService.getAllStatesWithGitBackedForProjectAsync(
+        project.path,
+        senderProjectId
+      );
+    return { worktrees: states as WorktreeState[], gitBacked };
   };
 
   const handleWorktreeRefresh = async (worktreeId?: string): Promise<void> => {
@@ -287,6 +320,9 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
     name: "worktreeLifecycle",
     ops: {
       getAll: op(CHANNELS.WORKTREE_GET_ALL, handleWorktreeGetAll, { withContext: true }),
+      getAllWithStatus: op(CHANNELS.WORKTREE_GET_ALL_WITH_STATUS, handleWorktreeGetAllWithStatus, {
+        withContext: true,
+      }),
       refresh: op(CHANNELS.WORKTREE_REFRESH, handleWorktreeRefresh),
       setActive: opValidated(
         CHANNELS.WORKTREE_SET_ACTIVE,

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1096,6 +1096,8 @@ function buildElectronApi(): ElectronAPI {
     worktree: {
       getAll: () => _unwrappingInvoke(CHANNELS.WORKTREE_GET_ALL),
 
+      getAllWithStatus: () => _unwrappingInvoke(CHANNELS.WORKTREE_GET_ALL_WITH_STATUS),
+
       refresh: (worktreeId?: string) => _unwrappingInvoke(CHANNELS.WORKTREE_REFRESH, worktreeId),
 
       refreshPullRequests: () => _unwrappingInvoke(CHANNELS.WORKTREE_PR_REFRESH),

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -987,6 +987,7 @@ export class WorkspaceClient extends EventEmitter {
     this.copyTree.dispose();
     this.pool.dispose();
     this._statesInflight.clear();
+    this._statesWithGitBackedInflight.clear();
     this.removeAllListeners();
   }
 }

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -79,6 +79,16 @@ function dedupeSnapshotsById(states: WorktreeSnapshot[]): WorktreeSnapshot[] {
   return deduped;
 }
 
+/**
+ * A host's worktree snapshot read plus its own "is there a repository here"
+ * verdict. `gitBacked: null` is "not classified" — never read it as `false`
+ * (#11650). Main-process shape; the renderer sees `WorktreeListResult`.
+ */
+export interface HostWorktreeStates {
+  states: WorktreeSnapshot[];
+  gitBacked: boolean | null;
+}
+
 export class WorkspaceClient extends EventEmitter {
   private isDisposed = false;
   private pool: WorkspaceHostPool;
@@ -86,6 +96,7 @@ export class WorkspaceClient extends EventEmitter {
   private copyTree: WorkspaceCopyTreeClient;
 
   private readonly _statesInflight = new Map<string, Promise<WorktreeSnapshot[]>>();
+  private readonly _statesWithGitBackedInflight = new Map<string, Promise<HostWorktreeStates>>();
 
   constructor(config: WorkspaceClientConfig = {}) {
     super();
@@ -482,6 +493,55 @@ export class WorkspaceClient extends EventEmitter {
   }
 
   /**
+   * The project-scoped read of {@link getAllStatesForProjectAsync}, but keeping
+   * the host's `gitBacked` verdict alongside the states instead of discarding
+   * it (#11650).
+   *
+   * Coalesced through its own map rather than sharing `_statesInflight`:
+   * callers of the array-shaped method rely on getting the *same promise
+   * object* back for concurrent equivalent calls, which deriving one from the
+   * other with `.then()` would break. The extra `get-all-states` round trip in
+   * the rare overlap is a snapshot read off an already-ready host's in-memory
+   * monitor map, not a git spawn.
+   */
+  getAllStatesWithGitBackedForProjectAsync(
+    projectPath: string,
+    expectedProjectId: string
+  ): Promise<HostWorktreeStates> {
+    const normalized = this.pool.normalizeProjectPath(projectPath);
+    const key = `p:${expectedProjectId}:${normalized}`;
+    const existing = this._statesWithGitBackedInflight.get(key);
+    if (existing) return existing;
+
+    const entry = this.pool.entries.get(normalized);
+    const matchedEntry =
+      entry !== undefined && entry.projectId === expectedProjectId ? entry : undefined;
+    const promise = (
+      matchedEntry === undefined
+        ? // No host for this project yet. `gitBacked: null` rather than `false`
+          // — nothing has probed the folder, so this is "unknown", and a caller
+          // that read it as "not a repository" would strip a real repo's saved
+          // worktree state during the boot race this sentinel exists for.
+          Promise.resolve({ states: [], gitBacked: null } satisfies HostWorktreeStates)
+        : this._readStatesWithGitBackedWhenReady(matchedEntry)
+    ).then(
+      (result) => {
+        setTimeout(
+          () => this._statesWithGitBackedInflight.delete(key),
+          STATES_INFLIGHT_COALESCE_WINDOW_MS
+        );
+        return result;
+      },
+      (error) => {
+        this._statesWithGitBackedInflight.delete(key);
+        throw error;
+      }
+    );
+    this._statesWithGitBackedInflight.set(key, promise);
+    return promise;
+  }
+
+  /**
    * States for one project's host, keyed by project path rather than window.
    * `windowToProject` is repointed to the incoming project the moment a switch
    * starts, so window-scoped lookups from a backgrounded view resolve against
@@ -555,15 +615,31 @@ export class WorkspaceClient extends EventEmitter {
    * steady-state reads are unaffected.
    */
   private async _readStatesWhenReady(entry: ProcessEntry): Promise<WorktreeSnapshot[]> {
-    if (!(await this._awaitHostReady(entry))) return [];
+    return (await this._readStatesWithGitBackedWhenReady(entry)).states;
+  }
+
+  /**
+   * The same readiness-gated read, keeping the host's `gitBacked` verdict.
+   *
+   * A host that never became ready answers `gitBacked: null`, matching the `[]`
+   * states sentinel: both mean "unknown", and a caller must not read either as
+   * "this folder has no repository" (#11650). A host that predates the field
+   * also answers `null` via the `?? null`, so an older host degrades to today's
+   * permissive behavior rather than to a wrong `false`.
+   */
+  private async _readStatesWithGitBackedWhenReady(
+    entry: ProcessEntry
+  ): Promise<HostWorktreeStates> {
+    if (!(await this._awaitHostReady(entry))) return { states: [], gitBacked: null };
     const requestId = entry.host.generateRequestId();
     const result = await entry.host.sendWithResponse<{
       states: WorktreeSnapshot[];
+      gitBacked?: boolean | null;
     }>({
       type: "get-all-states",
       requestId,
     });
-    return result.states;
+    return { states: result.states, gitBacked: result.gitBacked ?? null };
   }
 
   /**

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -721,6 +721,88 @@ describe("WorkspaceClient multi-process manager", () => {
     });
   });
 
+  // #11650. Hydration cannot read an empty list as "this folder has no
+  // repository" — the same `[]` also means "no host yet" and "readiness gate
+  // timed out". These cases pin which of those the envelope distinguishes.
+  describe("getAllStatesWithGitBackedForProjectAsync", () => {
+    const idFor = (p: string) => `id-for-${path.resolve(p)}`;
+
+    it("passes the host's verdict through beside the states", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const resultPromise = client.getAllStatesWithGitBackedForProjectAsync(
+        "/project-a",
+        idFor("/project-a")
+      );
+      await tick();
+      const req = h(0)
+        .getAllRequests()
+        .find((r: any) => r.type === "get-all-states")!;
+      h(0).resolveRequest(req.requestId, { states: [], gitBacked: false });
+
+      expect(await resultPromise).toEqual({ states: [], gitBacked: false });
+    });
+
+    // The distinction the whole fix rests on: same empty list, opposite verdict.
+    it("reports unknown, not false, when no host has classified the path", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const callsBefore = h(0).sendWithResponse.mock.calls.length;
+      const result = await client.getAllStatesWithGitBackedForProjectAsync(
+        "/no-such-project",
+        idFor("/no-such-project")
+      );
+      expect(result).toEqual({ states: [], gitBacked: null });
+      expect(h(0).sendWithResponse.mock.calls.length).toBe(callsBefore);
+    });
+
+    // A host predating the field omits it. Degrading to `null` keeps the
+    // permissive #11234 path; a `false` here would strip a real repo's state.
+    it("reports unknown when the host omits the field", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const resultPromise = client.getAllStatesWithGitBackedForProjectAsync(
+        "/project-a",
+        idFor("/project-a")
+      );
+      await tick();
+      const req = h(0)
+        .getAllRequests()
+        .find((r: any) => r.type === "get-all-states")!;
+      h(0).resolveRequest(req.requestId, { states: [{ id: "wt-a" }] });
+
+      expect(await resultPromise).toEqual({ states: [{ id: "wt-a" }], gitBacked: null });
+    });
+
+    // The array-shaped method hands the same promise back to concurrent callers
+    // and several tests above assert that identity. Deriving one method from the
+    // other with `.then()` would quietly break it, so the two coalesce apart.
+    it("does not disturb the array-shaped method's promise identity", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      void client.getAllStatesWithGitBackedForProjectAsync("/project-a", idFor("/project-a"));
+      const p1 = client.getAllStatesForProjectAsync("/project-a", idFor("/project-a"));
+      const p2 = client.getAllStatesForProjectAsync("/project-a", idFor("/project-a"));
+      expect(p2).toBe(p1);
+
+      await tick();
+      for (const req of h(0)
+        .getAllRequests()
+        .filter((r: any) => r.type === "get-all-states")) {
+        h(0).resolveRequest(req.requestId, { states: [{ id: "wt-a" }], gitBacked: true });
+      }
+      expect(await p1).toEqual([{ id: "wt-a" }]);
+    });
+  });
+
   describe("singleflight cache", () => {
     beforeEach(() => {
       vi.useFakeTimers();

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -642,6 +642,38 @@ describe("WorkspaceClient multi-process manager", () => {
             .filter((r: any) => r.type === "get-all-states")
         ).toHaveLength(0);
       });
+
+      // #11650's guard reads the verdict, so the gate has to give up into
+      // "unknown" here rather than "no repository". A `false` would tell
+      // hydration a real repository has no worktrees every time its host was
+      // merely slow — exactly the #11234 regression the empty list above is
+      // shaped to avoid, but arriving through the new field instead.
+      it("gives up into the unknown verdict, never a false one, when the host never posts ready", async () => {
+        const load = client.loadProject("/project-a", 1);
+        void load.catch(() => {});
+        expect(mockHosts).toHaveLength(1);
+
+        const resultPromise = client.getAllStatesWithGitBackedForProjectAsync(
+          "/project-a",
+          idFor("/project-a")
+        );
+        let resolved: any = undefined;
+        void resultPromise.then((r) => {
+          resolved = r;
+        });
+
+        await vi.advanceTimersByTimeAsync(0);
+        expect(resolved).toBeUndefined();
+
+        await vi.advanceTimersByTimeAsync(GATE_OBSERVATION_WINDOW_MS);
+
+        expect(await resultPromise).toEqual({ states: [], gitBacked: null });
+        expect(
+          h(0)
+            .getAllRequests()
+            .filter((r: any) => r.type === "get-all-states")
+        ).toHaveLength(0);
+      });
     });
 
     it("normalizes the path before keying — equivalent spellings share one request", async () => {

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -2064,6 +2064,12 @@ export class WorkspaceService {
       epoch: this.epoch,
       seq: this.seq,
       lastAcknowledgedMutationIds: [...this.acknowledgedMutations],
+      // Rides along with the snapshot so a caller learns *why* the list is
+      // empty in the same round trip (#11650). `loadProject` sets this from a
+      // live `checkIsRepo` probe of the folder, so it stays correct for a
+      // project registered as a repository whose `.git` was since deleted —
+      // the case the persisted `gitBacked` column silently gets wrong.
+      gitBacked: this.gitBacked,
     });
   }
 

--- a/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
@@ -195,6 +195,22 @@ describe("WorkspaceService adversarial", () => {
       expect(mockSimpleGit.raw).not.toHaveBeenCalled();
     });
 
+    // #11650. The empty state list this folder produces is indistinguishable
+    // from the one a host that has not finished registering produces, so the
+    // verdict has to ride along with it — otherwise the renderer has to guess,
+    // and guessing "no repository" would strip a real repo's worktree state
+    // during the boot race, while guessing "unknown" is what let a folder with
+    // no repository adopt another project's worktree in the first place.
+    it("reports the folder as not git-backed alongside its empty state list", async () => {
+      await service.loadProject("req-plain", "/downloads", "ws-plain");
+      sentEvents.length = 0;
+
+      service.getAllStates("states-plain");
+
+      const event = sentEvents.find((e) => e.type === "all-states");
+      expect(event).toMatchObject({ states: [], gitBacked: false });
+    });
+
     it("stays inert when the workspace is foregrounded again", async () => {
       await service.loadProject("req-plain", "/downloads", "ws-plain");
       const startWatcher = vi.spyOn(

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -29,6 +29,7 @@ export type {
   WorktreeLifecycleStatus,
   Worktree,
   WorktreeState,
+  WorktreeListResult,
   WslGitEligibility,
 } from "./worktree.js";
 

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -223,6 +223,12 @@ export interface ElectronAPI extends GeneratedElectronAPI {
   };
   worktree: {
     getAll(): Promise<WorktreeState[]>;
+    /**
+     * `getAll` plus the workspace host's own git-backed verdict, so a caller
+     * can tell an empty list that means "no repository here" from one that
+     * means "the host has not reported yet" (#11650).
+     */
+    getAllWithStatus(): Promise<import("../worktree.js").WorktreeListResult>;
     refresh(worktreeId?: string): Promise<void>;
     refreshPullRequests(): Promise<void>;
     getPRStatus(): Promise<import("../workspace-host.js").PRServiceStatus | null>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1767,6 +1767,10 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: Record<string, import("./worktree.js").IssueAssociation>;
   };
+  "worktree:get-all-with-status": {
+    args: [];
+    result: import("../worktree.js").WorktreeListResult;
+  };
   "worktree:get-available-branch": {
     args: [payload: { rootPath: string; branchName: string }];
     result: string;

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -603,6 +603,16 @@ export type WorkspaceHostEvent =
       // that predate this field; the port `get-all-states` response always
       // includes it.
       lastAcknowledgedMutationIds?: string[];
+      // The host's own probe of the project root, not a persisted flag: `false`
+      // once `load-project` found no repository, `true` once it found one,
+      // `null` before it has classified (or on a host that predates this
+      // field). `states` alone cannot carry this — an empty list means "no
+      // repository", "host not registered yet" and "readiness gate timed out"
+      // all at once, and the renderer needs to tell the first from the other
+      // two before it lets a workspace adopt the app-global active worktree
+      // (#11650). The project row's `gitBacked` column can't answer it either:
+      // NULL there means both "real repository" and "never classified".
+      gitBacked?: boolean | null;
     }
   | { type: "monitor"; requestId: string; state: WorktreeSnapshot | null }
   // Worktree operation responses

--- a/shared/types/worktree.ts
+++ b/shared/types/worktree.ts
@@ -393,3 +393,26 @@ export interface WorktreeState extends Worktree {
   /** Override to ensure the canonical dirty-file-or-commit activity timestamp is always present */
   lastActivityTimestamp: number | null;
 }
+
+/**
+ * A worktree list paired with the workspace host's own answer to "is there a
+ * repository here at all".
+ *
+ * The list on its own cannot be read as that answer. An empty array means "no
+ * repository", "the host has not registered yet" and "the readiness gate timed
+ * out" all at once, and the renderer has no way to tell them apart — so it has
+ * to treat every empty list as unknown and keep whatever worktree state it
+ * already had (#11234). That is correct for a slow host and wrong for a folder
+ * with no `.git`, which is how a workspace ends up adopting the app-global
+ * active worktree left behind by a different project (#11650).
+ *
+ * `gitBacked` closes that gap with the host's live probe rather than the
+ * project row's persisted `gitBacked` column, whose NULL means both "real
+ * repository" and "never classified" and so cannot gate anything. `null` here
+ * is the honest "not classified yet" — callers must treat it as unknown and
+ * stay permissive, never as `false`.
+ */
+export interface WorktreeListResult {
+  worktrees: WorktreeState[];
+  gitBacked: boolean | null;
+}

--- a/src/clients/worktreeClient.ts
+++ b/src/clients/worktreeClient.ts
@@ -1,5 +1,6 @@
 import type {
   WorktreeState,
+  WorktreeListResult,
   CreateWorktreeOptions,
   BranchInfo,
   AttachIssuePayload,
@@ -19,6 +20,20 @@ import type { WorktreeChanges } from "@shared/types/git";
 export const worktreeClient = {
   getAll: (): Promise<WorktreeState[]> => {
     return window.electron.worktree.getAll();
+  },
+
+  /**
+   * `getAll` plus the workspace host's own probe of the project root.
+   *
+   * Use this wherever an empty list would otherwise be read as "this workspace
+   * has no worktrees": on its own, `[]` also means "the host has not registered
+   * yet", and hydration races host startup by design. `gitBacked` is the host's
+   * live `checkIsRepo`, not the project row's persisted column — that column is
+   * NULL both for a real repository and for one never classified, so it cannot
+   * gate whether foreign worktree state may be adopted (#11650).
+   */
+  getAllWithStatus: (): Promise<WorktreeListResult> => {
+    return window.electron.worktree.getAllWithStatus();
   },
 
   refresh: (worktreeId?: string): Promise<void> => {

--- a/src/utils/__tests__/stateHydration.agentSessionOrdering.test.ts
+++ b/src/utils/__tests__/stateHydration.agentSessionOrdering.test.ts
@@ -16,6 +16,7 @@ const terminalClientMock = {
 
 const worktreeClientMock = {
   getAll: vi.fn(),
+  getAllWithStatus: vi.fn(),
 };
 
 const projectClientMock = {
@@ -182,7 +183,7 @@ describe("hydrateAppState", () => {
     terminalClientMock.getSerializedStates.mockRejectedValue(
       new Error("Batch serialized state endpoint unavailable")
     );
-    worktreeClientMock.getAll.mockResolvedValue([]);
+    worktreeClientMock.getAllWithStatus.mockResolvedValue({ worktrees: [], gitBacked: null });
     projectClientMock.getTabGroups.mockResolvedValue([]);
     projectClientMock.getTerminalSizes.mockResolvedValue({});
     projectClientMock.getDraftInputs.mockResolvedValue({});

--- a/src/utils/__tests__/stateHydration.liveAgentIdentity.test.ts
+++ b/src/utils/__tests__/stateHydration.liveAgentIdentity.test.ts
@@ -16,6 +16,7 @@ const terminalClientMock = {
 
 const worktreeClientMock = {
   getAll: vi.fn(),
+  getAllWithStatus: vi.fn(),
 };
 
 const projectClientMock = {
@@ -182,7 +183,7 @@ describe("hydrateAppState", () => {
     terminalClientMock.getSerializedStates.mockRejectedValue(
       new Error("Batch serialized state endpoint unavailable")
     );
-    worktreeClientMock.getAll.mockResolvedValue([]);
+    worktreeClientMock.getAllWithStatus.mockResolvedValue({ worktrees: [], gitBacked: null });
     projectClientMock.getTabGroups.mockResolvedValue([]);
     projectClientMock.getTerminalSizes.mockResolvedValue({});
     projectClientMock.getDraftInputs.mockResolvedValue({});

--- a/src/utils/__tests__/stateHydration.panelRehydration.test.ts
+++ b/src/utils/__tests__/stateHydration.panelRehydration.test.ts
@@ -16,6 +16,7 @@ const terminalClientMock = {
 
 const worktreeClientMock = {
   getAll: vi.fn(),
+  getAllWithStatus: vi.fn(),
 };
 
 const projectClientMock = {
@@ -183,7 +184,7 @@ describe("hydrateAppState", () => {
     terminalClientMock.getSerializedStates.mockRejectedValue(
       new Error("Batch serialized state endpoint unavailable")
     );
-    worktreeClientMock.getAll.mockResolvedValue([]);
+    worktreeClientMock.getAllWithStatus.mockResolvedValue({ worktrees: [], gitBacked: null });
     projectClientMock.getTabGroups.mockResolvedValue([]);
     projectClientMock.getTerminalSizes.mockResolvedValue({});
     projectClientMock.getDraftInputs.mockResolvedValue({});

--- a/src/utils/__tests__/stateHydration.payloadFolding.test.ts
+++ b/src/utils/__tests__/stateHydration.payloadFolding.test.ts
@@ -16,6 +16,7 @@ const terminalClientMock = {
 
 const worktreeClientMock = {
   getAll: vi.fn(),
+  getAllWithStatus: vi.fn(),
 };
 
 const projectClientMock = {
@@ -182,7 +183,7 @@ describe("hydrateAppState", () => {
     terminalClientMock.getSerializedStates.mockRejectedValue(
       new Error("Batch serialized state endpoint unavailable")
     );
-    worktreeClientMock.getAll.mockResolvedValue([]);
+    worktreeClientMock.getAllWithStatus.mockResolvedValue({ worktrees: [], gitBacked: null });
     projectClientMock.getTabGroups.mockResolvedValue([]);
     projectClientMock.getTerminalSizes.mockResolvedValue({});
     projectClientMock.getDraftInputs.mockResolvedValue({});

--- a/src/utils/__tests__/stateHydration.recoveryAndOrphans.test.ts
+++ b/src/utils/__tests__/stateHydration.recoveryAndOrphans.test.ts
@@ -16,6 +16,7 @@ const terminalClientMock = {
 
 const worktreeClientMock = {
   getAll: vi.fn(),
+  getAllWithStatus: vi.fn(),
 };
 
 const projectClientMock = {
@@ -182,7 +183,7 @@ describe("hydrateAppState", () => {
     terminalClientMock.getSerializedStates.mockRejectedValue(
       new Error("Batch serialized state endpoint unavailable")
     );
-    worktreeClientMock.getAll.mockResolvedValue([]);
+    worktreeClientMock.getAllWithStatus.mockResolvedValue({ worktrees: [], gitBacked: null });
     projectClientMock.getTabGroups.mockResolvedValue([]);
     projectClientMock.getTerminalSizes.mockResolvedValue({});
     projectClientMock.getDraftInputs.mockResolvedValue({});

--- a/src/utils/__tests__/stateHydration.restorePhaseMechanics.test.ts
+++ b/src/utils/__tests__/stateHydration.restorePhaseMechanics.test.ts
@@ -16,6 +16,7 @@ const terminalClientMock = {
 
 const worktreeClientMock = {
   getAll: vi.fn(),
+  getAllWithStatus: vi.fn(),
 };
 
 const projectClientMock = {
@@ -182,7 +183,7 @@ describe("hydrateAppState", () => {
     terminalClientMock.getSerializedStates.mockRejectedValue(
       new Error("Batch serialized state endpoint unavailable")
     );
-    worktreeClientMock.getAll.mockResolvedValue([]);
+    worktreeClientMock.getAllWithStatus.mockResolvedValue({ worktrees: [], gitBacked: null });
     projectClientMock.getTabGroups.mockResolvedValue([]);
     projectClientMock.getTerminalSizes.mockResolvedValue({});
     projectClientMock.getDraftInputs.mockResolvedValue({});
@@ -378,7 +379,7 @@ describe("hydrateAppState", () => {
       hydrateTabGroups: vi.fn(),
     });
 
-    expect(worktreeClientMock.getAll).toHaveBeenCalledTimes(1);
+    expect(worktreeClientMock.getAllWithStatus).toHaveBeenCalledTimes(1);
     expect(projectClientMock.getTabGroups).toHaveBeenCalledWith("project-1");
   });
 

--- a/src/utils/__tests__/stateHydration.worktreeSelection.test.ts
+++ b/src/utils/__tests__/stateHydration.worktreeSelection.test.ts
@@ -16,6 +16,7 @@ const terminalClientMock = {
 
 const worktreeClientMock = {
   getAll: vi.fn(),
+  getAllWithStatus: vi.fn(),
 };
 
 const projectClientMock = {
@@ -106,11 +107,16 @@ const gitProject = {
   lastOpened: 0,
 };
 
+/** The host's answer for a workspace it has classified as having a repository. */
+function hostReports(worktrees: unknown[], gitBacked: boolean | null = null) {
+  return { worktrees, gitBacked };
+}
+
 async function hydrateWith(payload: {
   project: unknown;
   workspaceId?: string;
   activeWorktreeId?: string;
-}): Promise<ReturnType<typeof vi.fn>> {
+}): Promise<{ setActiveWorktree: ReturnType<typeof vi.fn> }> {
   appClientMock.hydrate.mockResolvedValue({
     appState: { terminals: [], activeWorktreeId: payload.activeWorktreeId },
     terminalConfig,
@@ -126,7 +132,7 @@ async function hydrateWith(payload: {
     loadRecipes: vi.fn().mockResolvedValue(undefined),
     openDiagnosticsDock: vi.fn(),
   });
-  return setActiveWorktree;
+  return { setActiveWorktree };
 }
 
 describe("hydrateAppState active-worktree selection", () => {
@@ -136,7 +142,7 @@ describe("hydrateAppState active-worktree selection", () => {
     terminalClientMock.reconnect.mockResolvedValue({ exists: false });
     terminalClientMock.reconnectBulk.mockResolvedValue({});
     terminalClientMock.getSerializedStates.mockRejectedValue(new Error("unavailable"));
-    worktreeClientMock.getAll.mockResolvedValue([]);
+    worktreeClientMock.getAllWithStatus.mockResolvedValue(hostReports([]));
     projectClientMock.getTabGroups.mockResolvedValue([]);
     projectClientMock.getTerminalSizes.mockResolvedValue({});
     projectClientMock.getDraftInputs.mockResolvedValue({});
@@ -148,7 +154,7 @@ describe("hydrateAppState active-worktree selection", () => {
   // the grid rendering a bucket nothing can land in, and every worktree-resolving
   // action refusing with "Worktree not found".
   it("leaves the selection unset in a scratch workspace", async () => {
-    const setActiveWorktree = await hydrateWith({
+    const { setActiveWorktree } = await hydrateWith({
       project: null,
       workspaceId: "scratch-uuid",
       activeWorktreeId: "/other/project/worktree",
@@ -160,10 +166,10 @@ describe("hydrateAppState active-worktree selection", () => {
   // workspace that cannot have worktrees must ignore one even when it arrives
   // populated (a stale or cross-workspace answer).
   it("leaves the selection unset in a scratch workspace even when a worktree list arrives", async () => {
-    worktreeClientMock.getAll.mockResolvedValue([
-      { id: "wt-foreign", name: "main", isMainWorktree: true },
-    ]);
-    const setActiveWorktree = await hydrateWith({
+    worktreeClientMock.getAllWithStatus.mockResolvedValue(
+      hostReports([{ id: "wt-foreign", name: "main", isMainWorktree: true }], true)
+    );
+    const { setActiveWorktree } = await hydrateWith({
       project: null,
       workspaceId: "scratch-uuid",
       activeWorktreeId: "wt-foreign",
@@ -172,7 +178,7 @@ describe("hydrateAppState active-worktree selection", () => {
   });
 
   it("leaves the selection unset in a project opened without git", async () => {
-    const setActiveWorktree = await hydrateWith({
+    const { setActiveWorktree } = await hydrateWith({
       project: { ...gitProject, gitBacked: false },
       workspaceId: gitProject.id,
       activeWorktreeId: "/other/project/worktree",
@@ -183,7 +189,7 @@ describe("hydrateAppState active-worktree selection", () => {
   // #11234: for a git-backed project an empty list means "the host hasn't
   // reported yet", so the saved selection is kept rather than dropped.
   it("keeps the saved selection in a git-backed project whose worktree list is still unknown", async () => {
-    const setActiveWorktree = await hydrateWith({
+    const { setActiveWorktree } = await hydrateWith({
       project: gitProject,
       workspaceId: gitProject.id,
       activeWorktreeId: "wt-saved",
@@ -191,11 +197,12 @@ describe("hydrateAppState active-worktree selection", () => {
     expect(setActiveWorktree).toHaveBeenCalledExactlyOnceWith("wt-saved");
   });
 
-  // A rejected `worktree:get-all` resolves to the `null` sentinel, which is the
-  // other spelling of "unknown" — same outcome as the empty list above.
+  // A rejected `worktree:get-all-with-status` resolves to the `null` sentinel,
+  // which is the other spelling of "unknown" — same outcome as the empty list
+  // above. The host never answered, so it never said "no repository" either.
   it("keeps the saved selection when the worktree fetch fails outright", async () => {
-    worktreeClientMock.getAll.mockRejectedValue(new Error("host unavailable"));
-    const setActiveWorktree = await hydrateWith({
+    worktreeClientMock.getAllWithStatus.mockRejectedValue(new Error("host unavailable"));
+    const { setActiveWorktree } = await hydrateWith({
       project: gitProject,
       workspaceId: gitProject.id,
       activeWorktreeId: "wt-saved",
@@ -204,11 +211,16 @@ describe("hydrateAppState active-worktree selection", () => {
   });
 
   it("restores the saved selection when it is present in a known worktree list", async () => {
-    worktreeClientMock.getAll.mockResolvedValue([
-      { id: "wt-main", name: "main", isMainWorktree: true },
-      { id: "wt-feature", name: "feature", isMainWorktree: false },
-    ]);
-    const setActiveWorktree = await hydrateWith({
+    worktreeClientMock.getAllWithStatus.mockResolvedValue(
+      hostReports(
+        [
+          { id: "wt-main", name: "main", isMainWorktree: true },
+          { id: "wt-feature", name: "feature", isMainWorktree: false },
+        ],
+        true
+      )
+    );
+    const { setActiveWorktree } = await hydrateWith({
       project: gitProject,
       workspaceId: gitProject.id,
       activeWorktreeId: "wt-feature",
@@ -217,15 +229,47 @@ describe("hydrateAppState active-worktree selection", () => {
   });
 
   it("falls back to the main worktree when the saved selection is gone", async () => {
-    worktreeClientMock.getAll.mockResolvedValue([
-      { id: "wt-feature", name: "feature", isMainWorktree: false },
-      { id: "wt-main", name: "main", isMainWorktree: true },
-    ]);
-    const setActiveWorktree = await hydrateWith({
+    worktreeClientMock.getAllWithStatus.mockResolvedValue(
+      hostReports(
+        [
+          { id: "wt-feature", name: "feature", isMainWorktree: false },
+          { id: "wt-main", name: "main", isMainWorktree: true },
+        ],
+        true
+      )
+    );
+    const { setActiveWorktree } = await hydrateWith({
       project: gitProject,
       workspaceId: gitProject.id,
       activeWorktreeId: "wt-deleted",
     });
     expect(setActiveWorktree).toHaveBeenCalledExactlyOnceWith("wt-main");
+  });
+
+  // #11650. The row's discriminator cannot tell these two apart — both carry no
+  // `gitBacked` field, which `isGitBackedProject` reads as git-backed — so the
+  // pair only diverges on what the host reports. Asserting them together is the
+  // point: the fix must split them, and must not do it by making the unknown
+  // case conservative (that would resurrect #11234).
+  describe("a project row with no gitBacked discriminator", () => {
+    it("keeps the saved selection while the host has not classified the folder", async () => {
+      worktreeClientMock.getAllWithStatus.mockResolvedValue(hostReports([], null));
+      const { setActiveWorktree } = await hydrateWith({
+        project: gitProject,
+        workspaceId: gitProject.id,
+        activeWorktreeId: "wt-foreign",
+      });
+      expect(setActiveWorktree).toHaveBeenCalledExactlyOnceWith("wt-foreign");
+    });
+
+    it("ignores the saved selection once the host reports no repository", async () => {
+      worktreeClientMock.getAllWithStatus.mockResolvedValue(hostReports([], false));
+      const { setActiveWorktree } = await hydrateWith({
+        project: gitProject,
+        workspaceId: gitProject.id,
+        activeWorktreeId: "wt-foreign",
+      });
+      expect(setActiveWorktree).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -552,20 +552,29 @@ describe("restorePanelsPhase — worktree re-home validation (#11387)", () => {
       expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({ worktreeId: undefined });
     });
 
-    // The non-PTY builder falls back to `activeWorktreeId` when the panel saved
-    // none of its own, so stripping its *result* is not enough — the foreign id
-    // has to be withheld from the builder as well. Distinct from the case above,
-    // where the panel carried a saved id and the fallback never ran.
-    it("does not let a non-PTY panel with no saved worktree inherit the foreign active id", async () => {
+    // Restore ordering keys off "is this panel on the active worktree", which
+    // reads the same app-global id. Ungated, the foreign id makes a panel an
+    // earlier run wrongly stamped with it restore FIRST, while the correctly
+    // unattributed panel drops to the background tier — another project's
+    // selection steering this one's restore order. Saved order here is the
+    // reverse of the expectation, so echoing the input cannot pass this.
+    it("does not let the foreign active id steer restore priority", async () => {
       const ctx = makeContext({
         workspaceHasWorktreesPromise: Promise.resolve(false),
         activeWorktreeId: "/other/project/main",
         worktreesPromise: Promise.resolve([]),
       });
-      await restorePanelsPhase([panel("b1", { kind: "browser", worktreeId: undefined })], ctx);
-      expect(ctx.addPanel).toHaveBeenCalledTimes(1);
-      const args = ctx.addPanel.mock.calls[0]![0] as { worktreeId?: string };
-      expect(args.worktreeId).toBeUndefined();
+      ctx.backendTerminalMap.set("fw", backend("fw"));
+      ctx.backendTerminalMap.set("nw", backend("nw"));
+      await restorePanelsPhase(
+        [
+          panel("fw", { worktreeId: "/other/project/main" }),
+          panel("nw", { worktreeId: undefined }),
+        ],
+        ctx
+      );
+      const ids = ctx.addPanel.mock.calls.map((c) => (c[0] as { existingId?: string }).existingId);
+      expect(ids).toEqual(["nw", "fw"]);
     });
 
     it("leaves an orphan PTY worktree-less even when a foreign worktree matches its cwd", async () => {

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -170,7 +170,7 @@ function makeContext(overrides: Partial<RawContext> = {}): MockedContext {
     activeWorktreeId: null,
     // The default is the git-backed workspace every existing case assumes; the
     // worktree-less workspace cases override it.
-    workspaceHasWorktrees: true,
+    workspaceHasWorktreesPromise: Promise.resolve(true),
     projectRoot: "/proj",
     agentSettings: undefined,
     clipboardDirectory: undefined,
@@ -511,7 +511,7 @@ describe("restorePanelsPhase — worktree re-home validation (#11387)", () => {
   describe("worktree-less workspace", () => {
     it("restores a stranded panel with no worktree instead of re-homing onto the foreign active id", async () => {
       const ctx = makeContext({
-        workspaceHasWorktrees: false,
+        workspaceHasWorktreesPromise: Promise.resolve(false),
         activeWorktreeId: "/other/project/main",
         worktreesPromise: Promise.resolve([]),
       });
@@ -526,7 +526,7 @@ describe("restorePanelsPhase — worktree re-home validation (#11387)", () => {
 
     it("strips a foreign worktreeId a previous run persisted onto a panel", async () => {
       const ctx = makeContext({
-        workspaceHasWorktrees: false,
+        workspaceHasWorktreesPromise: Promise.resolve(false),
         activeWorktreeId: null,
         worktreesPromise: Promise.resolve([]),
       });
@@ -540,7 +540,7 @@ describe("restorePanelsPhase — worktree re-home validation (#11387)", () => {
 
     it("strips a foreign worktreeId from a non-PTY panel too", async () => {
       const ctx = makeContext({
-        workspaceHasWorktrees: false,
+        workspaceHasWorktreesPromise: Promise.resolve(false),
         activeWorktreeId: "/other/project/main",
         worktreesPromise: Promise.resolve([]),
       });
@@ -552,9 +552,25 @@ describe("restorePanelsPhase — worktree re-home validation (#11387)", () => {
       expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({ worktreeId: undefined });
     });
 
+    // The non-PTY builder falls back to `activeWorktreeId` when the panel saved
+    // none of its own, so stripping its *result* is not enough — the foreign id
+    // has to be withheld from the builder as well. Distinct from the case above,
+    // where the panel carried a saved id and the fallback never ran.
+    it("does not let a non-PTY panel with no saved worktree inherit the foreign active id", async () => {
+      const ctx = makeContext({
+        workspaceHasWorktreesPromise: Promise.resolve(false),
+        activeWorktreeId: "/other/project/main",
+        worktreesPromise: Promise.resolve([]),
+      });
+      await restorePanelsPhase([panel("b1", { kind: "browser", worktreeId: undefined })], ctx);
+      expect(ctx.addPanel).toHaveBeenCalledTimes(1);
+      const args = ctx.addPanel.mock.calls[0]![0] as { worktreeId?: string };
+      expect(args.worktreeId).toBeUndefined();
+    });
+
     it("leaves an orphan PTY worktree-less even when a foreign worktree matches its cwd", async () => {
       const ctx = makeContext({
-        workspaceHasWorktrees: false,
+        workspaceHasWorktreesPromise: Promise.resolve(false),
         activeWorktreeId: "/other/project/main",
         // A worktree-less view should never see a list, but if a stale one leaks
         // through, cwd inference must not attribute the orphan to it either.

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -266,17 +266,43 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
     // Whether this view's workspace can have git worktrees at all. A scratch has
     // no project row behind it, and a folder opened without git has one that is
     // explicitly not git-backed (#11405) — neither can ever enumerate a worktree.
-    // `isGitBackedProject` reads absence as git-backed (legacy rows carry no
-    // discriminator), so the null check has to be its own clause. Every use of
-    // the saved `appState.activeWorktreeId` below is gated on this: that value is
-    // one app-global field shared by every workspace, so in a worktree-less view
-    // it names whichever worktree the last git-backed project left behind.
-    const workspaceHasWorktrees = currentProject != null && isGitBackedProject(currentProject);
-
-    const worktreesPromise = worktreeClient.getAll().catch((error) => {
+    // Every use of the saved `appState.activeWorktreeId` below is gated on this:
+    // that value is one app-global field shared by every workspace, so in a
+    // worktree-less view it names whichever worktree the last git-backed project
+    // left behind.
+    //
+    // The project row alone cannot answer this. `isGitBackedProject` reads a
+    // missing discriminator as git-backed, and the column is NULL both for a
+    // real repository (a successful probe deliberately stores NULL) and for a
+    // folder that was never classified — including every row predating migration
+    // 0008, which added the column with no backfill. A folder with no `.git`
+    // behind such a row passed this check and adopted the foreign worktree
+    // anyway (#11650), which is exactly what the guard was written to prevent.
+    // So the row only supplies the fast, synchronous *negative* cases below; the
+    // authoritative answer comes from the workspace host, which probes the
+    // folder itself and is therefore also right about a project registered as a
+    // repository whose `.git` has since been deleted (#11649).
+    const statusPromise = worktreeClient.getAllWithStatus().catch((error) => {
       logWarn("Failed to prefetch worktrees during hydration", { error });
       return null;
     });
+
+    const worktreesPromise = statusPromise.then((status) => status?.worktrees ?? null);
+
+    // Resolved rather than synchronous, because the host is the only party that
+    // can distinguish "no repository" from "not reported yet". Costs nothing:
+    // every consumer already sits behind an await of the same fetch (see the
+    // call sites in panelRestorePhase and the selection block below), so this
+    // does not serialize panel restore behind worktree enumeration.
+    //
+    // Unknown stays permissive. A host that never became ready, a failed fetch
+    // and a host predating the field all answer `gitBacked: null`, and reading
+    // any of those as "no worktrees" would strip a real repository's saved
+    // selection during the boot race #11234 exists for.
+    const workspaceHasWorktreesPromise: Promise<boolean> =
+      currentProject == null || !isGitBackedProject(currentProject)
+        ? Promise.resolve(false)
+        : statusPromise.then((status) => status?.gitBacked !== false);
 
     // Each of these rides along in the batched hydrate payload when the main
     // process is new enough; the standalone IPC calls only fire as a fallback
@@ -452,11 +478,14 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
         // Fetch terminal sizes for restoration
         const terminalSizes = await terminalSizesPromise;
 
-        // Withheld from a worktree-less workspace rather than merely left
-        // unselected later: restore re-homes worktree-less and stale-worktree
-        // panels onto it, so passing it through would stamp another workspace's
-        // worktree onto this one's panels.
-        const activeWorktreeId = workspaceHasWorktrees ? (appState.activeWorktreeId ?? null) : null;
+        // Passed through raw and withheld inside `restorePanelsPhase` instead of
+        // being zeroed here: whether this workspace may adopt it is only known
+        // once the host answers, and every consumer there already awaits that
+        // fetch. Withheld rather than merely left unselected, because restore
+        // re-homes worktree-less and stale-worktree panels onto it — letting it
+        // through would stamp another workspace's worktree onto this one's
+        // panels.
+        const activeWorktreeId = appState.activeWorktreeId ?? null;
         const projectPresetsByAgent = await projectPresetsPromise;
 
         // Seed the persistence cache so the first save after launch can
@@ -503,7 +532,7 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
           prefetchedReconnectResults,
           terminalSizes,
           activeWorktreeId,
-          workspaceHasWorktrees,
+          workspaceHasWorktreesPromise,
           projectRoot: projectRoot || "",
           agentSettings,
           clipboardDirectory,
@@ -624,6 +653,7 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
 
     // Worktree fetch starts earlier to overlap with terminal restoration.
     const worktrees = await worktreesPromise;
+    const workspaceHasWorktrees = await workspaceHasWorktreesPromise;
     const savedActiveId = appState.activeWorktreeId;
     // An empty list means "unknown", not "none" — see `getKnownWorktreeIds` in
     // panelRestorePhase for why a cold boot can answer [] while the workspace
@@ -653,12 +683,14 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
 
     // A worktree-less workspace has nothing to select, now or ever, so its
     // selection stays null. The empty-list branch below reads an empty list as
-    // "the host hasn't reported yet" (#11234) — true for a project, never for a
-    // scratch — so without this gate the view adopts whichever worktree the last
-    // git-backed project left behind. Nothing then resolves it: the grid renders
-    // that foreign worktree's bucket while new panels land in the worktree-less
-    // one (invisible panels with live PTYs), and every worktree-resolving action
-    // refuses with "Worktree not found". Skipping the call — rather than clearing
+    // "the host hasn't reported yet" (#11234) — true while a project's host is
+    // still registering, never for a scratch, and never once the host has said
+    // the folder has no repository — so without this gate the view adopts
+    // whichever worktree the last git-backed project left behind. Nothing then
+    // resolves it: the grid renders that foreign worktree's bucket while new
+    // panels land in the worktree-less one (invisible panels with live PTYs),
+    // and every worktree-resolving action refuses with "Worktree not found".
+    // Skipping the call — rather than clearing
     // with `setActiveWorktree(null)` — also leaves the shared persisted restore
     // point intact for the projects that own it.
     if (!workspaceHasWorktrees) {

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -290,10 +290,9 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
     const worktreesPromise = statusPromise.then((status) => status?.worktrees ?? null);
 
     // Resolved rather than synchronous, because the host is the only party that
-    // can distinguish "no repository" from "not reported yet". Costs nothing:
-    // every consumer already sits behind an await of the same fetch (see the
-    // call sites in panelRestorePhase and the selection block below), so this
-    // does not serialize panel restore behind worktree enumeration.
+    // can distinguish "no repository" from "not reported yet". `restorePanelsPhase`
+    // folds it into one derived active id up front — see the note there for why
+    // that costs the usual restore nothing.
     //
     // Unknown stays permissive. A host that never became ready, a failed fetch
     // and a host predating the field all answer `gitBacked: null`, and reading

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -291,6 +291,13 @@ export interface PanelRestoreContext {
    */
   prefetchedReconnectResults?: Record<string, TerminalReconnectResult>;
   terminalSizes: Record<string, { cols: number; rows: number }>;
+  /**
+   * The saved selection exactly as persisted — one app-global field shared by
+   * every workspace, so in a worktree-less view it names another project's
+   * worktree. Read `effectiveActiveWorktreeId` inside the phase, never this:
+   * that local folds in {@link workspaceHasWorktreesPromise} once, so no
+   * consumer can forget the gate.
+   */
   activeWorktreeId: string | null;
   /**
    * Whether the workspace being restored can have git worktrees at all. `false`
@@ -388,6 +395,24 @@ export async function restorePanelsPhase(
     logHydrationInfo,
   } = ctx;
 
+  // Resolved once, up front, and folded straight into the active id every
+  // consumer below reads. Per-consumer gating was the alternative and it is a
+  // trap: the raw app-global id also feeds the restore-ordering comparison at
+  // `isActiveWorktree`, where forgetting the gate silently changes which panels
+  // restore first rather than failing loudly. One derived value cannot be
+  // read past.
+  //
+  // Near-free rather than free: the PTY paths (through
+  // `resolveRestoredWorktreeId`) and the orphan phase already await
+  // `worktreesPromise`, which settles from the same fetch, so the usual restore
+  // already carried this wait. What it does add is a wait for a workspace whose
+  // panels are ALL non-PTY, which previously recreated without touching the
+  // list. Accepted: those panels are cheap to recreate, hydration awaits the
+  // same fetch before it finishes regardless, and the alternative is attributing
+  // them to another project's worktree.
+  const workspaceHasWorktrees = await workspaceHasWorktreesPromise;
+  const effectiveActiveWorktreeId = workspaceHasWorktrees ? activeWorktreeId : null;
+
   const restoreTasks: TerminalRestoreTask[] = [];
   const savedIdToRestoredId = new Map<string, string>();
   // Adaptive staggered-restore params scaled to the machine's resource
@@ -434,7 +459,7 @@ export async function restorePanelsPhase(
     // workspace's worktree, and a saved id could only be one a buggy earlier run
     // stamped on. Normalize to none — the worktree-less bucket the grid renders
     // when nothing is selected.
-    if (!(await workspaceHasWorktreesPromise)) return undefined;
+    if (!workspaceHasWorktrees) return undefined;
     const known = await getKnownWorktreeIds();
     // Only re-home onto the active worktree when it is itself live. With a
     // complete, authoritative list (#11387) an activeWorktreeId absent from
@@ -445,8 +470,8 @@ export async function restorePanelsPhase(
     // against, so preserve the prior behavior of trusting activeWorktreeId
     // (#11234). This closes PR #11235's own unaddressed follow-up.
     const rehomeTarget =
-      activeWorktreeId !== null && (known === null || known.has(activeWorktreeId))
-        ? activeWorktreeId
+      effectiveActiveWorktreeId !== null && (known === null || known.has(effectiveActiveWorktreeId))
+        ? effectiveActiveWorktreeId
         : undefined;
     // No saved worktree (undefined, or a corrupt empty string): fall to the
     // validated active worktree, or leave it unset rather than guess onto a
@@ -543,7 +568,7 @@ export async function restorePanelsPhase(
       }
 
       const savedWorktreeId = saved.worktreeId ?? null;
-      const isActiveWorktree = savedWorktreeId === activeWorktreeId;
+      const isActiveWorktree = savedWorktreeId === effectiveActiveWorktreeId;
       // A non-active worktree's last-focused panel earns priority restore so
       // each worktree's last active panel reactivates quickly on return.
       const isMostRecentInOtherWorktree =
@@ -793,20 +818,20 @@ export async function restorePanelsPhase(
                 return;
               }
               logHydrationInfo(`Recreating ${kind} panel: ${saved.id}`);
-              const hasWorktrees = await workspaceHasWorktreesPromise;
               const nonPtyArgs = buildArgsForNonPtyRecreation(
                 saved,
                 kind,
                 projectRoot || "",
-                // The builder falls back to this when the panel has no saved id
-                // of its own, so a worktree-less workspace has to withhold it
-                // here rather than only clear the result below.
-                hasWorktrees ? activeWorktreeId : null
+                // The builder falls back to this when rescuing a non-dockable
+                // dock panel that saved no worktree of its own. The clear below
+                // already covers that today; passing the gated id keeps the two
+                // from having to agree.
+                effectiveActiveWorktreeId
               );
               // Same normalization the PTY paths get from
               // `resolveRestoredWorktreeId`: this builder keeps `saved.worktreeId`
               // untouched, so a worktree-less workspace needs it cleared here too.
-              if (!hasWorktrees) nonPtyArgs.worktreeId = undefined;
+              if (!workspaceHasWorktrees) nonPtyArgs.worktreeId = undefined;
               const nonPtyId = await addPanel(nonPtyArgs);
               restoredIdsByIndex.set(capturedIndex, nonPtyId);
             }
@@ -949,7 +974,6 @@ export async function restorePanelsPhase(
     // is awaited once; if it resolves to null or hasn't loaded, orphans fall
     // back to activeWorktreeId so they still appear in the grid.
     const worktreesForInfer = await worktreesPromise;
-    const workspaceHasWorktrees = await workspaceHasWorktreesPromise;
 
     const restoreOrphan = async (terminal: (typeof orphanedTerminals)[number]): Promise<void> => {
       try {
@@ -971,8 +995,8 @@ export async function restorePanelsPhase(
         if (inferred) {
           orphanArgs.worktreeId = inferred;
           orphanArgs.worktreeIdSource = "inferred";
-        } else if (workspaceHasWorktrees && activeWorktreeId) {
-          orphanArgs.worktreeId = activeWorktreeId;
+        } else if (effectiveActiveWorktreeId) {
+          orphanArgs.worktreeId = effectiveActiveWorktreeId;
           orphanArgs.worktreeIdSource = "inferred";
         }
         const restoredTerminalId = await addPanel(orphanArgs);

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -300,8 +300,16 @@ export interface PanelRestoreContext {
    * workspace. Without this the app-global saved `activeWorktreeId` (and any
    * id a previous run persisted onto a panel) restores panels into a worktree
    * bucket the grid never renders: a live PTY with no visible panel.
+   *
+   * A promise because only the workspace host can distinguish a folder with no
+   * repository from one whose host has not reported yet, and the project row's
+   * `gitBacked` column answers NULL for both a real repository and one never
+   * classified (#11650). Awaiting costs nothing: every consumer below already
+   * sits behind an await of `worktreesPromise`, which resolves from the same
+   * fetch. Resolves `true` whenever the answer is unknown, so the boot race
+   * keeps its saved state (#11234).
    */
-  workspaceHasWorktrees: boolean;
+  workspaceHasWorktreesPromise: Promise<boolean>;
   projectRoot: string;
   agentSettings: AgentSettings | undefined;
   clipboardDirectory: string | undefined;
@@ -367,7 +375,7 @@ export async function restorePanelsPhase(
     prefetchedReconnectResults,
     terminalSizes,
     activeWorktreeId,
-    workspaceHasWorktrees,
+    workspaceHasWorktreesPromise,
     projectRoot,
     agentSettings,
     clipboardDirectory,
@@ -426,7 +434,7 @@ export async function restorePanelsPhase(
     // workspace's worktree, and a saved id could only be one a buggy earlier run
     // stamped on. Normalize to none — the worktree-less bucket the grid renders
     // when nothing is selected.
-    if (!workspaceHasWorktrees) return undefined;
+    if (!(await workspaceHasWorktreesPromise)) return undefined;
     const known = await getKnownWorktreeIds();
     // Only re-home onto the active worktree when it is itself live. With a
     // complete, authoritative list (#11387) an activeWorktreeId absent from
@@ -785,16 +793,20 @@ export async function restorePanelsPhase(
                 return;
               }
               logHydrationInfo(`Recreating ${kind} panel: ${saved.id}`);
+              const hasWorktrees = await workspaceHasWorktreesPromise;
               const nonPtyArgs = buildArgsForNonPtyRecreation(
                 saved,
                 kind,
                 projectRoot || "",
-                activeWorktreeId
+                // The builder falls back to this when the panel has no saved id
+                // of its own, so a worktree-less workspace has to withhold it
+                // here rather than only clear the result below.
+                hasWorktrees ? activeWorktreeId : null
               );
               // Same normalization the PTY paths get from
               // `resolveRestoredWorktreeId`: this builder keeps `saved.worktreeId`
               // untouched, so a worktree-less workspace needs it cleared here too.
-              if (!workspaceHasWorktrees) nonPtyArgs.worktreeId = undefined;
+              if (!hasWorktrees) nonPtyArgs.worktreeId = undefined;
               const nonPtyId = await addPanel(nonPtyArgs);
               restoredIdsByIndex.set(capturedIndex, nonPtyId);
             }
@@ -937,6 +949,7 @@ export async function restorePanelsPhase(
     // is awaited once; if it resolves to null or hasn't loaded, orphans fall
     // back to activeWorktreeId so they still appear in the grid.
     const worktreesForInfer = await worktreesPromise;
+    const workspaceHasWorktrees = await workspaceHasWorktreesPromise;
 
     const restoreOrphan = async (terminal: (typeof orphanedTerminals)[number]): Promise<void> => {
       try {


### PR DESCRIPTION
## Summary

Hydration was deciding whether a workspace could adopt the app global `appState.activeWorktreeId` by reading a project row's `gitBacked` column through `isGitBackedProject`, defined as `project?.gitBacked !== false`. That column is `NULL` for two completely different reasons: a real repository (a successful probe deliberately stores `NULL` rather than `1`) and a folder that was never classified (migration `0008_add_project_git_backed.sql` added the column with no backfill, so every row predating it is `NULL`). A folder with no `.git` was passing the check, `workspaceHasWorktrees` came out `true`, and the guard added in `ff46df3ba` never fired. The workspace adopted whichever worktree the last git backed project had left behind, re-homing panels onto a foreign worktree, which is exactly what that guard was written to prevent.

Resolves #11650

## Why the issue's suggested fix needed refining

The issue proposed keying the guard on the worktree list instead, but the list can't answer the question either. `WorkspaceClient.getAllStatesForProjectAsync` returns an empty array for three situations the renderer can't tell apart: no host pool entry yet, the readiness gate timing out at 5 seconds, or a genuinely ready host reporting zero worktrees. Only the third case means "no repository". Reading every empty list as "no worktrees" would strip a real repository's saved selection on any cold boot that loses the startup race, which is the regression from #11234.

## What this does instead

The workspace host already computes the right answer and throws it away. `WorkspaceService.loadProject` probes the folder with `checkIsRepo` and stores a tri-state `gitBacked` value (boolean or null), but `getAllStates` never sends it to the renderer. This carries that verdict on the all-states reply, through a new additive IPC operation, `worktree:get-all-with-status`, to a new `worktreeClient.getAllWithStatus()`. The guard now reads the host's live probe instead of a persisted database flag, which also gets it right for a project registered as a repository whose `.git` folder has since been deleted.

Unknown stays permissive throughout. A `null` `gitBacked` value, a host predating this field, and a failed fetch all resolve to "assume it has worktrees", so #11234's boot race behavior is preserved exactly. Only an explicit `false` denies adoption.

`worktree:get-all` is untouched and still returns a bare array, so the seven existing e2e specs and the file browser path that call it are unaffected.

One thing worth flagging for review: `restorePanelsPhase` now resolves the guard once up front and folds it into a single derived `effectiveActiveWorktreeId` that every consumer reads, rather than gating each consumer separately. Per-consumer gating was the alternative and it's a trap: the raw app global id also feeds a restore ordering comparison elsewhere, where forgetting the gate would silently change which panels restore first instead of failing loudly. One derived value can't be read past.

## Changes

- New IPC operation `worktree:get-all-with-status` alongside the untouched `worktree:get-all`
- `worktreeClient.getAllWithStatus()` on the renderer side
- `WorkspaceService.loadProject`'s tri-state `gitBacked` probe result now flows through `getAllStates` instead of being discarded
- Hydration's worktree guard reads the host's live probe result instead of the project row's `gitBacked` column
- `restorePanelsPhase` resolves the guard once into a derived `effectiveActiveWorktreeId`

## Testing

- 307 targeted tests pass: hydration suites, `panelRestorePhase`, `WorkspaceClient` resilience and readiness tests, workspace-host tests, IPC handler tests
- Renderer and both electron tsconfig projects typecheck clean
- Lint ratchet holds at its existing baseline of 1105
- All five IPC, channel, and API surface guard scripts pass

## Related

#11649 is the upstream root cause: a database row whose `.git` folder vanished gets an in-memory-only correction on the host that never repairs the row. This fix is defense in depth at the read site and doesn't depend on #11649 landing.
