### PR TITLE
fix(hydration): give the legacy global workspace record a single owner

### DIFF
--- a/electron/ipc/__tests__/app.state.test.ts
+++ b/electron/ipc/__tests__/app.state.test.ts
@@ -20,21 +20,25 @@ vi.mock("electron", () => ({
 
 // Mutable so a test can vary the legacy global app state without replacing the
 // `store.get` implementation, which `clearAllMocks` would not restore.
-const { globalAppStateRef, defaultStoreGet } = vi.hoisted(() => {
+const { globalAppStateRef, legacyOwnerRef, defaultStoreGet } = vi.hoisted(() => {
   const globalAppStateRef = {
     current: { terminals: [], sidebarWidth: 350 } as Record<string, unknown>,
   };
+  // Which workspace, if any, has already claimed the legacy global record.
+  // `undefined` is the unclaimed state a fresh store reads back (#11651).
+  const legacyOwnerRef = { current: undefined as string | undefined };
   // Named so `beforeEach` can reinstate it. Several tests below still swap in
   // their own `store.get` implementation; without a reset every test declared
   // after them would silently read that hard-coded state instead of the ref,
   // which is exactly the trap the comment above warns about.
   const defaultStoreGet = (key: string): unknown => {
     if (key === "appState") return globalAppStateRef.current;
+    if (key === "legacyWorkspaceStateOwnerId") return legacyOwnerRef.current;
     if (key === "terminalConfig") return { resourceMonitoringEnabled: false };
     if (key === "agentSettings") return {};
     return undefined;
   };
-  return { globalAppStateRef, defaultStoreGet };
+  return { globalAppStateRef, legacyOwnerRef, defaultStoreGet };
 });
 
 const DEFAULT_GLOBAL_APP_STATE = { terminals: [], sidebarWidth: 350 };
@@ -359,6 +363,7 @@ describe("app:boot handler", () => {
     // swapped-in implementation in place, so without this every test after the
     // first swap reads that test's hard-coded app state instead of the ref.
     globalAppStateRef.current = { ...DEFAULT_GLOBAL_APP_STATE };
+    legacyOwnerRef.current = undefined;
     const storeModule = await import("../../store.js");
     vi.mocked(storeModule.store.get).mockImplementation(
       defaultStoreGet as typeof storeModule.store.get
@@ -886,10 +891,12 @@ describe("app:boot handler", () => {
     // Both unmigrated branches persist the legacy focus/worktree values to
     // per-project state but never assign the payload locals, so the payload
     // depends entirely on the initial seed. Gating that seed on anything
-    // broader than "has a Project row" would silently drop the user's worktree
-    // on the very boot that was supposed to carry it forward. (The MRU is not
-    // part of these updaters — it stays on the legacy global until the renderer
-    // next writes it — so only the payload half is asserted for `mruList`.)
+    // narrower than "the workspace that owns the legacy record" would silently
+    // drop the user's worktree on the very boot that was supposed to carry it
+    // forward. (The MRU is not part of these updaters — it stays on the legacy
+    // global until the renderer next writes it — so only the payload half is
+    // asserted for `mruList`.) The record starts unclaimed here, so this is
+    // also the case that proves the first real project becomes its heir.
     it.each([
       [
         "with legacy terminals to migrate",
@@ -907,6 +914,7 @@ describe("app:boot handler", () => {
         quarantinedPath: undefined,
       });
 
+      const storeModule = await import("../../store.js");
       const result = await invokeBoot({ deps: realProjectDeps(), senderId: 42 });
       const appState = result.appState as Record<string, unknown>;
 
@@ -915,6 +923,13 @@ describe("app:boot handler", () => {
       expect(appState.focusPanelState).toEqual(LEGACY_WORKSPACE_STATE.focusPanelState);
       expect(appState.activeWorktreeId).toBe(LEGACY_WORKSPACE_STATE.activeWorktreeId);
       expect(appState.mruList).toEqual(LEGACY_WORKSPACE_STATE.mruList);
+      // Claiming the record is what locks every later project row out of it.
+      // Without this write the next brand-new project reads the same unclaimed
+      // record and inherits the same panels all over again (#11651).
+      expect(storeModule.store.set).toHaveBeenCalledWith(
+        "legacyWorkspaceStateOwnerId",
+        REAL_PROJECT.id
+      );
       // The same values must land in the per-project record, or the next boot
       // reads an empty one and the migration is lost.
       const migrated = (await runEnqueuedUpdate())!;
@@ -979,6 +994,123 @@ describe("app:boot handler", () => {
       const result = await invokeBoot({ deps: realProjectDeps(), senderId: 42 });
 
       expect((result.appState as Record<string, unknown>).mruList).toEqual([]);
+    });
+
+    // The legacy record has exactly one heir. Nothing used to consume it, so
+    // every project row that had not saved terminals yet re-read the same list
+    // and was seeded with another project's panels — `cwd` and `worktreeId`
+    // included — before the renderer finished restoring (#11651).
+    describe("a project row that never owned the legacy record (#11651)", () => {
+      const OTHER_OWNER = "proj-first-heir";
+      const LEGACY_TERMINALS = [
+        { id: "legacy-panel", title: "Legacy", location: "grid", cwd: "/projects/first-heir" },
+      ];
+
+      beforeEach(() => {
+        legacyOwnerRef.current = OTHER_OWNER;
+        globalAppStateRef.current = {
+          ...DEFAULT_GLOBAL_APP_STATE,
+          ...LEGACY_WORKSPACE_STATE,
+          panelGridConfig: GLOBAL_PANEL_GRID_CONFIG,
+          terminals: LEGACY_TERMINALS,
+        };
+      });
+
+      it("inherits none of it and writes a clean per-project record", async () => {
+        vi.mocked(projectStore.getProjectStateWithRecovery).mockResolvedValue({
+          state: null,
+          quarantinedPath: undefined,
+        });
+
+        const result = await invokeBoot({ deps: realProjectDeps(), senderId: 42 });
+        const appState = result.appState as Record<string, unknown>;
+
+        // Not one of the four workspace-owned fields, and above all not the
+        // foreign panel — its `cwd` points at the heir's directory.
+        expect(appState.terminals).toEqual([]);
+        expect(appState.activeWorktreeId).toBeUndefined();
+        expect(appState.focusMode).toBe(false);
+        expect(appState.focusPanelState).toBeUndefined();
+        expect(appState.mruList).toBeUndefined();
+        // Genuinely app-global settings are untouched by the ownership gate.
+        expect(appState.panelGridConfig).toEqual(GLOBAL_PANEL_GRID_CONFIG);
+
+        // The disk write is the half that outlives the boot: a payload-only fix
+        // would still leave the foreign worktree persisted for the next launch.
+        const written = (await runEnqueuedUpdate())!;
+        expect(written.projectId).toBe(REAL_PROJECT.id);
+        expect(written.terminals).toEqual([]);
+        expect(written.activeWorktreeId).toBeUndefined();
+        expect(written.focusMode).toBeUndefined();
+        expect(written.focusPanelState).toBeUndefined();
+      });
+
+      it("leaves the existing claim alone instead of stealing the record", async () => {
+        vi.mocked(projectStore.getProjectStateWithRecovery).mockResolvedValue({
+          state: null,
+          quarantinedPath: undefined,
+        });
+        const storeModule = await import("../../store.js");
+
+        await invokeBoot({ deps: realProjectDeps(), senderId: 42 });
+
+        // Re-stamping would hand the record to whichever project booted last,
+        // which is the same "no owner identity" hole in a different shape.
+        expect(storeModule.store.set).not.toHaveBeenCalledWith(
+          "legacyWorkspaceStateOwnerId",
+          expect.anything()
+        );
+      });
+
+      it("keeps its own saved panels when crash recovery restores the heir's list", async () => {
+        // A pending panel filter makes the global list outrank saved per-project
+        // terminals. Ungated, that path overwrote an unrelated project's panels
+        // with the heir's — the same leak, reached through crash recovery.
+        crashService.consumePanelFilter.mockReturnValue(["own-panel"] as unknown as null);
+        vi.mocked(projectStore.getProjectStateWithRecovery).mockResolvedValue({
+          state: {
+            projectId: REAL_PROJECT.id,
+            sidebarWidth: 350,
+            terminals: [
+              { id: "own-panel", title: "Own", location: "grid", cwd: REAL_PROJECT.path },
+            ],
+          },
+        } as unknown as Awaited<ReturnType<typeof projectStore.getProjectStateWithRecovery>>);
+
+        const result = await invokeBoot({ deps: realProjectDeps(), senderId: 42 });
+        const terminals = (result.appState as Record<string, unknown>).terminals as Array<
+          Record<string, unknown>
+        >;
+
+        expect(terminals.map((t) => t.id)).toEqual(["own-panel"]);
+        expect(terminals.map((t) => t.cwd)).toEqual([REAL_PROJECT.path]);
+      });
+    });
+
+    it("still migrates for the heir on a later boot, so a discarded crash boot loses nothing", async () => {
+      // `app:boot` runs the migration, but the renderer drops that payload when
+      // a crash is pending and hydrates again. Claiming is a stamp, not a
+      // destructive consume, so the heir re-reads the record it already owns.
+      legacyOwnerRef.current = REAL_PROJECT.id;
+      globalAppStateRef.current = {
+        ...DEFAULT_GLOBAL_APP_STATE,
+        ...LEGACY_WORKSPACE_STATE,
+        terminals: [{ id: "legacy-panel", title: "Legacy", location: "grid", cwd: "/old/project" }],
+      };
+      vi.mocked(projectStore.getProjectStateWithRecovery).mockResolvedValue({
+        state: null,
+        quarantinedPath: undefined,
+      });
+
+      const result = await invokeBoot({ deps: realProjectDeps(), senderId: 42 });
+      const appState = result.appState as Record<string, unknown>;
+
+      expect((appState.terminals as Array<Record<string, unknown>>).map((t) => t.id)).toEqual([
+        "legacy-panel",
+      ]);
+      expect(appState.activeWorktreeId).toBe(LEGACY_WORKSPACE_STATE.activeWorktreeId);
+      const migrated = (await runEnqueuedUpdate())!;
+      expect(migrated.terminals.map((t) => t.id)).toEqual(["legacy-panel"]);
     });
   });
 

--- a/electron/ipc/__tests__/app.state.test.ts
+++ b/electron/ipc/__tests__/app.state.test.ts
@@ -81,6 +81,7 @@ vi.mock("../../store.js", () => ({
 const crashService = {
   scheduleBackup: vi.fn(),
   consumePanelFilter: vi.fn(() => null),
+  hasPendingPanelFilter: vi.fn(() => false),
   startBackupTimer: vi.fn(),
   resetToFresh: vi.fn(),
   restoreBackup: vi.fn(() => false),
@@ -726,10 +727,15 @@ describe("app:boot handler", () => {
       name: "P",
       path: "/p",
     } as unknown as ReturnType<typeof projectStoreModule.projectStore.getCurrentProject>);
+    // The cache is only eligible once the legacy record has an owner — without
+    // this the hydrate silently takes the slow path and stops testing the
+    // cache-hit path this case is named for (#11651).
+    legacyOwnerRef.current = "p1";
 
     const result = (await invokeBoot()) as Record<string, unknown>;
 
     expect(result.databaseRecovery).toEqual(recovery);
+    expect(consumePrefetchedHydrateResult).toHaveBeenCalledWith("p1");
   });
 
   it("hydrates the project bound to the sending project view instead of the stale global current project", async () => {
@@ -1184,8 +1190,42 @@ describe("app:boot handler", () => {
       } as unknown as HandlerDependencies;
 
       await invokeBoot({ deps: scratchDeps, senderId: 42 });
-
       expect(legacyOwnerRef.current).toBeUndefined();
+
+      // The record must still be there for the first real project — asserting
+      // only "the scratch wrote nothing" would also hold for an implementation
+      // that never wrote an owner at all.
+      const result = await invokeBoot({ deps: realProjectDeps(), senderId: 42 });
+      expect(legacyOwnerRef.current).toBe(REAL_PROJECT.id);
+      expect(
+        (
+          (result.appState as Record<string, unknown>).terminals as Array<Record<string, unknown>>
+        ).map((t) => t.id)
+      ).toEqual(["legacy-panel"]);
+    });
+
+    it("holds the crash panel filter for its owner instead of eating it", async () => {
+      // The filter is a one-shot keyed to the owner's panels. A non-owner that
+      // consumed it would leave the owner's next hydrate with nothing to filter
+      // by, silently restoring the panels the user had just deselected.
+      legacyOwnerRef.current = "proj-first-heir";
+      globalAppStateRef.current = {
+        ...DEFAULT_GLOBAL_APP_STATE,
+        terminals: [{ id: "legacy-panel", title: "Legacy", location: "grid", cwd: "/old/project" }],
+      };
+      crashService.consumePanelFilter.mockReturnValue(["legacy-panel"] as unknown as null);
+      crashService.hasPendingPanelFilter.mockReturnValue(true);
+      vi.mocked(projectStore.getProjectStateWithRecovery).mockResolvedValue({
+        state: {
+          projectId: REAL_PROJECT.id,
+          sidebarWidth: 350,
+          terminals: [{ id: "own-panel", title: "Own", location: "grid", cwd: REAL_PROJECT.path }],
+        },
+      } as unknown as Awaited<ReturnType<typeof projectStore.getProjectStateWithRecovery>>);
+
+      await invokeBoot({ deps: realProjectDeps(), senderId: 42 });
+
+      expect(crashService.consumePanelFilter).not.toHaveBeenCalled();
     });
 
     it("keeps a cached payload out of play until the record has an owner", async () => {

--- a/electron/ipc/__tests__/app.state.test.ts
+++ b/electron/ipc/__tests__/app.state.test.ts
@@ -20,7 +20,7 @@ vi.mock("electron", () => ({
 
 // Mutable so a test can vary the legacy global app state without replacing the
 // `store.get` implementation, which `clearAllMocks` would not restore.
-const { globalAppStateRef, legacyOwnerRef, defaultStoreGet } = vi.hoisted(() => {
+const { globalAppStateRef, legacyOwnerRef, defaultStoreGet, defaultStoreSet } = vi.hoisted(() => {
   const globalAppStateRef = {
     current: { terminals: [], sidebarWidth: 350 } as Record<string, unknown>,
   };
@@ -38,7 +38,16 @@ const { globalAppStateRef, legacyOwnerRef, defaultStoreGet } = vi.hoisted(() => 
     if (key === "agentSettings") return {};
     return undefined;
   };
-  return { globalAppStateRef, legacyOwnerRef, defaultStoreGet };
+  // Stateful on purpose: the whole concurrency argument is that a claim written
+  // during one hydrate is visible to the next read with no await in between. A
+  // `set` that only records the call would let a two-hydrate test pass while
+  // the claim never actually took.
+  const defaultStoreSet = (key: string, value: unknown): void => {
+    if (key === "legacyWorkspaceStateOwnerId") {
+      legacyOwnerRef.current = typeof value === "string" ? value : undefined;
+    }
+  };
+  return { globalAppStateRef, legacyOwnerRef, defaultStoreGet, defaultStoreSet };
 });
 
 const DEFAULT_GLOBAL_APP_STATE = { terminals: [], sidebarWidth: 350 };
@@ -62,7 +71,7 @@ const GLOBAL_PANEL_GRID_CONFIG = { strategy: "fixed-columns", value: 2 };
 vi.mock("../../store.js", () => ({
   store: {
     get: vi.fn(defaultStoreGet),
-    set: vi.fn(),
+    set: vi.fn(defaultStoreSet),
     delete: vi.fn(),
   },
   consumePendingSettingsRecovery: vi.fn(() => null),
@@ -368,6 +377,9 @@ describe("app:boot handler", () => {
     vi.mocked(storeModule.store.get).mockImplementation(
       defaultStoreGet as typeof storeModule.store.get
     );
+    vi.mocked(storeModule.store.set).mockImplementation(
+      defaultStoreSet as typeof storeModule.store.set
+    );
     // Same reason: these two are swapped in by individual tests below and would
     // otherwise stay swapped for every test declared after them.
     panelSuspectLedger.getQuarantinedPanelIds.mockReturnValue(new Set());
@@ -652,13 +664,16 @@ describe("app:boot handler", () => {
     vi.mocked(consumePrefetchedHydrateResult).mockReturnValue(
       cachedResult as ReturnType<typeof consumePrefetchedHydrateResult>
     );
-    // Force the cache path by giving handleAppHydrate a current project.
+    // Force the cache path by giving handleAppHydrate a current project and an
+    // already-claimed legacy record — the cache is only eligible once the
+    // record has an owner, since the read-only builder can't claim one (#11651).
     const projectStoreModule = await import("../../services/ProjectStore.js");
     vi.mocked(projectStoreModule.projectStore.getCurrentProject).mockReturnValue({
       id: "p1",
       name: "P",
       path: "/p",
     } as unknown as ReturnType<typeof projectStoreModule.projectStore.getCurrentProject>);
+    legacyOwnerRef.current = "p1";
 
     const result = (await invokeBoot()) as Record<string, unknown>;
     expect(result.terminalConfig).toEqual(cachedResult.terminalConfig);
@@ -1025,18 +1040,17 @@ describe("app:boot handler", () => {
         const result = await invokeBoot({ deps: realProjectDeps(), senderId: 42 });
         const appState = result.appState as Record<string, unknown>;
 
-        // Not one of the four workspace-owned fields, and above all not the
-        // foreign panel — its `cwd` points at the heir's directory.
+        // Above all not the foreign panel — its `cwd` points at the heir's
+        // directory — and not the heir's quick-switcher history either.
         expect(appState.terminals).toEqual([]);
-        expect(appState.activeWorktreeId).toBeUndefined();
-        expect(appState.focusMode).toBe(false);
-        expect(appState.focusPanelState).toBeUndefined();
         expect(appState.mruList).toBeUndefined();
         // Genuinely app-global settings are untouched by the ownership gate.
         expect(appState.panelGridConfig).toEqual(GLOBAL_PANEL_GRID_CONFIG);
 
         // The disk write is the half that outlives the boot: a payload-only fix
         // would still leave the foreign worktree persisted for the next launch.
+        // The payload keeps serving the live globals (see the note in the
+        // handler), but nothing this workspace never owned reaches its record.
         const written = (await runEnqueuedUpdate())!;
         expect(written.projectId).toBe(REAL_PROJECT.id);
         expect(written.terminals).toEqual([]);
@@ -1056,17 +1070,26 @@ describe("app:boot handler", () => {
 
         // Re-stamping would hand the record to whichever project booted last,
         // which is the same "no owner identity" hole in a different shape.
-        expect(storeModule.store.set).not.toHaveBeenCalledWith(
-          "legacyWorkspaceStateOwnerId",
-          expect.anything()
-        );
+        // Filter by key rather than using `expect.anything()`, which does not
+        // match a `set(key, undefined)` — the exact shape a botched claim takes.
+        // Read through an untyped view for the same reason as the app:set-state
+        // tests below: vi.mocked resolves the single-argument set(object)
+        // overload, so `call[0]` types as the whole schema.
+        const setCalls = vi.mocked(storeModule.store.set).mock.calls as unknown as unknown[][];
+        expect(setCalls.filter((call) => call[0] === "legacyWorkspaceStateOwnerId")).toEqual([]);
+        // The record must still be read — an implementation that ignored the
+        // owner entirely would also write nothing and pass the assertion above.
+        expect(storeModule.store.get).toHaveBeenCalledWith("legacyWorkspaceStateOwnerId");
+        expect(legacyOwnerRef.current).toBe(OTHER_OWNER);
       });
 
       it("keeps its own saved panels when crash recovery restores the heir's list", async () => {
-        // A pending panel filter makes the global list outrank saved per-project
-        // terminals. Ungated, that path overwrote an unrelated project's panels
-        // with the heir's — the same leak, reached through crash recovery.
-        crashService.consumePanelFilter.mockReturnValue(["own-panel"] as unknown as null);
+        // The filter ids come from the crash snapshot, which captures only the
+        // global record — so they name the OWNER's panels, never this project's.
+        // Ungated, the global list outranked the saved per-project one and this
+        // project booted holding the owner's panel; scoping the filter to the
+        // list it actually describes leaves this project's own panels alone.
+        crashService.consumePanelFilter.mockReturnValue(["legacy-panel"] as unknown as null);
         vi.mocked(projectStore.getProjectStateWithRecovery).mockResolvedValue({
           state: {
             projectId: REAL_PROJECT.id,
@@ -1087,11 +1110,89 @@ describe("app:boot handler", () => {
       });
     });
 
-    it("still migrates for the heir on a later boot, so a discarded crash boot loses nothing", async () => {
+    it("claims once and keeps migrating for the heir across repeated hydrates", async () => {
       // `app:boot` runs the migration, but the renderer drops that payload when
       // a crash is pending and hydrates again. Claiming is a stamp, not a
-      // destructive consume, so the heir re-reads the record it already owns.
-      legacyOwnerRef.current = REAL_PROJECT.id;
+      // destructive consume, so the second pass must find the record it already
+      // owns and migrate again — without re-stamping.
+      globalAppStateRef.current = {
+        ...DEFAULT_GLOBAL_APP_STATE,
+        ...LEGACY_WORKSPACE_STATE,
+        terminals: [{ id: "legacy-panel", title: "Legacy", location: "grid", cwd: "/old/project" }],
+      };
+      vi.mocked(projectStore.getProjectStateWithRecovery).mockResolvedValue({
+        state: null,
+        quarantinedPath: undefined,
+      });
+      const storeModule = await import("../../store.js");
+      // Untyped view: vi.mocked resolves the single-argument set(object)
+      // overload, so the (key, value) form needs reading through `unknown[][]`.
+      const ownerWriteCount = () =>
+        (vi.mocked(storeModule.store.set).mock.calls as unknown as unknown[][]).filter(
+          (call) => call[0] === "legacyWorkspaceStateOwnerId"
+        ).length;
+
+      // First hydrate: the record is unclaimed, so this project becomes the heir.
+      await invokeBoot({ deps: realProjectDeps(), senderId: 42 });
+      expect(legacyOwnerRef.current).toBe(REAL_PROJECT.id);
+      expect(ownerWriteCount()).toBe(1);
+
+      // Second hydrate reads back the claim the first one persisted.
+      vi.mocked(projectStore.enqueueProjectStateUpdate).mockClear();
+      const result = await invokeBoot({ deps: realProjectDeps(), senderId: 42 });
+      const appState = result.appState as Record<string, unknown>;
+
+      expect((appState.terminals as Array<Record<string, unknown>>).map((t) => t.id)).toEqual([
+        "legacy-panel",
+      ]);
+      const migrated = (await runEnqueuedUpdate())!;
+      expect(migrated.terminals.map((t) => t.id)).toEqual(["legacy-panel"]);
+      // Still exactly one claim — the second pass recognised itself as the heir
+      // instead of stamping the record again.
+      expect(ownerWriteCount()).toBe(1);
+    });
+
+    it("does not let a scratch claim the record out from under the first real project", async () => {
+      // A scratch has a workspaceId but no Project row. Stamping the scratch's
+      // id would lock every real project out of a record none of them ever had
+      // a chance to inherit.
+      const SCRATCH_WORKSPACE_ID = "b3d1f2a4-5c6e-4a8b-9d0f-1e2a3b4c5d6e";
+      globalAppStateRef.current = {
+        ...DEFAULT_GLOBAL_APP_STATE,
+        ...LEGACY_WORKSPACE_STATE,
+        terminals: [{ id: "legacy-panel", title: "Legacy", location: "grid", cwd: "/old/project" }],
+      };
+      vi.mocked(projectStore.getProjectStateWithRecovery).mockResolvedValue({
+        state: null,
+        quarantinedPath: undefined,
+      });
+      vi.mocked(getWindowForWebContents).mockReturnValue({
+        id: 7,
+        isDestroyed: () => false,
+      } as unknown as Electron.BrowserWindow);
+      vi.mocked(projectStore.getProjectById).mockReturnValue(null);
+      const scratchPvm = {
+        getProjectIdForWebContents: vi.fn().mockReturnValue(SCRATCH_WORKSPACE_ID),
+      };
+      const scratchDeps = {
+        windowRegistry: {
+          getByWindowId: vi.fn().mockReturnValue({
+            services: { projectViewManager: scratchPvm },
+          }),
+        },
+        projectViewManager: scratchPvm,
+      } as unknown as HandlerDependencies;
+
+      await invokeBoot({ deps: scratchDeps, senderId: 42 });
+
+      expect(legacyOwnerRef.current).toBeUndefined();
+    });
+
+    it("keeps a cached payload out of play until the record has an owner", async () => {
+      // `buildSwitchHydrateResult` writes nothing, so it can neither claim the
+      // record nor migrate. Serving its cached payload before the first claim
+      // would let the rightful heir boot without claiming, leaving the record
+      // for the next brand-new project to take instead.
       globalAppStateRef.current = {
         ...DEFAULT_GLOBAL_APP_STATE,
         ...LEGACY_WORKSPACE_STATE,
@@ -1102,15 +1203,12 @@ describe("app:boot handler", () => {
         quarantinedPath: undefined,
       });
 
-      const result = await invokeBoot({ deps: realProjectDeps(), senderId: 42 });
-      const appState = result.appState as Record<string, unknown>;
+      await invokeBoot({ deps: realProjectDeps(), senderId: 42 });
 
-      expect((appState.terminals as Array<Record<string, unknown>>).map((t) => t.id)).toEqual([
-        "legacy-panel",
-      ]);
-      expect(appState.activeWorktreeId).toBe(LEGACY_WORKSPACE_STATE.activeWorktreeId);
-      const migrated = (await runEnqueuedUpdate())!;
-      expect(migrated.terminals.map((t) => t.id)).toEqual(["legacy-panel"]);
+      // The cache is return-and-delete, so probing it at all would consume an
+      // entry the migration path still needs.
+      expect(consumePrefetchedHydrateResult).not.toHaveBeenCalled();
+      expect(legacyOwnerRef.current).toBe(REAL_PROJECT.id);
     });
   });
 
@@ -1427,6 +1525,10 @@ describe("app:boot handler", () => {
         name: "P",
         path: "/p",
       } as unknown as ReturnType<typeof projectStore.getCurrentProject>);
+      // Steady state for every install past its first boot: the legacy record
+      // has an owner, so the cache is eligible. An unclaimed record makes it
+      // ineligible on purpose — covered separately (#11651).
+      legacyOwnerRef.current = "p1";
     };
 
     it("emits exactly one hit mark when the prefetch cache services the hydrate", async () => {

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -88,7 +88,22 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
     // cache is only probed when the result is actually usable.
     const cacheGuard = getCrashLoopGuard();
     const cacheInSafeMode = cacheGuard.isSafeMode();
-    const cacheEligible = Boolean(workspaceId) && panelFilter === null && !cacheInSafeMode;
+    // Until the legacy global record has an owner, the cache cannot stand in
+    // for this handler: `buildSwitchHydrateResult` performs no writes, so it
+    // neither claims the record nor runs the terminal migration. Serving its
+    // payload here would let the rightful heir boot without ever claiming, and
+    // the next brand-new project would claim and inherit instead (#11651).
+    // Reading one scalar key ahead of the fast path is cheap next to the
+    // `appState` parse the fast path exists to avoid, and it only ever bites
+    // before the first claim.
+    const storedOwnerId = store.get("legacyWorkspaceStateOwnerId");
+    const persistedLegacyOwnerId =
+      typeof storedOwnerId === "string" && storedOwnerId ? storedOwnerId : undefined;
+    const cacheEligible =
+      Boolean(workspaceId) &&
+      panelFilter === null &&
+      !cacheInSafeMode &&
+      persistedLegacyOwnerId !== undefined;
     const cached = cacheEligible ? consumePrefetchedHydrateResult(workspaceId!) : undefined;
     markPerformance(PERF_MARKS.APP_HYDRATE_PREFETCH, {
       hit: Boolean(cached),
@@ -101,7 +116,9 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
             ? "safe-mode"
             : panelFilter !== null
               ? "panel-filter"
-              : "miss",
+              : persistedLegacyOwnerId === undefined
+                ? "legacy-state-unclaimed"
+                : "miss",
     });
     if (cached) {
       return {
@@ -143,15 +160,17 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
     // a redundant full config.json parse on every cache hit.
     const globalAppState = store.get("appState");
 
-    // The legacy global terminals/focus/worktree/MRU fields predate
-    // per-workspace state and belong to whichever real project was open when
-    // they were written. A scratch (workspaceId set, no Project row) or an
-    // unresolvable sender must never adopt them (#11497) — but "has a Project
-    // row" was never ownership either. Nothing consumed the global record, so
-    // every project row that had not saved terminals yet re-inherited the same
-    // list, handing a brand-new project another project's panels and `cwd`s
-    // (#11651). The record now names its heir: the first real project to
-    // hydrate claims it, and only that workspace may read it afterwards.
+    // A scratch (workspaceId set, no Project row) or an unresolvable sender
+    // must never adopt another workspace's worktree, focus, or MRU (#11497).
+    const hasProjectRow = currentProject !== null;
+
+    // Having a Project row was never ownership, though. The legacy terminal
+    // list predates per-workspace state and belongs to whichever project was
+    // open when it was written, but nothing ever consumed it — so every project
+    // row that had not saved terminals yet re-inherited the same list, handing
+    // a brand-new project another project's panels, `cwd` and `worktreeId`
+    // included (#11651). The record now names its heir: the first real project
+    // to hydrate claims it, and only that workspace may read it afterwards.
     //
     // The claim is written synchronously here, between the `store.get` above
     // and the first `await` below, so two project views hydrating in the same
@@ -160,10 +179,8 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
     // on inheriting on every later hydrate, which is what keeps the migration
     // intact when `app:boot`'s payload is discarded behind a pending crash and
     // the renderer hydrates again.
-    const storedOwnerId = store.get("legacyWorkspaceStateOwnerId");
-    let legacyWorkspaceStateOwnerId =
-      typeof storedOwnerId === "string" && storedOwnerId ? storedOwnerId : undefined;
-    if (currentProject !== null && workspaceId && legacyWorkspaceStateOwnerId === undefined) {
+    let legacyWorkspaceStateOwnerId = persistedLegacyOwnerId;
+    if (hasProjectRow && workspaceId && legacyWorkspaceStateOwnerId === undefined) {
       legacyWorkspaceStateOwnerId = workspaceId;
       store.set("legacyWorkspaceStateOwnerId", workspaceId);
       console.log(
@@ -171,7 +188,7 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
       );
     }
     const canInheritLegacyWorkspaceState =
-      currentProject !== null && legacyWorkspaceStateOwnerId === workspaceId;
+      hasProjectRow && legacyWorkspaceStateOwnerId === workspaceId;
 
     // Crash recovery hands the restored panel set over on the global record, so
     // it outranks saved per-project terminals — but only for the heir. Without
@@ -188,19 +205,21 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
     let terminalsToUse: StoreSchema["appState"]["terminals"] = [];
     let terminalsSource = "none";
 
-    // Focus mode state to include in response
-    let focusModeToUse = canInheritLegacyWorkspaceState
-      ? (globalAppState.focusMode ?? false)
-      : false;
-    let focusPanelStateToUse = canInheritLegacyWorkspaceState
-      ? globalAppState.focusPanelState
-      : undefined;
-    // Active worktree state to include in response
-    let activeWorktreeIdToUse = canInheritLegacyWorkspaceState
-      ? globalAppState.activeWorktreeId
-      : undefined;
+    // Focus mode and the active worktree still ride the global record in normal
+    // use: the renderer persists both through `app:set-state`, which writes them
+    // app-globally (`worktreeStore.persistActiveWorktree`), and readers outside
+    // hydration — `AgentNotificationService.isFocusedOnWorktree`, the cold-paint
+    // skeleton — depend on that. So their seed stays on the #11497 gate. Denying
+    // them to a non-owner would not be narrowing a legacy leak, it would drop a
+    // project's own live selection on every boot. What ownership does gate is
+    // the persisted half below: no workspace writes another's values to disk.
+    let focusModeToUse = hasProjectRow ? (globalAppState.focusMode ?? false) : false;
+    let focusPanelStateToUse = hasProjectRow ? globalAppState.focusPanelState : undefined;
+    let activeWorktreeIdToUse = hasProjectRow ? globalAppState.activeWorktreeId : undefined;
     // Quick-switcher MRU: prefer per-project, fall back to the legacy global
-    // list so existing users keep their MRU on first open after upgrade.
+    // list so existing users keep their MRU on first open after upgrade. Unlike
+    // the two above, this one already has a per-workspace write path (#9922), so
+    // the global copy is genuinely legacy and only its heir may read it.
     let mruListToUse = canInheritLegacyWorkspaceState ? globalAppState.mruList : undefined;
     let projectStateQuarantinedPath: string | undefined;
     // Per-project layout state folded into the payload so the renderer skips
@@ -467,9 +486,21 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
       quarantinedPanels = ledger.getQuarantinedPanels();
     }
 
-    // Apply one-shot crash recovery panel filter if set
-    // Empty array means "no specific selection" (legacy/no-panels case) — skip filtering
-    if (panelFilter !== null && panelFilter.length > 0) {
+    // Apply one-shot crash recovery panel filter if set.
+    // Empty array means "no specific selection" (legacy/no-panels case) — skip filtering.
+    // The ids come from the crash snapshot, which captures only the global
+    // `appState` (`CrashRecoveryService.extractPanelSummaries`), so they name
+    // the panels of whichever workspace owns that record. Applying them to a
+    // list this workspace loaded from its own per-project state would filter
+    // out every panel and hand back an empty workspace (#11651). Only filter
+    // the list the ids actually describe. For a modern install the global list
+    // is empty, no summaries are offered, and the filter arrives empty — so
+    // this narrowing changes nothing there.
+    // Derived from the branch inputs rather than `terminalsSource`, which the
+    // safe-mode block above rewrites: `!workspaceId` is the no-project fallback,
+    // the other branch that reads the global list.
+    const terminalsCameFromCrashSnapshot = hasCrashRestoreTerminals || !workspaceId;
+    if (terminalsCameFromCrashSnapshot && panelFilter !== null && panelFilter.length > 0) {
       const filterSet = new Set(panelFilter);
       terminalsToUse = terminalsToUse.filter((t) => filterSet.has(t.id));
       console.log(

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -142,8 +142,44 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
     // HydrateResult already carries appState, so reading it earlier would pay
     // a redundant full config.json parse on every cache hit.
     const globalAppState = store.get("appState");
+
+    // The legacy global terminals/focus/worktree/MRU fields predate
+    // per-workspace state and belong to whichever real project was open when
+    // they were written. A scratch (workspaceId set, no Project row) or an
+    // unresolvable sender must never adopt them (#11497) — but "has a Project
+    // row" was never ownership either. Nothing consumed the global record, so
+    // every project row that had not saved terminals yet re-inherited the same
+    // list, handing a brand-new project another project's panels and `cwd`s
+    // (#11651). The record now names its heir: the first real project to
+    // hydrate claims it, and only that workspace may read it afterwards.
+    //
+    // The claim is written synchronously here, between the `store.get` above
+    // and the first `await` below, so two project views hydrating in the same
+    // tick cannot both observe an unclaimed record — the event loop cannot
+    // interleave them. It is a stamp, not a destructive consume: the heir goes
+    // on inheriting on every later hydrate, which is what keeps the migration
+    // intact when `app:boot`'s payload is discarded behind a pending crash and
+    // the renderer hydrates again.
+    const storedOwnerId = store.get("legacyWorkspaceStateOwnerId");
+    let legacyWorkspaceStateOwnerId =
+      typeof storedOwnerId === "string" && storedOwnerId ? storedOwnerId : undefined;
+    if (currentProject !== null && workspaceId && legacyWorkspaceStateOwnerId === undefined) {
+      legacyWorkspaceStateOwnerId = workspaceId;
+      store.set("legacyWorkspaceStateOwnerId", workspaceId);
+      console.log(
+        `[AppHydrate] Claimed the legacy global workspace state for ${currentProject.name}`
+      );
+    }
+    const canInheritLegacyWorkspaceState =
+      currentProject !== null && legacyWorkspaceStateOwnerId === workspaceId;
+
+    // Crash recovery hands the restored panel set over on the global record, so
+    // it outranks saved per-project terminals — but only for the heir. Without
+    // the ownership half, a crash restore would overwrite an unrelated
+    // project's own saved panels with the heir's list (#11651).
     const hasCrashRestoreTerminals =
       panelFilter !== null &&
+      canInheritLegacyWorkspaceState &&
       Array.isArray(globalAppState.terminals) &&
       globalAppState.terminals.length > 0;
 
@@ -151,14 +187,6 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
     // Fall back to global appState.terminals for migration
     let terminalsToUse: StoreSchema["appState"]["terminals"] = [];
     let terminalsSource = "none";
-
-    // The legacy global focus/worktree/MRU fields predate per-workspace state
-    // and belong to whichever real project was open when they were written.
-    // Only a project with a real row may inherit them as migration input — a
-    // scratch (workspaceId set, no Project row) or an unresolvable sender must
-    // never adopt another workspace's worktree, focus, or MRU (#11497). The
-    // rest of `globalAppState` stays intentionally app-global.
-    const canInheritLegacyWorkspaceState = currentProject !== null;
 
     // Focus mode state to include in response
     let focusModeToUse = canInheritLegacyWorkspaceState
@@ -242,11 +270,15 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
           );
         }
       } else if (
-        currentProject &&
+        canInheritLegacyWorkspaceState &&
         globalAppState.terminals &&
         globalAppState.terminals.length > 0
       ) {
-        // Migration: use global terminals and migrate them to per-project
+        // Migration: use global terminals and migrate them to per-project.
+        // Gated on ownership, not merely on having a Project row: the copied
+        // snapshots keep their original `cwd` and `worktreeId`, so a row that
+        // never left this record behind would be seeded with another project's
+        // panels pointing at a foreign directory (#11651).
         terminalsToUse = filterValidTerminalEntries(
           globalAppState.terminals,
           AppStateTerminalEntrySchema,
@@ -334,17 +366,25 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
             }
           : undefined;
 
-        // No per-project state and no global terminals - create fresh state with focus mode migration
+        // No per-project state and no global terminals to migrate — create
+        // fresh state. Only the heir folds the legacy workspace fields in;
+        // every other row starts clean, or the record it never owned would be
+        // written straight onto its first save (#11651). `sidebarWidth` is a
+        // genuinely app-global preference and rides along either way.
         await projectStore.enqueueProjectStateUpdate(
           workspaceId,
           (existing) =>
             existing ?? {
               projectId: workspaceId,
-              activeWorktreeId: globalAppState.activeWorktreeId,
+              activeWorktreeId: canInheritLegacyWorkspaceState
+                ? globalAppState.activeWorktreeId
+                : undefined,
               sidebarWidth: globalAppState.sidebarWidth ?? 350,
               terminals: [],
-              focusMode: globalAppState.focusMode,
-              focusPanelState: normalizedFocusPanelState,
+              focusMode: canInheritLegacyWorkspaceState ? globalAppState.focusMode : undefined,
+              focusPanelState: canInheritLegacyWorkspaceState
+                ? normalizedFocusPanelState
+                : undefined,
             }
         );
       }

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -77,31 +77,53 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
 
   const handleAppHydrate = async (ctx?: IpcContext) => {
     const { project: currentProject, workspaceId } = resolveWorkspaceForHydration(ctx);
-    const panelFilter = getCrashRecoveryService().consumePanelFilter();
+
+    // Until the legacy global record has an owner, the prefetch cache cannot
+    // stand in for this handler: `buildSwitchHydrateResult` performs no writes,
+    // so it neither claims the record nor runs the terminal migration. Serving
+    // its payload here would let the rightful heir boot without ever claiming,
+    // and the next brand-new project would claim and inherit instead (#11651).
+    // Read before the fast path so the check is available to it; this asks for
+    // one scalar rather than the whole `appState` object, though electron-store
+    // may still reparse `config.json` if an intervening write invalidated its
+    // snapshot.
+    const storedOwnerId = store.get("legacyWorkspaceStateOwnerId");
+    const persistedLegacyOwnerId =
+      typeof storedOwnerId === "string" && storedOwnerId ? storedOwnerId : undefined;
+
+    // The crash panel filter is a one-shot whose ids come from the snapshot's
+    // global panel list, so only the workspace that owns that record can act on
+    // it. Consuming it from a workspace that will discard it anyway would leave
+    // the owner's next hydrate with nothing and silently restore the panels the
+    // user just deselected — so peek first and only take it when usable.
+    // "Is, or is about to become, the owner" — an unclaimed record counts,
+    // because a real project reaching this point claims it a few lines below,
+    // and that first post-upgrade boot is exactly when a crash filter is most
+    // likely to be waiting.
+    const crashService = getCrashRecoveryService();
+    const canUseCrashPanelFilter =
+      !workspaceId ||
+      (currentProject !== null &&
+        (persistedLegacyOwnerId === undefined || persistedLegacyOwnerId === workspaceId));
+    const panelFilter = canUseCrashPanelFilter ? crashService.consumePanelFilter() : null;
+    const crashPanelFilterWithheld =
+      !canUseCrashPanelFilter && crashService.hasPendingPanelFilter();
 
     // Hover-prefetch fast path: when a project switcher hover (or any other
     // pre-populated path) has primed the cache for this project, short-circuit
     // the disk read. Only safe when there's no in-flight crash recovery filter
     // and we aren't booting in safe mode — those scenarios layer constraints
-    // (`panelFilter`, dropped terminals) that the prefetch built without.
+    // (`panelFilter`, dropped terminals) that the prefetch built without. A
+    // filter withheld for another workspace counts too: this boot is still part
+    // of a crash recovery, so the cached payload is just as unusable.
     // consumePrefetchedHydrateResult is destructive (return-and-delete), so the
     // cache is only probed when the result is actually usable.
     const cacheGuard = getCrashLoopGuard();
     const cacheInSafeMode = cacheGuard.isSafeMode();
-    // Until the legacy global record has an owner, the cache cannot stand in
-    // for this handler: `buildSwitchHydrateResult` performs no writes, so it
-    // neither claims the record nor runs the terminal migration. Serving its
-    // payload here would let the rightful heir boot without ever claiming, and
-    // the next brand-new project would claim and inherit instead (#11651).
-    // Reading one scalar key ahead of the fast path is cheap next to the
-    // `appState` parse the fast path exists to avoid, and it only ever bites
-    // before the first claim.
-    const storedOwnerId = store.get("legacyWorkspaceStateOwnerId");
-    const persistedLegacyOwnerId =
-      typeof storedOwnerId === "string" && storedOwnerId ? storedOwnerId : undefined;
     const cacheEligible =
       Boolean(workspaceId) &&
       panelFilter === null &&
+      !crashPanelFilterWithheld &&
       !cacheInSafeMode &&
       persistedLegacyOwnerId !== undefined;
     const cached = cacheEligible ? consumePrefetchedHydrateResult(workspaceId!) : undefined;
@@ -114,7 +136,7 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
           ? "no-project"
           : cacheInSafeMode
             ? "safe-mode"
-            : panelFilter !== null
+            : panelFilter !== null || crashPanelFilterWithheld
               ? "panel-filter"
               : persistedLegacyOwnerId === undefined
                 ? "legacy-state-unclaimed"
@@ -205,21 +227,28 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
     let terminalsToUse: StoreSchema["appState"]["terminals"] = [];
     let terminalsSource = "none";
 
-    // Focus mode and the active worktree still ride the global record in normal
-    // use: the renderer persists both through `app:set-state`, which writes them
-    // app-globally (`worktreeStore.persistActiveWorktree`), and readers outside
-    // hydration — `AgentNotificationService.isFocusedOnWorktree`, the cold-paint
-    // skeleton — depend on that. So their seed stays on the #11497 gate. Denying
-    // them to a non-owner would not be narrowing a legacy leak, it would drop a
-    // project's own live selection on every boot. What ownership does gate is
-    // the persisted half below: no workspace writes another's values to disk.
-    let focusModeToUse = hasProjectRow ? (globalAppState.focusMode ?? false) : false;
-    let focusPanelStateToUse = hasProjectRow ? globalAppState.focusPanelState : undefined;
+    // Focus mode and the quick-switcher MRU are genuinely legacy here: both
+    // have had a per-workspace write path for a while (`project:set-focus-mode`
+    // from `AppLayout`'s persist effect, #9922 for the MRU), and the global copy
+    // is only written on the no-workspace fallback. So only their heir may read
+    // them — handing project B the global `focusMode: true` would collapse B's
+    // sidebar on open and then persist A's focus state into B's own record.
+    //
+    // `activeWorktreeId` is the exception and stays on the #11497 row gate:
+    // `worktreeStore.persistActiveWorktree` still writes it app-globally for
+    // every workspace, and readers outside hydration
+    // (`AgentNotificationService.isFocusedOnWorktree`) depend on that. Until it
+    // has a per-workspace write path, denying it to a non-owner would not narrow
+    // a legacy leak — it would drop that project's own live selection on every
+    // boot. Ownership still gates the persisted half below, so no workspace
+    // writes another's worktree into its record.
+    let focusModeToUse = canInheritLegacyWorkspaceState
+      ? (globalAppState.focusMode ?? false)
+      : false;
+    let focusPanelStateToUse = canInheritLegacyWorkspaceState
+      ? globalAppState.focusPanelState
+      : undefined;
     let activeWorktreeIdToUse = hasProjectRow ? globalAppState.activeWorktreeId : undefined;
-    // Quick-switcher MRU: prefer per-project, fall back to the legacy global
-    // list so existing users keep their MRU on first open after upgrade. Unlike
-    // the two above, this one already has a per-workspace write path (#9922), so
-    // the global copy is genuinely legacy and only its heir may read it.
     let mruListToUse = canInheritLegacyWorkspaceState ? globalAppState.mruList : undefined;
     let projectStateQuarantinedPath: string | undefined;
     // Per-project layout state folded into the payload so the renderer skips

--- a/electron/services/AppHydrationService.ts
+++ b/electron/services/AppHydrationService.ts
@@ -44,19 +44,21 @@ export async function buildSwitchHydrateResult(projectId: string): Promise<Hydra
   // with no row — this keeps the leak from reappearing in that window (#11497).
   const hasProjectRow = currentProject !== null;
 
-  // Focus mode and the active worktree are still live app-global state that the
-  // renderer rewrites through `app:set-state`, so they stay on the row gate —
-  // see the matching note in `handleAppHydrate`. The MRU is different: it has
-  // had a per-workspace write path since #9922, so the global copy is genuinely
-  // legacy and only the workspace that left it behind may read it (#11651).
+  // Focus mode and the MRU both have per-workspace write paths, so their global
+  // copies are genuinely legacy and only the workspace that left them behind may
+  // read them; `activeWorktreeId` is still written app-globally for every
+  // workspace and stays on the row gate. The matching note in `handleAppHydrate`
+  // carries the full reasoning — the two paths must agree (#11651).
   // This path never claims — it performs no writes by design — so an unclaimed
   // record has no heir here, and `handleAppHydrate` settles ownership instead.
   const legacyWorkspaceStateOwnerId = store.get("legacyWorkspaceStateOwnerId");
   const canInheritLegacyWorkspaceState = hasProjectRow && legacyWorkspaceStateOwnerId === projectId;
 
   let terminalsToUse: typeof globalAppState.terminals = [];
-  let focusModeToUse = hasProjectRow ? (globalAppState.focusMode ?? false) : false;
-  let focusPanelStateToUse = hasProjectRow ? globalAppState.focusPanelState : undefined;
+  let focusModeToUse = canInheritLegacyWorkspaceState ? (globalAppState.focusMode ?? false) : false;
+  let focusPanelStateToUse = canInheritLegacyWorkspaceState
+    ? globalAppState.focusPanelState
+    : undefined;
   let activeWorktreeIdToUse = hasProjectRow ? globalAppState.activeWorktreeId : undefined;
   // Quick-switcher MRU: prefer per-project, fall back to the legacy global list
   // so a switch can't serve the previous project's order (#9922).

--- a/electron/services/AppHydrationService.ts
+++ b/electron/services/AppHydrationService.ts
@@ -42,7 +42,15 @@ export async function buildSwitchHydrateResult(projectId: string): Promise<Hydra
   // cache prime) normally resolve the id to a row first, but none holds that
   // guarantee across its later awaits, so a row deleted mid-build lands here
   // with no row — this keeps the leak from reappearing in that window (#11497).
-  const canInheritLegacyWorkspaceState = currentProject !== null;
+  //
+  // Having a row is necessary but not sufficient: the record names the one
+  // workspace that left it behind, and only that heir may read it (#11651).
+  // This path never claims — it performs no writes by design — so a record no
+  // hydrate has claimed yet reads as owned by nobody, and this switch serves
+  // clean defaults until `handleAppHydrate` settles the ownership.
+  const legacyWorkspaceStateOwnerId = store.get("legacyWorkspaceStateOwnerId");
+  const canInheritLegacyWorkspaceState =
+    currentProject !== null && legacyWorkspaceStateOwnerId === projectId;
 
   let terminalsToUse: typeof globalAppState.terminals = [];
   let focusModeToUse = canInheritLegacyWorkspaceState ? (globalAppState.focusMode ?? false) : false;

--- a/electron/services/AppHydrationService.ts
+++ b/electron/services/AppHydrationService.ts
@@ -42,24 +42,22 @@ export async function buildSwitchHydrateResult(projectId: string): Promise<Hydra
   // cache prime) normally resolve the id to a row first, but none holds that
   // guarantee across its later awaits, so a row deleted mid-build lands here
   // with no row — this keeps the leak from reappearing in that window (#11497).
-  //
-  // Having a row is necessary but not sufficient: the record names the one
-  // workspace that left it behind, and only that heir may read it (#11651).
-  // This path never claims — it performs no writes by design — so a record no
-  // hydrate has claimed yet reads as owned by nobody, and this switch serves
-  // clean defaults until `handleAppHydrate` settles the ownership.
+  const hasProjectRow = currentProject !== null;
+
+  // Focus mode and the active worktree are still live app-global state that the
+  // renderer rewrites through `app:set-state`, so they stay on the row gate —
+  // see the matching note in `handleAppHydrate`. The MRU is different: it has
+  // had a per-workspace write path since #9922, so the global copy is genuinely
+  // legacy and only the workspace that left it behind may read it (#11651).
+  // This path never claims — it performs no writes by design — so an unclaimed
+  // record has no heir here, and `handleAppHydrate` settles ownership instead.
   const legacyWorkspaceStateOwnerId = store.get("legacyWorkspaceStateOwnerId");
-  const canInheritLegacyWorkspaceState =
-    currentProject !== null && legacyWorkspaceStateOwnerId === projectId;
+  const canInheritLegacyWorkspaceState = hasProjectRow && legacyWorkspaceStateOwnerId === projectId;
 
   let terminalsToUse: typeof globalAppState.terminals = [];
-  let focusModeToUse = canInheritLegacyWorkspaceState ? (globalAppState.focusMode ?? false) : false;
-  let focusPanelStateToUse = canInheritLegacyWorkspaceState
-    ? globalAppState.focusPanelState
-    : undefined;
-  let activeWorktreeIdToUse = canInheritLegacyWorkspaceState
-    ? globalAppState.activeWorktreeId
-    : undefined;
+  let focusModeToUse = hasProjectRow ? (globalAppState.focusMode ?? false) : false;
+  let focusPanelStateToUse = hasProjectRow ? globalAppState.focusPanelState : undefined;
+  let activeWorktreeIdToUse = hasProjectRow ? globalAppState.activeWorktreeId : undefined;
   // Quick-switcher MRU: prefer per-project, fall back to the legacy global list
   // so a switch can't serve the previous project's order (#9922).
   let mruListToUse = canInheritLegacyWorkspaceState ? globalAppState.mruList : undefined;

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -462,6 +462,18 @@ export class CrashRecoveryService {
     this.pendingPanelFilter = panelIds;
   }
 
+  /**
+   * Non-destructive companion to `consumePanelFilter`. The filter is a one-shot
+   * whose ids come from the crash snapshot's global panel list, so only the
+   * workspace that owns that record can act on it. A workspace that would
+   * discard it must be able to ask whether one is pending without eating it,
+   * or the owner's next hydrate finds nothing and silently restores the very
+   * panels the user deselected (#11651).
+   */
+  hasPendingPanelFilter(): boolean {
+    return this.pendingPanelFilter !== null;
+  }
+
   consumePanelFilter(): string[] | null {
     const filter = this.pendingPanelFilter;
     this.pendingPanelFilter = null;

--- a/electron/services/__tests__/AppHydrationService.adversarial.test.ts
+++ b/electron/services/__tests__/AppHydrationService.adversarial.test.ts
@@ -316,7 +316,7 @@ describe("AppHydrationService adversarial", () => {
     expect(result.projectStateRecovery).toBeNull();
   });
 
-  it("NO_PROJECT_STATE_DENIES_THE_LEGACY_MRU_TO_A_NON_OWNER", async () => {
+  it("NO_PROJECT_STATE_DENIES_THE_LEGACY_RECORD_TO_A_NON_OWNER", async () => {
     // Same shape as the test above — a real Project row with nothing saved yet
     // — but another workspace owns the legacy record. Serving it the legacy MRU
     // would seed this project's quick-switcher with another project's panels
@@ -328,11 +328,15 @@ describe("AppHydrationService adversarial", () => {
     const result = await buildSwitchHydrateResult("project-1");
 
     expect(result.appState.mruList).toBeUndefined();
-    // Focus and worktree are NOT denied: they are still live app-global state
-    // the renderer rewrites, so withholding them would drop this project's own
+    // Focus state is denied too — it has a per-workspace write path, so the
+    // global copy is legacy. Serving it would collapse this project's sidebar
+    // on open and then persist another project's focus into its own record.
+    expect(result.appState.focusMode).toBe(false);
+    expect(result.appState.focusPanelState).toBeUndefined();
+    // `activeWorktreeId` is NOT denied: it is still written app-globally for
+    // every workspace, so withholding it would drop this project's own live
     // selection rather than narrow a legacy leak.
     expect(result.appState.activeWorktreeId).toBe("wt-global");
-    expect(result.appState.focusMode).toBe(true);
     // The row itself still resolves — this is an ownership denial, not a
     // failure to find the project.
     expect(result.project).toEqual(mockState.project);

--- a/electron/services/__tests__/AppHydrationService.adversarial.test.ts
+++ b/electron/services/__tests__/AppHydrationService.adversarial.test.ts
@@ -303,39 +303,42 @@ describe("AppHydrationService adversarial", () => {
     const result = await buildSwitchHydrateResult("project-1");
 
     expect(result.appState.terminals).toEqual([]);
-    // This project claimed the legacy global record, so all four workspace
-    // fields still migrate through on this path (#11497). Having a Project row
-    // is no longer enough on its own — see the sibling test below (#11651).
+    // A real project row still inherits the two fields the renderer keeps
+    // rewriting app-globally (#11497) — see the ownership note in
+    // `buildSwitchHydrateResult`.
     expect(result.appState.activeWorktreeId).toBe("wt-global");
     expect(result.appState.focusMode).toBe(true);
     expect(result.appState.focusPanelState).toEqual(mockState.appState.focusPanelState);
+    // The MRU is the one legacy field here, so it takes the owner gate: this
+    // project claimed the record, so it gets the list back.
     expect(result.appState.mruList).toEqual(mockState.appState.mruList);
     expect(result.settingsRecovery).toBeNull();
     expect(result.projectStateRecovery).toBeNull();
   });
 
-  it("NO_PROJECT_STATE_DENIES_LEGACY_FIELDS_TO_A_NON_OWNER", async () => {
+  it("NO_PROJECT_STATE_DENIES_THE_LEGACY_MRU_TO_A_NON_OWNER", async () => {
     // Same shape as the test above — a real Project row with nothing saved yet
-    // — but another workspace owns the legacy record. Serving it here would
-    // hand this project a foreign worktree to re-home its panels onto, and the
-    // renderer would persist it on the first save (#11651).
+    // — but another workspace owns the legacy record. Serving it the legacy MRU
+    // would seed this project's quick-switcher with another project's panels
+    // and worktrees (#11651).
     mockState.projectState = undefined;
     mockState.legacyWorkspaceStateOwnerId = "project-somebody-else";
 
     const { buildSwitchHydrateResult } = await import("../AppHydrationService.js");
     const result = await buildSwitchHydrateResult("project-1");
 
-    expect(result.appState.terminals).toEqual([]);
-    expect(result.appState.activeWorktreeId).toBeUndefined();
-    expect(result.appState.focusMode).toBe(false);
-    expect(result.appState.focusPanelState).toBeUndefined();
     expect(result.appState.mruList).toBeUndefined();
+    // Focus and worktree are NOT denied: they are still live app-global state
+    // the renderer rewrites, so withholding them would drop this project's own
+    // selection rather than narrow a legacy leak.
+    expect(result.appState.activeWorktreeId).toBe("wt-global");
+    expect(result.appState.focusMode).toBe(true);
     // The row itself still resolves — this is an ownership denial, not a
     // failure to find the project.
     expect(result.project).toEqual(mockState.project);
   });
 
-  it("denies the legacy fields while the record is still unclaimed", async () => {
+  it("denies the legacy mruList while the record is still unclaimed", async () => {
     // This path performs no writes, so it can never claim the record itself.
     // Until `handleAppHydrate` settles ownership, an unclaimed record has no
     // heir, and serving it to whoever switches first is the guess the owner id
@@ -346,8 +349,6 @@ describe("AppHydrationService adversarial", () => {
     const { buildSwitchHydrateResult } = await import("../AppHydrationService.js");
     const result = await buildSwitchHydrateResult("project-1");
 
-    expect(result.appState.activeWorktreeId).toBeUndefined();
-    expect(result.appState.focusMode).toBe(false);
     expect(result.appState.mruList).toBeUndefined();
   });
 

--- a/electron/services/__tests__/AppHydrationService.adversarial.test.ts
+++ b/electron/services/__tests__/AppHydrationService.adversarial.test.ts
@@ -20,6 +20,13 @@ const mockState = vi.hoisted(() => ({
     activeWorktreeId: "wt-global",
     mruList: ["terminal:global-terminal"] as string[],
   },
+  /**
+   * The workspace that claimed the legacy global record. Defaults to the
+   * fixture's own project so the inheritance tests below read as "the heir
+   * gets its record back" rather than "any row with a Project row does"
+   * (#11651).
+   */
+  legacyWorkspaceStateOwnerId: "project-1" as string | undefined,
   terminalConfig: { scrollback: 5000 },
   agentSettings: { defaultAgent: "codex" },
   project: { id: "project-1", name: "Project One", path: "/project/one" },
@@ -57,6 +64,7 @@ const getProjectStateWithRecoveryMock = vi.hoisted(() =>
 const storeGetMock = vi.hoisted(() =>
   vi.fn((key: string) => {
     if (key === "appState") return mockState.appState;
+    if (key === "legacyWorkspaceStateOwnerId") return mockState.legacyWorkspaceStateOwnerId;
     if (key === "terminalConfig") return mockState.terminalConfig;
     if (key === "agentSettings") return mockState.agentSettings;
     return undefined;
@@ -130,6 +138,7 @@ describe("AppHydrationService adversarial", () => {
       activeWorktreeId: "wt-global",
       mruList: ["terminal:global-terminal"],
     };
+    mockState.legacyWorkspaceStateOwnerId = "project-1";
     mockState.terminalConfig = { scrollback: 5000 };
     mockState.agentSettings = { defaultAgent: "codex" };
     mockState.project = { id: "project-1", name: "Project One", path: "/project/one" };
@@ -294,14 +303,52 @@ describe("AppHydrationService adversarial", () => {
     const result = await buildSwitchHydrateResult("project-1");
 
     expect(result.appState.terminals).toEqual([]);
-    // A real project row is the legitimate heir of the legacy global record, so
-    // all four workspace fields still migrate through on this path (#11497).
+    // This project claimed the legacy global record, so all four workspace
+    // fields still migrate through on this path (#11497). Having a Project row
+    // is no longer enough on its own — see the sibling test below (#11651).
     expect(result.appState.activeWorktreeId).toBe("wt-global");
     expect(result.appState.focusMode).toBe(true);
     expect(result.appState.focusPanelState).toEqual(mockState.appState.focusPanelState);
     expect(result.appState.mruList).toEqual(mockState.appState.mruList);
     expect(result.settingsRecovery).toBeNull();
     expect(result.projectStateRecovery).toBeNull();
+  });
+
+  it("NO_PROJECT_STATE_DENIES_LEGACY_FIELDS_TO_A_NON_OWNER", async () => {
+    // Same shape as the test above — a real Project row with nothing saved yet
+    // — but another workspace owns the legacy record. Serving it here would
+    // hand this project a foreign worktree to re-home its panels onto, and the
+    // renderer would persist it on the first save (#11651).
+    mockState.projectState = undefined;
+    mockState.legacyWorkspaceStateOwnerId = "project-somebody-else";
+
+    const { buildSwitchHydrateResult } = await import("../AppHydrationService.js");
+    const result = await buildSwitchHydrateResult("project-1");
+
+    expect(result.appState.terminals).toEqual([]);
+    expect(result.appState.activeWorktreeId).toBeUndefined();
+    expect(result.appState.focusMode).toBe(false);
+    expect(result.appState.focusPanelState).toBeUndefined();
+    expect(result.appState.mruList).toBeUndefined();
+    // The row itself still resolves — this is an ownership denial, not a
+    // failure to find the project.
+    expect(result.project).toEqual(mockState.project);
+  });
+
+  it("denies the legacy fields while the record is still unclaimed", async () => {
+    // This path performs no writes, so it can never claim the record itself.
+    // Until `handleAppHydrate` settles ownership, an unclaimed record has no
+    // heir, and serving it to whoever switches first is the guess the owner id
+    // exists to remove (#11651).
+    mockState.projectState = undefined;
+    mockState.legacyWorkspaceStateOwnerId = undefined;
+
+    const { buildSwitchHydrateResult } = await import("../AppHydrationService.js");
+    const result = await buildSwitchHydrateResult("project-1");
+
+    expect(result.appState.activeWorktreeId).toBeUndefined();
+    expect(result.appState.focusMode).toBe(false);
+    expect(result.appState.mruList).toBeUndefined();
   });
 
   it("folds the system temp dir into the payload so the renderer can skip the IPC call", async () => {

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -170,6 +170,23 @@ export interface StoreSchema {
     actionHiddenIds?: string[];
     fleetScopeMode?: "legacy" | "scoped";
   };
+  /**
+   * Workspace that owns the legacy pre-multi-project fields of `appState`
+   * (`terminals`, `activeWorktreeId`, `focusMode`, `focusPanelState`,
+   * `mruList`). Those fields belong to whichever project was open before
+   * per-workspace state existed, but carry no owner identity of their own, so
+   * every project row without saved terminals used to re-inherit them —
+   * handing a brand-new project another project's panels and `cwd`s (#11651).
+   * The first real project to hydrate stamps its id here and becomes the sole
+   * heir; every later row reads its own state or clean defaults.
+   *
+   * Deliberately top-level rather than a field of `appState`:
+   * `CrashRecoveryService.applySessionSnapshot` replaces `appState` wholesale
+   * from a captured snapshot, which would roll an inner marker back to
+   * unclaimed. Also keeps the marker out of the hydrate IPC payload — it is
+   * main-process migration bookkeeping, not renderer state.
+   */
+  legacyWorkspaceStateOwnerId?: string;
   userConfig: {
     githubToken?: string;
   };


### PR DESCRIPTION
## Summary

- `handleAppHydrate` was copying the legacy pre-multi-project global workspace record into any project row without per-project terminals, gated only on the project row existing, and nothing ever consumed the record, so a brand new project folder could get minted with another project's panels (foreign `cwd` and `worktreeId` included) and have that written to disk before the renderer finished restoring.
- The legacy record now names an owner: the first real project to hydrate claims a new `legacyWorkspaceStateOwnerId`, and only that workspace can read the record afterward.
- Two adjacent bugs turned up while working on this and are fixed here too: a prefetch cache path that could serve state without ever claiming it, and a crash-recovery panel filter that was being applied to, and destructively consumed from, workspaces it didn't belong to.

Resolves #11651

## Problem

`handleAppHydrate` was copying the legacy, pre-multi-project global workspace record into any project row that didn't have its own per-project terminals saved. The only gate was that a Project row existed, a check added for #11497, but nothing was ever consuming the record afterward.

That makes this not a one-time leak. Every project row that hadn't saved terminals yet kept re-reading the same global list, and opening a brand new folder as a project could mint it with another project's panels, foreign `cwd` and `worktreeId` riding along in the spread, and that state got persisted to disk before the renderer finished restoring.

## Fix

The legacy record now gets to name its heir. `StoreSchema` gets a new top-level `legacyWorkspaceStateOwnerId`: the first real project to hydrate claims it, and only that workspace may read the record afterward.

The claim is written synchronously, between reading `appState` and the handler's first `await`, so two project views hydrating in the same tick can't both see the record unclaimed.

This is a stamp, not a destructive consume. The owning workspace keeps inheriting the legacy state on every later hydrate, which matters when the `app:boot` payload gets discarded behind a pending crash recovery and the renderer has to hydrate again.

The owner marker sits outside `appState` on purpose. `CrashRecoveryService.applySessionSnapshot` replaces `appState` wholesale, and an owner marker living inside it would get rolled back to unclaimed on every crash restore.

## Scope of the ownership gate

The gate covers the terminal migration, `focusMode`/`focusPanelState`, `mruList`, and every persisted write of legacy values into a project's `ProjectState`. All of these have per-workspace write paths, which is what makes their global copies genuinely legacy.

`activeWorktreeId` deliberately stays on the older #11497 project-row gate instead of moving to ownership. `worktreeStore.persistActiveWorktree` still writes it app-globally for every workspace, and `AgentNotificationService.isFocusedOnWorktree` reads that global value back, so denying it to a non-owner would drop a project's own live selection on every boot rather than narrow a leak. Ownership still gates the persisted half of it, so no workspace can write another workspace's worktree into its own record. Worth filing a follow-up to give `activeWorktreeId` its own per-workspace write path, the way `mruList` got routed per-workspace in #9922, so it can join the gate too.

## Adjacent fixes

Two related bugs turned up while reviewing this and are fixed in the same PR.

First, a prefetch cache hit could bypass the claim entirely. `buildSwitchHydrateResult` performs no writes, so it never claims ownership or migrates anything, it just serves a cached payload. That let the rightful heir boot unclaimed, and the next brand new project would then claim ownership and inherit the legacy state instead. Cached payloads are now ineligible until the record actually has an owner.

Second, the crash-recovery panel filter's ids come from the snapshot's global panel list, so they specifically name the owner's panels, but the filter was being applied to, and destructively consumed from, workspaces it didn't describe. That emptied a project's own restored workspace and left the true owner's next hydrate with nothing left to filter by. It's now peeked rather than consumed when it isn't usable, and only applied to a panel list that actually came from the crash snapshot.

## Known residual, not a regression

This fix guarantees at most one inheritor, not provably the correct one. There's no ownership data anywhere in the persisted model to do better: `Project` has no `createdAt`, and `lastOpened`/`lastAccessedAt` get stamped the same whether a project was just created or just reopened. So the first real project to hydrate after upgrading is treated as the heir, which in practice is the project restored at cold start. It replaces an unbounded, repeating leak with a single bounded choice.

## Testing

263 tests pass across every suite covering the changed modules: `app.state`, `AppHydrationService.adversarial`, `ProjectSwitchService`, `crashRecovery` handlers, `recovery.handlers`, and five `CrashRecoveryService` suites. Project typecheck is clean, lint ratchet is at baseline, formatting is clean.

New coverage added for:
- Denying a non-owner, both the in-memory payload and the persisted record
- Claiming ownership only once across repeated hydrates
- A scratch workspace unable to claim ownership
- An unclaimed record making the prefetch cache ineligible
- The crash-recovery filter withheld from its rightful owner
- A non-owner keeping its own panels intact through crash recovery
