### PR TITLE
fix(launcher): keep focus on the panel the dock launcher just created

### DIFF
--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -170,12 +170,21 @@ export function DockLaunchButton({
   // Single close path. Radix only calls onOpenChange for closes it initiates, so
   // the Enter-to-launch path (which sets `open` directly) would otherwise skip
   // the query reset and reopen still filtered.
-  const closeLauncher = useCallback(() => {
-    // Local state, not paletteId-backed — reset it ourselves so the next open
-    // starts unfiltered on the Recently launched / Pinned bands.
-    clearQuery();
-    setOpen(false);
-  }, [clearQuery]);
+  const closeLauncher = useCallback(
+    (suppressCloseAutoFocus = false) => {
+      // Assigned on every close, never merely armed on the ones that launch.
+      // Reopening inside the content's exit animation cancels Radix's unmount
+      // outright, so that close never reaches close-autofocus and its answer is
+      // left unspent — and the next Escape would spend it, losing the focus
+      // return the launcher owes a dismissal that launched nothing.
+      suppressCloseAutoFocusRef.current = suppressCloseAutoFocus;
+      // Local state, not paletteId-backed — reset it ourselves so the next open
+      // starts unfiltered on the Recently launched / Pinned bands.
+      clearQuery();
+      setOpen(false);
+    },
+    [clearQuery]
+  );
 
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {
@@ -199,14 +208,19 @@ export function DockLaunchButton({
       // genuinely launch: the two branches below navigate instead, into
       // dialogs that manage their own focus, and their dispatch can fail — the
       // WAI-ARIA return is what keeps the keyboard somewhere useful if it does.
+      //
+      // Decided on intent, not outcome: every launch below is fire-and-forget,
+      // so whether a panel actually appears is not knowable here. A launch that
+      // fails outright (the hard panel limit, a recipe that spawns nothing)
+      // therefore drops focus to the body rather than the trigger — the
+      // accepted cost of not stealing focus on the overwhelmingly common path.
       const launches =
         item !== undefined &&
         // Mirrors the redirect in activateDockLaunchItem: an agent that isn't
         // launchable opens its settings subtab rather than a panel.
         (item.category !== "agent" || isAgentLaunchable(item.agent.availability));
-      if (launches) suppressCloseAutoFocusRef.current = true;
 
-      closeLauncher();
+      closeLauncher(launches);
       if (!item) {
         activateCreateRecipeCue(activeWorktreeId, "menu");
         return;

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -62,6 +62,9 @@ export function DockLaunchButton({
   const [tooltipOpen, setTooltipOpen] = useState(false);
   const isRestoringFocusRef = useRef(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  // Armed on the way out of a launch, spent by the shell's close-autofocus.
+  // See activateRow.
+  const suppressCloseAutoFocusRef = useRef(false);
   const listboxId = useId();
   const getOptionId = useCallback((rowKey: string) => `${listboxId}-${rowKey}`, [listboxId]);
 
@@ -128,6 +131,15 @@ export function DockLaunchButton({
     isRestoringFocusRef.current = true;
   }, []);
 
+  // Read-and-disarm in one step, so a close the shell suppressed for its own
+  // reasons still spends the flag rather than leaving it to fire on the next
+  // Escape.
+  const consumeCloseAutoFocusSuppression = useCallback(() => {
+    const suppress = suppressCloseAutoFocusRef.current;
+    suppressCloseAutoFocusRef.current = false;
+    return suppress;
+  }, []);
+
   // Re-anchor the selection each time the launcher opens. Closing only clears
   // the query, so the hook's follow-anchor still points wherever browsing
   // ended, while the reopened popover mounts its scroller at the top and the
@@ -179,12 +191,27 @@ export function DockLaunchButton({
 
   const activateRow = useCallback(
     (row: DockLaunchRow) => {
+      const { item } = row;
+      // Everything closes through `closeLauncher`, so Radix cannot tell a
+      // launch from an Escape and restores focus to the trigger either way —
+      // landing a beat after the new panel took it, once the content's exit
+      // animation ends (#11664). Cancel that return, but only for rows that
+      // genuinely launch: the two branches below navigate instead, into
+      // dialogs that manage their own focus, and their dispatch can fail — the
+      // WAI-ARIA return is what keeps the keyboard somewhere useful if it does.
+      const launches =
+        item !== undefined &&
+        // Mirrors the redirect in activateDockLaunchItem: an agent that isn't
+        // launchable opens its settings subtab rather than a panel.
+        (item.category !== "agent" || isAgentLaunchable(item.agent.availability));
+      if (launches) suppressCloseAutoFocusRef.current = true;
+
       closeLauncher();
-      if (!row.item) {
+      if (!item) {
         activateCreateRecipeCue(activeWorktreeId, "menu");
         return;
       }
-      activateDockLaunchItem(row.item, {
+      activateDockLaunchItem(item, {
         cwd,
         activeWorktreeId,
         recipeContext,
@@ -288,6 +315,7 @@ export function DockLaunchButton({
         inputRef={inputRef}
         onClearQuery={clearQuery}
         onCloseAutoFocus={suppressTooltipDuringFocusRestore}
+        consumeCloseAutoFocusSuppression={consumeCloseAutoFocusSuppression}
         side="top"
         align="start"
         sideOffset={4}

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -988,8 +988,10 @@ describe("DockLaunchButton", () => {
     expect(popoverCloseAutoFocusSpy).toBeTruthy();
     expect(popoverPointerDownOutsideSpy).toBeTruthy();
 
-    // Keyboard close (no prior pointer-down-outside) must NOT preventDefault
-    // — focus restoration is required for WAI-ARIA Escape/Enter.
+    // Keyboard close with nothing launched (no prior pointer-down-outside) must
+    // NOT preventDefault — WAI-ARIA requires the return on a bare dismissal.
+    // Enter that activates a launch row is the deliberate exception, covered by
+    // the #11664 block below.
     const keyboardPreventDefault = vi.fn();
     popoverCloseAutoFocusSpy!({ preventDefault: keyboardPreventDefault });
     expect(keyboardPreventDefault).not.toHaveBeenCalled();
@@ -1043,14 +1045,54 @@ describe("DockLaunchButton", () => {
       expect(fireCloseAutoFocus()).toHaveBeenCalledTimes(1);
     });
 
-    it("spends the suppression on a single close", () => {
+    it("cancels the return when a clicked row launches a terminal", () => {
+      // Terminal routes through onLaunchAgent rather than addPanel — the exact
+      // path the issue was reported against.
+      const onLaunchAgent = vi.fn();
+      const { getByText } = renderButton({ onLaunchAgent });
+
+      fireEvent.click(getByText("Terminal"));
+
+      expect(onLaunchAgent).toHaveBeenCalledWith("terminal");
+      expect(fireCloseAutoFocus()).toHaveBeenCalledTimes(1);
+    });
+
+    it("cancels the return when a clicked row runs a recipe", async () => {
+      mockRecipes = [{ id: "r-1", name: "My recipe", worktreeId: undefined }];
+      const { getByText } = renderButton();
+
+      fireEvent.click(getByText("My recipe"));
+
+      // Decided on intent: the spawn is still in flight when the close lands.
+      expect(fireCloseAutoFocus()).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(notifySpawnFailuresMock).toHaveBeenCalled());
+    });
+
+    it("decides afresh on every close instead of staying suppressed", () => {
       const { getByText } = renderButton();
 
       fireEvent.click(getByText("Claude"));
-      fireCloseAutoFocus();
+      expect(fireCloseAutoFocus()).toHaveBeenCalledTimes(1);
 
-      // A later Escape has to get its focus return back, or the launcher
-      // strands the keyboard every time it is dismissed without launching.
+      // Dismissed without launching: the WAI-ARIA return has to come back, or
+      // the launcher strands the keyboard on every later Escape.
+      act(() => popoverOpenChangeSpy!(false));
+      expect(fireCloseAutoFocus()).not.toHaveBeenCalled();
+
+      fireEvent.click(getByText("Claude"));
+      expect(fireCloseAutoFocus()).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not carry a launch's suppression into a later dismissal", () => {
+      // Reopening inside the content's exit animation makes Radix cancel the
+      // unmount, so that launch's close never reaches close-autofocus and its
+      // answer is never spent. The next dismissal must still get its return.
+      const { getByText } = renderButton();
+
+      fireEvent.click(getByText("Claude"));
+      act(() => popoverOpenChangeSpy!(true));
+      act(() => popoverOpenChangeSpy!(false));
+
       expect(fireCloseAutoFocus()).not.toHaveBeenCalled();
     });
 
@@ -1073,9 +1115,10 @@ describe("DockLaunchButton", () => {
       expect(fireCloseAutoFocus()).not.toHaveBeenCalled();
     });
 
-    it("keeps the return when the launcher is dismissed without activating a row", () => {
+    it("keeps the return when an opened launcher is dismissed without activating a row", () => {
       renderButton();
 
+      act(() => popoverOpenChangeSpy!(true));
       act(() => popoverOpenChangeSpy!(false));
 
       expect(fireCloseAutoFocus()).not.toHaveBeenCalled();

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -1007,6 +1007,81 @@ describe("DockLaunchButton", () => {
     expect(resetPreventDefault).not.toHaveBeenCalled();
   });
 
+  describe("focus return after activation (#11664)", () => {
+    /** Radix's restore runs after the close; this is what would cancel it. */
+    function fireCloseAutoFocus() {
+      const preventDefault = vi.fn();
+      act(() => popoverCloseAutoFocusSpy!({ preventDefault }));
+      return preventDefault;
+    }
+
+    it("cancels the return when a clicked row launches an agent", () => {
+      const { getByText } = renderButton();
+
+      fireEvent.click(getByText("Claude"));
+
+      // Without this the trigger takes focus back once the content's exit
+      // animation ends — after the new panel already had it.
+      expect(fireCloseAutoFocus()).toHaveBeenCalledTimes(1);
+    });
+
+    it("cancels the return when a clicked row creates a panel", () => {
+      const { getByText } = renderButton({ activeWorktreeId: "wt-1" });
+
+      fireEvent.click(getByText("Review"));
+
+      expect(fireCloseAutoFocus()).toHaveBeenCalledTimes(1);
+    });
+
+    it("cancels the return when Enter launches the top result", () => {
+      const { container } = renderButton();
+      const input = searchInput(container);
+
+      fireEvent.change(input, { target: { value: "claude" } });
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(fireCloseAutoFocus()).toHaveBeenCalledTimes(1);
+    });
+
+    it("spends the suppression on a single close", () => {
+      const { getByText } = renderButton();
+
+      fireEvent.click(getByText("Claude"));
+      fireCloseAutoFocus();
+
+      // A later Escape has to get its focus return back, or the launcher
+      // strands the keyboard every time it is dismissed without launching.
+      expect(fireCloseAutoFocus()).not.toHaveBeenCalled();
+    });
+
+    it("keeps the return when a row routes to settings instead of launching", () => {
+      const onLaunchAgent = vi.fn();
+      const { getByText } = renderButton({ onLaunchAgent });
+
+      fireEvent.click(getByText("Gemini"));
+
+      expect(onLaunchAgent).not.toHaveBeenCalled();
+      expect(fireCloseAutoFocus()).not.toHaveBeenCalled();
+    });
+
+    it("keeps the return for the Create a recipe cue", () => {
+      mockRecipes = [];
+      const { getByText } = renderButton({ activeWorktreeId: "wt-1" });
+
+      fireEvent.click(getByText("Create a recipe"));
+
+      expect(fireCloseAutoFocus()).not.toHaveBeenCalled();
+    });
+
+    it("keeps the return when the launcher is dismissed without activating a row", () => {
+      renderButton();
+
+      act(() => popoverOpenChangeSpy!(false));
+
+      expect(fireCloseAutoFocus()).not.toHaveBeenCalled();
+    });
+  });
+
   it("invokes runRecipeWithResults with cwd, worktreeId, and recipe context when a recipe is selected", async () => {
     mockRecipes = [{ id: "r-1", name: "My recipe", worktreeId: undefined }];
 

--- a/src/components/ui/AppPalettePopover.tsx
+++ b/src/components/ui/AppPalettePopover.tsx
@@ -163,9 +163,13 @@ export interface AppPalettePopoverContentProps extends Omit<
    * Separate from `restoreFocusOnPointerDismiss` rather than folded into it:
    * that flag is a standing policy about how pointer dismissals should look,
    * this is one close that must not bounce. Named for the side effect — the
-   * shell calls it exactly once per close, including closes it was going to
-   * suppress anyway, so the consumer can disarm on the same call and never
-   * carry a stale answer into the next dismissal.
+   * shell asks exactly once per close, including closes the pointer branch was
+   * going to suppress anyway, so the answer can be disarmed on the same call.
+   *
+   * Decide per close rather than arming and waiting to be asked: reopening
+   * inside the content's exit animation cancels Radix's unmount, so that close
+   * never reaches close-autofocus and an armed answer would survive to be spent
+   * on the next dismissal.
    */
   consumeCloseAutoFocusSuppression?: () => boolean;
   /**
@@ -210,10 +214,9 @@ function AppPalettePopoverContent({
     // A dismissal that got vetoed, or one reversed mid-exit, can leave the
     // pointer flag armed with no close-autofocus to consume it.
     //
-    // Only this flag. The consumer's own suppression is armed on the way out,
-    // and the content survives its exit animation, so disarming anything here
-    // on a reopen inside that window would strip the pending close of the
-    // answer it is still about to ask for.
+    // Only this flag: `consumeCloseAutoFocusSuppression` is the consumer's to
+    // keep current, and reopening inside the exit animation cancels the unmount
+    // outright rather than leaving a close-autofocus in flight.
     wasPointerCloseRef.current = false;
     const frame = requestAnimationFrame(focusInput);
     return () => cancelAnimationFrame(frame);

--- a/src/components/ui/AppPalettePopover.tsx
+++ b/src/components/ui/AppPalettePopover.tsx
@@ -155,6 +155,20 @@ export interface AppPalettePopoverContentProps extends Omit<
    */
   restoreFocusOnPointerDismiss?: boolean;
   /**
+   * Asked once per close whether this particular close must not bounce focus
+   * back to the trigger. Activating a row is an inside close, so Radix has no
+   * event that tells it apart from Escape — the palette that just launched
+   * something is the only thing that knows focus is already travelling.
+   *
+   * Separate from `restoreFocusOnPointerDismiss` rather than folded into it:
+   * that flag is a standing policy about how pointer dismissals should look,
+   * this is one close that must not bounce. Named for the side effect — the
+   * shell calls it exactly once per close, including closes it was going to
+   * suppress anyway, so the consumer can disarm on the same call and never
+   * carry a stale answer into the next dismissal.
+   */
+  consumeCloseAutoFocusSuppression?: () => boolean;
+  /**
    * Fired before Radix restores focus, for triggers that have to suppress
    * something on the way out (a tooltip that would re-open on focus). The shell
    * keeps ownership of the Radix event itself.
@@ -167,6 +181,7 @@ function AppPalettePopoverContent({
   inputRef,
   onClearQuery,
   restoreFocusOnPointerDismiss = false,
+  consumeCloseAutoFocusSuppression,
   onCloseAutoFocus,
   onEscapeKeyDown,
   onInteractOutside,
@@ -194,6 +209,11 @@ function AppPalettePopoverContent({
     if (!isOpen) return;
     // A dismissal that got vetoed, or one reversed mid-exit, can leave the
     // pointer flag armed with no close-autofocus to consume it.
+    //
+    // Only this flag. The consumer's own suppression is armed on the way out,
+    // and the content survives its exit animation, so disarming anything here
+    // on a reopen inside that window would strip the pending close of the
+    // answer it is still about to ask for.
     wasPointerCloseRef.current = false;
     const frame = requestAnimationFrame(focusInput);
     return () => cancelAnimationFrame(frame);
@@ -231,8 +251,13 @@ function AppPalettePopoverContent({
 
   const handleCloseAutoFocus = useCallback(
     (event: Event) => {
+      // Unconditional, and ahead of everything else: the answer is a one-shot
+      // the consumer disarms as it hands it over, so skipping the call on a
+      // close the pointer branch would have suppressed anyway would leave it
+      // armed for the next one.
+      const suppressRequested = consumeCloseAutoFocusSuppression?.() === true;
       onCloseAutoFocus?.();
-      if (!restoreFocusOnPointerDismiss && wasPointerCloseRef.current) {
+      if (suppressRequested || (!restoreFocusOnPointerDismiss && wasPointerCloseRef.current)) {
         event.preventDefault();
       }
       // Cleared on every close, not just the suppressed ones: a palette that
@@ -240,7 +265,7 @@ function AppPalettePopoverContent({
       // pointer dismissal and taint the next keyboard close.
       wasPointerCloseRef.current = false;
     },
-    [onCloseAutoFocus, restoreFocusOnPointerDismiss]
+    [consumeCloseAutoFocusSuppression, onCloseAutoFocus, restoreFocusOnPointerDismiss]
   );
 
   const handleEscapeKeyDown = useCallback(

--- a/src/components/ui/__tests__/AppPalettePopover.test.tsx
+++ b/src/components/ui/__tests__/AppPalettePopover.test.tsx
@@ -80,6 +80,7 @@ interface HarnessProps {
   modal?: boolean;
   dismissOnForeignOverlay?: boolean;
   restoreFocusOnPointerDismiss?: boolean;
+  consumeCloseAutoFocusSuppression?: () => boolean;
   initialOpen?: boolean;
   /** Drives the open state from the test, overriding the harness's own. */
   open?: boolean;
@@ -580,6 +581,48 @@ describe("AppPalettePopover", () => {
       fireCloseAutoFocus();
 
       expect(onCloseAutoFocus).toHaveBeenCalledTimes(1);
+    });
+
+    it("suppresses the return when the consumer claims the close", () => {
+      // Opted into pointer restoration, so only the consumer's answer can be
+      // producing the suppression — the two policies are independent.
+      render(
+        <Harness
+          restoreFocusOnPointerDismiss={true}
+          consumeCloseAutoFocusSuppression={() => true}
+        />
+      );
+
+      expect(fireCloseAutoFocus().preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    it("leaves the return alone when the consumer declines", () => {
+      render(<Harness consumeCloseAutoFocusSuppression={() => false} />);
+
+      expect(fireCloseAutoFocus().preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("asks the consumer exactly once per close", () => {
+      const consume = vi.fn(() => false);
+      render(<Harness consumeCloseAutoFocusSuppression={consume} />);
+
+      fireCloseAutoFocus();
+      fireCloseAutoFocus();
+
+      // The consumer disarms itself on the call, so a second ask per close
+      // would spend an answer that belongs to the next one.
+      expect(consume).toHaveBeenCalledTimes(2);
+    });
+
+    it("still asks when a pointer dismissal already decided the outcome", () => {
+      // The pointer branch would short-circuit an `||`, leaving the consumer
+      // armed to fire on the following keyboard close.
+      const consume = vi.fn(() => false);
+      render(<Harness consumeCloseAutoFocusSuppression={consume} />);
+      act(() => contentProps.onPointerDownOutside?.());
+
+      expect(fireCloseAutoFocus().preventDefault).toHaveBeenCalledTimes(1);
+      expect(consume).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/components/ui/__tests__/AppPalettePopover.test.tsx
+++ b/src/components/ui/__tests__/AppPalettePopover.test.tsx
@@ -624,6 +624,27 @@ describe("AppPalettePopover", () => {
       expect(fireCloseAutoFocus().preventDefault).toHaveBeenCalledTimes(1);
       expect(consume).toHaveBeenCalledTimes(1);
     });
+
+    it("asks the consumer before telling it the close is happening", () => {
+      // All three policies live at once — a pointer dismissal the palette opted
+      // to restore from, plus a consumer claiming the close. The claim still
+      // wins, and the notification still fires on a suppressed close.
+      const calls: string[] = [];
+      render(
+        <Harness
+          restoreFocusOnPointerDismiss={true}
+          consumeCloseAutoFocusSuppression={() => {
+            calls.push("consume");
+            return true;
+          }}
+          onCloseAutoFocus={() => calls.push("notify")}
+        />
+      );
+      act(() => contentProps.onPointerDownOutside?.());
+
+      expect(fireCloseAutoFocus().preventDefault).toHaveBeenCalledTimes(1);
+      expect(calls).toEqual(["consume", "notify"]);
+    });
   });
 
   describe("foreign overlay dismissal", () => {


### PR DESCRIPTION
Launching a terminal or agent from the dock's `+` button left keyboard focus on the `+` itself — focus ring and all — so the first thing you typed went nowhere.

The panel store was doing its job; focus was being taken back afterwards. `AppPalettePopoverContent.handleCloseAutoFocus` only cancelled Radix's focus-return-to-trigger when the popover was dismissed by an outside pointer click. Activating a row is an *inside* close (`closeLauncher()` → `setOpen(false)`, a controlled-prop transition Radix emits no event for), so the return still fired — and because the content has a 120ms exit animation, it landed a beat *after* the new panel had already taken focus.

Radix can't tell the two apart, so the launcher has to say which kind of close it just performed. `AppPalettePopover.Content` gains an optional `consumeCloseAutoFocusSuppression?: () => boolean`, asked exactly once per close and OR'd with the existing pointer-dismiss branch. `DockLaunchButton` answers it from a ref that `closeLauncher` assigns on every close.

Kept narrow on purpose:

- **Escape and outside-click still return focus to the trigger**, per WAI-ARIA. Only a close that already handed focus somewhere else suppresses.
- **Rows that navigate rather than launch don't suppress** — the "Create a recipe" cue and an unavailable agent's redirect to Settings both open dialogs that manage their own focus, and their dispatch can fail, where the focus return is what keeps the keyboard somewhere useful.
- **The flag is assigned on every close, not armed on launches.** Reopening inside the exit animation makes Radix Presence cancel the unmount, so that close never reaches close-autofocus — an armed flag would have survived to suppress a later Escape and quietly break the return this change is meant to preserve. There's a regression test for exactly that sequence.
- **`ProjectSwitcherPalette`, the shell's other consumer, is unaffected** and unchanged. Its rows switch projects, which swaps the whole `WebContentsView` and focuses the incoming one in Main — the outgoing trigger was never the keyboard-owning surface. Suppressing there would also be wrong for re-selecting the already-active project, where closing and returning focus is the intended "never mind".

**Known trade-off:** suppression is decided on launch *intent*, because every launch path here is fire-and-forget and the outcome isn't knowable before the close. A launch that fails outright — the hard panel limit, a recipe that spawns nothing — now drops focus to the body instead of the trigger. Sampling `document.activeElement` at close time would be the obvious alternative but is unreliable here: panel focus is deferred one or two frames and launches resolve over IPC, so the check would race. Doing it properly means propagating a typed launch outcome through `activateDockLaunchItem`/`onLaunchAgent`, which is a bigger change than this bug warrants — worth its own issue.

**Testing:** 365 tests pass across the 10 affected suites. New coverage for the click, Enter, terminal (`onLaunchAgent`) and recipe launch paths, the non-launching exclusions, the reopen-during-exit regression, and the ordering guarantee that the consumer is asked before it's notified. The existing Escape and pointer-dismissal tests are unchanged — they encode the WAI-ARIA contract that had to keep passing. Assertions are on the `preventDefault` call rather than `document.activeElement`, matching the existing suites and avoiding jsdom focus-timing flake.

Resolves #11664