### PR TITLE
Fleet overview design audit: colour, vocabulary, ordering, keyboard

### DIFF
--- a/src/components/Pilot/PilotFilterBar.tsx
+++ b/src/components/Pilot/PilotFilterBar.tsx
@@ -101,7 +101,7 @@ export interface PilotFilterBarProps {
  * `aria-activedescendant`; Tab hands real focus to this bar, and from that
  * moment the input's virtual focus is simply inert rather than contradicted.
  * Arrow keys are bound HERE and nowhere else — `usePaletteTreeNavigation` owns
- * Home/End/←/→ as structural keys, but only while focus is physically in the
+ * Home/End as structural keys, but only while focus is physically in the
  * input, so the two never contend.
  *
  * Selection follows focus, per the radiogroup pattern: the filter is instant

--- a/src/components/Pilot/PilotFilterBar.tsx
+++ b/src/components/Pilot/PilotFilterBar.tsx
@@ -22,11 +22,9 @@ const NEUTRAL_TONE_FADED = "text-text-secondary/40";
  * the faded variant is spelled out rather than derived — the same constraint
  * `QuickStateFilterBar` documents.
  *
- * `working` has no demand tone at all because its rows have none: colour is
- * spent only where there is something to act on, and a hued Working segment
- * would put back one of the competing signals this surface exists to remove.
- * The other two carry the hue of the demand they can reveal, and only while
- * they are actually holding one — see `bandFilterHasDemand`.
+ * `working` is hued unconditionally — see `segmentIsHued`. The other two carry
+ * the hue of the demand they can reveal, and only while they are actually
+ * holding one; see `bandFilterHasDemand`.
  */
 const SEGMENT_TONE: Record<
   Exclude<PilotBandFilter, "all">,
@@ -39,15 +37,32 @@ const SEGMENT_TONE: Record<
   },
   working: {
     Icon: BAND_GLYPH.running,
-    tone: NEUTRAL_TONE,
-    toneFaded: NEUTRAL_TONE_FADED,
+    tone: "text-state-working",
+    toneFaded: "text-state-working/40",
   },
   finished: {
     Icon: BAND_GLYPH.review,
-    tone: "text-activity-completed",
-    toneFaded: "text-activity-completed/40",
+    tone: "text-category-blue",
+    toneFaded: "text-category-blue/40",
   },
 };
+
+/**
+ * Whether a segment gets its configured hue or falls back to neutral.
+ *
+ * `working` is exempt from the demand test rather than failing it. A working
+ * agent is genuinely not a demand — `bandFilterHasDemand` is right to report
+ * false for `running` — but green for working is the vocabulary the sidebar,
+ * the assistant header and the panel chrome already speak, and the segment has
+ * to match the row glyphs it filters to. Every other segment earns its hue only
+ * while it actually holds something to act on.
+ */
+function segmentIsHued(
+  bands: Readonly<FleetBandCounts>,
+  segment: Exclude<PilotBandFilter, "all">
+): boolean {
+  return segment === "working" || bandFilterHasDemand(bands, segment);
+}
 
 const SEGMENTS: readonly PilotBandFilter[] = ["all", ...PILOT_BAND_FILTERS];
 
@@ -167,14 +182,11 @@ export function PilotFilterBar({
         const label = PILOT_BAND_FILTER_LABEL[segment];
         const Icon = visual?.Icon;
         const isSpinning = segment === "working" && count > 0;
-        // Hued only while the segment actually holds a demand; otherwise it
-        // falls back to neutral like the rows it would reveal.
-        const tone = bandFilterHasDemand(bands, segment) ? visual?.tone : NEUTRAL_TONE;
+        const isHued = segment !== "all" && segmentIsHued(bands, segment);
+        const tone = isHued ? visual?.tone : NEUTRAL_TONE;
         // An empty bucket keeps its glyph and its "0" but mutes the glyph, so
         // the zero registers without having to be read.
-        const fadedTone = bandFilterHasDemand(bands, segment)
-          ? visual?.toneFaded
-          : NEUTRAL_TONE_FADED;
+        const fadedTone = isHued ? visual?.toneFaded : NEUTRAL_TONE_FADED;
 
         return (
           <button

--- a/src/components/Pilot/PilotRunState.tsx
+++ b/src/components/Pilot/PilotRunState.tsx
@@ -72,12 +72,11 @@ export const BAND_GLYPH: Record<FleetBand, ComponentType<{ className?: string }>
  * `done` and `idle` stay neutral: an acknowledged completion and an exited
  * shell are not news.
  *
- * Exported alongside the glyphs so a collapsed group's pips and a run's own
- * state mark cannot end up differently coloured for the same band — the two
- * read as one signal only if they agree by construction rather than by two
- * lists someone has to keep in step.
+ * Module-private: the collapsed-group pip cluster that used to draw from it is
+ * gone, and the filter bar spells its own segment tones out in full because
+ * Tailwind's scanner cannot see an assembled `${tone}/40`.
  */
-export const BAND_GLYPH_TONE: Record<FleetBand, string> = {
+const BAND_GLYPH_TONE: Record<FleetBand, string> = {
   blocked: "text-status-danger",
   "needs-you": "text-state-waiting",
   review: "text-category-blue",

--- a/src/components/Pilot/PilotRunState.tsx
+++ b/src/components/Pilot/PilotRunState.tsx
@@ -15,10 +15,10 @@ interface PilotRunStateProps {
 }
 
 /**
- * The neutral tone every non-demand state now carries.
+ * The neutral tone the quiet states carry.
  *
- * Colour is spent only where there is a demand, so `running`, `done` and `idle`
- * give theirs up and read as ordinary text. Deliberately `text-text-secondary`
+ * `done` and `idle` are finished business: nothing is in flight and nothing is
+ * being asked, so they read as ordinary text. Deliberately `text-text-secondary`
  * rather than `text-muted`: muted sits below the contrast floor against the
  * palette's raised surface in the dark themes, and a state glyph nobody can see
  * is worse than a loud one.
@@ -47,7 +47,23 @@ export const BAND_GLYPH: Record<FleetBand, ComponentType<{ className?: string }>
 };
 
 /**
- * Colour per band, and the one place the "only a demand is hued" rule lives.
+ * Colour per band, and the one place this surface's hue rule lives.
+ *
+ * A band is hued when it is a live fact about the fleet — something needs you,
+ * or something is happening. Green for `running` is the app's own vocabulary:
+ * the sidebar's quick filters, the assistant header, the dock and the panel
+ * chrome all already say working in green, and the overview reading it grey was
+ * the one surface speaking a second language.
+ *
+ * `review` is blue rather than the completed token because that token is unset
+ * in every built-in theme and falls back to `status-success` — the same hex as
+ * `activity-working` in five of them. Green working beside green ready-for-
+ * review would leave spinner-vs-check as the only difference between two states
+ * an operator has to tell apart at a glance. Blue is also what the sidebar's
+ * `QuickStateFilterBar` already gives Finished.
+ *
+ * `done` and `idle` stay neutral: an acknowledged completion and an exited
+ * shell are not news.
  *
  * Exported alongside the glyphs so a collapsed group's pips and a run's own
  * state mark cannot end up differently coloured for the same band — the two
@@ -57,8 +73,8 @@ export const BAND_GLYPH: Record<FleetBand, ComponentType<{ className?: string }>
 export const BAND_GLYPH_TONE: Record<FleetBand, string> = {
   blocked: "text-status-danger",
   "needs-you": "text-state-waiting",
-  review: "text-activity-completed",
-  running: NEUTRAL_TONE,
+  review: "text-category-blue",
+  running: "text-state-working",
   done: NEUTRAL_TONE,
   idle: NEUTRAL_TONE,
 };
@@ -75,11 +91,11 @@ export const BAND_GLYPH_TONE: Record<FleetBand, string> = {
  * ordering beside it: an acknowledged completion has to stop looking like a
  * hand-back at the same moment it stops being counted as one.
  *
- * Only the three demand bands are hued. Shape still carries the state as a
- * second channel for all six — spinner, hollow circle, check and exited stay
- * distinct — and the row keeps the state in text either way, visibly for a
- * demand and in its accessible name otherwise. Never colour alone, and now
- * never colour where there is nothing to act on.
+ * The three demand bands and `running` are hued; the two quiet ones are not.
+ * Shape still carries the state as a second channel for all six — spinner,
+ * hollow circle, prohibition, check and exited stay distinct — and the row
+ * keeps the state in text in its accessible name either way. Never colour
+ * alone, and never colour where there is nothing happening.
  */
 export function PilotRunState({ band, agentState }: PilotRunStateProps) {
   const className = `size-3.5 shrink-0 ${BAND_GLYPH_TONE[band]}`;

--- a/src/components/Pilot/PilotRunState.tsx
+++ b/src/components/Pilot/PilotRunState.tsx
@@ -5,6 +5,7 @@ import {
   InteractingCircle,
   ExitedCircle,
   CircleCheck,
+  CircleSlash,
 } from "@/components/icons";
 import type { FleetBand } from "@/lib/fleetAttention";
 import type { AgentState } from "@shared/types/agent";
@@ -36,9 +37,15 @@ const NEUTRAL_TONE = "text-text-secondary";
  * These are the BAND's representative shapes. `PilotRunState` refines two of
  * them where the row knows more than the band does — directing inside
  * `running`, and exited inside `idle`.
+ *
+ * `blocked` gets the prohibition sign rather than the hollow circle it used to
+ * share with `needs-you`. The row's visible status word was the only non-colour
+ * channel separating "the agent errored" from "the agent asked you a question";
+ * with that word gone, the shapes have to carry it. Same circle family as every
+ * other glyph here, so it still reads as one of the set.
  */
 export const BAND_GLYPH: Record<FleetBand, ComponentType<{ className?: string }>> = {
-  blocked: HollowCircle,
+  blocked: CircleSlash,
   "needs-you": HollowCircle,
   review: CircleCheck,
   running: SpinnerCircle,

--- a/src/components/Pilot/PilotRunState.tsx
+++ b/src/components/Pilot/PilotRunState.tsx
@@ -29,10 +29,9 @@ const NEUTRAL_TONE = "text-text-secondary";
 /**
  * One glyph per band, shared by every surface that speaks about bands.
  *
- * The filter bar's segments and a collapsed group's pip cluster both draw from
- * here, so "the amber hollow circle" means the same thing in the list, in the
- * header and in the control that filters on it. A second set for any one of
- * them would teach the reader two vocabularies for one fact.
+ * The filter bar's segments draw from here too, so "the amber hollow circle"
+ * means the same thing in the list as in the control that filters on it. A
+ * second set for either would teach the reader two vocabularies for one fact.
  *
  * These are the BAND's representative shapes. `PilotRunState` refines two of
  * them where the row knows more than the band does — directing inside

--- a/src/components/Pilot/PilotView.tsx
+++ b/src/components/Pilot/PilotView.tsx
@@ -747,7 +747,7 @@ export function PilotView() {
   // Counted by band, never off the raw row total: a fleet holding two working
   // agents and six exited ones is not "8 agents running".
   const live = fleet.bands.running;
-  const summary =
+  const fleetPhrase =
     status.kind === "loading" || status.kind === "unavailable"
       ? ""
       : needsYou > 0
@@ -760,13 +760,38 @@ export function PilotView() {
               ? `Nothing needs you · ${agentCount(fleet.total)}`
               : "";
 
+  /**
+   * The same sentence, qualified when the feed is dead.
+   *
+   * "Nothing needs you" over retained runs is the surface making a live
+   * all-clear claim out of data it cannot currently see — the exact thing the
+   * stale rule forbids, printed directly under the banner that contradicts it.
+   * The sentence stays whole rather than being rewritten, because what changed
+   * is how current it is, not what it says.
+   */
+  const summary =
+    status.kind === "stale" && fleetPhrase !== "" ? `Last known: ${fleetPhrase}` : fleetPhrase;
+
   const hasTree = renderGroups.length > 0;
-  // Stale counts as well as live: retained runs are real rows, so a query that
-  // matches none of them is a true statement about the query rather than a claim
-  // that the fleet is clear. `loading` and `unavailable` stay out — they already
-  // render the skeleton and the can't-reach-host message.
+
+  /**
+   * Whether either narrowing is in play, which is what an empty list means.
+   *
+   * A query or a filter turning up nothing is a true statement about the
+   * narrowing. A fleet with nothing in it at all is a statement about the
+   * fleet, and only live data can make that one.
+   */
+  const hasNarrowing = query.trim().length > 0 || bandFilter !== "all";
+
+  // Stale narrows honestly — retained runs are real rows, so a query matching
+  // none of them says something true — but a retained EMPTY fleet may not
+  // render the zero-data prompt: "Start an agent in any project" over a feed
+  // that stopped answering an hour ago presents an unknown as an all-clear.
+  // `loading` and `unavailable` stay out entirely; they already render the
+  // skeleton and the can't-reach-host message.
   const showEmpty =
-    (status.kind === "live" || status.kind === "stale") && renderGroups.length === 0;
+    renderGroups.length === 0 &&
+    (status.kind === "live" || (status.kind === "stale" && hasNarrowing));
   const showSkeleton = useDeferredLoading(status.kind === "loading", UI_DOHERTY_THRESHOLD);
 
   /**
@@ -1010,6 +1035,12 @@ export function PilotView() {
             demandCount={needsYou}
             onShowDemand={() => {
               setBandFilter("needs-you");
+              // The footer advertises the list's keys, and this button leaves
+              // focus on itself — where the body's handler bails on events that
+              // did not come from the scroller, so the arrows it is advertising
+              // do nothing. The Clear-filter button in the empty state already
+              // makes exactly this handoff.
+              searchRef.current?.focus();
             }}
           />
         </AppPaletteDialog.Footer>

--- a/src/components/Pilot/PilotView.tsx
+++ b/src/components/Pilot/PilotView.tsx
@@ -296,14 +296,13 @@ function RunRow({
       onClick={onActivate}
       onPointerMove={onPointerMove}
       // One line, ~32px. Two-line rows made 8 agents into 16 lines of identical
-      // shape with nothing to scan down; the trailing group below puts the
-      // facts into columns instead.
+      // shape with nothing to scan down; columns are what give it a grain.
       className={cn(ROW_BASE, ROW_TONE, "gap-2 py-1 pr-3 pl-3")}
     >
       {/*
-        State rides the chevron column, so every agent's mark sits in one
-        vertical line down the left edge and the fleet's working-vs-waiting
-        split reads in a single glance without tracking across each row.
+        State leads the row, so every agent's mark sits in one vertical line
+        down the left edge and the fleet's working-vs-waiting split reads in a
+        single glance without tracking across each row.
       */}
       <span className="flex size-3.5 shrink-0 items-center justify-center">
         <PilotRunState band={row.band} agentState={row.run.agentState} />
@@ -617,10 +616,6 @@ export function PilotView() {
       setBandFilter("all");
       // Closing takes focus with it without a blur ever reaching the bar.
       setIsFilterFocused(false);
-      // A hold belongs to one pointer over one list. Carrying it across a close
-      // would reopen the surface serving the ranking of a fleet that has moved
-      // on, which is the staleness this stopped doing in the first place.
-      setPointerOrder(null);
     }
   }, [isOpen]);
 
@@ -670,13 +665,40 @@ export function PilotView() {
    */
   const handleRowPointerMove = useCallback(
     (rowId: string) => {
-      setPointerOrder((held) => (held === null ? capturePilotOrder(liveGroups) : held));
+      // Captured from what this render DREW, not from the live ranking. The two
+      // are the same whenever there is no hold, but they part company in one
+      // real sequence: pointer-leave queues the release, a fast re-entry queues
+      // this updater from the same still-committed render, and the updater then
+      // sees `held === null` while the screen the pointer came back to was
+      // still showing the held order. Capturing `liveGroups` there would take a
+      // snapshot of an order the user never saw and move rows under the cursor
+      // on the next commit — the exact misclick this guards against.
+      setPointerOrder((held) => (held === null ? capturePilotOrder(orderedGroups) : held));
       selectRow(rowId);
     },
-    [liveGroups, selectRow]
+    [orderedGroups, selectRow]
   );
 
   const releasePointerOrder = useCallback(() => setPointerOrder(null), []);
+
+  /**
+   * The two ways a hold outlives the pointer that took it.
+   *
+   * Backgrounding the app is the dangerous one: the cursor never moves, so no
+   * boundary event fires, and coming back after ten minutes to a ranking frozen
+   * since before you left is precisely the staleness this replaced. An emptied
+   * list is the quieter one — there is no row left under the cursor to protect,
+   * and whether removing the element the pointer was over fires a leave is not
+   * something to depend on.
+   */
+  useEffect(() => {
+    if (!isOpen || renderGroups.length === 0) {
+      setPointerOrder(null);
+      return;
+    }
+    window.addEventListener("blur", releasePointerOrder);
+    return () => window.removeEventListener("blur", releasePointerOrder);
+  }, [isOpen, renderGroups.length, releasePointerOrder]);
 
   /**
    * The keyboard takes the list back, and the pointer's hold with it.

--- a/src/components/Pilot/PilotView.tsx
+++ b/src/components/Pilot/PilotView.tsx
@@ -9,10 +9,10 @@ import { useProjectStore } from "@/store/projectStore";
 import { useScratchStore } from "@/store/scratchStore";
 import { getViewWorkspaceId } from "@/store/viewWorkspaceId";
 import { actionService } from "@/services/ActionService";
-import { FLEET_BANDS, isDemandBand, type FleetBand } from "@/lib/fleetAttention";
+import { FLEET_BANDS, type FleetBand } from "@/lib/fleetAttention";
 import { UI_ANIMATION_DURATION, UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { useDeferredLoading } from "@/hooks/useDeferredLoading";
-import { agoPhrase, formatWaitAge, ROW_TONE_CLASS } from "@/lib/projectRowStatus";
+import { agoPhrase, formatWaitAge } from "@/lib/projectRowStatus";
 import {
   buildPilotGroups,
   countPilotBands,
@@ -244,7 +244,11 @@ function GroupHeader({
         // The summary rides the label in BOTH states. Collapsed it is the only
         // account of what is inside; expanded it saves a screen-reader user
         // walking the rows to learn what walking them would cost.
-        aria-label={`${group.name}, ${summary}`}
+        //
+        // Being in the current workspace decides whether opening a run is
+        // instant or swaps the whole view, which the header renders as a word
+        // and then hides. A fact that load-bearing cannot be visual-only.
+        aria-label={`${group.name}${group.isCurrent ? ", current workspace" : ""}, ${summary}`}
         data-testid="pilot-group-toggle"
         onClick={onToggle}
         className="flex shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-daintree-text/40 transition-colors hover:text-daintree-text"
@@ -299,25 +303,35 @@ function RunRow({
   domId: string;
   onActivate: () => void;
 }) {
-  // Only a demand gets a visible word. The other three states are neutral by
-  // design now, and a status word for each of them was half of what made every
-  // row look equally important — but the state still has to be readable as
-  // text, so it moves into the option's accessible name instead of vanishing.
-  const isDemand = isDemandBand(row.band);
+  /**
+   * The agent's brand, unless the title already is it.
+   *
+   * The brand is on the row as an icon only, and search matches on it precisely
+   * because "codex" is a plausible thing to type — so two identically-titled
+   * runs on different agents were one string to a screen reader. An untitled
+   * run falls back to its agent's name for the title, though, and "Claude,
+   * Claude" is a separator promising a second fact and then not delivering one.
+   */
+  const agentLabel =
+    row.chrome.label.toLowerCase() === row.title.toLowerCase() ? null : row.chrome.label;
 
   /**
    * Spelled out rather than left to the name-from-content computation.
    *
-   * Those spans are inline, so a computed name concatenates them with no
-   * separators at all: "Fix authWorkingfeature-x2m". Naming the parts here is
-   * what turns the row back into a sentence, and it lets the age be announced
-   * as an age ("2m ago") instead of a bare token a screen reader reads as
-   * "two em".
+   * The row's own spans are inline, so a computed name concatenates them with
+   * no separators at all: "Fix auth2m". Naming the parts here is what turns the
+   * row back into a sentence, and it lets the age be announced as an age
+   * ("2m ago") instead of a bare token a screen reader reads as "two em".
+   *
+   * The state is here and nowhere else on the row now. The worktree is neither:
+   * it is a scratch project's UUID as often as it is a branch, and dropping it
+   * from the drawn row without dropping it from the name would have left the
+   * noise exactly where it is least escapable.
    */
   const accessibleName = [
     row.title,
+    agentLabel,
     row.statusLabel,
-    row.worktreeLabel,
     row.age !== null ? agoPhrase(row.age) : null,
   ]
     .filter((part): part is string => part !== null)
@@ -370,34 +384,28 @@ function RunRow({
       </span>
 
       {/*
-        The scan column. Everything here is `aria-hidden` — the row's own label
-        above says all of it, in order and with separators, so announcing these
-        as well would read each row's facts twice.
+        The scan column, now a single fact wide.
 
-        The group may shrink, but only into the worktree: the status word and
-        the age are short and bounded, while an untruncatable 10rem worktree
-        beside a 3.5rem age floor could push the title out of a narrow palette
-        entirely and give the list a horizontal scrollbar.
+        `aria-hidden` — the row's own label above says this in order and with
+        separators, so announcing it here would read the age twice. Right-
+        aligned, tabular, and given a floor width so "just now" and "2h 15m"
+        start at the same x: without that the ages sit at eight different
+        offsets and "how long has this been stuck" goes back to being eight
+        separate reads instead of one scan.
+
+        The status word and the worktree used to sit to its left. The glyph in
+        the chevron column already says the state, and the worktree was as often
+        a scratch project's UUID as a branch name — both were charging the
+        truncating title for width to say nothing it needed.
       */}
-      <span aria-hidden="true" className="flex min-w-0 items-center gap-2 text-[11px] leading-none">
-        {isDemand && (
-          <span className={cn("shrink-0", ROW_TONE_CLASS[row.tone])}>{row.statusLabel}</span>
-        )}
-        {row.worktreeLabel !== null && (
-          <span className="max-w-[8rem] truncate text-daintree-text/40">{row.worktreeLabel}</span>
-        )}
-        {/*
-          Right-aligned, tabular, and given a floor width so "just now" and
-          "2h 15m" start at the same x. Without that the ages sit at eight
-          different offsets and "how long has this been stuck" goes back to
-          being eight separate reads instead of one scan.
-        */}
-        {row.age !== null && (
-          <span className="min-w-[3.5rem] shrink-0 text-right tabular-nums text-daintree-text/50">
-            {row.age}
-          </span>
-        )}
-      </span>
+      {row.age !== null && (
+        <span
+          aria-hidden="true"
+          className="min-w-[3.5rem] shrink-0 text-right text-[11px] leading-none tabular-nums text-daintree-text/50"
+        >
+          {row.age}
+        </span>
+      )}
     </div>
   );
 }

--- a/src/components/Pilot/PilotView.tsx
+++ b/src/components/Pilot/PilotView.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getProjectGradient } from "@/lib/colorUtils";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
@@ -9,8 +8,7 @@ import { useProjectStore } from "@/store/projectStore";
 import { useScratchStore } from "@/store/scratchStore";
 import { getViewWorkspaceId } from "@/store/viewWorkspaceId";
 import { actionService } from "@/services/ActionService";
-import { FLEET_BANDS, type FleetBand } from "@/lib/fleetAttention";
-import { UI_ANIMATION_DURATION, UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { useDeferredLoading } from "@/hooks/useDeferredLoading";
 import { agoPhrase, formatWaitAge } from "@/lib/projectRowStatus";
 import {
@@ -25,7 +23,7 @@ import {
   type PilotRow,
   type PilotWorkspaceMeta,
 } from "./pilotRows";
-import { BAND_GLYPH, BAND_GLYPH_TONE, PilotRunState } from "./PilotRunState";
+import { PilotRunState } from "./PilotRunState";
 import { PilotFilterBar } from "./PilotFilterBar";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { AppPaletteDialog, KBD_CLASS } from "@/components/ui/AppPaletteDialog";
@@ -48,9 +46,7 @@ const AGE_TICK_MS = 30_000;
 /** The loading rule's ">5s says something" threshold. */
 const LOADING_HINT_MS = 5_000;
 
-/**
- * Id of a project's run container, which its disclosure button `aria-controls`.
- */
+/** Id of a project's group container. */
 function groupDomId(workspaceId: string): string {
   return `pilot-option-group-${workspaceId}`;
 }
@@ -80,41 +76,9 @@ function agentCount(count: number): string {
   return count === 1 ? "1 agent" : `${count} agents`;
 }
 
-/** The worst band's own sentence, plural-aware. */
-function bandPhrase(band: FleetBand, count: number): string {
-  switch (band) {
-    case "blocked":
-      return count === 1 ? "Agent blocked" : `${count} agents blocked`;
-    case "needs-you":
-      return demandPhrase(count);
-    case "review":
-      return count === 1 ? "Ready for review" : `${count} agents ready for review`;
-    case "running":
-      return count === 1 ? "Agent working" : `${count} agents working`;
-    case "done":
-      return count === 1 ? "Agent finished" : `${count} agents finished`;
-    default:
-      return agentCount(count);
-  }
-}
-
-/**
- * A group's one status sentence, in the switcher's shape: what the worst thing
- * in it is, then how much else is there.
- *
- * Named rather than left to the tone: "blocked" and "needs input" are both
- * demands and would otherwise differ only in hue, which is the colour-only
- * encoding the switcher's own status line exists to avoid.
- *
- * The remainder is "N more" rather than a repeated total — "2 agents blocked ·
- * 3 agents" states the same population twice and reads as a contradiction, and
- * naming that remainder "running" would be false for an exited or idle run.
- */
-function groupSummary(group: PilotProjectGroup): string {
-  const inTopBand = group.rows.filter((row) => row.band === group.topBand).length;
-  const rest = group.rows.length - inTopBand;
-  const lead = bandPhrase(group.topBand, inTopBand);
-  return rest > 0 ? `${lead} · ${rest} more` : lead;
+/** Work handed back, plural-aware. The footer's sentence when nothing is asking. */
+function reviewPhrase(count: number): string {
+  return count === 1 ? "Ready for review" : `${count} agents ready for review`;
 }
 
 /** The resting tone. Selected is the shared row class's to own, off the attribute. */
@@ -167,102 +131,25 @@ function WorkspaceTile({ group }: { group: PilotProjectGroup }) {
 }
 
 /**
- * What a collapsed project is still holding, as one pip per band present.
- *
- * Expanded, the rows ARE the summary and a sentence restating them in prose is
- * a third thing to read for facts already on screen. Collapsed, the rows are
- * gone and something has to stop a project hiding a blocked agent behind a
- * chevron — so the summary earns its place at exactly the moment the rows stop
- * being visible, and nowhere else.
- *
- * Glyphs, not words, and the same glyphs the filter bar uses, so the cluster
- * reads as a compressed version of the list rather than a new notation.
- * `aria-hidden` throughout: the toggle's own label already carries
- * `groupSummary()` in both states, and announcing four glyph-count fragments
- * beside it would be the same fact twice, less intelligibly the second time.
- */
-function CollapsedBandPips({ group }: { group: PilotProjectGroup }) {
-  const counts = new Map<FleetBand, number>();
-  for (const row of group.rows) counts.set(row.band, (counts.get(row.band) ?? 0) + 1);
-
-  return (
-    <span aria-hidden="true" className="flex shrink-0 items-center gap-2">
-      {FLEET_BANDS.filter((band) => counts.has(band)).map((band) => {
-        const Glyph = BAND_GLYPH[band];
-        return (
-          <span key={band} className="flex items-center gap-1">
-            <Glyph className={cn("size-2.5 shrink-0", BAND_GLYPH_TONE[band])} />
-            <span className="text-[10px] leading-none tabular-nums text-daintree-text/50">
-              {counts.get(band)}
-            </span>
-          </span>
-        );
-      })}
-    </span>
-  );
-}
-
-/**
- * A project, as a heading — never a row.
+ * A project, as a heading — never a row, and never a control.
  *
  * Deliberately outside the selection domain. The arrow keys walk agents,
  * because agents are what this surface is for; stopping on a project on the way
  * past made the common case (compare what is working against what is waiting)
- * cost an extra keystroke per project, and put Enter one mistake away from
- * collapsing the group instead of opening the run you were aiming at.
+ * cost an extra keystroke per project.
  *
- * The disclosure is a real button rather than a click handler on the row, so it
- * announces its state and its target. `tabIndex={-1}` keeps it out of the tab
- * order — the search box owns the keyboard — matching the switcher's own
- * in-header sort control.
+ * It used to carry a disclosure, which is gone (#11669). A durable collapse set
+ * meant a project shut last week could hide an agent that blocked today, on the
+ * one surface that exists to show every agent — and a `<button>` inside a
+ * `role="group"` inside a `role="listbox"` was never structurally right either.
+ * The header's whole job now is to file the rows underneath it.
  */
-function GroupHeader({
-  group,
-  isCollapsed,
-  groupId,
-  className,
-  onToggle,
-}: {
-  group: PilotProjectGroup;
-  isCollapsed: boolean;
-  groupId: string;
-  className?: string;
-  onToggle: () => void;
-}) {
-  const summary = groupSummary(group);
-
+function GroupHeader({ group, className }: { group: PilotProjectGroup; className?: string }) {
   return (
     <div
       data-testid="pilot-group-header"
       className={cn("flex w-full items-center gap-2 py-1 pr-3 pl-3 select-none", className)}
     >
-      <button
-        type="button"
-        tabIndex={-1}
-        aria-expanded={!isCollapsed}
-        aria-controls={groupId}
-        // The summary rides the label in BOTH states. Collapsed it is the only
-        // account of what is inside; expanded it saves a screen-reader user
-        // walking the rows to learn what walking them would cost.
-        //
-        // Being in the current workspace decides whether opening a run is
-        // instant or swaps the whole view, which the header renders as a word
-        // and then hides. A fact that load-bearing cannot be visual-only.
-        aria-label={`${group.name}${group.isCurrent ? ", current workspace" : ""}, ${summary}`}
-        data-testid="pilot-group-toggle"
-        onClick={onToggle}
-        className="flex shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-daintree-text/40 transition-colors hover:text-daintree-text"
-      >
-        <ChevronRight
-          aria-hidden="true"
-          className={cn(
-            "size-3 transition-transform ease-out motion-reduce:transition-none",
-            !isCollapsed && "rotate-90"
-          )}
-          style={{ transitionDuration: `${UI_ANIMATION_DURATION}ms` }}
-        />
-      </button>
-
       <WorkspaceTile group={group} />
 
       {/*
@@ -272,8 +159,9 @@ function GroupHeader({
         semibold name plus a second coloured line outweighed the very rows it
         was meant to be filing.
 
-        The toggle's label already carries the name and the summary, so this is
-        hidden rather than announced a second time.
+        The enclosing `role="group"` already carries the name as the label for
+        every option inside it, so this is hidden rather than announced a second
+        time on the way past.
       */}
       <div aria-hidden="true" className="flex min-w-0 flex-1 items-center gap-1.5">
         <span className={cn(PALETTE_SECTION_LABEL_CLASS, "truncate")}>{group.name}</span>
@@ -286,8 +174,6 @@ function GroupHeader({
           <span className="shrink-0 text-[10px] leading-none text-daintree-text/30">Current</span>
         )}
       </div>
-
-      {isCollapsed && <CollapsedBandPips group={group} />}
     </div>
   );
 }
@@ -480,8 +366,6 @@ function PilotFooter({
 export function PilotView() {
   const isOpen = usePilotStore((s) => s.isOpen);
   const close = usePilotStore((s) => s.close);
-  const collapsedIds = usePilotStore((s) => s.collapsedWorkspaceIds);
-  const toggleCollapsed = usePilotStore((s) => s.toggleWorkspaceCollapsed);
   const snapshot = useFleetSnapshotStore((s) => s.snapshot);
   const projects = useProjectStore((s) => s.projects);
   const scratches = useScratchStore((s) => s.scratches);
@@ -495,21 +379,10 @@ export function PilotView() {
    * `pilotStore`.
    *
    * Both are narrowing state for one opening of the dialog and both reset when
-   * it closes. `collapsedWorkspaceIds` lives in the store because it is the
-   * opposite thing — a durable preference about a project that should survive
-   * closing — and a filter that persisted would reopen the surface already
-   * hiding agents, with the reason two openings in the past.
+   * it closes. A filter that persisted would reopen the surface already hiding
+   * agents, with the reason two openings in the past.
    */
   const [bandFilter, setBandFilter] = useState<PilotBandFilter>("all");
-  /**
-   * Collapse overrides that apply only while the list is narrowed.
-   *
-   * Narrowing force-expands every matching group, so without a separate set the
-   * header toggle would be a dead control: `aria-expanded` pinned open while the
-   * click silently edited the persisted set, collapsing the group minutes later
-   * when the query cleared.
-   */
-  const [narrowingCollapsed, setNarrowingCollapsed] = useState<readonly string[]>([]);
   /**
    * True while real focus sits on a filter segment.
    *
@@ -706,22 +579,12 @@ export function PilotView() {
   );
 
   /**
-   * Either narrowing is in play, so a group holding a match must open itself.
-   *
-   * The filter has exactly the same claim on this as the query does: finding
-   * the blocked agent you filtered for still collapsed behind a chevron is the
-   * same "narrowing failing to do its job" the query path already solves.
-   */
-  const isNarrowing = query.trim().length > 0 || bandFilter !== "all";
-
-  /**
    * The tree, in the shared model's shape.
    *
    * A project is structure, not content: its header is `navigable: false`, so
    * the arrow keys walk agents and never stop on a heading on the way past.
-   * That kept the common case — compare what is working against what is waiting
-   * — from costing an extra keystroke per project, and kept Enter from sitting
-   * one mistake away from collapsing a group instead of opening the run.
+   * That keeps the common case — compare what is working against what is
+   * waiting — from costing an extra keystroke per project.
    */
   const paletteGroups = useMemo<PaletteTreeGroupInput<PilotProjectGroup, PilotRow>[]>(
     () =>
@@ -730,21 +593,14 @@ export function PilotView() {
         group,
         header: {
           rowId: `group:${group.workspaceId}`,
-          // The runs container's id, which is what the disclosure button
-          // `aria-controls`. Safe only because the header is not navigable, so
-          // this id never reaches `aria-activedescendant`. Making headers
-          // navigable here would first have to give the header element an id
-          // of its own — pointing the active descendant at a role-less
-          // container is the dangling reference #11071 was about.
+          // The group container's id. Safe only because the header is not
+          // navigable, so this id never reaches `aria-activedescendant`.
+          // Making headers navigable here would first have to give the header
+          // element an id of its own — pointing the active descendant at a
+          // role-less container is the dangling reference #11071 was about.
           domId: groupDomId(group.workspaceId),
           navigable: false,
         },
-        // A collapsed group that contains a match opens itself — making someone
-        // click to reveal the thing they just narrowed to is the narrowing
-        // failing to do its job.
-        isCollapsed: isNarrowing
-          ? narrowingCollapsed.includes(group.workspaceId)
-          : collapsedIds.includes(group.workspaceId),
         items: group.rows.map((row) => ({
           rowId: row.run.runId,
           domId: runDomId(row.run.runId),
@@ -752,17 +608,8 @@ export function PilotView() {
           item: row,
         })),
       })),
-    [visibleGroups, isNarrowing, narrowingCollapsed, collapsedIds]
+    [visibleGroups]
   );
-
-  // The narrowing-scoped collapses belong to the query AND the filter that
-  // produced them — a collapse made while looking at blocked agents has no
-  // claim on the list once the segment changes. Closing drops them too, so a
-  // reopen doesn't restore state from a fleet that has moved on. The selection
-  // resets alongside, inside the navigation model.
-  useEffect(() => {
-    setNarrowingCollapsed([]);
-  }, [query, bandFilter, isOpen]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -772,21 +619,6 @@ export function PilotView() {
       setIsFilterFocused(false);
     }
   }, [isOpen]);
-
-  const setGroupCollapsed = useCallback(
-    (workspaceId: string, collapsed: boolean) => {
-      if (isNarrowing) {
-        setNarrowingCollapsed((ids) => {
-          const has = ids.includes(workspaceId);
-          if (collapsed === has) return ids;
-          return collapsed ? [...ids, workspaceId] : ids.filter((id) => id !== workspaceId);
-        });
-      } else if (collapsedIds.includes(workspaceId) !== collapsed) {
-        toggleCollapsed(workspaceId);
-      }
-    },
-    [isNarrowing, collapsedIds, toggleCollapsed]
-  );
 
   const activate = useCallback((row: NavigablePaletteTreeRow<PilotProjectGroup, PilotRow>) => {
     if (row.kind !== "item") return;
@@ -800,17 +632,17 @@ export function PilotView() {
    * `shouldPreserveInputCaretKey` is true where a caret exists to protect, and
    * the list's structural keys stand down for it.
    *
-   * Home/End/←/→ are structural keys, but they are also the search box's
-   * editing keys, and the box owns focus by default. While the query is
-   * non-empty they stay with the caret; an empty box has nothing to edit, so
-   * they navigate. Search force-expands every matching group anyway, which is
-   * where collapse would matter least.
+   * Home/End are structural keys, but they are also the search box's editing
+   * keys, and the box owns focus by default. While the query is non-empty they
+   * stay with the caret; an empty box has nothing to edit, so they jump to the
+   * first and last row. The horizontal arrows are no longer contested at all —
+   * with the disclosure gone the list has no horizontal axis, so they are the
+   * caret's outright.
    *
    * Deliberately keyed on the query alone and not on the band filter: an active
-   * filter with an empty box still leaves nothing to edit, and handing the
-   * caret keys over then would take collapse and expand away from a keyboard
-   * user for no gain. The filter bar binds its own arrows, but only while it
-   * physically holds focus, so the two never contend.
+   * filter with an empty box still leaves nothing to edit. The filter bar binds
+   * its own arrows, but only while it physically holds focus, so the two never
+   * contend.
    */
   const navigation = usePaletteTreeNavigation<PilotProjectGroup, PilotRow>({
     groups: paletteGroups,
@@ -819,7 +651,6 @@ export function PilotView() {
     // highlight would survive on a row the filter had just removed.
     selectionScopeKey: `${query}|${bandFilter}`,
     onActivate: activate,
-    onGroupCollapsedChange: setGroupCollapsed,
     shouldPreserveInputCaretKey: () => query.length > 0,
   });
 
@@ -871,7 +702,7 @@ export function PilotView() {
       : needsYou > 0
         ? demandPhrase(needsYou)
         : review > 0
-          ? bandPhrase("review", review)
+          ? reviewPhrase(review)
           : live > 0
             ? `Nothing needs you · ${live} ${live === 1 ? "agent" : "agents"} working`
             : fleet.total > 0
@@ -1075,33 +906,34 @@ export function PilotView() {
             // project's name as the label for every option inside it, which
             // is how a screen reader still hears which project a run belongs
             // to now that the header itself is not an item.
+            //
+            // Being in the current workspace decides whether opening a run is
+            // instant or swaps the whole view, and the header renders that as a
+            // word it then hides — so it rides the label rather than being
+            // visual-only. Short on purpose: this name is re-announced as
+            // context for every option inside, and the group's own contents are
+            // those options, so a prose summary here would be read once per row.
             <div
               key={header.domId}
+              id={header.domId}
               role="group"
-              aria-label={header.group.name}
+              aria-label={`${header.group.name}${header.group.isCurrent ? ", current workspace" : ""}`}
               // The scroller spaces siblings equally, so after a long run list
               // the next project arrives with no more separation than one more
               // agent. Only between groups — a leading gap would push the list
               // off its own top edge.
               className={groupIndex > 0 ? "mt-2" : undefined}
             >
-              <GroupHeader
-                group={header.group}
-                isCollapsed={header.isCollapsed}
-                groupId={header.domId}
-                onToggle={() => setGroupCollapsed(header.groupId, !header.isCollapsed)}
-              />
-              <div id={header.domId}>
-                {items.map((row) => (
-                  <RunRow
-                    key={row.domId}
-                    row={row.item}
-                    isSelected={row.rowId === selectedRow?.rowId}
-                    domId={row.domId}
-                    onActivate={() => navigation.activateRow(row.rowId)}
-                  />
-                ))}
-              </div>
+              <GroupHeader group={header.group} />
+              {items.map((row) => (
+                <RunRow
+                  key={row.domId}
+                  row={row.item}
+                  isSelected={row.rowId === selectedRow?.rowId}
+                  domId={row.domId}
+                  onActivate={() => navigation.activateRow(row.rowId)}
+                />
+              ))}
             </div>
           ))}
         </div>
@@ -1121,12 +953,6 @@ export function PilotView() {
             demandCount={needsYou}
             onShowDemand={() => {
               setBandFilter("needs-you");
-              // Cleared explicitly, not left to the narrowing effect. With the
-              // filter ALREADY on needs-you the state set is a no-op, the
-              // effect never re-runs, and a group the user had collapsed stays
-              // collapsed — leaving the button advertising agents it then
-              // failed to put on screen.
-              setNarrowingCollapsed([]);
             }}
           />
         </AppPaletteDialog.Footer>

--- a/src/components/Pilot/PilotView.tsx
+++ b/src/components/Pilot/PilotView.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { KeyboardEvent, KeyboardEventHandler } from "react";
 import { cn } from "@/lib/utils";
 import { getProjectGradient } from "@/lib/colorUtils";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
@@ -53,6 +54,58 @@ function groupDomId(workspaceId: string): string {
 
 function runDomId(runId: string): string {
   return `pilot-option-run-${runId}`;
+}
+
+/**
+ * A snapshot of where things were, by id.
+ *
+ * Ids rather than rows, so a held order cannot also freeze a glyph or an age:
+ * position is the only thing worth holding still under a pointer.
+ */
+interface PilotOrder {
+  groups: string[];
+  rows: Map<string, string[]>;
+}
+
+function capturePilotOrder(groups: readonly PilotProjectGroup[]): PilotOrder {
+  return {
+    groups: groups.map((group) => group.workspaceId),
+    rows: new Map(groups.map((group) => [group.workspaceId, group.rows.map((r) => r.run.runId)])),
+  };
+}
+
+/**
+ * The live fleet, re-sorted back into a captured order.
+ *
+ * Anything the capture never saw compares equal to its fellow newcomers and,
+ * `Array.sort` being stable, keeps its live relative rank at the tail — for as
+ * long as the hold lasts. Nothing is written back into the snapshot, so
+ * releasing puts every newcomer straight at its real position rather than
+ * leaving it stranded at the end of the list for the rest of the opening.
+ */
+function applyPilotOrder(
+  groups: readonly PilotProjectGroup[],
+  order: PilotOrder
+): PilotProjectGroup[] {
+  const groupIndex = new Map(order.groups.map((id, i) => [id, i]));
+  const rankOf = (index: Map<string, number>, id: string) =>
+    index.get(id) ?? Number.MAX_SAFE_INTEGER;
+
+  const ordered = [...groups].sort(
+    (a, b) => rankOf(groupIndex, a.workspaceId) - rankOf(groupIndex, b.workspaceId)
+  );
+
+  return ordered.map((group) => {
+    const rowOrder = order.rows.get(group.workspaceId);
+    if (!rowOrder) return group;
+    const rowIndex = new Map(rowOrder.map((id, i) => [id, i]));
+    return {
+      ...group,
+      rows: [...group.rows].sort(
+        (a, b) => rankOf(rowIndex, a.run.runId) - rankOf(rowIndex, b.run.runId)
+      ),
+    };
+  });
 }
 
 /** Layout only; the selected treatment comes from the shared row class. */
@@ -183,11 +236,21 @@ function RunRow({
   isSelected,
   domId,
   onActivate,
+  onPointerMove,
 }: {
   row: PilotRow;
   isSelected: boolean;
   domId: string;
   onActivate: () => void;
+  /**
+   * `onPointerMove`, never `onMouseEnter`.
+   *
+   * `SearchablePalette` documents the reason and this surface is exactly the
+   * case it describes: keyboard scrolling under a stationary cursor drags rows
+   * past the pointer, and `mouseenter` would read that as the user choosing
+   * each one on the way. Movement is what says a pointer is being aimed.
+   */
+  onPointerMove: () => void;
 }) {
   /**
    * The agent's brand, unless the title already is it.
@@ -231,6 +294,7 @@ function RunRow({
       aria-label={accessibleName}
       data-testid="pilot-row"
       onClick={onActivate}
+      onPointerMove={onPointerMove}
       // One line, ~32px. Two-line rows made 8 agents into 16 lines of identical
       // shape with nothing to scan down; the trailing group below puts the
       // facts into columns instead.
@@ -466,98 +530,31 @@ export function PilotView() {
   }, [snapshot, workspaces, nowMs]);
 
   /**
-   * Position, pinned for as long as the dialog stays open.
+   * Position, held only while the pointer is genuinely working the list.
    *
-   * Ordering is derived from live agent state, so without this a run changing
-   * state reorders the list under the cursor — the classic sort-thrash misclick,
-   * and the one that matters most here because every row is a navigation target.
-   * The ORDER is pinned; the rows keep updating in place, so a state glyph or
-   * an age still moves the instant it changes.
+   * Ordering is derived from live agent state and the ranking IS the answer
+   * this surface exists to give, so it has to stay true: an agent that blocks
+   * while you are looking at the list has to rise to where the ranking says it
+   * belongs, not sit below every idle agent until you close and reopen.
    *
-   * Held in state rather than a ref so every mutation is a declared input of the
-   * memo below. A ref read during render is invisible to memoization and would
-   * serve a stale order for a frame after reopening.
+   * The misclick this used to guard against is real but pointer-only. Selection
+   * is keyed by `rowId` (#11071), so a re-rank cannot make Enter commit a row
+   * the user did not choose — only a mouse aimed at a row that moves out from
+   * under it can go wrong. So the order is held from the first pointer movement
+   * over the list, and released the moment the pointer leaves or the keyboard
+   * takes over. Ids only: the rows themselves keep updating in place, so a
+   * glyph or an age still moves the instant it changes.
+   *
+   * Held in state rather than a ref so every mutation is a declared input of
+   * the memo below. A ref read during render is invisible to memoization and
+   * would serve a stale order for a frame.
    */
-  const [frozenOrder, setFrozenOrder] = useState<{
-    groups: string[];
-    rows: Map<string, string[]>;
-  } | null>(null);
+  const [pointerOrder, setPointerOrder] = useState<PilotOrder | null>(null);
 
-  useEffect(() => {
-    if (!isOpen) {
-      setFrozenOrder(null);
-      return;
-    }
-    // Pin on the FIRST non-empty fleet after opening, not on open itself: the
-    // snapshot can still be null when the dialog mounts.
-    if (liveGroups.length === 0) return;
-
-    setFrozenOrder((prev) => {
-      if (prev === null) {
-        return {
-          groups: liveGroups.map((g) => g.workspaceId),
-          rows: new Map(liveGroups.map((g) => [g.workspaceId, g.rows.map((r) => r.run.runId)])),
-        };
-      }
-
-      // Anything that appears while the dialog is open takes a permanent place
-      // at the end, assigned once. Leaving new ids unranked would let them keep
-      // sorting against each other on every snapshot — reintroducing exactly
-      // the movement this exists to prevent, just among the newcomers.
-      let changed = false;
-      const groups = [...prev.groups];
-      const seenGroups = new Set(groups);
-      const rows = new Map(prev.rows);
-
-      for (const group of liveGroups) {
-        if (!seenGroups.has(group.workspaceId)) {
-          groups.push(group.workspaceId);
-          seenGroups.add(group.workspaceId);
-          changed = true;
-        }
-        const known = rows.get(group.workspaceId);
-        const next = known ? [...known] : [];
-        const seenRows = new Set(next);
-        for (const row of group.rows) {
-          if (!seenRows.has(row.run.runId)) {
-            next.push(row.run.runId);
-            seenRows.add(row.run.runId);
-            changed = true;
-          }
-        }
-        if (!known || next.length !== known.length) rows.set(group.workspaceId, next);
-      }
-
-      // Returning the previous object when nothing moved is what stops this
-      // effect from re-rendering itself on every snapshot.
-      return changed ? { groups, rows } : prev;
-    });
-  }, [isOpen, liveGroups]);
-
-  const stableGroups = useMemo(() => {
-    if (!frozenOrder) return liveGroups;
-
-    const groupIndex = new Map(frozenOrder.groups.map((id, i) => [id, i]));
-    const ordered = [...liveGroups].sort((a, b) => {
-      const ai = groupIndex.get(a.workspaceId) ?? Number.MAX_SAFE_INTEGER;
-      const bi = groupIndex.get(b.workspaceId) ?? Number.MAX_SAFE_INTEGER;
-      return ai - bi;
-    });
-
-    return ordered.map((group) => {
-      const rowOrder = frozenOrder.rows.get(group.workspaceId);
-      if (!rowOrder) return group;
-      const rowIndex = new Map(rowOrder.map((id, i) => [id, i]));
-      return {
-        ...group,
-        rows: [...group.rows].sort((a, b) => {
-          const ai = rowIndex.get(a.run.runId) ?? Number.MAX_SAFE_INTEGER;
-          const bi = rowIndex.get(b.run.runId) ?? Number.MAX_SAFE_INTEGER;
-          return ai - bi;
-        }),
-      };
-    });
-  }, [liveGroups, frozenOrder]);
+  const orderedGroups = useMemo(
+    () => (pointerOrder === null ? liveGroups : applyPilotOrder(liveGroups, pointerOrder)),
+    [liveGroups, pointerOrder]
+  );
 
   /**
    * The narrowing pipeline, in the one order that makes the counts honest.
@@ -569,7 +566,10 @@ export function PilotView() {
    * user nothing. The two narrowings intersect with AND, so "the blocked agents
    * in this repo" is one question.
    */
-  const queryGroups = useMemo(() => filterPilotGroups(stableGroups, query), [stableGroups, query]);
+  const queryGroups = useMemo(
+    () => filterPilotGroups(orderedGroups, query),
+    [orderedGroups, query]
+  );
 
   const filterCounts = useMemo(() => countPilotBands(queryGroups), [queryGroups]);
 
@@ -617,6 +617,10 @@ export function PilotView() {
       setBandFilter("all");
       // Closing takes focus with it without a blur ever reaching the bar.
       setIsFilterFocused(false);
+      // A hold belongs to one pointer over one list. Carrying it across a close
+      // would reopen the surface serving the ranking of a fleet that has moved
+      // on, which is the staleness this stopped doing in the first place.
+      setPointerOrder(null);
     }
   }, [isOpen]);
 
@@ -654,7 +658,54 @@ export function PilotView() {
     shouldPreserveInputCaretKey: () => query.length > 0,
   });
 
-  const { selectedRow, activeDescendantId, renderGroups } = navigation;
+  const { selectedRow, activeDescendantId, renderGroups, selectRow } = navigation;
+
+  /**
+   * A pointer aimed at a row selects it, and takes the order still while it is
+   * being aimed.
+   *
+   * Both halves in one handler because they are one gesture: the hold exists to
+   * keep the row under the cursor from moving before the click lands, so it has
+   * to start at the same moment the cursor starts choosing.
+   */
+  const handleRowPointerMove = useCallback(
+    (rowId: string) => {
+      setPointerOrder((held) => (held === null ? capturePilotOrder(liveGroups) : held));
+      selectRow(rowId);
+    },
+    [liveGroups, selectRow]
+  );
+
+  const releasePointerOrder = useCallback(() => setPointerOrder(null), []);
+
+  /**
+   * The keyboard takes the list back, and the pointer's hold with it.
+   *
+   * Released AFTER delegating, never before: the arrow has to act on the order
+   * the user can currently see, and the resulting `rowId` then survives the
+   * re-rank because selection was never index-keyed. `defaultPrevented` is the
+   * signal because the model cancels exactly the keys it acted on — a Home the
+   * search caret kept, or an arrow over an empty list, leaves the hold alone.
+   */
+  const releaseOnConsumedKey = useCallback((event: KeyboardEvent<HTMLElement>) => {
+    if (event.defaultPrevented) setPointerOrder(null);
+  }, []);
+
+  const handleInputKeyDown = useCallback<KeyboardEventHandler<HTMLInputElement>>(
+    (event) => {
+      navigation.handleInputKeyDown(event);
+      releaseOnConsumedKey(event);
+    },
+    [navigation, releaseOnConsumedKey]
+  );
+
+  const handleBodyKeyDown = useCallback<KeyboardEventHandler<HTMLElement>>(
+    (event) => {
+      navigation.handleBodyKeyDown(event);
+      releaseOnConsumedKey(event);
+    },
+    [navigation, releaseOnConsumedKey]
+  );
 
   /**
    * What the surface can honestly claim right now.
@@ -728,7 +779,7 @@ export function PilotView() {
    * leave nothing on screen — that is precisely when it is the way back.
    */
   const showFilterBar =
-    (status.kind === "live" || status.kind === "stale") && stableGroups.length > 0;
+    (status.kind === "live" || status.kind === "stale") && orderedGroups.length > 0;
 
   // Removing a focused element does not reliably fire a blur, so a bar that
   // vanishes under the cursor — the fleet drains, or the host stops answering
@@ -754,7 +805,7 @@ export function PilotView() {
           inputRef={searchRef}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          onKeyDown={navigation.handleInputKeyDown}
+          onKeyDown={handleInputKeyDown}
           placeholder="Search agents…"
           aria-label="Search agents"
           // The role is constant, not conditional on there being results. A
@@ -794,7 +845,7 @@ export function PilotView() {
         className="p-0"
         ariaLabel="Agents"
         activeDescendant={activeDescendantId}
-        onNavigationKeyDown={navigation.handleBodyKeyDown}
+        onNavigationKeyDown={handleBodyKeyDown}
       >
         {showSkeleton && (
           /*
@@ -900,6 +951,11 @@ export function PilotView() {
         <div
           id={LIST_ID}
           {...(hasTree ? { role: "listbox", "aria-label": "Agents by project" } : {})}
+          // The pointer stops working the list the moment it leaves it, so the
+          // ranking goes back to being true. On the container rather than the
+          // rows: moving between two rows leaves one and enters the next, and a
+          // per-row handler would release and re-take the hold on the way past.
+          onPointerLeave={releasePointerOrder}
         >
           {renderGroups.map(({ header, items }, groupIndex) => (
             // `role="group"` is a permitted listbox child and carries the
@@ -932,6 +988,7 @@ export function PilotView() {
                   isSelected={row.rowId === selectedRow?.rowId}
                   domId={row.domId}
                   onActivate={() => navigation.activateRow(row.rowId)}
+                  onPointerMove={() => handleRowPointerMove(row.rowId)}
                 />
               ))}
             </div>

--- a/src/components/Pilot/__tests__/PilotFilterBar.test.tsx
+++ b/src/components/Pilot/__tests__/PilotFilterBar.test.tsx
@@ -95,7 +95,7 @@ describe("PilotFilterBar", () => {
 
     expect(segmentNames()).toEqual([
       "All, 7 agents",
-      "Needs you, 2 agents",
+      "Waiting, 2 agents",
       "Working, 4 agents",
       "Finished, 1 agent",
     ]);
@@ -104,7 +104,7 @@ describe("PilotFilterBar", () => {
   it("selects a segment on click", () => {
     const { onChange } = renderBar();
 
-    fireEvent.click(screen.getByRole("radio", { name: /Needs you/ }));
+    fireEvent.click(screen.getByRole("radio", { name: /Waiting/ }));
 
     expect(onChange).toHaveBeenCalledWith("needs-you");
   });
@@ -142,9 +142,9 @@ describe("PilotFilterBar", () => {
 
       press("ArrowLeft");
       expect(liveState()).toEqual({
-        checked: "Needs you",
-        tabbable: "Needs you",
-        focused: "Needs you",
+        checked: "Waiting",
+        tabbable: "Waiting",
+        focused: "Waiting",
       });
     });
 
@@ -220,8 +220,8 @@ describe("PilotFilterBar", () => {
       // fleet moved, and take away the control that proves the bucket is empty.
       const { onChange } = renderBar("all", counts({ all: 2, working: 2 }));
 
-      const empty = screen.getByRole("radio", { name: /Needs you/ });
-      expect(empty.getAttribute("aria-label")).toBe("Needs you, 0 agents");
+      const empty = screen.getByRole("radio", { name: /Waiting/ });
+      expect(empty.getAttribute("aria-label")).toBe("Waiting, 0 agents");
 
       fireEvent.click(empty);
       expect(onChange).toHaveBeenCalledWith("needs-you");
@@ -232,12 +232,12 @@ describe("PilotFilterBar", () => {
       // proved nothing — their base tones already differ, so deleting the fade
       // rule entirely would still have passed.
       renderBar("all", counts({ all: 0 }), bands());
-      const empty = glyphOf(/Needs you/)?.getAttribute("class") ?? "";
+      const empty = glyphOf(/Waiting/)?.getAttribute("class") ?? "";
 
       cleanup();
 
       renderBar("all", counts({ all: 1, "needs-you": 1 }), bands({ "needs-you": 1 }));
-      const populated = glyphOf(/Needs you/)?.getAttribute("class") ?? "";
+      const populated = glyphOf(/Waiting/)?.getAttribute("class") ?? "";
 
       expect(empty).not.toBe("");
       expect(empty).not.toBe(populated);
@@ -271,6 +271,68 @@ describe("PilotFilterBar", () => {
 
       renderBar("all", counts({ all: 1, working: 1 }));
       expect(glyphOf(/Working/)?.getAttribute("class")).toContain("animate-spin");
+    });
+  });
+
+  describe("segment hue", () => {
+    /**
+     * Only the colour utilities on a segment's glyph.
+     *
+     * The whole class string would have let the spinner's `animate-spin-slow`
+     * stand in for a hue difference, so a Working segment that had lost its
+     * colour entirely would still have compared as different.
+     */
+    function toneOf(name: RegExp): string {
+      const cls =
+        screen.getByRole("radio", { name }).querySelector("svg")?.getAttribute("class") ?? "";
+      return cls
+        .split(/\s+/)
+        .filter((token) => token.startsWith("text-"))
+        .sort()
+        .join(" ");
+    }
+
+    it("hues Working even though a working agent is not a demand", () => {
+      // Two segments, neither holding anything to act on. `bandFilterHasDemand`
+      // reports false for both — correctly, since `running` is not a demand and
+      // an acknowledged `done` is not either. Working is hued anyway, because
+      // green for working is the vocabulary the rest of the app speaks; Finished
+      // is not. If the demand test alone decided the hue these would match.
+      renderBar("all", counts({ all: 4, working: 2, finished: 2 }), bands({ running: 2, done: 2 }));
+
+      expect(toneOf(/Working/)).not.toBe("");
+      expect(toneOf(/Working/)).not.toBe(toneOf(/Finished/));
+    });
+
+    it("does not let a demand elsewhere in the fleet decide Working's hue", () => {
+      renderBar("all", counts({ all: 2, working: 2 }), bands({ running: 2 }));
+      const quietFleet = toneOf(/Working/);
+
+      cleanup();
+
+      renderBar(
+        "all",
+        counts({ all: 3, "needs-you": 1, working: 2 }),
+        bands({
+          "needs-you": 1,
+          running: 2,
+        })
+      );
+
+      expect(toneOf(/Working/)).toBe(quietFleet);
+    });
+
+    it("separates work in flight from work handed back", () => {
+      // The row glyphs make this distinction and the segments filter to them,
+      // so the two have to agree — a Finished segment sharing Working's colour
+      // would file "ready for review" under "still going".
+      renderBar(
+        "all",
+        counts({ all: 4, working: 2, finished: 2 }),
+        bands({ running: 2, review: 2 })
+      );
+
+      expect(toneOf(/Finished/)).not.toBe(toneOf(/Working/));
     });
   });
 

--- a/src/components/Pilot/__tests__/PilotRunState.test.tsx
+++ b/src/components/Pilot/__tests__/PilotRunState.test.tsx
@@ -105,6 +105,14 @@ describe("PilotRunState", () => {
     expect(new Set(shapes).size).toBe(shapes.length);
   });
 
+  it("separates an errored agent from one asking a question by shape, not just hue", () => {
+    // These two shared the hollow circle and differed only in colour, with the
+    // row's visible status word carrying the real distinction. That word is
+    // gone, and "the agent stopped" versus "the agent asked you something" is
+    // too far apart to leave resting on a hue a colour-vision remap can move.
+    expect(shapeOf("blocked")).not.toBe(shapeOf("needs-you"));
+  });
+
   it("spins only the run that is actually working", () => {
     const spinning = (band: FleetBand, agentState?: AgentState) => {
       const { container, unmount } = render(<PilotRunState band={band} agentState={agentState} />);

--- a/src/components/Pilot/__tests__/PilotRunState.test.tsx
+++ b/src/components/Pilot/__tests__/PilotRunState.test.tsx
@@ -42,14 +42,15 @@ function shapeOf(band: FleetBand, agentState?: AgentState): string {
 }
 
 const DEMAND_BANDS = FLEET_BANDS.filter(isDemandBand);
-const NEUTRAL_BANDS = FLEET_BANDS.filter((band) => !isDemandBand(band));
+/** Nothing in flight and nothing being asked — the two states that stay grey. */
+const QUIET_BANDS: FleetBand[] = ["done", "idle"];
 
 describe("PilotRunState", () => {
-  it("paints one shared neutral tone across every state without a demand", () => {
-    // Running, done and idle gave up their hue: colour is the signal that
-    // something needs the user, and three more hues competing with it is what
-    // made two waiting agents invisible among five working ones.
-    const tones = new Set(NEUTRAL_BANDS.map((band) => toneOf(band)));
+  it("paints one shared neutral tone across the states that are not news", () => {
+    // An acknowledged completion and an exited shell are finished business.
+    // Hueing them would put back the competing signals that made two waiting
+    // agents invisible among five working ones.
+    const tones = new Set(QUIET_BANDS.map((band) => toneOf(band)));
 
     expect(tones.size).toBe(1);
     // A set of one is also what "no tone at all" produces, and an uncoloured
@@ -57,25 +58,42 @@ describe("PilotRunState", () => {
     expect([...tones][0]).not.toBe("");
   });
 
-  it("keeps the directing and exited refinements inside that neutral tone", () => {
-    // Both used to carry a colour of their own — `directing` a category blue,
-    // `exited` a dimmer grey. Neither is a demand.
-    const neutral = toneOf("done");
-    expect(toneOf("running", "directing")).toBe(neutral);
-    expect(toneOf("idle", "exited")).toBe(neutral);
+  it("hues a working run, because working is a live fact and not a quiet one", () => {
+    // The rest of the app — the sidebar's quick filters, the assistant header,
+    // the dock — has always said working in colour. The overview reading it as
+    // ordinary text was the one surface speaking a second language.
+    expect(toneOf("running")).not.toBe(toneOf("done"));
   });
 
-  it("hues every band that is a demand, and none that isn't", () => {
-    const neutral = toneOf("done");
+  it("keeps the directing refinement inside the working tone", () => {
+    // Directing is a person typing at a working agent, not a different state.
+    expect(toneOf("running", "directing")).toBe(toneOf("running"));
+  });
+
+  it("keeps the exited refinement inside the quiet tone", () => {
+    expect(toneOf("idle", "exited")).toBe(toneOf("idle"));
+  });
+
+  it("separates work in flight from work handed back", () => {
+    // The collision this exists to prevent: `activity-completed` is unset in
+    // every built-in theme and falls back to `status-success`, which is the
+    // same hex as `activity-working` in five of them. Hueing `running` without
+    // moving `review` off that fallback would leave spinner-versus-check as the
+    // only difference between two states an operator has to tell apart.
+    expect(toneOf("review")).not.toBe(toneOf("running"));
+  });
+
+  it("hues every band that is a demand, in a colour of its own", () => {
+    const quiet = toneOf("done");
     for (const band of DEMAND_BANDS) {
-      expect(toneOf(band)).not.toBe(neutral);
+      expect(toneOf(band)).not.toBe(quiet);
     }
     expect(new Set(DEMAND_BANDS.map((band) => toneOf(band))).size).toBe(DEMAND_BANDS.length);
   });
 
-  it("keeps shape as a second channel, so the neutral states stay tellable apart", () => {
-    // Working, finished and exited are all neutral now, so geometry is the only
-    // thing left separating them — never colour alone, and never its absence.
+  it("keeps shape as a second channel, so the quiet states stay tellable apart", () => {
+    // Working, finished and exited carry no demand between them, so geometry is
+    // what separates them — never colour alone, and never its absence.
     const shapes = [
       shapeOf("running"),
       shapeOf("running", "directing"),

--- a/src/components/Pilot/__tests__/PilotView.test.tsx
+++ b/src/components/Pilot/__tests__/PilotView.test.tsx
@@ -513,19 +513,17 @@ describe("PilotView", () => {
     expect(age()).toContain("3m");
   });
 
-  it("re-pins the order on reopen rather than serving the previous session's", async () => {
+  it("does not carry a pointer's hold across a reopen", async () => {
     seed([
       run({ runId: "a", agentState: "working", title: "a", since: NOW - 10_000 }),
       run({ runId: "b", agentState: "working", title: "b", since: NOW - 5_000 }),
     ]);
     const view = render(<PilotView />);
-    expect(screen.getAllByTestId("pilot-row").map((r) => r.textContent)).toEqual([
-      expect.stringContaining("a"),
-      expect.stringContaining("b"),
-    ]);
+    fireEvent.pointerMove(screen.getAllByTestId("pilot-row")[0]!);
 
-    // Close, let the fleet change, reopen. The new order must reflect the fleet
-    // as it is NOW — a stale pin would keep serving the closed session's order.
+    // Close with the hold still taken, let the fleet change, reopen. The new
+    // order must reflect the fleet as it is NOW — a hold that survived would
+    // serve the ranking of a fleet that has moved on.
     usePilotStore.setState({ isOpen: false });
     view.rerender(<PilotView />);
     seed([
@@ -975,19 +973,20 @@ describe("PilotView", () => {
       expect(document.activeElement).toBe(screen.getByTestId("pilot-search"));
     });
 
-    it("holds the opening order while a filter comes and goes", () => {
-      // `frozenOrder` pins position for the whole opening. A filter must narrow
-      // that order, never re-derive one — every row here is a click target.
+    it("holds a pointer's order through a filter coming and going", () => {
+      // A filter must narrow the order the pointer is holding, never re-derive
+      // one underneath it — every row here is a click target.
       seed([
         run({ runId: "a", agentState: "waiting", title: "alpha", since: NOW - 10_000 }),
         run({ runId: "b", agentState: "waiting", title: "bravo", since: NOW - 5_000 }),
       ]);
       render(<PilotView />);
-      // Titles, not full text: "bravo" changes band below, so its visible
-      // status word legitimately changes. Position is what must not.
+      // Titles, not full text: "bravo" changes band below, so its glyph
+      // legitimately changes. Position is what must not.
       const titles = () =>
         screen.getAllByTestId("pilot-row").map((r) => r.getAttribute("aria-label")?.split(",")[0]);
-      const opening = titles();
+      fireEvent.pointerMove(screen.getAllByTestId("pilot-row")[0]!);
+      const held = titles();
 
       // "bravo" becomes the more urgent of the two, which would reorder them
       // on a fresh sort.
@@ -1006,11 +1005,11 @@ describe("PilotView", () => {
       fireEvent.click(screen.getByRole("radio", { name: /Waiting/ }));
       // Asserted WHILE narrowed, not only after returning to All: a filter that
       // re-derived the order would be invisible if the check waited until the
-      // pinned order had been restored anyway.
-      expect(titles()).toEqual(opening);
+      // held order had been restored anyway.
+      expect(titles()).toEqual(held);
 
       fireEvent.click(screen.getByRole("radio", { name: /^All/ }));
-      expect(titles()).toEqual(opening);
+      expect(titles()).toEqual(held);
     });
 
     it("clears the filter without discarding the query", () => {
@@ -1167,35 +1166,148 @@ describe("PilotView", () => {
     });
   });
 
-  it("keeps a row in place when its state changes while the dialog is open", async () => {
-    seed([
-      run({ runId: "first", agentState: "working", title: "first", since: NOW - 10_000 }),
-      run({ runId: "second", agentState: "working", title: "second", since: NOW - 5_000 }),
-    ]);
-    render(<PilotView />);
-    expect(screen.getAllByTestId("pilot-row").map((r) => r.textContent)).toEqual([
-      expect.stringContaining("first"),
-      expect.stringContaining("second"),
-    ]);
+  describe("ordering", () => {
+    /** Row titles in rendered order, read off the name so a glyph change can't confuse it. */
+    function order(): (string | undefined)[] {
+      return screen
+        .getAllByTestId("pilot-row")
+        .map((r) => r.getAttribute("aria-label")?.split(",")[0]);
+    }
 
-    // "second" becomes the most urgent run. Its badge must update, but the row
-    // must NOT jump above "first" — every row here is a click target, and
-    // reordering under the cursor is how a misclick happens.
-    seed([
-      run({ runId: "first", agentState: "working", title: "first", since: NOW - 10_000 }),
-      run({
-        runId: "second",
-        agentState: "waiting",
-        waitingReason: "error",
-        title: "second",
-        since: NOW,
-      }),
-    ]);
-    await vi.advanceTimersByTimeAsync(0);
+    function seedTwo(secondBlocked: boolean) {
+      seed([
+        run({ runId: "first", agentState: "working", title: "first", since: NOW - 10_000 }),
+        secondBlocked
+          ? run({
+              runId: "second",
+              agentState: "waiting",
+              waitingReason: "error",
+              title: "second",
+              since: NOW,
+            })
+          : run({ runId: "second", agentState: "working", title: "second", since: NOW - 5_000 }),
+      ]);
+    }
 
-    expect(screen.getAllByTestId("pilot-row").map((r) => r.textContent)).toEqual([
-      expect.stringContaining("first"),
-      expect.stringContaining("second"),
-    ]);
+    it("re-ranks a run that blocks while the list is being read", async () => {
+      // The ranking IS the answer this surface gives. An agent that blocks
+      // while you are looking at the list sitting below every working one until
+      // you close and reopen is the ranking lying.
+      seedTwo(false);
+      render(<PilotView />);
+      expect(order()).toEqual(["first", "second"]);
+
+      act(() => seedTwo(true));
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(order()).toEqual(["second", "first"]);
+    });
+
+    it("lands a newly-spawned run at its real rank rather than the end", async () => {
+      seedTwo(false);
+      render(<PilotView />);
+
+      act(() => {
+        seed([
+          run({ runId: "first", agentState: "working", title: "first", since: NOW - 10_000 }),
+          run({ runId: "second", agentState: "working", title: "second", since: NOW - 5_000 }),
+          run({
+            runId: "third",
+            agentState: "waiting",
+            waitingReason: "error",
+            title: "third",
+            since: NOW,
+          }),
+        ]);
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Appending it would bury a blocked agent under two working ones for the
+      // rest of the opening.
+      expect(order()[0]).toBe("third");
+    });
+
+    it("holds the order still while a pointer is working the list", async () => {
+      seedTwo(false);
+      render(<PilotView />);
+      fireEvent.pointerMove(screen.getAllByTestId("pilot-row")[0]!);
+
+      act(() => seedTwo(true));
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Every row is a click target, and a row that moves out from under an
+      // aimed cursor is how a misclick happens.
+      expect(order()).toEqual(["first", "second"]);
+    });
+
+    it("selects the row the pointer is aimed at", () => {
+      seedTwo(false);
+      render(<PilotView />);
+
+      fireEvent.pointerMove(screen.getAllByTestId("pilot-row")[1]!);
+
+      // Hover and the Enter target were two different lit rows before this.
+      expect(
+        document.querySelector('[aria-selected="true"]')?.getAttribute("aria-label")
+      ).toContain("second");
+    });
+
+    it("re-ranks the moment the pointer leaves the list", async () => {
+      seedTwo(false);
+      render(<PilotView />);
+      fireEvent.pointerMove(screen.getAllByTestId("pilot-row")[0]!);
+      act(() => seedTwo(true));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(order()).toEqual(["first", "second"]);
+
+      fireEvent.pointerLeave(document.getElementById("pilot-agent-list")!);
+
+      expect(order()).toEqual(["second", "first"]);
+    });
+
+    it("gives the list back to the keyboard on the next arrow, from what was on screen", async () => {
+      seedTwo(false);
+      render(<PilotView />);
+      fireEvent.pointerMove(screen.getAllByTestId("pilot-row")[0]!);
+      act(() => seedTwo(true));
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Stepping happens against the held order — "second" is still the row
+      // below "first" at the moment the key is pressed — and only then does the
+      // hold release. Selection is id-keyed, so it survives the re-rank.
+      fireEvent.keyDown(screen.getByTestId("pilot-search"), { key: "ArrowDown" });
+
+      expect(
+        document.querySelector('[aria-selected="true"]')?.getAttribute("aria-label")
+      ).toContain("second");
+      expect(order()).toEqual(["second", "first"]);
+    });
+
+    it("leaves the hold alone for a key the list never acted on", async () => {
+      seedTwo(false);
+      render(<PilotView />);
+      fireEvent.change(screen.getByTestId("pilot-search"), { target: { value: "s" } });
+      fireEvent.pointerMove(screen.getAllByTestId("pilot-row")[0]!);
+
+      // End belongs to the caret while there is a query to edit, so the list
+      // never moves — and a hold released by a key that did nothing would let
+      // the rows shift under a cursor that had not been given up.
+      fireEvent.keyDown(screen.getByTestId("pilot-search"), { key: "End" });
+      act(() => {
+        seed([
+          run({ runId: "first", agentState: "working", title: "first s", since: NOW - 10_000 }),
+          run({
+            runId: "second",
+            agentState: "waiting",
+            waitingReason: "error",
+            title: "second s",
+            since: NOW,
+          }),
+        ]);
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(order()).toEqual(["first s", "second s"]);
+    });
   });
 });

--- a/src/components/Pilot/__tests__/PilotView.test.tsx
+++ b/src/components/Pilot/__tests__/PilotView.test.tsx
@@ -262,6 +262,19 @@ describe("PilotView", () => {
     expect(name.match(/Claude/g)).toHaveLength(1);
   });
 
+  it("treats a differently-cased title as the same identity, not a second fact", () => {
+    // Titles come from terminal output, which does not agree with the agent
+    // registry about capitalisation. A case-sensitive comparison would let
+    // "CLAUDE, Claude, Working" through as though the two said different things.
+    seed([
+      run({ runId: "a", agentId: "claude", agentState: "working", title: "CLAUDE", since: NOW }),
+    ]);
+    render(<PilotView />);
+
+    const name = screen.getByTestId("pilot-row").getAttribute("aria-label") ?? "";
+    expect(name.match(/claude/gi)).toHaveLength(1);
+  });
+
   it("stops spending row width on a status word the glyph already carries", () => {
     // Seven rows, seven states, and not one of them prints what it is doing.
     // The word cost width beside a title that was already truncating, and the
@@ -352,16 +365,26 @@ describe("PilotView", () => {
     // The stale banner sits directly above this sentence. An unqualified
     // "Nothing needs you" underneath it is the surface making a live all-clear
     // claim out of data it cannot currently see.
-    seed([run({ agentState: "working", title: "one", since: NOW - 60_000 })], {
-      degraded: true,
-      lastSuccessfulAt: NOW - 12 * 60_000,
-    });
-    render(<PilotView />);
+    //
+    // The live sentence is CAPTURED rather than written out: asserting the
+    // literal would copy the summary copy into the test, and the claim here is
+    // about the transformation, not the wording.
+    const runs = [run({ agentState: "working", title: "one", since: NOW - 60_000 })];
+    seed(runs);
+    const view = render(<PilotView />);
+    const liveSummary = screen.getByTestId("pilot-summary").textContent ?? "";
+    expect(liveSummary).not.toBe("");
 
-    const live = "Nothing needs you · 1 agent working";
-    expect(screen.queryByText(live)).toBeNull();
-    expect(screen.getByText(new RegExp(live.replace(/[·]/g, "\\$&")))).toBeTruthy();
-    expect(screen.getByTestId("pilot-summary").textContent).toMatch(/last known/i);
+    act(() => {
+      seed(runs, { degraded: true, lastSuccessfulAt: NOW - 12 * 60_000 });
+    });
+    view.rerender(<PilotView />);
+
+    // The qualifier LEADS. Appended, the reader still meets the all-clear
+    // first and the correction only after it has landed.
+    const stale = screen.getByTestId("pilot-summary").textContent ?? "";
+    expect(stale).toMatch(/^last known/i);
+    expect(stale).toContain(liveSummary);
   });
 
   it("does not offer the zero-data prompt over a retained empty fleet", () => {
@@ -1106,7 +1129,14 @@ describe("PilotView", () => {
       ]);
       render(<PilotView />);
 
-      fireEvent.click(screen.getByTestId("pilot-demand-action"));
+      // Focus has to START on the button, or this passes on whatever the
+      // palette's autofocus happened to leave behind and would go on passing
+      // with the handoff deleted.
+      const action = screen.getByTestId("pilot-demand-action");
+      act(() => action.focus());
+      expect(document.activeElement).toBe(action);
+
+      fireEvent.click(action);
 
       expect(document.activeElement).toBe(screen.getByTestId("pilot-search"));
     });
@@ -1308,20 +1338,159 @@ describe("PilotView", () => {
     });
 
     it("gives the list back to the keyboard on the next arrow, from what was on screen", async () => {
+      // Three rows, and the one that blocks is the MIDDLE one. Two rows would
+      // prove nothing: whichever order they are in, the row after the first is
+      // the other one, so this would pass against an arrow that walked the live
+      // ranking instead of the held one.
+      const seedThree = (middleBlocked: boolean) => {
+        seed([
+          run({ runId: "a", agentState: "working", title: "aaa", since: NOW - 30_000 }),
+          middleBlocked
+            ? run({
+                runId: "b",
+                agentState: "waiting",
+                waitingReason: "error",
+                title: "bbb",
+                since: NOW,
+              })
+            : run({ runId: "b", agentState: "working", title: "bbb", since: NOW - 20_000 }),
+          run({ runId: "c", agentState: "working", title: "ccc", since: NOW - 10_000 }),
+        ]);
+      };
+      seedThree(false);
+      render(<PilotView />);
+      fireEvent.pointerMove(screen.getAllByTestId("pilot-row")[0]!);
+      act(() => seedThree(true));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(order()).toEqual(["aaa", "bbb", "ccc"]);
+
+      // Stepping happens against the held order, where "bbb" is still the row
+      // below "aaa"; against the live order it would be "ccc". Only then does
+      // the hold release, and the id-keyed selection survives the re-rank.
+      fireEvent.keyDown(screen.getByTestId("pilot-search"), { key: "ArrowDown" });
+
+      expect(
+        document.querySelector('[aria-selected="true"]')?.getAttribute("aria-label")
+      ).toContain("bbb");
+      expect(order()).toEqual(["bbb", "aaa", "ccc"]);
+    });
+
+    it("holds whole projects still, not just the rows inside them", async () => {
+      // The group half of the re-sort has its own branch, so a hold that kept
+      // rows in place while letting entire projects jump under the pointer
+      // would otherwise pass everything above.
+      const seedProjects = (spikeBlocked: boolean) => {
+        seed([
+          run({ runId: "a", workspaceId: "p1", agentState: "working", title: "in daintree" }),
+          spikeBlocked
+            ? run({
+                runId: "b",
+                workspaceId: "s1",
+                agentState: "waiting",
+                waitingReason: "error",
+                title: "in spike",
+                since: NOW,
+              })
+            : run({ runId: "b", workspaceId: "s1", agentState: "working", title: "in spike" }),
+        ]);
+      };
+      // Read through the rows rather than the header text: one row per project
+      // means row order IS group order, and the workspace-name lookup does not
+      // survive the microtask flush this test needs (the name loaders resolve
+      // against no IPC host and empty their stores).
+      seedProjects(false);
+      render(<PilotView />);
+      expect(order()).toEqual(["in daintree", "in spike"]);
+
+      fireEvent.pointerMove(screen.getAllByTestId("pilot-row")[0]!);
+      act(() => seedProjects(true));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(order()).toEqual(["in daintree", "in spike"]);
+
+      fireEvent.pointerLeave(document.getElementById("pilot-agent-list")!);
+
+      // The project holding the blocked agent leads the moment the pointer
+      // stops protecting the position it was aimed at.
+      expect(order()).toEqual(["in spike", "in daintree"]);
+    });
+
+    it("does not re-take the hold at a newer rank on every pointer move", async () => {
+      // Capture-once. Re-capturing on each move would make the hold track the
+      // live ranking rather than the screen, so a row could still shift under a
+      // cursor that had never left the list.
       seedTwo(false);
       render(<PilotView />);
       fireEvent.pointerMove(screen.getAllByTestId("pilot-row")[0]!);
       act(() => seedTwo(true));
       await vi.advanceTimersByTimeAsync(0);
 
-      // Stepping happens against the held order — "second" is still the row
-      // below "first" at the moment the key is pressed — and only then does the
-      // hold release. Selection is id-keyed, so it survives the re-rank.
-      fireEvent.keyDown(screen.getByTestId("pilot-search"), { key: "ArrowDown" });
+      fireEvent.pointerMove(screen.getAllByTestId("pilot-row")[0]!);
 
-      expect(
-        document.querySelector('[aria-selected="true"]')?.getAttribute("aria-label")
-      ).toContain("second");
+      expect(order()).toEqual(["first", "second"]);
+    });
+
+    it("parks a run that arrives during a hold, then ranks it on release", async () => {
+      seedTwo(false);
+      render(<PilotView />);
+      fireEvent.pointerMove(screen.getAllByTestId("pilot-row")[0]!);
+
+      act(() => {
+        seed([
+          run({ runId: "first", agentState: "working", title: "first", since: NOW - 10_000 }),
+          run({ runId: "second", agentState: "working", title: "second", since: NOW - 5_000 }),
+          run({
+            runId: "third",
+            agentState: "waiting",
+            waitingReason: "error",
+            title: "third",
+            since: NOW,
+          }),
+        ]);
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Nothing the capture never saw may displace a row the cursor is aimed
+      // at, so it waits at the tail...
+      expect(order()).toEqual(["first", "second", "third"]);
+
+      fireEvent.pointerLeave(document.getElementById("pilot-agent-list")!);
+
+      // ...and takes its real rank immediately, rather than being stranded at
+      // the end for the rest of the opening the way the old freeze left it.
+      expect(order()).toEqual(["third", "first", "second"]);
+    });
+
+    it("releases on a key consumed from the results region, not just from the input", async () => {
+      // After Tab the scroller owns the keyboard and forwards a fixed key set.
+      // A release wired only to the input path would leave the order held for
+      // anyone driving the list from there.
+      seedTwo(false);
+      render(<PilotView />);
+      fireEvent.pointerMove(screen.getAllByTestId("pilot-row")[0]!);
+      act(() => seedTwo(true));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(order()).toEqual(["first", "second"]);
+
+      fireEvent.keyDown(screen.getByRole("group", { name: "Agents" }), { key: "ArrowDown" });
+
+      expect(order()).toEqual(["second", "first"]);
+    });
+
+    it("releases the hold when the app goes to the background", async () => {
+      // Nothing else can: the cursor never moves while another app is focused,
+      // so no boundary event fires, and coming back to a ranking frozen since
+      // before you left is the staleness this replaced.
+      seedTwo(false);
+      render(<PilotView />);
+      fireEvent.pointerMove(screen.getAllByTestId("pilot-row")[0]!);
+      act(() => seedTwo(true));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(order()).toEqual(["first", "second"]);
+
+      act(() => {
+        window.dispatchEvent(new Event("blur"));
+      });
+
       expect(order()).toEqual(["second", "first"]);
     });
 

--- a/src/components/Pilot/__tests__/PilotView.test.tsx
+++ b/src/components/Pilot/__tests__/PilotView.test.tsx
@@ -198,12 +198,13 @@ describe("PilotView", () => {
   });
 
   it("names a row as a sentence rather than a run of jammed-together facts", () => {
-    // Left to the name-from-content computation these inline spans concatenate
-    // with no separators — "Fix authWorkingfeature-x2m". Naming the parts is
-    // what keeps the row a phrase, and what lets the age be read as an age.
+    // Left to the name-from-content computation the row's inline spans
+    // concatenate with no separators — "Fix auth2m". Naming the parts is what
+    // keeps the row a phrase, and what lets the age be read as an age.
     seed([
       run({
         runId: "a",
+        agentId: "claude",
         agentState: "waiting",
         title: "Fix auth",
         cwd: "/repo/feature-x",
@@ -213,24 +214,58 @@ describe("PilotView", () => {
     render(<PilotView />);
 
     expect(screen.getByTestId("pilot-row").getAttribute("aria-label")).toBe(
-      "Fix auth, Waiting, feature-x, 2m ago"
+      "Fix auth, Claude, Waiting, 2m ago"
     );
   });
 
   it("leaves no dangling separator when a run has no age to report", () => {
-    seed([run({ runId: "a", agentState: "working", title: "Fix auth", cwd: "/repo/feature-x" })]);
+    seed([
+      run({
+        runId: "a",
+        agentId: "claude",
+        agentState: "working",
+        title: "Fix auth",
+        cwd: "/repo/feature-x",
+      }),
+    ]);
     render(<PilotView />);
 
     expect(screen.getByTestId("pilot-row").getAttribute("aria-label")).toBe(
-      "Fix auth, Working, feature-x"
+      "Fix auth, Claude, Working"
     );
   });
 
-  it("spends colour only on the agents that are actually asking for something", () => {
-    // The whole point of the surface. One blocked agent among six working ones
-    // has to be the only status word on screen — six green labels beside one
-    // amber one is the wall this replaced, where nothing stood out because
-    // everything was shouting.
+  it("tells two identically-titled runs apart by the agent behind them", () => {
+    // The brand is on the row as an icon only, so without it in the name the
+    // two are one string to a screen reader — and search already matches on it,
+    // because "codex" is a plausible thing to type when looking for one.
+    seed([
+      run({ runId: "a", agentId: "claude", agentState: "working", title: "same", since: NOW }),
+      run({ runId: "b", agentId: "codex", agentState: "working", title: "same", since: NOW }),
+    ]);
+    render(<PilotView />);
+
+    const names = screen.getAllByTestId("pilot-row").map((r) => r.getAttribute("aria-label"));
+    expect(names).toHaveLength(2);
+    expect(new Set(names).size).toBe(2);
+  });
+
+  it("does not repeat the agent's name when the title already is it", () => {
+    // An untitled run falls back to its agent's name for the title, and
+    // "Claude, Claude" is a separator promising a second fact and
+    // then not delivering one.
+    seed([run({ runId: "a", agentId: "claude", agentState: "working", since: NOW })]);
+    render(<PilotView />);
+
+    const name = screen.getByTestId("pilot-row").getAttribute("aria-label") ?? "";
+    expect(name).toContain("Claude");
+    expect(name.match(/Claude/g)).toHaveLength(1);
+  });
+
+  it("stops spending row width on a status word the glyph already carries", () => {
+    // Seven rows, seven states, and not one of them prints what it is doing.
+    // The word cost width beside a title that was already truncating, and the
+    // glyph two columns to its left had said the same thing.
     seed([
       run({
         runId: "blocked",
@@ -247,17 +282,31 @@ describe("PilotView", () => {
 
     const rows = screen.getAllByTestId("pilot-row");
     expect(rows).toHaveLength(7);
-
-    // Rendered text is what the eye sees, and only the demand row spends a
-    // word on its state — the six working rows say nothing visible about
-    // theirs.
-    const withVisibleStatus = rows.filter((row) => /Blocked|Working/.test(row.textContent ?? ""));
-    expect(withVisibleStatus).toHaveLength(1);
-    expect(withVisibleStatus[0]!.textContent).toContain("Blocked");
+    expect(rows.filter((row) => /Blocked|Working/.test(row.textContent ?? ""))).toHaveLength(0);
 
     // ...and every one of the seven still says what it is doing, in text.
     expect(screen.getAllByRole("option", { name: /Working/ })).toHaveLength(6);
     expect(screen.getAllByRole("option", { name: /Blocked/ })).toHaveLength(1);
+  });
+
+  it("keeps the worktree searchable after it stops being drawn", () => {
+    // A scratch project's directory is a UUID, so the label was charging the
+    // title for width to say nothing readable. Typing a branch name to find a
+    // run is still useful, which is why the field stays on the row.
+    seed([
+      run({ runId: "a", agentState: "working", title: "one", cwd: "/repo/feature-x", since: NOW }),
+      run({ runId: "b", agentState: "working", title: "two", cwd: "/repo/main-line", since: NOW }),
+    ]);
+    render(<PilotView />);
+
+    const first = screen.getAllByTestId("pilot-row")[0]!;
+    expect(first.textContent).not.toContain("feature-x");
+    expect(first.getAttribute("aria-label")).not.toContain("feature-x");
+
+    fireEvent.change(screen.getByTestId("pilot-search"), { target: { value: "feature-x" } });
+
+    expect(screen.getAllByTestId("pilot-row")).toHaveLength(1);
+    expect(screen.getByText("one")).toBeTruthy();
   });
 
   it("marks the workspace this view already owns", () => {

--- a/src/components/Pilot/__tests__/PilotView.test.tsx
+++ b/src/components/Pilot/__tests__/PilotView.test.tsx
@@ -193,7 +193,7 @@ describe("PilotView", () => {
     ]);
     render(<PilotView />);
 
-    expect(screen.getByRole("option", { name: /Needs you/ }).textContent).toContain("one");
+    expect(screen.getByRole("option", { name: /Waiting/ }).textContent).toContain("one");
     expect(screen.getByRole("option", { name: /Idle/ }).textContent).toContain("two");
   });
 
@@ -213,7 +213,7 @@ describe("PilotView", () => {
     render(<PilotView />);
 
     expect(screen.getByTestId("pilot-row").getAttribute("aria-label")).toBe(
-      "Fix auth, Needs you, feature-x, 2m ago"
+      "Fix auth, Waiting, feature-x, 2m ago"
     );
   });
 
@@ -852,7 +852,7 @@ describe("PilotView", () => {
       render(<PilotView />);
       expect(rowTitles()).toHaveLength(4);
 
-      fireEvent.click(segment(/Needs you/));
+      fireEvent.click(segment(/Waiting/));
 
       expect(rowTitles()).toHaveLength(2);
       expect(rowTitles().join(" ")).toContain("auth blocked");
@@ -867,7 +867,7 @@ describe("PilotView", () => {
       fireEvent.change(screen.getByTestId("pilot-search"), { target: { value: "auth" } });
       expect(rowTitles()).toHaveLength(2);
 
-      fireEvent.click(segment(/Needs you/));
+      fireEvent.click(segment(/Waiting/));
 
       expect(rowTitles()).toHaveLength(1);
       expect(rowTitles()[0]).toContain("auth blocked");
@@ -883,7 +883,7 @@ describe("PilotView", () => {
       fireEvent.change(screen.getByTestId("pilot-search"), { target: { value: "auth" } });
 
       expect(segment(/^All/).getAttribute("aria-label")).toBe("All, 2 agents");
-      expect(segment(/Needs you/).getAttribute("aria-label")).toBe("Needs you, 1 agent");
+      expect(segment(/Waiting/).getAttribute("aria-label")).toBe("Waiting, 1 agent");
       expect(segment(/Working/).getAttribute("aria-label")).toBe("Working, 1 agent");
     });
 
@@ -894,14 +894,14 @@ describe("PilotView", () => {
       render(<PilotView />);
       const before = screen.getAllByRole("radio").map((el) => el.getAttribute("aria-label"));
 
-      fireEvent.click(segment(/Needs you/));
+      fireEvent.click(segment(/Waiting/));
 
       expect(screen.getAllByRole("radio").map((el) => el.getAttribute("aria-label"))).toEqual(
         before
       );
     });
 
-    it("sorts review into Finished and out of Needs you", () => {
+    it("sorts review into Finished and out of Waiting", () => {
       // The asymmetry worth pinning: `review` IS a demand band, so it counts
       // toward `demandCount`, but the Needs-you segment is blocked + needs-you
       // only. A review row must land in exactly one of the two segments.
@@ -911,7 +911,7 @@ describe("PilotView", () => {
       ]);
       render(<PilotView />);
 
-      expect(segment(/Needs you/).getAttribute("aria-label")).toBe("Needs you, 1 agent");
+      expect(segment(/Waiting/).getAttribute("aria-label")).toBe("Waiting, 1 agent");
       expect(segment(/Finished/).getAttribute("aria-label")).toBe("Finished, 1 agent");
 
       fireEvent.click(segment(/Finished/));
@@ -949,7 +949,7 @@ describe("PilotView", () => {
       render(<PilotView />);
       expect(rowTitles().join(" ")).not.toContain("auth blocked");
 
-      fireEvent.click(segment(/Needs you/));
+      fireEvent.click(segment(/Waiting/));
 
       // Same rule the query already follows: making someone click to reveal
       // what they just filtered for is the narrowing failing to do its job.
@@ -959,7 +959,7 @@ describe("PilotView", () => {
     it("scopes a collapse made under a filter to that filter", () => {
       seedMixedFleet();
       render(<PilotView />);
-      fireEvent.click(segment(/Needs you/));
+      fireEvent.click(segment(/Waiting/));
 
       fireEvent.click(screen.getAllByTestId("pilot-group-toggle")[0]!);
       expect(rowTitles()).toHaveLength(0);
@@ -1125,7 +1125,7 @@ describe("PilotView", () => {
           }),
         ]);
       });
-      fireEvent.click(screen.getByRole("radio", { name: /Needs you/ }));
+      fireEvent.click(screen.getByRole("radio", { name: /Waiting/ }));
       // Asserted WHILE narrowed, not only after returning to All: a filter that
       // re-derived the order would be invisible if the check waited until the
       // pinned order had been restored anyway.
@@ -1153,7 +1153,7 @@ describe("PilotView", () => {
     it("starts every opening back at All", () => {
       seedMixedFleet();
       const view = render(<PilotView />);
-      fireEvent.click(segment(/Needs you/));
+      fireEvent.click(segment(/Waiting/));
       expect(rowTitles()).toHaveLength(2);
 
       usePilotStore.setState({ isOpen: false });
@@ -1193,7 +1193,7 @@ describe("PilotView", () => {
     });
 
     it("delivers its count even when its filter is already the active one", () => {
-      // With the filter already on Needs you, setting it again is a no-op, so
+      // With the filter already on Waiting, setting it again is a no-op, so
       // nothing clears a collapse the user made — and the button would go on
       // advertising agents while showing none of them.
       seed([
@@ -1202,7 +1202,7 @@ describe("PilotView", () => {
       ]);
       render(<PilotView />);
 
-      fireEvent.click(screen.getByRole("radio", { name: /Needs you/ }));
+      fireEvent.click(screen.getByRole("radio", { name: /Waiting/ }));
       fireEvent.click(screen.getByTestId("pilot-group-toggle"));
       expect(screen.queryAllByTestId("pilot-row")).toHaveLength(0);
 

--- a/src/components/Pilot/__tests__/PilotView.test.tsx
+++ b/src/components/Pilot/__tests__/PilotView.test.tsx
@@ -99,7 +99,7 @@ beforeEach(() => {
   dispatchMock.mockClear();
   seedViewWorkspace(null);
   seed(null);
-  usePilotStore.setState({ isOpen: true, collapsedWorkspaceIds: [] });
+  usePilotStore.setState({ isOpen: true });
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test carrier: only id/name are read
   useProjectStore.setState({ projects: [{ id: "p1", name: "daintree" }] } as Partial<
     ReturnType<typeof useProjectStore.getState>
@@ -399,29 +399,6 @@ describe("PilotView", () => {
     expect(screen.getByText("Rebuild the fleet snapshot")).toBeTruthy();
   });
 
-  it("collapses a project's rows while keeping its header", () => {
-    seed([run({ agentState: "working", since: NOW - 10_000 })]);
-    render(<PilotView />);
-    expect(screen.getAllByTestId("pilot-row")).toHaveLength(1);
-
-    const toggle = screen.getByTestId("pilot-group-toggle");
-    expect(toggle.getAttribute("aria-expanded")).toBe("true");
-    fireEvent.click(toggle);
-
-    expect(screen.queryByTestId("pilot-row")).toBeNull();
-    expect(screen.getByTestId("pilot-group-header")).toBeTruthy();
-    expect(screen.getByTestId("pilot-group-toggle").getAttribute("aria-expanded")).toBe("false");
-  });
-
-  it("keeps the project out of the tab order", () => {
-    // The search box owns the keyboard. A focusable disclosure inside the list
-    // would put a tab stop between the query and the results.
-    seed([run({ agentState: "working", since: NOW - 10_000 })]);
-    render(<PilotView />);
-
-    expect(screen.getByTestId("pilot-group-toggle").getAttribute("tabindex")).toBe("-1");
-  });
-
   it("filters rows by title and drops projects left with nothing", () => {
     seed([
       run({ runId: "a", workspaceId: "p1", agentState: "working", title: "auth refactor" }),
@@ -435,55 +412,6 @@ describe("PilotView", () => {
     expect(screen.getAllByTestId("pilot-group-header")).toHaveLength(1);
     expect(screen.getByText("auth refactor")).toBeTruthy();
     expect(screen.queryByText("docs pass")).toBeNull();
-  });
-
-  it("reveals matches inside a collapsed project rather than hiding them", () => {
-    seed([run({ agentState: "working", title: "auth refactor" })]);
-    usePilotStore.setState({ isOpen: true, collapsedWorkspaceIds: ["p1"] });
-    render(<PilotView />);
-    expect(screen.queryByTestId("pilot-row")).toBeNull();
-
-    fireEvent.change(screen.getByTestId("pilot-search"), { target: { value: "auth" } });
-
-    // Making someone click to reveal what they just searched for is the search
-    // failing to do its job.
-    expect(screen.getByText("auth refactor")).toBeTruthy();
-  });
-
-  it("restores the collapsed state when the search is cleared", () => {
-    seed([run({ agentState: "working", title: "auth refactor" })]);
-    usePilotStore.setState({ isOpen: true, collapsedWorkspaceIds: ["p1"] });
-    render(<PilotView />);
-
-    const search = screen.getByTestId("pilot-search");
-    fireEvent.change(search, { target: { value: "auth" } });
-    expect(screen.getByText("auth refactor")).toBeTruthy();
-
-    fireEvent.change(search, { target: { value: "" } });
-    expect(screen.queryByTestId("pilot-row")).toBeNull();
-  });
-
-  it("keeps the collapse toggle live during a search without editing the saved set", () => {
-    seed([
-      run({ runId: "a", workspaceId: "p1", agentState: "working", title: "auth one" }),
-      run({ runId: "b", workspaceId: "p1", agentState: "working", title: "auth two" }),
-    ]);
-    render(<PilotView />);
-
-    fireEvent.change(screen.getByTestId("pilot-search"), { target: { value: "auth" } });
-    expect(screen.getAllByTestId("pilot-row")).toHaveLength(2);
-
-    // Collapsing during a search must actually collapse — a header whose
-    // aria-expanded never moves is a dead control.
-    fireEvent.click(screen.getByTestId("pilot-group-toggle"));
-    expect(screen.queryByTestId("pilot-row")).toBeNull();
-
-    // ...and it must not leak into the persisted set, or the group would
-    // mysteriously stay collapsed long after the search ended.
-    expect(usePilotStore.getState().collapsedWorkspaceIds).toEqual([]);
-
-    fireEvent.change(screen.getByTestId("pilot-search"), { target: { value: "" } });
-    expect(screen.getAllByTestId("pilot-row")).toHaveLength(2);
   });
 
   describe("Escape", () => {
@@ -527,26 +455,6 @@ describe("PilotView", () => {
       fireEvent.keyDown(screen.getByTestId("pilot-search"), { key: "Escape" });
 
       expect(usePilotStore.getState().isOpen).toBe(false);
-    });
-
-    it("starts the next search fully expanded", () => {
-      seed([
-        run({ runId: "a", workspaceId: "p1", agentState: "working", title: "auth one" }),
-        run({ runId: "b", workspaceId: "p1", agentState: "working", title: "auth two" }),
-      ]);
-      renderWithEscape();
-
-      const search = screen.getByTestId("pilot-search");
-      fireEvent.change(search, { target: { value: "auth" } });
-      fireEvent.click(screen.getByTestId("pilot-group-toggle"));
-      expect(screen.queryByTestId("pilot-row")).toBeNull();
-
-      // A collapse made during one search is scoped to it. Carrying it forward
-      // would hide matches the next search went looking for.
-      fireEvent.change(search, { target: { value: "" } });
-      fireEvent.change(search, { target: { value: "auth" } });
-
-      expect(screen.getAllByTestId("pilot-row")).toHaveLength(2);
     });
   });
 
@@ -728,8 +636,7 @@ describe("PilotView", () => {
       seedTwoProjects();
       render(<PilotView />);
 
-      // Every selectable row is an agent, so Enter has exactly one meaning —
-      // it can no longer land on a project and collapse it by accident.
+      // Every selectable row is an agent, so Enter has exactly one meaning.
       press("Enter");
 
       expect(dispatchMock).toHaveBeenCalledWith("pilot.openRun", {
@@ -738,86 +645,36 @@ describe("PilotView", () => {
       });
     });
 
-    it("collapses with Left and expands with Right, acting on the selected agent's project", () => {
-      seedTwoProjects();
-      render(<PilotView />);
-      expect(selected().text).toContain("alpha");
-
-      // No project is ever selected, so the disclosure keys act on the group
-      // holding the current agent rather than on a highlighted header.
-      press("ArrowLeft");
-      expect(screen.getAllByTestId("pilot-row")).toHaveLength(1);
-      expect(screen.getAllByTestId("pilot-group-toggle")[0]!.getAttribute("aria-expanded")).toBe(
-        "false"
-      );
-
-      // Selection followed the collapse out to a still-visible agent.
-      expect(selected().text).toContain("charlie");
-
-      press("ArrowRight");
-      expect(screen.getAllByTestId("pilot-row")).toHaveLength(3);
-    });
-
-    it("can reopen a project after collapsing every one of them", () => {
-      // Collapsing the last expanded project empties the list. The disclosures
-      // are not tab stops, so if Right bailed on an empty list the keyboard
-      // user would be shut out of their own fleet with no way back.
-      seedTwoProjects();
-      render(<PilotView />);
-
-      press("ArrowLeft");
-      press("ArrowLeft");
-      expect(screen.queryByTestId("pilot-row")).toBeNull();
-
-      press("ArrowRight");
-      expect(screen.getAllByTestId("pilot-row").length).toBeGreaterThan(0);
-    });
-
-    it("moves the highlight out of a group it collapses", () => {
-      seedTwoProjects();
-      render(<PilotView />);
-      expect(selected().text).toContain("alpha");
-
-      fireEvent.click(screen.getAllByTestId("pilot-group-toggle")[0]!);
-
-      // "alpha" has left the list. A highlight still pointing at it would leave
-      // Enter committing a row that isn't on screen.
-      expect(selected()).toMatchObject({
-        role: "option",
-        text: expect.stringContaining("charlie"),
-      });
-    });
-
     it("leaves the caret alone while there is a query to edit", () => {
       seedTwoProjects();
       render(<PilotView />);
 
       fireEvent.change(screen.getByTestId("pilot-search"), { target: { value: "a" } });
-      const before = screen.getAllByTestId("pilot-row").length;
 
-      // Left/Right are the tree's structural keys AND the search box's editing
-      // keys, and the box owns focus. With text in it, the caret wins.
-      press("ArrowLeft");
-      expect(screen.getAllByTestId("pilot-row")).toHaveLength(before);
+      // Home/End are the list's structural keys AND the search box's editing
+      // keys, and the box owns focus. With text in it, the caret wins, so the
+      // highlight must not jump to the last row.
+      press("End");
+      expect(selected().text).toContain("alpha");
       // ...but Up/Down never belong to a single-line caret.
       press("ArrowDown");
       expect(selected().text).not.toContain("alpha");
     });
 
-    it("still collapses from the results region after Tab moves focus there", () => {
+    it("hands the horizontal arrows to the caret outright", () => {
+      // With no disclosure the list has no horizontal axis, so neither the
+      // input nor the results region may cancel these — a palette that eats a
+      // key it does nothing with is a palette the browser can't work around.
       seedTwoProjects();
       render(<PilotView />);
 
-      // Tab moves focus off the input onto the scroll region, which forwards a
-      // fixed key set to the palette. Vertical movement survived that move
-      // already; the disclosure half has to as well, or the region is half a
-      // keyboard.
-      const region = screen.getByRole("group", { name: "Agents" });
-      fireEvent.keyDown(region, { key: "ArrowLeft" });
-      expect(screen.getAllByTestId("pilot-row")).toHaveLength(1);
+      const search = screen.getByTestId("pilot-search");
+      expect(fireEvent.keyDown(search, { key: "ArrowLeft" })).toBe(true);
+      expect(fireEvent.keyDown(search, { key: "ArrowRight" })).toBe(true);
 
-      fireEvent.keyDown(region, { key: "ArrowRight" });
-      expect(screen.getAllByTestId("pilot-row")).toHaveLength(3);
+      const region = screen.getByRole("group", { name: "Agents" });
+      expect(fireEvent.keyDown(region, { key: "ArrowLeft" })).toBe(true);
+      expect(fireEvent.keyDown(region, { key: "ArrowRight" })).toBe(true);
     });
 
     it("leaves the keys alone when there is nothing listed to navigate", () => {
@@ -990,34 +847,6 @@ describe("PilotView", () => {
       // Enter committing a row that is no longer listed is the bug this guards.
       const selected = document.querySelector('[aria-selected="true"]');
       expect(selected?.textContent).toContain("auth working");
-    });
-
-    it("opens a persistently collapsed group that the filter matches", () => {
-      seedMixedFleet();
-      usePilotStore.setState({ isOpen: true, collapsedWorkspaceIds: ["p1"] });
-      render(<PilotView />);
-      expect(rowTitles().join(" ")).not.toContain("auth blocked");
-
-      fireEvent.click(segment(/Waiting/));
-
-      // Same rule the query already follows: making someone click to reveal
-      // what they just filtered for is the narrowing failing to do its job.
-      expect(rowTitles().join(" ")).toContain("auth blocked");
-    });
-
-    it("scopes a collapse made under a filter to that filter", () => {
-      seedMixedFleet();
-      render(<PilotView />);
-      fireEvent.click(segment(/Waiting/));
-
-      fireEvent.click(screen.getAllByTestId("pilot-group-toggle")[0]!);
-      expect(rowTitles()).toHaveLength(0);
-      // It must not leak into the persisted set, or the group would stay
-      // collapsed long after the filter was cleared.
-      expect(usePilotStore.getState().collapsedWorkspaceIds).toEqual([]);
-
-      fireEvent.click(segment(/^All/));
-      expect(rowTitles()).toHaveLength(4);
     });
 
     it("keeps the bar reachable when the narrowing leaves nothing", () => {
@@ -1241,25 +1070,6 @@ describe("PilotView", () => {
       expect(screen.getAllByTestId("pilot-row")).toHaveLength(2);
     });
 
-    it("delivers its count even when its filter is already the active one", () => {
-      // With the filter already on Waiting, setting it again is a no-op, so
-      // nothing clears a collapse the user made — and the button would go on
-      // advertising agents while showing none of them.
-      seed([
-        run({ runId: "a", agentState: "waiting", title: "one", since: NOW - 60_000 }),
-        run({ runId: "b", agentState: "waiting", title: "two", since: NOW - 30_000 }),
-      ]);
-      render(<PilotView />);
-
-      fireEvent.click(screen.getByRole("radio", { name: /Waiting/ }));
-      fireEvent.click(screen.getByTestId("pilot-group-toggle"));
-      expect(screen.queryAllByTestId("pilot-row")).toHaveLength(0);
-
-      fireEvent.click(screen.getByTestId("pilot-demand-action"));
-
-      expect(screen.getAllByTestId("pilot-row")).toHaveLength(2);
-    });
-
     it("does not count work awaiting review as a demand it can isolate", () => {
       // `review` is a demand band but NOT part of the Needs-you segment, so
       // counting it here would promise agents the button then failed to show.
@@ -1310,53 +1120,50 @@ describe("PilotView", () => {
   });
 
   describe("group headers", () => {
-    it("summarises a project only once its rows are gone", () => {
-      // Expanded, the rows ARE the summary; a sentence restating them is a
-      // third thing to read for facts already on screen.
+    it("carries the project's name to every option filed under it", () => {
+      // The header is not an item, so a screen reader learns which project a
+      // run belongs to from the enclosing group's name and nowhere else.
       seed([
-        run({
-          runId: "a",
-          agentState: "waiting",
-          waitingReason: "error",
-          title: "one",
-          since: NOW - 60_000,
-        }),
-        run({ runId: "b", agentState: "working", title: "two", since: NOW - 60_000 }),
+        run({ runId: "a", workspaceId: "p1", agentState: "working", since: NOW - 60_000 }),
+        run({ runId: "b", workspaceId: "s1", agentState: "working", since: NOW - 60_000 }),
       ]);
       render(<PilotView />);
 
-      const header = () => screen.getByTestId("pilot-group-header").textContent ?? "";
-      // Expanded, the header is structure and nothing else — no prose summary,
-      // no counts.
-      expect(header()).not.toContain("Agent blocked");
-      expect(header()).not.toMatch(/\d/);
-
-      fireEvent.click(screen.getByTestId("pilot-group-toggle"));
-
-      // Collapsed, something has to stop a project hiding a blocked agent
-      // behind a chevron — one pip per band present, each with its count.
-      expect(header()).toMatch(/\d/);
+      const names = screen.getAllByRole("group").map((g) => g.getAttribute("aria-label"));
+      expect(names).toContain("daintree");
+      expect(names).toContain("spike");
     });
 
-    it("reports a collapsed project's blocked agent through the toggle's name", () => {
+    it("names the current workspace in the group's own label, not just on screen", () => {
+      // Which workspace you are already in decides whether opening a run is
+      // instant or swaps the whole view. The header renders that as a word and
+      // then hides it, so without this the fact is visual-only.
+      seedViewWorkspace("p1");
       seed([
-        run({
-          runId: "a",
-          agentState: "waiting",
-          waitingReason: "error",
-          title: "one",
-          since: NOW - 60_000,
-        }),
-        run({ runId: "b", agentState: "working", title: "two", since: NOW - 60_000 }),
+        run({ runId: "a", workspaceId: "p1", agentState: "working", since: NOW - 60_000 }),
+        run({ runId: "b", workspaceId: "s1", agentState: "working", since: NOW - 60_000 }),
       ]);
-      usePilotStore.setState({ isOpen: true, collapsedWorkspaceIds: ["p1"] });
       render(<PilotView />);
 
-      // The pips are decorative; the accessible account is the toggle's label,
-      // and it has to carry the demand in both states.
-      const label = screen.getByTestId("pilot-group-toggle").getAttribute("aria-label") ?? "";
-      expect(label).toContain("daintree");
-      expect(label).toContain("Agent blocked");
+      const labelled = screen
+        .getAllByRole("group")
+        .map((g) => g.getAttribute("aria-label") ?? "")
+        .filter((label) => label.includes("current workspace"));
+
+      expect(labelled).toHaveLength(1);
+      expect(labelled[0]).toContain("daintree");
+    });
+
+    it("is not a control, so the list holds nothing but options", () => {
+      // A `<button>` inside a `role="group"` inside a `role="listbox"` was
+      // never structurally right: a listbox's children are options. The
+      // disclosure it served is gone with it.
+      seed([run({ agentState: "working", since: NOW - 10_000 })]);
+      render(<PilotView />);
+
+      expect(screen.getByTestId("pilot-group-header")).toBeTruthy();
+      expect(screen.queryByTestId("pilot-group-toggle")).toBeNull();
+      expect(screen.getByRole("listbox").querySelector("button")).toBeNull();
     });
   });
 

--- a/src/components/Pilot/__tests__/PilotView.test.tsx
+++ b/src/components/Pilot/__tests__/PilotView.test.tsx
@@ -348,6 +348,33 @@ describe("PilotView", () => {
     expect(screen.getByTestId("pilot-stale").textContent).toContain("12m");
   });
 
+  it("qualifies the summary as last-known while the feed is stale", () => {
+    // The stale banner sits directly above this sentence. An unqualified
+    // "Nothing needs you" underneath it is the surface making a live all-clear
+    // claim out of data it cannot currently see.
+    seed([run({ agentState: "working", title: "one", since: NOW - 60_000 })], {
+      degraded: true,
+      lastSuccessfulAt: NOW - 12 * 60_000,
+    });
+    render(<PilotView />);
+
+    const live = "Nothing needs you · 1 agent working";
+    expect(screen.queryByText(live)).toBeNull();
+    expect(screen.getByText(new RegExp(live.replace(/[·]/g, "\\$&")))).toBeTruthy();
+    expect(screen.getByTestId("pilot-summary").textContent).toMatch(/last known/i);
+  });
+
+  it("does not offer the zero-data prompt over a retained empty fleet", () => {
+    // "Start an agent in any project" over a feed that stopped answering an
+    // hour ago presents an unknown as an all-clear. The banner is the only
+    // honest thing this state can say.
+    seed([], { degraded: true, lastSuccessfulAt: NOW - 12 * 60_000 });
+    render(<PilotView />);
+
+    expect(screen.getByTestId("pilot-stale")).toBeTruthy();
+    expect(screen.queryByText(EMPTY_FLEET_COPY)).toBeNull();
+  });
+
   it("leads with the demand count when agents need the user", () => {
     seed([
       run({ runId: "a", agentState: "waiting", waitingReason: "error", since: NOW - 60_000 }),
@@ -1067,6 +1094,21 @@ describe("PilotView", () => {
       // The sentence stated a demand the surface gave no way to act on. As a
       // control it has to deliver the number it advertised.
       expect(screen.getAllByTestId("pilot-row")).toHaveLength(2);
+    });
+
+    it("hands focus back to the search box after applying its filter", () => {
+      // The footer goes on advertising "↑↓ Navigate" while focus sits on the
+      // button, where the body's handler bails on events that did not come from
+      // the scroller — so the arrows it names do nothing at all.
+      seed([
+        run({ runId: "a", agentState: "waiting", title: "one", since: NOW - 60_000 }),
+        run({ runId: "b", agentState: "waiting", title: "two", since: NOW - 30_000 }),
+      ]);
+      render(<PilotView />);
+
+      fireEvent.click(screen.getByTestId("pilot-demand-action"));
+
+      expect(document.activeElement).toBe(screen.getByTestId("pilot-search"));
     });
 
     it("does not count work awaiting review as a demand it can isolate", () => {

--- a/src/components/Pilot/__tests__/pilotRows.test.ts
+++ b/src/components/Pilot/__tests__/pilotRows.test.ts
@@ -6,10 +6,17 @@ import {
   filterPilotBands,
   filterPilotGroups,
   summarizePilotGroups,
+  PILOT_BAND_FILTER_LABEL,
   type PilotRowContext,
 } from "../pilotRows";
 import type { FleetRunRow } from "@shared/types/ipc/fleet";
-import { emptyBandCounts, FLEET_BANDS, type FleetBand } from "@/lib/fleetAttention";
+import {
+  bandForRun,
+  bandLabel,
+  emptyBandCounts,
+  FLEET_BANDS,
+  type FleetBand,
+} from "@/lib/fleetAttention";
 
 const NOW = 1_700_000_000_000;
 
@@ -802,10 +809,23 @@ describe("bandFilterHasDemand", () => {
   });
 
   it("never reports a demand for Working or All", () => {
-    // Working holds none by definition; All is the null option and colouring it
-    // would hue the bar whenever the fleet held anything at all.
+    // Working holds none by definition; All is the null option and reporting a
+    // demand for it would make the answer "the fleet holds anything at all".
+    // The bar hues Working anyway, deliberately and around this function —
+    // see `segmentIsHued` in `PilotFilterBar`.
     expect(bandFilterHasDemand(bands({ running: 5 }), "working")).toBe(false);
     expect(bandFilterHasDemand(bands({ blocked: 5 }), "all")).toBe(false);
+  });
+});
+
+describe("state vocabulary", () => {
+  it("calls a waiting run the same thing on the row as on the segment that filters to it", () => {
+    // The segment and the row's status word are two surfaces naming one state.
+    // They drifted once — "Needs you" here against the sidebar's "Waiting" —
+    // and one state with two names is a vocabulary the user has to learn twice.
+    const waiting = run({ agentState: "waiting", waitingReason: "question" });
+
+    expect(bandLabel(bandForRun(waiting), waiting)).toBe(PILOT_BAND_FILTER_LABEL["needs-you"]);
   });
 });
 

--- a/src/components/Pilot/pilotRows.ts
+++ b/src/components/Pilot/pilotRows.ts
@@ -3,13 +3,12 @@ import type { FleetBand, FleetBandCounts } from "@/lib/fleetAttention";
 import {
   bandForRun,
   bandLabel,
-  BAND_TONE,
   compareWithinBand,
   emptyBandCounts,
   FLEET_BANDS,
   isDemandBand,
 } from "@/lib/fleetAttention";
-import { formatWaitAge, type ProjectRowTone } from "@/lib/projectRowStatus";
+import { formatWaitAge } from "@/lib/projectRowStatus";
 import { isFilterMatch } from "@/lib/projectSwitcherSearch";
 import { composeTitledPanel } from "@/utils/terminalTitleDisplay";
 import { deriveTerminalChrome, type TerminalChromeDescriptor } from "@/utils/terminalChrome";
@@ -26,11 +25,20 @@ export interface PilotRow {
   chrome: TerminalChromeDescriptor;
   /** Preset colour when the user picked one, which `BrandMark` treats as deliberate. */
   presetColor: string | undefined;
-  /** What the run is doing, in the same words the switcher uses for the same state. */
+  /**
+   * What the run is doing, in the same words the switcher uses for the same
+   * state. Not drawn — the glyph says this now — but it carries the state into
+   * the row's accessible name, which is where it may never stop being text.
+   */
   statusLabel: string;
-  /** Status colour for {@link statusLabel}. Always a status token, never the accent. */
-  tone: ProjectRowTone;
-  /** Worktree label, or null when it would only repeat the project name. */
+  /**
+   * Worktree label, or null when it would only repeat the project name.
+   *
+   * Not drawn either: a scratch project's directory is a UUID, and the title
+   * was truncating to make room for a string nobody can read. It stays on the
+   * row because {@link filterPilotGroups} matches on it — typing a branch name
+   * to find a run is useful whether or not the label is on screen.
+   */
   worktreeLabel: string | null;
   /** Compact age of the current state, or null when the run never recorded one. */
   age: string | null;
@@ -241,7 +249,6 @@ export function buildPilotGroups(
         chrome,
         presetColor: run.agentPresetColor,
         statusLabel: bandLabel(band, run),
-        tone: BAND_TONE[band],
         worktreeLabel: disambiguatingLabel(directoryLabel(run.cwd), name),
         age: run.since !== undefined ? formatWaitAge(run.since, ctx.nowMs) : null,
       };

--- a/src/components/Pilot/pilotRows.ts
+++ b/src/components/Pilot/pilotRows.ts
@@ -376,10 +376,14 @@ export const PILOT_BAND_FILTERS: readonly Exclude<PilotBandFilter, "all">[] = [
  * A segment's name, declared here rather than in the bar because two surfaces
  * say it: the segment itself, and the empty state that has to name which filter
  * produced no rows.
+ *
+ * "Waiting", not "Needs you", so the four segments read the same here as they
+ * do in the sidebar's `QuickStateFilterBar`. The key stays `needs-you` — it
+ * names the band set, which has not changed.
  */
 export const PILOT_BAND_FILTER_LABEL: Record<PilotBandFilter, string> = {
   all: "All",
-  "needs-you": "Needs you",
+  "needs-you": "Waiting",
   working: "Working",
   finished: "Finished",
 };

--- a/src/components/Pilot/pilotRows.ts
+++ b/src/components/Pilot/pilotRows.ts
@@ -113,11 +113,10 @@ function rank(band: FleetBand): number {
  * recomputed rather than inherited.
  *
  * `topBand` is found by RANK across the survivors rather than read off
- * `rows[0]`. Rows reaching a filter have already been through `frozenOrder`,
- * which pins the order captured when the dialog opened — so once a run changes
- * state the first row is no longer guaranteed to be the worst one present.
- * Inheriting either field would put a header's summary and its collapsed pip
- * cluster at odds with the rows directly underneath it.
+ * `rows[0]`. Rows reaching a filter may have been re-sorted into an order the
+ * fleet overview is holding still under a pointer, so the first row is not
+ * guaranteed to be the worst one present. Inheriting either field would put a
+ * group's derived facts at odds with the rows directly underneath it.
  */
 function narrowGroup(group: PilotProjectGroup, rows: PilotRow[]): PilotProjectGroup {
   let topBand: FleetBand = "idle";

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -15,6 +15,7 @@ export {
   ChartNoAxesColumn, // frecency sort order ("Most used" — decayed access score)
   CircleCheck, // finished run awaiting review (Pilot's review band)
   CircleHelp, // workspace whose metadata is missing (removed while its agents ran)
+  CircleSlash, // agent stopped on an error, distinct in shape from a waiting one (Pilot's blocked band)
   Clock, // recency sort order (most recently opened first)
   FileText, // view selected file path in the read-only file viewer
   FolderGit2, // git worktree (single)

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -375,19 +375,14 @@ AppPaletteDialog.Header = function AppPaletteHeader({
  * scroll container itself holds focus. Tab and Shift+Tab are deliberately
  * absent: the container is a real tab stop (see `tabIndex` below) and palettes
  * such as the project switcher render controls after it that must stay
- * reachable by native traversal. PageUp/PageDown/Space are left to the
- * browser so the region keeps its native scrolling.
+ * reachable by native traversal. Space is left to the browser so the region
+ * keeps its native scrolling. The horizontal arrows were here for the one
+ * palette with collapsible groups and left with it (#11669); no list on this
+ * shell has a horizontal axis now.
  */
 const BODY_NAVIGATION_KEYS = new Set([
   "ArrowUp",
   "ArrowDown",
-  // Horizontal arrows carry the disclosure half of the tree pattern for palettes
-  // whose list has collapsible groups (`PilotView`). Withholding them left the
-  // region able to move between rows but not in or out of a group, which is
-  // half a keyboard. Flat-list palettes have no case for them and ignore them,
-  // uncancelled, exactly as they did before.
-  "ArrowLeft",
-  "ArrowRight",
   "Home",
   "End",
   "Enter",

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -379,10 +379,17 @@ AppPaletteDialog.Header = function AppPaletteHeader({
  * keeps its native scrolling. The horizontal arrows were here for the one
  * palette with collapsible groups and left with it (#11669); no list on this
  * shell has a horizontal axis now.
+ *
+ * The page keys are NOT left to native scrolling, which is what they used to
+ * be: scrolling the viewport without moving the selection walks the highlighted
+ * row off screen and leaves Enter committing something the user can no longer
+ * see. Palettes move the selection by a page instead.
  */
 const BODY_NAVIGATION_KEYS = new Set([
   "ArrowUp",
   "ArrowDown",
+  "PageUp",
+  "PageDown",
   "Home",
   "End",
   "Enter",

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -380,10 +380,12 @@ AppPaletteDialog.Header = function AppPaletteHeader({
  * palette with collapsible groups and left with it (#11669); no list on this
  * shell has a horizontal axis now.
  *
- * The page keys are NOT left to native scrolling, which is what they used to
- * be: scrolling the viewport without moving the selection walks the highlighted
- * row off screen and leaves Enter committing something the user can no longer
- * see. Palettes move the selection by a page instead.
+ * The page keys are forwarded rather than left to native scrolling, so a
+ * palette CAN bind them: scrolling the viewport without moving the selection
+ * walks the highlighted row off screen and leaves Enter committing something
+ * the user can no longer see. Forwarding alone changes nothing for a palette
+ * that ignores them — the shell never cancels a key itself, so a handler with
+ * no case for these leaves them to the browser exactly as before.
  */
 const BODY_NAVIGATION_KEYS = new Set([
   "ArrowUp",

--- a/src/components/ui/__tests__/AppPaletteDialog.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteDialog.test.tsx
@@ -452,7 +452,7 @@ describe("AppPaletteDialog.Body results region (#11431)", () => {
     expect(document.getElementById(activeDescendant!)).not.toBeNull();
   });
 
-  it.each(["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Home", "End", "Enter"])(
+  it.each(["ArrowUp", "ArrowDown", "Home", "End", "Enter"])(
     "forwards %s to the palette's navigation handler",
     (key) => {
       const onNavigationKeyDown = vi.fn();
@@ -466,8 +466,10 @@ describe("AppPaletteDialog.Body results region (#11431)", () => {
   it.each([
     ["Tab", false],
     ["Tab", true],
-    ["PageDown", false],
-    ["PageUp", false],
+    // No list on this shell has a horizontal axis since the one palette with
+    // collapsible groups dropped its disclosure.
+    ["ArrowLeft", false],
+    ["ArrowRight", false],
     [" ", false],
     ["Escape", false],
   ])("leaves %s (shift: %s) to its native behaviour", (key, shiftKey) => {
@@ -475,8 +477,8 @@ describe("AppPaletteDialog.Body results region (#11431)", () => {
     const notCancelled = fireEvent.keyDown(renderBody(onNavigationKeyDown), { key, shiftKey });
 
     expect(onNavigationKeyDown).not.toHaveBeenCalled();
-    // Not merely unhandled — uncancelled, so Tab still traverses and
-    // Page/Space still scroll the region.
+    // Not merely unhandled — uncancelled, so Tab still traverses and Space
+    // still scrolls the region.
     expect(notCancelled).toBe(true);
   });
 

--- a/src/components/ui/__tests__/AppPaletteDialog.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteDialog.test.tsx
@@ -452,7 +452,7 @@ describe("AppPaletteDialog.Body results region (#11431)", () => {
     expect(document.getElementById(activeDescendant!)).not.toBeNull();
   });
 
-  it.each(["ArrowUp", "ArrowDown", "Home", "End", "Enter"])(
+  it.each(["ArrowUp", "ArrowDown", "PageUp", "PageDown", "Home", "End", "Enter"])(
     "forwards %s to the palette's navigation handler",
     (key) => {
       const onNavigationKeyDown = vi.fn();

--- a/src/hooks/__tests__/usePaletteTreeNavigation.test.tsx
+++ b/src/hooks/__tests__/usePaletteTreeNavigation.test.tsx
@@ -16,12 +16,8 @@ interface TestItem {
   label: string;
 }
 
-/** `[groupId, itemIds, { collapsed, navigableHeader }]` */
-type GroupSpec = [
-  string,
-  string[],
-  { collapsed?: boolean; navigableHeader?: boolean; skipItems?: string[] }?,
-];
+/** `[groupId, itemIds, { navigableHeader, skipItems }]` */
+type GroupSpec = [string, string[], { navigableHeader?: boolean; skipItems?: string[] }?];
 
 function buildGroups(specs: GroupSpec[]): PaletteTreeGroupInput<TestGroup, TestItem>[] {
   return specs.map(([groupId, itemIds, options = {}]) => ({
@@ -32,7 +28,6 @@ function buildGroups(specs: GroupSpec[]): PaletteTreeGroupInput<TestGroup, TestI
       domId: `dom-h-${groupId}`,
       navigable: options.navigableHeader ?? false,
     },
-    isCollapsed: options.collapsed ?? false,
     items: itemIds.map((itemId) => ({
       rowId: `i:${itemId}`,
       domId: `dom-i-${itemId}`,
@@ -87,7 +82,6 @@ function setup(
   specs: GroupSpec[],
   options: {
     onActivate?: (row: NavigablePaletteTreeRow<TestGroup, TestItem>) => void;
-    onGroupCollapsedChange?: (groupId: string, collapsed: boolean) => void;
     shouldPreserveInputCaretKey?: (event: KeyboardEvent<HTMLInputElement>) => boolean;
     selectionScopeKey?: string;
     isActive?: boolean;
@@ -101,7 +95,6 @@ function setup(
         isActive: options.isActive ?? true,
         selectionScopeKey: scope ?? null,
         onActivate,
-        onGroupCollapsedChange: options.onGroupCollapsedChange,
         shouldPreserveInputCaretKey: options.shouldPreserveInputCaretKey,
       }),
     { initialProps: { groups: buildGroups(specs), scope: options.selectionScopeKey } }
@@ -124,15 +117,14 @@ describe("usePaletteTreeNavigation", () => {
       expect(rowIds(result.current.rows)).toEqual(["h:a", "i:a1", "i:a2", "h:b", "i:b1"]);
     });
 
-    it("keeps a collapsed group's header while structurally excluding its items", () => {
+    it("builds the render model and the nav domain from the same pass", () => {
+      // A caller that maps over `renderGroups` is rendering exactly what the
+      // arrows address, so neither can hold a row the other does not.
       const { result } = setup([
-        ["a", ["a1", "a2"], { collapsed: true }],
+        ["a", ["a1", "a2"]],
         ["b", ["b1"]],
       ]);
 
-      expect(rowIds(result.current.rows)).toEqual(["h:a", "h:b", "i:b1"]);
-      // The render model and the nav domain are the same objects, so a hidden
-      // row cannot exist in one and not the other.
       const rendered = result.current.renderGroups.flatMap((g) => [g.header, ...g.items]);
       expect(rendered).toEqual(result.current.rows);
     });
@@ -284,11 +276,11 @@ describe("usePaletteTreeNavigation", () => {
       act(() => result.current.selectRow("i:b1"));
       expect(result.current.activeDescendantId).toBe("dom-i-b1");
 
-      // Collapsing b removes the selected row from the model entirely.
+      // b's run exits, removing the selected row from the model entirely.
       rerender({
         groups: buildGroups([
           ["a", ["a1", "a2"]],
-          ["b", ["b1"], { collapsed: true }],
+          ["b", []],
         ]),
         scope: undefined,
       });
@@ -315,140 +307,37 @@ describe("usePaletteTreeNavigation", () => {
     });
   });
 
-  describe("disclosure", () => {
-    it("collapses the selected row's group on ArrowLeft", () => {
-      const onGroupCollapsedChange = vi.fn();
-      const { result } = setup(
-        [
-          ["a", ["a1"]],
-          ["b", ["b1"]],
-        ],
-        { onGroupCollapsedChange }
-      );
-
-      act(() => result.current.selectRow("i:b1"));
-      const { event } = keyEvent("ArrowLeft");
-      act(() => result.current.handleBodyKeyDown(event));
-
-      expect(onGroupCollapsedChange).toHaveBeenCalledWith("b", true);
-    });
-
-    it("handles ArrowRight before the no-navigable-row guard", () => {
-      const onGroupCollapsedChange = vi.fn();
-      // Every group shut: nothing is navigable, so a guard placed first would
-      // strand the user with no way to reopen anything.
-      const { result } = setup([["a", ["a1"], { collapsed: true }]], { onGroupCollapsedChange });
-
-      expect(result.current.selectedRow).toBeNull();
-      const right = keyEvent("ArrowRight");
-      act(() => result.current.handleBodyKeyDown(right.event));
-
-      expect(onGroupCollapsedChange).toHaveBeenCalledWith("a", false);
-      expectConsumed(right, true, "ArrowRight with every group shut");
-    });
-
-    it("reopens the group ArrowLeft just closed rather than the first collapsed one", () => {
-      const onGroupCollapsedChange = vi.fn();
-      const { result, rerender } = setup(
-        [
-          ["a", ["a1"], { collapsed: true }],
-          ["b", ["b1"]],
-        ],
-        { onGroupCollapsedChange }
-      );
-
-      act(() => result.current.selectRow("i:b1"));
-      act(() => result.current.handleBodyKeyDown(keyEvent("ArrowLeft").event));
-      expect(onGroupCollapsedChange).toHaveBeenLastCalledWith("b", true);
-
-      rerender({
-        groups: buildGroups([
-          ["a", ["a1"], { collapsed: true }],
-          ["b", ["b1"], { collapsed: true }],
-        ]),
-        scope: undefined,
-      });
-      act(() => result.current.handleBodyKeyDown(keyEvent("ArrowRight").event));
-
-      expect(onGroupCollapsedChange).toHaveBeenLastCalledWith("b", false);
-    });
-
-    it("falls through to a still-collapsed group when the remembered one is gone", () => {
-      const onGroupCollapsedChange = vi.fn();
-      const { result, rerender } = setup(
-        [
-          ["a", ["a1"], { collapsed: true }],
-          ["b", ["b1"]],
-        ],
-        { onGroupCollapsedChange }
-      );
-
-      act(() => result.current.selectRow("i:b1"));
-      act(() => result.current.handleBodyKeyDown(keyEvent("ArrowLeft").event));
-
-      // b disappears entirely while the palette is open; the remembered target
-      // is now stale, and consuming the key against it would do nothing.
-      rerender({ groups: buildGroups([["a", ["a1"], { collapsed: true }]]), scope: undefined });
-      act(() => result.current.handleBodyKeyDown(keyEvent("ArrowRight").event));
-
-      expect(onGroupCollapsedChange).toHaveBeenLastCalledWith("a", false);
-    });
-
-    it("remembers the keyboard-collapsed group across a selection-scope change", () => {
-      // A new query re-ranks the list but says nothing about which group the
-      // keyboard last shut, so → must still reopen that one rather than
-      // whichever group happens to sit first.
-      const onGroupCollapsedChange = vi.fn();
-      const { result, rerender } = setup(
-        [
-          ["a", ["a1"], { collapsed: true }],
-          ["b", ["b1"]],
-        ],
-        { onGroupCollapsedChange, selectionScopeKey: "q1" }
-      );
-
-      act(() => result.current.selectRow("i:b1"));
-      act(() => result.current.handleBodyKeyDown(keyEvent("ArrowLeft").event));
-
-      rerender({
-        groups: buildGroups([
-          ["a", ["a1"], { collapsed: true }],
-          ["b", ["b1"], { collapsed: true }],
-        ]),
-        scope: "q2",
-      });
-      act(() => result.current.handleBodyKeyDown(keyEvent("ArrowRight").event));
-
-      expect(onGroupCollapsedChange).toHaveBeenLastCalledWith("b", false);
-    });
-
-    it("leaves the horizontal arrows alone when no collapse handler is supplied", () => {
-      const { result } = setup([["a", ["a1"]]]);
-
-      const left = keyEvent("ArrowLeft");
-      const right = keyEvent("ArrowRight");
-      act(() => result.current.handleBodyKeyDown(left.event));
-      act(() => result.current.handleBodyKeyDown(right.event));
-
-      expectConsumed(left, false, "ArrowLeft without a collapse handler");
-      expectConsumed(right, false, "ArrowRight without a collapse handler");
-    });
-  });
-
   describe("caret arbitration", () => {
-    it("leaves Home, End and the horizontal arrows to the caret when the predicate says so", () => {
-      const onGroupCollapsedChange = vi.fn();
+    it("leaves Home and End to the caret when the predicate says so", () => {
       const { result } = setup([["a", ["a1", "a2"]]], {
-        onGroupCollapsedChange,
         shouldPreserveInputCaretKey: (event) => event.currentTarget.value.length > 0,
       });
 
-      for (const key of ["Home", "End", "ArrowLeft", "ArrowRight"]) {
+      for (const key of ["Home", "End"]) {
         const handle = keyEvent(key, { value: "typed" });
         act(() => result.current.handleInputKeyDown(handle.event));
         expectConsumed(handle, false, `${key} should stay with the caret`);
       }
-      expect(onGroupCollapsedChange).not.toHaveBeenCalled();
+      expect(result.current.selectedRowId).toBe("i:a1");
+    });
+
+    it("never contests the horizontal arrows, whatever the predicate says", () => {
+      // The list has no horizontal axis: the disclosure that gave these keys a
+      // job is gone, so they belong to the caret unconditionally and must reach
+      // it uncancelled from the body region too.
+      const shouldPreserveInputCaretKey = vi.fn(() => false);
+      const { result } = setup([["a", ["a1", "a2"]]], { shouldPreserveInputCaretKey });
+
+      for (const key of ["ArrowLeft", "ArrowRight"]) {
+        const onInput = keyEvent(key, { value: "" });
+        act(() => result.current.handleInputKeyDown(onInput.event));
+        expectConsumed(onInput, false, `${key} on the input`);
+
+        const onBody = keyEvent(key);
+        act(() => result.current.handleBodyKeyDown(onBody.event));
+        expectConsumed(onBody, false, `${key} on the body region`);
+      }
+      expect(shouldPreserveInputCaretKey).not.toHaveBeenCalled();
       expect(result.current.selectedRowId).toBe("i:a1");
     });
 

--- a/src/hooks/__tests__/usePaletteTreeNavigation.test.tsx
+++ b/src/hooks/__tests__/usePaletteTreeNavigation.test.tsx
@@ -352,32 +352,58 @@ describe("usePaletteTreeNavigation", () => {
     });
 
     it("lands on the first row rather than wrapping past the start", () => {
-      const { result } = setup([["a", ["a1", "a2", "a3"]]]);
+      // Every non-first starting position, because a single one can agree with
+      // wrapping by coincidence: over a three-row list a wrapping PageUp from
+      // row 2 also lands on row 1, so that fixture alone proves nothing.
+      for (const from of ["i:a2", "i:a3"]) {
+        const { result, unmount } = setup([["a", ["a1", "a2", "a3"]]]);
 
-      act(() => result.current.selectRow("i:a2"));
-      act(() => result.current.handleBodyKeyDown(keyEvent("PageUp").event));
+        act(() => result.current.selectRow(from));
+        act(() => result.current.handleBodyKeyDown(keyEvent("PageUp").event));
 
-      expect(result.current.selectedRowId).toBe("i:a1");
+        expect(result.current.selectedRowId, `PageUp from ${from}`).toBe("i:a1");
+        unmount();
+      }
     });
 
-    it("keeps the page keys off the browser's own scrolling of the region", () => {
-      const { result } = setup(longList());
+    it.each(["PageUp", "PageDown"])(
+      "keeps %s off the browser's own scrolling of the region",
+      (key) => {
+        const { result } = setup(longList());
+        act(() => result.current.selectRow("i:a12"));
 
-      const pageDown = keyEvent("PageDown");
-      act(() => result.current.handleBodyKeyDown(pageDown.event));
+        const handle = keyEvent(key);
+        act(() => result.current.handleBodyKeyDown(handle.event));
 
-      // Native scrolling walks the viewport while the selection sits still,
-      // which is how the highlight ends up off screen with Enter still on it.
-      expectConsumed(pageDown, true, "PageDown must not also scroll natively");
-    });
+        // Native scrolling walks the viewport while the selection sits still,
+        // which is how the highlight ends up off screen with Enter still on it.
+        expectConsumed(handle, true, `${key} must not also scroll natively`);
+      }
+    );
 
-    it("leaves the page keys to the browser when nothing is navigable", () => {
+    it.each(["PageUp", "PageDown"])("leaves %s to the browser when nothing is navigable", (key) => {
       const { result } = setup([["a", []]]);
 
-      const pageDown = keyEvent("PageDown");
-      act(() => result.current.handleBodyKeyDown(pageDown.event));
+      const handle = keyEvent(key);
+      act(() => result.current.handleBodyKeyDown(handle.event));
 
-      expectConsumed(pageDown, false, "PageDown over an empty list");
+      expectConsumed(handle, false, `${key} over an empty list`);
+    });
+
+    it.each(["PageUp", "PageDown"])("takes %s from the input, where focus actually sits", (key) => {
+      // The body region is only reachable after Tab. The search box owns the
+      // keyboard by default, so a page key misclassified as a caret key would
+      // leave the main path broken with every body-path test still green.
+      const { result } = setup(longList(), {
+        shouldPreserveInputCaretKey: (event) => event.currentTarget.value.length > 0,
+      });
+      act(() => result.current.selectRow("i:a12"));
+
+      const handle = keyEvent(key, { value: "typed" });
+      act(() => result.current.handleInputKeyDown(handle.event));
+
+      expectConsumed(handle, true, `${key} on the input, caret keys preserved`);
+      expect(result.current.selectedRowId).not.toBe("i:a12");
     });
   });
 
@@ -568,6 +594,33 @@ describe("usePaletteTreeNavigation", () => {
       setup([["a", ["a1"]]], { isActive: false });
 
       expect(scrollIntoView).not.toHaveBeenCalled();
+    });
+
+    it("re-scrolls when the selected row keeps its id but changes position", () => {
+      // A list that re-ranks under an open palette moves the selected row
+      // without touching its id, so an effect watching the active descendant
+      // alone never fires: the highlight walks off screen while Enter still
+      // commits it. This is the whole reason position is a dependency.
+      //
+      // The effect resolves the row through `getElementById`, so the rows this
+      // case walks past need elements of their own — the shared setup only
+      // stands up the first one.
+      for (const id of ["dom-i-a2", "dom-i-a3"]) {
+        const node = document.createElement("div");
+        node.id = id;
+        document.body.append(node);
+      }
+
+      const { result, rerender } = setup([["a", ["a1", "a2", "a3"]]]);
+      act(() => result.current.selectRow("i:a3"));
+      scrollIntoView.mockClear();
+
+      // Same three rows, same selected id — re-ranked so it now leads.
+      rerender({ groups: buildGroups([["a", ["a3", "a1", "a2"]]]), scope: undefined });
+
+      expect(result.current.selectedRowId).toBe("i:a3");
+      expect(scrollIntoView).toHaveBeenCalledTimes(1);
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
     });
   });
 });

--- a/src/hooks/__tests__/usePaletteTreeNavigation.test.tsx
+++ b/src/hooks/__tests__/usePaletteTreeNavigation.test.tsx
@@ -307,6 +307,80 @@ describe("usePaletteTreeNavigation", () => {
     });
   });
 
+  describe("paging", () => {
+    /** Twenty-six rows, so a page-sized jump has somewhere to land. */
+    const longList = (): GroupSpec[] => [["a", Array.from({ length: 26 }, (_, i) => `a${i}`)]];
+
+    const selectedIndex = (result: { current: { selectedNavigableIndex: number } }) =>
+      result.current.selectedNavigableIndex;
+
+    it("moves further than an arrow does", () => {
+      // Asserted as a relationship rather than against the page size itself,
+      // which would just be the constant copied out of the implementation.
+      const { result } = setup(longList());
+
+      act(() => result.current.handleBodyKeyDown(keyEvent("ArrowDown").event));
+      const oneRow = selectedIndex(result);
+
+      act(() => result.current.selectRow("i:a0"));
+      act(() => result.current.handleBodyKeyDown(keyEvent("PageDown").event));
+
+      expect(selectedIndex(result)).toBeGreaterThan(oneRow);
+    });
+
+    it("returns to where it started when a page down is undone by a page up", () => {
+      const { result } = setup(longList());
+
+      act(() => result.current.selectRow("i:a12"));
+      act(() => result.current.handleBodyKeyDown(keyEvent("PageDown").event));
+      act(() => result.current.handleBodyKeyDown(keyEvent("PageUp").event));
+
+      expect(result.current.selectedRowId).toBe("i:a12");
+    });
+
+    it("lands on the last row rather than wrapping past the end", () => {
+      // The reason this cannot be `step(+n)`: modulo arithmetic over a list
+      // shorter than a page returns the row it started from, so the key would
+      // visibly do nothing at all.
+      const { result } = setup([["a", ["a1", "a2", "a3"]]]);
+
+      const pageDown = keyEvent("PageDown");
+      act(() => result.current.handleBodyKeyDown(pageDown.event));
+
+      expectConsumed(pageDown, true, "PageDown on a short list");
+      expect(result.current.selectedRowId).toBe("i:a3");
+    });
+
+    it("lands on the first row rather than wrapping past the start", () => {
+      const { result } = setup([["a", ["a1", "a2", "a3"]]]);
+
+      act(() => result.current.selectRow("i:a2"));
+      act(() => result.current.handleBodyKeyDown(keyEvent("PageUp").event));
+
+      expect(result.current.selectedRowId).toBe("i:a1");
+    });
+
+    it("keeps the page keys off the browser's own scrolling of the region", () => {
+      const { result } = setup(longList());
+
+      const pageDown = keyEvent("PageDown");
+      act(() => result.current.handleBodyKeyDown(pageDown.event));
+
+      // Native scrolling walks the viewport while the selection sits still,
+      // which is how the highlight ends up off screen with Enter still on it.
+      expectConsumed(pageDown, true, "PageDown must not also scroll natively");
+    });
+
+    it("leaves the page keys to the browser when nothing is navigable", () => {
+      const { result } = setup([["a", []]]);
+
+      const pageDown = keyEvent("PageDown");
+      act(() => result.current.handleBodyKeyDown(pageDown.event));
+
+      expectConsumed(pageDown, false, "PageDown over an empty list");
+    });
+  });
+
   describe("caret arbitration", () => {
     it("leaves Home and End to the caret when the predicate says so", () => {
       const { result } = setup([["a", ["a1", "a2"]]], {
@@ -411,7 +485,9 @@ describe("usePaletteTreeNavigation", () => {
     it("leaves every other key untouched", () => {
       const { result } = setup([["a", ["a1"]]]);
 
-      for (const key of ["Escape", "Tab", "Backspace", "PageDown", "a"]) {
+      // PageDown was here until the page keys were bound; everything left is a
+      // key the palette shell, the dialog or the browser still has a use for.
+      for (const key of ["Escape", "Tab", "Backspace", "a"]) {
         const handle = keyEvent(key);
         act(() => result.current.handleInputKeyDown(handle.event));
         expectConsumed(handle, false, `${key} should not be consumed`);

--- a/src/hooks/usePaletteTreeNavigation.ts
+++ b/src/hooks/usePaletteTreeNavigation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { KeyboardEvent, KeyboardEventHandler } from "react";
 
 /**
@@ -14,8 +14,12 @@ import type { KeyboardEvent, KeyboardEventHandler } from "react";
  * arrow-key domain are one derivation, never two. `renderGroups` and `rows`
  * hold the same row objects, built in a single pass — a caller that renders
  * `renderGroups` cannot show a row the arrows can't reach, or reach one that
- * isn't on screen. Collapsed items are absent from both rather than filtered
- * out of one, so `aria-activedescendant` can only ever name a rendered row.
+ * isn't on screen, so `aria-activedescendant` can only ever name a rendered row.
+ *
+ * Groups are structure, not state: they organise the rows and nothing more.
+ * This hook once carried a disclosure model too, whose horizontal arrows could
+ * act on a group the user was nowhere near, and whose only consumer has since
+ * dropped collapse entirely (#11669).
  */
 
 /** What every row carries, header or item. */
@@ -46,18 +50,11 @@ export interface PaletteTreeItemInput<TItem> extends PaletteTreeRowIdentity {
   item: TItem;
 }
 
-/**
- * One group as the caller has already ordered and filtered it.
- *
- * Collapse is the caller's to store — palettes split it across persisted and
- * search-scoped state for reasons that belong to their domain — so this takes
- * the resolved answer and reports changes back through `onGroupCollapsedChange`.
- */
+/** One group as the caller has already ordered and filtered it. */
 export interface PaletteTreeGroupInput<TGroup, TItem> {
   groupId: string;
   group: TGroup;
   header: PaletteTreeRowIdentity;
-  isCollapsed: boolean;
   items: readonly PaletteTreeItemInput<TItem>[];
 }
 
@@ -66,7 +63,6 @@ export type PaletteTreeRow<TGroup, TItem> =
       kind: "group";
       groupId: string;
       group: TGroup;
-      isCollapsed: boolean;
     })
   | (PaletteTreeRowIdentity & {
       kind: "item";
@@ -112,14 +108,12 @@ export interface UsePaletteTreeNavigationOptions<TGroup, TItem> {
    */
   selectionScopeKey?: string | number | null;
   onActivate: (row: NavigablePaletteTreeRow<TGroup, TItem>) => void;
-  /** Omitted, the horizontal arrows stay with the caret and nothing collapses. */
-  onGroupCollapsedChange?: (groupId: string, collapsed: boolean) => void;
   /**
    * Whether a caret exists that the structural keys must stand down for.
    *
-   * Home/End/←/→ are this list's structural keys, but they are also the search
+   * Home/End are this list's structural keys, but they are also the search
    * box's editing keys and the box owns focus by default. Consulted only for
-   * those four, and only on the input — the body region has no caret. Defaults
+   * those two, and only on the input — the body region has no caret. Defaults
    * to preserving them, because editable text should win unless a caller says
    * otherwise.
    */
@@ -146,7 +140,14 @@ export interface UsePaletteTreeNavigationResult<TGroup, TItem> {
   handleBodyKeyDown: KeyboardEventHandler<HTMLElement>;
 }
 
-const CARET_KEYS = new Set(["Home", "End", "ArrowLeft", "ArrowRight"]);
+/**
+ * Keys this list and a text caret both have a claim on.
+ *
+ * The horizontal arrows were here too while groups could collapse. With no
+ * disclosure left they are the caret's alone, so they never reach the switch
+ * below and never need arbitrating.
+ */
+const CARET_KEYS = new Set(["Home", "End"]);
 
 function isNavigable<TGroup, TItem>(
   row: PaletteTreeRow<TGroup, TItem>
@@ -159,16 +160,9 @@ export function usePaletteTreeNavigation<TGroup, TItem>({
   isActive,
   selectionScopeKey = null,
   onActivate,
-  onGroupCollapsedChange,
   shouldPreserveInputCaretKey,
 }: UsePaletteTreeNavigationOptions<TGroup, TItem>): UsePaletteTreeNavigationResult<TGroup, TItem> {
-  /**
-   * The render model and the flat nav list, built together.
-   *
-   * A collapsed group contributes no item rows at all rather than contributing
-   * them and hiding them later: a row that isn't built can't be selected, which
-   * is what makes the drift unrepresentable instead of merely guarded against.
-   */
+  /** The render model and the flat nav list, built together from one pass. */
   const renderGroups = useMemo<PaletteTreeRenderGroup<TGroup, TItem>[]>(
     () =>
       groups.map((input) => ({
@@ -179,19 +173,16 @@ export function usePaletteTreeNavigation<TGroup, TItem>({
           navigable: input.header.navigable,
           groupId: input.groupId,
           group: input.group,
-          isCollapsed: input.isCollapsed,
         },
-        items: input.isCollapsed
-          ? []
-          : input.items.map((item) => ({
-              kind: "item" as const,
-              rowId: item.rowId,
-              domId: item.domId,
-              navigable: item.navigable,
-              groupId: input.groupId,
-              group: input.group,
-              item: item.item,
-            })),
+        items: input.items.map((item) => ({
+          kind: "item" as const,
+          rowId: item.rowId,
+          domId: item.domId,
+          navigable: item.navigable,
+          groupId: input.groupId,
+          group: input.group,
+          item: item.item,
+        })),
       })),
     [groups]
   );
@@ -206,12 +197,11 @@ export function usePaletteTreeNavigation<TGroup, TItem>({
   /**
    * The selected ROW is the state; its index is derived. Tracking an index
    * instead would let it outlive the row it pointed at — the list shrinks under
-   * an open palette whenever a group collapses or an entry disappears, and the
-   * index would then address a different row than the user selected (#11071).
+   * an open palette whenever an entry disappears or a narrowing changes, and
+   * the index would then address a different row than the user selected
+   * (#11071).
    */
   const [selectedRowId, setSelectedRowId] = useState<string | null>(null);
-  /** The group the keyboard last closed, so → can re-open that one. */
-  const lastCollapsedGroupIdRef = useRef<string | null>(null);
 
   /** Unmoved, the highlight sits on the first row the arrows can reach. */
   const selectedNavigableIndex = useMemo(() => {
@@ -228,14 +218,6 @@ export function usePaletteTreeNavigation<TGroup, TItem>({
   useEffect(() => {
     setSelectedRowId(null);
   }, [selectionScopeKey, isActive]);
-
-  // Disclosure history is NOT selection state: a new query re-ranks the list
-  // but says nothing about which group the keyboard last closed, and dropping
-  // the memory there would send the next → to the first collapsed group
-  // instead of the one the user just shut. Only closing forgets it.
-  useEffect(() => {
-    lastCollapsedGroupIdRef.current = null;
-  }, [isActive]);
 
   // Keyed on the id rather than the row object: rows are rebuilt whenever their
   // content refreshes, and re-running this each tick would fight the user's own
@@ -278,43 +260,13 @@ export function usePaletteTreeNavigation<TGroup, TItem>({
     [navigableRows, onActivate]
   );
 
-  /**
-   * ←/→ act on the group holding the selected row, which is what lets a palette
-   * whose headers are not stops still open and close its groups.
-   */
+  /** Vertical movement, the two ends, and commit. Groups are structure only. */
   const handleNavigationKeyDown = useCallback(
     (event: KeyboardEvent<HTMLElement>, allowCaretKeys: boolean) => {
       const consume = () => {
         event.preventDefault();
         event.stopPropagation();
       };
-
-      // Expand BEFORE the empty-list guard, because collapsing the last open
-      // group is exactly what empties the list — and disclosures need not be
-      // tab stops, so bailing here could strand a keyboard user with every
-      // group shut and no way to reopen one.
-      if (event.key === "ArrowRight" && !allowCaretKeys && onGroupCollapsedChange) {
-        const remembered = lastCollapsedGroupIdRef.current;
-        // Validate the remembered group against the current list: it may have
-        // disappeared while the palette was open, and reopening a group that is
-        // no longer there would be a write against stale data.
-        const rememberedStillCollapsed =
-          remembered !== null &&
-          renderGroups.some(
-            (group) => group.header.groupId === remembered && group.header.isCollapsed
-          );
-        const target = rememberedStillCollapsed
-          ? remembered
-          : selectedRow && isCollapsedGroup(renderGroups, selectedRow.groupId)
-            ? selectedRow.groupId
-            : renderGroups.find((group) => group.header.isCollapsed)?.header.groupId;
-        if (target !== undefined) {
-          consume();
-          onGroupCollapsedChange(target, false);
-          lastCollapsedGroupIdRef.current = null;
-        }
-        return;
-      }
 
       // Nothing to navigate means the browser's own behaviour is the only
       // useful one left; swallowing the key would leave the region eating
@@ -340,15 +292,6 @@ export function usePaletteTreeNavigation<TGroup, TItem>({
           consume();
           setSelectedRowId(navigableRows[navigableRows.length - 1]!.rowId);
           break;
-        case "ArrowLeft": {
-          if (allowCaretKeys || !selectedRow || !onGroupCollapsedChange) break;
-          consume();
-          lastCollapsedGroupIdRef.current = selectedRow.groupId;
-          onGroupCollapsedChange(selectedRow.groupId, true);
-          // The highlight needs no explicit move: a hidden row is no longer in
-          // `rows`, so the derived index falls back to the first visible one.
-          break;
-        }
         case "Enter":
           consume();
           if (selectedRow) {
@@ -364,7 +307,7 @@ export function usePaletteTreeNavigation<TGroup, TItem>({
           break;
       }
     },
-    [navigableRows, onActivate, onGroupCollapsedChange, renderGroups, selectedRow, step]
+    [navigableRows, onActivate, selectedRow, step]
   );
 
   const handleInputKeyDown = useCallback<KeyboardEventHandler<HTMLInputElement>>(
@@ -396,11 +339,4 @@ export function usePaletteTreeNavigation<TGroup, TItem>({
     handleInputKeyDown,
     handleBodyKeyDown,
   };
-}
-
-function isCollapsedGroup<TGroup, TItem>(
-  renderGroups: readonly PaletteTreeRenderGroup<TGroup, TItem>[],
-  groupId: string
-): boolean {
-  return renderGroups.some((group) => group.header.groupId === groupId && group.header.isCollapsed);
 }

--- a/src/hooks/usePaletteTreeNavigation.ts
+++ b/src/hooks/usePaletteTreeNavigation.ts
@@ -149,6 +149,16 @@ export interface UsePaletteTreeNavigationResult<TGroup, TItem> {
  */
 const CARET_KEYS = new Set(["Home", "End"]);
 
+/**
+ * Rows a page key moves by.
+ *
+ * A constant, not a measurement: these lists are not virtualised and their rows
+ * vary in height, so any "visible page" computed from the scroller would be a
+ * different number every time it was asked. Ten is the figure the ARIA
+ * practices use and the one real listboxes settle on.
+ */
+const PAGE_SIZE = 10;
+
 function isNavigable<TGroup, TItem>(
   row: PaletteTreeRow<TGroup, TItem>
 ): row is NavigablePaletteTreeRow<TGroup, TItem> {
@@ -265,6 +275,30 @@ export function usePaletteTreeNavigation<TGroup, TItem>({
     [navigableRows]
   );
 
+  /**
+   * A page-sized jump that CLAMPS rather than wrapping.
+   *
+   * Deliberately not `step(±PAGE_SIZE)`: that normalises modulo the list, so
+   * PageDown over a five-row list would land back on the row it started from —
+   * a key that visibly does nothing. Running off the end lands on the end,
+   * which is both what the ARIA practices describe and what a reader expects
+   * from a page key.
+   */
+  const page = useCallback(
+    (delta: number) => {
+      if (navigableRows.length === 0) return;
+      setSelectedRowId((previousId) => {
+        const current = previousId
+          ? navigableRows.findIndex((row) => row.rowId === previousId)
+          : -1;
+        const from = current >= 0 ? current : 0;
+        const next = Math.min(navigableRows.length - 1, Math.max(0, from + delta));
+        return navigableRows[next]!.rowId;
+      });
+    },
+    [navigableRows]
+  );
+
   const selectRow = useCallback((rowId: string) => setSelectedRowId(rowId), []);
 
   const activateRow = useCallback(
@@ -299,6 +333,20 @@ export function usePaletteTreeNavigation<TGroup, TItem>({
           consume();
           step(-1);
           break;
+        // Bound HERE rather than left to the browser. Native scrolling walks
+        // the viewport several rows while the selection sits still, so the
+        // highlight goes off screen and Enter commits a row the user can no
+        // longer see. A fixed row count rather than a measured page: the rows
+        // are not virtualised and their heights vary, and every list that
+        // implements this at all uses a constant.
+        case "PageDown":
+          consume();
+          page(PAGE_SIZE);
+          break;
+        case "PageUp":
+          consume();
+          page(-PAGE_SIZE);
+          break;
         case "Home":
           if (allowCaretKeys) break;
           consume();
@@ -324,7 +372,7 @@ export function usePaletteTreeNavigation<TGroup, TItem>({
           break;
       }
     },
-    [navigableRows, onActivate, selectedRow, step]
+    [navigableRows, onActivate, page, selectedRow, step]
   );
 
   const handleInputKeyDown = useCallback<KeyboardEventHandler<HTMLInputElement>>(

--- a/src/hooks/usePaletteTreeNavigation.ts
+++ b/src/hooks/usePaletteTreeNavigation.ts
@@ -223,10 +223,27 @@ export function usePaletteTreeNavigation<TGroup, TItem>({
   // content refreshes, and re-running this each tick would fight the user's own
   // scroll.
   const activeDescendantId = selectedRow?.domId;
+
+  /**
+   * Where the selected row sits among ALL rendered rows, headers included.
+   *
+   * A list that re-ranks under an open palette moves the selected row without
+   * changing its id, so an effect watching the descendant alone never fires and
+   * the highlight walks off screen while Enter still commits it. Headers count
+   * because they occupy vertical space as surely as the options do.
+   *
+   * A number, not the row: it changes only when the position genuinely does, so
+   * a rebuild that leaves everything where it was still does not re-scroll.
+   */
+  const selectedRowPosition = useMemo(
+    () => (selectedRow ? rows.indexOf(selectedRow) : -1),
+    [rows, selectedRow]
+  );
+
   useEffect(() => {
     if (!isActive || activeDescendantId === undefined) return;
     document.getElementById(activeDescendantId)?.scrollIntoView({ block: "nearest" });
-  }, [isActive, activeDescendantId]);
+  }, [isActive, activeDescendantId, selectedRowPosition]);
 
   const step = useCallback(
     (delta: number) => {

--- a/src/lib/__tests__/fleetAttention.test.ts
+++ b/src/lib/__tests__/fleetAttention.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import {
   bandForRun,
   bandLabel,
-  BAND_TONE,
   compareWithinBand,
   emptyBandCounts,
   FLEET_BANDS,
@@ -107,10 +106,9 @@ describe("bandLabel", () => {
 });
 
 describe("band presentation", () => {
-  it("gives every band a tone and a count slot, so neither can miss one", () => {
+  it("gives every band a count slot, so a band cannot go uncounted", () => {
     const counts = emptyBandCounts();
     for (const band of FLEET_BANDS) {
-      expect(BAND_TONE[band]).toBeDefined();
       expect(counts[band]).toBe(0);
     }
   });

--- a/src/lib/fleetAttention.ts
+++ b/src/lib/fleetAttention.ts
@@ -1,5 +1,4 @@
 import type { FleetRunRow } from "@shared/types/ipc/fleet";
-import type { ProjectRowTone } from "./projectRowStatus";
 
 /**
  * Attention bands, worst-first.
@@ -24,20 +23,6 @@ const DEMAND_BANDS: ReadonlySet<FleetBand> = new Set<FleetBand>(["blocked", "nee
 export function isDemandBand(band: FleetBand): boolean {
   return DEMAND_BANDS.has(band);
 }
-
-/**
- * Tone for a band, reusing the switcher's palette so one vocabulary of status
- * colour serves both surfaces. Never the accent: status is a status token, and
- * the accent is reserved for the single focus anchor in the region.
- */
-export const BAND_TONE: Record<FleetBand, ProjectRowTone> = {
-  blocked: "blocked",
-  "needs-you": "waiting",
-  review: "review",
-  running: "working",
-  done: "muted",
-  idle: "muted",
-};
 
 /**
  * Which band a run belongs to.

--- a/src/lib/fleetAttention.ts
+++ b/src/lib/fleetAttention.ts
@@ -76,13 +76,19 @@ export function bandForRun(run: FleetRunRow, acknowledgedAt?: number): FleetBand
  * completion must not still say "ready for review" while sorting as done.
  * `running` and `idle` split on state because they each cover two situations
  * the user can tell apart and would want to.
+ *
+ * "Waiting" rather than "Needs you" for the same reason the filter segment says
+ * it: the sidebar has called this state waiting since it shipped, and one state
+ * with two names across two surfaces is a vocabulary the user has to learn
+ * twice. The prose sentences elsewhere ("2 agents need you") are sentences, not
+ * state labels, and keep their own phrasing.
  */
 export function bandLabel(band: FleetBand, run: FleetRunRow): string {
   switch (band) {
     case "blocked":
       return "Blocked";
     case "needs-you":
-      return "Needs you";
+      return "Waiting";
     case "review":
       return "Ready for review";
     case "running":

--- a/src/lib/projectRowStatus.ts
+++ b/src/lib/projectRowStatus.ts
@@ -11,10 +11,11 @@ export type ProjectRowTone = "blocked" | "waiting" | "review" | "working" | "run
 /**
  * Text colour for a status line, by tone.
  *
- * Lives here rather than in the switcher that first used it because the fleet
- * overview renders the same sentences about the same states. Two surfaces
- * colouring "blocked" differently would be a worse bug than either colour being
- * individually wrong.
+ * Lives here rather than in the switcher that first used it so any surface
+ * drawing a status sentence draws it in one vocabulary. The fleet overview no
+ * longer prints a status word at all — its rows say the state with a glyph and
+ * in their accessible name — so the switcher is the caller that keeps this
+ * honest today.
  */
 export const ROW_TONE_CLASS: Record<ProjectRowTone, string> = {
   blocked: "text-status-danger/80",

--- a/src/store/pilotStore.ts
+++ b/src/store/pilotStore.ts
@@ -1,73 +1,30 @@
 import { create } from "zustand";
-import { persist, createJSONStorage } from "zustand/middleware";
 
 interface PilotState {
   isOpen: boolean;
-  /**
-   * Workspace ids the user has collapsed. Stored as the exception rather than
-   * the rule so a newly-added project defaults to expanded — the opposite would
-   * silently hide a project's agents the first time it appears.
-   */
-  collapsedWorkspaceIds: string[];
   open: () => void;
   close: () => void;
   toggle: () => void;
-  toggleWorkspaceCollapsed: (workspaceId: string) => void;
-  isWorkspaceCollapsed: (workspaceId: string) => boolean;
 }
 
 /**
- * Open state and collapse memory for the fleet overview.
+ * Open state for the fleet overview.
  *
  * A store rather than local state threaded through `App`: Pilot is opened from
  * the action registry, the project switcher and a keybinding, and none of those
  * has a natural prop path to a `useState` in the app shell.
  *
- * Only the collapse set persists. `isOpen` deliberately does not — a dialog
- * that reopens itself on next launch because it was open at quit is a surprise,
- * not a restored preference.
+ * Nothing here persists, and there is no longer anything that could. `isOpen`
+ * deliberately does not — a dialog that reopens itself on next launch because
+ * it was open at quit is a surprise, not a restored preference — and the
+ * collapse set that used to ride the `persist` middleware went with the
+ * disclosure it served (#11669): a project collapsed last week hiding an agent
+ * that blocks today is the wrong default on a surface whose job is to show
+ * every agent. The orphaned `daintree-pilot` localStorage key is inert.
  */
-/**
- * `localStorage`, proven writable — or a thrown error, which is what disables
- * persistence.
- *
- * The throw is deliberate: `createJSONStorage` only skips persistence when its
- * getter THROWS. Returning undefined instead yields a storage object whose
- * every write dereferences undefined, turning a missing-storage environment
- * into a crash on each state change.
- *
- * A `typeof` guard is not enough either. Node defines the global but leaves it
- * unusable without `--localstorage-file`, so it is present and fails on write —
- * and this store is imported transitively by the action registry, which
- * node-environment tests load.
- */
-function assertWritableLocalStorage(): Storage {
-  const probe = "__daintree_pilot_probe__";
-  localStorage.setItem(probe, probe);
-  localStorage.removeItem(probe);
-  return localStorage;
-}
-
-export const usePilotStore = create<PilotState>()(
-  persist(
-    (set, get) => ({
-      isOpen: false,
-      collapsedWorkspaceIds: [],
-      open: () => set({ isOpen: true }),
-      close: () => set({ isOpen: false }),
-      toggle: () => set((state) => ({ isOpen: !state.isOpen })),
-      toggleWorkspaceCollapsed: (workspaceId) =>
-        set((state) => ({
-          collapsedWorkspaceIds: state.collapsedWorkspaceIds.includes(workspaceId)
-            ? state.collapsedWorkspaceIds.filter((id) => id !== workspaceId)
-            : [...state.collapsedWorkspaceIds, workspaceId],
-        })),
-      isWorkspaceCollapsed: (workspaceId) => get().collapsedWorkspaceIds.includes(workspaceId),
-    }),
-    {
-      name: "daintree-pilot",
-      storage: createJSONStorage(() => assertWritableLocalStorage()),
-      partialize: (state) => ({ collapsedWorkspaceIds: state.collapsedWorkspaceIds }),
-    }
-  )
-);
+export const usePilotStore = create<PilotState>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+  toggle: () => set((state) => ({ isOpen: !state.isOpen })),
+}));


### PR DESCRIPTION
## Summary

- Full design audit of the fleet overview palette (Option-Command-O, `PilotView`), the surface that lists every running agent across every project. It had drifted from the rest of the app in color, vocabulary, ordering, and keyboard support.
- Six commits bring it back in line: working goes green, vocabulary matches the sidebar, group collapse is gone, row ordering stays live instead of freezing on open, and the keyboard model grows past a single Enter key.
- No new dependencies, no schema or IPC changes. Everything here is contained to `PilotView` and the two shared pieces it leans on (`usePaletteTreeNavigation`, `pilotStore`).

Resolves #11669

## Changes

**Color and vocabulary** (`c74c896b2`)
- The running spinner moves from neutral gray to `text-state-working` (green), matching `QuickStateFilterBar` and the rest of the app.
- Review/finished moves to `text-category-blue`. It was falling back to a color that happens to render as the exact same hex as the working green in five of the built-in themes (atacama, bali, bondi, serengeti, svalbard), so the two states were visually indistinguishable there.
- A new `segmentIsHued()` replaces `bandFilterHasDemand()` for the Working filter segment, since the latter correctly reports `false` for a running agent and would never hue it.
- "Needs you" becomes "Waiting" in both the filter label and the band label, matching the sidebar's vocabulary. The underlying band key and prose sentences like "2 agents need you" are untouched.

**Row width** (`3cfa92539`)
- The visible per-row status word and the per-row worktree column are gone, handing that width back to the title. The status survives in the row's accessible name for screen readers, and the worktree still drives search even though it's no longer drawn.
- The accessible name now also includes the agent's brand unless the title already contains it.
- Blocked gets its own icon (Lucide `CircleSlash`) so an errored agent is distinguishable by shape, not just hue, from one waiting on a question.
- `PilotRow.tone` and `BAND_TONE` are deleted as dead code once the status word that consumed them is gone.

**Drop group collapse** (`b7e09d0cf`)
- The disclosure button, collapsed-group pips, and force-expand logic are removed entirely. Project-based grouping stays; only the collapse/expand affordance goes.
- `pilotStore` loses `collapsedWorkspaceIds`, which was the only thing its persist middleware ever saved, so the store drops localStorage persistence and `assertWritableLocalStorage()` along with it. It's a plain `create()` now. No migration needed, the old `daintree-pilot` key just goes inert.
- `usePaletteTreeNavigation` loses the group-collapse branches, and its horizontal arrow key handling narrows to just Home/End since Pilot was the hook's only consumer with a use for them.

**Live ordering** (`c78392ba1`)
- Row order used to freeze on first open and never move again, so a newly-blocked agent could sit at the bottom of the list until the palette was closed and reopened. Order now updates live.
- It only holds still while the pointer is actively moving over the list: captured on the first pointer move, released on pointer leave, on the next consumed key, on window blur, on an emptied list, or on close. That keeps an accidental re-rank under the cursor from causing a misclick, without freezing the list the rest of the time.
- Hovering a row now selects it too, so the hovered row and the row Enter would open are always the same row.
- Selection stays keyed by row ID rather than list position, so a re-rank mid keyboard-navigation can't retarget what Enter commits.

**Keyboard and staleness** (`174b7f03d`)
- The footer summary is prefixed "Last known:" while the data is stale, so a stale snapshot can no longer read as all-clear.
- A retained empty fleet from stale data no longer shows the zero-data call to action.
- PageUp/PageDown move the selection by a page, clamping at the ends instead of wrapping. Wrapping was rejected because on a short list a wrapping PageDown can compute back to the same row, a keypress that visibly does nothing.
- The footer's demand button now hands focus to the search input after applying its filter, instead of stranding it on the button.

**Review fixes** (`e192a8365`)
- Closes two edge-case holes in the pointer-order hold from the ordering commit, with tests asserting the specific behavior those holes exposed.

### Worth calling out

- `groupSummary()` was deleted rather than moved onto the project group's `aria-label`. A listbox group label gets re-announced as context for every option inside it, so a per-option "Agent blocked, 2 more" prefix on every row would be a regression, and the issue's own case for dropping collapse was that with everything expanded, the rows themselves are the summary. The group label is now the project name plus ", current workspace" when applicable, which was itself one of the audit's findings (that status wasn't reaching screen readers before).
- PageUp/PageDown clamp instead of routing through the existing wrapping `step()`, for the reason above.

## Testing

- 1444 tests pass across every module the branch touches, plus the `colorSystem`/accent-guard contract suites.
- `tsc --noEmit` clean, eslint clean on all 17 changed files.
- The new scroll-into-view test was mutation-checked: removing its dependency fails that test and only that test.

## Known, not fixed

- A pre-existing `role="group"`-inside-`role="listbox"` VoiceOver naming bug in `PilotView` is out of scope for this issue.
- On a selection-scope change where the previously selected row survives the new filter at a different position, the scroll effect can fire once before the scope reset commits. Both scrolls use `block: "nearest"`, so it's a no-op unless that row is off-screen. Fixing it properly means restructuring the shared hook's scope-reset logic, which is disproportionate here.
- `e2e/screenshots/palette-review.spec.ts:317` snapshots this dialog and will need a new reference image. It's not a gating suite.
