### PR TITLE
fix(terminal): stop the efficiency profile evicting live agent scrollback

### DIFF
--- a/electron/__tests__/headless-scrollback-trim.test.ts
+++ b/electron/__tests__/headless-scrollback-trim.test.ts
@@ -120,4 +120,37 @@ describe("@xterm/headless options.scrollback active truncation (issue #6215)", (
 
     expect(lengthAfterRepeat).toBe(lengthAfterFirstTrim);
   });
+
+  // #11673 — the renderer decides whether a shrink is destructive by measuring
+  // how much scrollback is retained. Measuring buffer.active gets that wrong
+  // under a TUI: the alternate screen is a bare viewport, so it reports zero
+  // retained lines while the setter still trims the normal buffer underneath.
+  it("trims the normal buffer while the alternate screen is active", async () => {
+    terminal = new Terminal({
+      cols: COLS,
+      rows: ROWS,
+      scrollback: INITIAL_SCROLLBACK,
+      allowProposedApi: true,
+    });
+
+    await writeAll(terminal, buildLines(LINES_TO_WRITE));
+    // Enter the alternate screen, as a full-screen TUI does.
+    await writeAll(terminal, "\x1b[?1049h");
+
+    expect(terminal.buffer.active.type).toBe("alternate");
+    const activeLengthBefore = terminal.buffer.active.length;
+    const normalLengthBefore = terminal.buffer.normal.length;
+
+    // The visible buffer is a viewport only — measuring it would report no
+    // retained scrollback and wave the destructive write through.
+    expect(activeLengthBefore - ROWS).toBeLessThanOrEqual(0);
+    expect(normalLengthBefore - ROWS).toBeGreaterThan(REDUCED_SCROLLBACK);
+
+    terminal.options.scrollback = REDUCED_SCROLLBACK;
+
+    expect(terminal.buffer.normal.length).toBeLessThan(normalLengthBefore);
+    expect(terminal.buffer.normal.length).toBeLessThanOrEqual(REDUCED_SCROLLBACK + ROWS);
+    // The alternate screen itself never carried the history that was lost.
+    expect(terminal.buffer.active.length).toBe(activeLengthBefore);
+  });
 });

--- a/src/services/terminal/TerminalScrollbackController.ts
+++ b/src/services/terminal/TerminalScrollbackController.ts
@@ -114,19 +114,28 @@ export function restoreScrollback(managed: ManagedTerminal): void {
       if (managed.isAltBuffer) return;
       if (managed.terminal.hasSelection()) return;
 
+      // Both a clamp and a destructive reduce rewrite options.scrollback, and
+      // either recreates xterm's CircularList — so they share one cooldown. An
+      // agent-detection flap raises the ceiling on every promotion, which would
+      // otherwise let a re-clamp through on every demotion.
+      const lastReduceAt = managed.lastScrollbackReduceAt;
+      if (lastReduceAt !== undefined && Date.now() - lastReduceAt < SCROLLBACK_REDUCE_COOLDOWN_MS) {
+        return;
+      }
+
       // A pane the user can see is not a safe place to drop history, but the
       // ceiling can still come down to the lines already retained: nothing on
       // screen is lost and the buffer stops growing toward the old ceiling, so
-      // a resource-profile downshift still takes effect. Idempotent — once
-      // applied the buffer sits at capacity and safeTarget stops moving.
-      // Deliberately below the four guards above: those are live interaction
-      // states, where clamping to capacity would start rolling history out
-      // from under a selection or a scrolled-back reader on the next line of
-      // output. Mere visibility carries no such reading position. #11673
+      // a resource-profile downshift still takes effect. Deliberately below the
+      // four guards above: those are live interaction states, where clamping to
+      // capacity would start rolling history out from under a selection or a
+      // scrolled-back reader on the next line of output. Mere visibility
+      // carries no such reading position. #11673
       if (managed.isVisible) {
         const safeTarget = Math.max(targetLines, scrollbackUsed);
         if (safeTarget < currentScrollback) {
           writeScrollback(managed, safeTarget);
+          managed.lastScrollbackReduceAt = Date.now();
           logDebug("Terminal scrollback ceiling clamped to retained history", {
             requestedTarget: targetLines,
             appliedTarget: safeTarget,
@@ -134,11 +143,6 @@ export function restoreScrollback(managed: ManagedTerminal): void {
             kind: managed.kind,
           });
         }
-        return;
-      }
-
-      const lastReduceAt = managed.lastScrollbackReduceAt;
-      if (lastReduceAt !== undefined && Date.now() - lastReduceAt < SCROLLBACK_REDUCE_COOLDOWN_MS) {
         return;
       }
     }

--- a/src/services/terminal/TerminalScrollbackController.ts
+++ b/src/services/terminal/TerminalScrollbackController.ts
@@ -3,7 +3,7 @@ import { useScrollbackStore } from "@/store/scrollbackStore";
 import { usePerformanceModeStore } from "@/store/performanceModeStore";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { getScrollbackForType, PERFORMANCE_MODE_SCROLLBACK } from "@/utils/scrollbackConfig";
-import { logInfo } from "@/utils/logger";
+import { logDebug, logInfo } from "@/utils/logger";
 
 function getValidScrollbackBase(value: number | undefined): number | undefined {
   if (typeof value !== "number" || Number.isNaN(value) || !Number.isFinite(value)) {
@@ -18,6 +18,16 @@ function readScrollback(managed: ManagedTerminal): number {
 
 function writeScrollback(managed: ManagedTerminal, lines: number): void {
   managed.terminal.options.scrollback = lines;
+}
+
+// Lines a scrollback write would have to evict, measured on the buffer the
+// setter actually trims. While the alternate screen is up `buffer.active` is
+// only `rows` tall, so measuring it reports zero eviction even though xterm
+// still resizes — and trims — the normal buffer underneath. reduceScrollback
+// bails on isAltBuffer before it measures, so active and normal always agree
+// there; restoreScrollback checks that guard further in and must not. #11673
+function retainedScrollback(managed: ManagedTerminal): number {
+  return Math.max(0, managed.terminal.buffer.normal.length - managed.terminal.rows);
 }
 
 export interface ReduceScrollbackOptions {
@@ -88,20 +98,44 @@ export function restoreScrollback(managed: ManagedTerminal): void {
   // Growth (agent promotion, resource-tier upgrade) is non-destructive — always
   // apply it. A shrink, though, synchronously and irreversibly evicts the
   // oldest buffer lines in xterm (same primitive as reduceScrollback). When
-  // this "restore" would actually drop history — e.g. an agent→plain demotion
+  // this "restore" would actually drop history — an agent→plain demotion
   // during a detection flap where the plain target is smaller than the agent
-  // ceiling — apply the same protections as reduceScrollback so a focused,
-  // selecting, or scrolled-back user doesn't lose scrollback to transient
-  // flapping. #10911
+  // ceiling, or a resource-profile downshift lowering the agent ceiling under
+  // every open pane at once — apply the same protections as reduceScrollback
+  // so a focused, selecting, or scrolled-back user doesn't lose scrollback to
+  // transient flapping. #10911, #11673
   const currentScrollback = readScrollback(managed);
   if (targetLines < currentScrollback) {
-    const scrollbackUsed = managed.terminal.buffer.active.length - managed.terminal.rows;
+    const scrollbackUsed = retainedScrollback(managed);
     const wouldEvict = scrollbackUsed > targetLines;
     if (wouldEvict) {
       if (managed.isFocused) return;
       if (managed.isUserScrolledBack) return;
       if (managed.isAltBuffer) return;
       if (managed.terminal.hasSelection()) return;
+
+      // A pane the user can see is not a safe place to drop history, but the
+      // ceiling can still come down to the lines already retained: nothing on
+      // screen is lost and the buffer stops growing toward the old ceiling, so
+      // a resource-profile downshift still takes effect. Idempotent — once
+      // applied the buffer sits at capacity and safeTarget stops moving.
+      // Deliberately below the four guards above: those are live interaction
+      // states, where clamping to capacity would start rolling history out
+      // from under a selection or a scrolled-back reader on the next line of
+      // output. Mere visibility carries no such reading position. #11673
+      if (managed.isVisible) {
+        const safeTarget = Math.max(targetLines, scrollbackUsed);
+        if (safeTarget < currentScrollback) {
+          writeScrollback(managed, safeTarget);
+          logDebug("Terminal scrollback ceiling clamped to retained history", {
+            requestedTarget: targetLines,
+            appliedTarget: safeTarget,
+            previousScrollback: currentScrollback,
+            kind: managed.kind,
+          });
+        }
+        return;
+      }
 
       const lastReduceAt = managed.lastScrollbackReduceAt;
       if (lastReduceAt !== undefined && Date.now() - lastReduceAt < SCROLLBACK_REDUCE_COOLDOWN_MS) {
@@ -112,6 +146,13 @@ export function restoreScrollback(managed: ManagedTerminal): void {
     writeScrollback(managed, targetLines);
     if (wouldEvict) {
       managed.lastScrollbackReduceAt = Date.now();
+      logInfo("Terminal scrollback ceiling lowered, evicting history", {
+        targetLines,
+        scrollbackUsed,
+        previousScrollback: currentScrollback,
+        rows: managed.terminal.rows,
+        kind: managed.kind,
+      });
     }
     return;
   }

--- a/src/services/terminal/__tests__/TerminalInstanceService.scrollback.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.scrollback.test.ts
@@ -79,11 +79,13 @@ type ScrollbackTestService = {
 
 function makeMockManaged(overrides: Record<string, unknown> = {}) {
   const writtenData: string[] = [];
+  // Normal screen: xterm reports one buffer through both handles.
+  const buffer = { length: 3000 };
   const managed = {
     terminal: {
       options: { scrollback: 5000 },
       rows: 24,
-      buffer: { active: { length: 3000 } },
+      buffer: { active: buffer, normal: buffer },
       write: (data: string) => writtenData.push(data),
       hasSelection: vi.fn(() => false),
     },

--- a/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
@@ -78,13 +78,17 @@ type TierTestService = {
 };
 
 function makeMockManaged(overrides: Record<string, unknown> = {}) {
+  // Normal screen: xterm reports one buffer through both handles, so the shrink
+  // path's normal-buffer accounting sees the same lengths as `active`.
+  const buffer = { length: 100, type: "normal", baseY: 0, viewportY: 0 };
   return {
     terminal: {
       options: { scrollback: 5000, cursorBlink: true },
       rows: 24,
       cols: 80,
       buffer: {
-        active: { length: 100, type: "normal", baseY: 0, viewportY: 0 },
+        active: buffer,
+        normal: buffer,
         onBufferChange: vi.fn(() => ({ dispose: vi.fn() })),
       },
       refresh: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
@@ -71,6 +71,8 @@ type WebGLVisibilityService = {
 };
 
 function makeMockManaged(overrides: Record<string, unknown> = {}) {
+  // Normal screen: one buffer reported through both handles.
+  const normalScreenBuffer = { length: 24 };
   const terminal = {
     rows: 24,
     cols: 80,
@@ -79,7 +81,7 @@ function makeMockManaged(overrides: Record<string, unknown> = {}) {
     dispose: vi.fn(),
     hasSelection: vi.fn(() => false),
     options: { scrollback: 1000 },
-    buffer: { active: { length: 24 } },
+    buffer: { active: normalScreenBuffer, normal: normalScreenBuffer },
     element: document.createElement("div"),
   };
 

--- a/src/services/terminal/__tests__/TerminalScrollbackController.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalScrollbackController.adversarial.test.ts
@@ -147,7 +147,6 @@ describe("TerminalScrollbackController adversarial", () => {
 
     // 3000 - 24 = 2976 retained vs a 1500 plain target ⇒ clamp, not evict.
     expect(managed.terminal.options.scrollback).toBe(2976);
-    expect(managed.lastScrollbackReduceAt).toBeUndefined();
   });
 
   it("HIDDEN_AT_BURST_TIER_IS_NOT_PROTECTED", () => {

--- a/src/services/terminal/__tests__/TerminalScrollbackController.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalScrollbackController.adversarial.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { reduceScrollback, restoreScrollback } from "../TerminalScrollbackController";
 import type { ManagedTerminal } from "../types";
+import { TerminalRefreshTier } from "@shared/types/panel";
 import { logInfo } from "@/utils/logger";
 
 const mockState = vi.hoisted(() => ({
@@ -36,11 +37,12 @@ function createManagedTerminal(
 ): ManagedTerminal {
   const write = vi.fn();
   const hasSelection = vi.fn(() => false);
+  const buffer = { length: 3000 };
 
   return {
     terminal: {
       options: { scrollback: 5000 },
-      buffer: { active: { length: 3000 } },
+      buffer: { active: buffer, normal: buffer },
       rows: 24,
       hasSelection,
       write,
@@ -99,7 +101,7 @@ describe("TerminalScrollbackController adversarial", () => {
     const managed = createManagedTerminal({}, {
       options: { scrollback: 4000 },
       rows: 24,
-      buffer: { active: { length: 12 } },
+      buffer: { active: { length: 12 }, normal: { length: 12 } },
     } as unknown as Partial<ManagedTerminal["terminal"]>);
 
     reduceScrollback(managed, 500);
@@ -112,7 +114,7 @@ describe("TerminalScrollbackController adversarial", () => {
   it("HUGE_BUFFER_REDUCTION_LOGS_ONCE_NO_TERMINAL_WRITE", () => {
     const managed = createManagedTerminal({}, {
       options: { scrollback: 2_000_000 },
-      buffer: { active: { length: 5_000_000 } },
+      buffer: { active: { length: 5_000_000 }, normal: { length: 5_000_000 } },
     } as unknown as Partial<ManagedTerminal["terminal"]>);
 
     reduceScrollback(managed, 500);
@@ -129,6 +131,35 @@ describe("TerminalScrollbackController adversarial", () => {
         rows: 24,
       })
     );
+  });
+
+  // #11673 — visibility is read from managed.isVisible, never derived from the
+  // refresh tier. A hidden pane can sit at BURST while streaming, and a visible
+  // pane can lag at BACKGROUND during a handoff; deriving one from the other
+  // protects the wrong terminals in both directions.
+  it("VISIBLE_AT_BACKGROUND_TIER_IS_PROTECTED", () => {
+    const managed = createManagedTerminal({
+      isVisible: true,
+      lastAppliedTier: TerminalRefreshTier.BACKGROUND,
+    });
+
+    restoreScrollback(managed);
+
+    // 3000 - 24 = 2976 retained vs a 1500 plain target ⇒ clamp, not evict.
+    expect(managed.terminal.options.scrollback).toBe(2976);
+    expect(managed.lastScrollbackReduceAt).toBeUndefined();
+  });
+
+  it("HIDDEN_AT_BURST_TIER_IS_NOT_PROTECTED", () => {
+    const managed = createManagedTerminal({
+      isVisible: false,
+      lastAppliedTier: TerminalRefreshTier.BURST,
+    });
+
+    restoreScrollback(managed);
+
+    expect(managed.terminal.options.scrollback).toBe(1500);
+    expect(managed.lastScrollbackReduceAt).toBeDefined();
   });
 
   it("STORE_FLIP_NO_CACHE", () => {

--- a/src/services/terminal/__tests__/TerminalScrollbackController.test.ts
+++ b/src/services/terminal/__tests__/TerminalScrollbackController.test.ts
@@ -429,35 +429,45 @@ describe("TerminalScrollbackController", () => {
       });
 
       it("is idempotent — a second pass on a clamped buffer does not touch the setter", () => {
+        const nowSpy = vi.spyOn(Date, "now");
+        try {
+          nowSpy.mockReturnValue(50_000);
+          const managed = makeMockManaged({ isVisible: true });
+          managed.terminal.options.scrollback = largeCurrent;
+          setBufferLength(managed, largeCurrent);
+
+          restoreScrollback(managed);
+          const afterFirst = managed.terminal.options.scrollback;
+          // Buffer now sits at the clamped capacity.
+          setBufferLength(managed, afterFirst + managed.terminal.rows);
+
+          // Step clear of the cooldown so this proves idempotence rather than
+          // rate limiting. Watch the setter itself: writing the same value
+          // again still rebuilds xterm's CircularList, so it has to fail.
+          nowSpy.mockReturnValue(50_000 + SCROLLBACK_REDUCE_COOLDOWN_MS + 1);
+          const writes = watchScrollbackWrites(managed);
+          restoreScrollback(managed);
+
+          expect(writes()).toEqual([]);
+          expect(managed.terminal.options.scrollback).toBe(afterFirst);
+        } finally {
+          nowSpy.mockRestore();
+        }
+      });
+
+      it("stamps the reduce cooldown for a clamp", () => {
         const managed = makeMockManaged({ isVisible: true });
         managed.terminal.options.scrollback = largeCurrent;
         setBufferLength(managed, largeCurrent);
+        const before = Date.now();
 
         restoreScrollback(managed);
-        const afterFirst = managed.terminal.options.scrollback;
-        // Buffer now sits at the clamped capacity.
-        setBufferLength(managed, afterFirst + managed.terminal.rows);
-
-        // Watch the setter itself: the cooldown this path skips exists to stop
-        // repeat writes churning xterm's CircularList, so "wrote the same
-        // value again" has to count as a failure.
-        const writes = watchScrollbackWrites(managed);
-        restoreScrollback(managed);
-
-        expect(writes()).toEqual([]);
-        expect(managed.terminal.options.scrollback).toBe(afterFirst);
+        // A clamp still rewrites options.scrollback, so it counts against the
+        // cooldown that rate-limits CircularList reallocation.
+        expect(managed.lastScrollbackReduceAt).toBeGreaterThanOrEqual(before);
       });
 
-      it("does not stamp the reduce cooldown for a clamp", () => {
-        const managed = makeMockManaged({ isVisible: true });
-        managed.terminal.options.scrollback = largeCurrent;
-        setBufferLength(managed, largeCurrent);
-
-        restoreScrollback(managed);
-        expect(managed.lastScrollbackReduceAt).toBeUndefined();
-      });
-
-      it("clamps regardless of a live reduce cooldown", () => {
+      it("holds the clamp off during a live reduce cooldown", () => {
         const nowSpy = vi.spyOn(Date, "now");
         try {
           const managed = makeMockManaged({ isVisible: true });
@@ -468,10 +478,35 @@ describe("TerminalScrollbackController", () => {
           nowSpy.mockReturnValue(10_000 + SCROLLBACK_REDUCE_COOLDOWN_MS - 1);
           restoreScrollback(managed);
 
-          // The cooldown exists to rate-limit destructive reduces; a clamp
-          // evicts nothing, so it must not be gated by one.
-          expect(managed.terminal.options.scrollback).toBe(retained(managed));
+          expect(managed.terminal.options.scrollback).toBe(largeCurrent);
           expect(managed.lastScrollbackReduceAt).toBe(10_000);
+        } finally {
+          nowSpy.mockRestore();
+        }
+      });
+
+      // An agent-detection flap promotes (growth, unguarded) and demotes
+      // (clamp) in turn. Without a shared cooldown each cycle would cost two
+      // CircularList rebuilds — the churn #10911's cooldown exists to damp.
+      it("does not re-clamp on every promotion/demotion flap", () => {
+        const nowSpy = vi.spyOn(Date, "now");
+        try {
+          nowSpy.mockReturnValue(50_000);
+          // Starts demoted: the plain target is below the agent-era ceiling.
+          const managed = makeMockManaged({ isVisible: true });
+          managed.terminal.options.scrollback = largeCurrent;
+          setBufferLength(managed, largeCurrent);
+
+          restoreScrollback(managed); // clamp
+          const writes = watchScrollbackWrites(managed);
+
+          managed.runtimeAgentId = "claude";
+          restoreScrollback(managed); // re-promoted → growth
+          managed.runtimeAgentId = undefined;
+          restoreScrollback(managed); // demoted again, still inside cooldown
+
+          // The growth write is unavoidable; the second clamp is not.
+          expect(writes().filter((value) => value < largeCurrent)).toEqual([]);
         } finally {
           nowSpy.mockRestore();
         }

--- a/src/services/terminal/__tests__/TerminalScrollbackController.test.ts
+++ b/src/services/terminal/__tests__/TerminalScrollbackController.test.ts
@@ -32,11 +32,15 @@ function getWrittenData(managed: ManagedTerminal): string[] {
 
 function makeMockManaged(overrides: Record<string, unknown> = {}): ManagedTerminal {
   const writtenData: string[] = [];
+  // On the normal screen xterm reports the same buffer through both handles.
+  // Shared here so setBufferLength keeps active and normal in agreement; the
+  // alt-buffer cases below deliberately split them.
+  const buffer = { length: 3000 };
   return {
     terminal: {
       options: { scrollback: 5000 },
       rows: 24,
-      buffer: { active: { length: 3000 } },
+      buffer: { active: buffer, normal: buffer },
       write: (data: string) => writtenData.push(data),
       hasSelection: vi.fn(() => false),
     },
@@ -48,6 +52,32 @@ function makeMockManaged(overrides: Record<string, unknown> = {}): ManagedTermin
     writtenData,
     ...overrides,
   } as unknown as ManagedTerminal;
+}
+
+// Shared by the #11673 blocks. Derived, not copied: the plain-terminal target
+// is whatever the policy computes for the mocked global setting, and a "large
+// current" above it stands in for a pre-downshift agent ceiling.
+const plainTarget = getScrollbackForType(false, 5000);
+const largeCurrent = plainTarget * 3;
+
+function setBufferLength(managed: ManagedTerminal, length: number): void {
+  Object.defineProperty(managed.terminal.buffer.active, "length", {
+    value: length,
+    writable: true,
+  });
+}
+
+function retained(managed: ManagedTerminal): number {
+  return managed.terminal.buffer.normal.length - managed.terminal.rows;
+}
+
+// Break the shared normal-screen buffer apart so the two handles can report
+// different lengths, as they do while the alternate screen is up.
+function splitBuffers(managed: ManagedTerminal, activeLength: number, normalLength: number): void {
+  (managed.terminal as unknown as { buffer: unknown }).buffer = {
+    active: { length: activeLength },
+    normal: { length: normalLength },
+  };
 }
 
 describe("TerminalScrollbackController", () => {
@@ -277,19 +307,6 @@ describe("TerminalScrollbackController", () => {
     // xterm, so it must respect the same protections as reduceScrollback when
     // history would actually be dropped. Growth must stay unguarded.
     describe("destructive shrink guard (#10911)", () => {
-      // Derived, not copied: the plain-terminal target is whatever the policy
-      // computes for the current global setting. A "large current" above that
-      // target stands in for the pre-demotion agent-era scrollback.
-      const plainTarget = getScrollbackForType(false, 5000);
-      const largeCurrent = plainTarget * 3;
-
-      function setBufferLength(managed: ManagedTerminal, length: number): void {
-        Object.defineProperty(managed.terminal.buffer.active, "length", {
-          value: length,
-          writable: true,
-        });
-      }
-
       it("skips a demotion shrink for a focused terminal (preserves history)", () => {
         const managed = makeMockManaged({ isFocused: true });
         managed.terminal.options.scrollback = largeCurrent; // was an agent
@@ -371,6 +388,193 @@ describe("TerminalScrollbackController", () => {
         const managed = makeMockManaged({ isFocused: true });
         managed.terminal.options.scrollback = Math.floor(plainTarget / 3); // below target ⇒ grow
         setBufferLength(managed, largeCurrent);
+
+        restoreScrollback(managed);
+        expect(managed.terminal.options.scrollback).toBe(plainTarget);
+      });
+    });
+
+    // #11673 — a resource-profile downshift lowers the agent ceiling and
+    // re-derives every foreground pane. Only one of them can be focused, so
+    // the guards above leave every other on-screen pane exposed to a
+    // destructive write.
+    describe("visible-pane shrink clamp (#11673)", () => {
+      it("clamps to retained history instead of evicting on a visible unfocused pane", () => {
+        const managed = makeMockManaged({ isVisible: true });
+        managed.terminal.options.scrollback = largeCurrent;
+        setBufferLength(managed, largeCurrent);
+
+        restoreScrollback(managed);
+
+        // Ceiling comes down, but only as far as the lines already held.
+        expect(managed.terminal.options.scrollback).toBe(retained(managed));
+        expect(managed.terminal.options.scrollback).toBeGreaterThan(plainTarget);
+        expect(managed.terminal.options.scrollback).toBeLessThan(largeCurrent);
+      });
+
+      it("keeps every retained line when it clamps", () => {
+        const managed = makeMockManaged({ isVisible: true });
+        managed.terminal.options.scrollback = largeCurrent;
+        setBufferLength(managed, largeCurrent);
+
+        restoreScrollback(managed);
+
+        // The applied ceiling still holds everything the buffer had.
+        expect(managed.terminal.options.scrollback).toBeGreaterThanOrEqual(retained(managed));
+      });
+
+      it("is idempotent — a second pass on a clamped buffer writes nothing", () => {
+        const managed = makeMockManaged({ isVisible: true });
+        managed.terminal.options.scrollback = largeCurrent;
+        setBufferLength(managed, largeCurrent);
+
+        restoreScrollback(managed);
+        const afterFirst = managed.terminal.options.scrollback;
+        // Buffer now sits at the clamped capacity.
+        setBufferLength(managed, afterFirst + managed.terminal.rows);
+
+        restoreScrollback(managed);
+        expect(managed.terminal.options.scrollback).toBe(afterFirst);
+      });
+
+      it("does not stamp the reduce cooldown for a clamp", () => {
+        const managed = makeMockManaged({ isVisible: true });
+        managed.terminal.options.scrollback = largeCurrent;
+        setBufferLength(managed, largeCurrent);
+
+        restoreScrollback(managed);
+        expect(managed.lastScrollbackReduceAt).toBeUndefined();
+      });
+
+      it("clamps regardless of a live reduce cooldown", () => {
+        const nowSpy = vi.spyOn(Date, "now");
+        try {
+          const managed = makeMockManaged({ isVisible: true });
+          managed.lastScrollbackReduceAt = 10_000;
+          managed.terminal.options.scrollback = largeCurrent;
+          setBufferLength(managed, largeCurrent);
+
+          nowSpy.mockReturnValue(10_000 + SCROLLBACK_REDUCE_COOLDOWN_MS - 1);
+          restoreScrollback(managed);
+
+          // The cooldown exists to rate-limit destructive reduces; a clamp
+          // evicts nothing, so it must not be gated by one.
+          expect(managed.terminal.options.scrollback).toBe(retained(managed));
+          expect(managed.lastScrollbackReduceAt).toBe(10_000);
+        } finally {
+          nowSpy.mockRestore();
+        }
+      });
+
+      it("still evicts on a hidden pane", () => {
+        const managed = makeMockManaged({ isVisible: false });
+        managed.terminal.options.scrollback = largeCurrent;
+        setBufferLength(managed, largeCurrent);
+
+        restoreScrollback(managed);
+        expect(managed.terminal.options.scrollback).toBe(plainTarget);
+        expect(managed.lastScrollbackReduceAt).toBeDefined();
+      });
+
+      it("logs the eviction on a hidden pane so the clip is not silent", () => {
+        const managed = makeMockManaged({ isVisible: false });
+        managed.terminal.options.scrollback = largeCurrent;
+        setBufferLength(managed, largeCurrent);
+
+        restoreScrollback(managed);
+        expect(logInfo).toHaveBeenCalledWith(
+          "Terminal scrollback ceiling lowered, evicting history",
+          expect.objectContaining({
+            targetLines: plainTarget,
+            previousScrollback: largeCurrent,
+            rows: managed.terminal.rows,
+          })
+        );
+      });
+
+      it("applies the full target on a visible pane when nothing would be evicted", () => {
+        const managed = makeMockManaged({ isVisible: true });
+        managed.terminal.options.scrollback = largeCurrent;
+        setBufferLength(managed, managed.terminal.rows + 10);
+
+        restoreScrollback(managed);
+        expect(managed.terminal.options.scrollback).toBe(plainTarget);
+      });
+
+      it("never clamps a growth restore on a visible pane", () => {
+        const managed = makeMockManaged({ isVisible: true });
+        managed.terminal.options.scrollback = Math.floor(plainTarget / 3);
+        setBufferLength(managed, largeCurrent);
+
+        restoreScrollback(managed);
+        expect(managed.terminal.options.scrollback).toBe(plainTarget);
+      });
+
+      it("leaves the focused bare-return ahead of the clamp", () => {
+        const managed = makeMockManaged({ isVisible: true, isFocused: true });
+        managed.terminal.options.scrollback = largeCurrent;
+        setBufferLength(managed, largeCurrent);
+
+        // Interaction guards win: no write at all, not even a lossless one.
+        restoreScrollback(managed);
+        expect(managed.terminal.options.scrollback).toBe(largeCurrent);
+      });
+
+      it("leaves the selection bare-return ahead of the clamp", () => {
+        const managed = makeMockManaged({ isVisible: true });
+        managed.terminal.hasSelection = vi.fn(() => true);
+        managed.terminal.options.scrollback = largeCurrent;
+        setBufferLength(managed, largeCurrent);
+
+        restoreScrollback(managed);
+        expect(managed.terminal.options.scrollback).toBe(largeCurrent);
+      });
+    });
+
+    // #11673 — while the alternate screen is up, buffer.active is only `rows`
+    // tall. Measuring eviction on it reported zero, so the isAltBuffer guard
+    // sat inside a branch that could not be entered and xterm trimmed the
+    // normal buffer underneath a visible TUI.
+    describe("alt-buffer eviction accounting (#11673)", () => {
+      function makeAltBufferManaged(overrides: Record<string, unknown> = {}): ManagedTerminal {
+        const managed = makeMockManaged({ isAltBuffer: true, ...overrides });
+        // Alternate screen active: the visible buffer holds a viewport only,
+        // while the normal buffer still carries the session's history.
+        splitBuffers(managed, managed.terminal.rows, largeCurrent);
+        managed.terminal.options.scrollback = largeCurrent;
+        return managed;
+      }
+
+      it("skips the shrink for an alt-buffer pane holding normal-buffer history", () => {
+        const managed = makeAltBufferManaged();
+
+        restoreScrollback(managed);
+
+        expect(managed.terminal.options.scrollback).toBe(largeCurrent);
+        expect(managed.lastScrollbackReduceAt).toBeUndefined();
+      });
+
+      it("skips it for a hidden alt-buffer pane too", () => {
+        const managed = makeAltBufferManaged({ isVisible: false });
+
+        restoreScrollback(managed);
+        expect(managed.terminal.options.scrollback).toBe(largeCurrent);
+      });
+
+      it("would have shrunk under viewport-only accounting", () => {
+        const managed = makeAltBufferManaged();
+
+        // Pins the regression: active.length is a bare viewport, so measuring
+        // eviction on it yields zero and lets the write through.
+        expect(managed.terminal.buffer.active.length - managed.terminal.rows).toBe(0);
+        expect(managed.terminal.buffer.normal.length - managed.terminal.rows).toBeGreaterThan(
+          plainTarget
+        );
+      });
+
+      it("applies the shrink when the normal buffer holds nothing to lose", () => {
+        const managed = makeAltBufferManaged();
+        splitBuffers(managed, managed.terminal.rows, managed.terminal.rows + 5);
 
         restoreScrollback(managed);
         expect(managed.terminal.options.scrollback).toBe(plainTarget);

--- a/src/services/terminal/__tests__/TerminalScrollbackController.test.ts
+++ b/src/services/terminal/__tests__/TerminalScrollbackController.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { reduceScrollback, restoreScrollback } from "../TerminalScrollbackController";
 import { type ManagedTerminal, SCROLLBACK_REDUCE_COOLDOWN_MS } from "../types";
-import { getScrollbackForType } from "@/utils/scrollbackConfig";
+import { getScrollbackForType, setAgentScrollbackMaxLines } from "@/utils/scrollbackConfig";
 import { logInfo } from "@/utils/logger";
 
 const mockScrollbackStore = { scrollbackLines: 5000 };
@@ -74,10 +74,26 @@ function retained(managed: ManagedTerminal): number {
 // Break the shared normal-screen buffer apart so the two handles can report
 // different lengths, as they do while the alternate screen is up.
 function splitBuffers(managed: ManagedTerminal, activeLength: number, normalLength: number): void {
-  (managed.terminal as unknown as { buffer: unknown }).buffer = {
-    active: { length: activeLength },
-    normal: { length: normalLength },
-  };
+  Object.defineProperty(managed.terminal, "buffer", {
+    value: { active: { length: activeLength }, normal: { length: normalLength } },
+    configurable: true,
+  });
+}
+
+// Record every write to terminal.options.scrollback. Value assertions alone
+// can't tell "left alone" from "written the same value again".
+function watchScrollbackWrites(managed: ManagedTerminal): () => number[] {
+  const writes: number[] = [];
+  let current = managed.terminal.options.scrollback;
+  Object.defineProperty(managed.terminal.options, "scrollback", {
+    get: () => current,
+    set: (value: number) => {
+      writes.push(value);
+      current = value;
+    },
+    configurable: true,
+  });
+  return () => writes;
 }
 
 describe("TerminalScrollbackController", () => {
@@ -412,18 +428,7 @@ describe("TerminalScrollbackController", () => {
         expect(managed.terminal.options.scrollback).toBeLessThan(largeCurrent);
       });
 
-      it("keeps every retained line when it clamps", () => {
-        const managed = makeMockManaged({ isVisible: true });
-        managed.terminal.options.scrollback = largeCurrent;
-        setBufferLength(managed, largeCurrent);
-
-        restoreScrollback(managed);
-
-        // The applied ceiling still holds everything the buffer had.
-        expect(managed.terminal.options.scrollback).toBeGreaterThanOrEqual(retained(managed));
-      });
-
-      it("is idempotent — a second pass on a clamped buffer writes nothing", () => {
+      it("is idempotent — a second pass on a clamped buffer does not touch the setter", () => {
         const managed = makeMockManaged({ isVisible: true });
         managed.terminal.options.scrollback = largeCurrent;
         setBufferLength(managed, largeCurrent);
@@ -433,7 +438,13 @@ describe("TerminalScrollbackController", () => {
         // Buffer now sits at the clamped capacity.
         setBufferLength(managed, afterFirst + managed.terminal.rows);
 
+        // Watch the setter itself: the cooldown this path skips exists to stop
+        // repeat writes churning xterm's CircularList, so "wrote the same
+        // value again" has to count as a failure.
+        const writes = watchScrollbackWrites(managed);
         restoreScrollback(managed);
+
+        expect(writes()).toEqual([]);
         expect(managed.terminal.options.scrollback).toBe(afterFirst);
       });
 
@@ -492,43 +503,105 @@ describe("TerminalScrollbackController", () => {
         );
       });
 
-      it("applies the full target on a visible pane when nothing would be evicted", () => {
+      it("applies the full target at the retained-equals-target fencepost", () => {
         const managed = makeMockManaged({ isVisible: true });
         managed.terminal.options.scrollback = largeCurrent;
-        setBufferLength(managed, managed.terminal.rows + 10);
+        // Exactly at the target ⇒ not evicting ⇒ no clamp, no cooldown.
+        setBufferLength(managed, plainTarget + managed.terminal.rows);
 
         restoreScrollback(managed);
         expect(managed.terminal.options.scrollback).toBe(plainTarget);
+        expect(managed.lastScrollbackReduceAt).toBeUndefined();
       });
 
-      it("never clamps a growth restore on a visible pane", () => {
-        const managed = makeMockManaged({ isVisible: true });
-        managed.terminal.options.scrollback = Math.floor(plainTarget / 3);
-        setBufferLength(managed, largeCurrent);
+      it("keeps the interaction guards ahead of the clamp", () => {
+        // Focused and selecting panes are visible too. They must bare-return,
+        // not clamp: clamping seats the buffer at capacity, so the next line of
+        // output would roll history out from under the reader.
+        const focused = makeMockManaged({ isVisible: true, isFocused: true });
+        focused.terminal.options.scrollback = largeCurrent;
+        setBufferLength(focused, largeCurrent);
+
+        const selecting = makeMockManaged({ isVisible: true });
+        selecting.terminal.hasSelection = vi.fn(() => true);
+        selecting.terminal.options.scrollback = largeCurrent;
+        setBufferLength(selecting, largeCurrent);
+
+        restoreScrollback(focused);
+        restoreScrollback(selecting);
+
+        expect(focused.terminal.options.scrollback).toBe(largeCurrent);
+        expect(selecting.terminal.options.scrollback).toBe(largeCurrent);
+      });
+    });
+
+    // #11673's reported scenario end to end: the Efficiency profile lowers the
+    // agent ceiling under a grid of panes where only one holds focus.
+    describe("efficiency-profile agent downshift (#11673)", () => {
+      const balancedCeiling = 10_000;
+      const efficiencyCeiling = 4_000;
+
+      function makeAgentPane(overrides: Record<string, unknown> = {}): ManagedTerminal {
+        const managed = makeMockManaged({ runtimeAgentId: "claude", ...overrides });
+        managed.terminal.options.scrollback = balancedCeiling;
+        // A long-running agent that has filled most of the balanced ceiling.
+        setBufferLength(managed, 9_000 + managed.terminal.rows);
+        return managed;
+      }
+
+      beforeEach(() => {
+        setAgentScrollbackMaxLines(efficiencyCeiling);
+      });
+
+      afterEach(() => {
+        setAgentScrollbackMaxLines(balancedCeiling);
+      });
+
+      it("keeps every line of a visible unfocused agent pane", () => {
+        const managed = makeAgentPane({ isVisible: true });
 
         restoreScrollback(managed);
-        expect(managed.terminal.options.scrollback).toBe(plainTarget);
+
+        // The reported symptom was this pane dropping to the 4k ceiling.
+        expect(managed.terminal.options.scrollback).toBe(retained(managed));
+        expect(managed.terminal.options.scrollback).toBeGreaterThan(efficiencyCeiling);
       });
 
-      it("leaves the focused bare-return ahead of the clamp", () => {
-        const managed = makeMockManaged({ isVisible: true, isFocused: true });
-        managed.terminal.options.scrollback = largeCurrent;
-        setBufferLength(managed, largeCurrent);
-
-        // Interaction guards win: no write at all, not even a lossless one.
-        restoreScrollback(managed);
-        expect(managed.terminal.options.scrollback).toBe(largeCurrent);
-      });
-
-      it("leaves the selection bare-return ahead of the clamp", () => {
-        const managed = makeMockManaged({ isVisible: true });
-        managed.terminal.hasSelection = vi.fn(() => true);
-        managed.terminal.options.scrollback = largeCurrent;
-        setBufferLength(managed, largeCurrent);
+      it("still applies the efficiency ceiling to a hidden agent pane", () => {
+        const managed = makeAgentPane({ isVisible: false });
 
         restoreScrollback(managed);
-        expect(managed.terminal.options.scrollback).toBe(largeCurrent);
+
+        expect(managed.terminal.options.scrollback).toBe(efficiencyCeiling);
       });
+
+      it("restores the full ceiling when the profile goes back up", () => {
+        const managed = makeAgentPane({ isVisible: true });
+        restoreScrollback(managed);
+        const clamped = managed.terminal.options.scrollback;
+
+        setAgentScrollbackMaxLines(balancedCeiling);
+        restoreScrollback(managed);
+
+        // Growth is unguarded, so the pane recovers its headroom.
+        expect(managed.terminal.options.scrollback).toBe(balancedCeiling);
+        expect(clamped).toBeLessThan(balancedCeiling);
+      });
+    });
+
+    // The manual performance-mode toggle deliberately opts out of every
+    // protection below: the user asked for the low-power ceiling explicitly,
+    // unlike the automatic resource profile that #11673 is about. Pinned so a
+    // future guard change has to decide about this path on purpose.
+    it("evicts on a visible pane in performance mode by design", () => {
+      mockPerformanceModeStore.performanceMode = true;
+      const managed = makeMockManaged({ isVisible: true });
+      managed.terminal.options.scrollback = largeCurrent;
+      setBufferLength(managed, largeCurrent);
+
+      restoreScrollback(managed);
+
+      expect(managed.terminal.options.scrollback).toBeLessThan(retained(managed));
     });
 
     // #11673 — while the alternate screen is up, buffer.active is only `rows`
@@ -548,6 +621,10 @@ describe("TerminalScrollbackController", () => {
       it("skips the shrink for an alt-buffer pane holding normal-buffer history", () => {
         const managed = makeAltBufferManaged();
 
+        // The trap this pins: active.length is a bare viewport under a TUI, so
+        // measuring it reports nothing to evict and waves the write through.
+        expect(managed.terminal.buffer.active.length - managed.terminal.rows).toBe(0);
+
         restoreScrollback(managed);
 
         expect(managed.terminal.options.scrollback).toBe(largeCurrent);
@@ -559,17 +636,6 @@ describe("TerminalScrollbackController", () => {
 
         restoreScrollback(managed);
         expect(managed.terminal.options.scrollback).toBe(largeCurrent);
-      });
-
-      it("would have shrunk under viewport-only accounting", () => {
-        const managed = makeAltBufferManaged();
-
-        // Pins the regression: active.length is a bare viewport, so measuring
-        // eviction on it yields zero and lets the write through.
-        expect(managed.terminal.buffer.active.length - managed.terminal.rows).toBe(0);
-        expect(managed.terminal.buffer.normal.length - managed.terminal.rows).toBeGreaterThan(
-          plainTarget
-        );
       });
 
       it("applies the shrink when the normal buffer holds nothing to lose", () => {


### PR DESCRIPTION
Resolves #11673.

## What was wrong

Two defects in `restoreScrollback()` (`src/services/terminal/TerminalScrollbackController.ts`), not one.

1. **The visible-unfocused pane.** `restoreScrollbackAllForeground()` re-derives every non-BACKGROUND pane on a profile change, but the only visibility guard was `managed.isFocused` — true for at most one terminal. With a grid of agents, every pane except the focused one took the full destructive clip when the agent ceiling dropped 10000 -> 4000. That is the bug as reported.

2. **Alt-buffer accounting was measuring the wrong buffer.** `wouldEvict` came from `buffer.active`, but while the alternate screen is up `active.length` is only `rows`, so it reported zero retained lines and `wouldEvict` was false. The `isAltBuffer` guard sits inside `if (wouldEvict)`, so it was unreachable for the exact case it was written for — while xterm still trimmed the normal buffer underneath a visible TUI. Found during review, confirmed empirically with a new headless test.

## The fix

- `retainedScrollback()` measures `buffer.normal`, the buffer the setter actually trims. `reduceScrollback` is deliberately unchanged: it bails on `isAltBuffer` before it measures, so the two handles always agree there and the value is log-only.
- A visible pane clamps to `max(targetLines, retained)` instead of evicting — the ceiling comes down as far as it can without dropping a line the user can still scroll to, so a downshift still caps growth. This implements the issue's own rule: reducing the ceiling for future output is fine, evicting what is already on screen is not.
- The four interaction guards stay bare returns ahead of the clamp. Clamping seats the buffer at capacity, so the next line of output would roll history out from under a selection or a scrolled-back reader. Mere visibility carries no reading position.
- The clamp shares the reduce cooldown. Both writes recreate xterm's CircularList, and an agent-detection flap raises the ceiling on every promotion, which would otherwise let a re-clamp through on every demotion.
- Logs both the clamp (`logDebug`) and the eviction (`logInfo`). No toast: there is no recovery action, and a fleet-wide profile flip would be noise.

## Verification

- 4680 tests across 253 files (every terminal, PTY and Terminal-component suite) pass.
- Negative control: reverting only the production file and re-running fails 9 of the new tests, so the suite catches the bug rather than documenting current behaviour.
- New headless test proves the setter trims `buffer.normal` while `buffer.active.type === "alternate"`.
- All eight existing #10911 assertions are unchanged.

## Notes for review

- Two pre-existing fixtures (`TerminalInstanceService.tier`, `.webglVisibility`) needed a normal buffer; both reach shrink paths and would have thrown on the new accounting.
- `performanceMode` still writes 100 unconditionally, including on a visible pane. That is the manual low-power toggle the user asks for explicitly, distinct from the automatic profile this issue is about. Pinned with a test so a future guard change has to decide about it on purpose.
- Follow-up worth considering, deliberately not built here: a clamped pane keeps its inflated ceiling until it is next restored while hidden, because the BACKGROUND transition does not reduce. Memory is capped either way, and main-process memory pressure still drives `reduceScrollback` with an explicit target, so this is a tuning question rather than a leak.