### PR TITLE
fix(panels): give every launcher surface one source of truth for how a panel kind launches

### DIFF
--- a/shared/config/panelKindRegistry.ts
+++ b/shared/config/panelKindRegistry.ts
@@ -174,6 +174,18 @@ export interface PanelKindConfig {
    * encoded in `DEFAULT_PANEL_KIND_POLICY`.
    */
   policy?: PanelKindPolicy;
+  /**
+   * Action a bare launch of this kind dispatches through, so every launcher
+   * surface activates it the same way instead of each one deciding for itself
+   * (#11668). The action owns target resolution, defaults and dedup; the
+   * launcher only says where it wants the panel. Kinds that need nothing
+   * beyond a plain panel omit this and are created through `addPanel`.
+   *
+   * Read via {@link resolvePanelKindLaunchActionId}, never directly — plugin
+   * configs arrive over IPC, and a plugin naming an arbitrary action here
+   * would turn its own launcher row into a dispatch of that action.
+   */
+  launchActionId?: string;
 }
 
 /**
@@ -194,6 +206,7 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     canConvert: true,
     keepAliveOnProjectSwitch: true,
     showInPalette: false,
+    launchActionId: "agent.launch",
   },
   browser: {
     id: "browser",
@@ -213,6 +226,7 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     // Reading surface like file/review: focus returns to what the user was
     // last viewing when the panel leaves the grid, not the first grid terminal.
     policy: { dockFallbackTarget: "previous-focused" },
+    launchActionId: "agent.launch",
   },
   "dev-preview": {
     id: "dev-preview",
@@ -231,6 +245,9 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     searchAliases: ["localhost", "server", "preview", "port"],
     firstRenderRestore: true,
     lazyImportPath: "src/components/DevPreview/DevPreviewPane.tsx",
+    // Not `agent.launch`: that path creates a bare preview with no command, so
+    // only this one honours the project's configured dev-server command.
+    launchActionId: "devServer.start",
   },
   review: {
     id: "review",
@@ -298,6 +315,9 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     // Reading surface like review, file and diff: focus returns to what the
     // user was last reading when the panel leaves the grid.
     policy: { dockFallbackTarget: "previous-focused" },
+    // Resolves its own browse root, composes the title, and focuses an existing
+    // browser for the same folder instead of opening a second one.
+    launchActionId: "worktree.openFileBrowserPanel",
   },
   diff: {
     id: "diff",
@@ -550,6 +570,28 @@ export function resolvePanelKindPolicy(
 ): Required<PanelKindPolicy> {
   const config = typeof source === "string" ? getPanelKindConfig(source) : (source ?? undefined);
   return { ...DEFAULT_PANEL_KIND_POLICY, ...(config?.policy ?? {}) };
+}
+
+/**
+ * Resolve the action a bare launch of this kind should dispatch through, or
+ * `undefined` when the kind is created through a plain `addPanel`.
+ *
+ * Plugin-contributed kinds always resolve to `undefined`, whatever their config
+ * declares: their `PanelKindConfig` arrives over IPC from a plugin manifest, so
+ * honouring the field would let a plugin turn its own launcher row into a
+ * dispatch of any action it names. Plugin panels are spawned generically
+ * instead — `panel.openPluginPanel` remains the explicit, capability-gated way
+ * to reach one.
+ *
+ * Takes the same `PanelKindConfig | PanelKind | undefined` source as
+ * {@link resolvePanelKindPolicy}; sync and side-effect free.
+ */
+export function resolvePanelKindLaunchActionId(
+  source: PanelKindConfig | PanelKind | undefined
+): string | undefined {
+  const config = typeof source === "string" ? getPanelKindConfig(source) : (source ?? undefined);
+  if (!config || config.extensionId !== undefined) return undefined;
+  return config.launchActionId;
 }
 
 /**

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -124,12 +124,7 @@ function AppInner() {
     }))
   );
 
-  const { focusedId, addPanel } = usePanelStore(
-    useShallow((state) => ({
-      focusedId: state.focusedId,
-      addPanel: state.addPanel,
-    }))
-  );
+  const focusedId = usePanelStore((state) => state.focusedId);
 
   const { launchAgent, availability, agentSettings, refreshSettings } = useAgentLauncher();
 
@@ -545,7 +540,6 @@ function AppInner() {
                 shouldMountPanelPalette={shouldMountPanelPalette}
                 resumeSession={resumeSession}
                 handleLaunchAgent={handleLaunchAgent}
-                addPanel={addPanel}
                 defaultTerminalCwd={defaultTerminalCwd}
                 activeWorktreeId={activeWorktreeId}
                 isProjectSwitcherModalOpen={isProjectSwitcherModalOpen}

--- a/src/ModalHostLayer.tsx
+++ b/src/ModalHostLayer.tsx
@@ -275,9 +275,11 @@ export function ModalHostLayer({
         notify({
           type: "error",
           title: `Couldn't open ${name}`,
-          // Same purpose-written copy the other launcher surfaces use — the
-          // action's own messages name internal ids and carry no fix.
-          message: "No folder resolved for this workspace. Select a worktree and try again.",
+          // Purpose-written, and general enough to stay true across every kind
+          // the palette offers — the action's own messages name internal ids
+          // and carry no fix.
+          message:
+            "No project folder or worktree resolved for this launch. Open a project or select a worktree, then try again.",
           // `uiFeedback` is passive; without this the palette's only signal
           // would be an inbox row.
           priority: "high",

--- a/src/ModalHostLayer.tsx
+++ b/src/ModalHostLayer.tsx
@@ -271,10 +271,16 @@ export function ModalHostLayer({
         if (outcome.route !== "action" || outcome.result.ok) return;
         // A full grid is already reported by `addPanel` with the real recovery.
         if (isPanelLimitError(outcome.result.error.message)) return;
+        logError("Panel launch from palette refused", outcome.result.error);
         notify({
           type: "error",
           title: `Couldn't open ${name}`,
-          message: outcome.result.error.message,
+          // Same purpose-written copy the other launcher surfaces use — the
+          // action's own messages name internal ids and carry no fix.
+          message: "No folder resolved for this workspace. Select a worktree and try again.",
+          // `uiFeedback` is passive; without this the palette's only signal
+          // would be an inbox row.
+          priority: "high",
           context: { eventKind: "uiFeedback" },
           action: { label: "Retry", onClick: () => launchPanelFromPalette(kindId, name) },
         });

--- a/src/ModalHostLayer.tsx
+++ b/src/ModalHostLayer.tsx
@@ -16,8 +16,11 @@ import type { UseAgentLauncherReturn } from "./hooks/useAgentLauncher";
 import type { PluginDeepLinkState } from "./hooks/app";
 import type { SettingsTab } from "./components/Settings";
 import type { NonGitFolderStep } from "./components/Project/NonGitFolderDialog";
-import type { BuiltInPanelKind } from "./types";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { launchPanelKind } from "@/registry/panelKindLaunch";
+import { isPanelLimitError } from "@/services/actions/definitions/panelLimitError";
+import { notify } from "@/lib/notify";
+import { logError } from "@/utils/logger";
 import { ConfirmDialog } from "./components/ui/ConfirmDialog";
 import { usePilotStore } from "@/store/pilotStore";
 import { Toaster } from "./components/ui/toaster";
@@ -26,7 +29,7 @@ import { ReEntrySummary } from "./components/ui/ReEntrySummary";
 import { TerminalInfoDialogHost } from "./components/Terminal/TerminalInfoDialogHost";
 import { PostHydrationListeners } from "./components/PostHydrationListeners";
 import { PanelTransitionOverlay } from "./components/Panel";
-import { usePanelStore, usePluginManagerStore } from "./store";
+import { usePluginManagerStore } from "./store";
 import { actionService } from "./services/ActionService";
 import {
   LazyQuickSwitcher,
@@ -83,7 +86,6 @@ interface ModalHostLayerProps {
   shouldMountPanelPalette: boolean;
   resumeSession: (session: AgentSessionRecord) => Promise<void>;
   handleLaunchAgent: (type: string) => void | Promise<void>;
-  addPanel: ReturnType<typeof usePanelStore.getState>["addPanel"];
   defaultTerminalCwd: string | undefined;
   activeWorktreeId: string | null;
   isProjectSwitcherModalOpen: boolean;
@@ -177,7 +179,6 @@ export function ModalHostLayer({
   shouldMountPanelPalette,
   resumeSession,
   handleLaunchAgent,
-  addPanel,
   defaultTerminalCwd,
   activeWorktreeId,
   isProjectSwitcherModalOpen,
@@ -253,6 +254,33 @@ export function ModalHostLayer({
   // registry, a keybinding and the project switcher, none of which has a prop
   // path into this layer.
   const isPilotOpen = usePilotStore((s) => s.isOpen);
+
+  // Both palette activation paths (click and Enter) launch the same way, and
+  // through the same seam the dock uses, so a kind can't behave differently
+  // depending on which launcher opened it (#11668). The palette closes on
+  // select, so a refusal has to be reported or it leaves no trace.
+  const launchPanelFromPalette = (kindId: string, name: string) => {
+    void launchPanelKind({
+      kindId,
+      location: "grid",
+      cwd: defaultTerminalCwd,
+      worktreeId: activeWorktreeId,
+      source: "user",
+    })
+      .then((outcome) => {
+        if (outcome.route !== "action" || outcome.result.ok) return;
+        // A full grid is already reported by `addPanel` with the real recovery.
+        if (isPanelLimitError(outcome.result.error.message)) return;
+        notify({
+          type: "error",
+          title: `Couldn't open ${name}`,
+          message: outcome.result.error.message,
+          context: { eventKind: "uiFeedback" },
+          action: { label: "Retry", onClick: () => launchPanelFromPalette(kindId, name) },
+        });
+      })
+      .catch((error) => logError("Panel launch from palette failed", error));
+  };
 
   return (
     <>
@@ -391,12 +419,7 @@ export function ModalHostLayer({
                     void handleLaunchAgent(agentId);
                   }
                 } else {
-                  addPanel({
-                    kind: result.id as BuiltInPanelKind,
-                    cwd: defaultTerminalCwd,
-                    worktreeId: activeWorktreeId ?? undefined,
-                    location: "grid",
-                  });
+                  launchPanelFromPalette(result.id, result.name);
                 }
               }}
               onConfirm={() => {
@@ -411,12 +434,7 @@ export function ModalHostLayer({
                     void handleLaunchAgent(agentId);
                   }
                 } else {
-                  addPanel({
-                    kind: selected.id as BuiltInPanelKind,
-                    cwd: defaultTerminalCwd,
-                    worktreeId: activeWorktreeId ?? undefined,
-                    location: "grid",
-                  });
+                  launchPanelFromPalette(selected.id, selected.name);
                 }
               }}
               onClose={panelPalette.close}

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -668,7 +668,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
           recipeContext={recipeContext}
           onLaunchAgent={(agentId) => void handleAddTerminal(agentId, "context-menu")}
           surface="dock"
-          settingsSource="context-menu"
+          source="context-menu"
         />
         <ContextMenuSeparator />
         <ContextMenuSub>

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -230,7 +230,7 @@ export function DockLaunchButton({
         activeWorktreeId,
         recipeContext,
         onLaunchAgent,
-        settingsSource: "menu",
+        source: "menu",
       });
     },
     [activeWorktreeId, closeLauncher, cwd, onLaunchAgent, recipeContext]

--- a/src/components/Layout/DockLaunchMenuItems.tsx
+++ b/src/components/Layout/DockLaunchMenuItems.tsx
@@ -43,11 +43,11 @@ interface DockLaunchMenuItemsProps {
    * don't pass it.
    */
   pinnedCount?: number;
-  // The surface attribution to attach to the settings dispatch for
-  // non-launchable rows. Defaults to "menu"; ContentDock's context-menu
-  // path overrides it so telemetry stays consistent with how the user
-  // actually opened the launcher.
-  settingsSource?: ActionSource;
+  // The surface attribution to attach to everything this launcher dispatches —
+  // panel launches and the settings redirect for non-launchable rows. Defaults
+  // to "menu"; ContentDock's context-menu path overrides it so attribution
+  // stays consistent with how the user actually opened the launcher.
+  source?: ActionSource;
   /**
    * Where this surface creates panels. The grid's context menu launches into
    * the grid, so it must not offer a dock destination it won't honour.
@@ -69,7 +69,7 @@ export function DockLaunchMenuItems({
   recipeContext,
   onLaunchAgent,
   pinnedCount,
-  settingsSource = "menu",
+  source = "menu",
   surface,
 }: DockLaunchMenuItemsProps) {
   const model = useDockLaunchModel({ agents, pinnedCount, activeWorktreeId, surface });
@@ -80,7 +80,7 @@ export function DockLaunchMenuItems({
       activeWorktreeId,
       recipeContext,
       onLaunchAgent,
-      settingsSource,
+      source,
     });
 
   const renderAgentItem = (agent: DockLaunchAgent, keyPrefix?: string) => {
@@ -133,7 +133,7 @@ export function DockLaunchMenuItems({
   );
 
   const renderCreateRecipeCue = () => (
-    <C.Item onSelect={() => activateCreateRecipeCue(activeWorktreeId, settingsSource)}>
+    <C.Item onSelect={() => activateCreateRecipeCue(activeWorktreeId, source)}>
       <Workflow className="w-3.5 h-3.5 mr-2" />
       Create a recipe
     </C.Item>

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -677,6 +677,10 @@ export function Toolbar({
           type: "error",
           title: "Couldn't open the file browser",
           message: "No folder resolved for this workspace. Select a worktree and try again.",
+          // `uiFeedback` is a passive kind that resolves to `priority: "low"`
+          // (inbox only), which would leave this refusal — and its Retry — with
+          // no visible signal at all.
+          priority: "high",
           context: { eventKind: "uiFeedback" },
           action: { label: "Retry", onClick: openFileBrowser },
         });

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -41,7 +41,9 @@ vi.mock("@/registry", () => ({
 }));
 
 vi.mock("@/store/panelStore", () => ({
-  usePanelStore: { getState: () => ({ addPanel: addPanelMock }) },
+  usePanelStore: {
+    getState: () => ({ addPanel: addPanelMock, panelsById: { "panel-1": { location: "grid" } } }),
+  },
 }));
 
 vi.mock("@/components/PanelPalette/PanelKindIcon", () => ({
@@ -257,9 +259,9 @@ beforeEach(() => {
   });
   notifySpawnFailuresMock.mockReset();
   logErrorMock.mockReset();
-  actionDispatchMock.mockReset();
+  actionDispatchMock.mockReset().mockResolvedValue({ ok: true, result: null });
   recordActionMruMock.mockReset();
-  addPanelMock.mockReset();
+  addPanelMock.mockReset().mockResolvedValue("panel-1");
   popoverCloseAutoFocusSpy = null;
   popoverPointerDownOutsideSpy = null;
   popoverEscapeKeyDownSpy = null;
@@ -411,7 +413,14 @@ describe("DockLaunchButton", () => {
       const { getByText } = renderButton({ onLaunchAgent });
 
       fireEvent.click(getByText("Terminal"));
-      expect(onLaunchAgent).toHaveBeenLastCalledWith("terminal");
+      // Through the launch action its registry entry names, so a shell opened
+      // here resolves its preset and command exactly as one opened elsewhere
+      // does — never as a bare panel.
+      expect(actionDispatchMock).toHaveBeenCalledWith(
+        getPanelKindConfig("terminal")!.launchActionId,
+        expect.objectContaining({ agentId: "terminal" }),
+        { source: "menu" }
+      );
       expect(addPanelMock).not.toHaveBeenCalled();
     });
   });
@@ -577,7 +586,12 @@ describe("DockLaunchButton", () => {
       // proved nothing about what Enter would do.
       const movedName = moved?.textContent;
       fireEvent.keyDown(input, { key: "Enter" });
-      const launched = onLaunchAgent.mock.calls.length > 0 || addPanelMock.mock.calls.length > 0;
+      // A row launches through whichever path its category uses: agents call
+      // back, panels dispatch their launch action or create directly.
+      const launched =
+        onLaunchAgent.mock.calls.length > 0 ||
+        addPanelMock.mock.calls.length > 0 ||
+        actionDispatchMock.mock.calls.length > 0;
       expect(launched).toBe(true);
       expect(movedName).toBeTruthy();
     });
@@ -1046,14 +1060,18 @@ describe("DockLaunchButton", () => {
     });
 
     it("cancels the return when a clicked row launches a terminal", () => {
-      // Terminal routes through onLaunchAgent rather than addPanel — the exact
-      // path the issue was reported against.
+      // Terminal dispatches its launch action rather than creating a bare
+      // panel — the exact path the issue was reported against.
       const onLaunchAgent = vi.fn();
       const { getByText } = renderButton({ onLaunchAgent });
 
       fireEvent.click(getByText("Terminal"));
 
-      expect(onLaunchAgent).toHaveBeenCalledWith("terminal");
+      expect(actionDispatchMock).toHaveBeenCalledWith(
+        getPanelKindConfig("terminal")!.launchActionId,
+        expect.objectContaining({ agentId: "terminal" }),
+        { source: "menu" }
+      );
       expect(fireCloseAutoFocus()).toHaveBeenCalledTimes(1);
     });
 

--- a/src/components/Layout/__tests__/DockLaunchMenuItems.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchMenuItems.test.tsx
@@ -164,7 +164,7 @@ describe("DockLaunchMenuItems", () => {
 
   it("routes a blocked agent to its settings subtab under the caller's source", () => {
     const onLaunchAgent = vi.fn();
-    const { getByText } = renderItems({ onLaunchAgent, settingsSource: "context-menu" });
+    const { getByText } = renderItems({ onLaunchAgent, source: "context-menu" });
 
     fireEvent.click(getByText("Gemini"));
     expect(onLaunchAgent).not.toHaveBeenCalled();

--- a/src/components/Layout/__tests__/dockLaunchItems.test.ts
+++ b/src/components/Layout/__tests__/dockLaunchItems.test.ts
@@ -13,6 +13,7 @@ const runRecipeWithResultsMock = vi.fn();
 const recordActionMruMock = vi.fn();
 const actionDispatchMock = vi.fn();
 const notifySpawnFailuresMock = vi.fn();
+const notifyMock = vi.fn();
 const logErrorMock = vi.fn();
 
 // The real `@/registry` eagerly pulls in TerminalPane and the whole panel
@@ -37,7 +38,13 @@ vi.mock("@/registry", () => ({
 }));
 
 vi.mock("@/store/panelStore", () => ({
-  usePanelStore: { getState: () => ({ addPanel: addPanelMock }) },
+  usePanelStore: {
+    getState: () => ({ addPanel: addPanelMock, panelsById: { "panel-1": { location: "grid" } } }),
+  },
+}));
+
+vi.mock("@/lib/notify", () => ({
+  notify: (...args: unknown[]) => notifyMock(...args),
 }));
 
 vi.mock("@/store/recipeStore", () => ({
@@ -71,6 +78,7 @@ import {
   type DockLaunchPanelItem,
 } from "../dockLaunchItems";
 import type { TerminalRecipe } from "@shared/types";
+import { PANEL_LIMIT_ERROR_SUFFIX } from "@/services/actions/definitions/panelLimitError";
 
 const AGENTS: DockLaunchAgent[] = [
   { id: "claude", name: "Claude", availability: "ready" },
@@ -92,16 +100,19 @@ function build(over: Partial<Parameters<typeof buildDockLaunchModel>[0]> = {}) {
   });
 }
 
+const PANEL_LIMIT_MESSAGE = `Can't open another panel: ${PANEL_LIMIT_ERROR_SUFFIX}`;
+
 const PLUGIN_DOCKABLE = "test-plugin-dockable";
 const PLUGIN_GRID_ONLY = "test-plugin-grid-only";
 const PLUGIN_HIDDEN = "test-plugin-hidden";
 
 beforeEach(() => {
-  addPanelMock.mockReset();
+  addPanelMock.mockReset().mockResolvedValue("panel-1");
   runRecipeWithResultsMock.mockReset().mockResolvedValue({ spawned: [], failed: [] });
   recordActionMruMock.mockReset();
-  actionDispatchMock.mockReset();
+  actionDispatchMock.mockReset().mockResolvedValue({ ok: true, result: null });
   notifySpawnFailuresMock.mockReset();
+  notifyMock.mockReset();
   logErrorMock.mockReset();
 });
 
@@ -365,7 +376,7 @@ describe("activateDockLaunchItem", () => {
     activeWorktreeId: "wt-1",
     recipeContext: undefined,
     onLaunchAgent: vi.fn(),
-    settingsSource: "menu" as const,
+    source: "menu" as const,
   };
 
   beforeEach(() => ctx.onLaunchAgent.mockReset());
@@ -377,18 +388,67 @@ describe("activateDockLaunchItem", () => {
     return found;
   }
 
-  it("routes the kinds agent.launch understands through onLaunchAgent", () => {
-    // resolveAgentLaunchKind throws on an id it can't resolve, so only these
-    // three may take that path.
-    for (const kind of ["terminal", "browser", "dev-preview"]) {
+  it("activates a panel kind through its registered launch action, not onLaunchAgent", () => {
+    for (const kind of ["terminal", "browser", "dev-preview", "file-browser"]) {
       activateDockLaunchItem(panelItem(kind), ctx);
     }
-    expect(ctx.onLaunchAgent.mock.calls.map((c) => c[0])).toEqual([
-      "terminal",
-      "browser",
-      "dev-preview",
+    // Each kind reaches the action its registry entry names, so the dock can't
+    // drift from the toolbar or the palette (#11668).
+    expect(actionDispatchMock.mock.calls.map((c) => c[0])).toEqual([
+      getPanelKindConfig("terminal")!.launchActionId,
+      getPanelKindConfig("browser")!.launchActionId,
+      getPanelKindConfig("dev-preview")!.launchActionId,
+      getPanelKindConfig("file-browser")!.launchActionId,
     ]);
+    expect(ctx.onLaunchAgent).not.toHaveBeenCalled();
     expect(addPanelMock).not.toHaveBeenCalled();
+  });
+
+  it("tells the launch action where the menu heading promised the panel would land", () => {
+    activateDockLaunchItem(panelItem("browser"), ctx);
+    expect(actionDispatchMock).toHaveBeenCalledWith(
+      getPanelKindConfig("browser")!.launchActionId,
+      expect.objectContaining({
+        agentId: "browser",
+        location: "dock",
+        cwd: "/repo",
+        worktreeId: "wt-1",
+        activateDockOnCreate: true,
+      }),
+      { source: "menu" }
+    );
+  });
+
+  it("reports a refused launch, since the menu closes on select", async () => {
+    actionDispatchMock.mockResolvedValue({
+      ok: false,
+      error: { code: "EXECUTION_ERROR", message: "No folder to browse" },
+    });
+
+    activateDockLaunchItem(panelItem("file-browser"), ctx);
+    await vi.waitFor(() => expect(notifyMock).toHaveBeenCalled());
+
+    const payload = notifyMock.mock.calls[0]![0] as {
+      type: string;
+      message: string;
+      action?: { label: string };
+    };
+    expect(payload.type).toBe("error");
+    expect(payload.message).toBe("No folder to browse");
+    expect(payload.action?.label).toBe("Retry");
+  });
+
+  it("stays quiet when addPanel already reported a full grid", async () => {
+    actionDispatchMock.mockResolvedValue({
+      ok: false,
+      error: { code: "EXECUTION_ERROR", message: PANEL_LIMIT_MESSAGE },
+    });
+
+    activateDockLaunchItem(panelItem("file-browser"), ctx);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(notifyMock).not.toHaveBeenCalled();
   });
 
   it("creates every other kind via addPanel at its advertised location", () => {

--- a/src/components/Layout/__tests__/dockLaunchItems.test.ts
+++ b/src/components/Layout/__tests__/dockLaunchItems.test.ts
@@ -430,16 +430,15 @@ describe("activateDockLaunchItem", () => {
     activateDockLaunchItem(panelItem("file-browser"), ctx);
     await vi.waitFor(() => expect(notifyMock).toHaveBeenCalled());
 
-    const payload = notifyMock.mock.calls[0]![0] as {
-      type: string;
-      priority?: string;
-      action?: { label: string };
-    };
-    expect(payload.type).toBe("error");
-    // `uiFeedback` is passive, so without an explicit high priority this
-    // refusal would be an inbox row the closed menu never surfaces.
-    expect(payload.priority).toBe("high");
-    expect(payload.action?.label).toBe("Retry");
+    expect(notifyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "error",
+        // `uiFeedback` is passive, so without an explicit high priority this
+        // refusal would be an inbox row the closed menu never surfaces.
+        priority: "high",
+        action: expect.objectContaining({ label: "Retry" }),
+      })
+    );
   });
 
   it("stays quiet when addPanel already reported a full grid", async () => {

--- a/src/components/Layout/__tests__/dockLaunchItems.test.ts
+++ b/src/components/Layout/__tests__/dockLaunchItems.test.ts
@@ -412,11 +412,13 @@ describe("activateDockLaunchItem", () => {
         agentId: "browser",
         location: "dock",
         cwd: "/repo",
-        worktreeId: "wt-1",
         activateDockOnCreate: true,
       }),
       { source: "menu" }
     );
+    // The launcher's ambient worktree is not a named target — the action
+    // resolves its own, so a ghost selection still lands beside its terminals.
+    expect(actionDispatchMock.mock.calls[0]![1]).not.toHaveProperty("worktreeId");
   });
 
   it("reports a refused launch, since the menu closes on select", async () => {
@@ -430,11 +432,13 @@ describe("activateDockLaunchItem", () => {
 
     const payload = notifyMock.mock.calls[0]![0] as {
       type: string;
-      message: string;
+      priority?: string;
       action?: { label: string };
     };
     expect(payload.type).toBe("error");
-    expect(payload.message).toBe("No folder to browse");
+    // `uiFeedback` is passive, so without an explicit high priority this
+    // refusal would be an inbox row the closed menu never surfaces.
+    expect(payload.priority).toBe("high");
     expect(payload.action?.label).toBe("Retry");
   });
 
@@ -445,10 +449,19 @@ describe("activateDockLaunchItem", () => {
     });
 
     activateDockLaunchItem(panelItem("file-browser"), ctx);
-    await Promise.resolve();
-    await Promise.resolve();
-
+    // Drain past the continuation rather than counting microtasks: the control
+    // below proves an ordinary refusal does reach notify through this same
+    // flush, so silence here is suppression and not a race.
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(notifyMock).not.toHaveBeenCalled();
+
+    actionDispatchMock.mockResolvedValue({
+      ok: false,
+      error: { code: "EXECUTION_ERROR", message: "No folder to browse" },
+    });
+    activateDockLaunchItem(panelItem("file-browser"), ctx);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(notifyMock).toHaveBeenCalledTimes(1);
   });
 
   it("creates every other kind via addPanel at its advertised location", () => {

--- a/src/components/Layout/dockLaunchItems.ts
+++ b/src/components/Layout/dockLaunchItems.ts
@@ -482,9 +482,11 @@ export function activateDockLaunchItem(
           title: `Couldn't open ${item.name}`,
           // Purpose-written rather than the action's own message: those name
           // internal ids ("Worktree not found: wt-3f2") and state a cause
-          // without a fix. Every refusal reachable here comes down to nothing
-          // resolving to open against.
-          message: "No folder resolved for this workspace. Select a worktree and try again.",
+          // without a fix. Covers every kind this launcher offers, so it stays
+          // true for a dev preview with no project open as well as a browser
+          // with no folder — unlike the file-browser-only surfaces.
+          message:
+            "No project folder or worktree resolved for this launch. Open a project or select a worktree, then try again.",
           // `uiFeedback` is a passive kind, so without this the toast the
           // closed menu depends on would be an inbox row nobody sees.
           priority: "high",

--- a/src/components/Layout/dockLaunchItems.ts
+++ b/src/components/Layout/dockLaunchItems.ts
@@ -476,10 +476,18 @@ export function activateDockLaunchItem(
         // A full grid is already reported by `addPanel`, with an accurate
         // message and the actual recovery (#11666).
         if (isPanelLimitError(outcome.result.error.message)) return;
+        logError("Panel launch from dock refused", outcome.result.error);
         notify({
           type: "error",
           title: `Couldn't open ${item.name}`,
-          message: outcome.result.error.message,
+          // Purpose-written rather than the action's own message: those name
+          // internal ids ("Worktree not found: wt-3f2") and state a cause
+          // without a fix. Every refusal reachable here comes down to nothing
+          // resolving to open against.
+          message: "No folder resolved for this workspace. Select a worktree and try again.",
+          // `uiFeedback` is a passive kind, so without this the toast the
+          // closed menu depends on would be an inbox row nobody sees.
+          priority: "high",
           context: { eventKind: "uiFeedback" },
           action: { label: "Retry", onClick: () => activateDockLaunchItem(item, ctx) },
         });

--- a/src/components/Layout/dockLaunchItems.ts
+++ b/src/components/Layout/dockLaunchItems.ts
@@ -10,16 +10,17 @@ import {
   subscribeToPanelKindRegistry,
   getPanelKindRegistrySnapshot,
 } from "@shared/config/panelKindRegistry";
-import { usePanelStore } from "@/store/panelStore";
 import { useRecipeStore } from "@/store/recipeStore";
 import { useActionMruStore } from "@/store/actionMruStore";
 import { actionService } from "@/services/ActionService";
+import { launchPanelKind } from "@/registry/panelKindLaunch";
+import { isPanelLimitError } from "@/services/actions/definitions/panelLimitError";
+import { notify } from "@/lib/notify";
 import { notifyRecipeSpawnFailures } from "@/utils/recipeNotify";
 import { getRecipeScope } from "@/utils/recipeScope";
 import { logError } from "@/utils/logger";
 import { isAgentLaunchable } from "@shared/utils/agentAvailability";
 import type { ActionSource, AgentAvailabilityState, TerminalRecipe } from "@shared/types";
-import type { AddPanelOptions } from "@shared/types/addPanelOptions";
 import type { RecipeContext } from "@/utils/recipeVariables";
 
 export const AGENT_MRU_PREFIX = "agent.";
@@ -27,19 +28,6 @@ export const AGENT_MRU_PREFIX = "agent.";
 /** Cap the "Recently launched" band so it stays a quick-reach shortcut rather
  * than a second full agent list above the fixed Pinned/Other groups. */
 export const RECENCY_BAND_CAP = 3;
-
-/**
- * Panel kinds `agent.launch` understands. `terminal` resolves to the plain
- * shell; `browser` and `dev-preview` return from their own branches in
- * `launchAgent` (seeding the dev-server title, reusing the launch reentrancy
- * guard). Every other kind must be created through `addPanel` directly —
- * `resolveAgentLaunchKind` throws on an id it can't resolve as an agent (#11498).
- */
-const AGENT_LAUNCH_PANEL_KINDS: ReadonlySet<string> = new Set([
-  "terminal",
-  "browser",
-  "dev-preview",
-]);
 
 /** Terminal opts out of the palette (it has dedicated spawn actions) but is the
  * launcher's most-used entry, so it is added back explicitly here. */
@@ -441,13 +429,15 @@ export interface ActivateDockLaunchItemContext {
   activeWorktreeId: string | null;
   recipeContext?: RecipeContext;
   onLaunchAgent: (agentId: string) => void;
-  settingsSource: ActionSource;
+  /** Dispatch source for everything this activation dispatches. Must stay a
+   * foreground source, or panel actions silently skip their focus handling. */
+  source: ActionSource;
 }
 
 /**
- * Run a launcher entry. Agents and the three kinds `launchAgent` special-cases
- * keep routing through `onLaunchAgent`; everything else creates its panel
- * directly at the location its menu heading advertised.
+ * Run a launcher entry. Agents keep routing through `onLaunchAgent`; panels go
+ * through the shared launch seam, so a kind activates here exactly as it does
+ * from the palette or the toolbar (#11668).
  */
 export function activateDockLaunchItem(
   item: DockLaunchItem,
@@ -462,7 +452,7 @@ export function activateDockLaunchItem(
       void actionService.dispatch(
         "app.settings.openTab",
         { tab: "agents", subtab: agent.id },
-        { source: ctx.settingsSource }
+        { source: ctx.source }
       );
       return;
     }
@@ -472,22 +462,29 @@ export function activateDockLaunchItem(
   }
 
   if (item.category === "panel") {
-    if (AGENT_LAUNCH_PANEL_KINDS.has(item.kindId)) {
-      ctx.onLaunchAgent(item.kindId);
-      return;
-    }
-    void usePanelStore.getState().addPanel({
-      kind: item.kindId,
-      cwd: ctx.cwd,
-      worktreeId: ctx.activeWorktreeId ?? undefined,
+    // The menu closes on select, so an action that refuses leaves no trace
+    // otherwise — the same reason LauncherQuickActions reports its refusals.
+    void launchPanelKind({
+      kindId: item.kindId,
       location: item.location,
-      // Folds dock activation into the same set() that commits the panel, so
-      // the offscreen-container watchdog can't close it in the render gap (#6590).
-      activateDockOnCreate: item.location === "dock",
-      // Plugin kinds are deliberately outside the built-in AddPanelOptions
-      // union (a `string & {}` member would defeat discriminated narrowing),
-      // so widening happens here at the integration boundary.
-    } as AddPanelOptions);
+      cwd: ctx.cwd,
+      worktreeId: ctx.activeWorktreeId,
+      source: ctx.source,
+    })
+      .then((outcome) => {
+        if (outcome.route !== "action" || outcome.result.ok) return;
+        // A full grid is already reported by `addPanel`, with an accurate
+        // message and the actual recovery (#11666).
+        if (isPanelLimitError(outcome.result.error.message)) return;
+        notify({
+          type: "error",
+          title: `Couldn't open ${item.name}`,
+          message: outcome.result.error.message,
+          context: { eventKind: "uiFeedback" },
+          action: { label: "Retry", onClick: () => activateDockLaunchItem(item, ctx) },
+        });
+      })
+      .catch((error) => logError("Panel launch from dock failed", error));
     return;
   }
 

--- a/src/components/Terminal/LauncherQuickActions.tsx
+++ b/src/components/Terminal/LauncherQuickActions.tsx
@@ -153,6 +153,10 @@ export function LauncherQuickActions() {
           // hit ("No folder to browse", a worktree that no longer exists) come
           // down to the same thing for the user, and the recovery is the same.
           message: "No folder resolved for this workspace. Select a worktree and try again.",
+          // `uiFeedback` is a passive kind that resolves to `priority: "low"`
+          // (inbox only), which would leave this refusal — and its Retry — with
+          // no visible signal at all.
+          priority: "high",
           context: { eventKind: "uiFeedback" },
           action: { label: "Retry", onClick: openFileBrowser },
         });

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -1123,7 +1123,7 @@ export function useContentGridContext({
         recipeContext={gridRecipeContext}
         onLaunchAgent={handleGridLaunch}
         surface="grid"
-        settingsSource="context-menu"
+        source="context-menu"
       />
       <ContextMenuSeparator />
       <ContextMenuSub>

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -14,7 +14,7 @@ import { useHomeDir } from "@/hooks/app/useHomeDir";
 import { logError, logWarn } from "@/utils/logger";
 import { markRendererPerformance } from "@/utils/performance";
 import { resolveWorkspaceCwd } from "@/utils/workspaceCwd";
-import { readDevServerCommand } from "@/utils/devServerCommand";
+import { readViewDevServerCommand } from "@/utils/devServerCommand";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
@@ -412,12 +412,9 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
             // The same command `devServer.start` seeds. Without it a preview
             // opened from the worktree menu or over MCP carries none of its
             // own, so it behaves differently from one opened anywhere else
-            // (#11668). A settings read must not fail the launch — the pane
-            // falls back to the settings store when the field is absent.
-            const projectId = currentProject?.id;
-            const devCommand = projectId
-              ? await readDevServerCommand(projectId).catch(() => undefined)
-              : undefined;
+            // (#11668). Resolved from the view's own project, never the
+            // globally-current one.
+            const devCommand = await readViewDevServerCommand();
             const terminalId = await addPanel({
               kind: "dev-preview",
               title: "Dev Server",

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -14,6 +14,7 @@ import { useHomeDir } from "@/hooks/app/useHomeDir";
 import { logError, logWarn } from "@/utils/logger";
 import { markRendererPerformance } from "@/utils/performance";
 import { resolveWorkspaceCwd } from "@/utils/workspaceCwd";
+import { readDevServerCommand } from "@/utils/devServerCommand";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
@@ -408,9 +409,19 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
         // Handle dev-preview pane specially
         if (agentId === "dev-preview") {
           try {
+            // The same command `devServer.start` seeds. Without it a preview
+            // opened from the worktree menu or over MCP carries none of its
+            // own, so it behaves differently from one opened anywhere else
+            // (#11668). A settings read must not fail the launch — the pane
+            // falls back to the settings store when the field is absent.
+            const projectId = currentProject?.id;
+            const devCommand = projectId
+              ? await readDevServerCommand(projectId).catch(() => undefined)
+              : undefined;
             const terminalId = await addPanel({
               kind: "dev-preview",
               title: "Dev Server",
+              devCommand,
               cwd,
               worktreeId: effectiveWorktreeId || undefined,
               location: launchOptions?.location,

--- a/src/registry/__tests__/panelKindLaunch.test.ts
+++ b/src/registry/__tests__/panelKindLaunch.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  registerPanelKind,
+  unregisterPanelKind,
+  getPanelKindConfig,
+} from "@shared/config/panelKindRegistry";
+
+const addPanelMock = vi.fn();
+const panelsByIdRef: { current: Record<string, { location: string }> } = { current: {} };
+const actionDispatchMock = vi.fn();
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: {
+    getState: () => ({ addPanel: addPanelMock, panelsById: panelsByIdRef.current }),
+  },
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: (...args: unknown[]) => actionDispatchMock(...args) },
+}));
+
+import { launchPanelKind } from "../panelKindLaunch";
+
+const PLUGIN_KIND = "test-plugin-launch-kind";
+
+beforeEach(() => {
+  addPanelMock.mockReset().mockResolvedValue("panel-1");
+  actionDispatchMock.mockReset().mockResolvedValue({ ok: true, result: null });
+  panelsByIdRef.current = { "panel-1": { location: "grid" } };
+});
+
+afterEach(() => {
+  unregisterPanelKind(PLUGIN_KIND);
+});
+
+function launch(over: Partial<Parameters<typeof launchPanelKind>[0]> = {}) {
+  return launchPanelKind({
+    kindId: "file-browser",
+    location: "grid",
+    cwd: "/repo",
+    worktreeId: "wt-1",
+    source: "menu",
+    ...over,
+  });
+}
+
+describe("launchPanelKind", () => {
+  it("dispatches the action the kind's registry entry names", async () => {
+    const outcome = await launch({ kindId: "dev-preview" });
+
+    expect(actionDispatchMock).toHaveBeenCalledTimes(1);
+    expect(actionDispatchMock.mock.calls[0]![0]).toBe(
+      getPanelKindConfig("dev-preview")!.launchActionId
+    );
+    expect(addPanelMock).not.toHaveBeenCalled();
+    expect(outcome).toMatchObject({ route: "action" });
+  });
+
+  it("routes each built-in kind to a different action rather than one shared path", async () => {
+    const dispatched = new Map<string, string>();
+    for (const kindId of ["terminal", "browser", "dev-preview", "file-browser"]) {
+      actionDispatchMock.mockClear();
+      await launch({ kindId });
+      dispatched.set(kindId, actionDispatchMock.mock.calls[0]![0] as string);
+    }
+
+    // The bug this fixes: dev-preview and file-browser were launched through
+    // the generic agent path, dropping the dev-server command and the file
+    // browser's target resolution.
+    expect(dispatched.get("dev-preview")).not.toBe(dispatched.get("browser"));
+    expect(dispatched.get("file-browser")).not.toBe(dispatched.get("browser"));
+    expect(dispatched.get("terminal")).toBe(dispatched.get("browser"));
+  });
+
+  it("passes the surface's destination and target to the action", async () => {
+    await launch({ kindId: "browser", location: "dock", cwd: "/repo", worktreeId: "wt-9" });
+
+    const [, args, opts] = actionDispatchMock.mock.calls[0]!;
+    expect(args).toMatchObject({
+      agentId: "browser",
+      location: "dock",
+      cwd: "/repo",
+      worktreeId: "wt-9",
+      activateDockOnCreate: true,
+    });
+    expect(opts).toEqual({ source: "menu" });
+  });
+
+  it("does not ask for dock activation on a grid launch", async () => {
+    await launch({ kindId: "browser", location: "grid" });
+
+    expect(actionDispatchMock.mock.calls[0]![1]).toMatchObject({ activateDockOnCreate: false });
+  });
+
+  it("sends an empty worktree id as absent so the action resolves its own target", async () => {
+    await launch({ worktreeId: "" });
+
+    expect(actionDispatchMock.mock.calls[0]![1]).toMatchObject({ worktreeId: undefined });
+  });
+
+  it("forwards the caller's dispatch source unchanged", async () => {
+    await launch({ source: "user" });
+
+    expect(actionDispatchMock.mock.calls[0]![2]).toEqual({ source: "user" });
+  });
+
+  it("returns a failed dispatch instead of reporting it", async () => {
+    const error = { code: "EXECUTION_ERROR", message: "No folder to browse" };
+    actionDispatchMock.mockResolvedValue({ ok: false, error });
+
+    const outcome = await launch();
+
+    expect(outcome).toEqual({
+      route: "action",
+      actionId: getPanelKindConfig("file-browser")!.launchActionId,
+      result: { ok: false, error },
+    });
+  });
+
+  it("creates a kind with no launch action through addPanel", async () => {
+    const outcome = await launch({ kindId: "review" });
+
+    expect(actionDispatchMock).not.toHaveBeenCalled();
+    expect(addPanelMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "review",
+        cwd: "/repo",
+        worktreeId: "wt-1",
+        location: "grid",
+      })
+    );
+    expect(outcome).toEqual({ route: "panel", panelId: "panel-1", location: "grid" });
+  });
+
+  it("reports where the panel actually landed, not where it was asked to land", async () => {
+    panelsByIdRef.current = { "panel-1": { location: "grid" } };
+
+    const outcome = await launch({ kindId: "review", location: "dock" });
+
+    expect(addPanelMock.mock.calls[0]![0]).toMatchObject({ location: "dock" });
+    expect(outcome).toMatchObject({ route: "panel", location: "grid" });
+  });
+
+  it("reports a refused addPanel without inventing a location", async () => {
+    addPanelMock.mockResolvedValue(null);
+
+    const outcome = await launch({ kindId: "review" });
+
+    expect(outcome).toEqual({ route: "panel", panelId: null, location: null });
+  });
+
+  it("ignores a launch action a plugin declared for its own kind", async () => {
+    registerPanelKind({
+      id: PLUGIN_KIND,
+      name: "Malicious",
+      iconId: "box",
+      color: "#fff",
+      hasPty: false,
+      canRestart: false,
+      canConvert: false,
+      extensionId: "evil-plugin",
+      launchActionId: "worktree.delete",
+    });
+
+    const outcome = await launch({ kindId: PLUGIN_KIND });
+
+    expect(actionDispatchMock).not.toHaveBeenCalled();
+    expect(addPanelMock).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: PLUGIN_KIND, location: "grid" })
+    );
+    expect(outcome).toMatchObject({ route: "panel" });
+  });
+
+  it("creates an unregistered kind generically rather than throwing", async () => {
+    const outcome = await launch({ kindId: "not-a-registered-kind" });
+
+    expect(actionDispatchMock).not.toHaveBeenCalled();
+    expect(outcome).toMatchObject({ route: "panel" });
+  });
+});

--- a/src/registry/__tests__/panelKindLaunch.test.ts
+++ b/src/registry/__tests__/panelKindLaunch.test.ts
@@ -20,8 +20,21 @@ vi.mock("@/services/ActionService", () => ({
 }));
 
 import { launchPanelKind } from "../panelKindLaunch";
+import { BUILT_IN_ACTION_IDS } from "@shared/config/actionIds";
 
 const PLUGIN_KIND = "test-plugin-launch-kind";
+
+/**
+ * The product contract from issue #11668, stated independently of the registry
+ * so a wrong value there fails here: routing dev-preview or file-browser
+ * through the generic agent path is the bug being fixed.
+ */
+const expectedLaunchActions = {
+  terminal: "agent.launch",
+  browser: "agent.launch",
+  "dev-preview": "devServer.start",
+  "file-browser": "worktree.openFileBrowserPanel",
+} as const;
 
 beforeEach(() => {
   addPanelMock.mockReset().mockResolvedValue("panel-1");
@@ -56,31 +69,30 @@ describe("launchPanelKind", () => {
     expect(outcome).toMatchObject({ route: "action" });
   });
 
-  it("routes each built-in kind to a different action rather than one shared path", async () => {
-    const dispatched = new Map<string, string>();
-    for (const kindId of ["terminal", "browser", "dev-preview", "file-browser"]) {
+  it("routes each kind to the action issue #11668 requires", async () => {
+    for (const [kindId, actionId] of Object.entries(expectedLaunchActions)) {
       actionDispatchMock.mockClear();
       await launch({ kindId });
-      dispatched.set(kindId, actionDispatchMock.mock.calls[0]![0] as string);
+      expect(actionDispatchMock.mock.calls[0]![0]).toBe(actionId);
     }
-
-    // The bug this fixes: dev-preview and file-browser were launched through
-    // the generic agent path, dropping the dev-server command and the file
-    // browser's target resolution.
-    expect(dispatched.get("dev-preview")).not.toBe(dispatched.get("browser"));
-    expect(dispatched.get("file-browser")).not.toBe(dispatched.get("browser"));
-    expect(dispatched.get("terminal")).toBe(dispatched.get("browser"));
   });
 
-  it("passes the surface's destination and target to the action", async () => {
-    await launch({ kindId: "browser", location: "dock", cwd: "/repo", worktreeId: "wt-9" });
+  it("only names actions the app actually registers", () => {
+    for (const kindId of Object.keys(expectedLaunchActions)) {
+      const actionId = getPanelKindConfig(kindId)!.launchActionId!;
+      // A typo here dispatches to nothing and refuses the launch at runtime.
+      expect(BUILT_IN_ACTION_IDS).toContain(actionId);
+    }
+  });
+
+  it("passes the surface's destination to the action", async () => {
+    await launch({ kindId: "browser", location: "dock", cwd: "/repo" });
 
     const [, args, opts] = actionDispatchMock.mock.calls[0]!;
     expect(args).toMatchObject({
       agentId: "browser",
       location: "dock",
       cwd: "/repo",
-      worktreeId: "wt-9",
       activateDockOnCreate: true,
     });
     expect(opts).toEqual({ source: "menu" });
@@ -92,10 +104,20 @@ describe("launchPanelKind", () => {
     expect(actionDispatchMock.mock.calls[0]![1]).toMatchObject({ activateDockOnCreate: false });
   });
 
-  it("sends an empty worktree id as absent so the action resolves its own target", async () => {
-    await launch({ worktreeId: "" });
+  it("never names the surface's worktree as an explicit target", async () => {
+    // A launcher's ambient selection is not a named target. `resolveLaunchTarget`
+    // keeps an inherited ghost id but makes an explicit one throw (#10812), and
+    // `resolveFileBrowserTarget` prefers the focused worktree over the active
+    // one — forwarding this would override both.
+    await launch({ kindId: "browser", worktreeId: "ghost-wt" });
 
-    expect(actionDispatchMock.mock.calls[0]![1]).toMatchObject({ worktreeId: undefined });
+    expect(actionDispatchMock.mock.calls[0]![1]).not.toHaveProperty("worktreeId");
+  });
+
+  it("sends an empty cwd as absent so the action resolves its own", async () => {
+    await launch({ kindId: "browser", cwd: "" });
+
+    expect(actionDispatchMock.mock.calls[0]![1]).toMatchObject({ cwd: undefined });
   });
 
   it("forwards the caller's dispatch source unchanged", async () => {

--- a/src/registry/panelKindLaunch.ts
+++ b/src/registry/panelKindLaunch.ts
@@ -1,0 +1,97 @@
+import { resolvePanelKindLaunchActionId } from "@shared/config/panelKindRegistry";
+import { actionService } from "@/services/ActionService";
+import { usePanelStore } from "@/store/panelStore";
+import type { ActionSource, ActionDispatchResult } from "@shared/types";
+import type { AddPanelOptions } from "@shared/types/addPanelOptions";
+
+export interface LaunchPanelKindOptions {
+  kindId: string;
+  /** Where the surface told the user this panel would land. */
+  location: "dock" | "grid";
+  cwd?: string;
+  worktreeId: string | null;
+  source: ActionSource;
+}
+
+/**
+ * A kind with a `launchActionId` was activated by dispatching it; the caller
+ * gets the dispatch result so it can present a refusal in its own voice.
+ */
+export interface PanelKindActionLaunch {
+  route: "action";
+  actionId: string;
+  result: ActionDispatchResult;
+}
+
+/** A kind with no launch action was created directly. */
+export interface PanelKindPanelLaunch {
+  route: "panel";
+  /** `null` when `addPanel` refused — it has already reported why. */
+  panelId: string | null;
+  /** Where the panel actually landed, which is not always what was requested. */
+  location: string | null;
+}
+
+export type PanelKindLaunchOutcome = PanelKindActionLaunch | PanelKindPanelLaunch;
+
+/**
+ * Activate a panel kind the way its registry entry says it activates, so the
+ * launcher surfaces (dock `+`, panel palette, …) can't drift from each other or
+ * from the toolbar (#11668). Curation and presentation stay with each surface —
+ * this only answers "how does this kind launch", and never notifies.
+ *
+ * Kinds that name a `launchActionId` dispatch it and let it own target
+ * resolution, titles and dedup. Everything else is created through `addPanel`
+ * exactly as before.
+ */
+export async function launchPanelKind({
+  kindId,
+  location,
+  cwd,
+  worktreeId,
+  source,
+}: LaunchPanelKindOptions): Promise<PanelKindLaunchOutcome> {
+  const activateDockOnCreate = location === "dock";
+  const actionId = resolvePanelKindLaunchActionId(kindId);
+
+  if (actionId !== undefined) {
+    // One bag for every launch action: each declares the fields it wants and
+    // `ActionService` hands `run()` the parsed args, so the rest are dropped
+    // before they reach it. `agentId` is what `agent.launch` calls the kind —
+    // its schema admits the synthetic `terminal`/`browser`/`dev-preview` ids.
+    const result = await actionService.dispatch(
+      actionId,
+      {
+        agentId: kindId,
+        location,
+        cwd,
+        // Empty ids are rejected by the stricter arg schemas, and mean the same
+        // thing as an absent one: resolve the target from context.
+        worktreeId: worktreeId || undefined,
+        activateDockOnCreate,
+      },
+      { source }
+    );
+    return { route: "action", actionId, result };
+  }
+
+  const panelId = await usePanelStore.getState().addPanel({
+    kind: kindId,
+    cwd,
+    worktreeId: worktreeId ?? undefined,
+    location,
+    // Folds dock activation into the same set() that commits the panel, so the
+    // offscreen-container watchdog can't close it in the render gap (#6590).
+    activateDockOnCreate,
+    // Plugin kinds are deliberately outside the built-in AddPanelOptions union
+    // (a `string & {}` member would defeat discriminated narrowing), so
+    // widening happens here at the integration boundary.
+  } as AddPanelOptions);
+
+  // The committed location, not the requested one: a non-dockable kind asked
+  // for the dock lands in the grid instead.
+  const committed = panelId
+    ? (usePanelStore.getState().panelsById[panelId]?.location ?? null)
+    : null;
+  return { route: "panel", panelId: panelId ?? null, location: committed };
+}

--- a/src/registry/panelKindLaunch.ts
+++ b/src/registry/panelKindLaunch.ts
@@ -9,6 +9,11 @@ export interface LaunchPanelKindOptions {
   /** Where the surface told the user this panel would land. */
   location: "dock" | "grid";
   cwd?: string;
+  /**
+   * The surface's ambient worktree. Used to place a directly-created panel; it
+   * is deliberately NOT forwarded to a launch action, which resolves its own
+   * target from the dispatch context — see {@link launchPanelKind}.
+   */
   worktreeId: string | null;
   source: ActionSource;
 }
@@ -59,17 +64,17 @@ export async function launchPanelKind({
     // `ActionService` hands `run()` the parsed args, so the rest are dropped
     // before they reach it. `agentId` is what `agent.launch` calls the kind —
     // its schema admits the synthetic `terminal`/`browser`/`dev-preview` ids.
+    //
+    // No `worktreeId`: a launcher's ambient selection is not a named target,
+    // and the two resolve differently on purpose. `resolveLaunchTarget` keeps
+    // an inherited ghost id so the panel joins its worktree's surviving
+    // terminals but makes an explicit one throw (#10812/#11232), and
+    // `resolveFileBrowserTarget` prefers the focused worktree over the active
+    // one. Forwarding the surface's id would assert a target nobody named and
+    // override both. Every launch action reads the dispatch context instead.
     const result = await actionService.dispatch(
       actionId,
-      {
-        agentId: kindId,
-        location,
-        cwd,
-        // Empty ids are rejected by the stricter arg schemas, and mean the same
-        // thing as an absent one: resolve the target from context.
-        worktreeId: worktreeId || undefined,
-        activateDockOnCreate,
-      },
+      { agentId: kindId, location, cwd: cwd || undefined, activateDockOnCreate },
       { source }
     );
     return { route: "action", actionId, result };
@@ -78,7 +83,9 @@ export async function launchPanelKind({
   const panelId = await usePanelStore.getState().addPanel({
     kind: kindId,
     cwd,
-    worktreeId: worktreeId ?? undefined,
+    // An empty id would place the panel in a bucket nothing renders, so it
+    // means the same as an absent one.
+    worktreeId: worktreeId || undefined,
     location,
     // Folds dock activation into the same set() that commits the panel, so the
     // offscreen-container watchdog can't close it in the render gap (#6590).

--- a/src/services/actions/definitions/__tests__/devServerActions.test.ts
+++ b/src/services/actions/definitions/__tests__/devServerActions.test.ts
@@ -75,6 +75,22 @@ describe("devServerActions", () => {
     );
   });
 
+  it("falls back to the scratch path when no project is open", async () => {
+    projectStoreMock.getState.mockReturnValue({ currentProject: null });
+    const run = setupActions();
+
+    await run("devServer.start", { scratchPath: "/scratch/workspace" });
+
+    expect(projectClientMock.getSettings).not.toHaveBeenCalled();
+    expect(panelStoreMock.getState().addPanel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "dev-preview",
+        cwd: "/scratch/workspace",
+        devCommand: undefined,
+      })
+    );
+  });
+
   it("rejects launch when no absolute cwd can be resolved", async () => {
     projectStoreMock.getState.mockReturnValue({
       currentProject: { id: "project-1", path: "relative" },

--- a/src/services/actions/definitions/devServerActions.ts
+++ b/src/services/actions/definitions/devServerActions.ts
@@ -2,6 +2,7 @@ import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import type { ActionContext } from "@shared/types/actions";
 import { isAbsolute } from "@shared/utils/path";
 import { projectClient } from "@/clients";
+import { readDevServerCommand } from "@/utils/devServerCommand";
 import { usePanelStore } from "@/store/panelStore";
 import { useProjectStore } from "@/store/projectStore";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
@@ -56,8 +57,7 @@ export function registerDevServerActions(
         throw new Error("No project is currently open");
       }
 
-      const settings = await projectClient.getSettings(projectId);
-      const devServerCommand = settings?.devServerCommand?.trim();
+      const devServerCommand = await readDevServerCommand(projectId);
 
       const cwd = firstAbsolutePath(
         ctx.activeWorktreePath,
@@ -75,7 +75,7 @@ export function registerDevServerActions(
         cwd,
         worktreeId: ctx.activeWorktreeId,
         location: "grid",
-        devCommand: devServerCommand || undefined,
+        devCommand: devServerCommand,
       });
     },
   }));

--- a/src/services/actions/definitions/devServerActions.ts
+++ b/src/services/actions/definitions/devServerActions.ts
@@ -53,17 +53,16 @@ export function registerDevServerActions(
         (await projectClient.getCurrent().catch(() => null));
       const projectId = ctx.projectId ?? currentProject?.id;
 
-      if (!projectId) {
-        throw new Error("No project is currently open");
-      }
-
-      const devServerCommand = await readDevServerCommand(projectId);
+      // Scratch-owned views have no project, and the dock/palette launcher used
+      // to open a dev preview there via the workspace cwd fallback (#11673).
+      const devServerCommand = projectId ? await readDevServerCommand(projectId) : undefined;
 
       const cwd = firstAbsolutePath(
         ctx.activeWorktreePath,
         readActiveWorktreePath(ctx.activeWorktreeId),
         ctx.projectPath,
-        currentProject?.path
+        currentProject?.path,
+        ctx.scratchPath
       );
       if (!cwd) {
         throw new Error("No absolute project path is available for Dev Preview");

--- a/src/utils/__tests__/devServerCommand.test.ts
+++ b/src/utils/__tests__/devServerCommand.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const getSettingsMock = vi.fn();
+const viewWorkspaceIdRef: { current: string | null } = { current: null };
+const projectStateRef: {
+  current: { projects: Array<{ id: string; path: string }>; currentProject: unknown };
+} = { current: { projects: [], currentProject: null } };
+
+vi.mock("@/clients", () => ({
+  projectClient: { getSettings: (...args: unknown[]) => getSettingsMock(...args) },
+}));
+
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: { getState: () => projectStateRef.current },
+}));
+
+vi.mock("@/store/viewWorkspaceId", () => ({
+  getViewWorkspaceId: () => viewWorkspaceIdRef.current,
+}));
+
+import { readDevServerCommand, readViewDevServerCommand } from "../devServerCommand";
+
+const PROJECT_A = { id: "proj-a", path: "/a" };
+const PROJECT_B = { id: "proj-b", path: "/b" };
+
+beforeEach(() => {
+  getSettingsMock
+    .mockReset()
+    .mockImplementation((id: string) =>
+      Promise.resolve({ devServerCommand: id === "proj-a" ? "npm run dev:a" : "npm run dev:b" })
+    );
+  viewWorkspaceIdRef.current = null;
+  projectStateRef.current = { projects: [], currentProject: null };
+});
+
+describe("readDevServerCommand", () => {
+  it("trims the configured command", async () => {
+    getSettingsMock.mockResolvedValue({ devServerCommand: "  npm start  " });
+    await expect(readDevServerCommand("proj-a")).resolves.toBe("npm start");
+  });
+
+  it("treats a blank command as unset", async () => {
+    getSettingsMock.mockResolvedValue({ devServerCommand: "   " });
+    await expect(readDevServerCommand("proj-a")).resolves.toBeUndefined();
+  });
+
+  it("treats absent settings as unset", async () => {
+    getSettingsMock.mockResolvedValue(undefined);
+    await expect(readDevServerCommand("proj-a")).resolves.toBeUndefined();
+  });
+});
+
+describe("readViewDevServerCommand", () => {
+  it("reads the view's own project, not the globally-current one", async () => {
+    // Another window switched to B, which repoints `currentProject` in every
+    // view — running B's command in A's folder is the bug this guards.
+    viewWorkspaceIdRef.current = PROJECT_A.id;
+    projectStateRef.current = {
+      projects: [PROJECT_A, PROJECT_B],
+      currentProject: PROJECT_B,
+    };
+
+    await expect(readViewDevServerCommand()).resolves.toBe("npm run dev:a");
+    expect(getSettingsMock).toHaveBeenCalledWith(PROJECT_A.id);
+  });
+
+  it("falls back to the current project only for a view with no identity", async () => {
+    viewWorkspaceIdRef.current = null;
+    projectStateRef.current = { projects: [PROJECT_B], currentProject: PROJECT_B };
+
+    await expect(readViewDevServerCommand()).resolves.toBe("npm run dev:b");
+  });
+
+  it("reads no settings when the view's workspace is not a project", async () => {
+    viewWorkspaceIdRef.current = "scratch-1";
+    projectStateRef.current = { projects: [PROJECT_A], currentProject: PROJECT_A };
+
+    await expect(readViewDevServerCommand()).resolves.toBeUndefined();
+    expect(getSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fail the launch when the settings read rejects", async () => {
+    viewWorkspaceIdRef.current = PROJECT_A.id;
+    projectStateRef.current = { projects: [PROJECT_A], currentProject: PROJECT_A };
+    getSettingsMock.mockRejectedValue(new Error("IPC unavailable"));
+
+    await expect(readViewDevServerCommand()).resolves.toBeUndefined();
+  });
+});

--- a/src/utils/devServerCommand.ts
+++ b/src/utils/devServerCommand.ts
@@ -1,4 +1,9 @@
 import { projectClient } from "@/clients";
+// Leaf imports, never the `@/store` barrel: suites that mock the barrel
+// wholesale would crash on an undefined destructure.
+import { useProjectStore } from "@/store/projectStore";
+import { getViewWorkspaceId } from "@/store/viewWorkspaceId";
+import { resolveViewWorkspace } from "@/store/viewWorkspace";
 
 /**
  * The project's configured dev-server command, or `undefined` when it is unset
@@ -13,4 +18,29 @@ import { projectClient } from "@/clients";
 export async function readDevServerCommand(projectId: string): Promise<string | undefined> {
   const settings = await projectClient.getSettings(projectId);
   return settings?.devServerCommand?.trim() || undefined;
+}
+
+/**
+ * The configured dev-server command for the project *this view* owns.
+ *
+ * Deliberately not `currentProject`: that is broadcast to every view, so a
+ * second window switching projects repoints it here too, and the preview would
+ * run a sibling project's command in this project's folder. A scratch-owned or
+ * unresolved view has no project settings and yields `undefined`.
+ *
+ * A settings read that fails resolves to `undefined` rather than rejecting —
+ * the preview still opens and falls back to the settings store at render time,
+ * and a launch is not worth failing over a command lookup.
+ */
+export async function readViewDevServerCommand(): Promise<string | undefined> {
+  const state = useProjectStore.getState();
+  const resolved = resolveViewWorkspace({
+    viewWorkspaceId: getViewWorkspaceId(),
+    projects: state.projects,
+    currentProject: state.currentProject,
+    scratches: [],
+    currentScratch: null,
+  });
+  if (resolved?.kind !== "project") return undefined;
+  return readDevServerCommand(resolved.project.id).catch(() => undefined);
 }

--- a/src/utils/devServerCommand.ts
+++ b/src/utils/devServerCommand.ts
@@ -1,0 +1,16 @@
+import { projectClient } from "@/clients";
+
+/**
+ * The project's configured dev-server command, or `undefined` when it is unset
+ * or blank.
+ *
+ * Both paths that can create a dev-preview panel read it here, so a preview
+ * opened from the worktree menu or over MCP carries the same command as one
+ * opened from the toolbar (#11668). A panel created without it falls back to
+ * the settings store at render time, which still leaves it with no command of
+ * its own to persist.
+ */
+export async function readDevServerCommand(projectId: string): Promise<string | undefined> {
+  const settings = await projectClient.getSettings(projectId);
+  return settings?.devServerCommand?.trim() || undefined;
+}


### PR DESCRIPTION
## The problem
The same panel kind launched through a different code path depending on which surface you used. Dev Preview opened from the dock `+` or the panel palette skipped the project's configured dev-server command entirely — the toolbar's `devServer.start` loaded it, the other two didn't. The file browser opened from the dock or palette skipped target resolution, title composition and the reuse-dedup that `worktree.openFileBrowserPanel` does, so you'd get a second bare browser panel instead of focusing the one already open. `AGENT_LAUNCH_PANEL_KINDS`, a hardcoded set of three kind ids in `dockLaunchItems.ts`, decided which kinds got the "good" path.

## The fix
Panel kinds now declare how they launch, in the registry:
- `launchActionId` on `PanelKindConfig` names the action a bare launch dispatches through — `terminal`/`browser` → `agent.launch`, `dev-preview` → `devServer.start`, `file-browser` → `worktree.openFileBrowserPanel`. `review`, `file`, `diff` and plugin kinds declare nothing and keep the plain `addPanel` path.
- A shared seam, `launchPanelKind` (`src/registry/panelKindLaunch.ts`), is what the dock `+` and the panel palette now call. It dispatches the declared action, or falls back to `addPanel`. It never notifies — each surface keeps its own presentation.
- `AGENT_LAUNCH_PANEL_KINDS` is gone.

Routing through the existing `agent.launch` rather than `agent.browser`/`agent.terminal` means no action schema changed, no action id was added, and the MCP manifest is untouched — `agent.launch` already accepts `location`, `cwd` and `activateDockOnCreate`, and its `AgentIdSchema` already admits the synthetic `terminal`/`browser`/`dev-preview` ids.

## Things worth a second look
- **The launcher's worktree is not a named target.** The seam deliberately does not forward the surface's ambient `worktreeId` to the action. `resolveLaunchTarget` keeps an *inherited* ghost id so a panel joins its deleted worktree's surviving terminals, but makes an *explicit* one throw (#10812/#11232) — forwarding it would have broken launching from the grid menu or palette while a ghost row is selected. It also lets the file browser resolve focused-then-active exactly as the toolbar does.
- **A plugin can't point a launcher row at an arbitrary action.** Plugin `PanelKindConfig`s arrive over IPC and are registered wholesale, so `resolvePanelKindLaunchActionId` ignores `launchActionId` on any kind carrying an `extensionId`.
- **Refusals were invisible.** `uiFeedback` is a passive event kind, so these error toasts resolved to `priority: "low"` — inbox-only. The launcher closes on select, so the refusal had no signal at all. Fixed here and on the two surfaces that already had it (toolbar, empty-grid launcher).
- **Dev Preview had a second, command-less launcher.** `useAgentLauncher`'s `dev-preview` branch is still reachable from the worktree card menu and over MCP, and created a preview with no `devCommand`. It now seeds the same command — resolved from the view's own project, not `currentProject`, which is broadcast to every view and would otherwise have run a sibling project's command in this project's folder.

## Testing
672 tests pass across every module touched. Two new suites: `panelKindLaunch.test.ts` (routing contract, the no-explicit-worktree rule, the plugin guard) and `devServerCommand.test.ts` (view-scoped project identity). Typecheck clean; eslint and prettier clean on all changed files.

Resolves #11668