### PR TITLE
fix(terminal): verify worktreeId belongs to its claimed project

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -669,31 +669,21 @@ describe("terminal spawn handler - worktree/project ownership (#11653)", () => {
     expect(spawnArgsOf().worktreeId).toBe("wt-a1");
   });
 
-  // A folder opened without git enumerates no worktrees at all (#11405), so the
-  // claim is incoherent without asking anyone.
-  it("drops a worktreeId claimed against a lightweight project without a host round trip", async () => {
+  // A folder opened without git owns no worktrees, but the project row is not
+  // the authority on whether it is git-backed — the host probes the folder, so
+  // an external `git init` leaves a stale `gitBacked: false` beside a host
+  // serving real ids. The row must not short-circuit the lookup.
+  it("still asks the host about a project whose row says it is not git-backed", async () => {
     mockGetProjectById.mockReturnValue(lightweightProject);
-
-    await spawnWith({
-      projectId: "lightweight-id",
-      worktreeId: "wt-a1",
-      cwd: process.cwd(),
-    });
-
-    expect(worktreeService.isWorktreeOwnedByProject).not.toHaveBeenCalled();
-    expect(spawnArgsOf().worktreeId).toBeUndefined();
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("wt-a1"));
-  });
-
-  // Legacy rows predate the discriminator; absence means git-backed, so they
-  // must still take the normal verification path rather than be dropped.
-  it("treats a project with no gitBacked discriminator as git-backed", async () => {
-    mockGetProjectById.mockReturnValue(projectA);
     worktreeService.isWorktreeOwnedByProject.mockResolvedValue(true);
 
-    await spawnWith({ projectId: "project-a-id", worktreeId: "wt-a1" });
+    await spawnWith({ projectId: "lightweight-id", worktreeId: "wt-a1" });
 
-    expect(worktreeService.isWorktreeOwnedByProject).toHaveBeenCalledTimes(1);
+    expect(worktreeService.isWorktreeOwnedByProject).toHaveBeenCalledWith(
+      "wt-a1",
+      lightweightProject.path,
+      lightweightProject.id
+    );
     expect(spawnArgsOf().worktreeId).toBe("wt-a1");
   });
 

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -447,6 +447,215 @@ describe("terminal spawn handler - projectId resolution", () => {
   });
 });
 
+// A request naming both a projectId and a worktreeId asserts a relationship
+// between them, and main used to forward it unchecked — so a terminal could be
+// stamped with another project's worktree and journal a cross-project resume
+// record on close. Main verifies the claim; the renderer still chooses.
+describe("terminal spawn handler - worktree/project ownership (#11653)", () => {
+  const projectA = { id: "project-a-id", name: "Project A", path: "/projects/a" };
+  const projectB = { id: "project-b-id", name: "Project B", path: "/projects/b" };
+  const lightweightProject = {
+    id: "lightweight-id",
+    name: "Notes",
+    path: "/folders/notes",
+    gitBacked: false as const,
+  };
+
+  let ptyClient: {
+    spawn: ReturnType<typeof vi.fn>;
+    hasTerminal: ReturnType<typeof vi.fn>;
+    write: ReturnType<typeof vi.fn>;
+  };
+  let worktreeService: { isWorktreeOwnedByProject: ReturnType<typeof vi.fn> };
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  const spawnArgsOf = () => ptyClient.spawn.mock.calls[0][1];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ptyClient = {
+      spawn: vi.fn(),
+      hasTerminal: vi.fn(() => false),
+      write: vi.fn(),
+    };
+    worktreeService = { isWorktreeOwnedByProject: vi.fn() };
+    mockGetCurrentProject.mockReturnValue(null);
+    mockGetProjectById.mockReturnValue(null);
+    mockGetProjectSettings.mockResolvedValue({});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  // Pass `null` to model "no workspace client wired up" — an explicit
+  // `undefined` would trigger the default parameter and silently hand the test
+  // the mock service instead.
+  const spawnWith = async (
+    options: Record<string, unknown>,
+    svc: unknown = worktreeService
+  ): Promise<void> => {
+    const deps = { ptyClient, worktreeService: svc } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+    const handler = getSpawnHandler();
+    await handler({} as Electron.IpcMainInvokeEvent, { cols: 80, rows: 24, ...options });
+  };
+
+  it("checks the claim against the resolved project's own path and id", async () => {
+    mockGetProjectById.mockReturnValue(projectA);
+    worktreeService.isWorktreeOwnedByProject.mockResolvedValue(true);
+
+    await spawnWith({ projectId: "project-a-id", worktreeId: "wt-a1" });
+
+    expect(worktreeService.isWorktreeOwnedByProject).toHaveBeenCalledWith(
+      "wt-a1",
+      projectA.path,
+      "project-a-id"
+    );
+  });
+
+  it("forwards the worktreeId when the owning project confirms it", async () => {
+    mockGetProjectById.mockReturnValue(projectA);
+    worktreeService.isWorktreeOwnedByProject.mockResolvedValue(true);
+
+    await spawnWith({ projectId: "project-a-id", worktreeId: "wt-a1" });
+
+    expect(spawnArgsOf().worktreeId).toBe("wt-a1");
+  });
+
+  // The core of the issue: project A claiming one of project B's worktrees.
+  it("drops a worktreeId the claimed project provably does not own", async () => {
+    mockGetProjectById.mockReturnValue(projectA);
+    worktreeService.isWorktreeOwnedByProject.mockResolvedValue(false);
+
+    await spawnWith({
+      projectId: "project-a-id",
+      worktreeId: "wt-belonging-to-b",
+      cwd: "/projects/b/wt",
+    });
+
+    expect(spawnArgsOf().worktreeId).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  // Dropping the stamp must not become a way to fail or relocate the terminal.
+  // A real directory, because the handler validates that the cwd exists — a
+  // synthetic path would fall back to home and hide whether the drop moved it.
+  it("still spawns at the requested cwd and workspace id after dropping", async () => {
+    const existingDir = process.cwd();
+    mockGetProjectById.mockReturnValue(projectA);
+    worktreeService.isWorktreeOwnedByProject.mockResolvedValue(false);
+
+    await spawnWith({
+      projectId: "project-a-id",
+      worktreeId: "wt-belonging-to-b",
+      cwd: existingDir,
+    });
+
+    expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
+    expect(spawnArgsOf().cwd).toBe(existingDir);
+    expect(spawnArgsOf().projectId).toBe("project-a-id");
+  });
+
+  // `null` is "unknown", not "mismatch" — a cold or mid-sync host must not
+  // strip metadata on a guess (#11131, #11235).
+  it("forwards the worktreeId when ownership is unknown", async () => {
+    mockGetProjectById.mockReturnValue(projectA);
+    worktreeService.isWorktreeOwnedByProject.mockResolvedValue(null);
+
+    await spawnWith({ projectId: "project-a-id", worktreeId: "wt-a1" });
+
+    expect(spawnArgsOf().worktreeId).toBe("wt-a1");
+  });
+
+  it("fails open when the ownership lookup rejects", async () => {
+    mockGetProjectById.mockReturnValue(projectA);
+    worktreeService.isWorktreeOwnedByProject.mockRejectedValue(new Error("host exited"));
+
+    await spawnWith({ projectId: "project-a-id", worktreeId: "wt-a1" });
+
+    expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
+    expect(spawnArgsOf().worktreeId).toBe("wt-a1");
+  });
+
+  it("forwards the worktreeId when no workspace client is wired up", async () => {
+    mockGetProjectById.mockReturnValue(projectA);
+
+    await spawnWith({ projectId: "project-a-id", worktreeId: "wt-a1" }, null);
+
+    expect(spawnArgsOf().worktreeId).toBe("wt-a1");
+  });
+
+  // #5182 sends a worktreeId with no projectId. That asserts no relationship,
+  // so there is nothing to verify and nothing to drop.
+  it("asserts nothing, and checks nothing, when only a worktreeId is supplied", async () => {
+    mockGetCurrentProject.mockReturnValue(projectA);
+
+    await spawnWith({ worktreeId: "wt-a1" });
+
+    expect(worktreeService.isWorktreeOwnedByProject).not.toHaveBeenCalled();
+    expect(spawnArgsOf().worktreeId).toBe("wt-a1");
+  });
+
+  // The current project is not a claim the caller made — auditing against it
+  // would invent an assertion the request never contained.
+  it("does not audit against the current project when the caller named none", async () => {
+    mockGetCurrentProject.mockReturnValue(projectB);
+
+    await spawnWith({ worktreeId: "wt-belonging-to-a" });
+
+    expect(worktreeService.isWorktreeOwnedByProject).not.toHaveBeenCalled();
+    expect(spawnArgsOf().worktreeId).toBe("wt-belonging-to-a");
+  });
+
+  // A scratch id is opaque and owns no worktrees; there is no project to ask.
+  it("skips the check for an explicit workspace id that resolves to no project", async () => {
+    mockGetProjectById.mockReturnValue(null);
+
+    await spawnWith({
+      projectId: "scratch-uuid",
+      worktreeId: "wt-a1",
+      cwd: "/tmp/scratches/scratch-uuid",
+    });
+
+    expect(worktreeService.isWorktreeOwnedByProject).not.toHaveBeenCalled();
+    expect(spawnArgsOf().worktreeId).toBe("wt-a1");
+  });
+
+  // A folder opened without git enumerates no worktrees at all (#11405), so the
+  // claim is incoherent without asking anyone.
+  it("drops a worktreeId claimed against a lightweight project without a host round trip", async () => {
+    mockGetProjectById.mockReturnValue(lightweightProject);
+
+    await spawnWith({ projectId: "lightweight-id", worktreeId: "wt-a1" });
+
+    expect(worktreeService.isWorktreeOwnedByProject).not.toHaveBeenCalled();
+    expect(spawnArgsOf().worktreeId).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  // Legacy rows predate the discriminator; absence means git-backed, so they
+  // must still take the normal verification path rather than be dropped.
+  it("treats a project with no gitBacked discriminator as git-backed", async () => {
+    mockGetProjectById.mockReturnValue(projectA);
+    worktreeService.isWorktreeOwnedByProject.mockResolvedValue(true);
+
+    await spawnWith({ projectId: "project-a-id", worktreeId: "wt-a1" });
+
+    expect(worktreeService.isWorktreeOwnedByProject).toHaveBeenCalledTimes(1);
+    expect(spawnArgsOf().worktreeId).toBe("wt-a1");
+  });
+
+  it("does not check ownership when no worktreeId is claimed", async () => {
+    mockGetProjectById.mockReturnValue(projectA);
+
+    await spawnWith({ projectId: "project-a-id" });
+
+    expect(worktreeService.isWorktreeOwnedByProject).not.toHaveBeenCalled();
+  });
+});
+
 describe("terminal spawn handler - PTY pool eligibility (#7945 regression guard)", () => {
   let ptyClient: {
     spawn: ReturnType<typeof vi.fn>;

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -525,24 +525,10 @@ describe("terminal spawn handler - worktree/project ownership (#11653)", () => {
   });
 
   // The core of the issue: project A claiming one of project B's worktrees.
-  it("drops a worktreeId the claimed project provably does not own", async () => {
-    mockGetProjectById.mockReturnValue(projectA);
-    worktreeService.isWorktreeOwnedByProject.mockResolvedValue(false);
-
-    await spawnWith({
-      projectId: "project-a-id",
-      worktreeId: "wt-belonging-to-b",
-      cwd: "/projects/b/wt",
-    });
-
-    expect(spawnArgsOf().worktreeId).toBeUndefined();
-    expect(warnSpy).toHaveBeenCalled();
-  });
-
-  // Dropping the stamp must not become a way to fail or relocate the terminal.
-  // A real directory, because the handler validates that the cwd exists — a
-  // synthetic path would fall back to home and hide whether the drop moved it.
-  it("still spawns at the requested cwd and workspace id after dropping", async () => {
+  // Uses a real directory so the handler's cwd-existence check passes — a
+  // synthetic path would fall back to home and both hide whether the drop
+  // relocated the terminal and emit its own warning, masking this one.
+  it("drops a worktreeId the claimed project provably does not own, without relocating the terminal", async () => {
     const existingDir = process.cwd();
     mockGetProjectById.mockReturnValue(projectA);
     worktreeService.isWorktreeOwnedByProject.mockResolvedValue(false);
@@ -553,9 +539,44 @@ describe("terminal spawn handler - worktree/project ownership (#11653)", () => {
       cwd: existingDir,
     });
 
+    expect(spawnArgsOf().worktreeId).toBeUndefined();
+    // Dropping the stamp must not become a way to fail or move the terminal.
     expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
     expect(spawnArgsOf().cwd).toBe(existingDir);
     expect(spawnArgsOf().projectId).toBe("project-a-id");
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("wt-belonging-to-b"));
+  });
+
+  // The verdict has to be settled BEFORE the spawn, not raced against it: a
+  // floating .then() that assigns a mutable variable would still pass every
+  // test whose mock resolves immediately.
+  it("waits for the verdict before spawning", async () => {
+    mockGetProjectById.mockReturnValue(projectA);
+    let settle: (owned: boolean | null) => void = () => {};
+    worktreeService.isWorktreeOwnedByProject.mockReturnValue(
+      new Promise((resolve) => {
+        settle = resolve;
+      })
+    );
+
+    const deps = { ptyClient, worktreeService } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+    const pending = getSpawnHandler()({} as Electron.IpcMainInvokeEvent, {
+      cols: 80,
+      rows: 24,
+      projectId: "project-a-id",
+      worktreeId: "wt-belonging-to-b",
+    });
+
+    // Let every other await in the handler drain; the spawn must still be held.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(ptyClient.spawn).not.toHaveBeenCalled();
+
+    settle(false);
+    await pending;
+
+    expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
+    expect(spawnArgsOf().worktreeId).toBeUndefined();
   });
 
   // `null` is "unknown", not "mismatch" — a cold or mid-sync host must not
@@ -575,6 +596,8 @@ describe("terminal spawn handler - worktree/project ownership (#11653)", () => {
 
     await spawnWith({ projectId: "project-a-id", worktreeId: "wt-a1" });
 
+    // Asserted so this can't pass merely because the lookup was skipped.
+    expect(worktreeService.isWorktreeOwnedByProject).toHaveBeenCalledTimes(1);
     expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
     expect(spawnArgsOf().worktreeId).toBe("wt-a1");
   });
@@ -587,10 +610,28 @@ describe("terminal spawn handler - worktree/project ownership (#11653)", () => {
     expect(spawnArgsOf().worktreeId).toBe("wt-a1");
   });
 
-  // #5182 sends a worktreeId with no projectId. That asserts no relationship,
-  // so there is nothing to verify and nothing to drop.
-  it("asserts nothing, and checks nothing, when only a worktreeId is supplied", async () => {
-    mockGetCurrentProject.mockReturnValue(projectA);
+  // The pair that gets journaled is the one that matters. A caller sending only
+  // a worktreeId still gets the current project stamped beside it, so that
+  // derived pair is checked too — otherwise the identical corruption arrives by
+  // omitting a field.
+  it("checks the pair it is about to stamp, even when the project was only derived", async () => {
+    mockGetCurrentProject.mockReturnValue(projectB);
+    worktreeService.isWorktreeOwnedByProject.mockResolvedValue(true);
+
+    await spawnWith({ worktreeId: "wt-b1" });
+
+    expect(worktreeService.isWorktreeOwnedByProject).toHaveBeenCalledWith(
+      "wt-b1",
+      projectB.path,
+      projectB.id
+    );
+  });
+
+  // #5182: a worktreeId with no project resolved anywhere stamps no pair, so
+  // there is nothing to check and nothing to drop.
+  it("checks nothing when no project resolves at all", async () => {
+    mockGetCurrentProject.mockReturnValue(null);
+    mockGetProjectById.mockReturnValue(null);
 
     await spawnWith({ worktreeId: "wt-a1" });
 
@@ -598,15 +639,20 @@ describe("terminal spawn handler - worktree/project ownership (#11653)", () => {
     expect(spawnArgsOf().worktreeId).toBe("wt-a1");
   });
 
-  // The current project is not a claim the caller made — auditing against it
-  // would invent an assertion the request never contained.
-  it("does not audit against the current project when the caller named none", async () => {
-    mockGetCurrentProject.mockReturnValue(projectB);
+  // A blank id is treated as absent everywhere else in the spawn path, so it
+  // must resolve — and be audited — exactly like an omitted one rather than
+  // being audited against the empty string.
+  it("treats a blank projectId as absent rather than as a claim on nothing", async () => {
+    mockGetCurrentProject.mockReturnValue(projectA);
+    worktreeService.isWorktreeOwnedByProject.mockResolvedValue(true);
 
-    await spawnWith({ worktreeId: "wt-belonging-to-a" });
+    await spawnWith({ projectId: "   ", worktreeId: "wt-a1" });
 
-    expect(worktreeService.isWorktreeOwnedByProject).not.toHaveBeenCalled();
-    expect(spawnArgsOf().worktreeId).toBe("wt-belonging-to-a");
+    expect(worktreeService.isWorktreeOwnedByProject).toHaveBeenCalledWith(
+      "wt-a1",
+      projectA.path,
+      projectA.id
+    );
   });
 
   // A scratch id is opaque and owns no worktrees; there is no project to ask.
@@ -628,11 +674,15 @@ describe("terminal spawn handler - worktree/project ownership (#11653)", () => {
   it("drops a worktreeId claimed against a lightweight project without a host round trip", async () => {
     mockGetProjectById.mockReturnValue(lightweightProject);
 
-    await spawnWith({ projectId: "lightweight-id", worktreeId: "wt-a1" });
+    await spawnWith({
+      projectId: "lightweight-id",
+      worktreeId: "wt-a1",
+      cwd: process.cwd(),
+    });
 
     expect(worktreeService.isWorktreeOwnedByProject).not.toHaveBeenCalled();
     expect(spawnArgsOf().worktreeId).toBeUndefined();
-    expect(warnSpy).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("wt-a1"));
   });
 
   // Legacy rows predate the discriminator; absence means git-backed, so they
@@ -653,6 +703,8 @@ describe("terminal spawn handler - worktree/project ownership (#11653)", () => {
     await spawnWith({ projectId: "project-a-id" });
 
     expect(worktreeService.isWorktreeOwnedByProject).not.toHaveBeenCalled();
+    // Proves the spawn actually ran, so this can't pass via an early return.
+    expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -28,7 +28,7 @@ import type {
   AgentSessionRecord,
   AgentSessionRetentionDays,
 } from "../../../../shared/types/ipc/agentSessionHistory.js";
-import { isGitBackedProject, resolveDaintreeMcpTier } from "../../../../shared/types/project.js";
+import { resolveDaintreeMcpTier } from "../../../../shared/types/project.js";
 import { normalizeTerminalGridDimension } from "../../../../shared/types/terminal.js";
 import { DEFAULT_DANGEROUS_ARGS } from "../../../../shared/types/agentSettings.js";
 import {
@@ -255,28 +255,30 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     // a resolved Project because an explicit id is often a scratch id owning no
     // worktrees (#11079), and a spawn with no project resolved at all stamps no
     // pair to check (#5182).
+    // Deliberately NOT short-circuited on the project row's `gitBacked: false`
+    // flag, tempting as it is — a folder opened without git owns no worktrees,
+    // so the claim looks incoherent on its face. But the row is not the
+    // authority on that: the workspace host probes the folder on load and
+    // enumerates real worktrees if git appeared since (WorkspaceService's
+    // "the folder is the authority"), while the row is only promoted when the
+    // project is re-added. An external `git init` therefore leaves a stale
+    // `false` beside a host serving genuine ids, and trusting it would drop
+    // them. Ask the host, which knows.
     const ownershipClaim =
       resolvedProject && validatedOptions.worktreeId
         ? {
             projectId: resolvedProject.id,
             worktreeId: validatedOptions.worktreeId,
             projectPath: resolvedProject.path,
-            gitBacked: isGitBackedProject(resolvedProject),
           }
         : null;
 
-    // A project opened without git enumerates no worktrees at all (#11405), so
-    // any worktree id claimed against one is incoherent on its face — decided
-    // here, with no host round trip to spend.
-    const claimsWorktreeOnLightweightProject = ownershipClaim !== null && !ownershipClaim.gitBacked;
-
-    // Started here, awaited just before the spawn, so the round trip overlaps
-    // the settings read, cwd validation and env assembly below instead of
-    // adding to them. Settled to `null` (unknown) at creation so an early
-    // failure elsewhere in this handler can never surface as an unhandled
-    // rejection on a floating promise.
+    // Started here, awaited below, so the round trip overlaps the settings read
+    // and cwd validation instead of adding to them. Settled to `null`
+    // (unknown) at creation so an early failure elsewhere in this handler can
+    // never surface as an unhandled rejection on a floating promise.
     const worktreeOwnership: Promise<boolean | null> =
-      ownershipClaim && ownershipClaim.gitBacked && deps.worktreeService
+      ownershipClaim && deps.worktreeService
         ? deps.worktreeService
             .isWorktreeOwnedByProject(
               ownershipClaim.worktreeId,
@@ -359,13 +361,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     // revoke them against a PTY that does not exist yet, leaving the spawn to
     // proceed untracked.
     let spawnWorktreeId = validatedOptions.worktreeId;
-    if (claimsWorktreeOnLightweightProject) {
-      console.warn(
-        `[TerminalSpawn] Dropping worktreeId ${spawnWorktreeId} for terminal ${id.slice(0, 8)}: ` +
-          `project ${ownershipClaim?.projectId} was opened without git and has no worktrees`
-      );
-      spawnWorktreeId = undefined;
-    } else if ((await worktreeOwnership) === false) {
+    if ((await worktreeOwnership) === false) {
       console.warn(
         `[TerminalSpawn] Dropping worktreeId ${spawnWorktreeId} for terminal ${id.slice(0, 8)}: ` +
           `it belongs to another project, not ${ownershipClaim?.projectId}`

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -212,7 +212,10 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     // and leaving it unset made ownership fall back to PtyClient's global
     // `activeProjectId`, so deleting a scratch never killed its terminals (#11079).
     // Only a caller that sent no id at all falls back to the current project.
-    const explicitWorkspaceId = validatedOptions.projectId;
+    // Blank is absent, not an identity: PtyClient already substitutes its
+    // active project for a blank id, so leaving it as `""` here would let a
+    // whitespace projectId slip past checks that a missing one is subject to.
+    const explicitWorkspaceId = validatedOptions.projectId?.trim() || undefined;
     const resolvedProject = explicitWorkspaceId
       ? projectStore.getProjectById(explicitWorkspaceId)
       : projectStore.getCurrentProject();
@@ -241,17 +244,31 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     // Requires the explicit id too — falling back to the current project would
     // audit a claim the caller never made. A worktreeId sent with no projectId
     // asserts no relationship and stays untouched (#5182).
-    const assertsWorktreeOwnership =
-      explicitWorkspaceId !== undefined &&
-      validatedOptions.worktreeId !== undefined &&
-      resolvedProject !== null &&
-      resolvedProject !== undefined;
+    // Truthiness, not `!== undefined`: a blank id is already treated as absent
+    // when resolving the project above (and again by PtyClient, which swaps in
+    // the active project), so it must not be taken as an assertion here either
+    // — auditing a claim against the empty string would be auditing nothing.
+    // Keyed on the pair actually about to be PERSISTED, not on the pair the
+    // caller spelled out. A request carrying only a worktreeId still gets the
+    // current project stamped beside it below, and that derived pair is
+    // journaled and can go cross-project exactly like an asserted one. Gated on
+    // a resolved Project because an explicit id is often a scratch id owning no
+    // worktrees (#11079), and a spawn with no project resolved at all stamps no
+    // pair to check (#5182).
+    const ownershipClaim =
+      resolvedProject && validatedOptions.worktreeId
+        ? {
+            projectId: resolvedProject.id,
+            worktreeId: validatedOptions.worktreeId,
+            projectPath: resolvedProject.path,
+            gitBacked: isGitBackedProject(resolvedProject),
+          }
+        : null;
 
     // A project opened without git enumerates no worktrees at all (#11405), so
     // any worktree id claimed against one is incoherent on its face — decided
     // here, with no host round trip to spend.
-    const claimsWorktreeOnLightweightProject =
-      assertsWorktreeOwnership && !isGitBackedProject(resolvedProject);
+    const claimsWorktreeOnLightweightProject = ownershipClaim !== null && !ownershipClaim.gitBacked;
 
     // Started here, awaited just before the spawn, so the round trip overlaps
     // the settings read, cwd validation and env assembly below instead of
@@ -259,12 +276,12 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     // failure elsewhere in this handler can never surface as an unhandled
     // rejection on a floating promise.
     const worktreeOwnership: Promise<boolean | null> =
-      assertsWorktreeOwnership && !claimsWorktreeOnLightweightProject && deps.worktreeService
+      ownershipClaim && ownershipClaim.gitBacked && deps.worktreeService
         ? deps.worktreeService
             .isWorktreeOwnedByProject(
-              validatedOptions.worktreeId as string,
-              resolvedProject.path,
-              explicitWorkspaceId
+              ownershipClaim.worktreeId,
+              ownershipClaim.projectPath,
+              ownershipClaim.projectId
             )
             .catch(() => null)
         : Promise.resolve(null);
@@ -320,6 +337,40 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     } catch (_error) {
       console.warn(`Invalid cwd: ${cwd}, falling back to project root or home`);
       cwd = await getValidatedFallback();
+    }
+
+    // Resolve the ownership claim. Only a PROVEN disowning drops the id — an
+    // unknown verdict (no host, host not ready, timed out, nothing to
+    // corroborate against, service absent) forwards it exactly as before, so a
+    // cold or busy workspace host degrades to today's behaviour instead of
+    // stripping metadata on a guess.
+    //
+    // Dropping, not rejecting: the terminal still spawns, at the cwd the caller
+    // asked for, under the workspace id it claimed. Only the unverifiable
+    // worktree stamp goes, which keeps the blast radius of a wrong verdict at
+    // "this terminal contributes no resume metadata" rather than "the user
+    // can't open a terminal". Nothing above reads worktreeId, so sanitizing it
+    // here covers every consumer — the close and bookmark paths read it back
+    // off the PTY record and observe the sanitized value for free.
+    //
+    // Awaited HERE rather than at the spawn call: everything below binds
+    // resources to this terminal id (help-session token, MCP pane config), and
+    // an await between those bindings and the spawn lets a competing provision
+    // revoke them against a PTY that does not exist yet, leaving the spawn to
+    // proceed untracked.
+    let spawnWorktreeId = validatedOptions.worktreeId;
+    if (claimsWorktreeOnLightweightProject) {
+      console.warn(
+        `[TerminalSpawn] Dropping worktreeId ${spawnWorktreeId} for terminal ${id.slice(0, 8)}: ` +
+          `project ${ownershipClaim?.projectId} was opened without git and has no worktrees`
+      );
+      spawnWorktreeId = undefined;
+    } else if ((await worktreeOwnership) === false) {
+      console.warn(
+        `[TerminalSpawn] Dropping worktreeId ${spawnWorktreeId} for terminal ${id.slice(0, 8)}: ` +
+          `it belongs to another project, not ${ownershipClaim?.projectId}`
+      );
+      spawnWorktreeId = undefined;
     }
 
     // Debug: log projectId assignment
@@ -674,34 +725,6 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     // faithfully with no postSpawnInput.
     const postSpawnInput =
       safeCommand.length > 0 && !commandLaunchShell ? `${safeCommand}\r` : undefined;
-
-    // Resolve the ownership claim. Only a PROVEN disowning drops the id — an
-    // unknown verdict (no host, host not ready, timed out, service absent)
-    // forwards it exactly as before, so a cold or busy workspace host degrades
-    // to today's behaviour instead of stripping metadata on a guess.
-    //
-    // Dropping, not rejecting: the terminal still spawns, at the cwd the caller
-    // asked for, under the workspace id it claimed. Only the unverifiable
-    // worktree stamp goes, which keeps the blast radius of a wrong verdict at
-    // "this terminal contributes no resume metadata" rather than "the user
-    // can't open a terminal". Nothing above reads worktreeId, so sanitizing it
-    // at the single point it leaves the handler is the whole fix — the close
-    // and bookmark paths read it back off the PTY record and observe the
-    // sanitized value for free.
-    let spawnWorktreeId = validatedOptions.worktreeId;
-    if (claimsWorktreeOnLightweightProject) {
-      console.warn(
-        `[TerminalSpawn] Dropping worktreeId ${spawnWorktreeId} for terminal ${id.slice(0, 8)}: ` +
-          `project ${explicitWorkspaceId} was opened without git and has no worktrees`
-      );
-      spawnWorktreeId = undefined;
-    } else if ((await worktreeOwnership) === false) {
-      console.warn(
-        `[TerminalSpawn] Dropping worktreeId ${spawnWorktreeId} for terminal ${id.slice(0, 8)}: ` +
-          `it does not belong to project ${explicitWorkspaceId}`
-      );
-      spawnWorktreeId = undefined;
-    }
 
     try {
       // Every terminal is an interactive shell. Agent launches inject their

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -238,12 +238,6 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     // worktrees, defaultWorkingDirectory, scratch, the home-dir fallback), so
     // containment is not evidence of anything here.
     //
-    // Gated on a RESOLVED Project, not merely on the id being present: an
-    // explicit workspace id is often a scratch id that resolves to no Project
-    // (#11079), and scratch workspaces have no worktrees to check against.
-    // Requires the explicit id too — falling back to the current project would
-    // audit a claim the caller never made. A worktreeId sent with no projectId
-    // asserts no relationship and stays untouched (#5182).
     // Truthiness, not `!== undefined`: a blank id is already treated as absent
     // when resolving the project above (and again by PtyClient, which swaps in
     // the active project), so it must not be taken as an assertion here either

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -28,7 +28,7 @@ import type {
   AgentSessionRecord,
   AgentSessionRetentionDays,
 } from "../../../../shared/types/ipc/agentSessionHistory.js";
-import { resolveDaintreeMcpTier } from "../../../../shared/types/project.js";
+import { isGitBackedProject, resolveDaintreeMcpTier } from "../../../../shared/types/project.js";
 import { normalizeTerminalGridDimension } from "../../../../shared/types/terminal.js";
 import { DEFAULT_DANGEROUS_ARGS } from "../../../../shared/types/agentSettings.js";
 import {
@@ -221,6 +221,53 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     // overrides, project-path cwd fallback) stays gated on a resolved Project.
     const projectId = explicitWorkspaceId ?? resolvedProject?.id;
     const projectPath = resolvedProject?.path;
+
+    // A request naming BOTH a project and a worktree asserts that the worktree
+    // belongs to that project, and main has never checked it (#11653). The
+    // claim is not inert: worktreeId is forwarded to the PTY and journaled
+    // beside projectId on close (persistCloseRecord / prepare-bookmark), so an
+    // unchecked pair puts one project's worktree into another's resumable-
+    // session history and lets a worktree-scoped clear reach across the
+    // boundary.
+    //
+    // Verify only the relationship the request itself asserts — never infer a
+    // project from cwd. A cwd legitimately sits outside its project (linked
+    // worktrees, defaultWorkingDirectory, scratch, the home-dir fallback), so
+    // containment is not evidence of anything here.
+    //
+    // Gated on a RESOLVED Project, not merely on the id being present: an
+    // explicit workspace id is often a scratch id that resolves to no Project
+    // (#11079), and scratch workspaces have no worktrees to check against.
+    // Requires the explicit id too — falling back to the current project would
+    // audit a claim the caller never made. A worktreeId sent with no projectId
+    // asserts no relationship and stays untouched (#5182).
+    const assertsWorktreeOwnership =
+      explicitWorkspaceId !== undefined &&
+      validatedOptions.worktreeId !== undefined &&
+      resolvedProject !== null &&
+      resolvedProject !== undefined;
+
+    // A project opened without git enumerates no worktrees at all (#11405), so
+    // any worktree id claimed against one is incoherent on its face — decided
+    // here, with no host round trip to spend.
+    const claimsWorktreeOnLightweightProject =
+      assertsWorktreeOwnership && !isGitBackedProject(resolvedProject);
+
+    // Started here, awaited just before the spawn, so the round trip overlaps
+    // the settings read, cwd validation and env assembly below instead of
+    // adding to them. Settled to `null` (unknown) at creation so an early
+    // failure elsewhere in this handler can never surface as an unhandled
+    // rejection on a floating promise.
+    const worktreeOwnership: Promise<boolean | null> =
+      assertsWorktreeOwnership && !claimsWorktreeOnLightweightProject && deps.worktreeService
+        ? deps.worktreeService
+            .isWorktreeOwnedByProject(
+              validatedOptions.worktreeId as string,
+              resolvedProject.path,
+              explicitWorkspaceId
+            )
+            .catch(() => null)
+        : Promise.resolve(null);
 
     // Fetch project-level terminal overrides when there's no agent launch
     // hint. Agent launches intentionally use the default shell configuration
@@ -628,6 +675,34 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     const postSpawnInput =
       safeCommand.length > 0 && !commandLaunchShell ? `${safeCommand}\r` : undefined;
 
+    // Resolve the ownership claim. Only a PROVEN disowning drops the id — an
+    // unknown verdict (no host, host not ready, timed out, service absent)
+    // forwards it exactly as before, so a cold or busy workspace host degrades
+    // to today's behaviour instead of stripping metadata on a guess.
+    //
+    // Dropping, not rejecting: the terminal still spawns, at the cwd the caller
+    // asked for, under the workspace id it claimed. Only the unverifiable
+    // worktree stamp goes, which keeps the blast radius of a wrong verdict at
+    // "this terminal contributes no resume metadata" rather than "the user
+    // can't open a terminal". Nothing above reads worktreeId, so sanitizing it
+    // at the single point it leaves the handler is the whole fix — the close
+    // and bookmark paths read it back off the PTY record and observe the
+    // sanitized value for free.
+    let spawnWorktreeId = validatedOptions.worktreeId;
+    if (claimsWorktreeOnLightweightProject) {
+      console.warn(
+        `[TerminalSpawn] Dropping worktreeId ${spawnWorktreeId} for terminal ${id.slice(0, 8)}: ` +
+          `project ${explicitWorkspaceId} was opened without git and has no worktrees`
+      );
+      spawnWorktreeId = undefined;
+    } else if ((await worktreeOwnership) === false) {
+      console.warn(
+        `[TerminalSpawn] Dropping worktreeId ${spawnWorktreeId} for terminal ${id.slice(0, 8)}: ` +
+          `it does not belong to project ${explicitWorkspaceId}`
+      );
+      spawnWorktreeId = undefined;
+    }
+
     try {
       // Every terminal is an interactive shell. Agent launches inject their
       // command after the shell's first prompt renders — never `exec`'d over
@@ -651,7 +726,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
         isEphemeral: validatedOptions.isEphemeral,
         agentLaunchFlags: validatedOptions.agentLaunchFlags,
         agentModelId: validatedOptions.agentModelId,
-        worktreeId: validatedOptions.worktreeId,
+        worktreeId: spawnWorktreeId,
         agentPresetId: validatedOptions.agentPresetId,
         agentPresetColor: validatedOptions.agentPresetColor,
         originalAgentPresetId:

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -717,24 +717,37 @@ export class WorkspaceClient extends EventEmitter {
    * repointed, so naming the true owner would buy nothing and cost a serial
    * fan-out across every loaded host on a latency-sensitive path.
    *
-   * Why a ready host's `state: null` is proof rather than a race: every
-   * worktree id in circulation is minted BY the owning host — `createWorktree`
-   * returns the id the host itself assigned, and every other id reaches a
-   * renderer through that host's snapshots. So there is no window in which a
-   * caller legitimately holds an id for a worktree its own host hasn't
-   * registered. Combined with the readiness gate (which excludes the
-   * mid-`syncMonitors` partial map, #11387), a completed "not mine" is
-   * authoritative.
+   * Absence alone is NOT proof, which is the subtle part. A worktree id is a
+   * path, but the two places that mint one disagree on how to spell it:
+   * creation stores `realpath(path)` (WorkspaceService.performCreateWorktree)
+   * while enumeration stores `pathResolve(wt.path)` off `git worktree list
+   * --porcelain` (WorktreeListService.mapToWorktrees). Those differ whenever
+   * the path crosses a symlink, and porcelain paths are relative — and
+   * explicitly untrustworthy — under Git 2.48+ `worktree.useRelativePaths`. So
+   * a host can genuinely own a worktree whose id, as the caller spells it, is
+   * missing from its map. Treating that as a disowning would drop valid ids.
+   *
+   * A `false` therefore requires CORROBORATION: the named project's ready host
+   * must not hold the id AND some other project's host must positively claim
+   * it. A positive claim is sound however the id was spelled, because it is the
+   * claimant that spelled it. If nobody claims it, the honest answer is `null`
+   * — which is exactly what the spelling mismatch produces, so the failure mode
+   * degrades to "unknown" instead of to a false accusation.
+   *
+   * The corroborating fan-out only runs when the named host has already
+   * disclaimed the id, so the common case stays a single round trip.
    *
    * `expectedProjectId` must equal the entry's immutable projectId for the same
    * reason {@link getAllStatesForProjectAsync} requires it: the project row's
    * path is mutable, so a path alone is not an authorization identity.
    *
    * Never rejects. Bounded by {@link WORKTREE_OWNERSHIP_CHECK_TIMEOUT_MS} end
-   * to end, shared between the readiness gate and the round trip so the two
+   * to end, shared across the readiness gate and every round trip so they
    * cannot compound. The remaining budget is handed to `sendWithResponse`
    * itself rather than raced against it — a race would resolve on time while
-   * leaving the host's 30s default request pending behind it.
+   * leaving the host's 30s default request pending behind it. Elapsed time is
+   * measured with `performance.now()`, so a system clock adjustment mid-check
+   * can't hand the broker an inflated timeout.
    */
   async isWorktreeOwnedByProject(
     worktreeId: string,
@@ -745,28 +758,54 @@ export class WorkspaceClient extends EventEmitter {
     const entry = this.pool.entries.get(normalized);
     if (entry === undefined || entry.projectId !== expectedProjectId) return null;
 
-    const deadline = Date.now() + WORKTREE_OWNERSHIP_CHECK_TIMEOUT_MS;
-    if (!(await this._awaitHostReady(entry, WORKTREE_OWNERSHIP_CHECK_TIMEOUT_MS))) return null;
+    const start = performance.now();
+    const remaining = () =>
+      Math.ceil(WORKTREE_OWNERSHIP_CHECK_TIMEOUT_MS - (performance.now() - start));
 
-    const remainingMs = deadline - Date.now();
-    if (remainingMs <= 0) return null;
+    // Readiness matters only for proving ABSENCE: a partial map that already
+    // contains the id still proves containment, but one that doesn't may
+    // simply be mid-populate (#11387).
+    if (!(await this._awaitHostReady(entry, remaining()))) return null;
+    if (remaining() <= 0) return null;
 
+    const claimed = await this._hostClaimsWorktree(entry, worktreeId, remaining());
+    if (claimed === true) return true;
+    // Unknown from the project's own host stays unknown — no accusation to
+    // corroborate.
+    if (claimed === null) return null;
+
+    const others = [...this.pool.entries.values()].filter((e) => e !== entry);
+    if (others.length === 0) return null;
+
+    const budget = remaining();
+    if (budget <= 0) return null;
+
+    // In parallel, and with no readiness gate: a host that answers "mine" is
+    // authoritative about its own worktree whether or not its map is complete.
+    const claims = await Promise.all(
+      others.map((other) => this._hostClaimsWorktree(other, worktreeId, budget))
+    );
+    return claims.some((c) => c === true) ? false : null;
+  }
+
+  /**
+   * `true` the host holds this exact worktree, `false` it completed the lookup
+   * without it, `null` the question could not be answered. Never rejects.
+   */
+  private async _hostClaimsWorktree(
+    entry: ProcessEntry,
+    worktreeId: string,
+    timeoutMs: number
+  ): Promise<boolean | null> {
+    if (timeoutMs <= 0) return null;
     try {
       const requestId = entry.host.generateRequestId();
       const result = await entry.host.sendWithResponse<{
         state: WorktreeSnapshot | null;
-      }>(
-        {
-          type: "get-monitor",
-          requestId,
-          worktreeId,
-        },
-        remainingMs
-      );
-      if (result.state === null) return false;
-      // A snapshot for some *other* worktree answers a question we didn't ask;
-      // treat it as unknown rather than as either verdict.
-      return result.state?.id === worktreeId ? true : null;
+      }>({ type: "get-monitor", requestId, worktreeId }, timeoutMs);
+      if (result?.state == null) return false;
+      // A snapshot for some *other* worktree answers a question we didn't ask.
+      return result.state.id === worktreeId ? true : null;
     } catch {
       return null;
     }

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -66,6 +66,19 @@ const REFRESH_PRS_TIMEOUT_MS = 45_000;
 // job in every non-pathological case.
 const STATES_READY_GATE_TIMEOUT_MS = 5_000;
 
+// Total budget for one worktree-ownership check — readiness gate AND the
+// monitor round trip share it, they do not each get their own.
+//
+// Sized against terminal spawn, the only caller: the check is a coherence
+// assertion on metadata the request already supplied, never something the
+// spawn needs in order to proceed, so it must not become a latency floor.
+// Matches resolveBranchForMain's bound (terminal/lifecycle.ts), the other
+// best-effort WorkspaceClient lookup on a terminal's critical path. Exceeding
+// it reports "unknown" (null), which forwards the caller's worktreeId
+// untouched — the pre-existing behaviour — so a slow host costs nothing but
+// the check itself.
+const WORKTREE_OWNERSHIP_CHECK_TIMEOUT_MS = 200;
+
 export type CopyTreeProgressCallback = (progress: CopyTreeProgress) => void;
 
 function dedupeSnapshotsById(states: WorktreeSnapshot[]): WorktreeSnapshot[] {
@@ -644,14 +657,19 @@ export class WorkspaceClient extends EventEmitter {
 
   /**
    * Resolves `true` when the host's monitor populate completed, `false` if it
-   * failed or did not settle within {@link STATES_READY_GATE_TIMEOUT_MS}.
-   * Callers must treat `false` as "unknown" and return `[]` rather than reading
-   * a possibly-partial map. Never rejects.
+   * failed or did not settle within `timeoutMs` (default
+   * {@link STATES_READY_GATE_TIMEOUT_MS}). Callers must treat `false` as
+   * "unknown" — state reads return `[]` rather than a possibly-partial map;
+   * the ownership check returns `null` rather than a false accusation. Never
+   * rejects.
    */
-  private _awaitHostReady(entry: ProcessEntry): Promise<boolean> {
+  private _awaitHostReady(
+    entry: ProcessEntry,
+    timeoutMs: number = STATES_READY_GATE_TIMEOUT_MS
+  ): Promise<boolean> {
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timedOut = new Promise<boolean>((resolve) => {
-      timer = setTimeout(() => resolve(false), STATES_READY_GATE_TIMEOUT_MS);
+      timer = setTimeout(() => resolve(false), timeoutMs);
     });
     const settled = entry.currentReadyPromise.then(
       () => true,
@@ -678,6 +696,80 @@ export class WorkspaceClient extends EventEmitter {
         .filter((r): r is PromiseFulfilledResult<WorktreeSnapshot[]> => r.status === "fulfilled")
         .flatMap((r) => r.value)
     );
+  }
+
+  /**
+   * Does `worktreeId` belong to the project identified by
+   * `projectPath` + `expectedProjectId`? Tri-state, and the third state is the
+   * whole point:
+   *
+   * - `true`  — that project's host is ready and returned the monitor.
+   * - `false` — that project's host is ready and completed the lookup with
+   *             `state: null`. A PROVEN disowning.
+   * - `null`  — UNKNOWN. No pool entry for the path, the entry's immutable
+   *             projectId doesn't match, readiness never settled, the request
+   *             timed out, the host errored, or the reply was malformed.
+   *
+   * Callers must never treat `null` as a mismatch. Only `false` is evidence,
+   * and only ever about the project that was asked about — this deliberately
+   * does not scan other hosts to discover the real owner. A caller holding a
+   * disowned id has nothing to reconcile it to (#4881): the id is dropped, not
+   * repointed, so naming the true owner would buy nothing and cost a serial
+   * fan-out across every loaded host on a latency-sensitive path.
+   *
+   * Why a ready host's `state: null` is proof rather than a race: every
+   * worktree id in circulation is minted BY the owning host — `createWorktree`
+   * returns the id the host itself assigned, and every other id reaches a
+   * renderer through that host's snapshots. So there is no window in which a
+   * caller legitimately holds an id for a worktree its own host hasn't
+   * registered. Combined with the readiness gate (which excludes the
+   * mid-`syncMonitors` partial map, #11387), a completed "not mine" is
+   * authoritative.
+   *
+   * `expectedProjectId` must equal the entry's immutable projectId for the same
+   * reason {@link getAllStatesForProjectAsync} requires it: the project row's
+   * path is mutable, so a path alone is not an authorization identity.
+   *
+   * Never rejects. Bounded by {@link WORKTREE_OWNERSHIP_CHECK_TIMEOUT_MS} end
+   * to end, shared between the readiness gate and the round trip so the two
+   * cannot compound. The remaining budget is handed to `sendWithResponse`
+   * itself rather than raced against it — a race would resolve on time while
+   * leaving the host's 30s default request pending behind it.
+   */
+  async isWorktreeOwnedByProject(
+    worktreeId: string,
+    projectPath: string,
+    expectedProjectId: string
+  ): Promise<boolean | null> {
+    const normalized = this.pool.normalizeProjectPath(projectPath);
+    const entry = this.pool.entries.get(normalized);
+    if (entry === undefined || entry.projectId !== expectedProjectId) return null;
+
+    const deadline = Date.now() + WORKTREE_OWNERSHIP_CHECK_TIMEOUT_MS;
+    if (!(await this._awaitHostReady(entry, WORKTREE_OWNERSHIP_CHECK_TIMEOUT_MS))) return null;
+
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) return null;
+
+    try {
+      const requestId = entry.host.generateRequestId();
+      const result = await entry.host.sendWithResponse<{
+        state: WorktreeSnapshot | null;
+      }>(
+        {
+          type: "get-monitor",
+          requestId,
+          worktreeId,
+        },
+        remainingMs
+      );
+      if (result.state === null) return false;
+      // A snapshot for some *other* worktree answers a question we didn't ask;
+      // treat it as unknown rather than as either verdict.
+      return result.state?.id === worktreeId ? true : null;
+    } catch {
+      return null;
+    }
   }
 
   async getMonitorAsync(worktreeId: string): Promise<WorktreeSnapshot | null> {

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -704,18 +704,17 @@ export class WorkspaceClient extends EventEmitter {
    * whole point:
    *
    * - `true`  — that project's host is ready and returned the monitor.
-   * - `false` — that project's host is ready and completed the lookup with
-   *             `state: null`. A PROVEN disowning.
+   * - `false` — that project's ready host disclaimed the id AND another loaded
+   *             project's host positively claimed it.
    * - `null`  — UNKNOWN. No pool entry for the path, the entry's immutable
    *             projectId doesn't match, readiness never settled, the request
-   *             timed out, the host errored, or the reply was malformed.
+   *             timed out, the host errored, the reply was malformed, or the
+   *             disclaim went uncorroborated.
    *
-   * Callers must never treat `null` as a mismatch. Only `false` is evidence,
-   * and only ever about the project that was asked about — this deliberately
-   * does not scan other hosts to discover the real owner. A caller holding a
-   * disowned id has nothing to reconcile it to (#4881): the id is dropped, not
-   * repointed, so naming the true owner would buy nothing and cost a serial
-   * fan-out across every loaded host on a latency-sensitive path.
+   * Callers must never treat `null` as a mismatch; only `false` is evidence.
+   * The verdict is deliberately not used to name the real owner — a caller
+   * holding a disowned id has nothing to reconcile it to (#4881), so the id is
+   * dropped, never repointed.
    *
    * Absence alone is NOT proof, which is the subtle part. A worktree id is a
    * path, but the two places that mint one disagree on how to spell it:
@@ -736,6 +735,17 @@ export class WorkspaceClient extends EventEmitter {
    *
    * The corroborating fan-out only runs when the named host has already
    * disclaimed the id, so the common case stays a single round trip.
+   *
+   * KNOWN LIMIT: corroboration proves membership in the claimant, not absence
+   * from the named project, and those come apart when the same repository is
+   * registered as two projects rooted at different linked worktrees. Both
+   * enumerate the shared worktree set, so if the spelling divergence above hides
+   * the id from one and not the other, this reports `false` for a worktree both
+   * legitimately contain. Closing that needs canonicalized path comparison, i.e.
+   * `realpath` per candidate on the spawn path — rejected because `realpath`
+   * blocks indefinitely on an unreachable network mount. The cost of the gap is
+   * a terminal that contributes no resume metadata, never a wrong or failed
+   * spawn, which is the same cost as the `null` path it would otherwise take.
    *
    * `expectedProjectId` must equal the entry's immutable projectId for the same
    * reason {@link getAllStatesForProjectAsync} requires it: the project row's
@@ -803,9 +813,13 @@ export class WorkspaceClient extends EventEmitter {
       const result = await entry.host.sendWithResponse<{
         state: WorktreeSnapshot | null;
       }>({ type: "get-monitor", requestId, worktreeId }, timeoutMs);
-      if (result?.state == null) return false;
+      // Strictly `null`: only an explicit "I looked, it isn't mine" is a
+      // disclaim. A missing field or an absent reply never reached that
+      // conclusion, and since a disclaim is half of a `false` verdict,
+      // conflating them would let a malformed response help condemn a valid id.
+      if (result?.state === null) return false;
       // A snapshot for some *other* worktree answers a question we didn't ask.
-      return result.state.id === worktreeId ? true : null;
+      return result?.state?.id === worktreeId ? true : null;
     } catch {
       return null;
     }

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -835,6 +835,228 @@ describe("WorkspaceClient multi-process manager", () => {
     });
   });
 
+  // Terminal spawn asks this before trusting a request that claims a worktree
+  // belongs to a project (#11653). The tri-state is the contract: only `false`
+  // is evidence of a mismatch, `null` means the question could not be answered
+  // and the caller must not treat it as an accusation.
+  describe("isWorktreeOwnedByProject", () => {
+    const idFor = (p: string) => `id-for-${path.resolve(p)}`;
+
+    const monitorReqs = (hostIndex: number) =>
+      h(hostIndex)
+        .getAllRequests()
+        .filter((r: any) => r.type === "get-monitor");
+
+    it("returns true when the project's own host answers with the requested monitor", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const ownedPromise = client.isWorktreeOwnedByProject(
+        "wt-a",
+        "/project-a",
+        idFor("/project-a")
+      );
+      await tick();
+      const req = monitorReqs(0)[0];
+      expect(req.worktreeId).toBe("wt-a");
+      h(0).resolveRequest(req.requestId, { state: { id: "wt-a", name: "A" } });
+
+      expect(await ownedPromise).toBe(true);
+    });
+
+    // The disowning that makes the whole check worth doing.
+    it("returns false when a ready host completes the lookup with no such monitor", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const ownedPromise = client.isWorktreeOwnedByProject(
+        "wt-belonging-to-b",
+        "/project-a",
+        idFor("/project-a")
+      );
+      await tick();
+      h(0).resolveRequest(monitorReqs(0)[0].requestId, { state: null });
+
+      expect(await ownedPromise).toBe(false);
+    });
+
+    it("asks only the named project's host, never the others", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const loadB = client.loadProject("/project-b", 2);
+      await readyAndResolveLoad(1);
+      await loadB;
+
+      const ownedPromise = client.isWorktreeOwnedByProject(
+        "wt-b",
+        "/project-a",
+        idFor("/project-a")
+      );
+      await tick();
+
+      expect(monitorReqs(1)).toHaveLength(0);
+      h(0).resolveRequest(monitorReqs(0)[0].requestId, { state: null });
+      expect(await ownedPromise).toBe(false);
+    });
+
+    it("returns unknown for a path no host is loaded for, without contacting any host", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const callsBefore = h(0).sendWithResponse.mock.calls.length;
+      const owned = await client.isWorktreeOwnedByProject(
+        "wt-a",
+        "/no-such-project",
+        idFor("/no-such-project")
+      );
+
+      expect(owned).toBeNull();
+      expect(h(0).sendWithResponse.mock.calls.length).toBe(callsBefore);
+    });
+
+    // Same immutable-identity rule getAllStatesForProjectAsync enforces: a
+    // project row's path is mutable, so a path alone is not an identity.
+    it("returns unknown when the entry's immutable projectId does not match", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const callsBefore = h(0).sendWithResponse.mock.calls.length;
+      const owned = await client.isWorktreeOwnedByProject(
+        "wt-a",
+        "/project-a",
+        idFor("/project-b")
+      );
+
+      expect(owned).toBeNull();
+      expect(h(0).sendWithResponse.mock.calls.length).toBe(callsBefore);
+    });
+
+    it("returns unknown when the host errors", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const ownedPromise = client.isWorktreeOwnedByProject(
+        "wt-a",
+        "/project-a",
+        idFor("/project-a")
+      );
+      await tick();
+      h(0).rejectRequest(monitorReqs(0)[0].requestId, new Error("host crashed"));
+
+      expect(await ownedPromise).toBeNull();
+    });
+
+    // A reply about a different worktree answers a question we didn't ask —
+    // neither a confirmation nor an accusation.
+    it("returns unknown when the host answers about a different worktree", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const ownedPromise = client.isWorktreeOwnedByProject(
+        "wt-a",
+        "/project-a",
+        idFor("/project-a")
+      );
+      await tick();
+      h(0).resolveRequest(monitorReqs(0)[0].requestId, { state: { id: "wt-something-else" } });
+
+      expect(await ownedPromise).toBeNull();
+    });
+
+    // The check rides terminal spawn, so it must give up far sooner than the
+    // host's 30s per-request budget rather than becoming a latency floor.
+    it("bounds the round trip well inside the host's per-request budget", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const ownedPromise = client.isWorktreeOwnedByProject(
+        "wt-a",
+        "/project-a",
+        idFor("/project-a")
+      );
+      await tick();
+
+      const monitorCall = h(0).sendWithResponse.mock.calls.find(
+        ([req]: any) => req.type === "get-monitor"
+      )!;
+      const timeoutMs = monitorCall[1];
+      expect(timeoutMs).toBeGreaterThan(0);
+      expect(timeoutMs).toBeLessThan(1_000);
+
+      h(0).resolveRequest(monitorCall[0].requestId, { state: { id: "wt-a" } });
+      await ownedPromise;
+    });
+
+    describe("readiness gate", () => {
+      beforeEach(() => {
+        vi.useFakeTimers();
+      });
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      // Long enough that any spawn-facing deadline has elapsed, short enough to
+      // prove the gate is not riding the 5s hydration bound. Asserts behavior,
+      // not the constant.
+      const SPAWN_OBSERVATION_WINDOW_MS = 2_000;
+
+      it("gives up as unknown when the host never becomes ready, and never reads its partial map", async () => {
+        const load = client.loadProject("/project-a", 1);
+        void load.catch(() => {});
+        expect(mockHosts).toHaveLength(1);
+
+        let settled: any = "pending";
+        void client
+          .isWorktreeOwnedByProject("wt-a", "/project-a", idFor("/project-a"))
+          .then((r) => {
+            settled = r;
+          });
+
+        await vi.advanceTimersByTimeAsync(0);
+        expect(settled).toBe("pending");
+
+        await vi.advanceTimersByTimeAsync(SPAWN_OBSERVATION_WINDOW_MS);
+
+        // Unknown, not a mismatch — a spawn must not lose its worktree stamp
+        // just because the host was still warming up (#11131, #11235).
+        expect(settled).toBeNull();
+        expect(monitorReqs(0)).toHaveLength(0);
+      });
+
+      it("leaves no readiness timer behind once it settles", async () => {
+        // `readyAndResolveLoad` awaits a real setTimeout, which never fires
+        // under fake timers — drive the load through the fake clock instead.
+        const loadA = client.loadProject("/project-a", 1);
+        h(0).simulateReady();
+        await vi.advanceTimersByTimeAsync(0);
+        h(0).resolveRequest(h(0).getLastRequest()!.requestId);
+        await loadA;
+
+        const ownedPromise = client.isWorktreeOwnedByProject(
+          "wt-a",
+          "/project-a",
+          idFor("/project-a")
+        );
+        await vi.advanceTimersByTimeAsync(0);
+        h(0).resolveRequest(monitorReqs(0)[0].requestId, { state: { id: "wt-a" } });
+        expect(await ownedPromise).toBe(true);
+
+        // The gate's timeout must be cleared on the success path, not left to
+        // fire against an already-settled race.
+        expect(vi.getTimerCount()).toBe(0);
+      });
+    });
+  });
+
   describe("singleflight cache", () => {
     beforeEach(() => {
       vi.useFakeTimers();

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -39,12 +39,16 @@ const { mockHosts, MockWorkspaceHostProcess } = vi.hoisted(() => {
 
     send = vi.fn(() => true);
 
-    sendWithResponse = vi.fn(<T>(request: { requestId: string; type: string }): Promise<T> => {
-      return new Promise<T>((resolve, reject) => {
-        this.responseHandlers.set(request.requestId, resolve);
-        this.responseRejects.set(request.requestId, reject);
-      });
-    });
+    // `timeoutMs` mirrors the real WorkspaceHostProcess signature so callers
+    // that scope a request's budget can be asserted on.
+    sendWithResponse = vi.fn(
+      <T>(request: { requestId: string; type: string }, _timeoutMs?: number): Promise<T> => {
+        return new Promise<T>((resolve, reject) => {
+          this.responseHandlers.set(request.requestId, resolve);
+          this.responseRejects.set(request.requestId, reject);
+        });
+      }
+    );
 
     pauseHealthCheck = vi.fn();
     resumeHealthCheck = vi.fn();
@@ -865,11 +869,16 @@ describe("WorkspaceClient multi-process manager", () => {
       expect(await ownedPromise).toBe(true);
     });
 
-    // The disowning that makes the whole check worth doing.
-    it("returns false when a ready host completes the lookup with no such monitor", async () => {
+    // The disowning that makes the whole check worth doing — and it takes
+    // corroboration: A disclaims the id AND B positively claims it.
+    it("returns false when the named project disclaims an id another project claims", async () => {
       const loadA = client.loadProject("/project-a", 1);
       await readyAndResolveLoad(0);
       await loadA;
+
+      const loadB = client.loadProject("/project-b", 2);
+      await readyAndResolveLoad(1);
+      await loadB;
 
       const ownedPromise = client.isWorktreeOwnedByProject(
         "wt-belonging-to-b",
@@ -878,10 +887,60 @@ describe("WorkspaceClient multi-process manager", () => {
       );
       await tick();
       h(0).resolveRequest(monitorReqs(0)[0].requestId, { state: null });
+      await tick();
+      h(1).resolveRequest(monitorReqs(1)[0].requestId, {
+        state: { id: "wt-belonging-to-b" },
+      });
 
       expect(await ownedPromise).toBe(false);
     });
 
+    // The heart of the soundness argument: creation spells a worktree id with
+    // `realpath` while enumeration spells it with `pathResolve`, so a project
+    // can genuinely own a worktree whose id is missing from its map. Nobody
+    // else claiming it means the spelling diverged, not that it was stolen.
+    it("returns unknown, not false, when the id is simply unclaimed everywhere", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const loadB = client.loadProject("/project-b", 2);
+      await readyAndResolveLoad(1);
+      await loadB;
+
+      const ownedPromise = client.isWorktreeOwnedByProject(
+        "/symlinked/spelling/of/wt-a",
+        "/project-a",
+        idFor("/project-a")
+      );
+      await tick();
+      h(0).resolveRequest(monitorReqs(0)[0].requestId, { state: null });
+      await tick();
+      h(1).resolveRequest(monitorReqs(1)[0].requestId, { state: null });
+
+      expect(await ownedPromise).toBeNull();
+    });
+
+    // With nothing to corroborate against, a disclaim cannot become a verdict.
+    it("returns unknown when the named project is the only one loaded", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const ownedPromise = client.isWorktreeOwnedByProject(
+        "wt-unknown",
+        "/project-a",
+        idFor("/project-a")
+      );
+      await tick();
+      h(0).resolveRequest(monitorReqs(0)[0].requestId, { state: null });
+
+      expect(await ownedPromise).toBeNull();
+    });
+
+    // Asks about the SECOND-loaded project on purpose: querying about the
+    // first would also pass for an implementation that just takes whichever
+    // host happens to be first in the pool.
     it("asks only the named project's host, never the others", async () => {
       const loadA = client.loadProject("/project-a", 1);
       await readyAndResolveLoad(0);
@@ -893,14 +952,15 @@ describe("WorkspaceClient multi-process manager", () => {
 
       const ownedPromise = client.isWorktreeOwnedByProject(
         "wt-b",
-        "/project-a",
-        idFor("/project-a")
+        "/project-b",
+        idFor("/project-b")
       );
       await tick();
 
-      expect(monitorReqs(1)).toHaveLength(0);
-      h(0).resolveRequest(monitorReqs(0)[0].requestId, { state: null });
-      expect(await ownedPromise).toBe(false);
+      expect(monitorReqs(0)).toHaveLength(0);
+      expect(monitorReqs(1)).toHaveLength(1);
+      h(1).resolveRequest(monitorReqs(1)[0].requestId, { state: { id: "wt-b" } });
+      expect(await ownedPromise).toBe(true);
     });
 
     it("returns unknown for a path no host is loaded for, without contacting any host", async () => {
@@ -953,6 +1013,42 @@ describe("WorkspaceClient multi-process manager", () => {
       expect(await ownedPromise).toBeNull();
     });
 
+    // Only an explicit `state: null` is a disowning. A reply that merely lacks
+    // the field never reached that conclusion, so collapsing the two (`!state`
+    // instead of `=== null`) would manufacture proof out of a malformed
+    // response.
+    it("returns unknown for an absent state rather than treating it as a disowning", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const ownedPromise = client.isWorktreeOwnedByProject(
+        "wt-a",
+        "/project-a",
+        idFor("/project-a")
+      );
+      await tick();
+      h(0).resolveRequest(monitorReqs(0)[0].requestId, { state: undefined });
+
+      expect(await ownedPromise).toBeNull();
+    });
+
+    it("returns unknown for a reply with no state field at all", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const ownedPromise = client.isWorktreeOwnedByProject(
+        "wt-a",
+        "/project-a",
+        idFor("/project-a")
+      );
+      await tick();
+      h(0).resolveRequest(monitorReqs(0)[0].requestId, {});
+
+      expect(await ownedPromise).toBeNull();
+    });
+
     // A reply about a different worktree answers a question we didn't ask —
     // neither a confirmation nor an accusation.
     it("returns unknown when the host answers about a different worktree", async () => {
@@ -988,7 +1084,9 @@ describe("WorkspaceClient multi-process manager", () => {
       const monitorCall = h(0).sendWithResponse.mock.calls.find(
         ([req]: any) => req.type === "get-monitor"
       )!;
-      const timeoutMs = monitorCall[1];
+      // `?? 0` so a budget that was never passed at all fails the lower bound
+      // rather than blowing up the comparison.
+      const timeoutMs = monitorCall[1] ?? 0;
       expect(timeoutMs).toBeGreaterThan(0);
       expect(timeoutMs).toBeLessThan(1_000);
 
@@ -1030,6 +1128,54 @@ describe("WorkspaceClient multi-process manager", () => {
         // just because the host was still warming up (#11131, #11235).
         expect(settled).toBeNull();
         expect(monitorReqs(0)).toHaveLength(0);
+      });
+
+      // The budget is one deadline shared by the readiness gate and the round
+      // trip, not one each — time spent waiting for readiness must come out of
+      // what the request gets, or a warming host could cost double.
+      it("charges time spent waiting for readiness against the request's budget", async () => {
+        const loadA = client.loadProject("/project-a", 1);
+        h(0).simulateReady();
+        await vi.advanceTimersByTimeAsync(0);
+        h(0).resolveRequest(h(0).getLastRequest()!.requestId);
+        await loadA;
+
+        // Baseline: a check against an already-ready host spends nothing on the
+        // gate, so the request gets essentially the whole budget.
+        const baselinePromise = client.isWorktreeOwnedByProject(
+          "wt-a",
+          "/project-a",
+          idFor("/project-a")
+        );
+        await vi.advanceTimersByTimeAsync(0);
+        const baselineCall = h(0).sendWithResponse.mock.calls.find(
+          ([req]: any) => req.type === "get-monitor"
+        )!;
+        h(0).resolveRequest(baselineCall[0].requestId, { state: { id: "wt-a" } });
+        await baselinePromise;
+
+        // Now restart the host so the next check has to wait on readiness, and
+        // burn part of the budget before the gate opens.
+        h(0).emit("restarted");
+        await vi.advanceTimersByTimeAsync(0);
+        const reloadReq = h(0).getLastRequest()!;
+
+        const delayedPromise = client.isWorktreeOwnedByProject(
+          "wt-a",
+          "/project-a",
+          idFor("/project-a")
+        );
+        await vi.advanceTimersByTimeAsync(50);
+        h(0).resolveRequest(reloadReq.requestId);
+        await vi.advanceTimersByTimeAsync(0);
+
+        const delayedCall = h(0)
+          .sendWithResponse.mock.calls.filter(([req]: any) => req.type === "get-monitor")
+          .at(-1)!;
+        expect(delayedCall[1] ?? 0).toBeLessThan(baselineCall[1] ?? 0);
+
+        h(0).resolveRequest(delayedCall[0].requestId, { state: { id: "wt-a" } });
+        await delayedPromise;
       });
 
       it("leaves no readiness timer behind once it settles", async () => {

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -1015,12 +1015,21 @@ describe("WorkspaceClient multi-process manager", () => {
 
     // Only an explicit `state: null` is a disowning. A reply that merely lacks
     // the field never reached that conclusion, so collapsing the two (`!state`
-    // instead of `=== null`) would manufacture proof out of a malformed
-    // response.
-    it("returns unknown for an absent state rather than treating it as a disowning", async () => {
+    // instead of `=== null`) would let a malformed response supply half of a
+    // `false` verdict. Project B is loaded and DOES claim the id, so a
+    // conflating implementation would return false here — without a
+    // corroborator both paths return null and the test proves nothing.
+    it.each([
+      ["a state field explicitly set to undefined", { state: undefined }],
+      ["a reply with no state field at all", {}],
+    ])("returns unknown, not false, for %s", async (_label, reply) => {
       const loadA = client.loadProject("/project-a", 1);
       await readyAndResolveLoad(0);
       await loadA;
+
+      const loadB = client.loadProject("/project-b", 2);
+      await readyAndResolveLoad(1);
+      await loadB;
 
       const ownedPromise = client.isWorktreeOwnedByProject(
         "wt-a",
@@ -1028,23 +1037,11 @@ describe("WorkspaceClient multi-process manager", () => {
         idFor("/project-a")
       );
       await tick();
-      h(0).resolveRequest(monitorReqs(0)[0].requestId, { state: undefined });
-
-      expect(await ownedPromise).toBeNull();
-    });
-
-    it("returns unknown for a reply with no state field at all", async () => {
-      const loadA = client.loadProject("/project-a", 1);
-      await readyAndResolveLoad(0);
-      await loadA;
-
-      const ownedPromise = client.isWorktreeOwnedByProject(
-        "wt-a",
-        "/project-a",
-        idFor("/project-a")
-      );
+      h(0).resolveRequest(monitorReqs(0)[0].requestId, reply);
       await tick();
-      h(0).resolveRequest(monitorReqs(0)[0].requestId, {});
+      if (monitorReqs(1).length > 0) {
+        h(1).resolveRequest(monitorReqs(1)[0].requestId, { state: { id: "wt-a" } });
+      }
 
       expect(await ownedPromise).toBeNull();
     });


### PR DESCRIPTION
## Summary

- `handleTerminalSpawn` forwarded a caller-supplied `worktreeId` into `ptyClient.spawn` without checking it belonged to the `projectId` stamped beside it. That pair is journaled into agent session history (`agentSessionHistory.ts` groups by `worktreeId` and filters by both), so a mismatched pair could put one project's worktree into another project's resumable-session list, and let a worktree-scoped `clearAgentSessions` call reach across the project boundary.
- The original issue ruled out a blanket "cwd must sit under `project.path`" rule, since that breaks scratch workspaces, linked worktrees living outside the repo directory, `defaultWorkingDirectory`, and projectless home-directory fallbacks.
- Added `WorkspaceClient.isWorktreeOwnedByProject(worktreeId, projectPath, expectedProjectId)`, a tri-state `Promise<boolean | null>` check, and wired `handleTerminalSpawn` to drop an unverifiable `worktreeId` rather than reject the spawn.

Resolves #11653

## Changes

- New `WorkspaceClient.isWorktreeOwnedByProject` is scoped to the named project's host and resolves membership using the host's immutable `projectId`, not the project's (mutable) path, the same rule `getAllStatesForProjectAsync` already enforces.
- `handleTerminalSpawn` now drops an unverifiable `worktreeId` instead of rejecting the spawn. The terminal still starts, at the requested cwd, under the workspace id it claimed; only the unverifiable stamp goes.
- Absence isn't proof, so a `false` verdict needs corroboration. Worktree ids are paths, but the two places that mint one disagree on spelling: creation stores `realpath(path)`, enumeration stores `pathResolve(wt.path)` off `git worktree list --porcelain`. Those diverge across a symlink, and porcelain paths are relative (and documented as untrustworthy) under Git 2.48+ with `worktree.useRelativePaths`. So a host can genuinely own a worktree whose id, as spelled by the caller, is missing from its map. A `false` therefore requires the named project's ready host to disclaim the id AND another loaded project's host to positively claim it. A positive claim is sound regardless of spelling, since the claimant is what spelled it. The fan-out only runs after a disclaim and stays parallel, so the common case is one round trip.
- A `null` (unknown) result forwards the `worktreeId` unchanged: no host, host not ready, timeout, nothing to corroborate against, or no workspace client wired up. Cold and evicted hosts are normal, and failing closed here would deterministically erase valid resume metadata. This follows precedent already in the codebase: #11131 established rejecting only a proven mismatch, and #11235 established that an unknown result is never ground truth.
- Validates the pair actually stamped on the request, not just the pair spelled out by the caller: a request carrying only a `worktreeId` still gets the current project stamped beside it, so that derived pairing gets checked too.
- Deliberately doesn't short-circuit on a project row's `gitBacked: false`. Tempting, since a folder opened without git owns no worktrees, but that flag isn't authoritative: the workspace host probes the folder on load, and the row only gets promoted when the project is re-added, so an external `git init` leaves a stale `false` beside a host serving genuine ids.
- Bounded at 200ms end to end, shared across the readiness gate and every round trip so wait times can't compound, measured with `performance.now()`. Matches the existing budget on `resolveBranchForMain`, the other best-effort `WorkspaceClient` lookup on a terminal's critical path.
- Doesn't contradict #5139 ("worktreeId is renderer-owned"): the renderer still chooses the target, main just verifies a claim before trusting it into persisted state, consistent with #5182, which made `worktreeId` backend-durable resume metadata.

## Known limits

- Corroboration proves membership in the claimant, not absence from the named project. Those come apart when one repository is registered as two projects rooted at different linked worktrees: both hosts enumerate the same shared worktree set, so a spelling divergence that hides an id from one but not the other yields a `false` for a worktree both legitimately contain. Closing it would need canonicalized path comparison (`realpath` per candidate during spawn), which was rejected because `realpath` can block indefinitely against an unreachable network mount. The cost is a terminal with no resume metadata, the same cost as the `null` path it would otherwise take, never a wrong or failed spawn.
- Separately, when no project resolves at all, `PtyClient` can still substitute its own cached `activeProjectId` (`PtyClient.ts:1425`), which isn't cleared when the current project closes (`crud.ts:333`). A worktree-only spawn can end up persisted beside that stale id. That's a pre-existing defect in a different subsystem, the fix being to clear `activeProjectId` on project close, and it's left out of scope here.

## Testing

284 tests pass across `electron/ipc/handlers/terminal/__tests__/` and all five `WorkspaceClient.*` suites. Project-wide `npm run typecheck` is clean. Prettier and eslint are clean on the four changed files (four pre-existing `preserve-caught-error` warnings in `lifecycle.ts` are untouched, already present on `develop`, and sit in the eslint ratchet baseline).

New coverage: handler disposition (confirmed, proven-mismatch, unknown, rejected-lookup, no-service, derived-pair, blank-projectId, scratch-id, no-worktreeId), confirming the verdict is awaited before the spawn happens, and `WorkspaceClient` host routing, corroboration, malformed replies, immutable-id mismatch handling, readiness give-up behavior, shared-budget arithmetic, and timer cleanup.