### PR TITLE
feat(toolbar): ship the file browser visible and move web tools into a panel tray

### DIFF
--- a/e2e/full/panels/core-dev-preview.spec.ts
+++ b/e2e/full/panels/core-dev-preview.spec.ts
@@ -5,7 +5,11 @@ import path from "path";
 import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
 import { createFixtureRepo } from "../../helpers/fixtures";
 import { openAndOnboardProject } from "../../helpers/project";
-import { getGridPanelCount } from "../../helpers/panels";
+import {
+  expectToolbarButtonReachable,
+  getGridPanelCount,
+  openDevPreview,
+} from "../../helpers/panels";
 import { SEL } from "../../helpers/selectors";
 import { T_SHORT, T_MEDIUM, T_LONG } from "../../helpers/timeouts";
 
@@ -34,10 +38,12 @@ test.describe.serial("Core: Dev Preview", () => {
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureRepoPath, PROJECT_NAME);
 
-    // Fail fast if the dev preview entry point is missing — the button renders
-    // for any onboarded project, so its absence is a real regression, not a
-    // launch-state quirk to silently skip past.
-    await expect(ctx.window.locator(SEL.toolbar.openDevPreview)).toBeVisible({ timeout: T_LONG });
+    // Fail fast if the dev preview entry point is missing — it is reachable for
+    // any onboarded project, so its absence is a real regression, not a
+    // launch-state quirk to silently skip past. Reachability rather than direct
+    // visibility since #11667: `dev-server` is no longer a default toolbar
+    // button, so on a fresh profile it lives in the panel tray.
+    await expectToolbarButtonReachable(ctx.window, SEL.toolbar.openDevPreview, T_LONG);
   });
 
   test.afterAll(async () => {
@@ -50,9 +56,8 @@ test.describe.serial("Core: Dev Preview", () => {
     test("opening dev preview panel adds to grid", async () => {
       const { window } = ctx;
 
-      const devBtn = window.locator(SEL.toolbar.openDevPreview);
       const before = await getGridPanelCount(window);
-      await devBtn.click();
+      await openDevPreview(window);
 
       await expect.poll(() => getGridPanelCount(window), { timeout: T_LONG }).toBe(before + 1);
     });
@@ -165,9 +170,8 @@ server.listen(0, '127.0.0.1', () => {
       const { window } = ctx;
 
       // Open dev preview panel
-      const devBtn = window.locator(SEL.toolbar.openDevPreview);
       const before = await getGridPanelCount(window);
-      await devBtn.click();
+      await openDevPreview(window);
       await expect.poll(() => getGridPanelCount(window), { timeout: T_LONG }).toBe(before + 1);
 
       // Confirm unconfigured state

--- a/e2e/full/panels/dev-preview-console-capture.spec.ts
+++ b/e2e/full/panels/dev-preview-console-capture.spec.ts
@@ -4,7 +4,7 @@ import path from "path";
 import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
 import { createFixtureRepo } from "../../helpers/fixtures";
 import { openAndOnboardProject } from "../../helpers/project";
-import { getGridPanelCount } from "../../helpers/panels";
+import { getGridPanelCount, isToolbarButtonReachable, openDevPreview } from "../../helpers/panels";
 import { SEL } from "../../helpers/selectors";
 import { T_SHORT, T_MEDIUM, T_LONG } from "../../helpers/timeouts";
 
@@ -48,11 +48,13 @@ server.listen(0, '127.0.0.1', () => {
   test("captures guest console errors into the Console tab", async () => {
     const { window } = ctx;
 
-    const devBtn = window.locator(SEL.toolbar.openDevPreview);
-    if (!(await devBtn.isVisible().catch(() => false))) {
+    // Reachability, not direct button visibility: since #11667 `dev-server` is
+    // not a default toolbar button, so probing the locator would fail on every
+    // fresh profile and skip this test permanently while still reporting green.
+    if (!(await isToolbarButtonReachable(window, SEL.toolbar.openDevPreview))) {
       test.info().annotations.push({
         type: "conditional-skip",
-        description: "Dev preview toolbar button not visible in this launch state",
+        description: "Dev preview entry point not reachable in this launch state",
       });
 
       test.skip();
@@ -60,7 +62,7 @@ server.listen(0, '127.0.0.1', () => {
     }
 
     const before = await getGridPanelCount(window);
-    await devBtn.click();
+    await openDevPreview(window);
     await expect.poll(() => getGridPanelCount(window), { timeout: T_LONG }).toBe(before + 1);
 
     await expect(window.getByRole("heading", { name: "Set a dev command" })).toBeVisible({

--- a/e2e/full/panels/dev-preview-promote-to-portal.spec.ts
+++ b/e2e/full/panels/dev-preview-promote-to-portal.spec.ts
@@ -4,7 +4,7 @@ import path from "path";
 import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
 import { createFixtureRepo } from "../../helpers/fixtures";
 import { openAndOnboardProject } from "../../helpers/project";
-import { getGridPanelCount } from "../../helpers/panels";
+import { getGridPanelCount, isToolbarButtonReachable, openDevPreview } from "../../helpers/panels";
 import { saveCurrentProjectSettings } from "../../helpers/projectSettings";
 import { SEL } from "../../helpers/selectors";
 import { T_MEDIUM, T_LONG, T_SETTLE } from "../../helpers/timeouts";
@@ -60,18 +60,20 @@ test.describe.serial("Core: Dev preview promote to portal", () => {
   test("promoting a dev preview opens a portal tab sharing the session cookie", async () => {
     const { window } = ctx;
 
-    // 1. Open a dev-preview panel.
-    const devBtn = window.locator(SEL.toolbar.openDevPreview);
-    if (!(await devBtn.isVisible().catch(() => false))) {
+    // 1. Open a dev-preview panel. Reachability, not direct button visibility:
+    //    since #11667 `dev-server` is not a default toolbar button, so probing
+    //    the locator would fail on every fresh profile and skip this test
+    //    permanently while still reporting green.
+    if (!(await isToolbarButtonReachable(window, SEL.toolbar.openDevPreview))) {
       test.info().annotations.push({
         type: "conditional-skip",
-        description: "Dev preview toolbar button not visible in this launch state",
+        description: "Dev preview entry point not reachable in this launch state",
       });
       test.skip();
       return;
     }
     const before = await getGridPanelCount(window);
-    await devBtn.click();
+    await openDevPreview(window);
     await expect.poll(() => getGridPanelCount(window), { timeout: T_LONG }).toBe(before + 1);
 
     // 2. Wait for the configured dev server to be running, then write a cookie

--- a/e2e/helpers/panels.ts
+++ b/e2e/helpers/panels.ts
@@ -268,8 +268,11 @@ async function clickPanelTrayItem(
   const tray = toolbar.locator('[data-toolbar-button-id="panel-tray"] button');
   if (!(await clickFirstVisible(tray, 1000, 500))) return false;
 
+  // The caller's timeout, not a fixed second: the dropdown primitives are
+  // lazy-loaded, so the first tray open on a cold release runner can be slower
+  // than any menu this suite has already warmed.
   const row = page.locator(`[data-testid="panel-tray-row-${itemId}"]`);
-  if (!(await row.isVisible({ timeout: 1000 }).catch(() => false))) {
+  if (!(await row.isVisible({ timeout }).catch(() => false))) {
     await page.keyboard.press("Escape").catch(() => undefined);
     return false;
   }
@@ -449,6 +452,39 @@ export async function openTerminal(page: Page): Promise<void> {
  */
 export async function openBrowser(page: Page): Promise<void> {
   await clickToolbarButton(page, SEL.toolbar.openBrowser);
+}
+
+/**
+ * Open the dev preview panel.
+ *
+ * Always route through here rather than clicking `SEL.toolbar.openDevPreview`
+ * directly: since #11667 `dev-server` is not a default toolbar button, so on a
+ * fresh profile — which every e2e profile is — that locator matches nothing and
+ * the panel is reached through the panel tray instead. A direct click would
+ * fail, and a direct `isVisible()` probe guarding a `test.skip()` would skip
+ * forever while still reporting green.
+ */
+export async function openDevPreview(page: Page): Promise<void> {
+  await clickToolbarButton(page, SEL.toolbar.openDevPreview);
+}
+
+/**
+ * Whether a toolbar command can be reached at all — as a direct button, an
+ * overflow row, or a panel-tray row. The boolean sibling of
+ * `expectToolbarButtonReachable`, for specs that legitimately skip when an entry
+ * point is absent in a given launch state rather than failing.
+ */
+export async function isToolbarButtonReachable(
+  page: Page,
+  selector: string,
+  timeout = 5000
+): Promise<boolean> {
+  try {
+    await expectToolbarButtonReachable(page, selector, timeout);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function getFirstGridPanel(page: Page): Locator {

--- a/e2e/helpers/panels.ts
+++ b/e2e/helpers/panels.ts
@@ -22,6 +22,20 @@ const toolbarButtonIds: Record<string, string> = {
   Notifications: "notification-center",
 };
 
+/**
+ * Toolbar commands that live in the panel tray (#11667).
+ *
+ * `browser` and `dev-server` left the default toolbar in v13, so on a fresh
+ * profile — which is every e2e profile — they have no direct button and no
+ * overflow row of their own. The tray dropdown is their route. Keyed by the
+ * button's aria-label, valued by the tray row's item id.
+ */
+const toolbarPanelTrayItemIds: Record<string, string> = {
+  "Open browser": "browser",
+  "Open dev preview": "dev-server",
+  "Browse files": "file-browser",
+};
+
 const toolbarShortcuts: Record<string, string> = {
   "Open terminal": `${mod}+Alt+t`,
   "Open browser": `${mod}+Alt+b`,
@@ -233,6 +247,57 @@ async function clickToolbarOverflowItem(
   return false;
 }
 
+/**
+ * Open the panel tray and activate one of its rows.
+ *
+ * Sits between the overflow attempt and the keyboard fallback in
+ * `clickToolbarButton`: when the tray is itself in overflow its rows are inlined
+ * and the overflow path already found them, so this only runs for the case the
+ * overflow path can't cover — a visible tray whose items have no button of their
+ * own.
+ */
+async function clickPanelTrayItem(
+  page: Page,
+  toolbar: Locator,
+  label: string,
+  timeout: number
+): Promise<boolean> {
+  const itemId = toolbarPanelTrayItemIds[label];
+  if (!itemId) return false;
+
+  const tray = toolbar.locator('[data-toolbar-button-id="panel-tray"] button');
+  if (!(await clickFirstVisible(tray, 1000, 500))) return false;
+
+  const row = page.locator(`[data-testid="panel-tray-row-${itemId}"]`);
+  if (!(await row.isVisible({ timeout: 1000 }).catch(() => false))) {
+    await page.keyboard.press("Escape").catch(() => undefined);
+    return false;
+  }
+
+  try {
+    await row.click({ timeout });
+  } catch {
+    // Same ambiguity as a direct toolbar button: once the row was there, don't
+    // retry a non-idempotent command through another route.
+  }
+  return true;
+}
+
+async function hasPanelTrayItem(page: Page, toolbar: Locator, label: string): Promise<boolean> {
+  const itemId = toolbarPanelTrayItemIds[label];
+  if (!itemId) return false;
+
+  const tray = toolbar.locator('[data-toolbar-button-id="panel-tray"] button');
+  if (!(await clickFirstVisible(tray, 1000, 250))) return false;
+
+  const visible = await page
+    .locator(`[data-testid="panel-tray-row-${itemId}"]`)
+    .isVisible({ timeout: 500 })
+    .catch(() => false);
+  await page.keyboard.press("Escape").catch(() => undefined);
+  return visible;
+}
+
 async function hasToolbarOverflowItem(
   page: Page,
   toolbar: Locator,
@@ -289,6 +354,10 @@ export async function clickToolbarButton(
     return;
   }
 
+  if (label && (await clickPanelTrayItem(page, toolbar, label, timeout))) {
+    return;
+  }
+
   if (label && toolbarShortcuts[label]) {
     await page.keyboard.press(toolbarShortcuts[label]);
     return;
@@ -326,6 +395,10 @@ export async function expectToolbarButtonReachable(
     }
 
     if (label && (await hasToolbarOverflowItem(page, toolbar, label))) {
+      return;
+    }
+
+    if (label && (await hasPanelTrayItem(page, toolbar, label))) {
       return;
     }
 

--- a/e2e/screenshots/store-reel.spec.ts
+++ b/e2e/screenshots/store-reel.spec.ts
@@ -33,6 +33,7 @@ import {
 } from "../helpers/launch";
 import { dismissTelemetryConsent } from "../helpers/project";
 import { dismissBlockingPalette } from "../helpers/overlays";
+import { isToolbarButtonReachable, openDevPreview } from "../helpers/panels";
 import { SEL } from "../helpers/selectors";
 import { configureClaudeAuthEnv, hasClaudeApiKey } from "../helpers/claudeAuth";
 import { writeTerminalInput, getTerminalText } from "../helpers/terminal";
@@ -436,10 +437,13 @@ test.describe.serial("Marketing Screenshots — Daintree Store Reel", () => {
       });
       annotateAgentResponse(devResponded, "Claude (dev preview)", 240_000);
 
-      // Open the dev preview panel.
-      const devBtn = page.locator(SEL.toolbar.openDevPreview);
-      if (await devBtn.isVisible({ timeout: T_MEDIUM }).catch(() => false)) {
-        await devBtn.click();
+      // Open the dev preview panel. Reachability rather than a direct locator:
+      // since #11667 `dev-server` is not a default toolbar button, so on this
+      // scene's fresh profile it is reached through the panel tray — a direct
+      // probe would silently skip the panel and produce a screenshot of the
+      // wrong scene.
+      if (await isToolbarButtonReachable(page, SEL.toolbar.openDevPreview, T_MEDIUM)) {
+        await openDevPreview(page);
       }
 
       // Wait for the panel to reach a "Running" state if possible — gracefully

--- a/shared/types/toolbar.ts
+++ b/shared/types/toolbar.ts
@@ -65,10 +65,12 @@ export type ToolbarButtonId =
  * permanently converted an implicit default into an explicit choice and made a
  * deliberate hide indistinguishable from a seed. v13 deletes that stamp. Seeding
  * a default here again would forfeit the same option a second time, so a
- * built-in's pin entry stays absent until the user acts on it. Note that
- * `true` is never written for a built-in: a positioned built-in with no entry is
- * already visible, so an explicit `true` would carry no information the array
- * doesn't. (Plugin contributions are the sole exception — see below.)
+ * built-in's pin entry stays absent until the user acts on it.
+ *
+ * A `true` therefore only ever appears where the user asked for a button whose
+ * default is *off* the toolbar — a promoted plugin contribution, or a
+ * `panel-tray` button the user pinned. For a button that is already a default,
+ * `true` would say nothing its array membership doesn't, so nothing writes one.
  *
  * Plugin contributions default to tray-only (#11304) — they always appear in
  * the plugin tray, and `true` additionally promotes one to its own top-level

--- a/shared/types/toolbar.ts
+++ b/shared/types/toolbar.ts
@@ -110,6 +110,34 @@ export function isPanelTrayButtonId(id: AnyToolbarButtonId): id is PanelTrayButt
   return (PANEL_TRAY_BUTTON_IDS as readonly string[]).includes(id);
 }
 
+/**
+ * Whether a panel-tray button currently has its own top-level toolbar button.
+ *
+ * Three states, in priority order. An explicit `false` is a hide and wins over
+ * any position. An explicit `true` is a promotion the user made, and reads as on
+ * even in the window between a stale cross-view write dropping the position and
+ * `restorePromotedPanelButtons` rebuilding it. Otherwise the position decides:
+ * that is the legacy profile, which carries `browser`/`dev-server` in its arrays
+ * with no pin entry at all and must keep reading as promoted so an existing
+ * user's toolbar looks untouched.
+ *
+ * Lives here rather than beside `isToolbarButtonVisible` because it is the only
+ * resolver that reads the side arrays, and every surface that shows one of these
+ * buttons has to agree with the tray: the tray itself, and Settings → Toolbar.
+ * `isToolbarButtonVisible` cannot answer this — without the arrays a fresh
+ * profile's absent `browser` pin reads as visible when the button isn't there.
+ */
+export function isPanelButtonOnToolbar(
+  id: PanelTrayButtonId,
+  pinnedButtons: ToolbarPinnedState,
+  leftButtons: AnyToolbarButtonId[],
+  rightButtons: AnyToolbarButtonId[]
+): boolean {
+  if (pinnedButtons[id] === false) return false;
+  if (pinnedButtons[id] === true) return true;
+  return leftButtons.includes(id) || rightButtons.includes(id);
+}
+
 /** Configuration for which toolbar buttons are visible and their order */
 export interface ToolbarLayout {
   /** Ordered list of button IDs to show on the left side (excluding sidebar-toggle which is always first) */

--- a/shared/types/toolbar.ts
+++ b/shared/types/toolbar.ts
@@ -28,6 +28,7 @@ export type ToolbarButtonId =
   | "sidebar-toggle"
   | "agent-tray"
   | "plugin-tray"
+  | "panel-tray"
   | BuiltInAgentId
   | "terminal"
   | "browser"
@@ -49,16 +50,25 @@ export type ToolbarButtonId =
  * used by `agentSettingsStore.agents[id].pinned`, but the default the missing
  * entry falls back to differs by button kind:
  *
- * Built-in buttons (incl. `agent-tray` / `plugin-tray`) default to visible:
+ * Built-in buttons (incl. `agent-tray` / `plugin-tray` / `panel-tray`) default
+ * to visible:
  *   - `false`      → user explicitly hid this button
- *   - `true`       → user explicitly pinned this button
  *   - `undefined`  → visible
  *
- * A built-in can still *ship* hidden by seeding an explicit `false` — see
- * `file-browser` in `toolbarPreferencesStore`, which offers the button in
- * Settings without changing anyone's existing toolbar (#11495). That seed is
- * load-bearing, not redundant with the v12 migration: a fresh install never
- * runs `migrate`.
+ * This map records ONLY explicit user intent, and nothing may ever backfill a
+ * default into it (#11667). A built-in that should be absent from a fresh
+ * toolbar is expressed by leaving it out of `DEFAULT_LEFT_BUTTONS` /
+ * `DEFAULT_RIGHT_BUTTONS` — array membership, which is per-profile and needs no
+ * write — never by seeding a `false`.
+ *
+ * v12 got this wrong: it stamped `file-browser: false` onto every profile, which
+ * permanently converted an implicit default into an explicit choice and made a
+ * deliberate hide indistinguishable from a seed. v13 deletes that stamp. Seeding
+ * a default here again would forfeit the same option a second time, so a
+ * built-in's pin entry stays absent until the user acts on it. Note that
+ * `true` is never written for a built-in: a positioned built-in with no entry is
+ * already visible, so an explicit `true` would carry no information the array
+ * doesn't. (Plugin contributions are the sole exception — see below.)
  *
  * Plugin contributions default to tray-only (#11304) — they always appear in
  * the plugin tray, and `true` additionally promotes one to its own top-level
@@ -67,10 +77,23 @@ export type ToolbarButtonId =
  *   - `false`/`undefined` → tray row only
  *
  * Agent-button IDs (entries in `BUILT_IN_AGENT_IDS`) live in
- * `agentSettingsStore`, not here. Only `agent-tray`, `plugin-tray`, the
- * non-agent built-ins, and plugin buttons are governed by this map.
+ * `agentSettingsStore`, not here. Only `agent-tray`, `plugin-tray`,
+ * `panel-tray`, the non-agent built-ins, and plugin buttons are governed by
+ * this map.
  */
 export type ToolbarPinnedState = Partial<Record<AnyToolbarButtonId, boolean>>;
+
+/**
+ * The built-in panel buttons the panel tray can promote to (or demote from) a
+ * top-level toolbar slot (#11667).
+ *
+ * `browser` and `dev-server` left `DEFAULT_LEFT_BUTTONS` in v13, so on a fresh
+ * profile they sit in neither side array — which means promoting one has to
+ * give it a position as well as clear any hide. `toggleButtonVisibility` only
+ * ever touches `pinnedButtons`, so the tray routes through
+ * `setPanelButtonOnToolbar` instead.
+ */
+export type PanelTrayButtonId = "file-browser" | "browser" | "dev-server";
 
 /** Configuration for which toolbar buttons are visible and their order */
 export interface ToolbarLayout {
@@ -107,6 +130,11 @@ export const TOOLBAR_BUTTON_PRIORITIES: Record<ToolbarButtonId, ToolbarButtonPri
   "voice-recording": 1,
   "agent-tray": 2,
   "plugin-tray": 2,
+  // Same tier as the other trays, and deliberately ahead of the individual
+  // panel buttons at 3: on a fresh profile the tray is the only toolbar route
+  // to `browser` and `dev-server`, so evicting it before them would strand
+  // panels whose own buttons aren't there to fall back to.
+  "panel-tray": 2,
   ...(Object.fromEntries(
     BUILT_IN_AGENT_IDS.map((id) => [id, 2 as ToolbarButtonPriority])
   ) as Record<BuiltInAgentId, ToolbarButtonPriority>),

--- a/shared/types/toolbar.ts
+++ b/shared/types/toolbar.ts
@@ -67,10 +67,12 @@ export type ToolbarButtonId =
  * a default here again would forfeit the same option a second time, so a
  * built-in's pin entry stays absent until the user acts on it.
  *
- * A `true` therefore only ever appears where the user asked for a button whose
- * default is *off* the toolbar — a promoted plugin contribution, or a
- * `panel-tray` button the user pinned. For a button that is already a default,
- * `true` would say nothing its array membership doesn't, so nothing writes one.
+ * A `true` therefore only ever appears where the user asked for the button
+ * directly — a promoted plugin contribution, or a `panel-tray` button they
+ * pinned (`setPanelButtonOnToolbar`). It is a record of an action, never of a
+ * default. `toggleButtonVisibility`, which every other built-in uses, still
+ * never writes one: for a button that is already a default, `true` would say
+ * nothing its array membership doesn't.
  *
  * Plugin contributions default to tray-only (#11304) — they always appear in
  * the plugin tray, and `true` additionally promotes one to its own top-level
@@ -87,15 +89,26 @@ export type ToolbarPinnedState = Partial<Record<AnyToolbarButtonId, boolean>>;
 
 /**
  * The built-in panel buttons the panel tray can promote to (or demote from) a
- * top-level toolbar slot (#11667).
+ * top-level toolbar slot (#11667), in the order the tray lists them.
  *
  * `browser` and `dev-server` left `DEFAULT_LEFT_BUTTONS` in v13, so on a fresh
  * profile they sit in neither side array — which means promoting one has to
- * give it a position as well as clear any hide. `toggleButtonVisibility` only
- * ever touches `pinnedButtons`, so the tray routes through
- * `setPanelButtonOnToolbar` instead.
+ * give it a position as well as clear any hide, and has to leave behind an
+ * explicit `true` that survives a cross-view array overwrite.
+ * `toggleButtonVisibility` does neither: it only ever writes `false` or deletes
+ * the key. Every surface that can show or hide one of these buttons must route
+ * through `setPanelButtonOnToolbar` instead — the tray, and Settings → Toolbar.
+ *
+ * One exported list so a fourth surface can't quietly disagree about which ids
+ * those are.
  */
-export type PanelTrayButtonId = "file-browser" | "browser" | "dev-server";
+export const PANEL_TRAY_BUTTON_IDS = ["file-browser", "browser", "dev-server"] as const;
+
+export type PanelTrayButtonId = (typeof PANEL_TRAY_BUTTON_IDS)[number];
+
+export function isPanelTrayButtonId(id: AnyToolbarButtonId): id is PanelTrayButtonId {
+  return (PANEL_TRAY_BUTTON_IDS as readonly string[]).includes(id);
+}
 
 /** Configuration for which toolbar buttons are visible and their order */
 export interface ToolbarLayout {

--- a/src/components/Layout/PanelTrayButton.tsx
+++ b/src/components/Layout/PanelTrayButton.tsx
@@ -49,8 +49,8 @@ export interface PanelTrayItem {
  * needs a resolved worktree while the other two need a file. The "More panels…"
  * footer routes to the palette, which carries the complete dynamic inventory.
  *
- * Order is the reading order of the row, not the toolbar's — `file-browser`
- * leads because it is the promoted one.
+ * Order matches `PANEL_TRAY_BUTTON_IDS`, which the store and Settings also read,
+ * so no surface can disagree about what the tray holds.
  */
 export const PANEL_TRAY_ITEMS: readonly PanelTrayItem[] = [
   {

--- a/src/components/Layout/PanelTrayButton.tsx
+++ b/src/components/Layout/PanelTrayButton.tsx
@@ -66,11 +66,13 @@ export const PANEL_TRAY_ITEMS: readonly PanelTrayItem[] = [
 /**
  * Whether a tray item currently has its own top-level toolbar button.
  *
- * Two factors, not one: since v13 `browser` and `dev-server` are absent from
- * `DEFAULT_LEFT_BUTTONS`, so a fresh profile has no position for them at all and
- * an unhidden pin state alone doesn't put them on the toolbar. A legacy profile
- * that carries the position with no pin entry reads as promoted, which is what
- * keeps an existing user's toolbar looking untouched.
+ * Three states, in priority order. An explicit `false` is a hide and wins over
+ * any position. An explicit `true` is a promotion the user made, and reads as on
+ * even in the window between a stale cross-view write dropping the position and
+ * `restorePromotedPanelButtons` rebuilding it. Otherwise the position decides:
+ * that is the legacy profile, which carries `browser`/`dev-server` in its arrays
+ * with no pin entry at all and must keep reading as promoted so an existing
+ * user's toolbar looks untouched.
  */
 export function isPanelButtonOnToolbar(
   id: PanelTrayButtonId,
@@ -79,6 +81,7 @@ export function isPanelButtonOnToolbar(
   rightButtons: AnyToolbarButtonId[]
 ): boolean {
   if (pinnedButtons[id] === false) return false;
+  if (pinnedButtons[id] === true) return true;
   return leftButtons.includes(id) || rightButtons.includes(id);
 }
 
@@ -110,13 +113,22 @@ function PanelTrayRow({
 
   return (
     <DropdownMenuItem
-      onSelect={() => {
-        if (!disabled) onSelect(item);
+      onSelect={(e) => {
+        if (disabled) {
+          // Radix does not read `aria-disabled` as its own `disabled` prop, so
+          // selection still fires and would close the menu on a row that opens
+          // nothing. Guarding the dispatch alone isn't enough — the menu has to
+          // stay put too.
+          e.preventDefault();
+          return;
+        }
+        onSelect(item);
       }}
       onKeyDown={handleKeyDown}
       // `aria-disabled` rather than `disabled`: a disabled Radix item is skipped
       // by type-ahead and arrow keys, which would also make its pin affordance
-      // unreachable from the keyboard. The row still explains why it can't open.
+      // unreachable from the keyboard — and pinning a panel you haven't opened a
+      // project for yet is a reasonable thing to want.
       aria-disabled={disabled || undefined}
       className={cn("group h-7", disabled && "opacity-50")}
       data-testid={`panel-tray-row-${item.id}`}
@@ -125,7 +137,17 @@ function PanelTrayRow({
         <Icon className="h-3.5 w-3.5 text-text-muted" />
       </span>
 
-      <span className="flex-1">{disabled && disabledReason ? disabledReason : item.label}</span>
+      {/*
+        The label never changes with state — the reason rides alongside it. A
+        command whose visible name mutates re-announces as a different item to a
+        screen reader and stops matching its own name under type-ahead. Same
+        shape as the `copy-tree` overflow item, which keeps its label and
+        surfaces unavailability separately.
+      */}
+      <span className="flex-1">{item.label}</span>
+      {disabled && disabledReason && (
+        <span className="ml-2 text-xs text-text-muted">{disabledReason}</span>
+      )}
 
       {displayCombo && <DropdownMenuShortcut>{displayCombo}</DropdownMenuShortcut>}
 
@@ -210,8 +232,8 @@ export function PanelTrayButton({
     (id === "file-browser" && !hasWorkspace) || (id === "dev-server" && !hasProject);
 
   const disabledReasonFor = (id: PanelTrayButtonId) => {
-    if (id === "file-browser") return "Open a project or scratch to browse files";
-    if (id === "dev-server") return "Open a project to run a dev preview";
+    if (id === "file-browser") return "Needs a workspace";
+    if (id === "dev-server") return "Needs a project";
     return null;
   };
 

--- a/src/components/Layout/PanelTrayButton.tsx
+++ b/src/components/Layout/PanelTrayButton.tsx
@@ -56,7 +56,7 @@ export const PANEL_TRAY_ITEMS: readonly PanelTrayItem[] = [
     id: "file-browser",
     label: "Browse files",
     icon: FolderTree,
-    actionId: "worktree.openFileBrowser",
+    actionId: "worktree.openFileBrowserPanel",
   },
   { id: "browser", label: "Browser", icon: Globe, actionId: "agent.browser" },
   { id: "dev-server", label: "Dev preview", icon: MonitorPlay, actionId: "devServer.start" },

--- a/src/components/Layout/PanelTrayButton.tsx
+++ b/src/components/Layout/PanelTrayButton.tsx
@@ -23,11 +23,10 @@ import { actionService } from "@/services/ActionService";
 import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
 import { useKeybindingDisplay } from "@/hooks";
 import type { BuiltInActionId } from "@shared/types/actions";
-import type {
-  AnyToolbarButtonId,
-  PanelTrayButtonId,
-  ToolbarPinnedState,
-} from "@shared/types/toolbar";
+// `@shared/...` because this is a value import — the type-only spelling below is
+// erased at compile time and never has to resolve at runtime.
+import { isPanelButtonOnToolbar } from "@shared/types/toolbar";
+import type { PanelTrayButtonId } from "@shared/types/toolbar";
 import { cn } from "@/lib/utils";
 
 export interface PanelTrayItem {
@@ -62,28 +61,6 @@ export const PANEL_TRAY_ITEMS: readonly PanelTrayItem[] = [
   { id: "browser", label: "Browser", icon: Globe, actionId: "agent.browser" },
   { id: "dev-server", label: "Dev preview", icon: MonitorPlay, actionId: "devServer.start" },
 ];
-
-/**
- * Whether a tray item currently has its own top-level toolbar button.
- *
- * Three states, in priority order. An explicit `false` is a hide and wins over
- * any position. An explicit `true` is a promotion the user made, and reads as on
- * even in the window between a stale cross-view write dropping the position and
- * `restorePromotedPanelButtons` rebuilding it. Otherwise the position decides:
- * that is the legacy profile, which carries `browser`/`dev-server` in its arrays
- * with no pin entry at all and must keep reading as promoted so an existing
- * user's toolbar looks untouched.
- */
-export function isPanelButtonOnToolbar(
-  id: PanelTrayButtonId,
-  pinnedButtons: ToolbarPinnedState,
-  leftButtons: AnyToolbarButtonId[],
-  rightButtons: AnyToolbarButtonId[]
-): boolean {
-  if (pinnedButtons[id] === false) return false;
-  if (pinnedButtons[id] === true) return true;
-  return leftButtons.includes(id) || rightButtons.includes(id);
-}
 
 function PanelTrayRow({
   item,
@@ -134,7 +111,7 @@ function PanelTrayRow({
       data-testid={`panel-tray-row-${item.id}`}
     >
       <span className="mr-2 inline-flex h-4 w-4 items-center justify-center">
-        <Icon className="h-3.5 w-3.5 text-text-muted" />
+        <Icon className="h-3.5 w-3.5 text-text-secondary" />
       </span>
 
       {/*
@@ -328,7 +305,7 @@ export function PanelTrayButton({
 
         <DropdownMenuSeparator />
         <DropdownMenuActionItem actionId="panel.palette" className="h-7">
-          <SquareMenu className="mr-2 h-3.5 w-3.5 text-text-muted" />
+          <SquareMenu className="mr-2 h-3.5 w-3.5 text-text-secondary" />
           More panels…
         </DropdownMenuActionItem>
         <DropdownMenuActionItem
@@ -336,7 +313,7 @@ export function PanelTrayButton({
           args={{ tab: "toolbar" }}
           className="h-7"
         >
-          <Settings2 className="mr-2 h-3.5 w-3.5 text-text-muted" />
+          <Settings2 className="mr-2 h-3.5 w-3.5 text-text-secondary" />
           {TOOLBAR_CUSTOMIZE_LABEL}
         </DropdownMenuActionItem>
       </DropdownMenuContent>

--- a/src/components/Layout/PanelTrayButton.tsx
+++ b/src/components/Layout/PanelTrayButton.tsx
@@ -1,0 +1,323 @@
+import { useRef, useState, type ComponentType, type KeyboardEvent } from "react";
+import { Globe, MonitorPlay, Pin, Settings2, SquareMenu } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
+import {
+  DropdownMenu,
+  DropdownMenuActionItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ToolbarContextMenuItems } from "./ToolbarContextMenuItems";
+import {
+  TOOLBAR_CUSTOMIZE_LABEL,
+  TOOLBAR_PIN_LABEL,
+  TOOLBAR_UNPIN_LABEL,
+} from "./toolbarMenuStrings";
+import { FolderTree, LayoutPanelTop } from "@/components/icons";
+import { actionService } from "@/services/ActionService";
+import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
+import { useKeybindingDisplay } from "@/hooks";
+import type { BuiltInActionId } from "@shared/types/actions";
+import type {
+  AnyToolbarButtonId,
+  PanelTrayButtonId,
+  ToolbarPinnedState,
+} from "@shared/types/toolbar";
+import { cn } from "@/lib/utils";
+
+export interface PanelTrayItem {
+  id: PanelTrayButtonId;
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+  /** Drives the row's shortcut hint and, for every item but the file browser, its activation. */
+  actionId: BuiltInActionId;
+}
+
+/**
+ * The tray's inventory: every non-agent panel the toolbar can spawn without a
+ * target (#11667).
+ *
+ * Fixed rather than derived from `panelKindRegistry`, because a tray row needs
+ * three things a panel kind doesn't carry — a toolbar button id to pin, an
+ * action to dispatch, and an availability rule. `review`, `file` and `diff` are
+ * out for exactly that reason: they have no toolbar button id, and the first
+ * needs a resolved worktree while the other two need a file. The "More panels…"
+ * footer routes to the palette, which carries the complete dynamic inventory.
+ *
+ * Order is the reading order of the row, not the toolbar's — `file-browser`
+ * leads because it is the promoted one.
+ */
+export const PANEL_TRAY_ITEMS: readonly PanelTrayItem[] = [
+  {
+    id: "file-browser",
+    label: "Browse files",
+    icon: FolderTree,
+    actionId: "worktree.openFileBrowser",
+  },
+  { id: "browser", label: "Browser", icon: Globe, actionId: "agent.browser" },
+  { id: "dev-server", label: "Dev preview", icon: MonitorPlay, actionId: "devServer.start" },
+];
+
+/**
+ * Whether a tray item currently has its own top-level toolbar button.
+ *
+ * Two factors, not one: since v13 `browser` and `dev-server` are absent from
+ * `DEFAULT_LEFT_BUTTONS`, so a fresh profile has no position for them at all and
+ * an unhidden pin state alone doesn't put them on the toolbar. A legacy profile
+ * that carries the position with no pin entry reads as promoted, which is what
+ * keeps an existing user's toolbar looking untouched.
+ */
+export function isPanelButtonOnToolbar(
+  id: PanelTrayButtonId,
+  pinnedButtons: ToolbarPinnedState,
+  leftButtons: AnyToolbarButtonId[],
+  rightButtons: AnyToolbarButtonId[]
+): boolean {
+  if (pinnedButtons[id] === false) return false;
+  return leftButtons.includes(id) || rightButtons.includes(id);
+}
+
+function PanelTrayRow({
+  item,
+  onToolbar,
+  disabled,
+  disabledReason,
+  onSelect,
+  onTogglePin,
+}: {
+  item: PanelTrayItem;
+  onToolbar: boolean;
+  disabled: boolean;
+  disabledReason: string | null;
+  onSelect: (item: PanelTrayItem) => void;
+  onTogglePin: (item: PanelTrayItem) => void;
+}) {
+  const displayCombo = useKeybindingDisplay(item.actionId);
+  const Icon = item.icon;
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "p" || e.key === "P") {
+      e.preventDefault();
+      e.stopPropagation();
+      onTogglePin(item);
+    }
+  };
+
+  return (
+    <DropdownMenuItem
+      onSelect={() => {
+        if (!disabled) onSelect(item);
+      }}
+      onKeyDown={handleKeyDown}
+      // `aria-disabled` rather than `disabled`: a disabled Radix item is skipped
+      // by type-ahead and arrow keys, which would also make its pin affordance
+      // unreachable from the keyboard. The row still explains why it can't open.
+      aria-disabled={disabled || undefined}
+      className={cn("group h-7", disabled && "opacity-50")}
+      data-testid={`panel-tray-row-${item.id}`}
+    >
+      <span className="mr-2 inline-flex h-4 w-4 items-center justify-center">
+        <Icon className="h-3.5 w-3.5 text-text-muted" />
+      </span>
+
+      <span className="flex-1">{disabled && disabledReason ? disabledReason : item.label}</span>
+
+      {displayCombo && <DropdownMenuShortcut>{displayCombo}</DropdownMenuShortcut>}
+
+      <span className="sr-only">Press P to {onToolbar ? "unpin from" : "pin to"} toolbar</span>
+
+      <span
+        role="presentation"
+        aria-hidden="true"
+        data-testid={`panel-tray-pin-${item.id}`}
+        data-pinned={onToolbar ? "true" : "false"}
+        title={onToolbar ? `${TOOLBAR_UNPIN_LABEL} (P)` : `${TOOLBAR_PIN_LABEL} (P)`}
+        onPointerDown={(e) => e.stopPropagation()}
+        onPointerUp={(e) => e.stopPropagation()}
+        onClick={(e) => {
+          e.stopPropagation();
+          onTogglePin(item);
+        }}
+        className={cn(
+          "ml-1 inline-flex h-5 w-5 items-center justify-center rounded-sm text-daintree-text/50 transition-opacity hover:bg-overlay-emphasis hover:text-daintree-text",
+          onToolbar ? "opacity-100" : "opacity-0 group-data-[highlighted]:opacity-100"
+        )}
+      >
+        <Pin
+          className={cn(
+            "h-3 w-3",
+            onToolbar &&
+              "fill-current text-daintree-text/40 group-data-[highlighted]:text-daintree-text"
+          )}
+          strokeWidth={onToolbar ? 2 : 1.75}
+        />
+      </span>
+    </DropdownMenuItem>
+  );
+}
+
+/**
+ * One toolbar button collecting the non-agent panels (#11667).
+ *
+ * `browser` and `dev-server` used to hold their own always-visible slots even
+ * though both assume web development; they now ship inside this tray while
+ * `file-browser` — which assumes only that the project has files — takes the
+ * first-class slot. A promoted panel keeps its tray row as well as its button,
+ * matching the plugin tray.
+ *
+ * Mirrors `PluginTrayButton`'s structure deliberately: same controlled Dropdown
+ * + ContextMenu + Tooltip nesting, same focus-restoration suppression, and the
+ * same hover-reveal pin affordance — here granting a built-in its own top-level
+ * slot instead of promoting a plugin contribution.
+ */
+export function PanelTrayButton({
+  hasWorkspace,
+  hasProject,
+  onOpenFileBrowser,
+  "data-toolbar-item": dataToolbarItem,
+}: {
+  /** Gates `file-browser`, whose action resolves no folder without one (#11499). */
+  hasWorkspace: boolean;
+  /** Gates `dev-server`, which has no project to start a server for without one. */
+  hasProject: boolean;
+  /**
+   * The toolbar's own file-browser handler, reused so a refusal surfaces the
+   * same retry toast here as it does from the button (Toolbar.tsx).
+   */
+  onOpenFileBrowser: () => void;
+  "data-toolbar-item"?: string;
+}) {
+  const pinnedButtons = useToolbarPreferencesStore((s) => s.layout.pinnedButtons);
+  const leftButtons = useToolbarPreferencesStore((s) => s.layout.leftButtons);
+  const rightButtons = useToolbarPreferencesStore((s) => s.layout.rightButtons);
+  const setPanelButtonOnToolbar = useToolbarPreferencesStore((s) => s.setPanelButtonOnToolbar);
+
+  const [open, setOpen] = useState(false);
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+  // Mirrors PluginTrayButton: Radix reopens the Tooltip whenever the trigger
+  // regains focus, including the programmatic restore from onCloseAutoFocus.
+  // Hold the suppression until the next genuine pointer hover (see #5153).
+  const isRestoringFocusRef = useRef(false);
+  const wasPointerCloseRef = useRef(false);
+  const lastPinActionAt = useRef(0);
+
+  const isDisabled = (id: PanelTrayButtonId) =>
+    (id === "file-browser" && !hasWorkspace) || (id === "dev-server" && !hasProject);
+
+  const disabledReasonFor = (id: PanelTrayButtonId) => {
+    if (id === "file-browser") return "Open a project or scratch to browse files";
+    if (id === "dev-server") return "Open a project to run a dev preview";
+    return null;
+  };
+
+  const handleSelect = (item: PanelTrayItem) => {
+    if (item.id === "file-browser") {
+      onOpenFileBrowser();
+      return;
+    }
+    void actionService.dispatch(item.actionId, undefined, { source: "user" });
+  };
+
+  const handleTogglePin = (item: PanelTrayItem) => {
+    const now = Date.now();
+    if (now - lastPinActionAt.current < 50) return;
+    lastPinActionAt.current = now;
+    setPanelButtonOnToolbar(
+      item.id,
+      !isPanelButtonOnToolbar(item.id, pinnedButtons, leftButtons, rightButtons)
+    );
+  };
+
+  return (
+    <DropdownMenu
+      open={open}
+      onOpenChange={(next) => {
+        setTooltipOpen(false);
+        setOpen(next);
+      }}
+    >
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <Tooltip
+            open={tooltipOpen}
+            onOpenChange={(next) => {
+              if (next && isRestoringFocusRef.current) return;
+              setTooltipOpen(next);
+            }}
+          >
+            <TooltipTrigger asChild>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  data-toolbar-item={dataToolbarItem}
+                  className="toolbar-icon-button text-daintree-text relative"
+                  aria-label="Panel tray"
+                  onPointerEnter={() => {
+                    isRestoringFocusRef.current = false;
+                  }}
+                >
+                  <LayoutPanelTop />
+                </Button>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Panel tray</TooltipContent>
+          </Tooltip>
+        </ContextMenuTrigger>
+        <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
+          <ToolbarContextMenuItems buttonId="panel-tray" side="left" />
+        </ContextMenuContent>
+      </ContextMenu>
+      <DropdownMenuContent
+        align="start"
+        sideOffset={4}
+        className="min-w-[16rem]"
+        onPointerDownOutside={() => {
+          wasPointerCloseRef.current = true;
+        }}
+        onCloseAutoFocus={(e) => {
+          setTooltipOpen(false);
+          isRestoringFocusRef.current = true;
+          // Skip focus restoration for pointer dismissals so the trigger
+          // doesn't keep a focus-visible ring the user never asked for;
+          // keyboard close still returns focus for WAI-ARIA.
+          if (wasPointerCloseRef.current) {
+            e.preventDefault();
+            wasPointerCloseRef.current = false;
+          }
+        }}
+      >
+        {PANEL_TRAY_ITEMS.map((item) => (
+          <PanelTrayRow
+            key={item.id}
+            item={item}
+            onToolbar={isPanelButtonOnToolbar(item.id, pinnedButtons, leftButtons, rightButtons)}
+            disabled={isDisabled(item.id)}
+            disabledReason={disabledReasonFor(item.id)}
+            onSelect={handleSelect}
+            onTogglePin={handleTogglePin}
+          />
+        ))}
+
+        <DropdownMenuSeparator />
+        <DropdownMenuActionItem actionId="panel.palette" className="h-7">
+          <SquareMenu className="mr-2 h-3.5 w-3.5 text-text-muted" />
+          More panels…
+        </DropdownMenuActionItem>
+        <DropdownMenuActionItem
+          actionId="app.settings.openTab"
+          args={{ tab: "toolbar" }}
+          className="h-7"
+        >
+          <Settings2 className="mr-2 h-3.5 w-3.5 text-text-muted" />
+          {TOOLBAR_CUSTOMIZE_LABEL}
+        </DropdownMenuActionItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/Layout/PluginTrayButton.tsx
+++ b/src/components/Layout/PluginTrayButton.tsx
@@ -169,7 +169,7 @@ function PluginTrayRow({
       data-testid={`plugin-tray-row-${config.id}`}
     >
       <span className="mr-2 inline-flex h-4 w-4 items-center justify-center">
-        <Icon className="h-3.5 w-3.5 text-text-muted" />
+        <Icon className="h-3.5 w-3.5 text-text-secondary" />
       </span>
 
       <span className="flex-1">{config.label}</span>
@@ -355,7 +355,7 @@ export function PluginTrayButton({
 
         <DropdownMenuSeparator />
         <DropdownMenuActionItem actionId="app.pluginManager" className="h-7">
-          <Package className="mr-2 h-3.5 w-3.5 text-text-muted" />
+          <Package className="mr-2 h-3.5 w-3.5 text-text-secondary" />
           Manage plugins
         </DropdownMenuActionItem>
         <DropdownMenuActionItem
@@ -363,7 +363,7 @@ export function PluginTrayButton({
           args={{ tab: "toolbar" }}
           className="h-7"
         >
-          <Settings2 className="mr-2 h-3.5 w-3.5 text-text-muted" />
+          <Settings2 className="mr-2 h-3.5 w-3.5 text-text-secondary" />
           {TOOLBAR_CUSTOMIZE_LABEL}
         </DropdownMenuActionItem>
       </DropdownMenuContent>

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -44,6 +44,7 @@ import {
   groupPluginToolbarButtons,
   type PluginTrayGroup,
 } from "./PluginTrayButton";
+import { PANEL_TRAY_ITEMS, PanelTrayButton } from "./PanelTrayButton";
 import { usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
 import { resolvePluginIcon } from "@/components/icons/pluginIconRegistry";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -190,6 +191,9 @@ interface OverflowMenuProps {
   // overflows, its dropdown is unreachable, so the overflow menu inlines these
   // groups instead — an un-promoted contribution has no other toolbar route.
   pluginTrayGroups: PluginTrayGroup[];
+  // Per-item availability for the inlined `panel-tray` rows, mirroring the gates
+  // the tray applies to its own rows.
+  panelTrayDisabled: Partial<Record<string, boolean>>;
   // Shortcut display strings keyed by toolbar button id, so each overflow item
   // shows the same hint its visible button does (issue #9821).
   shortcutById: Partial<Record<string, string | null>>;
@@ -214,6 +218,7 @@ function OverflowMenu({
   overflowActions,
   pluginOverflowMeta,
   pluginTrayGroups,
+  panelTrayDisabled,
   shortcutById,
 }: OverflowMenuProps) {
   const [open, setOpen] = useState(false);
@@ -386,6 +391,42 @@ function OverflowMenu({
                 </DropdownMenuGroup>
               )),
               ...(isLast ? [] : [<DropdownMenuSeparator key="plugin-tray-sep" />]),
+            ];
+          }
+          if (id === "panel-tray") {
+            // Same reason as `plugin-tray` above: the tray's dropdown can't be
+            // opened from inside this menu, and since v13 `browser` and
+            // `dev-server` have no top-level button of their own on a fresh
+            // profile — so a bare row here would dismiss the menu and open
+            // nothing. Pins are omitted: promoting a button while the toolbar
+            // is too narrow to show it has nothing to reveal.
+            //
+            // Items that already carry their own overflow row are skipped: an
+            // existing profile keeps its `browser`/`dev-server` buttons, and
+            // when those overflow alongside the tray the generic rows below
+            // already offer them. Inlining anyway would put two identically
+            // labelled rows in one menu.
+            const inlined = PANEL_TRAY_ITEMS.filter((item) => !overflowIds.includes(item.id));
+            if (inlined.length === 0) return [];
+            const isLast = idx === overflowIds.length - 1;
+            return [
+              ...inlined.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <DropdownMenuItem
+                    key={`panel-tray-${item.id}`}
+                    disabled={panelTrayDisabled[item.id]}
+                    onClick={() => overflowActions[item.id]?.()}
+                  >
+                    <Icon className="mr-2 h-3.5 w-3.5" />
+                    <span className="flex-1">{item.label}</span>
+                    {shortcutById[item.id] && (
+                      <DropdownMenuShortcut>{shortcutById[item.id]}</DropdownMenuShortcut>
+                    )}
+                  </DropdownMenuItem>
+                );
+              }),
+              ...(isLast ? [] : [<DropdownMenuSeparator key="panel-tray-sep" />]),
             ];
           }
           const meta = OVERFLOW_MENU_META[id] ?? pluginOverflowMeta[id];
@@ -1188,6 +1229,20 @@ export function Toolbar({
         // contributions the button doesn't render at all (#11304).
         isAvailable: pluginConfigs.size > 0,
       },
+      "panel-tray": {
+        // Always available, unlike the plugin tray: its inventory is fixed, so
+        // there is no empty state. Individual rows gate themselves instead.
+        render: () => (
+          <PanelTrayButton
+            key="panel-tray"
+            hasWorkspace={hasWorkspace}
+            hasProject={!!currentProject}
+            onOpenFileBrowser={openFileBrowser}
+            data-toolbar-item=""
+          />
+        ),
+        isAvailable: true,
+      },
       // Individual contributions still need a top-level renderer, but only
       // reach the toolbar once explicitly promoted — `isToolbarButtonVisible`
       // gates that below, not `isAvailable`.
@@ -1509,6 +1564,13 @@ export function Toolbar({
     ]
   );
 
+  // Mirrors PanelTrayButton's own row gates so an inlined overflow row degrades
+  // the same way the tray row does rather than silently opening nothing.
+  const panelTrayDisabled: Partial<Record<string, boolean>> = {
+    "file-browser": !hasWorkspace,
+    "dev-server": !currentProject,
+  };
+
   const overflowShortcutById: Partial<Record<string, string | null>> = {
     "copy-tree": copyTreeShortcut,
     "notification-center": notificationsShortcut,
@@ -1540,6 +1602,7 @@ export function Toolbar({
       overflowActions={overflowActions}
       pluginOverflowMeta={pluginOverflowMeta}
       pluginTrayGroups={pluginTrayGroups}
+      panelTrayDisabled={panelTrayDisabled}
       shortcutById={overflowShortcutById}
     />
   );

--- a/src/components/Layout/__tests__/PanelTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/PanelTrayButton.test.tsx
@@ -1,0 +1,274 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+
+const dispatchMock = vi.fn();
+const setPanelButtonOnToolbarMock = vi.fn();
+
+let mockPinnedButtons: Record<string, boolean> = {};
+let mockLeftButtons: string[] = [];
+let mockRightButtons: string[] = [];
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: (...args: unknown[]) => dispatchMock(...args) },
+}));
+
+type MockToolbarStoreState = {
+  layout: {
+    pinnedButtons: Record<string, boolean>;
+    leftButtons: string[];
+    rightButtons: string[];
+  };
+  setPanelButtonOnToolbar: typeof setPanelButtonOnToolbarMock;
+  toggleButtonVisibility: () => void;
+};
+
+vi.mock("@/store/toolbarPreferencesStore", () => ({
+  useToolbarPreferencesStore: (selector: (s: MockToolbarStoreState) => unknown) =>
+    selector({
+      layout: {
+        pinnedButtons: mockPinnedButtons,
+        leftButtons: mockLeftButtons,
+        rightButtons: mockRightButtons,
+      },
+      setPanelButtonOnToolbar: setPanelButtonOnToolbarMock,
+      toggleButtonVisibility: () => {},
+    }),
+}));
+
+let mockKeybindingDisplay: Record<string, string | null> = {};
+
+vi.mock("@/hooks", () => ({
+  useKeybindingDisplay: (actionId: string) => mockKeybindingDisplay[actionId] ?? null,
+  useAriaKeyshortcuts: () => undefined,
+  useShortcutHintHover: () => ({}),
+}));
+
+vi.mock("@/components/ui/context-menu", () => ({
+  ContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="context-menu-content">{children}</div>
+  ),
+}));
+
+vi.mock("../ToolbarContextMenuItems", () => ({
+  ToolbarContextMenuItems: ({ buttonId }: { buttonId: string }) => (
+    <button data-testid="toolbar-context-items" data-button-id={buttonId}>
+      unpin
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dropdown-content">{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+    onKeyDown,
+    ...props
+  }: {
+    children: React.ReactNode;
+    onSelect?: (e: Event) => void;
+    onKeyDown?: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+  } & React.HTMLAttributes<HTMLDivElement>) => (
+    <div
+      role="menuitem"
+      tabIndex={0}
+      onClick={(e) => onSelect?.(e as unknown as Event)}
+      onKeyDown={onKeyDown}
+      {...props}
+    >
+      {children}
+    </div>
+  ),
+  DropdownMenuActionItem: ({
+    actionId,
+    args,
+    children,
+  }: {
+    actionId: string;
+    args?: unknown;
+    children: React.ReactNode;
+  }) => (
+    <div role="menuitem" data-action-id={actionId} data-args={JSON.stringify(args)}>
+      {children}
+    </div>
+  ),
+  DropdownMenuSeparator: () => <hr data-testid="menu-separator" />,
+  DropdownMenuShortcut: ({ children }: { children: React.ReactNode }) => (
+    <span data-testid="menu-shortcut">{children}</span>
+  ),
+}));
+
+const { PanelTrayButton, PANEL_TRAY_ITEMS, isPanelButtonOnToolbar } =
+  await import("../PanelTrayButton");
+
+function renderTray(
+  overrides: {
+    hasWorkspace?: boolean;
+    hasProject?: boolean;
+    onOpenFileBrowser?: () => void;
+  } = {}
+) {
+  const onOpenFileBrowser = overrides.onOpenFileBrowser ?? vi.fn();
+  const utils = render(
+    <PanelTrayButton
+      hasWorkspace={overrides.hasWorkspace ?? true}
+      hasProject={overrides.hasProject ?? true}
+      onOpenFileBrowser={onOpenFileBrowser}
+    />
+  );
+  return { ...utils, onOpenFileBrowser };
+}
+
+beforeEach(() => {
+  dispatchMock.mockClear();
+  setPanelButtonOnToolbarMock.mockClear();
+  mockPinnedButtons = {};
+  mockLeftButtons = ["terminal", "file-browser", "panel-tray"];
+  mockRightButtons = ["settings"];
+  mockKeybindingDisplay = {};
+});
+
+describe("PanelTrayButton (#11667)", () => {
+  it("lists every non-agent panel button, promoted ones included", () => {
+    // The plugin tray's rule: promotion adds an access point, it never moves the
+    // button out of the tray. `file-browser` has its own slot and still appears.
+    const { getByTestId } = renderTray();
+    for (const item of PANEL_TRAY_ITEMS) {
+      expect(getByTestId(`panel-tray-row-${item.id}`)).toBeTruthy();
+    }
+    expect(PANEL_TRAY_ITEMS.map((i) => i.id)).toEqual(["file-browser", "browser", "dev-server"]);
+  });
+
+  it("routes the file browser through the toolbar's own handler, not a bare dispatch", () => {
+    // That handler surfaces a retry toast when the action refuses; dispatching
+    // directly here would make the tray fail silently where the button doesn't.
+    const { getByTestId, onOpenFileBrowser } = renderTray();
+    fireEvent.click(getByTestId("panel-tray-row-file-browser"));
+    expect(onOpenFileBrowser).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it("dispatches the panel actions for the other rows", () => {
+    const { getByTestId } = renderTray();
+
+    fireEvent.click(getByTestId("panel-tray-row-browser"));
+    expect(dispatchMock).toHaveBeenCalledWith("agent.browser", undefined, { source: "user" });
+
+    fireEvent.click(getByTestId("panel-tray-row-dev-server"));
+    expect(dispatchMock).toHaveBeenCalledWith("devServer.start", undefined, { source: "user" });
+  });
+
+  it("does not open a row whose precondition is missing", () => {
+    const { getByTestId, onOpenFileBrowser } = renderTray({
+      hasWorkspace: false,
+      hasProject: false,
+    });
+
+    fireEvent.click(getByTestId("panel-tray-row-file-browser"));
+    fireEvent.click(getByTestId("panel-tray-row-dev-server"));
+
+    expect(onOpenFileBrowser).not.toHaveBeenCalled();
+    expect(dispatchMock).not.toHaveBeenCalled();
+    expect(getByTestId("panel-tray-row-dev-server").getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("keeps a disabled row focusable so its pin stays reachable", () => {
+    // `aria-disabled` rather than `disabled`: Radix skips a disabled item in
+    // arrow-key and type-ahead navigation, which would strand the pin control on
+    // a row the user may well want to promote before opening a project.
+    const { getByTestId } = renderTray({ hasProject: false });
+    const row = getByTestId("panel-tray-row-dev-server");
+    expect(row.getAttribute("disabled")).toBeNull();
+    expect(row.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("promotes an unpositioned button when its pin is clicked", () => {
+    mockLeftButtons = ["terminal", "file-browser", "panel-tray"];
+    const { getByTestId } = renderTray();
+
+    expect(getByTestId("panel-tray-pin-browser").getAttribute("data-pinned")).toBe("false");
+    fireEvent.click(getByTestId("panel-tray-pin-browser"));
+
+    expect(setPanelButtonOnToolbarMock).toHaveBeenCalledWith("browser", true);
+  });
+
+  it("demotes a positioned button when its pin is clicked", () => {
+    mockLeftButtons = ["terminal", "browser", "file-browser", "panel-tray"];
+    const { getByTestId } = renderTray();
+
+    expect(getByTestId("panel-tray-pin-browser").getAttribute("data-pinned")).toBe("true");
+    fireEvent.click(getByTestId("panel-tray-pin-browser"));
+
+    expect(setPanelButtonOnToolbarMock).toHaveBeenCalledWith("browser", false);
+  });
+
+  it("toggles the pin from the P key without activating the row", () => {
+    const { getByTestId, onOpenFileBrowser } = renderTray();
+    fireEvent.keyDown(getByTestId("panel-tray-row-file-browser"), { key: "P" });
+
+    expect(setPanelButtonOnToolbarMock).toHaveBeenCalledWith("file-browser", false);
+    expect(onOpenFileBrowser).not.toHaveBeenCalled();
+  });
+
+  it("does not activate the row when the pin itself is clicked", () => {
+    const { getByTestId, onOpenFileBrowser } = renderTray();
+    fireEvent.click(getByTestId("panel-tray-pin-file-browser"));
+
+    expect(setPanelButtonOnToolbarMock).toHaveBeenCalledTimes(1);
+    expect(onOpenFileBrowser).not.toHaveBeenCalled();
+  });
+
+  it("offers the palette and the toolbar settings tab as footer routes", () => {
+    // The tray carries the buttons it can pin; `review`, `file` and `diff` have
+    // no toolbar id to pin, so the palette is their route rather than a row here.
+    const { container } = renderTray();
+    const actionIds = Array.from(container.querySelectorAll("[data-action-id]")).map((el) =>
+      el.getAttribute("data-action-id")
+    );
+    expect(actionIds).toContain("panel.palette");
+    expect(actionIds).toContain("app.settings.openTab");
+  });
+
+  it("targets panel-tray from its own context menu", () => {
+    const { getByTestId } = renderTray();
+    expect(getByTestId("toolbar-context-items").getAttribute("data-button-id")).toBe("panel-tray");
+  });
+
+  it("shows each row's keybinding hint", () => {
+    mockKeybindingDisplay = { "devServer.start": "⌘⌥D" };
+    const { getByTestId } = renderTray();
+    expect(getByTestId("panel-tray-row-dev-server").textContent).toContain("⌘⌥D");
+  });
+});
+
+describe("isPanelButtonOnToolbar", () => {
+  it("requires a position as well as an unhidden pin", () => {
+    // Two factors since v13: `browser` has no default position, so an absent pin
+    // entry alone does not put it on the toolbar.
+    expect(isPanelButtonOnToolbar("browser", {}, ["terminal"], ["settings"])).toBe(false);
+    expect(isPanelButtonOnToolbar("browser", {}, ["terminal", "browser"], ["settings"])).toBe(true);
+  });
+
+  it("reads an explicit hide as off the toolbar even when positioned", () => {
+    expect(isPanelButtonOnToolbar("browser", { browser: false }, ["terminal", "browser"], [])).toBe(
+      false
+    );
+  });
+
+  it("counts a position on either side", () => {
+    expect(isPanelButtonOnToolbar("dev-server", {}, [], ["dev-server"])).toBe(true);
+  });
+});

--- a/src/components/Layout/__tests__/PanelTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/PanelTrayButton.test.tsx
@@ -142,14 +142,22 @@ beforeEach(() => {
 });
 
 describe("PanelTrayButton (#11667)", () => {
-  it("lists every non-agent panel button, promoted ones included", () => {
+  it("renders a row for every inventory item, promoted ones included", () => {
     // The plugin tray's rule: promotion adds an access point, it never moves the
-    // button out of the tray. `file-browser` has its own slot and still appears.
-    const { getByTestId } = renderTray();
-    for (const item of PANEL_TRAY_ITEMS) {
-      expect(getByTestId(`panel-tray-row-${item.id}`)).toBeTruthy();
-    }
-    expect(PANEL_TRAY_ITEMS.map((i) => i.id)).toEqual(["file-browser", "browser", "dev-server"]);
+    // button out of the tray. `file-browser` is positioned (see beforeEach) and
+    // still gets a row.
+    //
+    // Read from the DOM and compare to the inventory, rather than iterating the
+    // inventory to look each row up — the latter can't notice a row that failed
+    // to render, and comparing the exported constant to a hard-coded list would
+    // just restate the source of truth.
+    const { container } = renderTray();
+    const renderedIds = Array.from(container.querySelectorAll("[data-testid^='panel-tray-row-']"))
+      .map((el) => el.getAttribute("data-testid")?.replace("panel-tray-row-", ""))
+      .filter(Boolean);
+
+    expect(renderedIds).toEqual(PANEL_TRAY_ITEMS.map((i) => i.id));
+    expect(renderedIds).toContain("file-browser");
   });
 
   it("routes the file browser through the toolbar's own handler, not a bare dispatch", () => {
@@ -185,14 +193,22 @@ describe("PanelTrayButton (#11667)", () => {
     expect(getByTestId("panel-tray-row-dev-server").getAttribute("aria-disabled")).toBe("true");
   });
 
-  it("keeps a disabled row focusable so its pin stays reachable", () => {
-    // `aria-disabled` rather than `disabled`: Radix skips a disabled item in
-    // arrow-key and type-ahead navigation, which would strand the pin control on
-    // a row the user may well want to promote before opening a project.
+  it("keeps a disabled row's label stable and its pin still operable", () => {
+    // The label must not swap to the unavailability reason: a command whose
+    // visible name changes with state re-announces as a different item and stops
+    // matching itself under type-ahead. The reason rides alongside instead.
+    //
+    // And the row stays `aria-disabled` rather than `disabled` so Radix keeps it
+    // in arrow-key and type-ahead order — which is what leaves the pin reachable
+    // on a panel the user hasn't opened a project for yet.
     const { getByTestId } = renderTray({ hasProject: false });
     const row = getByTestId("panel-tray-row-dev-server");
-    expect(row.getAttribute("disabled")).toBeNull();
-    expect(row.getAttribute("tabindex")).toBe("0");
+
+    expect(row.textContent).toContain("Dev preview");
+    expect(row.textContent).toContain("Needs a project");
+
+    fireEvent.click(getByTestId("panel-tray-pin-dev-server"));
+    expect(setPanelButtonOnToolbarMock).toHaveBeenCalledWith("dev-server", true);
   });
 
   it("promotes an unpositioned button when its pin is clicked", () => {

--- a/src/components/Layout/__tests__/PanelTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/PanelTrayButton.test.tsx
@@ -113,6 +113,7 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
 
 const { PanelTrayButton, PANEL_TRAY_ITEMS, isPanelButtonOnToolbar } =
   await import("../PanelTrayButton");
+const { PANEL_TRAY_BUTTON_IDS } = await import("@shared/types/toolbar");
 
 function renderTray(
   overrides: {
@@ -158,6 +159,14 @@ describe("PanelTrayButton (#11667)", () => {
 
     expect(renderedIds).toEqual(PANEL_TRAY_ITEMS.map((i) => i.id));
     expect(renderedIds).toContain("file-browser");
+  });
+
+  it("covers exactly the shared panel-button id list", () => {
+    // The store's hydration repair and Settings' toggle routing both key off
+    // `PANEL_TRAY_BUTTON_IDS`. A row here with no entry there would never get its
+    // position rebuilt after a cross-view overwrite; an id there with no row
+    // would be unpinnable. Neither failure is visible from either side alone.
+    expect(PANEL_TRAY_ITEMS.map((i) => i.id)).toEqual([...PANEL_TRAY_BUTTON_IDS]);
   });
 
   it("routes the file browser through the toolbar's own handler, not a bare dispatch", () => {

--- a/src/components/Layout/__tests__/PanelTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/PanelTrayButton.test.tsx
@@ -111,9 +111,8 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
   ),
 }));
 
-const { PanelTrayButton, PANEL_TRAY_ITEMS, isPanelButtonOnToolbar } =
-  await import("../PanelTrayButton");
-const { PANEL_TRAY_BUTTON_IDS } = await import("@shared/types/toolbar");
+const { PanelTrayButton, PANEL_TRAY_ITEMS } = await import("../PanelTrayButton");
+const { PANEL_TRAY_BUTTON_IDS, isPanelButtonOnToolbar } = await import("@shared/types/toolbar");
 
 function renderTray(
   overrides: {

--- a/src/components/Layout/toolbarButtonMetadata.ts
+++ b/src/components/Layout/toolbarButtonMetadata.ts
@@ -11,7 +11,7 @@ import {
   SquareMenu,
   SquareTerminal,
 } from "lucide-react";
-import { FolderTree, Folders, History, Package } from "@/components/icons";
+import { FolderTree, Folders, History, LayoutPanelTop, Package } from "@/components/icons";
 import {
   BUILT_IN_AGENT_IDS,
   isBuiltInAgentId,
@@ -62,6 +62,11 @@ export const TOOLBAR_BUTTON_METADATA: Partial<Record<AnyToolbarButtonId, Toolbar
     label: "Plugin tray",
     icon: Package,
     description: "Dropdown collecting every plugin's toolbar buttons",
+  },
+  "panel-tray": {
+    label: "Panel tray",
+    icon: LayoutPanelTop,
+    description: "Dropdown for opening the non-agent panels and pinning them to the toolbar",
   },
   ...AGENT_METADATA,
   terminal: {

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -29,6 +29,9 @@ import { useToolbarPreferencesStore } from "@/store";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import type { AnyToolbarButtonId, PluginToolbarButtonId } from "@/../../shared/types/toolbar";
+// `@shared/...` because this is a value import — the type-only spelling above
+// is erased at compile time and never has to resolve at runtime.
+import { isPanelTrayButtonId } from "@shared/types/toolbar";
 import { LAUNCHABLE_AGENT_IDS } from "@shared/config/agentIds";
 import {
   TOOLBAR_BUTTON_METADATA,
@@ -292,6 +295,7 @@ export function ToolbarSettingsTab() {
   const moveButton = useToolbarPreferencesStore((s) => s.moveButton);
   const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
   const setPluginButtonPromoted = useToolbarPreferencesStore((s) => s.setPluginButtonPromoted);
+  const setPanelButtonOnToolbar = useToolbarPreferencesStore((s) => s.setPanelButtonOnToolbar);
   const setAlwaysShowDevServer = useToolbarPreferencesStore((s) => s.setAlwaysShowDevServer);
   const setDefaultSelection = useToolbarPreferencesStore((s) => s.setDefaultSelection);
   const reset = useToolbarPreferencesStore((s) => s.reset);
@@ -482,6 +486,17 @@ export function ToolbarSettingsTab() {
     // the switch could never turn the button on (#11304).
     if (pluginConfigs.has(buttonId) && isPluginToolbarButtonId(buttonId)) {
       setPluginButtonPromoted(buttonId, !isVisible(buttonId));
+      return;
+    }
+    // Panel-tray buttons need the same treatment for a different reason
+    // (#11667). `browser` and `dev-server` are not defaults, so the generic
+    // toggle's "delete the key to show" leaves nothing recording that the user
+    // wants them — and a stale sibling view's write, which replaces the position
+    // arrays wholesale, would then silently un-promote them with nothing left to
+    // rebuild from. `setPanelButtonOnToolbar` writes the explicit `true` that
+    // survives, and positions the button if it has no slot yet.
+    if (isPanelTrayButtonId(buttonId)) {
+      setPanelButtonOnToolbar(buttonId, !isVisible(buttonId));
       return;
     }
     dispatchToolbarVisibility(buttonId, side, {

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -25,13 +25,22 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { GripVertical, LayoutGrid, Rocket, RotateCcw } from "lucide-react";
+import { LayoutPanelTop } from "@/components/icons";
 import { useToolbarPreferencesStore } from "@/store";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
-import type { AnyToolbarButtonId, PluginToolbarButtonId } from "@/../../shared/types/toolbar";
-// `@shared/...` because this is a value import — the type-only spelling above
+import type {
+  AnyToolbarButtonId,
+  PanelTrayButtonId,
+  PluginToolbarButtonId,
+} from "@/../../shared/types/toolbar";
+// `@shared/...` because these are value imports — the type-only spelling above
 // is erased at compile time and never has to resolve at runtime.
-import { isPanelTrayButtonId } from "@shared/types/toolbar";
+import {
+  PANEL_TRAY_BUTTON_IDS,
+  isPanelButtonOnToolbar,
+  isPanelTrayButtonId,
+} from "@shared/types/toolbar";
 import { LAUNCHABLE_AGENT_IDS } from "@shared/config/agentIds";
 import {
   TOOLBAR_BUTTON_METADATA,
@@ -178,19 +187,21 @@ function SortableButtonItem({
   );
 }
 
-interface PluginButtonRowProps {
-  buttonId: PluginToolbarButtonId;
+interface TrayButtonRowProps {
+  buttonId: AnyToolbarButtonId;
   isVisible: boolean;
-  onToggle: (buttonId: PluginToolbarButtonId) => void;
+  onToggle: (buttonId: AnyToolbarButtonId) => void;
   metadata: ToolbarButtonMetadata | undefined;
 }
 
-// Plugin buttons toggle promotion, not visibility — they always remain
-// reachable in the plugin tray (#11304), and they're never persisted into the
-// position arrays, so they get no drag handle and stay out of cross-side
-// movement. Reusing `SortableButtonItem` would call `useSortable` outside a
-// `SortableContext` and crash; this is a plain non-sortable row.
-function PluginButtonRow({ buttonId, isVisible, onToggle, metadata }: PluginButtonRowProps) {
+// Tray-backed buttons toggle promotion, not visibility — they always remain
+// reachable in their tray, whether that's the plugin tray (#11304) or the panel
+// tray (#11667). A plugin contribution is never persisted into the position
+// arrays at all, and a panel button may or may not be, so neither gets a drag
+// handle or takes part in cross-side movement. Reusing `SortableButtonItem`
+// would call `useSortable` outside a `SortableContext` and crash; this is a
+// plain non-sortable row.
+function TrayButtonRow({ buttonId, isVisible, onToggle, metadata }: TrayButtonRowProps) {
   if (!metadata) return null;
   const Icon = metadata.icon;
 
@@ -352,6 +363,18 @@ export function ToolbarSettingsTab() {
     [layout.pinnedButtons, agentSettings, agentAvailability, pluginConfigs]
   );
 
+  // Panel-tray buttons need the array-aware resolver, not `isVisible`: since
+  // v13 `browser`/`dev-server` carry no pin entry on a fresh profile, so
+  // `isToolbarButtonVisible`'s "absent means visible" default would report both
+  // as on while neither is anywhere on the toolbar (#11667). Inside the side
+  // columns the two agree — a column only ever renders ids the arrays already
+  // hold — but the panel section below lists all three regardless.
+  const isPanelOnToolbar = useCallback(
+    (id: PanelTrayButtonId) =>
+      isPanelButtonOnToolbar(id, layout.pinnedButtons, layout.leftButtons, layout.rightButtons),
+    [layout.pinnedButtons, layout.leftButtons, layout.rightButtons]
+  );
+
   const findContainer = (id: UniqueIdentifier, lists: SideLists): ToolbarSide | null => {
     if (id === "left" || id === "right") return id;
     const buttonId = toButtonId(id);
@@ -496,7 +519,7 @@ export function ToolbarSettingsTab() {
     // rebuild from. `setPanelButtonOnToolbar` writes the explicit `true` that
     // survives, and positions the button if it has no slot yet.
     if (isPanelTrayButtonId(buttonId)) {
-      setPanelButtonOnToolbar(buttonId, !isVisible(buttonId));
+      setPanelButtonOnToolbar(buttonId, !isPanelOnToolbar(buttonId));
       return;
     }
     dispatchToolbarVisibility(buttonId, side, {
@@ -556,6 +579,33 @@ export function ToolbarSettingsTab() {
         </DndContext>
       </SettingsSection>
 
+      {/*
+        Its own section rather than relying on the two side columns above: those
+        render `layout.leftButtons`/`layout.rightButtons`, and since v13
+        `browser` and `dev-server` are in neither array on a fresh profile
+        (#11667). Without this the panel tray's "Customize toolbar…" footer would
+        land the user on a page that lists none of the buttons they were just
+        looking at. Enumerating `PANEL_TRAY_BUTTON_IDS` keeps the page honest
+        regardless of array membership, the same way the plugin section does.
+      */}
+      <SettingsSection
+        icon={LayoutPanelTop}
+        title="Panel buttons"
+        description={`Every panel button lives in the panel tray. Pin one to give it its own toolbar button too. ${PANEL_TRAY_BUTTON_IDS.filter(isPanelOnToolbar).length} of ${PANEL_TRAY_BUTTON_IDS.length} pinned.`}
+      >
+        <div className="space-y-2">
+          {PANEL_TRAY_BUTTON_IDS.map((buttonId) => (
+            <TrayButtonRow
+              key={buttonId}
+              buttonId={buttonId}
+              isVisible={isPanelOnToolbar(buttonId)}
+              onToggle={(id) => handleToggle(id, "left")}
+              metadata={allMetadata[buttonId]}
+            />
+          ))}
+        </div>
+      </SettingsSection>
+
       {pluginButtonIds.length > 0 && (
         <SettingsSection
           icon={DEFAULT_PLUGIN_ICON}
@@ -564,7 +614,7 @@ export function ToolbarSettingsTab() {
         >
           <div className="space-y-2">
             {pluginButtonIds.map((buttonId) => (
-              <PluginButtonRow
+              <TrayButtonRow
                 key={buttonId}
                 buttonId={buttonId}
                 isVisible={isVisible(buttonId)}

--- a/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
@@ -691,3 +691,94 @@ describe("ToolbarSettingsTab — plugin button promotion (#11304)", () => {
     expect(setPluginButtonPromotedMock).not.toHaveBeenCalled();
   });
 });
+
+describe("ToolbarSettingsTab — panel button pinning (#11667)", () => {
+  // A fresh v13 profile: `browser` and `dev-server` left the defaults, so they
+  // sit in neither side array and the two drag columns can't render them.
+  function freshV13Profile() {
+    return makeToolbarState({
+      leftButtons: ["terminal", "file-browser", "panel-tray"],
+      rightButtons: ["settings"],
+      pinnedButtons: {},
+    });
+  }
+
+  beforeEach(() => {
+    clearStoreMocks();
+    vi.mocked(useSortable).mockImplementation(defaultSortable);
+    mockToolbarState = freshV13Profile();
+    mockAgentSettings = null;
+  });
+
+  it("lists a panel button the side columns cannot reach", () => {
+    // The reason this section exists: the panel tray's "Customize toolbar…"
+    // footer routes here, so the page has to list the buttons the tray holds
+    // even when no side array carries them.
+    const { getByLabelText, queryByLabelText } = render(<ToolbarSettingsTab />);
+
+    expect(queryByLabelText("Toggle Browser visibility")).toBeNull();
+    expect(queryByLabelText("Toggle Dev preview visibility")).toBeNull();
+    expect(getByLabelText("Show Browser in toolbar")).toBeTruthy();
+    expect(getByLabelText("Show Dev preview in toolbar")).toBeTruthy();
+  });
+
+  it("reads an unpositioned panel button as off, not as an absent-means-visible default", () => {
+    // `isToolbarButtonVisible` answers "no pin entry" with `true`, which would
+    // show both switches on while neither button is anywhere on the toolbar —
+    // and cost the user two clicks to promote one.
+    const { getByLabelText } = render(<ToolbarSettingsTab />);
+
+    expect(getByLabelText("Show Browser in toolbar").getAttribute("aria-checked")).toBe("false");
+    expect(getByLabelText("Show Browse files in toolbar").getAttribute("aria-checked")).toBe(
+      "true"
+    );
+  });
+
+  it("promotes an unpositioned panel button in a single click", () => {
+    const { getByLabelText } = render(<ToolbarSettingsTab />);
+    fireEvent.click(getByLabelText("Show Dev preview in toolbar"));
+
+    expect(setPanelButtonOnToolbarMock).toHaveBeenCalledTimes(1);
+    expect(setPanelButtonOnToolbarMock).toHaveBeenCalledWith("dev-server", true);
+    expect(toggleButtonVisibilityMock).not.toHaveBeenCalled();
+  });
+
+  it("demotes a positioned panel button through the same action", () => {
+    const { getByLabelText } = render(<ToolbarSettingsTab />);
+    fireEvent.click(getByLabelText("Show Browse files in toolbar"));
+
+    expect(setPanelButtonOnToolbarMock).toHaveBeenCalledWith("file-browser", false);
+    expect(toggleButtonVisibilityMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps an explicitly promoted button on while its position is missing", () => {
+    // The cross-view window: a stale sibling's write replaced the arrays and
+    // dropped the position, and `restorePromotedPanelButtons` has not rebuilt it
+    // yet. The explicit `true` is what keeps the switch honest until it does.
+    mockToolbarState = makeToolbarState({
+      leftButtons: ["terminal", "file-browser", "panel-tray"],
+      rightButtons: ["settings"],
+      pinnedButtons: { browser: true },
+    });
+
+    const { getByLabelText } = render(<ToolbarSettingsTab />);
+    expect(getByLabelText("Show Browser in toolbar").getAttribute("aria-checked")).toBe("true");
+
+    fireEvent.click(getByLabelText("Show Browser in toolbar"));
+    expect(setPanelButtonOnToolbarMock).toHaveBeenCalledWith("browser", false);
+  });
+
+  it("counts pinned panel buttons in the section description", () => {
+    mockToolbarState = makeToolbarState({
+      leftButtons: ["terminal", "file-browser", "browser", "panel-tray"],
+      rightButtons: ["settings"],
+      pinnedButtons: {},
+    });
+
+    const { getByTestId } = render(<ToolbarSettingsTab />);
+    // file-browser + browser positioned, dev-server absent.
+    expect(getByTestId("section-Panel buttons").getAttribute("data-description")).toContain(
+      "2 of 3 pinned"
+    );
+  });
+});

--- a/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
@@ -8,6 +8,7 @@ const setRightButtonsMock = vi.fn();
 const moveButtonMock = vi.fn();
 const toggleButtonVisibilityMock = vi.fn();
 const setPluginButtonPromotedMock = vi.fn();
+const setPanelButtonOnToolbarMock = vi.fn();
 const setAlwaysShowDevServerMock = vi.fn();
 const setDefaultSelectionMock = vi.fn();
 const resetMock = vi.fn();
@@ -28,6 +29,7 @@ interface ToolbarState {
   moveButton: typeof moveButtonMock;
   toggleButtonVisibility: typeof toggleButtonVisibilityMock;
   setPluginButtonPromoted: typeof setPluginButtonPromotedMock;
+  setPanelButtonOnToolbar: typeof setPanelButtonOnToolbarMock;
   setAlwaysShowDevServer: typeof setAlwaysShowDevServerMock;
   setDefaultSelection: typeof setDefaultSelectionMock;
   reset: typeof resetMock;
@@ -49,6 +51,7 @@ function makeToolbarState(
     moveButton: moveButtonMock,
     toggleButtonVisibility: toggleButtonVisibilityMock,
     setPluginButtonPromoted: setPluginButtonPromotedMock,
+    setPanelButtonOnToolbar: setPanelButtonOnToolbarMock,
     setAlwaysShowDevServer: setAlwaysShowDevServerMock,
     setDefaultSelection: setDefaultSelectionMock,
     reset: resetMock,
@@ -64,6 +67,7 @@ function clearStoreMocks() {
   moveButtonMock.mockClear();
   toggleButtonVisibilityMock.mockClear();
   setPluginButtonPromotedMock.mockClear();
+  setPanelButtonOnToolbarMock.mockClear();
   setAlwaysShowDevServerMock.mockClear();
   setDefaultSelectionMock.mockClear();
   resetMock.mockClear();
@@ -319,9 +323,9 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     expect(toggleButtonVisibilityMock).toHaveBeenCalledWith("copy-tree", "right");
   });
 
-  it("lists the hidden-by-default file browser with its switch off (#11495)", () => {
-    // The whole point of the issue: the button has to be *offered* in Settings
-    // while staying off the toolbar until the user opts in. A fixture of its own
+  it("shows a hidden file browser with its switch off (#11495)", () => {
+    // `file-browser` ships visible since #11667, but a user can still hide it —
+    // and Settings has to render that state honestly. A fixture of its own
     // rather than the shared default, so the visible-count and drag-array
     // expectations elsewhere in this file stay put.
     mockToolbarState = makeToolbarState({
@@ -336,19 +340,38 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     expect(toggle.getAttribute("aria-checked")).toBe("false");
   });
 
-  it("routes the file browser opt-in to toggleButtonVisibility on its own side", () => {
+  it("routes a panel-button opt-in to setPanelButtonOnToolbar, never the generic toggle (#11667)", () => {
+    // The generic toggle shows a button by DELETING its pin key, which leaves
+    // nothing recording that the user asked for it. `browser` and `dev-server`
+    // are not defaults, so a stale sibling view's write — which replaces the
+    // position arrays wholesale — would then silently un-promote them with
+    // nothing left to rebuild the position from.
     mockToolbarState = makeToolbarState({
-      leftButtons: ["terminal", "file-browser"],
+      leftButtons: ["terminal", "browser", "file-browser", "panel-tray"],
       rightButtons: ["settings"],
-      pinnedButtons: { "file-browser": false },
+      pinnedButtons: { browser: false },
+    });
+
+    const { getByLabelText } = render(<ToolbarSettingsTab />);
+    fireEvent.click(getByLabelText("Toggle Browser visibility"));
+
+    expect(setPanelButtonOnToolbarMock).toHaveBeenCalledWith("browser", true);
+    expect(toggleButtonVisibilityMock).not.toHaveBeenCalled();
+    expect(setAgentPinnedMock).not.toHaveBeenCalled();
+  });
+
+  it("routes a panel-button hide through the same action", () => {
+    mockToolbarState = makeToolbarState({
+      leftButtons: ["terminal", "file-browser", "panel-tray"],
+      rightButtons: ["settings"],
+      pinnedButtons: {},
     });
 
     const { getByLabelText } = render(<ToolbarSettingsTab />);
     fireEvent.click(getByLabelText("Toggle Browse files visibility"));
 
-    expect(toggleButtonVisibilityMock).toHaveBeenCalledTimes(1);
-    expect(toggleButtonVisibilityMock).toHaveBeenCalledWith("file-browser", "left");
-    expect(setAgentPinnedMock).not.toHaveBeenCalled();
+    expect(setPanelButtonOnToolbarMock).toHaveBeenCalledWith("file-browser", false);
+    expect(toggleButtonVisibilityMock).not.toHaveBeenCalled();
   });
 
   it("reflects pinned agents in the side visible-count summary", () => {

--- a/src/store/__tests__/toolbarPreferencesStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.crossViewMerge.test.ts
@@ -133,11 +133,13 @@ describe("toolbarPreferencesStore cross-view write merge (#11351)", () => {
     const backing = installLocalStorage({});
     const { useToolbarPreferencesStore: store } = await import("../toolbarPreferencesStore");
 
-    // A sibling view enabled the file browser — the toggle deletes the key.
+    // The sibling made a real edit this view has never seen: an explicit hide.
+    // Asserting against `{}` on both sides would pass even under a wholesale
+    // overwrite, so the sibling has to hold something distinguishable.
     backing.set(
       STORAGE_KEY,
       siblingBlob({
-        layout: { leftButtons: [], rightButtons: [], pinnedButtons: {} },
+        layout: { leftButtons: [], rightButtons: [], pinnedButtons: { "copy-tree": false } },
       })
     );
 
@@ -146,6 +148,35 @@ describe("toolbarPreferencesStore cross-view write merge (#11351)", () => {
 
     const written = readBlob(backing);
     expect(written.state.layout.pinnedButtons["file-browser"]).toBeUndefined();
+    // The sibling's untouched edit survives this view's unrelated write.
+    expect(written.state.layout.pinnedButtons["copy-tree"]).toBe(false);
+    expect(written.state.launcher.alwaysShowDevServer).toBe(true);
+  });
+
+  it("preserves a sibling's panel promotion when a stale view writes something unrelated (#11667)", async () => {
+    // Array orderings reconcile last-writer-wins, so this view's write DOES
+    // replace the sibling's side arrays and drop the promoted position. The
+    // explicit `true` is what has to survive — `restorePromotedPanelButtons`
+    // rebuilds the position from it on the next hydration. Without the pin entry
+    // the promotion would be gone with nothing left to reconstruct it from.
+    const backing = installLocalStorage({});
+    const { useToolbarPreferencesStore: store } = await import("../toolbarPreferencesStore");
+
+    backing.set(
+      STORAGE_KEY,
+      siblingBlob({
+        layout: {
+          leftButtons: ["terminal", "browser", "panel-tray"],
+          rightButtons: [],
+          pinnedButtons: { browser: true },
+        },
+      })
+    );
+
+    store.getState().setAlwaysShowDevServer(true);
+
+    const written = readBlob(backing);
+    expect(written.state.layout.pinnedButtons["browser"]).toBe(true);
     expect(written.state.launcher.alwaysShowDevServer).toBe(true);
   });
 

--- a/src/store/__tests__/toolbarPreferencesStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.crossViewMerge.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
  */
 describe("toolbarPreferencesStore cross-view write merge (#11351)", () => {
   const STORAGE_KEY = "daintree-toolbar-preferences";
-  const VERSION = 12;
+  const VERSION = 13;
   const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
 
   type Layout = {
@@ -123,11 +123,13 @@ describe("toolbarPreferencesStore cross-view write merge (#11351)", () => {
     expect(written.state.launcher.alwaysShowDevServer).toBe(true);
   });
 
-  it("does not revert a sibling's file-browser opt-in from an untouched default (#11495)", async () => {
-    // `file-browser` ships hidden, so every fresh view holds `false` without the
-    // user having chosen it. If the null baseline normalizes to `{}`, that
-    // untouched `false` reads as this view's own edit and overwrites a sibling
-    // view that legitimately turned the button on.
+  it("does not revert a sibling's file-browser opt-in from an untouched default (#11495, #11667)", async () => {
+    // Originally this guarded the v12 seed: `file-browser` shipped hidden, so
+    // every fresh view held a `false` nobody chose, and a null baseline
+    // normalizing to `{}` made that untouched value read as this view's own edit.
+    // v13 removed the seed, so a fresh view now holds no entry at all and there
+    // is nothing to mistake for an edit — but the outcome the sibling depends on
+    // is identical, so the case stays as the regression probe for it.
     const backing = installLocalStorage({});
     const { useToolbarPreferencesStore: store } = await import("../toolbarPreferencesStore");
 
@@ -154,8 +156,9 @@ describe("toolbarPreferencesStore cross-view write merge (#11351)", () => {
     const backing = installLocalStorage({});
     const { useToolbarPreferencesStore: store } = await import("../toolbarPreferencesStore");
 
-    // Start from the opt-in state so the toggle records a departure from it.
-    store.getState().toggleButtonVisibility("file-browser", "left");
+    // Since v13 the store already starts in the shown state with no pin entry
+    // (#11667), so the single toggle below IS the departure from it. Before v13
+    // this needed a priming toggle first to clear the shipped `false` seed.
     expect(store.getState().layout.pinnedButtons["file-browser"]).toBeUndefined();
 
     backing.set(

--- a/src/store/__tests__/toolbarPreferencesStore.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.test.ts
@@ -1,10 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type {
-  AnyToolbarButtonId,
-  PluginToolbarButtonId,
-  ToolbarPinnedState,
-} from "@/../../shared/types/toolbar";
+import type { AnyToolbarButtonId, PluginToolbarButtonId } from "@/../../shared/types/toolbar";
 
 // Mirror the production agent IDs so the v5 migration is exercised against
 // the real set, not a subset. Keeping the mock in sync guards against
@@ -82,25 +78,11 @@ function setStoredState(state: Record<string, unknown>, version = 2) {
   storageMock.setItem(STORAGE_KEY, JSON.stringify({ state, version }));
 }
 
-/**
- * `pinnedButtons` minus the hides that ship as defaults — currently just
- * `file-browser`, which the store seeds and the v12 migration stamps onto every
- * older profile so a new built-in can be offered in Settings without appearing
- * on anyone's toolbar (#11495).
- *
- * The per-version cases below assert what their own migration step produced, so
- * they compare against this rather than the raw map; the seed itself is covered
- * by the v11→v12 block. Filtering in one place is what keeps the next
- * ships-hidden button a one-line change here instead of an edit to every
- * expectation in the file.
- */
-function pinsWithoutShippedHides(pinned: ToolbarPinnedState): Record<string, boolean> {
-  const rest: Record<string, boolean> = {};
-  for (const [key, value] of Object.entries(pinned)) {
-    if (key !== "file-browser" && typeof value === "boolean") rest[key] = value;
-  }
-  return rest;
-}
+// The cases below compare `pinnedButtons` directly. They used to route through a
+// `pinsWithoutShippedHides()` filter that stripped the `file-browser: false`
+// seed v12 stamped onto every profile; v13 removed that seed and the store no
+// longer ships any hidden built-in, so there is nothing left to filter out
+// (#11667). An empty map is now the correct expectation everywhere.
 
 async function loadStore() {
   const mod = await import("../toolbarPreferencesStore");
@@ -389,7 +371,7 @@ describe("toolbarPreferencesStore", () => {
       store.getState().setLeftButtons([...store.getState().layout.leftButtons].reverse());
 
       store.getState().reset();
-      expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({});
+      expect(store.getState().layout.pinnedButtons).toEqual({});
       expect(store.getState().layout.leftButtons).toEqual(defaults.leftButtons);
       expect(store.getState().layout.rightButtons).toEqual(defaults.rightButtons);
     });
@@ -443,14 +425,14 @@ describe("toolbarPreferencesStore", () => {
 
       const store = await loadStore();
       // v9→v10 renames "github-stats" to "forge-stats" after the v8 conversion.
-      expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({
+      expect(store.getState().layout.pinnedButtons).toEqual({
         terminal: false,
         "forge-stats": false,
         "copy-tree": false,
       });
     });
 
-    it("merges new default buttons without re-inserting hidden ones", async () => {
+    it("preserves a hidden button's pin state without giving it a position back", async () => {
       setStoredState(
         {
           layout: {
@@ -464,12 +446,38 @@ describe("toolbarPreferencesStore", () => {
       );
 
       const store = await loadStore();
-      // "browser" was hidden — it should be re-added to leftButtons by mergeButtonList
-      // (since it was missing from the persisted leftButtons) but its hide-state
-      // is preserved as `pinnedButtons.browser === false`.
+      // The v7→v8 conversion still translates the old `hiddenButtons` entry into
+      // an explicit `false`.
       expect(store.getState().layout.pinnedButtons["browser"]).toBe(false);
-      // mergeButtonList will add browser back to leftButtons since it's a default
-      expect(store.getState().layout.leftButtons).toContain("browser");
+      // But `browser` left the defaults in v13 (#11667), so `mergeButtonList`
+      // has nothing to re-insert — the id is simply absent from this profile.
+      expect(store.getState().layout.leftButtons).not.toContain("browser");
+    });
+
+    it("keeps browser and dev-server positioned when a profile already carries them", async () => {
+      // The invariant the whole #11667 migration policy rests on: dropping the
+      // two from `DEFAULT_LEFT_BUTTONS` must not evict them from a profile that
+      // has them, because array membership is the only thing distinguishing an
+      // existing toolbar from a fresh one.
+      setStoredState(
+        {
+          layout: {
+            leftButtons: ["terminal", "browser", "file-browser", "dev-server"],
+            rightButtons: ["settings"],
+            pinnedButtons: {},
+          },
+          launcher: { alwaysShowDevServer: false },
+        },
+        12
+      );
+
+      const store = await loadStore();
+      const { leftButtons, pinnedButtons } = store.getState().layout;
+      expect(leftButtons).toContain("browser");
+      expect(leftButtons).toContain("dev-server");
+      // Untouched pin state — no `false` stamped onto either.
+      expect(pinnedButtons["browser"]).toBeUndefined();
+      expect(pinnedButtons["dev-server"]).toBeUndefined();
     });
   });
 
@@ -490,12 +498,20 @@ describe("toolbarPreferencesStore", () => {
       );
 
       const store = await loadStore();
-      expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({});
+      expect(store.getState().layout.pinnedButtons).toEqual({});
     });
 
-    it("includes dev-server in default left buttons", async () => {
+    it("omits browser and dev-server from default left buttons but keeps the ids valid", async () => {
       const store = await loadStore();
-      expect(store.getState().layout.leftButtons).toContain("dev-server");
+      const { leftButtons, rightButtons } = store.getState().layout;
+      // Both moved into the panel tray for fresh profiles (#11667). They are not
+      // deleted ids — `TOOLBAR_BUTTON_PRIORITIES` and the metadata registry
+      // still carry them — they simply aren't defaults any more.
+      expect(leftButtons).not.toContain("browser");
+      expect(leftButtons).not.toContain("dev-server");
+      expect(rightButtons).not.toContain("browser");
+      expect(rightButtons).not.toContain("dev-server");
+      expect(leftButtons).toContain("panel-tray");
     });
 
     it("includes command-palette in default right buttons before settings", async () => {
@@ -576,7 +592,7 @@ describe("toolbarPreferencesStore", () => {
       expect(layout.pinnedButtons["command-palette"]).toBe(false);
     });
 
-    it("re-inserts dev-server for persisted state missing it via mergeButtonList", async () => {
+    it("re-inserts a still-defaulted button for persisted state missing it via mergeButtonList", async () => {
       setStoredState({
         layout: {
           leftButtons: ["terminal", "browser", "notes"],
@@ -587,7 +603,11 @@ describe("toolbarPreferencesStore", () => {
       });
 
       const store = await loadStore();
-      expect(store.getState().layout.leftButtons).toContain("dev-server");
+      // `file-browser` stands in for what `dev-server` used to prove here: a
+      // default missing from the persisted list gets inserted on hydration.
+      // `dev-server` can no longer make the point — it left the defaults in v13.
+      expect(store.getState().layout.leftButtons).toContain("file-browser");
+      expect(store.getState().layout.leftButtons).not.toContain("dev-server");
     });
 
     it("v2→v3 renames 'agent-setup' to 'agent-tray' across all button arrays", async () => {
@@ -720,7 +740,7 @@ describe("toolbarPreferencesStore", () => {
       const store = await loadStore();
       const { layout } = store.getState();
       // Agent IDs stripped at v5, then v8 converts the remainder to a map.
-      expect(pinsWithoutShippedHides(layout.pinnedButtons)).toEqual({ "copy-tree": false });
+      expect(layout.pinnedButtons).toEqual({ "copy-tree": false });
       // Ordering arrays untouched.
       expect(layout.leftButtons).toContain("claude");
       expect(layout.leftButtons).toContain("gemini");
@@ -755,7 +775,7 @@ describe("toolbarPreferencesStore", () => {
 
       const store = await loadStore();
       // All built-in agent IDs stripped; non-agent entry survives into pinnedButtons.
-      expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({
+      expect(store.getState().layout.pinnedButtons).toEqual({
         "copy-tree": false,
       });
     });
@@ -777,7 +797,7 @@ describe("toolbarPreferencesStore", () => {
       );
 
       const store = await loadStore();
-      expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({
+      expect(store.getState().layout.pinnedButtons).toEqual({
         "forge-stats": false,
         "copy-tree": false,
       });
@@ -804,7 +824,7 @@ describe("toolbarPreferencesStore", () => {
       );
 
       const store = await loadStore();
-      expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({
+      expect(store.getState().layout.pinnedButtons).toEqual({
         "copy-tree": false,
       });
       // Ordering arrays untouched.
@@ -880,7 +900,7 @@ describe("toolbarPreferencesStore", () => {
       expect(layout.leftButtons).toContain("terminal");
       expect(layout.leftButtons).toContain("browser");
       expect(layout.rightButtons).toContain("settings");
-      expect(pinsWithoutShippedHides(layout.pinnedButtons)).toEqual({});
+      expect(layout.pinnedButtons).toEqual({});
     });
 
     it("sanitizeButtonList strips assistant-toggle when set via setRightButtons", async () => {
@@ -941,12 +961,18 @@ describe("toolbarPreferencesStore", () => {
       );
 
       const store = await loadStore();
-      // v0→v1: removes old dev-server, mergeButtonList re-adds it from current defaults
-      expect(store.getState().layout.leftButtons).toContain("dev-server");
+      // v0→v1 strips the old `dev-server` entry, and since v13 the current
+      // defaults no longer undo that — the removal finally sticks. This
+      // assertion used to read `toContain`, which only passed because
+      // `mergeButtonList` re-added what v0→v1 had just removed (#11667).
+      expect(store.getState().layout.leftButtons).not.toContain("dev-server");
+      // `browser` was never touched by v0→v1, and dropping it from the defaults
+      // doesn't evict it from a profile that carries it.
+      expect(store.getState().layout.leftButtons).toContain("browser");
       // v0→v1: resets defaultSelection that was "dev-server"
       expect(store.getState().launcher.defaultSelection).toBeUndefined();
       // v7→v8: replaces the hiddenButtons array with the pinnedButtons map.
-      expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({});
+      expect(store.getState().layout.pinnedButtons).toEqual({});
     });
 
     describe("v7→v8 hiddenButtons → pinnedButtons", () => {
@@ -968,7 +994,7 @@ describe("toolbarPreferencesStore", () => {
 
         const store = await loadStore();
         const { layout } = store.getState();
-        expect(pinsWithoutShippedHides(layout.pinnedButtons)).toEqual({
+        expect(layout.pinnedButtons).toEqual({
           terminal: false,
           "copy-tree": false,
         });
@@ -996,7 +1022,7 @@ describe("toolbarPreferencesStore", () => {
         );
 
         const store = await loadStore();
-        expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({});
+        expect(store.getState().layout.pinnedButtons).toEqual({});
       });
 
       it("synthesizes a v8 layout shape when v7 state lacks the layout block", async () => {
@@ -1011,7 +1037,7 @@ describe("toolbarPreferencesStore", () => {
         const store = await loadStore();
         // merge() should fall back to defaults rather than crash; pinnedButtons
         // must still be the canonical empty map.
-        expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({});
+        expect(store.getState().layout.pinnedButtons).toEqual({});
         expect(store.getState().layout.leftButtons).toBeDefined();
       });
 
@@ -1036,7 +1062,7 @@ describe("toolbarPreferencesStore", () => {
         );
 
         const store = await loadStore();
-        expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({
+        expect(store.getState().layout.pinnedButtons).toEqual({
           terminal: true,
           "copy-tree": false,
         });
@@ -1059,7 +1085,7 @@ describe("toolbarPreferencesStore", () => {
         );
 
         const store = await loadStore();
-        expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({
+        expect(store.getState().layout.pinnedButtons).toEqual({
           "copy-tree": false,
         });
       });
@@ -1112,7 +1138,7 @@ describe("toolbarPreferencesStore", () => {
         );
 
         const store = await loadStore();
-        expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({
+        expect(store.getState().layout.pinnedButtons).toEqual({
           "copy-tree": false,
           terminal: false,
         });
@@ -1219,7 +1245,7 @@ describe("toolbarPreferencesStore", () => {
         );
 
         const store = await loadStore();
-        expect(pinsWithoutShippedHides(store.getState().layout.pinnedButtons)).toEqual({
+        expect(store.getState().layout.pinnedButtons).toEqual({
           "forge-stats": false,
         });
         expect(store.getState().layout.rightButtons).toContain("forge-stats");
@@ -1286,7 +1312,7 @@ describe("toolbarPreferencesStore", () => {
         );
         expect(rightButtons.indexOf("forge-stats")).toBeLessThan(rightButtons.indexOf("settings"));
         // The pin map is a Record — unique keys by construction, left untouched.
-        expect(pinsWithoutShippedHides(pinnedButtons)).toEqual({ "forge-stats": false });
+        expect(pinnedButtons).toEqual({ "forge-stats": false });
       });
 
       it("heals duplicates on an already-current blob via merge() (#10937)", async () => {
@@ -1319,8 +1345,12 @@ describe("toolbarPreferencesStore", () => {
       });
     });
 
-    describe("v11→v12 file-browser ships hidden (#11495)", () => {
-      it("hides file-browser for a profile that has never seen the button", async () => {
+    describe("v11→v13 file-browser is stamped hidden then un-stamped (#11495, #11667)", () => {
+      // A pre-v12 profile now runs both steps back to back: v12 stamps
+      // `file-browser: false` onto it, v13 removes that stamp. These assert the
+      // net result, which is what a real upgrade produces — the v12 step is not
+      // reachable on its own any more.
+      it("leaves no file-browser pin for a profile that has never seen the button", async () => {
         storageMock.setItem(
           STORAGE_KEY,
           JSON.stringify({
@@ -1338,18 +1368,14 @@ describe("toolbarPreferencesStore", () => {
 
         const store = await loadStore();
         const { leftButtons, rightButtons, pinnedButtons } = store.getState().layout;
-        expect(pinnedButtons["file-browser"]).toBe(false);
-        // Offered in Settings (so it needs a position) but not on the toolbar.
+        expect(pinnedButtons["file-browser"]).toBeUndefined();
+        // Positioned exactly once, and now actually on the toolbar.
         expect(
           [...leftButtons, ...rightButtons].filter((id) => id === "file-browser")
         ).toHaveLength(1);
       });
 
-      it("hides file-browser even for a heavily customized layout, with no carve-out", async () => {
-        // The reflexive instinct is to infer "this user would want it" from what
-        // they already show. #10709: a newly-introduced default belongs in the
-        // safe state for every pre-existing profile, unconditionally — otherwise
-        // the migration hands some users a toolbar change they never asked for.
+      it("leaves every unrelated preference untouched through both steps", async () => {
         storageMock.setItem(
           STORAGE_KEY,
           JSON.stringify({
@@ -1368,9 +1394,7 @@ describe("toolbarPreferencesStore", () => {
         const store = await loadStore();
         const { pinnedButtons } = store.getState().layout;
         const { launcher } = store.getState();
-        expect(pinnedButtons["file-browser"]).toBe(false);
-        // Every unrelated preference survives the step untouched.
-        expect(pinsWithoutShippedHides(pinnedButtons)).toEqual({
+        expect(pinnedButtons).toEqual({
           "copy-tree": false,
           terminal: true,
           "acme.tool": true,
@@ -1378,11 +1402,11 @@ describe("toolbarPreferencesStore", () => {
         expect(launcher.alwaysShowDevServer).toBe(true);
       });
 
-      it("overwrites a stray pre-v12 file-browser opt-in", async () => {
-        // `file-browser` was not a shipped built-in before v12, so a `true` here
-        // can only be junk (a hand-edited profile, or a dev build that carried
-        // the id early). Treating it as a user choice would let exactly the
-        // toolbar change this migration exists to prevent through.
+      it("preserves a stray file-browser `true` rather than deleting it", async () => {
+        // v12 overwrote this with `false`; v13 only removes a literal `false`, so
+        // the overwrite survives as an explicit-but-inert entry. Deleting a
+        // `true` would be the same overreach v13 exists to undo — and nothing in
+        // the app writes `true` for a built-in, so it can only be hand-authored.
         storageMock.setItem(
           STORAGE_KEY,
           JSON.stringify({
@@ -1394,12 +1418,12 @@ describe("toolbarPreferencesStore", () => {
               },
               launcher: { alwaysShowDevServer: false },
             },
-            version: 11,
+            version: 12,
           })
         );
 
         const store = await loadStore();
-        expect(store.getState().layout.pinnedButtons["file-browser"]).toBe(false);
+        expect(store.getState().layout.pinnedButtons["file-browser"]).toBe(true);
       });
 
       it("synthesizes a layout when a pre-v12 blob has none", async () => {
@@ -1412,19 +1436,71 @@ describe("toolbarPreferencesStore", () => {
         );
 
         const store = await loadStore();
-        expect(store.getState().layout.pinnedButtons["file-browser"]).toBe(false);
+        expect(store.getState().layout.pinnedButtons).toEqual({});
+        expect(store.getState().layout.leftButtons).toContain("file-browser");
       });
+    });
 
-      it("keeps an opt-in made after the migration ran", async () => {
-        // Already at the current version, so `migrate` does not run again — a
-        // user who turned the button on must not have it switched back off on
-        // every subsequent launch.
+    describe("v12→v13 un-hides file-browser (#11667)", () => {
+      it("deletes the v12 stamp and nothing else", async () => {
         storageMock.setItem(
           STORAGE_KEY,
           JSON.stringify({
             state: {
               layout: {
-                leftButtons: ["terminal", "file-browser"],
+                leftButtons: ["terminal", "browser", "file-browser", "dev-server"],
+                rightButtons: ["settings"],
+                pinnedButtons: { "file-browser": false, "copy-tree": false, "acme.tool": true },
+              },
+              launcher: { alwaysShowDevServer: false },
+            },
+            version: 12,
+          })
+        );
+
+        const store = await loadStore();
+        expect(store.getState().layout.pinnedButtons).toEqual({
+          "copy-tree": false,
+          "acme.tool": true,
+        });
+      });
+
+      it("never stamps browser or dev-server hidden on an existing profile", async () => {
+        // The whole point of the additive policy: converging existing users would
+        // mean mass-backfilling a default into their records, which permanently
+        // destroys the ability to change that default again — the exact mistake
+        // v12 made with file-browser and that v13 is undoing.
+        storageMock.setItem(
+          STORAGE_KEY,
+          JSON.stringify({
+            state: {
+              layout: {
+                leftButtons: ["terminal", "browser", "file-browser", "dev-server"],
+                rightButtons: ["settings"],
+                pinnedButtons: { "file-browser": false },
+              },
+              launcher: { alwaysShowDevServer: false },
+            },
+            version: 12,
+          })
+        );
+
+        const store = await loadStore();
+        const { leftButtons, pinnedButtons } = store.getState().layout;
+        expect(pinnedButtons["browser"]).toBeUndefined();
+        expect(pinnedButtons["dev-server"]).toBeUndefined();
+        // Still positioned, so still visible — nobody loses a button they use.
+        expect(leftButtons).toContain("browser");
+        expect(leftButtons).toContain("dev-server");
+      });
+
+      it("adds panel-tray through the hydration merge, not a migration step", async () => {
+        storageMock.setItem(
+          STORAGE_KEY,
+          JSON.stringify({
+            state: {
+              layout: {
+                leftButtons: ["terminal", "browser", "dev-server"],
                 rightButtons: ["settings"],
                 pinnedButtons: {},
               },
@@ -1435,24 +1511,58 @@ describe("toolbarPreferencesStore", () => {
         );
 
         const store = await loadStore();
-        // No entry at all is the "visible" state for a built-in, which is what
-        // `toggleButtonVisibility` leaves behind when a user re-enables it.
-        expect(store.getState().layout.pinnedButtons["file-browser"]).toBeUndefined();
+        const { leftButtons, rightButtons } = store.getState().layout;
+        // Exactly once — pushing a newly-defaulted id into the arrays from a
+        // migration as well is how a profile ends up carrying it twice (#10938).
+        expect([...leftButtons, ...rightButtons].filter((id) => id === "panel-tray")).toHaveLength(
+          1
+        );
+        expect(leftButtons).toContain("panel-tray");
+      });
+
+      it("leaves a profile already at v13 alone", async () => {
+        // `migrate` doesn't run for a current-version blob, so a user who hid
+        // file-browser after v13 must not have that choice reverted on launch.
+        storageMock.setItem(
+          STORAGE_KEY,
+          JSON.stringify({
+            state: {
+              layout: {
+                leftButtons: ["terminal", "file-browser", "panel-tray"],
+                rightButtons: ["settings"],
+                pinnedButtons: { "file-browser": false },
+              },
+              launcher: { alwaysShowDevServer: false },
+            },
+            version: 13,
+          })
+        );
+
+        const store = await loadStore();
+        expect(store.getState().layout.pinnedButtons["file-browser"]).toBe(false);
       });
     });
   });
 
-  describe("file-browser defaults (#11495)", () => {
-    it("offers file-browser on the left between browser and dev-server, hidden", async () => {
+  describe("panel button defaults (#11495, #11667)", () => {
+    it("ships file-browser visible and the panel tray after it", async () => {
       // No stored state on purpose: a fresh install never runs `migrate`, so the
-      // store's own defaults are the only thing standing between a new user and
-      // a toolbar button the issue says must be opt-in.
+      // store's own defaults are the only source of truth for a new user.
       const store = await loadStore();
       const { leftButtons, pinnedButtons } = store.getState().layout;
 
-      expect(pinnedButtons["file-browser"]).toBe(false);
-      expect(leftButtons.indexOf("browser")).toBeLessThan(leftButtons.indexOf("file-browser"));
-      expect(leftButtons.indexOf("file-browser")).toBeLessThan(leftButtons.indexOf("dev-server"));
+      expect(pinnedButtons["file-browser"]).toBeUndefined();
+      expect(leftButtons).toContain("file-browser");
+      expect(leftButtons.indexOf("file-browser")).toBeLessThan(leftButtons.indexOf("panel-tray"));
+    });
+
+    it("synthesizes no pin entries at all for a fresh profile", async () => {
+      // The #11667 invariant: `pinnedButtons` records user intent only. A profile
+      // nobody has touched has expressed none, so an empty map is the only
+      // correct state — a seeded default here is what made a deliberate hide
+      // indistinguishable from a migration artifact in v12.
+      const store = await loadStore();
+      expect(store.getState().layout.pinnedButtons).toEqual({});
     });
 
     it("keeps file-browser on the side the user moved it to across hydration", async () => {
@@ -1484,10 +1594,11 @@ describe("toolbarPreferencesStore", () => {
       );
     });
 
-    it("stays hidden for a current-version blob whose layout carries no pin map", async () => {
-      // A blob already stamped v12 never reaches `migrate`, so `merge()` is the
-      // only thing standing between a missing pin map and a visible button.
-      // Falling back to `{}` here would read as "no pins" — i.e. visible.
+    it("synthesizes no pins for a current-version blob whose layout carries no pin map", async () => {
+      // A blob already stamped at the current version never reaches `migrate`,
+      // so `merge()` alone decides what a missing pin map resolves to. Since
+      // #11667 that is `{}` — there is no ships-hidden default left to restore,
+      // and inventing one here would put a value in the map the user never chose.
       storageMock.setItem(
         STORAGE_KEY,
         JSON.stringify({
@@ -1495,12 +1606,12 @@ describe("toolbarPreferencesStore", () => {
             layout: { leftButtons: ["terminal", "file-browser"], rightButtons: ["settings"] },
             launcher: { alwaysShowDevServer: false },
           },
-          version: 12,
+          version: 13,
         })
       );
 
       const store = await loadStore();
-      expect(store.getState().layout.pinnedButtons["file-browser"]).toBe(false);
+      expect(store.getState().layout.pinnedButtons).toEqual({});
     });
 
     it("hydrates cleanly with no persisted blob at all", async () => {
@@ -1510,14 +1621,14 @@ describe("toolbarPreferencesStore", () => {
       const store = await loadStore();
 
       expect(store.persist.hasHydrated()).toBe(true);
-      expect(store.getState().layout.pinnedButtons["file-browser"]).toBe(false);
+      expect(store.getState().layout.pinnedButtons).toEqual({});
       expect(store.getState().layout.leftButtons).toContain("file-browser");
     });
 
-    it("restores the hidden default on a re-hydrate onto a blob with no pin map", async () => {
+    it("does not carry the previous blob's pins into a re-hydrate onto one with no pin map", async () => {
       // zustand hands `merge` the LIVE state on a second `rehydrate()`, not the
       // creator defaults, so resolving a missing pin map from current state would
-      // carry the previous blob's opt-in into one that has none.
+      // leak the previous blob's overrides into one that has none.
       storageMock.setItem(
         STORAGE_KEY,
         JSON.stringify({
@@ -1525,6 +1636,45 @@ describe("toolbarPreferencesStore", () => {
             layout: {
               leftButtons: ["terminal", "file-browser"],
               rightButtons: ["settings"],
+              pinnedButtons: { "copy-tree": false },
+            },
+            launcher: { alwaysShowDevServer: false },
+          },
+          version: 13,
+        })
+      );
+
+      const store = await loadStore();
+      expect(store.getState().layout.pinnedButtons).toEqual({ "copy-tree": false });
+
+      storageMock.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            layout: { leftButtons: ["terminal", "file-browser"], rightButtons: ["settings"] },
+            launcher: { alwaysShowDevServer: false },
+          },
+          version: 13,
+        })
+      );
+      await store.persist.rehydrate();
+
+      expect(store.getState().layout.pinnedButtons).toEqual({});
+    });
+
+    it("heals a browser duplicated across sides toward the moved copy after it left the defaults", async () => {
+      // `browser` is no longer in `DEFAULT_LEFT_BUTTONS`, but a profile old
+      // enough to have duplicated it had it as a left-side button at the time.
+      // `healCrossSideDuplicates` reads a frozen home set rather than the live
+      // defaults precisely so the repair still keeps the copy the user dragged
+      // away, instead of flipping and deleting it (#11667).
+      storageMock.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            layout: {
+              leftButtons: ["terminal", "browser"],
+              rightButtons: ["browser", "settings"],
               pinnedButtons: {},
             },
             launcher: { alwaysShowDevServer: false },
@@ -1534,21 +1684,10 @@ describe("toolbarPreferencesStore", () => {
       );
 
       const store = await loadStore();
-      expect(store.getState().layout.pinnedButtons["file-browser"]).toBeUndefined();
-
-      storageMock.setItem(
-        STORAGE_KEY,
-        JSON.stringify({
-          state: {
-            layout: { leftButtons: ["terminal", "file-browser"], rightButtons: ["settings"] },
-            launcher: { alwaysShowDevServer: false },
-          },
-          version: 12,
-        })
-      );
-      await store.persist.rehydrate();
-
-      expect(store.getState().layout.pinnedButtons["file-browser"]).toBe(false);
+      const { leftButtons, rightButtons } = store.getState().layout;
+      expect([...leftButtons, ...rightButtons].filter((id) => id === "browser")).toHaveLength(1);
+      expect(rightButtons).toContain("browser");
+      expect(leftButtons).not.toContain("browser");
     });
 
     it("heals a default already duplicated onto both sides by the old hydration", async () => {
@@ -1625,6 +1764,101 @@ describe("toolbarPreferencesStore", () => {
       const { leftButtons, rightButtons } = store.getState().layout;
       expect(leftButtons).not.toContain("terminal");
       expect(rightButtons).toContain("terminal");
+    });
+  });
+
+  describe("setPanelButtonOnToolbar (#11667)", () => {
+    it("gives an unpositioned button a slot before the tray without writing a pin", async () => {
+      // The case `toggleButtonVisibility` cannot handle: on a fresh profile
+      // `browser` is in neither side array, so clearing a pin alone would leave
+      // it with nowhere to render.
+      const store = await loadStore();
+      expect(store.getState().layout.leftButtons).not.toContain("browser");
+
+      store.getState().setPanelButtonOnToolbar("browser", true);
+
+      const { leftButtons, pinnedButtons } = store.getState().layout;
+      expect(leftButtons).toContain("browser");
+      expect(leftButtons.indexOf("browser")).toBe(leftButtons.indexOf("panel-tray") - 1);
+      // No `true` written: a positioned built-in with no entry is already
+      // visible, so recording one would put a value in the map the user's own
+      // action didn't require — the seeding habit v13 exists to end.
+      expect(pinnedButtons["browser"]).toBeUndefined();
+    });
+
+    it("hides by writing false and keeps the position for a later re-show", async () => {
+      const store = await loadStore();
+      store.getState().setPanelButtonOnToolbar("browser", true);
+      const promotedIndex = store.getState().layout.leftButtons.indexOf("browser");
+
+      store.getState().setPanelButtonOnToolbar("browser", false);
+      expect(store.getState().layout.pinnedButtons["browser"]).toBe(false);
+      // Position retained, so re-showing restores it where the user had it
+      // rather than appending it somewhere new.
+      expect(store.getState().layout.leftButtons.indexOf("browser")).toBe(promotedIndex);
+
+      store.getState().setPanelButtonOnToolbar("browser", true);
+      expect(store.getState().layout.pinnedButtons["browser"]).toBeUndefined();
+      expect(store.getState().layout.leftButtons.indexOf("browser")).toBe(promotedIndex);
+    });
+
+    it("never positions the same id twice", async () => {
+      const store = await loadStore();
+      store.getState().setPanelButtonOnToolbar("dev-server", true);
+      store.getState().setPanelButtonOnToolbar("dev-server", true);
+
+      const { leftButtons, rightButtons } = store.getState().layout;
+      expect([...leftButtons, ...rightButtons].filter((id) => id === "dev-server")).toHaveLength(1);
+    });
+
+    it("clears an existing hide without moving an already-positioned button", async () => {
+      storageMock.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            layout: {
+              leftButtons: ["terminal", "browser", "file-browser", "panel-tray"],
+              rightButtons: ["settings"],
+              pinnedButtons: { browser: false },
+            },
+            launcher: { alwaysShowDevServer: false },
+          },
+          version: 13,
+        })
+      );
+
+      const store = await loadStore();
+      const before = store.getState().layout.leftButtons.indexOf("browser");
+
+      store.getState().setPanelButtonOnToolbar("browser", true);
+
+      expect(store.getState().layout.pinnedButtons["browser"]).toBeUndefined();
+      expect(store.getState().layout.leftButtons.indexOf("browser")).toBe(before);
+    });
+
+    it("follows the tray to the right side when the user moved it there", async () => {
+      storageMock.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            layout: {
+              leftButtons: ["terminal", "file-browser"],
+              rightButtons: ["panel-tray", "settings"],
+              pinnedButtons: {},
+            },
+            launcher: { alwaysShowDevServer: false },
+          },
+          version: 13,
+        })
+      );
+
+      const store = await loadStore();
+      store.getState().setPanelButtonOnToolbar("dev-server", true);
+
+      const { leftButtons, rightButtons } = store.getState().layout;
+      expect(rightButtons).toContain("dev-server");
+      expect(leftButtons).not.toContain("dev-server");
+      expect(rightButtons.indexOf("dev-server")).toBe(rightButtons.indexOf("panel-tray") - 1);
     });
   });
 });

--- a/src/store/__tests__/toolbarPreferencesStore.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.test.ts
@@ -473,11 +473,17 @@ describe("toolbarPreferencesStore", () => {
 
       const store = await loadStore();
       const { leftButtons, pinnedButtons } = store.getState().layout;
-      expect(leftButtons).toContain("browser");
-      expect(leftButtons).toContain("dev-server");
-      // Untouched pin state — no `false` stamped onto either.
-      expect(pinnedButtons["browser"]).toBeUndefined();
-      expect(pinnedButtons["dev-server"]).toBeUndefined();
+      // Relative order preserved, not merely membership: `mergeButtonList` takes
+      // the persisted list verbatim and only inserts what's missing, so an
+      // existing toolbar must come through with its own arrangement intact.
+      // Filtered to the carried ids rather than compared whole — hydration also
+      // inserts `agent-tray`, the agent buttons and `panel-tray`, none of which
+      // this case is about.
+      const carried = ["terminal", "browser", "file-browser", "dev-server"];
+      expect(leftButtons.filter((id) => carried.includes(id))).toEqual(carried);
+      // The whole map, not two lookups: nothing at all may be written for a
+      // profile that expressed no overrides.
+      expect(pinnedButtons).toEqual({});
     });
   });
 
@@ -1768,7 +1774,7 @@ describe("toolbarPreferencesStore", () => {
   });
 
   describe("setPanelButtonOnToolbar (#11667)", () => {
-    it("gives an unpositioned button a slot before the tray without writing a pin", async () => {
+    it("gives an unpositioned button a slot before the tray and records the promotion", async () => {
       // The case `toggleButtonVisibility` cannot handle: on a fresh profile
       // `browser` is in neither side array, so clearing a pin alone would leave
       // it with nowhere to render.
@@ -1780,10 +1786,11 @@ describe("toolbarPreferencesStore", () => {
       const { leftButtons, pinnedButtons } = store.getState().layout;
       expect(leftButtons).toContain("browser");
       expect(leftButtons.indexOf("browser")).toBe(leftButtons.indexOf("panel-tray") - 1);
-      // No `true` written: a positioned built-in with no entry is already
-      // visible, so recording one would put a value in the map the user's own
-      // action didn't require — the seeding habit v13 exists to end.
-      expect(pinnedButtons["browser"]).toBeUndefined();
+      // An explicit `true`, unlike `toggleButtonVisibility`. `browser` is not a
+      // default, so the promotion is a real choice with nothing else recording
+      // it — and it's the only part that survives a stale sibling view
+      // overwriting the position arrays.
+      expect(pinnedButtons["browser"]).toBe(true);
     });
 
     it("hides by writing false and keeps the position for a later re-show", async () => {
@@ -1798,8 +1805,58 @@ describe("toolbarPreferencesStore", () => {
       expect(store.getState().layout.leftButtons.indexOf("browser")).toBe(promotedIndex);
 
       store.getState().setPanelButtonOnToolbar("browser", true);
-      expect(store.getState().layout.pinnedButtons["browser"]).toBeUndefined();
+      expect(store.getState().layout.pinnedButtons["browser"]).toBe(true);
       expect(store.getState().layout.leftButtons.indexOf("browser")).toBe(promotedIndex);
+    });
+
+    it("rebuilds a promoted button's position when hydration finds it missing", async () => {
+      // The cross-view repair. Orderings reconcile last-writer-wins, so a stale
+      // sibling view writing any toolbar preference replaces the arrays wholesale
+      // and drops a promotion this view just made. `pinnedButtons` merges per id
+      // and survives, so the explicit `true` is what the position is rebuilt from
+      // — otherwise the button would silently un-promote itself.
+      storageMock.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            layout: {
+              leftButtons: ["terminal", "file-browser", "panel-tray"],
+              rightButtons: ["settings"],
+              pinnedButtons: { browser: true },
+            },
+            launcher: { alwaysShowDevServer: false },
+          },
+          version: 13,
+        })
+      );
+
+      const store = await loadStore();
+      const { leftButtons, rightButtons } = store.getState().layout;
+      expect(leftButtons).toContain("browser");
+      expect(leftButtons.indexOf("browser")).toBe(leftButtons.indexOf("panel-tray") - 1);
+      expect([...leftButtons, ...rightButtons].filter((id) => id === "browser")).toHaveLength(1);
+    });
+
+    it("does not rebuild a position for a button the user hid", async () => {
+      storageMock.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            layout: {
+              leftButtons: ["terminal", "file-browser", "panel-tray"],
+              rightButtons: ["settings"],
+              pinnedButtons: { browser: false, "dev-server": false },
+            },
+            launcher: { alwaysShowDevServer: false },
+          },
+          version: 13,
+        })
+      );
+
+      const store = await loadStore();
+      const { leftButtons, rightButtons } = store.getState().layout;
+      expect([...leftButtons, ...rightButtons]).not.toContain("browser");
+      expect([...leftButtons, ...rightButtons]).not.toContain("dev-server");
     });
 
     it("never positions the same id twice", async () => {
@@ -1832,7 +1889,7 @@ describe("toolbarPreferencesStore", () => {
 
       store.getState().setPanelButtonOnToolbar("browser", true);
 
-      expect(store.getState().layout.pinnedButtons["browser"]).toBeUndefined();
+      expect(store.getState().layout.pinnedButtons["browser"]).toBe(true);
       expect(store.getState().layout.leftButtons.indexOf("browser")).toBe(before);
     });
 

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -5,6 +5,7 @@ import type {
   ToolbarPreferences,
   ToolbarButtonId,
   AnyToolbarButtonId,
+  PanelTrayButtonId,
   PluginToolbarButtonId,
   ToolbarPinnedState,
 } from "@/../../shared/types/toolbar";
@@ -17,13 +18,25 @@ import {
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 import { BUILT_IN_AGENT_IDS, LAUNCHABLE_AGENT_IDS } from "@shared/config/agentIds";
 
+/**
+ * `browser` and `dev-server` are deliberately absent (#11667). Both assume web
+ * development; the file browser assumes only that the project has files, so it
+ * takes the first-class slot and the other two move into the panel tray.
+ *
+ * Absence from this array — not a seeded `pinnedButtons` entry — is what makes
+ * them ship hidden. `mergeButtonList` only ever *adds* defaults a profile is
+ * missing and never removes an id a profile carries, so an existing toolbar
+ * keeps both buttons untouched while a fresh one never grows them. That
+ * per-profile discriminator is the whole reason no migration has to stamp
+ * anything: see the `ToolbarPinnedState` doc comment on why stamping a default
+ * would forfeit the ability to ever change it again.
+ */
 const DEFAULT_LEFT_BUTTONS: ToolbarButtonId[] = [
   "agent-tray",
   ...(LAUNCHABLE_AGENT_IDS as unknown as ToolbarButtonId[]),
   "terminal",
-  "browser",
   "file-browser",
-  "dev-server",
+  "panel-tray",
 ];
 
 const DEFAULT_RIGHT_BUTTONS: ToolbarButtonId[] = [
@@ -38,27 +51,16 @@ const DEFAULT_RIGHT_BUTTONS: ToolbarButtonId[] = [
   "problems",
 ];
 
-/**
- * Built-ins that ship hidden: offered in Settings → Toolbar, but absent from the
- * toolbar until the user opts in (#11495).
- *
- * Every path that materializes "no persisted pin map" has to resolve to this,
- * not to `{}` — the defaults, the hydration merge, and the cross-view baseline
- * alike. `{}` means "the user has no pins", which for a built-in reads as
- * *visible*; using it for a missing map is what would leak the button onto a
- * toolbar. An explicitly stored `{}` is different and must be respected: that is
- * exactly what `toggleButtonVisibility` leaves behind when a user turns the
- * button on.
- */
-const DEFAULT_PINNED_BUTTONS: ToolbarPinnedState = { "file-browser": false };
-
 const DEFAULT_PREFERENCES: ToolbarPreferences = {
   layout: {
     leftButtons: DEFAULT_LEFT_BUTTONS,
     rightButtons: DEFAULT_RIGHT_BUTTONS,
-    // Not redundant with the v12 migration: a fresh install has no persisted
-    // blob, so `migrate` never runs and this is the only source of truth.
-    pinnedButtons: DEFAULT_PINNED_BUTTONS,
+    // Always empty, and there is no `DEFAULT_PINNED_BUTTONS` constant to seed it
+    // from any more (#11667). A default belongs in the arrays above; this map
+    // holds user overrides only, so a fresh profile has nothing to say here.
+    // Reintroducing a seeded default would repeat the v12 mistake — see the
+    // `ToolbarPinnedState` doc comment.
+    pinnedButtons: {},
   },
   launcher: {
     alwaysShowDevServer: false,
@@ -68,8 +70,19 @@ const DEFAULT_PREFERENCES: ToolbarPreferences = {
 
 const FIXED_BUTTON_IDS: ToolbarButtonId[] = ["sidebar-toggle", "assistant-toggle", "portal-toggle"];
 
-/** Home side lookup, used to pick the survivor when an id sits on both sides. */
-const DEFAULT_LEFT_BUTTON_SET = new Set<AnyToolbarButtonId>(DEFAULT_LEFT_BUTTONS);
+/**
+ * Home side lookup, used *only* to pick the survivor when an id sits on both
+ * sides. Deliberately not `DEFAULT_LEFT_BUTTONS` itself: `browser` and
+ * `dev-server` left the defaults in v13 (#11667) but a profile old enough to
+ * carry a cross-side duplicate of one still had it as a left-side button when
+ * the duplicate formed. Reading the live defaults here would flip the repair for
+ * exactly those profiles and keep the copy the user dragged *away* from.
+ *
+ * Membership here never causes a button to be inserted anywhere — that is
+ * `mergeButtonList`'s job, and it reads the defaults, not this set.
+ */
+const LEFT_HOME_BUTTON_IDS: ToolbarButtonId[] = [...DEFAULT_LEFT_BUTTONS, "browser", "dev-server"];
+const DEFAULT_LEFT_BUTTON_SET = new Set<AnyToolbarButtonId>(LEFT_HOME_BUTTON_IDS);
 
 function sanitizeButtonList(buttons: AnyToolbarButtonId[]): AnyToolbarButtonId[] {
   const filtered = buttons.filter((id) => !FIXED_BUTTON_IDS.includes(id as ToolbarButtonId));
@@ -205,16 +218,14 @@ function toToolbarPersisted(
     layout: {
       leftButtons: sanitizeButtonList(asButtonList(layout?.leftButtons) ?? DEFAULT_LEFT_BUTTONS),
       rightButtons: sanitizeButtonList(asButtonList(layout?.rightButtons) ?? DEFAULT_RIGHT_BUTTONS),
-      // Absent falls back to defaults like the two lists above; an explicitly
-      // stored map (including `{}`) is normalized as-is. The distinction decides
-      // whether a ships-hidden button survives a cross-view merge: normalizing a
-      // *missing* map to `{}` would make a sibling view's untouched
-      // `file-browser: false` look like a fresh edit and revert another view's
-      // opt-in (#11495).
-      pinnedButtons:
-        layout?.pinnedButtons === undefined
-          ? { ...DEFAULT_PINNED_BUTTONS }
-          : normalizePinnedButtons(layout.pinnedButtons),
+      // Both a missing and an explicitly-stored-empty map normalize to `{}`,
+      // because as of #11667 no built-in ships hidden and the defaults carry no
+      // pins to preserve. The distinction used to matter: while `file-browser`
+      // shipped as a seeded `false`, normalizing a *missing* map to `{}` made a
+      // sibling view's untouched seed look like a fresh edit and reverted
+      // another view's opt-in (#11495). With nothing seeded there is no baseline
+      // `false` left to misread, so the two cases converge.
+      pinnedButtons: normalizePinnedButtons(layout?.pinnedButtons),
     },
     launcher: {
       alwaysShowDevServer:
@@ -316,6 +327,26 @@ interface ToolbarPreferencesState extends ToolbarPreferences {
    */
   setPluginButtonPromoted: (buttonId: PluginToolbarButtonId, promoted: boolean) => void;
   /**
+   * Give a panel-tray button its own top-level toolbar slot, or take it away
+   * (#11667).
+   *
+   * Distinct from `toggleButtonVisibility` because that only ever touches
+   * `pinnedButtons`, and since v13 `browser`/`dev-server` are absent from
+   * `DEFAULT_LEFT_BUTTONS` — so on a fresh profile they sit in neither side
+   * array and clearing a pin alone would leave them with nowhere to render.
+   *
+   * Showing deletes any hide entry and, only when the id is positioned on
+   * neither side, gives it one; it never writes `true`. A positioned built-in
+   * with no pin entry is already visible, so a `true` would record nothing the
+   * arrays don't already say — and seeding this map with values the user did not
+   * choose is the v12 mistake (see `ToolbarPinnedState`).
+   *
+   * Hiding writes `false` and leaves the position alone, exactly like
+   * `toggleButtonVisibility`, so re-showing restores the button where the user
+   * had it rather than appending it somewhere new.
+   */
+  setPanelButtonOnToolbar: (buttonId: PanelTrayButtonId, onToolbar: boolean) => void;
+  /**
    * Prune `pinnedButtons` entries for plugin buttons that are no longer in
    * the loaded plugin set. `pinnedButtons` is renderer-local persisted state
    * with no main-process access, so an uninstalled plugin's stale hide entry
@@ -393,6 +424,38 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
             layout: { ...state.layout, pinnedButtons: pinned },
           };
         }),
+      setPanelButtonOnToolbar: (buttonId, onToolbar) =>
+        set((state) => {
+          const pinned: ToolbarPinnedState = { ...state.layout.pinnedButtons };
+          if (!onToolbar) {
+            if (pinned[buttonId] === false) return state;
+            pinned[buttonId] = false;
+            return { layout: { ...state.layout, pinnedButtons: pinned } };
+          }
+
+          delete pinned[buttonId];
+          const isPositioned =
+            state.layout.leftButtons.includes(buttonId) ||
+            state.layout.rightButtons.includes(buttonId);
+          if (isPositioned) {
+            if (state.layout.pinnedButtons[buttonId] === undefined) return state;
+            return { layout: { ...state.layout, pinnedButtons: pinned } };
+          }
+
+          // Unpositioned: land it next to the tray it was promoted from, so the
+          // panel buttons stay grouped instead of the id appearing at whichever
+          // end of the row a bare append would put it. `panel-tray` can only be
+          // missing from a hand-edited profile, in which case the left side is
+          // where these buttons have always lived (`LEFT_HOME_BUTTON_IDS`).
+          const trayOnRight = state.layout.rightButtons.includes("panel-tray");
+          const side = trayOnRight ? "rightButtons" : "leftButtons";
+          const target = [...state.layout[side]];
+          const trayIndex = target.indexOf("panel-tray");
+          target.splice(trayIndex === -1 ? target.length : trayIndex, 0, buttonId);
+          return {
+            layout: { ...state.layout, pinnedButtons: pinned, [side]: sanitizeButtonList(target) },
+          };
+        }),
       setPluginButtonPromoted: (buttonId, promoted) =>
         set((state) => {
           const current = state.layout.pinnedButtons[buttonId];
@@ -449,7 +512,7 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
     }),
     {
       name: "daintree-toolbar-preferences",
-      version: 12,
+      version: 13,
       storage: createSafeJSONStorage<ToolbarPreferencesPersistedState>({
         mergeOnWrite: mergeToolbarPreferencesPersistedWrite,
       }),
@@ -680,6 +743,60 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
             pinnedButtons: { ...carriedPins, "file-browser": false },
           };
         }
+        if (version < 13) {
+          // Undo the v12 stamp above (#11667). `file-browser` now ships visible,
+          // and the `false` v12 wrote onto every profile was never user intent —
+          // removing it repairs a bad write rather than overriding a preference.
+          //
+          // Only a literal `false` is removed. A `true` is left alone: nothing
+          // writes `true` for a built-in, so one can only have arrived from a
+          // hand-edited profile, and deleting it would be the same overreach v12
+          // committed.
+          //
+          // One reset is unavoidable and is NOT a bug: a user who deliberately
+          // hid `file-browser` after v12 carries the identical `false` as the
+          // stamp, so the button reappears for them once. The two are
+          // indistinguishable precisely because v12 materialized a default into
+          // user state — the reason this map now records overrides only. The
+          // affected population is small: the shipped state was already hidden,
+          // so hiding it again required showing it first.
+          //
+          // `browser` and `dev-server` are deliberately untouched — no `false`
+          // stamp, no position change. They ship absent from the *defaults*
+          // (`DEFAULT_LEFT_BUTTONS`), which leaves every existing profile's copy
+          // exactly where it is while fresh profiles never grow one. Stamping
+          // them here would mass-backfill a default into existing records and
+          // forfeit the ability to change it again, which is the whole mistake
+          // this step exists to undo.
+          //
+          // `panel-tray` needs no placement here either: `mergeButtonList`
+          // inserts a newly-defaulted id on every hydration, and pushing it into
+          // the arrays as well is how a profile ends up with the id twice
+          // (#10938).
+          //
+          // Narrowed rather than asserted, matching the v12 step: `state` is
+          // already `Record<string, unknown>`, so `in`/`typeof` guards reach the
+          // same place without a type assertion, and the lint ratchet scores
+          // `no-unsafe-type-assertion` per rule.
+          const layout = state.layout;
+          const hasLayout = typeof layout === "object" && layout !== null && !Array.isArray(layout);
+          const existingPins = hasLayout && "pinnedButtons" in layout ? layout.pinnedButtons : null;
+          const carriedPins =
+            typeof existingPins === "object" &&
+            existingPins !== null &&
+            !Array.isArray(existingPins)
+              ? existingPins
+              : {};
+          const repairedPins = Object.fromEntries(
+            Object.entries(carriedPins).filter(
+              ([key, value]) => !(key === "file-browser" && value === false)
+            )
+          );
+          state.layout = {
+            ...(hasLayout ? layout : {}),
+            pinnedButtons: repairedPins,
+          };
+        }
         return state as unknown as ToolbarPreferencesState;
       },
       partialize: (state) => ({
@@ -715,17 +832,14 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
               currentState.layout.rightButtons,
               healed.leftButtons
             ),
-            // Defaults, never `{}` — see `DEFAULT_PINNED_BUTTONS`. A blob already
-            // stamped at the current version skips `migrate` entirely, so a
-            // layout that carries no pin map would otherwise surface a
-            // ships-hidden button. An explicitly stored `{}` still wins, which is
-            // how a genuine opt-in survives.
-            //
-            // The constant rather than `currentState.layout.pinnedButtons`: on a
-            // re-`rehydrate()` zustand passes live state here, not the creator
-            // defaults, so reading from it would carry the previous blob's pins
-            // into a blob that has none.
-            pinnedButtons: persisted.layout?.pinnedButtons ?? { ...DEFAULT_PINNED_BUTTONS },
+            // A literal `{}`, never `currentState.layout.pinnedButtons`: on a
+            // re-`rehydrate()` zustand passes live state here rather than the
+            // creator defaults, so reading from it would carry the previous
+            // blob's pins into a blob that has none. There is no default pin map
+            // to fall back to any more (#11667) — a profile with no persisted
+            // pins has expressed no overrides, and every built-in it positions
+            // is therefore visible.
+            pinnedButtons: persisted.layout?.pinnedButtons ?? {},
           },
         };
       },

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -184,18 +184,24 @@ function mergeButtonList(
  *
  * `panel-tray` can only be missing from a hand-edited profile; the left side is
  * where these buttons have always lived (`LEFT_HOME_BUTTON_IDS`), so that is the
- * fallback. Returns the single side it touched, for spreading over `layout`.
+ * fallback. Returns both sides — the untouched one passed straight through —
+ * rather than a computed-key object for the side it changed: the latter needs a
+ * type assertion to describe, and the lint ratchet scores
+ * `no-unsafe-type-assertion` per rule, so one more costs a baseline bump the
+ * ratchet exists to prevent.
  */
 function positionPanelButton(
   layout: ToolbarLayoutState,
   buttonId: AnyToolbarButtonId
-): { leftButtons: AnyToolbarButtonId[] } | { rightButtons: AnyToolbarButtonId[] } {
-  const side = layout.rightButtons.includes("panel-tray") ? "rightButtons" : "leftButtons";
-  const target = [...layout[side]];
+): { leftButtons: AnyToolbarButtonId[]; rightButtons: AnyToolbarButtonId[] } {
+  const trayOnRight = layout.rightButtons.includes("panel-tray");
+  const target = [...(trayOnRight ? layout.rightButtons : layout.leftButtons)];
   const trayIndex = target.indexOf("panel-tray");
   target.splice(trayIndex === -1 ? target.length : trayIndex, 0, buttonId);
-  return { [side]: sanitizeButtonList(target) } as
-    { leftButtons: AnyToolbarButtonId[] } | { rightButtons: AnyToolbarButtonId[] };
+  const positioned = sanitizeButtonList(target);
+  return trayOnRight
+    ? { leftButtons: layout.leftButtons, rightButtons: positioned }
+    : { leftButtons: positioned, rightButtons: layout.rightButtons };
 }
 
 type ToolbarLayoutState = ToolbarPreferences["layout"];

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -173,6 +173,59 @@ function mergeButtonList(
   return sanitizeButtonList(result);
 }
 
+/** Panel-tray buttons, in the order the tray lists them. */
+const PANEL_TRAY_BUTTON_IDS: PanelTrayButtonId[] = ["file-browser", "browser", "dev-server"];
+
+/**
+ * Give a panel button a slot next to the tray it was promoted from, so the panel
+ * buttons stay grouped rather than landing at whichever end of the row a bare
+ * append would put them.
+ *
+ * `panel-tray` can only be missing from a hand-edited profile; the left side is
+ * where these buttons have always lived (`LEFT_HOME_BUTTON_IDS`), so that is the
+ * fallback. Returns the single side it touched, for spreading over `layout`.
+ */
+function positionPanelButton(
+  layout: ToolbarLayoutState,
+  buttonId: AnyToolbarButtonId
+): { leftButtons: AnyToolbarButtonId[] } | { rightButtons: AnyToolbarButtonId[] } {
+  const side = layout.rightButtons.includes("panel-tray") ? "rightButtons" : "leftButtons";
+  const target = [...layout[side]];
+  const trayIndex = target.indexOf("panel-tray");
+  target.splice(trayIndex === -1 ? target.length : trayIndex, 0, buttonId);
+  return { [side]: sanitizeButtonList(target) } as
+    { leftButtons: AnyToolbarButtonId[] } | { rightButtons: AnyToolbarButtonId[] };
+}
+
+type ToolbarLayoutState = ToolbarPreferences["layout"];
+
+/**
+ * Re-materialize a position for a panel button the user explicitly promoted but
+ * that no longer has one.
+ *
+ * Runs on every hydration rather than in a migration, which is where this store
+ * puts durable invariants (`migrate` runs once, `merge` runs every load). The
+ * case it repairs is cross-view: button orderings are reconciled last-writer-wins
+ * — two divergent orders can't be merged — so a stale sibling view writing any
+ * toolbar preference replaces the arrays wholesale and drops a promotion another
+ * view just made. Before #11667 that only cost ordering, because every built-in
+ * was in an array regardless; now array membership carries visibility for
+ * `browser`/`dev-server`, so the same overwrite would silently un-promote them.
+ *
+ * `pinnedButtons` survives that overwrite (it merges per id, #11351), so the
+ * explicit `true` is the durable record of intent and the position is rebuilt
+ * from it here.
+ */
+function restorePromotedPanelButtons(layout: ToolbarLayoutState): ToolbarLayoutState {
+  let next = layout;
+  for (const buttonId of PANEL_TRAY_BUTTON_IDS) {
+    if (next.pinnedButtons[buttonId] !== true) continue;
+    if (next.leftButtons.includes(buttonId) || next.rightButtons.includes(buttonId)) continue;
+    next = { ...next, ...positionPanelButton(next, buttonId) };
+  }
+  return next;
+}
+
 /**
  * The exact subset persisted by `partialize` (note: the launcher's `defaultAgent`
  * is deliberately not persisted). The write merge (#11351) reconciles against
@@ -335,11 +388,13 @@ interface ToolbarPreferencesState extends ToolbarPreferences {
    * `DEFAULT_LEFT_BUTTONS` — so on a fresh profile they sit in neither side
    * array and clearing a pin alone would leave them with nowhere to render.
    *
-   * Showing deletes any hide entry and, only when the id is positioned on
-   * neither side, gives it one; it never writes `true`. A positioned built-in
-   * with no pin entry is already visible, so a `true` would record nothing the
-   * arrays don't already say — and seeding this map with values the user did not
-   * choose is the v12 mistake (see `ToolbarPinnedState`).
+   * Showing writes an explicit `true` and, only when the id is positioned on
+   * neither side, gives it a position. The `true` is not a seeded default — it
+   * records a choice the user made, the same way `setPluginButtonPromoted` does
+   * for a plugin contribution whose default is also "not on the toolbar". It is
+   * load-bearing across project views: orderings reconcile last-writer-wins, so
+   * a stale sibling's write drops the new position, and `restorePromotedPanelButtons`
+   * rebuilds it from this flag on the next hydration.
    *
    * Hiding writes `false` and leaves the position alone, exactly like
    * `toggleButtonVisibility`, so re-showing restores the button where the user
@@ -433,27 +488,21 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
             return { layout: { ...state.layout, pinnedButtons: pinned } };
           }
 
-          delete pinned[buttonId];
+          if (state.layout.pinnedButtons[buttonId] === true) return state;
+          pinned[buttonId] = true;
           const isPositioned =
             state.layout.leftButtons.includes(buttonId) ||
             state.layout.rightButtons.includes(buttonId);
           if (isPositioned) {
-            if (state.layout.pinnedButtons[buttonId] === undefined) return state;
             return { layout: { ...state.layout, pinnedButtons: pinned } };
           }
 
-          // Unpositioned: land it next to the tray it was promoted from, so the
-          // panel buttons stay grouped instead of the id appearing at whichever
-          // end of the row a bare append would put it. `panel-tray` can only be
-          // missing from a hand-edited profile, in which case the left side is
-          // where these buttons have always lived (`LEFT_HOME_BUTTON_IDS`).
-          const trayOnRight = state.layout.rightButtons.includes("panel-tray");
-          const side = trayOnRight ? "rightButtons" : "leftButtons";
-          const target = [...state.layout[side]];
-          const trayIndex = target.indexOf("panel-tray");
-          target.splice(trayIndex === -1 ? target.length : trayIndex, 0, buttonId);
           return {
-            layout: { ...state.layout, pinnedButtons: pinned, [side]: sanitizeButtonList(target) },
+            layout: {
+              ...state.layout,
+              pinnedButtons: pinned,
+              ...positionPanelButton(state.layout, buttonId),
+            },
           };
         }),
       setPluginButtonPromoted: (buttonId, promoted) =>
@@ -748,10 +797,13 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
           // and the `false` v12 wrote onto every profile was never user intent —
           // removing it repairs a bad write rather than overriding a preference.
           //
-          // Only a literal `false` is removed. A `true` is left alone: nothing
-          // writes `true` for a built-in, so one can only have arrived from a
-          // hand-edited profile, and deleting it would be the same overreach v12
-          // committed.
+          // Only a literal `false` is removed. A `true` is left alone — it means
+          // an explicit promotion (`setPanelButtonOnToolbar`), which is a real
+          // choice and not this step's to revoke. Note the v12 step above
+          // overwrites a pre-v12 `true` with `false` before this runs, so a
+          // profile entering below v12 loses it; that only reaches hand-edited
+          // or early-development blobs, since `file-browser` was not a shipped
+          // built-in before v12.
           //
           // One reset is unavoidable and is NOT a bug: a user who deliberately
           // hid `file-browser` after v12 carries the identical `false` as the
@@ -821,7 +873,7 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
         return {
           ...currentState,
           ...persisted,
-          layout: {
+          layout: restorePromotedPanelButtons({
             leftButtons: mergeButtonList(
               healed.leftButtons,
               currentState.layout.leftButtons,
@@ -840,7 +892,7 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
             // pins has expressed no overrides, and every built-in it positions
             // is therefore visible.
             pinnedButtons: persisted.layout?.pinnedButtons ?? {},
-          },
+          }),
         };
       },
     }

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -9,6 +9,10 @@ import type {
   PluginToolbarButtonId,
   ToolbarPinnedState,
 } from "@/../../shared/types/toolbar";
+// `@shared/...`, not the `@/../../shared/...` spelling the type-only import
+// above uses: that path is erased at compile time and never has to resolve at
+// runtime, but a value import does.
+import { PANEL_TRAY_BUTTON_IDS } from "@shared/types/toolbar";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
 import {
   mergeRecordByWriterDelta,
@@ -172,9 +176,6 @@ function mergeButtonList(
 
   return sanitizeButtonList(result);
 }
-
-/** Panel-tray buttons, in the order the tray lists them. */
-const PANEL_TRAY_BUTTON_IDS: PanelTrayButtonId[] = ["file-browser", "browser", "dev-server"];
 
 /**
  * Give a panel button a slot next to the tray it was promoted from, so the panel


### PR DESCRIPTION
## Summary

- `file-browser` was the only non-agent built-in toolbar button that shipped hidden (a persist-v12 migration stamped `pinnedButtons["file-browser"] = false` onto every profile), while `browser` (web browser panel) and `dev-server` (dev preview) shipped visible. That's backwards: file browsing only needs the project to have files, the other two assume web development.
- Fixes it without touching a single existing user's saved layout, and without repeating the mistake that caused the bug in the first place.
- Adds a `panel-tray` toolbar button that groups the less-common panels behind a dropdown, and a store action that makes "show this button" an explicit, durable choice instead of an implicit one.

Resolves #11667

## Changes

- Removed `browser` and `dev-server` from `DEFAULT_LEFT_BUTTONS` in `shared/types/toolbar.ts`. Fresh vs. existing profiles are told apart by array membership, not by seeded pin values, and `mergeButtonList` only ever adds defaults a profile lacks, it never removes an id a profile already carries. So this only changes fresh profiles; every existing toolbar is untouched.
- New persist migration v13: deletes the v12-stamped `pinnedButtons["file-browser"] = false` and does nothing else. No `false` gets backfilled onto `browser` or `dev-server` for existing users, that would be the exact Default Freeze / Lossy Backfill anti-pattern the issue calls out.
- Deleted `DEFAULT_PINNED_BUTTONS` entirely. `pinnedButtons` now records only explicit user intent, an id the user never touched just falls through to the default registry. That's what makes the next default change cheap instead of destructive.
- New `PanelTrayButton.tsx`, modeled on `PluginTrayButton`: a dropdown carrying the non-agent panel inventory (file browser, browser, dev preview), with hover and `P`-key pin affordances and a "More panels…" footer into the panel palette. Includes the inline overflow expansion `plugin-tray` already has, since a dropdown trigger can't be opened from inside the overflow menu.
- New `setPanelButtonOnToolbar` store action. Showing a button writes an explicit `true` and gives it a slot if it doesn't have one; hiding writes `false` and leaves the slot alone. `toggleButtonVisibility` alone can't reach a button that has no position at all.
- Cross-view fix: button position arrays reconcile last-writer-wins across project views, so a stale sibling view's write can overwrite the whole array. Since visibility now rides on array membership, that could have silently un-promoted a button another view just showed. `pinnedButtons` merges per id and survives that write, so the explicit `true` stays the durable record, and `restorePromotedPanelButtons` rebuilds the position on the next hydration. The Settings toggle routes through the same action for the same reason.
- `healCrossSideDuplicates` now reads a frozen `LEFT_HOME_BUTTON_IDS` set instead of the live defaults, so dropping two ids out of `DEFAULT_LEFT_BUTTONS` doesn't flip the duplicate-repair direction for legacy profiles.
- `e2e/helpers/panels.ts` gained a panel-tray fallback plus `openDevPreview` and `isToolbarButtonReachable`, and four specs moved off direct `SEL.toolbar.openDevPreview` locators. Two of those were guarding a `test.skip()` on direct button visibility and would have skipped permanently while still reporting green.

One deliberate, unavoidable side effect, called out directly in the migration: a user who explicitly hid `file-browser` after v12 carries the identical `false` value the stamp wrote, so they're indistinguishable from it and the button reappears for them once. Affected population should be small: the shipped state was already hidden, so hiding it again required showing it first.

Left out on purpose: the issue's related cleanup of `launcher.alwaysShowDevServer` and `launcher.defaultSelection`. Confirmed both are write-only (`getDefaultAgentId`'s only caller hard-codes `defaultSelection` as `undefined`), but pulling a Settings toggle is its own user-facing change with its own migration question, and this diff is migration-sensitive enough without it.

## Testing

- 445 targeted tests passing: toolbar store, cross-view merge, panel tray, plugin tray, toolbar metadata/overflow/shortcuts/responsive, Settings toolbar tab, overflow hook, visibility dispatch, launcher quick actions.
- Typecheck clean.
- Own-file lint: 0 errors, zero new warnings (ratchet stays flat).
- Prettier clean.
- E2E not run locally, it needs a packaged build and this repo doesn't run E2E on PRs.