### PR TITLE
fix(terminal): scope reconnect to the sender's own workspace

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/snapshots.reconnectBulk.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/snapshots.reconnectBulk.test.ts
@@ -1,13 +1,51 @@
+/**
+ * #11652: `terminal:reconnect` resolved a terminal by id alone. Terminal ids are
+ * globally unique, so any project could reattach to any other project's running
+ * terminal — and the result carries the live `projectId`/`cwd`, which the
+ * renderer trusts over its own saved snapshot, so a foreign id in saved state
+ * (#11651) was silently adopted.
+ *
+ * The gate resolves the sender's workspace from the sender itself. `ctx.projectId`
+ * is authoritative once the view is bound, but reconnect runs during cold-boot
+ * hydration, when the startup-restore renderer may still be unbound — there the
+ * `?projectId=` query string on its URL is the only sender-local identity.
+ *
+ * These specs drive the real `defineIpcNamespace` → `typedHandleWithContext`
+ * chain so the context is built by production code, not by the fixture.
+ */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-vi.mock("electron", () => ({
-  ipcMain: {
-    handle: vi.fn(),
-    removeHandler: vi.fn(),
-  },
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+  on: vi.fn(),
+  removeListener: vi.fn(),
 }));
 
-const mockIsHelpTerminal = vi.fn((_id: string) => false);
+vi.mock("electron", () => ({
+  ipcMain: ipcMainMock,
+  BrowserWindow: { fromWebContents: vi.fn(() => null), getAllWindows: () => [] },
+  webContents: { fromId: vi.fn(() => null) },
+}));
+
+const getWindowForWebContentsMock = vi.hoisted(() =>
+  vi.fn<(wc: { id: number }) => unknown>(() => null)
+);
+const getProjectForWebContentsMock = vi.hoisted(() =>
+  vi.fn<(id: number) => string | null>(() => null)
+);
+
+vi.mock("../../../../window/webContentsRegistry.js", () => ({
+  getWindowForWebContents: getWindowForWebContentsMock,
+  getProjectForWebContents: getProjectForWebContentsMock,
+  getAppWebContents: vi.fn(() => null),
+  getAllAppWebContents: vi.fn(() => []),
+  getWebContentsForProject: vi.fn(() => []),
+  hasRegisteredProjectViews: vi.fn(() => true),
+  isCachedViewWebContents: vi.fn(() => false),
+}));
+
+const mockIsHelpTerminal = vi.hoisted(() => vi.fn((_id: string) => false));
 
 vi.mock("../../../../services/AgentAvailabilityStore.js", () => ({
   getAgentAvailabilityStore: () => ({
@@ -15,129 +53,315 @@ vi.mock("../../../../services/AgentAvailabilityStore.js", () => ({
   }),
 }));
 
-import { ipcMain } from "electron";
 import { CHANNELS } from "../../../channels.js";
 import { registerTerminalSnapshotHandlers } from "../snapshots.js";
+import { _resetIpcGuardForTesting, markIpcSecurityReady } from "../../../ipcGuard.js";
 import type { HandlerDependencies } from "../../../types.js";
 
-type ReconnectBulkHandler = (
-  event: unknown,
-  terminalIds: string[]
-) => Promise<Record<string, { exists: boolean; id?: string; hasPty?: boolean }>>;
+const SENDER_A = 101;
+const SENDER_B = 202;
 
-function makeTerminal(id: string) {
+/** Sender A's view is bound to project A; sender B's to project B. */
+const VIEW_TO_PROJECT = new Map([
+  [SENDER_A, "project-a"],
+  [SENDER_B, "project-b"],
+]);
+
+type ReconnectResult = { exists: boolean; id?: string; hasPty?: boolean; cwd?: string };
+
+function makeTerminal(id: string, projectId: string | null = "project-a") {
   return {
     id,
-    projectId: "project-1",
+    projectId,
     kind: "terminal",
-    cwd: "/tmp",
+    cwd: `/tmp/${projectId ?? "unowned"}`,
     spawnedAt: 1,
     hasPty: true,
   };
 }
 
-describe("terminal:reconnect-bulk handler", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockIsHelpTerminal.mockReturnValue(false);
+const TERMINALS = new Map([
+  ["t-a", makeTerminal("t-a", "project-a")],
+  ["t-a2", makeTerminal("t-a2", "project-a")],
+  ["t-b", makeTerminal("t-b", "project-b")],
+  ["t-unowned", makeTerminal("t-unowned", null)],
+  ["t-scratch", makeTerminal("t-scratch", "scratch-1")],
+]);
+
+/** An invoke event whose URL can be mutated mid-flight, to prove identity is snapshotted. */
+function makeEvent(id: number, url?: string) {
+  const state = { url };
+  const event = {
+    sender: {
+      id,
+      ...(url === undefined ? {} : { getURL: () => state.url as string }),
+    },
+  };
+  return { event, setUrl: (next: string) => (state.url = next) };
+}
+
+function defaultPtyClient() {
+  return {
+    getTerminalAsync: vi.fn(async (id: string) => TERMINALS.get(id) ?? null),
+  };
+}
+
+function register(ptyClient: unknown = defaultPtyClient()) {
+  registerTerminalSnapshotHandlers({ ptyClient } as unknown as HandlerDependencies);
+  return ptyClient as ReturnType<typeof defaultPtyClient>;
+}
+
+function getHandler(channel: string) {
+  const call = ipcMainMock.handle.mock.calls.find(([registered]) => registered === channel);
+  if (!call) throw new Error(`handler for ${channel} was never registered`);
+  return call[1] as (event: unknown, ...args: unknown[]) => Promise<unknown>;
+}
+
+function reconnect(event: unknown, terminalId: string): Promise<ReconnectResult> {
+  return getHandler(CHANNELS.TERMINAL_RECONNECT)(event, terminalId) as Promise<ReconnectResult>;
+}
+
+function reconnectBulk(
+  event: unknown,
+  terminalIds: unknown
+): Promise<Record<string, ReconnectResult>> {
+  return getHandler(CHANNELS.TERMINAL_RECONNECT_BULK)(event, terminalIds) as Promise<
+    Record<string, ReconnectResult>
+  >;
+}
+
+/** A bound sender, the ordinary post-startup case. */
+function boundEvent(id: number) {
+  return makeEvent(id, "app://index.html").event;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  _resetIpcGuardForTesting();
+  markIpcSecurityReady();
+  mockIsHelpTerminal.mockReturnValue(false);
+  getProjectForWebContentsMock.mockImplementation((id) => VIEW_TO_PROJECT.get(id) ?? null);
+  getWindowForWebContentsMock.mockReturnValue(null);
+});
+
+describe("terminal:reconnect — workspace ownership", () => {
+  it("reconnects a terminal the sender's own project owns", async () => {
+    register();
+
+    await expect(reconnect(boundEvent(SENDER_A), "t-a")).resolves.toMatchObject({
+      exists: true,
+      id: "t-a",
+      hasPty: true,
+    });
   });
 
-  function getHandler(): ReconnectBulkHandler {
-    const calls = (ipcMain.handle as unknown as { mock: { calls: Array<[string, unknown]> } }).mock
-      .calls;
-    const handlerCall = calls.find((call) => call[0] === CHANNELS.TERMINAL_RECONNECT_BULK);
-    expect(handlerCall).toBeTruthy();
-    return handlerCall?.[1] as ReconnectBulkHandler;
-  }
+  it("refuses a terminal owned by another project, leaking no metadata", async () => {
+    register();
 
+    const result = await reconnect(boundEvent(SENDER_A), "t-b");
+
+    expect(result).toEqual({ exists: false });
+    expect(result.cwd).toBeUndefined();
+  });
+
+  it("serves each project its own terminal in the same session", async () => {
+    register();
+
+    const [a, b] = await Promise.all([
+      reconnect(boundEvent(SENDER_A), "t-a"),
+      reconnect(boundEvent(SENDER_B), "t-b"),
+    ]);
+
+    expect(a).toMatchObject({ exists: true, id: "t-a" });
+    expect(b).toMatchObject({ exists: true, id: "t-b" });
+  });
+
+  // Null is an identity, not a wildcard — all three asymmetries below matter.
+  it("serves an unbound sender its own projectless terminal", async () => {
+    register();
+
+    await expect(reconnect(boundEvent(999), "t-unowned")).resolves.toMatchObject({
+      exists: true,
+      id: "t-unowned",
+    });
+  });
+
+  it("refuses an unbound sender a project-owned terminal", async () => {
+    register();
+
+    await expect(reconnect(boundEvent(999), "t-a")).resolves.toEqual({ exists: false });
+  });
+
+  it("refuses a project-bound sender an unowned terminal", async () => {
+    register();
+
+    await expect(reconnect(boundEvent(SENDER_A), "t-unowned")).resolves.toEqual({ exists: false });
+  });
+
+  it("reconnects a scratch workspace's own terminal", async () => {
+    getProjectForWebContentsMock.mockReturnValue("scratch-1");
+    register();
+
+    await expect(reconnect(boundEvent(SENDER_A), "t-scratch")).resolves.toMatchObject({
+      exists: true,
+      id: "t-scratch",
+    });
+  });
+
+  it("still reports a missing terminal as not found", async () => {
+    register();
+
+    await expect(reconnect(boundEvent(SENDER_A), "gone")).resolves.toEqual({ exists: false });
+  });
+
+  it("tolerates a sender with no getURL", async () => {
+    getProjectForWebContentsMock.mockReturnValue(null);
+    register();
+
+    await expect(reconnect({ sender: { id: 1 } }, "t-unowned")).resolves.toMatchObject({
+      exists: true,
+    });
+  });
+});
+
+describe("terminal:reconnect — cold-boot startup URL fallback", () => {
+  // The startup-restore renderer hydrates before `registerInitialView` binds it,
+  // so the registry answers null while its URL still names the project. Without
+  // the fallback every restored terminal would be refused and respawned.
+  it("reconnects via ?projectId= while the view is still unbound", async () => {
+    getProjectForWebContentsMock.mockReturnValue(null);
+    register();
+
+    const { event } = makeEvent(SENDER_A, "app://index.html?projectId=project-a");
+
+    await expect(reconnect(event, "t-a")).resolves.toMatchObject({ exists: true, id: "t-a" });
+  });
+
+  it("still refuses a foreign terminal when identity came from the URL", async () => {
+    getProjectForWebContentsMock.mockReturnValue(null);
+    register();
+
+    const { event } = makeEvent(SENDER_A, "app://index.html?projectId=project-a");
+
+    await expect(reconnect(event, "t-b")).resolves.toEqual({ exists: false });
+  });
+
+  it("lets the registry binding win over a stale URL", async () => {
+    register();
+
+    // Registry says project-a; the query string disagrees. The binding is
+    // authoritative, so project-b's terminal stays refused.
+    const { event } = makeEvent(SENDER_A, "app://index.html?projectId=project-b");
+
+    await expect(reconnect(event, "t-b")).resolves.toEqual({ exists: false });
+    await expect(reconnect(event, "t-a")).resolves.toMatchObject({ exists: true });
+  });
+
+  it("snapshots the sender's identity before the PTY lookup resolves", async () => {
+    let release!: (terminal: unknown) => void;
+    const pending = new Promise<unknown>((resolve) => (release = resolve));
+    getProjectForWebContentsMock.mockReturnValue(null);
+    register({ getTerminalAsync: vi.fn(() => pending) });
+
+    const { event, setUrl } = makeEvent(SENDER_A, "app://index.html?projectId=project-a");
+    const inFlight = reconnect(event, "t-a");
+
+    // The sender navigates while the lookup is outstanding. Re-reading identity
+    // after the await would flip this decision to a refusal.
+    setUrl("app://index.html?projectId=project-b");
+    release(TERMINALS.get("t-a"));
+
+    await expect(inFlight).resolves.toMatchObject({ exists: true, id: "t-a" });
+  });
+});
+
+describe("terminal:reconnect-bulk handler", () => {
   it("returns a per-id map matching the single reconnect contract", async () => {
-    const ptyClient = {
-      getTerminalAsync: vi.fn(async (id: string) => (id === "t-live" ? makeTerminal(id) : null)),
-    };
+    register();
 
-    registerTerminalSnapshotHandlers({ ptyClient } as unknown as HandlerDependencies);
-    const handler = getHandler();
+    const result = await reconnectBulk(boundEvent(SENDER_A), ["t-a", "t-dead"]);
 
-    const result = await handler({}, ["t-live", "t-dead"]);
-
-    expect(result["t-live"]).toMatchObject({ exists: true, id: "t-live", hasPty: true });
+    expect(result["t-a"]).toMatchObject({ exists: true, id: "t-a", hasPty: true });
     expect(result["t-dead"]).toEqual({ exists: false });
   });
 
+  it("refuses only the foreign ids in a mixed batch", async () => {
+    register();
+
+    const result = await reconnectBulk(boundEvent(SENDER_A), ["t-a", "t-b", "t-unowned", "gone"]);
+
+    expect(result["t-a"]).toMatchObject({ exists: true });
+    expect(result["t-b"]).toEqual({ exists: false });
+    expect(result["t-unowned"]).toEqual({ exists: false });
+    expect(result["gone"]).toEqual({ exists: false });
+  });
+
+  it("applies one snapshotted identity to every id in the batch", async () => {
+    getProjectForWebContentsMock.mockReturnValue(null);
+    register();
+
+    const { event, setUrl } = makeEvent(SENDER_A, "app://index.html?projectId=project-a");
+    const inFlight = reconnectBulk(event, ["t-a", "t-a2"]);
+    setUrl("app://index.html?projectId=project-b");
+
+    const result = await inFlight;
+
+    expect(result["t-a"]).toMatchObject({ exists: true });
+    expect(result["t-a2"]).toMatchObject({ exists: true });
+  });
+
   it("deduplicates ids before probing", async () => {
-    const ptyClient = {
-      getTerminalAsync: vi.fn(async (id: string) => makeTerminal(id)),
-    };
+    const ptyClient = register();
 
-    registerTerminalSnapshotHandlers({ ptyClient } as unknown as HandlerDependencies);
-    const handler = getHandler();
+    const result = await reconnectBulk(boundEvent(SENDER_A), ["t-a", "t-a", "t-a2"]);
 
-    const result = await handler({}, ["t-1", "t-1", "t-2"]);
-
-    expect(Object.keys(result).sort()).toEqual(["t-1", "t-2"]);
+    expect(Object.keys(result).sort()).toEqual(["t-a", "t-a2"]);
     expect(ptyClient.getTerminalAsync).toHaveBeenCalledTimes(2);
   });
 
   it("degrades a failing id to { exists: false } without failing the batch", async () => {
-    const ptyClient = {
+    register({
       getTerminalAsync: vi.fn(async (id: string) => {
         if (id === "t-fail") throw new Error("boom");
-        return makeTerminal(id);
+        return TERMINALS.get(id) ?? null;
       }),
-    };
+    });
 
-    registerTerminalSnapshotHandlers({ ptyClient } as unknown as HandlerDependencies);
-    const handler = getHandler();
+    const result = await reconnectBulk(boundEvent(SENDER_A), ["t-a", "t-fail"]);
 
-    const result = await handler({}, ["t-ok", "t-fail"]);
-
-    expect(result["t-ok"]).toMatchObject({ exists: true });
+    expect(result["t-a"]).toMatchObject({ exists: true });
     expect(result["t-fail"]).toEqual({ exists: false });
   });
 
   it("reports help terminals as { exists: false }, mirroring single reconnect", async () => {
-    mockIsHelpTerminal.mockImplementation((id: string) => id === "t-help");
-    const ptyClient = {
-      getTerminalAsync: vi.fn(async (id: string) => makeTerminal(id)),
-    };
+    mockIsHelpTerminal.mockImplementation((id: string) => id === "t-a2");
+    register();
 
-    registerTerminalSnapshotHandlers({ ptyClient } as unknown as HandlerDependencies);
-    const handler = getHandler();
+    const result = await reconnectBulk(boundEvent(SENDER_A), ["t-a2", "t-a"]);
 
-    const result = await handler({}, ["t-help", "t-normal"]);
-
-    expect(result["t-help"]).toEqual({ exists: false });
-    expect(result["t-normal"]).toMatchObject({ exists: true });
+    expect(result["t-a2"]).toEqual({ exists: false });
+    expect(result["t-a"]).toMatchObject({ exists: true });
   });
 
   it("rejects invalid payloads", async () => {
-    const ptyClient = {
-      getTerminalAsync: vi.fn(async () => null),
-    };
+    register();
+    const event = boundEvent(SENDER_A);
 
-    registerTerminalSnapshotHandlers({ ptyClient } as unknown as HandlerDependencies);
-    const handler = getHandler();
-
-    await expect(handler({}, null as unknown as string[])).rejects.toThrow(
+    await expect(reconnectBulk(event, null)).rejects.toThrow(
       "Invalid terminal IDs: must be an array"
     );
-    await expect(handler({}, ["" as unknown as string])).rejects.toThrow(
+    await expect(reconnectBulk(event, [""])).rejects.toThrow(
       "Invalid terminal ID in batch payload"
     );
-    await expect(handler({}, new Array(257).fill("id"))).rejects.toThrow(
+    await expect(reconnectBulk(event, new Array(257).fill("id"))).rejects.toThrow(
       "Invalid terminal IDs: maximum 256 IDs allowed"
     );
   });
 
   it("returns an empty map for an empty id list", async () => {
-    const ptyClient = {
-      getTerminalAsync: vi.fn(async () => null),
-    };
+    const ptyClient = register();
 
-    registerTerminalSnapshotHandlers({ ptyClient } as unknown as HandlerDependencies);
-    const handler = getHandler();
-
-    await expect(handler({}, [])).resolves.toEqual({});
+    await expect(reconnectBulk(boundEvent(SENDER_A), [])).resolves.toEqual({});
     expect(ptyClient.getTerminalAsync).not.toHaveBeenCalled();
   });
 });

--- a/electron/ipc/handlers/terminal/__tests__/snapshots.reconnectBulk.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/snapshots.reconnectBulk.test.ts
@@ -10,6 +10,10 @@
  * hydration, when the startup-restore renderer may still be unbound — there the
  * `?projectId=` query string on its URL is the only sender-local identity.
  *
+ * A refusal is `{ exists: false, conflict: true }`: no metadata, but distinct
+ * from "not found" so restore mints a fresh id instead of respawning onto the
+ * still-live foreign one.
+ *
  * These specs drive the real `defineIpcNamespace` → `typedHandleWithContext`
  * chain so the context is built by production code, not by the fixture.
  */
@@ -60,6 +64,8 @@ import type { HandlerDependencies } from "../../../types.js";
 
 const SENDER_A = 101;
 const SENDER_B = 202;
+/** A webContents id deliberately absent from the registry — an unbound window. */
+const UNBOUND_SENDER = 999;
 
 /** Sender A's view is bound to project A; sender B's to project B. */
 const VIEW_TO_PROJECT = new Map([
@@ -67,7 +73,12 @@ const VIEW_TO_PROJECT = new Map([
   [SENDER_B, "project-b"],
 ]);
 
-type ReconnectResult = { exists: boolean; id?: string; hasPty?: boolean; cwd?: string };
+/** What a refused (live, but foreign) terminal must look like on the wire. */
+const REFUSED = { exists: false, conflict: true };
+/** What a genuinely absent terminal must look like — no conflict flag. */
+const NOT_FOUND = { exists: false };
+
+type ReconnectResult = { exists: boolean; conflict?: boolean; id?: string; cwd?: string };
 
 function makeTerminal(id: string, projectId: string | null = "project-a") {
   return {
@@ -80,11 +91,19 @@ function makeTerminal(id: string, projectId: string | null = "project-a") {
   };
 }
 
-const TERMINALS = new Map([
+/**
+ * `t-absent` omits `projectId` entirely. The production wire shape is
+ * `projectId?: string`, so an unowned terminal reaches this handler as
+ * `undefined`, not `null` — both must normalize to the same identity.
+ */
+const { projectId: _omitted, ...terminalWithNoProjectField } = makeTerminal("t-absent", null);
+
+const TERMINALS = new Map<string, Record<string, unknown>>([
   ["t-a", makeTerminal("t-a", "project-a")],
   ["t-a2", makeTerminal("t-a2", "project-a")],
   ["t-b", makeTerminal("t-b", "project-b")],
   ["t-unowned", makeTerminal("t-unowned", null)],
+  ["t-absent", terminalWithNoProjectField],
   ["t-scratch", makeTerminal("t-scratch", "scratch-1")],
 ]);
 
@@ -98,6 +117,14 @@ function makeEvent(id: number, url?: string) {
     },
   };
   return { event, setUrl: (next: string) => (state.url = next) };
+}
+
+/**
+ * An ordinary post-startup event: a plain URL with no `?projectId=`, so identity
+ * comes from the registry alone.
+ */
+function senderEvent(id: number) {
+  return makeEvent(id, "app://index.html").event;
 }
 
 function defaultPtyClient() {
@@ -130,11 +157,6 @@ function reconnectBulk(
   >;
 }
 
-/** A bound sender, the ordinary post-startup case. */
-function boundEvent(id: number) {
-  return makeEvent(id, "app://index.html").event;
-}
-
 beforeEach(() => {
   vi.clearAllMocks();
   _resetIpcGuardForTesting();
@@ -148,7 +170,7 @@ describe("terminal:reconnect — workspace ownership", () => {
   it("reconnects a terminal the sender's own project owns", async () => {
     register();
 
-    await expect(reconnect(boundEvent(SENDER_A), "t-a")).resolves.toMatchObject({
+    await expect(reconnect(senderEvent(SENDER_A), "t-a")).resolves.toMatchObject({
       exists: true,
       id: "t-a",
       hasPty: true,
@@ -158,18 +180,17 @@ describe("terminal:reconnect — workspace ownership", () => {
   it("refuses a terminal owned by another project, leaking no metadata", async () => {
     register();
 
-    const result = await reconnect(boundEvent(SENDER_A), "t-b");
-
-    expect(result).toEqual({ exists: false });
-    expect(result.cwd).toBeUndefined();
+    // toStrictEqual, not toEqual: toEqual ignores own properties whose value is
+    // undefined, so a leak of `cwd: undefined` would slip through.
+    await expect(reconnect(senderEvent(SENDER_A), "t-b")).resolves.toStrictEqual(REFUSED);
   });
 
   it("serves each project its own terminal in the same session", async () => {
     register();
 
     const [a, b] = await Promise.all([
-      reconnect(boundEvent(SENDER_A), "t-a"),
-      reconnect(boundEvent(SENDER_B), "t-b"),
+      reconnect(senderEvent(SENDER_A), "t-a"),
+      reconnect(senderEvent(SENDER_B), "t-b"),
     ]);
 
     expect(a).toMatchObject({ exists: true, id: "t-a" });
@@ -180,51 +201,61 @@ describe("terminal:reconnect — workspace ownership", () => {
   it("serves an unbound sender its own projectless terminal", async () => {
     register();
 
-    await expect(reconnect(boundEvent(999), "t-unowned")).resolves.toMatchObject({
+    await expect(reconnect(senderEvent(UNBOUND_SENDER), "t-unowned")).resolves.toMatchObject({
       exists: true,
       id: "t-unowned",
     });
   });
 
+  it("treats an absent projectId the same as an explicit null", async () => {
+    register();
+
+    await expect(reconnect(senderEvent(UNBOUND_SENDER), "t-absent")).resolves.toMatchObject({
+      exists: true,
+      id: "t-absent",
+    });
+    await expect(reconnect(senderEvent(SENDER_A), "t-absent")).resolves.toStrictEqual(REFUSED);
+  });
+
   it("refuses an unbound sender a project-owned terminal", async () => {
     register();
 
-    await expect(reconnect(boundEvent(999), "t-a")).resolves.toEqual({ exists: false });
+    await expect(reconnect(senderEvent(UNBOUND_SENDER), "t-a")).resolves.toStrictEqual(REFUSED);
   });
 
   it("refuses a project-bound sender an unowned terminal", async () => {
     register();
 
-    await expect(reconnect(boundEvent(SENDER_A), "t-unowned")).resolves.toEqual({ exists: false });
+    await expect(reconnect(senderEvent(SENDER_A), "t-unowned")).resolves.toStrictEqual(REFUSED);
   });
 
   it("reconnects a scratch workspace's own terminal", async () => {
     getProjectForWebContentsMock.mockReturnValue("scratch-1");
     register();
 
-    await expect(reconnect(boundEvent(SENDER_A), "t-scratch")).resolves.toMatchObject({
+    await expect(reconnect(senderEvent(SENDER_A), "t-scratch")).resolves.toMatchObject({
       exists: true,
       id: "t-scratch",
     });
   });
 
-  it("still reports a missing terminal as not found", async () => {
+  it("reports a missing terminal as not found, with no conflict flag", async () => {
     register();
 
-    await expect(reconnect(boundEvent(SENDER_A), "gone")).resolves.toEqual({ exists: false });
+    // The distinction is load-bearing: only a plain not-found lets restore reuse
+    // the saved id.
+    await expect(reconnect(senderEvent(SENDER_A), "gone")).resolves.toStrictEqual(NOT_FOUND);
   });
 
-  it("tolerates a sender with no getURL", async () => {
-    getProjectForWebContentsMock.mockReturnValue(null);
+  it("reports a help terminal as not found, not as a conflict", async () => {
+    mockIsHelpTerminal.mockImplementation((id: string) => id === "t-a");
     register();
 
-    await expect(reconnect({ sender: { id: 1 } }, "t-unowned")).resolves.toMatchObject({
-      exists: true,
-    });
+    await expect(reconnect(senderEvent(SENDER_A), "t-a")).resolves.toStrictEqual(NOT_FOUND);
   });
 });
 
-describe("terminal:reconnect — cold-boot startup URL fallback", () => {
+describe("terminal:reconnect — sender identity resolution", () => {
   // The startup-restore renderer hydrates before `registerInitialView` binds it,
   // so the registry answers null while its URL still names the project. Without
   // the fallback every restored terminal would be refused and respawned.
@@ -243,7 +274,7 @@ describe("terminal:reconnect — cold-boot startup URL fallback", () => {
 
     const { event } = makeEvent(SENDER_A, "app://index.html?projectId=project-a");
 
-    await expect(reconnect(event, "t-b")).resolves.toEqual({ exists: false });
+    await expect(reconnect(event, "t-b")).resolves.toStrictEqual(REFUSED);
   });
 
   it("lets the registry binding win over a stale URL", async () => {
@@ -253,8 +284,44 @@ describe("terminal:reconnect — cold-boot startup URL fallback", () => {
     // authoritative, so project-b's terminal stays refused.
     const { event } = makeEvent(SENDER_A, "app://index.html?projectId=project-b");
 
-    await expect(reconnect(event, "t-b")).resolves.toEqual({ exists: false });
+    await expect(reconnect(event, "t-b")).resolves.toStrictEqual(REFUSED);
     await expect(reconnect(event, "t-a")).resolves.toMatchObject({ exists: true });
+  });
+
+  it("falls back to no identity when the sender has no getURL", async () => {
+    getProjectForWebContentsMock.mockReturnValue(null);
+    register();
+
+    await expect(reconnect({ sender: { id: 1 } }, "t-unowned")).resolves.toMatchObject({
+      exists: true,
+    });
+  });
+
+  it("falls back to no identity when getURL throws", async () => {
+    getProjectForWebContentsMock.mockReturnValue(null);
+    register();
+
+    const event = {
+      sender: {
+        id: SENDER_A,
+        getURL: () => {
+          throw new Error("webContents destroyed");
+        },
+      },
+    };
+
+    await expect(reconnect(event, "t-unowned")).resolves.toMatchObject({ exists: true });
+    await expect(reconnect(event, "t-a")).resolves.toStrictEqual(REFUSED);
+  });
+
+  it("falls back to no identity when the URL is malformed", async () => {
+    getProjectForWebContentsMock.mockReturnValue(null);
+    register();
+
+    const { event } = makeEvent(SENDER_A, "not-a-valid-url");
+
+    await expect(reconnect(event, "t-unowned")).resolves.toMatchObject({ exists: true });
+    await expect(reconnect(event, "t-a")).resolves.toStrictEqual(REFUSED);
   });
 
   it("snapshots the sender's identity before the PTY lookup resolves", async () => {
@@ -276,44 +343,57 @@ describe("terminal:reconnect — cold-boot startup URL fallback", () => {
 });
 
 describe("terminal:reconnect-bulk handler", () => {
-  it("returns a per-id map matching the single reconnect contract", async () => {
+  it("returns per-id results identical to the single reconnect contract", async () => {
     register();
+    const event = senderEvent(SENDER_A);
 
-    const result = await reconnectBulk(boundEvent(SENDER_A), ["t-a", "t-dead"]);
+    const [single, bulk] = await Promise.all([
+      reconnect(event, "t-a"),
+      reconnectBulk(event, ["t-a"]),
+    ]);
 
-    expect(result["t-a"]).toMatchObject({ exists: true, id: "t-a", hasPty: true });
-    expect(result["t-dead"]).toEqual({ exists: false });
+    // Full equality, so bulk can't quietly drop live metadata the single path returns.
+    expect(bulk["t-a"]).toStrictEqual(single);
   });
 
   it("refuses only the foreign ids in a mixed batch", async () => {
     register();
 
-    const result = await reconnectBulk(boundEvent(SENDER_A), ["t-a", "t-b", "t-unowned", "gone"]);
+    const result = await reconnectBulk(senderEvent(SENDER_A), ["t-a", "t-b", "t-unowned", "gone"]);
 
     expect(result["t-a"]).toMatchObject({ exists: true });
-    expect(result["t-b"]).toEqual({ exists: false });
-    expect(result["t-unowned"]).toEqual({ exists: false });
-    expect(result["gone"]).toEqual({ exists: false });
+    expect(result["t-b"]).toStrictEqual(REFUSED);
+    expect(result["t-unowned"]).toStrictEqual(REFUSED);
+    expect(result["gone"]).toStrictEqual(NOT_FOUND);
   });
 
-  it("applies one snapshotted identity to every id in the batch", async () => {
+  it("resolves the sender's identity once for the whole batch", async () => {
     getProjectForWebContentsMock.mockReturnValue(null);
     register();
 
-    const { event, setUrl } = makeEvent(SENDER_A, "app://index.html?projectId=project-a");
-    const inFlight = reconnectBulk(event, ["t-a", "t-a2"]);
-    setUrl("app://index.html?projectId=project-b");
+    // Identity read once → both ids judged as project-a. A per-id resolver would
+    // see project-b on the second read and refuse t-a2.
+    let reads = 0;
+    const event = {
+      sender: {
+        id: SENDER_A,
+        getURL: () =>
+          ++reads === 1
+            ? "app://index.html?projectId=project-a"
+            : "app://index.html?projectId=project-b",
+      },
+    };
 
-    const result = await inFlight;
+    const result = await reconnectBulk(event, ["t-a", "t-a2"]);
 
-    expect(result["t-a"]).toMatchObject({ exists: true });
-    expect(result["t-a2"]).toMatchObject({ exists: true });
+    expect(result["t-a"]).toMatchObject({ exists: true, id: "t-a" });
+    expect(result["t-a2"]).toMatchObject({ exists: true, id: "t-a2" });
   });
 
   it("deduplicates ids before probing", async () => {
     const ptyClient = register();
 
-    const result = await reconnectBulk(boundEvent(SENDER_A), ["t-a", "t-a", "t-a2"]);
+    const result = await reconnectBulk(senderEvent(SENDER_A), ["t-a", "t-a", "t-a2"]);
 
     expect(Object.keys(result).sort()).toEqual(["t-a", "t-a2"]);
     expect(ptyClient.getTerminalAsync).toHaveBeenCalledTimes(2);
@@ -327,25 +407,36 @@ describe("terminal:reconnect-bulk handler", () => {
       }),
     });
 
-    const result = await reconnectBulk(boundEvent(SENDER_A), ["t-a", "t-fail"]);
+    const result = await reconnectBulk(senderEvent(SENDER_A), ["t-a", "t-fail"]);
 
     expect(result["t-a"]).toMatchObject({ exists: true });
-    expect(result["t-fail"]).toEqual({ exists: false });
+    expect(result["t-fail"]).toStrictEqual(NOT_FOUND);
   });
 
   it("reports help terminals as { exists: false }, mirroring single reconnect", async () => {
     mockIsHelpTerminal.mockImplementation((id: string) => id === "t-a2");
     register();
 
-    const result = await reconnectBulk(boundEvent(SENDER_A), ["t-a2", "t-a"]);
+    const result = await reconnectBulk(senderEvent(SENDER_A), ["t-a2", "t-a"]);
 
-    expect(result["t-a2"]).toEqual({ exists: false });
+    expect(result["t-a2"]).toStrictEqual(NOT_FOUND);
     expect(result["t-a"]).toMatchObject({ exists: true });
+  });
+
+  it("accepts a full batch at the 256-id cap and rejects one more", async () => {
+    register();
+    const event = senderEvent(SENDER_A);
+    const ids = Array.from({ length: 256 }, (_, i) => `t-${i}`);
+
+    await expect(reconnectBulk(event, ids)).resolves.toHaveProperty("t-255");
+    await expect(reconnectBulk(event, [...ids, "t-256"])).rejects.toThrow(
+      "Invalid terminal IDs: maximum 256 IDs allowed"
+    );
   });
 
   it("rejects invalid payloads", async () => {
     register();
-    const event = boundEvent(SENDER_A);
+    const event = senderEvent(SENDER_A);
 
     await expect(reconnectBulk(event, null)).rejects.toThrow(
       "Invalid terminal IDs: must be an array"
@@ -353,15 +444,12 @@ describe("terminal:reconnect-bulk handler", () => {
     await expect(reconnectBulk(event, [""])).rejects.toThrow(
       "Invalid terminal ID in batch payload"
     );
-    await expect(reconnectBulk(event, new Array(257).fill("id"))).rejects.toThrow(
-      "Invalid terminal IDs: maximum 256 IDs allowed"
-    );
   });
 
   it("returns an empty map for an empty id list", async () => {
     const ptyClient = register();
 
-    await expect(reconnectBulk(boundEvent(SENDER_A), [])).resolves.toEqual({});
+    await expect(reconnectBulk(senderEvent(SENDER_A), [])).resolves.toEqual({});
     expect(ptyClient.getTerminalAsync).not.toHaveBeenCalled();
   });
 });

--- a/electron/ipc/handlers/terminal/snapshots.ts
+++ b/electron/ipc/handlers/terminal/snapshots.ts
@@ -425,8 +425,14 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       // Null is an identity here, not a wildcard: an unbound window (Cmd+N,
       // project picker) still reconnects its own projectless terminal, but it
       // cannot reach a project-owned one, and a project-bound sender cannot
-      // reach an unowned one. Refusing looks exactly like "not found", so
-      // restore falls through to its normal respawn path instead of attaching.
+      // reach an unowned one.
+      //
+      // `conflict` marks this as "live, but not yours" rather than plain "not
+      // found". Both withhold every field, but restore reuses the saved id when
+      // a terminal is merely gone — and that id is still live here, so reusing
+      // it would re-place the owner's PTY in PtyClient.terminalOwners before the
+      // host could reject the duplicate. The flag makes restore mint a fresh id
+      // instead, exactly as it already does for a timed-out reconnect.
       const ownerWorkspaceId = terminal.projectId ?? null;
       if (ownerWorkspaceId !== senderWorkspaceId) {
         logWarn(`terminal:reconnect: refusing ${terminalId} — owned by another workspace`, {
@@ -434,7 +440,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
           ownerWorkspaceId,
           senderWorkspaceId,
         });
-        return { exists: false };
+        return { exists: false, conflict: true };
       }
 
       if (getAgentAvailabilityStore().isHelpTerminal(terminal.id)) {

--- a/electron/ipc/handlers/terminal/snapshots.ts
+++ b/electron/ipc/handlers/terminal/snapshots.ts
@@ -4,15 +4,39 @@
 
 import { z } from "zod";
 import { CHANNELS } from "../../channels.js";
-import type { HandlerDependencies } from "../../types.js";
+import type { HandlerDependencies, IpcContext } from "../../types.js";
 import { TerminalReplayHistoryPayloadSchema } from "../../../schemas/index.js";
 import { logDebug, logInfo, logWarn } from "../../../utils/logger.js";
 import { getAgentAvailabilityStore } from "../../../services/AgentAvailabilityStore.js";
+import { getProjectIdFromSenderUrl } from "../../senderIdentity.js";
 import { defineIpcNamespace, op, opValidated } from "../../define.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import type { SerializedTerminalSnapshot } from "../../../../shared/types/terminal.js";
 
 type ValidatedReplayHistoryPayload = z.output<typeof TerminalReplayHistoryPayloadSchema>;
+
+/**
+ * The workspace a reconnect request speaks for, resolved from the sender alone.
+ *
+ * `ctx.projectId` — the webContents→project registry, which spans every window
+ * — is authoritative once the view is bound. But reconnect runs during cold-boot
+ * hydration, and the startup-restore renderer issues it while `registerInitialView`
+ * may not have bound the view yet: main dispatches `loadURL` without awaiting it,
+ * then yields several times (PATH refresh, PTY readiness, store init) before
+ * binding, and the renderer mounts and hydrates inside that gap. `?projectId=`
+ * on that renderer's URL is the only sender-local identity there, and it is the
+ * same fallback `app:boot` already resolves hydration's own workspace id through,
+ * so the two agree by construction rather than by timing.
+ *
+ * Registry first: a bound view must never be overridden by a stale query string.
+ *
+ * Must be called before the first `await` — the context is a snapshot of the
+ * sender at invoke time, and re-resolving after a PTY round-trip would race the
+ * very binding this works around.
+ */
+function resolveSenderWorkspaceId(ctx: IpcContext): string | null {
+  return ctx.projectId ?? getProjectIdFromSenderUrl(ctx.event.sender);
+}
 
 export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () => void {
   const { ptyClient } = deps;
@@ -370,7 +394,14 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
     }
   };
 
-  const handleTerminalReconnect = async (
+  /**
+   * Probe one terminal on behalf of an already-resolved sender workspace.
+   *
+   * Split out so the bulk variant resolves the sender's identity once, up front,
+   * instead of re-deriving it per id after an await has already elapsed.
+   */
+  const probeTerminalForWorkspace = async (
+    senderWorkspaceId: string | null,
     terminalId: string
   ): Promise<import("../../../../shared/types/ipc.js").TerminalReconnectResult> => {
     try {
@@ -382,6 +413,27 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
 
       if (!terminal) {
         logWarn(`terminal:reconnect: Terminal ${terminalId} not found`);
+        return { exists: false };
+      }
+
+      // Ownership gate (#11652). Terminal ids are globally unique, so an id
+      // alone resolved a terminal in ANY project — and the result carries the
+      // live `projectId`/`cwd`, which the renderer trusts over its own saved
+      // snapshot. A foreign id in a project's saved state (#11651) therefore
+      // let that project adopt another's running terminal.
+      //
+      // Null is an identity here, not a wildcard: an unbound window (Cmd+N,
+      // project picker) still reconnects its own projectless terminal, but it
+      // cannot reach a project-owned one, and a project-bound sender cannot
+      // reach an unowned one. Refusing looks exactly like "not found", so
+      // restore falls through to its normal respawn path instead of attaching.
+      const ownerWorkspaceId = terminal.projectId ?? null;
+      if (ownerWorkspaceId !== senderWorkspaceId) {
+        logWarn(`terminal:reconnect: refusing ${terminalId} — owned by another workspace`, {
+          terminalId,
+          ownerWorkspaceId,
+          senderWorkspaceId,
+        });
         return { exists: false };
       }
 
@@ -424,13 +476,24 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
     }
   };
 
+  const handleTerminalReconnect = async (
+    ctx: IpcContext,
+    terminalId: string
+  ): Promise<import("../../../../shared/types/ipc.js").TerminalReconnectResult> =>
+    probeTerminalForWorkspace(resolveSenderWorkspaceId(ctx), terminalId);
+
   // Bulk variant for the cold-boot panel-restore prefetch (#10390): one IPC
   // round-trip probes every saved panel id instead of N serialized probes
   // inside the spawn queue. Mirrors getSerializedStates' batch contract —
   // per-id failures degrade to { exists: false } rather than failing the batch.
   const handleTerminalReconnectBulk = async (
+    ctx: IpcContext,
     terminalIds: string[]
   ): Promise<Record<string, import("../../../../shared/types/ipc.js").TerminalReconnectResult>> => {
+    // Resolved once, before any await: every id in this batch is judged against
+    // the sender as it was at invoke time.
+    const senderWorkspaceId = resolveSenderWorkspaceId(ctx);
+
     if (!Array.isArray(terminalIds)) {
       throw new Error("Invalid terminal IDs: must be an array");
     }
@@ -453,7 +516,10 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
     const results = await Promise.all(
       normalizedIds.map(async (terminalId) => {
         try {
-          return [terminalId, await handleTerminalReconnect(terminalId)] as const;
+          return [
+            terminalId,
+            await probeTerminalForWorkspace(senderWorkspaceId, terminalId),
+          ] as const;
         } catch (error) {
           logWarn(`terminal:reconnect-bulk(${terminalId}) failed`, { error });
           return [terminalId, { exists: false as const }] as const;
@@ -491,8 +557,10 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
         CHANNELS.TERMINAL_SEARCH_SEMANTIC_BUFFERS,
         handleTerminalSearchSemanticBuffers
       ),
-      reconnect: op(CHANNELS.TERMINAL_RECONNECT, handleTerminalReconnect),
-      reconnectBulk: op(CHANNELS.TERMINAL_RECONNECT_BULK, handleTerminalReconnectBulk),
+      reconnect: op(CHANNELS.TERMINAL_RECONNECT, handleTerminalReconnect, { withContext: true }),
+      reconnectBulk: op(CHANNELS.TERMINAL_RECONNECT_BULK, handleTerminalReconnectBulk, {
+        withContext: true,
+      }),
     },
   });
 

--- a/electron/ipc/projectContext.ts
+++ b/electron/ipc/projectContext.ts
@@ -1,7 +1,10 @@
 import type { Project } from "../types/index.js";
 import { projectStore } from "../services/ProjectStore.js";
 import { getWindowForWebContents } from "../window/webContentsRegistry.js";
+import { getProjectIdFromSenderUrl } from "./senderIdentity.js";
 import type { HandlerDependencies, IpcContext } from "./types.js";
+
+export { getProjectIdFromSenderUrl };
 
 export interface ScopedProjectResolution {
   project: Project | null;
@@ -28,24 +31,6 @@ function resolveWorkspaceById(workspaceId: string): ScopedProjectResolution {
   const project = projectStore.getProjectById(workspaceId);
   if (project?.status === "closed") return { project: null, workspaceId: null };
   return { project: project ?? null, workspaceId };
-}
-
-/**
- * Project id carried on a view's document URL. Only the initial (startup-restore)
- * renderer gets a `?projectId=` query string; ProjectViewManager's cold switch
- * views load a static URL. So this is the sole per-sender identity during the
- * startup window where the restored view is already live but `registerInitialView`
- * has not bound it in the project maps yet.
- */
-export function getProjectIdFromSenderUrl(sender: Electron.WebContents): string | null {
-  const senderWithUrl = sender as Electron.WebContents & { getURL?: () => string };
-  if (typeof senderWithUrl.getURL !== "function") return null;
-
-  try {
-    return new URL(senderWithUrl.getURL()).searchParams.get("projectId");
-  } catch {
-    return null;
-  }
 }
 
 /**

--- a/electron/ipc/senderIdentity.ts
+++ b/electron/ipc/senderIdentity.ts
@@ -1,0 +1,26 @@
+/**
+ * Sender-derived identity helpers.
+ *
+ * Deliberately dependency-free: ownership gates on hot IPC paths (terminal
+ * reconnect, project switch) need to read a sender's identity without dragging
+ * `ProjectStore` — and with it the database, electron-store, and GitService —
+ * into their module graph.
+ */
+
+/**
+ * Project id carried on a view's document URL. Only the initial (startup-restore)
+ * renderer gets a `?projectId=` query string; ProjectViewManager's cold switch
+ * views load a static URL. So this is the sole per-sender identity during the
+ * startup window where the restored view is already live but `registerInitialView`
+ * has not bound it in the project maps yet.
+ */
+export function getProjectIdFromSenderUrl(sender: Electron.WebContents): string | null {
+  const senderWithUrl = sender as Electron.WebContents & { getURL?: () => string };
+  if (typeof senderWithUrl.getURL !== "function") return null;
+
+  try {
+    return new URL(senderWithUrl.getURL()).searchParams.get("projectId");
+  } catch {
+    return null;
+  }
+}

--- a/shared/types/ipc/terminal.ts
+++ b/shared/types/ipc/terminal.ts
@@ -234,6 +234,14 @@ export interface BackendTerminalInfo {
 /** Result from terminal reconnect operation */
 export interface TerminalReconnectResult {
   exists: boolean;
+  /**
+   * Set when the terminal is alive but owned by another workspace (#11652).
+   * `exists` is false either way — the caller gets no metadata — but restore
+   * must not respawn under this id: it is still live, so reusing it would
+   * re-place the owner's PTY in `PtyClient.terminalOwners` before the host
+   * rejects the duplicate, stranding a terminal that belongs to someone else.
+   */
+  conflict?: boolean;
   id?: string;
   projectId?: string;
   kind?: PanelKind;

--- a/src/utils/stateHydration/__tests__/reconnectManager.test.ts
+++ b/src/utils/stateHydration/__tests__/reconnectManager.test.ts
@@ -55,6 +55,27 @@ describe("reconnectWithTimeout", () => {
     expect(reconnectMock).not.toHaveBeenCalled();
   });
 
+  // #11652: a refused reconnect means the id is still LIVE under another
+  // workspace. Collapsing it into not_found would let restore respawn onto that
+  // id and re-place the owner's PTY, so it has to stay distinguishable.
+  it("maps a prefetched ownership refusal to conflict, not not_found", async () => {
+    const outcome = await reconnectWithTimeout("t-foreign", noopLog, {
+      exists: false,
+      conflict: true,
+    } as TerminalReconnectResult);
+
+    expect(outcome).toEqual({ status: "conflict" });
+    expect(reconnectMock).not.toHaveBeenCalled();
+  });
+
+  it("maps an ownership refusal to conflict on the fallback path too", async () => {
+    reconnectMock.mockResolvedValueOnce({ exists: false, conflict: true });
+
+    const outcome = await reconnectWithTimeout("t-foreign", noopLog);
+
+    expect(outcome).toEqual({ status: "conflict" });
+  });
+
   it("falls back to the per-panel IPC when no prefetched result is supplied", async () => {
     reconnectMock.mockResolvedValueOnce({ exists: true, id: "t-2", hasPty: true });
 

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -685,7 +685,12 @@ export async function restorePanelsPhase(
                 logHydrationInfo,
                 prefetchedReconnectResults?.[saved.id]
               );
-              const reconnectTimedOut = reconnectOutcome.status === "timeout";
+              // Both statuses mean "do not respawn under the saved id". A timeout
+              // may have left the original alive; a conflict definitely did, and
+              // it belongs to another workspace (#11652) — reusing the id would
+              // re-place that terminal's PTY under this project.
+              const mintFreshTerminalId =
+                reconnectOutcome.status === "timeout" || reconnectOutcome.status === "conflict";
               const reconnectedTerminal =
                 reconnectOutcome.status === "found" ? reconnectOutcome.terminal : null;
 
@@ -752,7 +757,7 @@ export async function restorePanelsPhase(
                   kind,
                   projectRoot || "",
                   agentSettings,
-                  reconnectTimedOut,
+                  mintFreshTerminalId,
                   clipboardDirectory,
                   projectPresetsByAgent,
                   {

--- a/src/utils/stateHydration/reconnectManager.ts
+++ b/src/utils/stateHydration/reconnectManager.ts
@@ -7,6 +7,8 @@ export const RECONNECT_TIMEOUT_MS = 2000;
 export type ReconnectOutcome =
   | { status: "found"; terminal: NonNullable<Awaited<ReturnType<typeof terminalClient.reconnect>>> }
   | { status: "not_found" }
+  /** Alive, but owned by another workspace (#11652) — the saved id must not be reused. */
+  | { status: "conflict" }
   | { status: "timeout" }
   | { status: "error"; error: unknown };
 
@@ -21,6 +23,10 @@ export async function reconnectWithTimeout(
     if (prefetchedResult.exists && prefetchedResult.hasPty) {
       logHydrationInfo(`Reconnect prefetch hit for ${terminalId} - terminal exists in backend`);
       return { status: "found", terminal: prefetchedResult };
+    }
+    if (prefetchedResult.conflict) {
+      logWarn(`Reconnect prefetch: terminal ${terminalId} is owned by another workspace`);
+      return { status: "conflict" };
     }
     logHydrationInfo(
       `Reconnect prefetch: terminal ${terminalId} not found (exists=${prefetchedResult.exists}, hasPty=${prefetchedResult.hasPty})`
@@ -43,6 +49,11 @@ export async function reconnectWithTimeout(
         `Reconnect fallback succeeded for ${terminalId} - terminal exists in backend but was missed by getForProject`
       );
       return { status: "found", terminal: reconnectedTerminal };
+    }
+
+    if (reconnectedTerminal?.conflict) {
+      logWarn(`Reconnect fallback: terminal ${terminalId} is owned by another workspace`);
+      return { status: "conflict" };
     }
 
     logHydrationInfo(

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -511,7 +511,12 @@ export function buildArgsForRespawn(
   kind: PanelKind,
   projectRoot: string,
   agentSettings: AgentSettingsData | undefined,
-  reconnectTimedOut: boolean,
+  /**
+   * The saved id must not be reused — the original may still be live. True for a
+   * timed-out reconnect, and for one refused because the id belongs to another
+   * workspace (#11652).
+   */
+  mintFreshTerminalId: boolean,
   clipboardDirectory: string | undefined,
   projectPresetsByAgent?: Record<string, AgentPreset[]>,
   options?: BuildArgsForRespawnOptions
@@ -713,7 +718,7 @@ export function buildArgsForRespawn(
     cwd: saved.cwd || projectRoot || "",
     worktreeId: saved.worktreeId,
     location,
-    requestedId: reconnectTimedOut ? undefined : saved.id,
+    requestedId: mintFreshTerminalId ? undefined : saved.id,
     command: isAgentPanel ? command : saved.command?.trim() || undefined,
     isInputLocked: saved.isInputLocked,
     devCommand: isDevPreview ? command : undefined,


### PR DESCRIPTION
## Summary

- `handleTerminalReconnect` resolved a terminal by id alone via `ptyClient.getTerminalAsync(terminalId)`, with no ownership check, then handed back that terminal's live `projectId` and `cwd`, which the renderer trusts over its own saved snapshot. Since terminal ids are globally unique, any project could reattach to and adopt another project's running terminal.
- This amplified #11651: once a foreign snapshot id leaked into a project's saved state, reconnect silently adopted it instead of refusing it.
- The fix adds an exact, null-inclusive workspace ownership gate to the reconnect handler, resolved from the sender rather than from anything the caller passes. It mirrors the fix already applied to the sibling `terminal/io.ts` ingest-port handler in #11100/#11131.

Resolves #11652

## Changes

- The sender's workspace is computed as `ctx.projectId ?? getProjectIdFromSenderUrl(ctx.event.sender)`: registry first, startup URL second. The URL fallback is load-bearing, not defensive. Reconnect runs on the cold-boot hydration path: main dispatches `loadURL` without awaiting it, then yields several times (PATH refresh, PTY readiness, store init) before `registerInitialView` binds the view, and the renderer mounts and hydrates inside that gap. A plain `ctx.projectId` gate would have refused every restored terminal at startup and respawned them all, orphaning live agent sessions. `app:boot` already resolves hydration's own workspace id through the same fallback, so the two agree by construction.
- Null is treated as an identity, not a wildcard: an unbound (Cmd+N) window can still reconnect its own projectless terminal, but can't reach a project-owned one, and a project-bound sender can't reach an unowned one.
- Identity is snapshotted synchronously, before any `await`, and once per bulk batch.
- A refusal returns `{ exists: false, conflict: true }`, no metadata leaked, but distinguishable from a genuine not-found. That distinction matters: restore reuses the saved id when a terminal is merely gone, but a refused id is still live, so respawning onto it would re-place the owner's PTY in `PtyClient.terminalOwners` before the pty-host could reject the duplicate. The `conflict` flag makes restore mint a fresh id instead, exactly as it already does for a timed-out reconnect.
- Extracted `getProjectIdFromSenderUrl` into a new dependency-free `electron/ipc/senderIdentity.ts`, re-exported from `projectContext.ts` so existing consumers are untouched. The terminal handler no longer pulls `ProjectStore`, and with it SQLite, electron-store, and GitService, into its module graph.
- No wire-argument, preload, renderer-client, or generated-IPC changes.

## Testing

- Reworked `electron/ipc/handlers/terminal/__tests__/snapshots.reconnectBulk.test.ts` to drive the real `defineIpcNamespace` to `typedHandleWithContext` chain with real sender events. Covers same-project success, cross-project refusal (asserting no metadata leak), all null-identity asymmetries, `undefined` vs `null` projectId, scratch workspaces, cold-boot URL fallback, registry-wins-over-stale-URL, throwing and malformed sender URLs, identity snapshotting before the PTY await, once-per-batch identity resolution, single/bulk parity, and the 256-id cap boundary.
- Added conflict-mapping cases to `reconnectManager.test.ts`.
- Locally verified 587 targeted tests pass (terminal IPC handlers plus all stateHydration suites); `npm run typecheck`, `check:ipc`, `check:ipc-renderer`, `check:api-surface`, and `lint:ratchet` all clean; prettier and eslint clean on changed files with 0 errors.

## Known follow-up

Pre-existing and deliberately not fixed here: when restore mints a fresh terminal id, persisted draft input and Quick-Switch MRU rank aren't remapped through `savedIdToRestoredId`. This already affects the existing timed-out-reconnect path; this change just adds a second, rarer trigger. Fixing the remap would change timeout behavior too, so it belongs in its own issue.
