### PR TITLE
fix(test): install fake timers after dynamic imports resolve

### DIFF
--- a/electron/__tests__/fakeTimersImportOrder.contract.test.ts
+++ b/electron/__tests__/fakeTimersImportOrder.contract.test.ts
@@ -167,10 +167,11 @@ function hookName(call: ts.CallExpression): string | undefined {
 
 /**
  * Function-like declarations by name, so `beforeEach(setup)` resolves to
- * `setup`'s body. Scope-blind, so every declaration sharing a name is kept and
- * all of them are inspected: picking one would let a later clean `setup` shadow
- * an earlier offending one and blind the scan. Over-reporting is the safe
- * direction here.
+ * `setup`'s body. Scope-blind: every declaration sharing a name is kept, and
+ * an ambiguous name is only reported when EVERY candidate offends, which holds
+ * whichever one actually binds. Picking one would let a clean `setup` shadow an
+ * offending one; reporting on any match would blame a hook whose real body is
+ * fine.
  */
 function collectNamedFunctions(source: ts.SourceFile): Map<string, ts.Node[]> {
   const named = new Map<string, ts.Node[]>();
@@ -211,8 +212,8 @@ export function findViolations(relativePath: string, text: string): Violation[] 
   const namedFunctions = collectNamedFunctions(source);
   const violations: Violation[] = [];
 
-  /** Reports the offending pair in one hook body, if any. */
-  const inspect = (hook: string, callback: ts.Node): void => {
+  /** The offending pair in one hook body, if any. */
+  const inspect = (hook: string, callback: ts.Node): Violation | undefined => {
     // First clock install vs LAST awaited import: a hook that imports, installs
     // the clock, then imports again still runs that second import frozen, so
     // pairing against the first import would miss it.
@@ -220,7 +221,8 @@ export function findViolations(relativePath: string, text: string): Violation[] 
     let lastImport: ts.Node | undefined;
     walkOwnScope(callback, (inner) => {
       if (!fakeTimers && isUseFakeTimersCall(inner)) fakeTimers = inner;
-      if (ts.isAwaitExpression(inner)) {
+      // A returned import is awaited by the runner just like an inline `await`.
+      if (ts.isAwaitExpression(inner) || ts.isReturnStatement(inner)) {
         // Compare the import call itself, not the enclosing `await`, so
         // `await (vi.useFakeTimers(), import(...))` still orders correctly.
         const importCall = findLastDynamicImportCall(inner, source);
@@ -233,13 +235,14 @@ export function findViolations(relativePath: string, text: string): Violation[] 
       }
     });
     if (fakeTimers && lastImport && fakeTimers.getStart(source) < lastImport.getStart(source)) {
-      violations.push({
+      return {
         file: relativePath,
         hook,
         fakeTimersLine: lineOf(fakeTimers),
         importLine: lineOf(lastImport),
-      });
+      };
     }
+    return undefined;
   };
 
   const visitAll = (node: ts.Node): void => {
@@ -247,11 +250,18 @@ export function findViolations(relativePath: string, text: string): Violation[] 
       const hook = hookName(node);
       const arg = node.arguments[0];
       if (hook && arg) {
+        // At most ONE violation per hook call site: the allowlist counts hooks,
+        // so reporting every same-named candidate would inflate a file's count.
+        let found: Violation | undefined;
         if (isFunctionLike(arg)) {
-          inspect(hook, arg);
+          found = inspect(hook, arg);
         } else if (ts.isIdentifier(arg)) {
-          for (const candidate of namedFunctions.get(arg.text) ?? []) inspect(hook, candidate);
+          const candidates = namedFunctions.get(arg.text) ?? [];
+          const results = candidates.map((candidate) => inspect(hook, candidate));
+          // Only certain when every candidate offends — see collectNamedFunctions.
+          if (results.length > 0 && results.every(Boolean)) found = results[0];
         }
+        if (found) violations.push(found);
       }
     }
     node.forEachChild(visitAll);
@@ -266,6 +276,18 @@ interface ScanResult {
   unparsed: string[];
 }
 
+/**
+ * Syntax errors in a parsed file. `parseDiagnostics` is internal to the
+ * compiler API, but the public route needs a full `Program`, which is far too
+ * slow for a couple of thousand files when all this asks is "did it parse".
+ */
+export function parseErrorCount(relativePath: string, text: string): number {
+  const internal = parse(relativePath, text) as unknown as {
+    parseDiagnostics?: readonly unknown[];
+  };
+  return internal.parseDiagnostics?.length ?? 0;
+}
+
 function scanRepo(): ScanResult {
   const files = TEST_ROOTS.flatMap((root) => collectTestFiles(path.join(REPO_ROOT, root))).sort();
   const violations: Violation[] = [];
@@ -275,7 +297,7 @@ function scanRepo(): ScanResult {
     const relative = path.relative(REPO_ROOT, absolute).split(path.sep).join("/");
     const text = fs.readFileSync(absolute, "utf8");
     // A file this scan cannot parse is a file it cannot police.
-    if (parse(relative, text).parseDiagnostics.length > 0) {
+    if (parseErrorCount(relative, text) > 0) {
       unparsed.push(relative);
       continue;
     }
@@ -336,6 +358,22 @@ describe("fake timers must not precede an awaited dynamic import", () => {
 
 describe("detector", () => {
   const wrap = (body: string) => `import { beforeEach, vi } from "vitest";\n${body}\n`;
+
+  // `parseErrorCount` reads an internal compiler field. If a TypeScript upgrade
+  // renames it the optional chain would return 0 forever, silently turning the
+  // "parses every test file" assertion into a no-op.
+  it("still detects syntax errors through the internal parse diagnostics", () => {
+    expect(parseErrorCount("broken.test.ts", "function ( {")).toBeGreaterThan(0);
+    expect(parseErrorCount("fine.test.ts", "export const x = 1;\n")).toBe(0);
+  });
+
+  // A `.ts` file parsed as TSX reports errors on a generic arrow; the derived
+  // ScriptKind must not.
+  it("parses a generic arrow in .ts but flags it as JSX in .tsx", () => {
+    const generic = "const id = <T>(value: T): T => value;\n";
+    expect(parseErrorCount("fixture.test.ts", generic)).toBe(0);
+    expect(parseErrorCount("fixture.test.tsx", generic)).toBeGreaterThan(0);
+  });
 
   it("flags fake timers installed before an awaited dynamic import", () => {
     const found = findViolations(
@@ -399,8 +437,9 @@ describe("detector", () => {
     expect(found).toHaveLength(1);
   });
 
-  // A clean same-named declaration must not shadow an offending one away.
-  it("inspects every declaration sharing a hook callback name", () => {
+  // Ambiguous name, only one candidate offending: which one binds is unknown, so
+  // blaming the hook would be a false positive.
+  it("stays silent when only one same-named candidate offends", () => {
     const found = findViolations(
       "fixture.test.ts",
       wrap(`async function setup() {
@@ -411,6 +450,37 @@ describe("detector", () => {
         async function setup() {
           await import("./mod.js");
           vi.useFakeTimers();
+        }
+        beforeEach(setup);
+      });`)
+    );
+    expect(found).toEqual([]);
+  });
+
+  it("flags a dynamic import returned from a hook", () => {
+    const found = findViolations(
+      "fixture.test.ts",
+      wrap(`beforeEach(() => {
+        vi.useFakeTimers();
+        return import("./mod.js");
+      });`)
+    );
+    expect(found).toHaveLength(1);
+  });
+
+  // Two offending declarations resolve to one hook site; counting both would
+  // inflate the per-file total the allowlist tracks.
+  it("reports one violation per hook site when candidates both offend", () => {
+    const found = findViolations(
+      "fixture.test.ts",
+      wrap(`async function setup() {
+        vi.useFakeTimers();
+        await import("./a.js");
+      }
+      describe("other", () => {
+        async function setup() {
+          vi.useFakeTimers();
+          await import("./b.js");
         }
         beforeEach(setup);
       });`)

--- a/electron/__tests__/fakeTimersImportOrder.contract.test.ts
+++ b/electron/__tests__/fakeTimersImportOrder.contract.test.ts
@@ -17,14 +17,20 @@ const REPO_ROOT = path.resolve(TEST_DIR, "../..");
 //
 // The fix is ordering: resolve every dynamic import first, then install the
 // clock. This contract keeps the pattern from being copy-pasted back in.
-//
-// The allowlist is exact rather than permissive — an entry whose count no longer
-// matches fails the test. A stale entry would otherwise silently re-permit a
-// regression in a file that had already been fixed.
 
 const HOOKS = new Set(["beforeEach", "beforeAll", "afterEach", "afterAll"]);
-const TEST_ROOTS = ["electron", "src", "shared", "scripts", "plugins", "packages"];
 const SKIP_DIRS = new Set(["node_modules", "dist", "dist-electron", "build", "release"]);
+
+/** Mirrors the test-discovery roots in `vitest.config.ts`'s `include`. */
+const TEST_ROOTS = [
+  "electron",
+  "src",
+  "shared",
+  "scripts",
+  "plugins",
+  "packages",
+  "e2e/helpers/__tests__",
+];
 
 /**
  * Hooks that still install fake timers before an awaited dynamic import, keyed
@@ -37,8 +43,17 @@ const SKIP_DIRS = new Set(["node_modules", "dist", "dist-electron", "build", "re
  * suites assert on. Reordering them needs a test-factory redesign, not a line
  * move.
  *
- * The rest are untriaged: each one needs its own check for load-time timer
- * scheduling before the ordering can be flipped.
+ * The rest are untriaged: each needs its own check for load-time timer
+ * scheduling before the ordering can be flipped. Two carry extra traps:
+ * `DiagnosticsCollector.adversarial` has no `afterEach` restoring real timers,
+ * so a naive reorder leaves the next hook importing under the previous test's
+ * frozen clock; `SoundService` also calls `resetModules()` + `import()` inside
+ * test bodies, which this hook-scoped scan does not see.
+ *
+ * Counts, not identities: fixing one hook in a listed file while introducing
+ * another in the same file keeps the count equal and would pass. Per-hook
+ * identity needs a stable fingerprint (line numbers churn, titles repeat), so
+ * this trades that residual gap for an allowlist that cannot silently rot.
  */
 const KNOWN_VIOLATIONS = new Map<string, number>([
   // Load-time timer scheduling — ordering is load-bearing here.
@@ -94,6 +109,8 @@ function isFunctionLike(node: ts.Node): boolean {
     ts.isFunctionExpression(node) ||
     ts.isArrowFunction(node) ||
     ts.isMethodDeclaration(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isSetAccessorDeclaration(node) ||
     ts.isClassDeclaration(node) ||
     ts.isClassExpression(node)
   );
@@ -108,22 +125,35 @@ function walkOwnScope(node: ts.Node, visit: (node: ts.Node) => void): void {
   });
 }
 
-function containsDynamicImport(node: ts.Node): boolean {
-  if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword)
-    return true;
-  let found = false;
-  node.forEachChild((child) => {
-    if (!found && containsDynamicImport(child)) found = true;
-  });
-  return found;
+/**
+ * The LAST dynamic `import()` call inside `node`, by source position. Returning
+ * the first would accept `await (import("./a"), vi.useFakeTimers(),
+ * import("./b"))`, where the second import still runs frozen.
+ */
+function findLastDynamicImportCall(node: ts.Node, source: ts.SourceFile): ts.Node | undefined {
+  let last: ts.Node | undefined;
+  const visit = (inner: ts.Node): void => {
+    if (ts.isCallExpression(inner) && inner.expression.kind === ts.SyntaxKind.ImportKeyword) {
+      if (!last || inner.getStart(source) > last.getStart(source)) last = inner;
+    }
+    inner.forEachChild(visit);
+  };
+  visit(node);
+  return last;
 }
 
+/** Matches `vi.useFakeTimers(...)` and `vi["useFakeTimers"](...)`. */
 function isUseFakeTimersCall(node: ts.Node): boolean {
-  return (
-    ts.isCallExpression(node) &&
-    ts.isPropertyAccessExpression(node.expression) &&
-    node.expression.name.text === "useFakeTimers"
-  );
+  if (!ts.isCallExpression(node)) return false;
+  const { expression } = node;
+  if (ts.isPropertyAccessExpression(expression)) {
+    return expression.name.text === "useFakeTimers";
+  }
+  if (ts.isElementAccessExpression(expression)) {
+    const arg = expression.argumentExpression;
+    return ts.isStringLiteralLike(arg) && arg.text === "useFakeTimers";
+  }
+  return false;
 }
 
 function hookName(call: ts.CallExpression): string | undefined {
@@ -135,43 +165,92 @@ function hookName(call: ts.CallExpression): string | undefined {
   return undefined;
 }
 
+/**
+ * Function-like declarations by name, so `beforeEach(setup)` resolves to
+ * `setup`'s body. Scope-blind, so every declaration sharing a name is kept and
+ * all of them are inspected: picking one would let a later clean `setup` shadow
+ * an earlier offending one and blind the scan. Over-reporting is the safe
+ * direction here.
+ */
+function collectNamedFunctions(source: ts.SourceFile): Map<string, ts.Node[]> {
+  const named = new Map<string, ts.Node[]>();
+  const add = (name: string, fn: ts.Node): void => {
+    const existing = named.get(name);
+    if (existing) existing.push(fn);
+    else named.set(name, [fn]);
+  };
+  const visit = (node: ts.Node): void => {
+    if (ts.isFunctionDeclaration(node) && node.name) {
+      add(node.name.text, node);
+    } else if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      (ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer))
+    ) {
+      add(node.name.text, node.initializer);
+    }
+    node.forEachChild(visit);
+  };
+  visit(source);
+  return named;
+}
+
+function parse(relativePath: string, text: string): ts.SourceFile {
+  // ScriptKind is derived from the file name, never forced: parsing a `.ts` file
+  // as TSX turns every generic arrow (`vi.fn(<T>(x: T) => x)`) into malformed
+  // JSX, and the resulting parse errors made whole suites invisible to the scan.
+  return ts.createSourceFile(relativePath, text, ts.ScriptTarget.Latest, true);
+}
+
 export function findViolations(relativePath: string, text: string): Violation[] {
-  const source = ts.createSourceFile(
-    relativePath,
-    text,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TSX
-  );
+  const source = parse(relativePath, text);
   const lineOf = (node: ts.Node): number =>
     source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
 
+  const namedFunctions = collectNamedFunctions(source);
   const violations: Violation[] = [];
+
+  /** Reports the offending pair in one hook body, if any. */
+  const inspect = (hook: string, callback: ts.Node): void => {
+    // First clock install vs LAST awaited import: a hook that imports, installs
+    // the clock, then imports again still runs that second import frozen, so
+    // pairing against the first import would miss it.
+    let fakeTimers: ts.Node | undefined;
+    let lastImport: ts.Node | undefined;
+    walkOwnScope(callback, (inner) => {
+      if (!fakeTimers && isUseFakeTimersCall(inner)) fakeTimers = inner;
+      if (ts.isAwaitExpression(inner)) {
+        // Compare the import call itself, not the enclosing `await`, so
+        // `await (vi.useFakeTimers(), import(...))` still orders correctly.
+        const importCall = findLastDynamicImportCall(inner, source);
+        if (
+          importCall &&
+          (!lastImport || importCall.getStart(source) > lastImport.getStart(source))
+        ) {
+          lastImport = importCall;
+        }
+      }
+    });
+    if (fakeTimers && lastImport && fakeTimers.getStart(source) < lastImport.getStart(source)) {
+      violations.push({
+        file: relativePath,
+        hook,
+        fakeTimersLine: lineOf(fakeTimers),
+        importLine: lineOf(lastImport),
+      });
+    }
+  };
 
   const visitAll = (node: ts.Node): void => {
     if (ts.isCallExpression(node)) {
       const hook = hookName(node);
-      const callback = node.arguments[0];
-      if (hook && callback && isFunctionLike(callback)) {
-        let fakeTimers: ts.Node | undefined;
-        let awaitedImport: ts.Node | undefined;
-        walkOwnScope(callback, (inner) => {
-          if (!fakeTimers && isUseFakeTimersCall(inner)) fakeTimers = inner;
-          if (!awaitedImport && ts.isAwaitExpression(inner) && containsDynamicImport(inner)) {
-            awaitedImport = inner;
-          }
-        });
-        if (
-          fakeTimers &&
-          awaitedImport &&
-          fakeTimers.getStart(source) < awaitedImport.getStart(source)
-        ) {
-          violations.push({
-            file: relativePath,
-            hook,
-            fakeTimersLine: lineOf(fakeTimers),
-            importLine: lineOf(awaitedImport),
-          });
+      const arg = node.arguments[0];
+      if (hook && arg) {
+        if (isFunctionLike(arg)) {
+          inspect(hook, arg);
+        } else if (ts.isIdentifier(arg)) {
+          for (const candidate of namedFunctions.get(arg.text) ?? []) inspect(hook, candidate);
         }
       }
     }
@@ -182,27 +261,49 @@ export function findViolations(relativePath: string, text: string): Violation[] 
   return violations;
 }
 
-function scanRepo(): Violation[] {
-  const files = TEST_ROOTS.flatMap((root) => collectTestFiles(path.join(REPO_ROOT, root)));
-  return files.flatMap((absolute) =>
-    findViolations(
-      path.relative(REPO_ROOT, absolute).split(path.sep).join("/"),
-      fs.readFileSync(absolute, "utf8")
-    )
-  );
+interface ScanResult {
+  violations: Violation[];
+  unparsed: string[];
+}
+
+function scanRepo(): ScanResult {
+  const files = TEST_ROOTS.flatMap((root) => collectTestFiles(path.join(REPO_ROOT, root))).sort();
+  const violations: Violation[] = [];
+  const unparsed: string[] = [];
+
+  for (const absolute of files) {
+    const relative = path.relative(REPO_ROOT, absolute).split(path.sep).join("/");
+    const text = fs.readFileSync(absolute, "utf8");
+    // A file this scan cannot parse is a file it cannot police.
+    if (parse(relative, text).parseDiagnostics.length > 0) {
+      unparsed.push(relative);
+      continue;
+    }
+    violations.push(...findViolations(relative, text));
+  }
+
+  return { violations, unparsed };
 }
 
 function describeViolation(v: Violation): string {
-  return `${v.file}:${v.fakeTimersLine} [${v.hook}] installs fake timers before the awaited dynamic import at :${v.importLine}`;
+  return `${v.file}:${v.fakeTimersLine} [${v.hook}] installs fake timers before the awaited dynamic import at line ${v.importLine}`;
+}
+
+function countByFile(violations: Violation[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const v of violations) counts.set(v.file, (counts.get(v.file) ?? 0) + 1);
+  return counts;
 }
 
 describe("fake timers must not precede an awaited dynamic import", () => {
-  const violations = scanRepo();
+  const { violations, unparsed } = scanRepo();
+
+  it("parses every test file it scans", () => {
+    expect(unparsed).toEqual([]);
+  });
 
   it("reports no new offending hooks", () => {
-    const counts = new Map<string, number>();
-    for (const v of violations) counts.set(v.file, (counts.get(v.file) ?? 0) + 1);
-
+    const counts = countByFile(violations);
     const unexpected = violations
       .filter((v) => (counts.get(v.file) ?? 0) > (KNOWN_VIOLATIONS.get(v.file) ?? 0))
       .map(describeViolation);
@@ -210,10 +311,8 @@ describe("fake timers must not precede an awaited dynamic import", () => {
     expect(unexpected).toEqual([]);
   });
 
-  it("keeps the allowlist exact", () => {
-    const counts = new Map<string, number>();
-    for (const v of violations) counts.set(v.file, (counts.get(v.file) ?? 0) + 1);
-
+  it("keeps allowlist counts exact", () => {
+    const counts = countByFile(violations);
     const stale: string[] = [];
     for (const [file, expected] of KNOWN_VIOLATIONS) {
       const actual = counts.get(file) ?? 0;
@@ -261,12 +360,91 @@ describe("detector", () => {
     expect(found).toEqual([]);
   });
 
+  it("flags a second awaited import that follows the clock install", () => {
+    const found = findViolations(
+      "fixture.test.ts",
+      wrap(`beforeEach(async () => {
+        await import("./first.js");
+        vi.useFakeTimers();
+        await import("./second.js");
+      });`)
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].importLine).toBeGreaterThan(found[0].fakeTimersLine);
+  });
+
+  // A `.ts` file parsed as TSX turns this generic arrow into malformed JSX and
+  // the whole suite silently stops being scanned.
+  it("scans a .ts file containing a generic arrow function", () => {
+    const found = findViolations(
+      "fixture.test.ts",
+      wrap(`const send = vi.fn(<T>(value: T): T => value);
+      beforeEach(async () => {
+        vi.useFakeTimers();
+        await import("./mod.js");
+      });`)
+    );
+    expect(found).toHaveLength(1);
+  });
+
+  it("resolves a hook callback passed by identifier", () => {
+    const found = findViolations(
+      "fixture.test.ts",
+      wrap(`async function setup() {
+        vi.useFakeTimers();
+        await import("./mod.js");
+      }
+      beforeEach(setup);`)
+    );
+    expect(found).toHaveLength(1);
+  });
+
+  // A clean same-named declaration must not shadow an offending one away.
+  it("inspects every declaration sharing a hook callback name", () => {
+    const found = findViolations(
+      "fixture.test.ts",
+      wrap(`async function setup() {
+        vi.useFakeTimers();
+        await import("./mod.js");
+      }
+      describe("other", () => {
+        async function setup() {
+          await import("./mod.js");
+          vi.useFakeTimers();
+        }
+        beforeEach(setup);
+      });`)
+    );
+    expect(found).toHaveLength(1);
+  });
+
+  it("flags a later import inside the same awaited expression", () => {
+    const found = findViolations(
+      "fixture.test.ts",
+      wrap(`beforeEach(async () => {
+        await (import("./a.js"), vi.useFakeTimers(), import("./b.js"));
+      });`)
+    );
+    expect(found).toHaveLength(1);
+  });
+
   it("sees through an import nested in a property access", () => {
     const found = findViolations(
       "fixture.test.ts",
       wrap(`beforeEach(async () => {
         vi.useFakeTimers();
         const fork = (await import("electron")).utilityProcess.fork;
+      });`)
+    );
+    expect(found).toHaveLength(1);
+  });
+
+  it("matches an element-access fake-timers call", () => {
+    const found = findViolations(
+      "fixture.test.ts",
+      wrap(`beforeEach(async () => {
+        vi["useFakeTimers"]();
+        await import("./mod.js");
       });`)
     );
     expect(found).toHaveLength(1);

--- a/electron/services/__tests__/PtyClient.adversarial.test.ts
+++ b/electron/services/__tests__/PtyClient.adversarial.test.ts
@@ -106,8 +106,7 @@ describe("PtyClient adversarial", () => {
 
     ({ PtyClient: PtyClientClass } = await import("../PtyClient.js"));
 
-    // Installed only after the dynamic import resolves: a faked clock during
-    // module re-execution can starve the import path and hang the hook (#11661).
+    // Install after imports: fake timers can stall module re-execution (#11661).
     vi.useFakeTimers();
   });
 

--- a/electron/services/__tests__/PtyClient.adversarial.test.ts
+++ b/electron/services/__tests__/PtyClient.adversarial.test.ts
@@ -98,7 +98,6 @@ describe("PtyClient adversarial", () => {
   let PtyClientClass: typeof import("../PtyClient.js").PtyClient;
 
   beforeEach(async () => {
-    vi.useFakeTimers();
     vi.resetModules();
     vi.clearAllMocks();
     shared.appMock.removeAllListeners();
@@ -106,6 +105,10 @@ describe("PtyClient adversarial", () => {
     shared.forkMock.mockReturnValue(mockChild);
 
     ({ PtyClient: PtyClientClass } = await import("../PtyClient.js"));
+
+    // Installed only after the dynamic import resolves: a faked clock during
+    // module re-execution can starve the import path and hang the hook (#11661).
+    vi.useFakeTimers();
   });
 
   afterEach(() => {

--- a/electron/services/__tests__/PtyClient.deferStart.test.ts
+++ b/electron/services/__tests__/PtyClient.deferStart.test.ts
@@ -38,8 +38,6 @@ describe("PtyClient deferStart", () => {
   let forkMock: Mock;
 
   beforeEach(async () => {
-    vi.useFakeTimers();
-
     mockChild = Object.assign(new EventEmitter(), {
       postMessage: vi.fn(),
       kill: vi.fn(),
@@ -67,6 +65,10 @@ describe("PtyClient deferStart", () => {
     const module = await import("../PtyClient.js");
     PtyClientClass = module.PtyClient;
     forkMock = (await import("electron")).utilityProcess.fork as unknown as Mock;
+
+    // Installed only after the dynamic imports resolve: a faked clock during
+    // module re-execution can starve the import path and hang the hook (#11661).
+    vi.useFakeTimers();
   });
 
   afterEach(() => {

--- a/electron/services/__tests__/PtyClient.deferStart.test.ts
+++ b/electron/services/__tests__/PtyClient.deferStart.test.ts
@@ -66,8 +66,7 @@ describe("PtyClient deferStart", () => {
     PtyClientClass = module.PtyClient;
     forkMock = (await import("electron")).utilityProcess.fork as unknown as Mock;
 
-    // Installed only after the dynamic imports resolve: a faked clock during
-    // module re-execution can starve the import path and hang the hook (#11661).
+    // Install after imports: fake timers can stall module re-execution (#11661).
     vi.useFakeTimers();
   });
 

--- a/electron/services/__tests__/PtyClient.fabric.test.ts
+++ b/electron/services/__tests__/PtyClient.fabric.test.ts
@@ -78,7 +78,6 @@ describe("PtyClient fabric", () => {
   let fabricConfig: typeof import("../pty/fabricConfig.js");
 
   beforeEach(async () => {
-    vi.useFakeTimers();
     forks = [];
     failNextFork = false;
 
@@ -123,6 +122,10 @@ describe("PtyClient fabric", () => {
     // would be a different module instance than the one PtyClient reads, so
     // registrations here would be invisible to the code under test.
     pluginProcessTools = await import("../../../shared/config/pluginProcessToolRegistry.js");
+
+    // Installed only after the dynamic imports resolve: a faked clock during
+    // module re-execution can starve the import path and hang the hook (#11661).
+    vi.useFakeTimers();
   });
 
   afterEach(() => {

--- a/electron/services/__tests__/PtyClient.fabric.test.ts
+++ b/electron/services/__tests__/PtyClient.fabric.test.ts
@@ -123,8 +123,7 @@ describe("PtyClient fabric", () => {
     // registrations here would be invisible to the code under test.
     pluginProcessTools = await import("../../../shared/config/pluginProcessToolRegistry.js");
 
-    // Installed only after the dynamic imports resolve: a faked clock during
-    // module re-execution can starve the import path and hang the hook (#11661).
+    // Install after imports: fake timers can stall module re-execution (#11661).
     vi.useFakeTimers();
   });
 

--- a/electron/services/__tests__/PtyClient.handshake.test.ts
+++ b/electron/services/__tests__/PtyClient.handshake.test.ts
@@ -67,8 +67,7 @@ describe("PtyClient Handshake Protocol", () => {
     logBuffer = (await import("../LogBuffer.js")).logBuffer;
     logBuffer.clear();
 
-    // Installed only after the dynamic imports resolve: a faked clock during
-    // module re-execution can starve the import path and hang the hook (#11661).
+    // Install after imports: fake timers can stall module re-execution (#11661).
     vi.useFakeTimers();
   });
 

--- a/electron/services/__tests__/PtyClient.handshake.test.ts
+++ b/electron/services/__tests__/PtyClient.handshake.test.ts
@@ -35,8 +35,6 @@ describe("PtyClient Handshake Protocol", () => {
   let logBuffer: LogBuffer;
 
   beforeEach(async () => {
-    vi.useFakeTimers();
-
     // Create mock utility process
     mockChild = Object.assign(new EventEmitter(), {
       postMessage: vi.fn(),
@@ -68,6 +66,10 @@ describe("PtyClient Handshake Protocol", () => {
     forkMock = (await import("electron")).utilityProcess.fork as unknown as Mock;
     logBuffer = (await import("../LogBuffer.js")).logBuffer;
     logBuffer.clear();
+
+    // Installed only after the dynamic imports resolve: a faked clock during
+    // module re-execution can starve the import path and hang the hook (#11661).
+    vi.useFakeTimers();
   });
 
   afterEach(() => {

--- a/electron/services/__tests__/PtyClient.lifecycleLedger.test.ts
+++ b/electron/services/__tests__/PtyClient.lifecycleLedger.test.ts
@@ -97,9 +97,7 @@ describe("PtyClient lifecycle ledger", () => {
     ({ PtyClient: PtyClientClass } = await import("../PtyClient.js"));
     ({ getLifecycleLedger, disposeLifecycleLedger } = await import("../pty/lifecycleLedger.js"));
 
-    // Installed only after the dynamic imports resolve: a faked clock during
-    // module re-execution can starve the import path and hang the hook (#11661).
-    // Still ahead of the dispose below, which ran under the fake clock before.
+    // Install after imports: fake timers can stall module re-execution (#11661).
     vi.useFakeTimers();
     disposeLifecycleLedger();
   });

--- a/electron/services/__tests__/PtyClient.lifecycleLedger.test.ts
+++ b/electron/services/__tests__/PtyClient.lifecycleLedger.test.ts
@@ -88,7 +88,6 @@ describe("PtyClient lifecycle ledger", () => {
   let disposeLifecycleLedger: typeof import("../pty/lifecycleLedger.js").disposeLifecycleLedger;
 
   beforeEach(async () => {
-    vi.useFakeTimers();
     vi.resetModules();
     vi.clearAllMocks();
     shared.appMock.removeAllListeners();
@@ -97,6 +96,11 @@ describe("PtyClient lifecycle ledger", () => {
 
     ({ PtyClient: PtyClientClass } = await import("../PtyClient.js"));
     ({ getLifecycleLedger, disposeLifecycleLedger } = await import("../pty/lifecycleLedger.js"));
+
+    // Installed only after the dynamic imports resolve: a faked clock during
+    // module re-execution can starve the import path and hang the hook (#11661).
+    // Still ahead of the dispose below, which ran under the fake clock before.
+    vi.useFakeTimers();
     disposeLifecycleLedger();
   });
 

--- a/electron/services/__tests__/PtyClient.multiPort.test.ts
+++ b/electron/services/__tests__/PtyClient.multiPort.test.ts
@@ -63,8 +63,7 @@ describe("PtyClient multi-port support", () => {
     PtyClientClass = module.PtyClient;
     forkMock = (await import("electron")).utilityProcess.fork as unknown as Mock;
 
-    // Installed only after the dynamic imports resolve: a faked clock during
-    // module re-execution can starve the import path and hang the hook (#11661).
+    // Install after imports: fake timers can stall module re-execution (#11661).
     vi.useFakeTimers();
   });
 

--- a/electron/services/__tests__/PtyClient.multiPort.test.ts
+++ b/electron/services/__tests__/PtyClient.multiPort.test.ts
@@ -37,8 +37,6 @@ describe("PtyClient multi-port support", () => {
   let forkMock: Mock;
 
   beforeEach(async () => {
-    vi.useFakeTimers();
-
     mockChild = Object.assign(new EventEmitter(), {
       postMessage: vi.fn(),
       kill: vi.fn(),
@@ -64,6 +62,10 @@ describe("PtyClient multi-port support", () => {
     const module = await import("../PtyClient.js");
     PtyClientClass = module.PtyClient;
     forkMock = (await import("electron")).utilityProcess.fork as unknown as Mock;
+
+    // Installed only after the dynamic imports resolve: a faked clock during
+    // module re-execution can starve the import path and hang the hook (#11661).
+    vi.useFakeTimers();
   });
 
   afterEach(() => {

--- a/electron/services/__tests__/PtyClient.projectId.test.ts
+++ b/electron/services/__tests__/PtyClient.projectId.test.ts
@@ -29,8 +29,6 @@ describe("PtyClient projectId assignment", () => {
   let PtyClientClass: typeof import("../PtyClient.js").PtyClient;
 
   beforeEach(async () => {
-    vi.useFakeTimers();
-
     mockChild = Object.assign(new EventEmitter(), {
       postMessage: vi.fn(),
       kill: vi.fn(),
@@ -57,6 +55,10 @@ describe("PtyClient projectId assignment", () => {
 
     const module = await import("../PtyClient.js");
     PtyClientClass = module.PtyClient;
+
+    // Installed only after the dynamic import resolves: a faked clock during
+    // module re-execution can starve the import path and hang the hook (#11661).
+    vi.useFakeTimers();
   });
 
   afterEach(() => {

--- a/electron/services/__tests__/PtyClient.projectId.test.ts
+++ b/electron/services/__tests__/PtyClient.projectId.test.ts
@@ -56,8 +56,7 @@ describe("PtyClient projectId assignment", () => {
     const module = await import("../PtyClient.js");
     PtyClientClass = module.PtyClient;
 
-    // Installed only after the dynamic import resolves: a faked clock during
-    // module re-execution can starve the import path and hang the hook (#11661).
+    // Install after imports: fake timers can stall module re-execution (#11661).
     vi.useFakeTimers();
   });
 

--- a/electron/services/__tests__/PtyClient.watchdog.test.ts
+++ b/electron/services/__tests__/PtyClient.watchdog.test.ts
@@ -80,8 +80,7 @@ describe("PtyClient watchdog", () => {
 
     ({ PtyClient: PtyClientClass } = await import("../PtyClient.js"));
 
-    // Installed only after the dynamic import resolves: a faked clock during
-    // module re-execution can starve the import path and hang the hook (#11661).
+    // Install after imports: fake timers can stall module re-execution (#11661).
     vi.useFakeTimers();
   });
 

--- a/electron/services/__tests__/PtyClient.watchdog.test.ts
+++ b/electron/services/__tests__/PtyClient.watchdog.test.ts
@@ -71,7 +71,6 @@ describe("PtyClient watchdog", () => {
   let killSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(async () => {
-    vi.useFakeTimers();
     vi.resetModules();
     vi.clearAllMocks();
     shared.appMock.removeAllListeners();
@@ -80,6 +79,10 @@ describe("PtyClient watchdog", () => {
     killSpy = vi.spyOn(process, "kill").mockImplementation((() => true) as typeof process.kill);
 
     ({ PtyClient: PtyClientClass } = await import("../PtyClient.js"));
+
+    // Installed only after the dynamic import resolves: a faked clock during
+    // module re-execution can starve the import path and hang the hook (#11661).
+    vi.useFakeTimers();
   });
 
   afterEach(() => {

--- a/scripts/__tests__/fakeTimersImportOrder.contract.test.ts
+++ b/scripts/__tests__/fakeTimersImportOrder.contract.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(TEST_DIR, "../..");
+
+// Installing fake timers before an awaited dynamic `import()` in the same hook
+// runs the module re-execution path against a frozen clock. Vitest 4 delegates
+// `toFake` to @sinonjs/fake-timers, which fakes every timer-shaped global except
+// `process.nextTick` — `setImmediate` included — so anything on the loader path
+// that resolves through a timer stalls with nothing to advance it. On a cold or
+// contended CI shard that burns the whole hook timeout; locally the module is
+// warm and it passes, which is why #11661 only ever failed in CI.
+//
+// The fix is ordering: resolve every dynamic import first, then install the
+// clock. This contract keeps the pattern from being copy-pasted back in.
+//
+// The allowlist is exact rather than permissive — an entry whose count no longer
+// matches fails the test. A stale entry would otherwise silently re-permit a
+// regression in a file that had already been fixed.
+
+const HOOKS = new Set(["beforeEach", "beforeAll", "afterEach", "afterAll"]);
+const TEST_ROOTS = ["electron", "src", "shared", "scripts", "plugins", "packages"];
+const SKIP_DIRS = new Set(["node_modules", "dist", "dist-electron", "build", "release"]);
+
+/**
+ * Hooks that still install fake timers before an awaited dynamic import, keyed
+ * by repo-relative path to the exact number of offending hooks in that file.
+ *
+ * `TerminalInstanceService.*` is NOT mechanical debt: that module builds an
+ * eager top-level singleton whose `TerminalReflowController` arms a 3s
+ * `setInterval` during construction, so the module must be imported with the
+ * clock already faked or `advanceTimersByTime` cannot drive the heartbeat those
+ * suites assert on. Reordering them needs a test-factory redesign, not a line
+ * move.
+ *
+ * The rest are untriaged: each one needs its own check for load-time timer
+ * scheduling before the ordering can be flipped.
+ */
+const KNOWN_VIOLATIONS = new Map<string, number>([
+  // Load-time timer scheduling — ordering is load-bearing here.
+  ["src/services/terminal/__tests__/TerminalInstanceService.adversarial.test.ts", 1],
+  ["src/services/terminal/__tests__/TerminalInstanceService.attach.test.ts", 1],
+  ["src/services/terminal/__tests__/TerminalInstanceService.batchResize.test.ts", 2],
+  ["src/services/terminal/__tests__/TerminalInstanceService.installerCallSite.test.ts", 1],
+  ["src/services/terminal/__tests__/TerminalInstanceService.postWake.test.ts", 1],
+  ["src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts", 1],
+  ["src/services/terminal/__tests__/TerminalInstanceService.resizePass.test.ts", 1],
+  ["src/services/terminal/__tests__/TerminalInstanceService.resizeResult.test.ts", 1],
+  ["src/services/terminal/__tests__/TerminalInstanceService.switchBackObligation.test.ts", 1],
+  ["src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts", 2],
+  ["src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts", 1],
+  // Untriaged — mechanically movable pending a per-file load-time timer check.
+  ["electron/services/__tests__/DevPreviewSessionService.adversarial.test.ts", 1],
+  ["electron/services/__tests__/DevPreviewSessionService.crashLoopGuard.test.ts", 1],
+  ["electron/services/__tests__/DiagnosticsCollector.adversarial.test.ts", 1],
+  ["electron/services/__tests__/MainProcessWatchdogClient.test.ts", 1],
+  ["electron/services/__tests__/SoundService.test.ts", 1],
+  ["electron/window/__tests__/powerMonitor.test.ts", 1],
+  ["electron/window/__tests__/windowFocusThrottle.test.ts", 1],
+  ["electron/workspace-host/__tests__/WorkspaceService.forgeRemote.test.ts", 1],
+  ["src/clients/__tests__/filesClient.test.ts", 1],
+  ["src/clients/__tests__/projectClient.test.ts", 1],
+  ["src/components/ui/__tests__/reentry-summary.test.tsx", 1],
+  ["src/services/terminal/__tests__/TerminalRendererPolicy.test.ts", 2],
+]);
+
+interface Violation {
+  file: string;
+  hook: string;
+  fakeTimersLine: number;
+  importLine: number;
+}
+
+function collectTestFiles(dir: string, out: string[] = []): string[] {
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      collectTestFiles(path.join(dir, entry.name), out);
+    } else if (/\.(test|spec)\.(ts|tsx|js|jsx|mts|mjs)$/.test(entry.name)) {
+      out.push(path.join(dir, entry.name));
+    }
+  }
+  return out;
+}
+
+function isFunctionLike(node: ts.Node): boolean {
+  return (
+    ts.isFunctionDeclaration(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isArrowFunction(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isClassDeclaration(node) ||
+    ts.isClassExpression(node)
+  );
+}
+
+/** Walks `node`'s subtree without descending into nested function bodies. */
+function walkOwnScope(node: ts.Node, visit: (node: ts.Node) => void): void {
+  node.forEachChild((child) => {
+    visit(child);
+    if (isFunctionLike(child)) return;
+    walkOwnScope(child, visit);
+  });
+}
+
+function containsDynamicImport(node: ts.Node): boolean {
+  if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword)
+    return true;
+  let found = false;
+  node.forEachChild((child) => {
+    if (!found && containsDynamicImport(child)) found = true;
+  });
+  return found;
+}
+
+function isUseFakeTimersCall(node: ts.Node): boolean {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === "useFakeTimers"
+  );
+}
+
+function hookName(call: ts.CallExpression): string | undefined {
+  const { expression } = call;
+  if (ts.isIdentifier(expression) && HOOKS.has(expression.text)) return expression.text;
+  if (ts.isPropertyAccessExpression(expression) && HOOKS.has(expression.name.text)) {
+    return expression.name.text;
+  }
+  return undefined;
+}
+
+export function findViolations(relativePath: string, text: string): Violation[] {
+  const source = ts.createSourceFile(
+    relativePath,
+    text,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  );
+  const lineOf = (node: ts.Node): number =>
+    source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
+
+  const violations: Violation[] = [];
+
+  const visitAll = (node: ts.Node): void => {
+    if (ts.isCallExpression(node)) {
+      const hook = hookName(node);
+      const callback = node.arguments[0];
+      if (hook && callback && isFunctionLike(callback)) {
+        let fakeTimers: ts.Node | undefined;
+        let awaitedImport: ts.Node | undefined;
+        walkOwnScope(callback, (inner) => {
+          if (!fakeTimers && isUseFakeTimersCall(inner)) fakeTimers = inner;
+          if (!awaitedImport && ts.isAwaitExpression(inner) && containsDynamicImport(inner)) {
+            awaitedImport = inner;
+          }
+        });
+        if (
+          fakeTimers &&
+          awaitedImport &&
+          fakeTimers.getStart(source) < awaitedImport.getStart(source)
+        ) {
+          violations.push({
+            file: relativePath,
+            hook,
+            fakeTimersLine: lineOf(fakeTimers),
+            importLine: lineOf(awaitedImport),
+          });
+        }
+      }
+    }
+    node.forEachChild(visitAll);
+  };
+  visitAll(source);
+
+  return violations;
+}
+
+function scanRepo(): Violation[] {
+  const files = TEST_ROOTS.flatMap((root) => collectTestFiles(path.join(REPO_ROOT, root)));
+  return files.flatMap((absolute) =>
+    findViolations(
+      path.relative(REPO_ROOT, absolute).split(path.sep).join("/"),
+      fs.readFileSync(absolute, "utf8")
+    )
+  );
+}
+
+function describeViolation(v: Violation): string {
+  return `${v.file}:${v.fakeTimersLine} [${v.hook}] installs fake timers before the awaited dynamic import at :${v.importLine}`;
+}
+
+describe("fake timers must not precede an awaited dynamic import", () => {
+  const violations = scanRepo();
+
+  it("reports no new offending hooks", () => {
+    const counts = new Map<string, number>();
+    for (const v of violations) counts.set(v.file, (counts.get(v.file) ?? 0) + 1);
+
+    const unexpected = violations
+      .filter((v) => (counts.get(v.file) ?? 0) > (KNOWN_VIOLATIONS.get(v.file) ?? 0))
+      .map(describeViolation);
+
+    expect(unexpected).toEqual([]);
+  });
+
+  it("keeps the allowlist exact", () => {
+    const counts = new Map<string, number>();
+    for (const v of violations) counts.set(v.file, (counts.get(v.file) ?? 0) + 1);
+
+    const stale: string[] = [];
+    for (const [file, expected] of KNOWN_VIOLATIONS) {
+      const actual = counts.get(file) ?? 0;
+      if (actual !== expected) {
+        stale.push(
+          actual === 0
+            ? `${file} is fixed — remove it from KNOWN_VIOLATIONS`
+            : `${file} has ${actual} offending hook(s), allowlist says ${expected}`
+        );
+      }
+    }
+
+    expect(stale).toEqual([]);
+  });
+
+  it("keeps every PtyClient suite ordered correctly", () => {
+    const offenders = violations.filter((v) => v.file.includes("PtyClient")).map(describeViolation);
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("detector", () => {
+  const wrap = (body: string) => `import { beforeEach, vi } from "vitest";\n${body}\n`;
+
+  it("flags fake timers installed before an awaited dynamic import", () => {
+    const found = findViolations(
+      "fixture.test.ts",
+      wrap(`beforeEach(async () => {
+        vi.useFakeTimers();
+        await import("./mod.js");
+      });`)
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].hook).toBe("beforeEach");
+  });
+
+  it("accepts fake timers installed after the awaited dynamic import", () => {
+    const found = findViolations(
+      "fixture.test.ts",
+      wrap(`beforeEach(async () => {
+        await import("./mod.js");
+        vi.useFakeTimers();
+      });`)
+    );
+    expect(found).toEqual([]);
+  });
+
+  it("sees through an import nested in a property access", () => {
+    const found = findViolations(
+      "fixture.test.ts",
+      wrap(`beforeEach(async () => {
+        vi.useFakeTimers();
+        const fork = (await import("electron")).utilityProcess.fork;
+      });`)
+    );
+    expect(found).toHaveLength(1);
+  });
+
+  // A text scanner would treat the `//` as starting a comment and miss the call
+  // that follows on the next line.
+  it("is not fooled by a comment marker inside a template literal", () => {
+    const found = findViolations(
+      "fixture.test.ts",
+      wrap(`const snippet = \`https://example.com
+        not code
+      \`;
+      beforeEach(async () => {
+        vi.useFakeTimers();
+        await import("./mod.js");
+      });`)
+    );
+    expect(found).toHaveLength(1);
+  });
+
+  it("ignores calls that only look like a violation inside a template literal", () => {
+    const found = findViolations(
+      "fixture.test.ts",
+      `const sample = \`beforeEach(async () => {
+        vi.useFakeTimers();
+        await import("./mod.js");
+      });\`;\n`
+    );
+    expect(found).toEqual([]);
+  });
+
+  it("ignores fake timers installed inside a nested function", () => {
+    const found = findViolations(
+      "fixture.test.ts",
+      wrap(`beforeEach(async () => {
+        vi.doMock("electron", () => {
+          vi.useFakeTimers();
+          return {};
+        });
+        await import("./mod.js");
+      });`)
+    );
+    expect(found).toEqual([]);
+  });
+
+  it("ignores a dynamic import that is not awaited", () => {
+    const found = findViolations(
+      "fixture.test.ts",
+      wrap(`beforeEach(() => {
+        vi.useFakeTimers();
+        void import("./mod.js");
+      });`)
+    );
+    expect(found).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- `PtyClient.multiPort.test.ts` was failing intermittently in CI with `Hook timed out in 10000ms` in `beforeEach`, which cascaded into a second test failure once the aborted hook left `vi.doMock("electron", ...)` half applied.
- Root cause: Vitest 4 changed its fake timer defaults, so calling `vi.useFakeTimers()` before an awaited dynamic import freezes the clock underneath the whole module re-execution path.
- Fix: reorder `vi.useFakeTimers()` to after the dynamic imports in the 8 `PtyClient.*` suites, plus a new AST contract test so the pattern can't creep back in.

Resolves #11661

## Root cause

Vitest 4 delegates `toFake` to `@sinonjs/fake-timers`, which now fakes every timer-shaped global except `process.nextTick`. That includes `setImmediate`. Calling `vi.useFakeTimers()` before `vi.resetModules()` and an awaited `import()` runs the entire module re-execution path against a frozen clock, so anything on the loader path that resolves via a faked timer just stalls with nothing to advance it. On a cold or contended CI shard that's enough to burn the default 10 second `hookTimeout`. Locally the module is warm, which is why this only ever showed up in CI.

I confirmed this rather than just inferring it. I injected a shim into the `doMock` factory that awaits a `setImmediate`, then ran with `--hookTimeout=1000`. The old order timed out in `beforeEach`. The new order passed all 9 tests, same shim, same timeout. The shim was removed before this was committed.

## The fix

`vi.useFakeTimers()` now runs after the awaited dynamic imports in all 8 `PtyClient.*` suites. I deliberately didn't raise `hookTimeout`: a frozen clock doesn't resolve because you waited longer, so that would only mask real regressions and slow CI down for no benefit. No production code changed.

## Scope: why 8 files and not all 34

A repo-wide scan found 34 hooks across 32 files installing fake timers before an awaited dynamic import, and none of them were doing it safely. The 8 `PtyClient.*` suites are provably safe to reorder: `PtyClient` is a lazy singleton never constructed at import time, and nothing in its import graph schedules a timer or reads the clock at module scope.

The 13 `TerminalInstanceService.*` hooks are not safe. That module builds an eager top-level singleton whose `TerminalReflowController` arms a 3 second `setInterval` during construction, so it needs the clock already faked before import or `advanceTimersByTime` can't drive the heartbeat those suites assert on. I verified this empirically by reordering `TerminalInstanceService.reflow.test.ts`, which broke exactly its two heartbeat tests. Those need a test-factory redesign, not a line move.

## Regression guard

Added `electron/__tests__/fakeTimersImportOrder.contract.test.ts`, a TypeScript AST contract test that fails when any hook installs fake timers before an awaited dynamic import. I made it repo-wide rather than scoping it to the fixed family: a family-scoped guard wouldn't stop the pattern being copy-pasted into a brand new file, which is exactly how the 34 sites accumulated in the first place.

The remaining 26 hooks sit in an exact-count allowlist, annotated by category (load-bearing vs. untriaged). The counts are asserted exact, so fixing a file forces deleting its entry instead of letting a stale entry silently re-permit a regression.

## Verification

- 265 tests across 12 files pass, including `TerminalInstanceService.reflow` as a negative control proving the exclusion was honored.
- 20 fresh-process runs of `PtyClient.multiPort.test.ts` and 6 runs of the whole changed family, all green.
- `tsc -b electron/tsconfig.json --force`, eslint, and prettier are clean on all 9 changed files. (The 10 `no-explicit-any` eslint warnings in `handshake.test.ts` are pre-existing and outside the changed lines.)

## Follow-up (separate PR)

Both are recorded in the guard's allowlist comment:

- The 13 `TerminalInstanceService.*` hooks need the factory redesign described above.
- Of the untriaged set, `DiagnosticsCollector.adversarial` has no `afterEach` restoring real timers, so a naive reorder would leave the next hook importing under the previous test's frozen clock. `SoundService` also calls `resetModules()` and `import()` inside test bodies, which a hook-scoped guard can't see.
