### PR TITLE
fix(memory): stop tier-1 trim from destroying live agent scrollback

### DIFF
--- a/electron/pty-host/handlers/__tests__/dispatcher.test.ts
+++ b/electron/pty-host/handlers/__tests__/dispatcher.test.ts
@@ -9,6 +9,7 @@ import { clearPluginAgentRegistryForTests } from "../../../../shared/config/plug
 import { getEffectiveAgentConfig } from "../../../../shared/config/agentRegistry.js";
 import { clearPluginProcessToolRegistryForTests } from "../../../../shared/config/pluginProcessToolRegistry.js";
 import { buildDetectedCandidate } from "../../../services/ProcessDetector/candidateHelpers.js";
+import { normalizeScrollbackLines } from "../../../../shared/config/scrollback.js";
 
 function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
   const ptyManager = {
@@ -44,7 +45,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
     markChecked: vi.fn(),
     updateObservedTitle: vi.fn(),
     transitionState: vi.fn(() => true),
-    trimScrollback: vi.fn(),
+    trimScrollback: vi.fn(() => ({ trimmed: 7, skipped: 0 })),
     trimIdleAnalysisSessions: vi.fn(() => ({ trimmed: 2, skipped: 5 })),
     setActivityMonitorTier: vi.fn(),
     setProcessTreeCache: vi.fn(),
@@ -363,30 +364,43 @@ describe("createPtyHostMessageDispatcher", () => {
   });
 
   describe("trim-state (#11674)", () => {
-    it("routes main's pressure trim through the guarded pass, never the bulk flatten", () => {
-      // trimScrollback exempts nothing by design — it is the resource
-      // governor's last-resort lever before an actual PTY pause. Main's
-      // pressure trim is not that, so reaching it from here would flatten a
-      // working agent's scrollback (and its serialize source) for a reclaim
-      // main cannot even measure.
+    it("routes an idle-only trim through the guarded pass, never the bulk flatten", () => {
+      // trimScrollback exempts nothing by design — it is an emergency lever.
+      // A graduated pressure trim reaching it would flatten a working agent's
+      // scrollback (and its serialize source) for a reclaim main cannot even
+      // measure.
       const ctx = makeCtx();
       const dispatch = createPtyHostMessageDispatcher(ctx);
 
-      dispatch({ type: "trim-state", targetLines: 500, requestId: "trim-1" });
+      dispatch({ type: "trim-state", targetLines: 500, requestId: "trim-1", scope: "idle-only" });
 
       expect(ctx.ptyManager.trimIdleAnalysisSessions).toHaveBeenCalledWith({ targetLines: 500 });
       expect(ctx.ptyManager.trimScrollback).not.toHaveBeenCalled();
+    });
+
+    it("routes an 'all' trim through the unguarded flatten (#10948)", () => {
+      // The post-pause emergency: the governor skips its own pre-pause trim at
+      // critical utilization, so this is the last reclaim available. Applying
+      // the governance policy here would spare exactly the active agents
+      // holding the memory and leave nothing to reclaim.
+      const ctx = makeCtx();
+      const dispatch = createPtyHostMessageDispatcher(ctx);
+
+      dispatch({ type: "trim-state", targetLines: 500, requestId: "trim-2", scope: "all" });
+
+      expect(ctx.ptyManager.trimScrollback).toHaveBeenCalledWith(500);
+      expect(ctx.ptyManager.trimIdleAnalysisSessions).not.toHaveBeenCalled();
     });
 
     it("replies with the manager's counts against the request id", () => {
       const ctx = makeCtx();
       const dispatch = createPtyHostMessageDispatcher(ctx);
 
-      dispatch({ type: "trim-state", targetLines: 500, requestId: "trim-2" });
+      dispatch({ type: "trim-state", targetLines: 500, requestId: "trim-3", scope: "idle-only" });
 
       expect(ctx.sendEvent).toHaveBeenCalledWith({
         type: "trim-state-result",
-        requestId: "trim-2",
+        requestId: "trim-3",
         result: { trimmed: 2, skipped: 5 },
       });
     });
@@ -397,10 +411,10 @@ describe("createPtyHostMessageDispatcher", () => {
       const ctx = makeCtx();
       const dispatch = createPtyHostMessageDispatcher(ctx);
 
-      dispatch({ type: "trim-state", targetLines: 0, requestId: "trim-3" });
+      dispatch({ type: "trim-state", targetLines: 0, requestId: "trim-4", scope: "idle-only" });
 
       const [[opts]] = vi.mocked(ctx.ptyManager.trimIdleAnalysisSessions).mock.calls;
-      expect(opts?.targetLines).toBeGreaterThan(0);
+      expect(opts?.targetLines).toBe(normalizeScrollbackLines(0));
     });
   });
 });

--- a/electron/pty-host/handlers/__tests__/dispatcher.test.ts
+++ b/electron/pty-host/handlers/__tests__/dispatcher.test.ts
@@ -45,6 +45,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
     updateObservedTitle: vi.fn(),
     transitionState: vi.fn(() => true),
     trimScrollback: vi.fn(),
+    trimIdleAnalysisSessions: vi.fn(() => ({ trimmed: 2, skipped: 5 })),
     setActivityMonitorTier: vi.fn(),
     setProcessTreeCache: vi.fn(),
     setPtyPool: vi.fn(),
@@ -358,6 +359,48 @@ describe("createPtyHostMessageDispatcher", () => {
       requestId: 7,
       id: "term-1",
       agentSessionId: "session-42",
+    });
+  });
+
+  describe("trim-state (#11674)", () => {
+    it("routes main's pressure trim through the guarded pass, never the bulk flatten", () => {
+      // trimScrollback exempts nothing by design — it is the resource
+      // governor's last-resort lever before an actual PTY pause. Main's
+      // pressure trim is not that, so reaching it from here would flatten a
+      // working agent's scrollback (and its serialize source) for a reclaim
+      // main cannot even measure.
+      const ctx = makeCtx();
+      const dispatch = createPtyHostMessageDispatcher(ctx);
+
+      dispatch({ type: "trim-state", targetLines: 500, requestId: "trim-1" });
+
+      expect(ctx.ptyManager.trimIdleAnalysisSessions).toHaveBeenCalledWith({ targetLines: 500 });
+      expect(ctx.ptyManager.trimScrollback).not.toHaveBeenCalled();
+    });
+
+    it("replies with the manager's counts against the request id", () => {
+      const ctx = makeCtx();
+      const dispatch = createPtyHostMessageDispatcher(ctx);
+
+      dispatch({ type: "trim-state", targetLines: 500, requestId: "trim-2" });
+
+      expect(ctx.sendEvent).toHaveBeenCalledWith({
+        type: "trim-state-result",
+        requestId: "trim-2",
+        result: { trimmed: 2, skipped: 5 },
+      });
+    });
+
+    it("normalizes the target before applying it", () => {
+      // 0 is the legacy "unlimited" sentinel; passing it through unnormalized
+      // would ask xterm for a scrollback it rejects.
+      const ctx = makeCtx();
+      const dispatch = createPtyHostMessageDispatcher(ctx);
+
+      dispatch({ type: "trim-state", targetLines: 0, requestId: "trim-3" });
+
+      const [[opts]] = vi.mocked(ctx.ptyManager.trimIdleAnalysisSessions).mock.calls;
+      expect(opts?.targetLines).toBeGreaterThan(0);
     });
   });
 });

--- a/electron/pty-host/handlers/stateConfig.ts
+++ b/electron/pty-host/handlers/stateConfig.ts
@@ -25,12 +25,25 @@ export function createStateConfigHandlers(ctx: HostContext): HandlerMap {
       }
     },
 
+    /**
+     * Main's memory-pressure trim (ProcessMemoryMonitor tier 1 and the
+     * `host-throttled` listener both land here). Routed through the guarded
+     * pass, not `trimScrollback`: this lever is redundant with the governor's
+     * own ranked reclaim, and flattening a live agent's canonical scrollback —
+     * which is also its serialize/restore source — costs far more than it
+     * reclaims (#11674).
+     *
+     * The counts are the reply because a scrollback trim only drops JS
+     * references; main's footprint re-sample cannot attribute a delta to it.
+     */
     "trim-state": (msg) => {
       const targetLines = normalizeScrollbackLines(msg.targetLines);
-      ptyManager.trimScrollback(targetLines);
-      setTimeout(() => {
-        if (global.gc) global.gc();
-      }, 100);
+      const { trimmed, skipped } = ptyManager.trimIdleAnalysisSessions({ targetLines });
+      sendEvent({
+        type: "trim-state-result",
+        requestId: msg.requestId,
+        result: { trimmed, skipped },
+      });
     },
 
     "set-session-persist-suppressed": (msg) => {

--- a/electron/pty-host/handlers/stateConfig.ts
+++ b/electron/pty-host/handlers/stateConfig.ts
@@ -26,19 +26,29 @@ export function createStateConfigHandlers(ctx: HostContext): HandlerMap {
     },
 
     /**
-     * Main's memory-pressure trim (ProcessMemoryMonitor tier 1 and the
-     * `host-throttled` listener both land here). Routed through the guarded
-     * pass, not `trimScrollback`: this lever is redundant with the governor's
-     * own ranked reclaim, and flattening a live agent's canonical scrollback —
-     * which is also its serialize/restore source — costs far more than it
-     * reclaims (#11674).
+     * Main's memory-pressure trim. The scope decides who is fair game, because
+     * main's two callers are not the same kind of event (#11674):
+     *
+     * - `idle-only` (ProcessMemoryMonitor tier 1) is a graduated lever,
+     *   redundant with the governor's own ranked reclaim. Flattening a live
+     *   agent's canonical scrollback — which is also its serialize/restore
+     *   source — costs far more there than it reclaims, so the governance
+     *   policy protects it.
+     * - `all` (the `host-throttled` listener) is the post-pause emergency. The
+     *   governor skips its own pre-pause trim entirely at critical utilization
+     *   and pauses immediately, so this is the only buffer reclaim left on that
+     *   path; exempting the active agents holding the memory would leave
+     *   nothing to reclaim (#10948).
      *
      * The counts are the reply because a scrollback trim only drops JS
      * references; main's footprint re-sample cannot attribute a delta to it.
      */
     "trim-state": (msg) => {
       const targetLines = normalizeScrollbackLines(msg.targetLines);
-      const { trimmed, skipped } = ptyManager.trimIdleAnalysisSessions({ targetLines });
+      const { trimmed, skipped } =
+        msg.scope === "all"
+          ? ptyManager.trimScrollback(targetLines)
+          : ptyManager.trimIdleAnalysisSessions({ targetLines });
       sendEvent({
         type: "trim-state-result",
         requestId: msg.requestId,

--- a/electron/services/ProcessMemoryMonitor.ts
+++ b/electron/services/ProcessMemoryMonitor.ts
@@ -64,6 +64,33 @@ export const TIER1_MITIGATION_COOLDOWN_MS = 5 * 60 * 1000;
  */
 export const RECLAIM_SETTLE_MS = 3_000;
 
+/**
+ * Reclaim, in MB, that tier 1 must show to earn a reprieve from escalation
+ * while pressure persists but system memory is healthy.
+ *
+ * This is a suppressor, never an authorizer. Failing to clear it is not
+ * evidence tier 1 failed — only levers whose effect the sampler can attribute
+ * can clear it at all, in practice the hidden-portal-tab teardown that kills a
+ * renderer. The pty-host scrollback trim never can (see
+ * {@link RECLAIM_SETTLE_MS}), which is why the old gate — where a sub-threshold
+ * delta was one of the two conditions *permitting* escalation — rubber-stamped
+ * the tier-2 eviction tier 1 exists to prevent (#11674).
+ */
+export const MIN_RECLAIMED_MB = 50;
+
+/**
+ * How long a measured tier-1 reclaim stays evidence about current pressure.
+ *
+ * The tiers run on independent cooldowns (5 min vs 10 min), so the escalation
+ * poll is usually not the poll tier 1 acted on. A recent reclaim still says
+ * something about the pressure being judged — memory came back moments ago,
+ * give it a beat before destroying user state — but an old one does not, and
+ * the previous gate consulted it with no expiry at all. Three poll intervals
+ * spans the usual "tier 1 acts, tier 2 becomes eligible two polls later"
+ * sequence and expires long before tier 1 could run again.
+ */
+export const TIER1_REPRIEVE_MS = 3 * POLL_INTERVAL_MS;
+
 interface PidTrendState {
   startedAt: number;
   tickInBucket: number;
@@ -372,6 +399,8 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
   let pollCount = 0;
   let consecutivePressureCount = 0;
   let lastTier1At = 0;
+  /** Paired with {@link lastTier1At}: only read while that stamp is fresh. */
+  let lastTier1ReclaimMb = 0;
   let lastTier2At = 0;
   let mitigationInFlight = false;
   const thresholdExceededPids = new Set<number>();
@@ -537,6 +566,7 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
       } else {
         consecutivePressureCount = 0;
         lastTier1At = 0;
+        lastTier1ReclaimMb = 0;
         return;
       }
 
@@ -652,6 +682,7 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
 
           const deltaMb = resampleFailed ? 0 : Math.max(0, beforeMb - afterMb);
           if (shouldRunTier1) {
+            lastTier1ReclaimMb = deltaMb;
             logInfo("memory-pressure-tier1-reclaim", {
               beforeMb: Math.round(beforeMb),
               afterMb: Math.round(afterMb),
@@ -678,20 +709,25 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
             });
           }
 
-          // Pressure measured *after* tier 1 settled is the whole test. The gate
-          // used to also require `lastTier1ReclaimMb < MIN_RECLAIMED_MB`, which
-          // was unsound twice over: the pty-host trim can never move that number
-          // inside the settle window, so the term was true by construction and
-          // rubber-stamped every escalation; and because the two tiers run on
-          // out-of-phase cooldowns (5 min vs 10 min), the delta being consulted
-          // was usually a *stale* reading from an earlier poll, gating a
-          // present-tense decision on a past one. A footprint still over
-          // threshold after the settle is the honest signal, and it is the one
-          // that survives whether or not any lever's effect was observable
-          // (#11674).
+          // The reclaim can suppress escalation, but only while it is still
+          // evidence about the pressure being judged. Two things were wrong
+          // before: the delta is blind to tier 1's dominant lever, so
+          // "reclaimed < MIN" read as "tier 1 failed" by construction and
+          // *permitted* the escalation tier 1 exists to prevent; and it was
+          // consulted with no expiry, so a reading from an earlier poll gated a
+          // present-tense decision. Inverting it to a bounded suppressor keeps
+          // the half worth keeping — memory demonstrably came back moments ago,
+          // so wait a beat before destroying user state — while a lever whose
+          // effect is unobservable simply earns nothing rather than authorizing
+          // anything (#11674). System-level pressure overrides any reprieve:
+          // that floor is about the machine, not about whether we helped.
+          const tier1ReclaimIsFresh =
+            lastTier1At !== 0 && Date.now() - lastTier1At <= TIER1_REPRIEVE_MS;
+          const tier1EarnedReprieve = tier1ReclaimIsFresh && lastTier1ReclaimMb >= MIN_RECLAIMED_MB;
           if (
             shouldCheckTier2 &&
             pressureRemains &&
+            (systemPressureRemains || !tier1EarnedReprieve) &&
             Date.now() - lastTier2At >= MITIGATION_COOLDOWN_MS
           ) {
             // Stamp the cooldown BEFORE the tier-2 actions so a thrown
@@ -820,6 +856,7 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
       trendWarnedPids.clear();
       consecutivePressureCount = 0;
       lastTier1At = 0;
+      lastTier1ReclaimMb = 0;
       lastTier2At = 0;
       mitigationInFlight = false;
     });

--- a/electron/services/ProcessMemoryMonitor.ts
+++ b/electron/services/ProcessMemoryMonitor.ts
@@ -316,9 +316,9 @@ export interface MemoryPressureActions {
   /**
    * Asks the pty-host to trim the scrollback of terminals its governance policy
    * clears — never one with a live agent. Resolves with the trimmed/skipped
-   * counts, which are the only observable evidence it ran: the trim drops JS
-   * references, and no footprint re-sample within a settle window can see that
-   * (#11674). The counts are logged, never used to gate escalation.
+   * counts, which are the only observable account of what it did: the trim
+   * drops JS references, and no footprint re-sample within a settle window can
+   * see that (#11674). The counts are logged, never used to gate escalation.
    */
   trimPtyHostState?: () => Promise<TrimStateSummary>;
   /**
@@ -641,6 +641,12 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
           let tier1TrimFailed = false;
           if (shouldRunTier1) {
             lastTier1At = Date.now();
+            // Retire the previous reclaim as the stamp it is paired with moves.
+            // Without this, a lever throwing before the measurement below (an
+            // un-caught destroyHiddenWebviews) would leave an old figure sitting
+            // behind a fresh timestamp — stale evidence reading as current, the
+            // exact failure the expiry exists to prevent.
+            lastTier1ReclaimMb = 0;
             logInfo("memory-pressure-tier1-mitigation", {
               pollCount,
               consecutivePressureCount,
@@ -649,9 +655,12 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
 
             tier1TabsEvicted = await actions.destroyHiddenWebviews(1);
 
-            // Awaited so the settle window below brackets a *completed* trim.
-            // Fire-and-forget left the host still processing the message while
-            // the sampler was already reading the "after" footprint.
+            // Awaited so the host has at least accepted and applied the request
+            // before the settle window opens; fire-and-forget left it still
+            // parsing the message while the sampler read the "after" footprint.
+            // Not a completion barrier — the worker-backed path posts the
+            // resize onward without waiting — which is precisely why the gate
+            // below does not treat this lever as measurable.
             try {
               tier1Trim = (await actions.trimPtyHostState?.()) ?? null;
             } catch {
@@ -721,9 +730,13 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
           // effect is unobservable simply earns nothing rather than authorizing
           // anything (#11674). System-level pressure overrides any reprieve:
           // that floor is about the machine, not about whether we helped.
+          // A failed re-sample voids the reprieve outright: we cannot see
+          // current pressure, so an earlier reclaim is not grounds to wait.
+          // Fail toward escalation, matching the catch above.
           const tier1ReclaimIsFresh =
             lastTier1At !== 0 && Date.now() - lastTier1At <= TIER1_REPRIEVE_MS;
-          const tier1EarnedReprieve = tier1ReclaimIsFresh && lastTier1ReclaimMb >= MIN_RECLAIMED_MB;
+          const tier1EarnedReprieve =
+            !resampleFailed && tier1ReclaimIsFresh && lastTier1ReclaimMb >= MIN_RECLAIMED_MB;
           if (
             shouldCheckTier2 &&
             pressureRemains &&

--- a/electron/services/ProcessMemoryMonitor.ts
+++ b/electron/services/ProcessMemoryMonitor.ts
@@ -11,6 +11,7 @@ import { getSystemSleepService } from "./SystemSleepService.js";
 import { getWritesSuppressed } from "./diskPressureState.js";
 import { getIsE2EFaultMode } from "../setup/runtimeFlags.js";
 import { getSystemMemoryThresholds, readAvailableSystemMemoryMb } from "../utils/systemMemory.js";
+import type { TrimStateSummary } from "../../shared/types/pty-host.js";
 
 const POLL_INTERVAL_MS = 30_000;
 const SNAPSHOT_COOLDOWN_MS = 5 * 60 * 1000;
@@ -53,17 +54,15 @@ export const TIER1_MITIGATION_COOLDOWN_MS = 5 * 60 * 1000;
  * macOS/Linux, Windows background trim), so privateBytes lags reclamation by
  * a few seconds. 3s sits within the 2–5s window confirmed reliable on all
  * three platforms while staying well under {@link POLL_INTERVAL_MS}.
+ *
+ * This window brackets tier 1's *destructive* levers — tearing down a hidden
+ * portal tab kills a renderer, and that footprint does come back inside it. It
+ * says nothing about the pty-host scrollback trim, which only drops JS
+ * references: the collection is a GC away and the pages are an OS reclaim pass
+ * after that, both far outside any window worth blocking a 30s poll on. That
+ * lever reports what it did instead of what the sampler can see (#11674).
  */
 export const RECLAIM_SETTLE_MS = 3_000;
-
-/**
- * Below this MB delta, tier 1 is considered to have reclaimed effectively
- * nothing — if pressure also persists after the settle window, the ladder
- * escalates to tier 2. Above this threshold tier 1 is judged to have worked
- * (the pressure that prompted us may have legitimately re-arrived, but
- * that's a different cycle and should not chain into immediate escalation).
- */
-export const MIN_RECLAIMED_MB = 50;
 
 interface PidTrendState {
   startedAt: number;
@@ -287,7 +286,14 @@ export interface MemoryPressureActions {
   hibernateIdleProjects: () => Promise<void>;
   /** Returns the number of cached project views evicted. */
   evictCachedProjectViews?: () => Promise<number> | number;
-  trimPtyHostState?: () => void;
+  /**
+   * Asks the pty-host to trim the scrollback of terminals its governance policy
+   * clears — never one with a live agent. Resolves with the trimmed/skipped
+   * counts, which are the only observable evidence it ran: the trim drops JS
+   * references, and no footprint re-sample within a settle window can see that
+   * (#11674). The counts are logged, never used to gate escalation.
+   */
+  trimPtyHostState?: () => Promise<TrimStateSummary>;
   /**
    * Optional Blink memory sampler. If wired, called once per poll BEFORE
    * pressure evaluation so renderer samples land alongside the metrics
@@ -366,7 +372,6 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
   let pollCount = 0;
   let consecutivePressureCount = 0;
   let lastTier1At = 0;
-  let lastTier1ReclaimMb = 0;
   let lastTier2At = 0;
   let mitigationInFlight = false;
   const thresholdExceededPids = new Set<number>();
@@ -532,7 +537,6 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
       } else {
         consecutivePressureCount = 0;
         lastTier1At = 0;
-        lastTier1ReclaimMb = 0;
         return;
       }
 
@@ -603,6 +607,8 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
           }
 
           let tier1TabsEvicted = 0;
+          let tier1Trim: TrimStateSummary | null = null;
+          let tier1TrimFailed = false;
           if (shouldRunTier1) {
             lastTier1At = Date.now();
             logInfo("memory-pressure-tier1-mitigation", {
@@ -613,10 +619,13 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
 
             tier1TabsEvicted = await actions.destroyHiddenWebviews(1);
 
+            // Awaited so the settle window below brackets a *completed* trim.
+            // Fire-and-forget left the host still processing the message while
+            // the sampler was already reading the "after" footprint.
             try {
-              actions.trimPtyHostState?.();
+              tier1Trim = (await actions.trimPtyHostState?.()) ?? null;
             } catch {
-              /* non-critical */
+              tier1TrimFailed = true;
             }
 
             await new Promise<void>((resolve) => setTimeout(resolve, RECLAIM_SETTLE_MS));
@@ -632,12 +641,9 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
             pressureRemains = measured.pressureRemains;
             systemPressureRemains = measured.systemPressureRemains;
           } catch {
-            // Re-sample failed — assume pressure persists and treat reclaim
-            // as zero so the gate falls through to escalation. Without
-            // forcing afterMb=beforeMb here, deltaMb would equal the full
-            // beforeMb, satisfying `deltaMb >= MIN_RECLAIMED_MB` and
-            // *suppressing* escalation, which is the opposite of the
-            // safe-side intent.
+            // Re-sample failed — assume pressure persists so the gate falls
+            // through to escalation, and force afterMb=beforeMb so the logged
+            // delta reads as the zero it is rather than the full beforeMb.
             pressureRemains = true;
             systemPressureRemains = systemPressureActive;
             resampleFailed = true;
@@ -646,10 +652,12 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
 
           const deltaMb = resampleFailed ? 0 : Math.max(0, beforeMb - afterMb);
           if (shouldRunTier1) {
-            lastTier1ReclaimMb = deltaMb;
             logInfo("memory-pressure-tier1-reclaim", {
               beforeMb: Math.round(beforeMb),
               afterMb: Math.round(afterMb),
+              // Attributable to the portal-tab teardown only. The scrollback
+              // trim cannot move this inside the settle window whatever it did,
+              // so a zero here is not evidence either lever failed.
               deltaMb: Math.round(deltaMb),
               // Portal tabs are the only part of this lever whose outcome main
               // can observe (the webview push is fire-and-forget), so this is a
@@ -657,15 +665,33 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
               // "it found none" when the delta reads zero — previously
               // indistinguishable.
               portalTabsDestroyed: tier1TabsEvicted,
+              // The trim's own report, for the same reason: separates "every
+              // terminal was deliberately protected" (trimmed 0 / skipped N)
+              // from "the trim never reached the host" (shardsFailed > 0).
+              ptyTerminalsTrimmed: tier1Trim?.trimmed ?? 0,
+              ptyTerminalsSkipped: tier1Trim?.skipped ?? 0,
+              ptyTrimShardsTotal: tier1Trim?.shardsTotal ?? 0,
+              ptyTrimShardsFailed: tier1Trim?.shardsFailed ?? 0,
+              ptyTrimFailed: tier1TrimFailed,
               pressureRemains,
               resampleFailed,
             });
           }
 
+          // Pressure measured *after* tier 1 settled is the whole test. The gate
+          // used to also require `lastTier1ReclaimMb < MIN_RECLAIMED_MB`, which
+          // was unsound twice over: the pty-host trim can never move that number
+          // inside the settle window, so the term was true by construction and
+          // rubber-stamped every escalation; and because the two tiers run on
+          // out-of-phase cooldowns (5 min vs 10 min), the delta being consulted
+          // was usually a *stale* reading from an earlier poll, gating a
+          // present-tense decision on a past one. A footprint still over
+          // threshold after the settle is the honest signal, and it is the one
+          // that survives whether or not any lever's effect was observable
+          // (#11674).
           if (
             shouldCheckTier2 &&
             pressureRemains &&
-            (systemPressureRemains || lastTier1ReclaimMb < MIN_RECLAIMED_MB) &&
             Date.now() - lastTier2At >= MITIGATION_COOLDOWN_MS
           ) {
             // Stamp the cooldown BEFORE the tier-2 actions so a thrown
@@ -681,7 +707,6 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
             logInfo("memory-pressure-tier2-mitigation", {
               pollCount,
               consecutivePressureCount,
-              tier1ReclaimMb: Math.round(lastTier1ReclaimMb),
               systemPressureRemains,
             });
 
@@ -795,7 +820,6 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
       trendWarnedPids.clear();
       consecutivePressureCount = 0;
       lastTier1At = 0;
-      lastTier1ReclaimMb = 0;
       lastTier2At = 0;
       mitigationInFlight = false;
     });

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -102,6 +102,8 @@ import type {
   MemoryRollup,
   GracefulKillResult,
   PtyHostWorkerGovernanceSnapshot,
+  TrimStateResult,
+  TrimStateSummary,
 } from "../../shared/types/pty-host.js";
 import type { TerminalSnapshot } from "./PtyManager.js";
 import type { AgentStateChangeTrigger } from "../types/index.js";
@@ -2312,11 +2314,44 @@ export class PtyClient extends EventEmitter {
     return promise.catch(() => false);
   }
 
-  /** Request every shard to trim scrollback on all terminals to reduce memory */
-  trimState(targetLines: number): void {
-    for (const shard of this.shards.values()) {
-      shard.send({ type: "trim-state", targetLines });
+  /**
+   * Ask every shard to trim the scrollback of terminals its governance policy
+   * says are safe to touch — quiet past the idle floor with no active agent.
+   * Terminals running an agent keep their history (#11674).
+   *
+   * Resolves with the summed counts rather than void because the trim's effect
+   * is invisible to a footprint re-sample: it drops JS references, and nothing
+   * returns to the OS inside any settle window main can afford to wait. The
+   * counts are the only evidence it ran. Failed shards are reported, never
+   * folded into `skipped` — an incomplete fan-out must not read as "nothing was
+   * eligible".
+   */
+  async trimState(targetLines: number): Promise<TrimStateSummary> {
+    const shards = this.fanOutShards();
+    const results = await Promise.all(
+      shards.map((shard) =>
+        sendPtyHostRpc<TrimStateResult>(shard, "trim-state", (requestId) => ({
+          type: "trim-state",
+          targetLines,
+          requestId,
+        })).catch(() => null)
+      )
+    );
+    const summary: TrimStateSummary = {
+      trimmed: 0,
+      skipped: 0,
+      shardsTotal: shards.length,
+      shardsFailed: 0,
+    };
+    for (const result of results) {
+      if (!result) {
+        summary.shardsFailed++;
+        continue;
+      }
+      summary.trimmed += result.trimmed;
+      summary.skipped += result.skipped;
     }
+    return summary;
   }
 
   /** Suppress or resume terminal session persistence across all shards */

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -103,6 +103,7 @@ import type {
   GracefulKillResult,
   PtyHostWorkerGovernanceSnapshot,
   TrimStateResult,
+  TrimStateScope,
   TrimStateSummary,
 } from "../../shared/types/pty-host.js";
 import type { TerminalSnapshot } from "./PtyManager.js";
@@ -2315,32 +2316,39 @@ export class PtyClient extends EventEmitter {
   }
 
   /**
-   * Ask every shard to trim the scrollback of terminals its governance policy
-   * says are safe to touch — quiet past the idle floor with no active agent.
-   * Terminals running an agent keep their history (#11674).
+   * Ask the shards to trim terminal scrollback. `scope` decides who is fair
+   * game: `idle-only` spares terminals with a live agent, `all` exempts
+   * nothing and is only for the post-pause emergency (#11674).
    *
    * Resolves with the summed counts rather than void because the trim's effect
    * is invisible to a footprint re-sample: it drops JS references, and nothing
    * returns to the OS inside any settle window main can afford to wait. The
-   * counts are the only evidence it ran. Failed shards are reported, never
-   * folded into `skipped` — an incomplete fan-out must not read as "nothing was
-   * eligible".
+   * counts are the only evidence it ran.
+   *
+   * `shardsTotal` counts every live shard, not just the ones that could be
+   * reached — a shard still booting or mid-restart is counted as failed rather
+   * than quietly dropped from the denominator, so an incomplete fan-out can
+   * never read as "nothing was eligible".
    */
-  async trimState(targetLines: number): Promise<TrimStateSummary> {
-    const shards = this.fanOutShards();
+  async trimState(targetLines: number, scope: TrimStateScope): Promise<TrimStateSummary> {
+    const liveShards = [...this.shards.values()].filter((shard) => !shard.retired);
+    const reachable = new Set(this.fanOutShards());
     const results = await Promise.all(
-      shards.map((shard) =>
-        sendPtyHostRpc<TrimStateResult>(shard, "trim-state", (requestId) => ({
-          type: "trim-state",
-          targetLines,
-          requestId,
-        })).catch(() => null)
+      liveShards.map((shard) =>
+        reachable.has(shard)
+          ? sendPtyHostRpc<TrimStateResult>(shard, "trim-state", (requestId) => ({
+              type: "trim-state",
+              targetLines,
+              requestId,
+              scope,
+            })).catch(() => null)
+          : Promise.resolve(null)
       )
     );
     const summary: TrimStateSummary = {
       trimmed: 0,
       skipped: 0,
-      shardsTotal: shards.length,
+      shardsTotal: liveShards.length,
       shardsFailed: 0,
     };
     for (const result of results) {

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -2323,7 +2323,8 @@ export class PtyClient extends EventEmitter {
    * Resolves with the summed counts rather than void because the trim's effect
    * is invisible to a footprint re-sample: it drops JS references, and nothing
    * returns to the OS inside any settle window main can afford to wait. The
-   * counts are the only evidence it ran.
+   * counts are the only account of what it did — a record of the shrink each
+   * host applied and dispatched, not of a worker confirming it landed.
    *
    * `shardsTotal` counts every live shard, not just the ones that could be
    * reached — a shard still booting or mid-restart is counted as failed rather

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -145,18 +145,33 @@ export class PtyManager extends EventEmitter {
   /**
    * Uniform, unguarded flatten of every terminal's analysis scrollback.
    *
-   * Deliberately exempts nothing. Its only caller is the resource governor's
-   * `trimBuffers` fallback (`electron/pty-host.ts`), which runs on the host's
-   * fixed heap budget as the last step before an actual PTY pause — there,
-   * active agents are the dominant consumer, so exempting them leaves nothing
-   * to reclaim and self-defeats into the visible pause it exists to avoid
-   * (#10948, reverted). Pressure levers that are *not* the last line of
-   * defense must use {@link trimIdleAnalysisSessions} instead (#11674).
+   * Deliberately exempts nothing, and both its callers are emergencies: the
+   * resource governor's `trimBuffers` fallback (`electron/pty-host.ts`) and the
+   * `"all"`-scoped `trim-state` main sends after the governor has already
+   * paused every PTY. On the host's fixed heap budget active agents ARE the
+   * dominant consumer, so sparing them leaves nothing to reclaim and
+   * self-defeats into the visible pause this exists to avoid (#10948,
+   * reverted). Graduated pressure levers — which are redundant with the
+   * governor and must not cost more than they reclaim — use
+   * {@link trimIdleAnalysisSessions} instead (#11674).
+   *
+   * Counts are reported for the same reason they are on the guarded pass: the
+   * caller cannot observe this trim any other way. `skipped` here means "was
+   * already at or below the target", never "was protected".
    */
-  trimScrollback(targetLines: number): void {
+  trimScrollback(targetLines: number): { trimmed: number; skipped: number } {
+    let trimmed = 0;
+    let skipped = 0;
     for (const terminal of this.registry.getAll()) {
+      const before = terminal.getCurrentScrollback();
       terminal.trimScrollback(targetLines);
+      if (terminal.getCurrentScrollback() < before) {
+        trimmed++;
+      } else {
+        skipped++;
+      }
     }
+    return { trimmed, skipped };
   }
 
   /**

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -230,18 +230,20 @@ export class PtyManager extends EventEmitter {
    * (ACTIVE_AGENT_STATES — the same set that protects against eviction and
    * hibernation).
    *
-   * Two callers, both of which reach it through a host handler: the
-   * profile-driven efficiency entry, and main's memory-pressure `trim-state`
-   * fan-out (tier 1 and `host-throttled`). Neither is a last-resort lever — the
-   * governor's own ranked reclaim has already run or been skipped by the time
-   * `trim-state` lands — so the per-session policy is the only thing between
-   * either of them and a working agent, and it must stay conservative. The
-   * buffer this shrinks is also what `getSerializedStateAsync()` serializes, so
-   * an over-eager trim costs restore fidelity, not just live scrollback.
+   * Two callers, both reaching it through a host handler: the profile-driven
+   * efficiency entry, and the `idle-only` scope of main's memory-pressure
+   * `trim-state`. Neither is a last-resort lever, so the per-session policy is
+   * the only thing between either of them and a working agent and it must stay
+   * conservative. The post-pause emergency (`trim-state` scope `all`) and the
+   * governor's own fallback deliberately bypass this and use
+   * {@link trimScrollback}. The buffer this shrinks is also what
+   * `getSerializedStateAsync()` serializes, so an over-eager trim costs restore
+   * fidelity, not just live scrollback.
    *
-   * `trimmed` counts only terminals whose cap actually moved: the analysis
-   * backend can refuse a resize, and a count that reported those as trimmed
-   * would be exactly the unfalsifiable telemetry #11674 is about.
+   * `trimmed` counts only terminals whose cap moved: the analysis backend can
+   * refuse a resize, and reporting those as trimmed would be exactly the
+   * unfalsifiable telemetry #11674 is about. It still describes the shrink this
+   * process applied and dispatched, not a worker's confirmation of it.
    */
   trimIdleAnalysisSessions(opts?: { now?: number; targetLines?: number; idleTrimMs?: number }): {
     trimmed: number;

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -142,6 +142,17 @@ export class PtyManager extends EventEmitter {
     }
   }
 
+  /**
+   * Uniform, unguarded flatten of every terminal's analysis scrollback.
+   *
+   * Deliberately exempts nothing. Its only caller is the resource governor's
+   * `trimBuffers` fallback (`electron/pty-host.ts`), which runs on the host's
+   * fixed heap budget as the last step before an actual PTY pause — there,
+   * active agents are the dominant consumer, so exempting them leaves nothing
+   * to reclaim and self-defeats into the visible pause it exists to avoid
+   * (#10948, reverted). Pressure levers that are *not* the last line of
+   * defense must use {@link trimIdleAnalysisSessions} instead (#11674).
+   */
   trimScrollback(targetLines: number): void {
     for (const terminal of this.registry.getAll()) {
       terminal.trimScrollback(targetLines);
@@ -202,9 +213,20 @@ export class PtyManager extends EventEmitter {
    * Governance trim pass: shrink the analysis scrollback of terminals that have
    * been quiet past the idle floor and have no active agent
    * (ACTIVE_AGENT_STATES — the same set that protects against eviction and
-   * hibernation). Unlike the resource governor's heap-pressure trims this is
-   * profile-driven (efficiency entry), so the per-session policy is the only
-   * thing between it and a working agent — it must stay conservative.
+   * hibernation).
+   *
+   * Two callers, both of which reach it through a host handler: the
+   * profile-driven efficiency entry, and main's memory-pressure `trim-state`
+   * fan-out (tier 1 and `host-throttled`). Neither is a last-resort lever — the
+   * governor's own ranked reclaim has already run or been skipped by the time
+   * `trim-state` lands — so the per-session policy is the only thing between
+   * either of them and a working agent, and it must stay conservative. The
+   * buffer this shrinks is also what `getSerializedStateAsync()` serializes, so
+   * an over-eager trim costs restore fidelity, not just live scrollback.
+   *
+   * `trimmed` counts only terminals whose cap actually moved: the analysis
+   * backend can refuse a resize, and a count that reported those as trimmed
+   * would be exactly the unfalsifiable telemetry #11674 is about.
    */
   trimIdleAnalysisSessions(opts?: { now?: number; targetLines?: number; idleTrimMs?: number }): {
     trimmed: number;
@@ -216,11 +238,12 @@ export class PtyManager extends EventEmitter {
     let skipped = 0;
     for (const terminal of this.registry.getAll()) {
       const info = terminal.getInfo();
+      const before = terminal.getCurrentScrollback();
       const eligible = shouldTrimAnalysisSession({
         agentState: info.agentState,
         lastInputTime: info.lastInputTime,
         lastOutputTime: info.lastOutputTime,
-        scrollbackLines: terminal.getCurrentScrollback(),
+        scrollbackLines: before,
         minScrollbackLines: targetLines,
         now,
         idleTrimMs: opts?.idleTrimMs,
@@ -230,7 +253,11 @@ export class PtyManager extends EventEmitter {
         continue;
       }
       terminal.trimScrollback(targetLines);
-      trimmed++;
+      if (terminal.getCurrentScrollback() < before) {
+        trimmed++;
+      } else {
+        skipped++;
+      }
     }
     return { trimmed, skipped };
   }

--- a/electron/services/__tests__/ProcessMemoryMonitor.test.ts
+++ b/electron/services/__tests__/ProcessMemoryMonitor.test.ts
@@ -51,6 +51,8 @@ import {
   PRESSURE_COUNT_TIER2,
   MITIGATION_COOLDOWN_MS,
   RECLAIM_SETTLE_MS,
+  MIN_RECLAIMED_MB,
+  TIER1_REPRIEVE_MS,
   recordBlinkSample,
   forgetBlinkSample,
   getBlinkSamples,
@@ -805,9 +807,9 @@ describe("ProcessMemoryMonitor", () => {
       expect(mockActions.destroyHiddenWebviews).toHaveBeenCalledWith(1);
     });
 
-    it("does not escalate to tier 2 when tier 1 clears the pressure", async () => {
-      // The post-settle sample drops below the Browser pressure threshold, so
-      // there is nothing left to escalate about.
+    it("runs tier 1 alone on the first pressure poll, never tier 2", async () => {
+      // Tier 2 needs PRESSURE_COUNT_TIER2 consecutive pressure polls; one is
+      // never enough, whatever the post-settle sample says.
       arrangeClosedLoopMetrics({ beforeMb: 350, afterMb: 250 });
       stop = startAppMetricsMonitor(mockActions);
 
@@ -828,9 +830,9 @@ describe("ProcessMemoryMonitor", () => {
       expect(mockActions.destroyHiddenWebviews).toHaveBeenCalledWith(2);
     });
 
-    it("does NOT escalate to tier 2 when post-settle re-sample shows pressure cleared", async () => {
-      // Pressure dropped below threshold after the settle window, so the gate
-      // suppresses escalation.
+    it("stops the ladder at tier 1 when pressure clears before the count builds", async () => {
+      // Pressure drops below threshold after the settle window, so the streak
+      // resets and tier 2 is never reached.
       arrangeClosedLoopMetrics({ beforeMb: 305, afterMb: 295 });
       stop = startAppMetricsMonitor(mockActions);
 
@@ -1010,6 +1012,48 @@ describe("ProcessMemoryMonitor", () => {
       );
     });
 
+    it("surfaces an incomplete fan-out rather than reporting a clean pass", async () => {
+      // A shard that could not be reached must be visible: counts from a
+      // partial fan-out are a floor, and reading them as a census would say
+      // "nothing was eligible" about terminals nobody asked.
+      const trimPtyHostState = vi.fn(async () =>
+        makeTrimSummary({ trimmed: 1, skipped: 2, shardsTotal: 3, shardsFailed: 2 })
+      );
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 350 * 1024, 100)]);
+      stop = startAppMetricsMonitor({ ...mockActions, trimPtyHostState });
+
+      await advancePolls(WARMUP_INTERVALS + 1);
+
+      expect(logInfo).toHaveBeenCalledWith(
+        "memory-pressure-tier1-reclaim",
+        expect.objectContaining({
+          ptyTerminalsTrimmed: 1,
+          ptyTerminalsSkipped: 2,
+          ptyTrimShardsTotal: 3,
+          ptyTrimShardsFailed: 2,
+          ptyTrimFailed: false,
+        })
+      );
+    });
+
+    it("does not report an unwired trim action as a failed one", async () => {
+      // trimPtyHostState is optional. "Never asked" and "asked and it threw"
+      // are different states and the log must not conflate them.
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 350 * 1024, 100)]);
+      stop = startAppMetricsMonitor({ ...mockActions, trimPtyHostState: undefined });
+
+      await advancePolls(WARMUP_INTERVALS + 1);
+
+      expect(logInfo).toHaveBeenCalledWith(
+        "memory-pressure-tier1-reclaim",
+        expect.objectContaining({
+          ptyTerminalsTrimmed: 0,
+          ptyTrimShardsTotal: 0,
+          ptyTrimFailed: false,
+        })
+      );
+    });
+
     it("calls destroyHiddenWebviews(1) on tier 1 mitigation", async () => {
       mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 350 * 1024, 100)]);
       stop = startAppMetricsMonitor(mockActions);
@@ -1070,21 +1114,50 @@ describe("ProcessMemoryMonitor", () => {
       expect(mockActions.hibernateIdleProjects).not.toHaveBeenCalled();
     });
 
-    it("escalates on surviving pressure even when tier 1's measured reclaim was large (#11674)", async () => {
-      // The gate used to suppress escalation whenever the tier-1 delta cleared
-      // MIN_RECLAIMED_MB. That term was unsound twice over: the pty-host
-      // scrollback trim can never move it inside the settle window, so it was
-      // true by construction and rubber-stamped every escalation; and because
-      // the tiers run on out-of-phase cooldowns the delta consulted here was
-      // usually stale. A footprint still over threshold after the settle is the
-      // only honest signal — 50 MB back is not a reprieve when 350 remain.
-      arrangeClosedLoopMetrics({ beforeMb: 400, afterMb: 350 });
+    it("holds tier 2 back while tier 1's measured reclaim is still fresh", async () => {
+      // The half of the old gate worth keeping: memory demonstrably came back
+      // moments ago and system memory is healthy, so wait a beat before
+      // destroying user state. Tier 1 acts on the first pressure poll and tier
+      // 2 becomes eligible two polls later — inside the reprieve window.
+      arrangeClosedLoopMetrics({ beforeMb: 400, afterMb: 400 - MIN_RECLAIMED_MB });
       stop = startAppMetricsMonitor(mockActions);
 
       await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2);
 
+      expect(mockActions.destroyHiddenWebviews).toHaveBeenCalledWith(1);
+      expect(mockActions.hibernateIdleProjects).not.toHaveBeenCalled();
+      expect(mockActions.destroyHiddenWebviews).not.toHaveBeenCalledWith(2);
+    });
+
+    it("escalates once that reclaim is too old to be evidence about now (#11674)", async () => {
+      // The old gate consulted the reclaim with no expiry, so one successful
+      // tier 1 could suppress escalation long after the number stopped
+      // describing current pressure. Same reclaim as above, a few polls later:
+      // pressure is still over threshold and nothing has acted since.
+      arrangeClosedLoopMetrics({ beforeMb: 400, afterMb: 400 - MIN_RECLAIMED_MB });
+      stop = startAppMetricsMonitor(mockActions);
+
+      await advancePolls(
+        WARMUP_INTERVALS + PRESSURE_COUNT_TIER2 + Math.ceil(TIER1_REPRIEVE_MS / 30_000)
+      );
+
       expect(mockActions.hibernateIdleProjects).toHaveBeenCalledTimes(1);
       expect(mockActions.destroyHiddenWebviews).toHaveBeenCalledWith(2);
+    });
+
+    it("never lets the unobservable trim earn a reprieve it cannot demonstrate", async () => {
+      // The reported bug: a scrollback trim cannot move deltaMb inside the
+      // settle window, so tier 1 shows ~0 reclaim however much it did. That
+      // must simply earn nothing — it must never read as proof tier 1 failed,
+      // nor as grounds to suppress a genuine escalation.
+      const trimPtyHostState = vi.fn(async () => makeTrimSummary({ trimmed: 6, skipped: 0 }));
+      arrangeClosedLoopMetrics({ beforeMb: 400, afterMb: 400 });
+      stop = startAppMetricsMonitor({ ...mockActions, trimPtyHostState });
+
+      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2);
+
+      expect(trimPtyHostState).toHaveBeenCalled();
+      expect(mockActions.hibernateIdleProjects).toHaveBeenCalledTimes(1);
     });
 
     it("escalates to tier 2 when the post-settle re-sample throws", async () => {

--- a/electron/services/__tests__/ProcessMemoryMonitor.test.ts
+++ b/electron/services/__tests__/ProcessMemoryMonitor.test.ts
@@ -51,7 +51,6 @@ import {
   PRESSURE_COUNT_TIER2,
   MITIGATION_COOLDOWN_MS,
   RECLAIM_SETTLE_MS,
-  MIN_RECLAIMED_MB,
   recordBlinkSample,
   forgetBlinkSample,
   getBlinkSamples,
@@ -65,10 +64,15 @@ import {
   getTrendSnapshot,
   type MemoryPressureActions,
 } from "../ProcessMemoryMonitor.js";
+import type { TrimStateSummary } from "../../../shared/types/pty-host.js";
 
 const EIGHT_GB = 8 * 1024 * 1024 * 1024;
 
 const mockGetAppMetrics = app.getAppMetrics as ReturnType<typeof vi.fn>;
+
+function makeTrimSummary(overrides: Partial<TrimStateSummary> = {}): TrimStateSummary {
+  return { trimmed: 0, skipped: 0, shardsTotal: 1, shardsFailed: 0, ...overrides };
+}
 
 function makeMetric(
   type: string,
@@ -801,10 +805,9 @@ describe("ProcessMemoryMonitor", () => {
       expect(mockActions.destroyHiddenWebviews).toHaveBeenCalledWith(1);
     });
 
-    it("does not escalate to tier 2 when tier 1 reclaims above the minimum", async () => {
-      // Tier 1 frees 100 MB (well above MIN_RECLAIMED_MB), and the post-
-      // settle sample drops below the Browser pressure threshold — both
-      // halves of the AND gate should suppress escalation.
+    it("does not escalate to tier 2 when tier 1 clears the pressure", async () => {
+      // The post-settle sample drops below the Browser pressure threshold, so
+      // there is nothing left to escalate about.
       arrangeClosedLoopMetrics({ beforeMb: 350, afterMb: 250 });
       stop = startAppMetricsMonitor(mockActions);
 
@@ -815,8 +818,7 @@ describe("ProcessMemoryMonitor", () => {
       expect(mockActions.destroyHiddenWebviews).not.toHaveBeenCalledWith(2);
     });
 
-    it("escalates to tier 2 when tier 1 reclaims insufficient memory and pressure remains", async () => {
-      // Tier 1 freed only 10 MB (< MIN_RECLAIMED_MB) and pressure persists.
+    it("escalates to tier 2 when pressure survives tier 1", async () => {
       arrangeClosedLoopMetrics({ beforeMb: 350, afterMb: 340 });
       stop = startAppMetricsMonitor(mockActions);
 
@@ -827,9 +829,8 @@ describe("ProcessMemoryMonitor", () => {
     });
 
     it("does NOT escalate to tier 2 when post-settle re-sample shows pressure cleared", async () => {
-      // Tier 1 freed only 5 MB (< MIN_RECLAIMED_MB) but pressure dropped
-      // below threshold after the settle window — pressureRemains is false,
-      // so the AND gate suppresses escalation even though delta is small.
+      // Pressure dropped below threshold after the settle window, so the gate
+      // suppresses escalation.
       arrangeClosedLoopMetrics({ beforeMb: 305, afterMb: 295 });
       stop = startAppMetricsMonitor(mockActions);
 
@@ -918,7 +919,7 @@ describe("ProcessMemoryMonitor", () => {
     });
 
     it("calls trimPtyHostState during tier 1 mitigation", async () => {
-      const trimPtyHostState = vi.fn();
+      const trimPtyHostState = vi.fn(async () => makeTrimSummary());
       const actionsWithTrim: MemoryPressureActions = {
         ...mockActions,
         trimPtyHostState,
@@ -931,10 +932,8 @@ describe("ProcessMemoryMonitor", () => {
       expect(trimPtyHostState).toHaveBeenCalledTimes(1);
     });
 
-    it("continues tier 1 even if trimPtyHostState throws", async () => {
-      const trimPtyHostState = vi.fn().mockImplementation(() => {
-        throw new Error("trim failed");
-      });
+    it("continues tier 1 even if trimPtyHostState rejects", async () => {
+      const trimPtyHostState = vi.fn().mockRejectedValue(new Error("trim failed"));
       const actionsWithTrim: MemoryPressureActions = {
         ...mockActions,
         trimPtyHostState,
@@ -948,6 +947,67 @@ describe("ProcessMemoryMonitor", () => {
 
       expect(trimPtyHostState).toHaveBeenCalled();
       expect(actionsWithTrim.destroyHiddenWebviews).toHaveBeenCalledWith(1);
+      expect(logInfo).toHaveBeenCalledWith(
+        "memory-pressure-tier1-reclaim",
+        expect.objectContaining({ ptyTrimFailed: true })
+      );
+    });
+
+    it("awaits the pty-host trim before opening the settle window (#11674)", async () => {
+      // Fire-and-forget left the host still processing the trim while the
+      // sampler was already reading the "after" footprint, so the bracket
+      // measured a mitigation that had not finished.
+      const order: string[] = [];
+      let releaseTrim: () => void = () => {};
+      const trimPtyHostState = vi.fn(
+        () =>
+          new Promise<ReturnType<typeof makeTrimSummary>>((resolve) => {
+            order.push("trim-started");
+            releaseTrim = () => resolve(makeTrimSummary());
+          })
+      );
+      mockGetAppMetrics.mockImplementation(() => {
+        order.push("sampled");
+        return [makeMetric("Browser", 350 * 1024, 100)];
+      });
+      stop = startAppMetricsMonitor({ ...mockActions, trimPtyHostState });
+
+      await advancePolls(WARMUP_INTERVALS + 1);
+
+      // The trim is still pending, so the post-settle re-sample must not have
+      // run yet — no matter how much time has passed.
+      const sampledBeforeRelease = order.filter((e) => e === "sampled").length;
+      releaseTrim();
+      await vi.advanceTimersByTimeAsync(RECLAIM_SETTLE_MS);
+
+      expect(order).toContain("trim-started");
+      expect(order.filter((e) => e === "sampled").length).toBeGreaterThan(sampledBeforeRelease);
+    });
+
+    it("logs the trim's own counts so a zero delta stays attributable (#11674)", async () => {
+      // A scrollback trim only drops JS references, so `deltaMb` cannot see it
+      // however many terminals it touched. The counts are the evidence, and
+      // they must distinguish "every terminal was deliberately protected" from
+      // "the trim never reached the host".
+      const trimPtyHostState = vi.fn(async () =>
+        makeTrimSummary({ trimmed: 0, skipped: 8, shardsTotal: 2, shardsFailed: 0 })
+      );
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 350 * 1024, 100)]);
+      stop = startAppMetricsMonitor({ ...mockActions, trimPtyHostState });
+
+      await advancePolls(WARMUP_INTERVALS + 1);
+
+      expect(logInfo).toHaveBeenCalledWith(
+        "memory-pressure-tier1-reclaim",
+        expect.objectContaining({
+          deltaMb: 0,
+          ptyTerminalsTrimmed: 0,
+          ptyTerminalsSkipped: 8,
+          ptyTrimShardsTotal: 2,
+          ptyTrimShardsFailed: 0,
+          ptyTrimFailed: false,
+        })
+      );
     });
 
     it("calls destroyHiddenWebviews(1) on tier 1 mitigation", async () => {
@@ -1010,16 +1070,21 @@ describe("ProcessMemoryMonitor", () => {
       expect(mockActions.hibernateIdleProjects).not.toHaveBeenCalled();
     });
 
-    it("escalation gate honors MIN_RECLAIMED_MB at the boundary", async () => {
-      // Reclaim exactly equals MIN_RECLAIMED_MB → the gate `deltaMb <
-      // MIN_RECLAIMED_MB` is false, so no escalation even with pressure
-      // persisting.
-      arrangeClosedLoopMetrics({ beforeMb: 400, afterMb: 400 - MIN_RECLAIMED_MB });
+    it("escalates on surviving pressure even when tier 1's measured reclaim was large (#11674)", async () => {
+      // The gate used to suppress escalation whenever the tier-1 delta cleared
+      // MIN_RECLAIMED_MB. That term was unsound twice over: the pty-host
+      // scrollback trim can never move it inside the settle window, so it was
+      // true by construction and rubber-stamped every escalation; and because
+      // the tiers run on out-of-phase cooldowns the delta consulted here was
+      // usually stale. A footprint still over threshold after the settle is the
+      // only honest signal — 50 MB back is not a reprieve when 350 remain.
+      arrangeClosedLoopMetrics({ beforeMb: 400, afterMb: 350 });
       stop = startAppMetricsMonitor(mockActions);
 
       await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2);
 
-      expect(mockActions.hibernateIdleProjects).not.toHaveBeenCalled();
+      expect(mockActions.hibernateIdleProjects).toHaveBeenCalledTimes(1);
+      expect(mockActions.destroyHiddenWebviews).toHaveBeenCalledWith(2);
     });
 
     it("escalates to tier 2 when the post-settle re-sample throws", async () => {
@@ -1204,8 +1269,10 @@ describe("ProcessMemoryMonitor", () => {
 
       expect(mitigation).toBeDefined();
       expect(mitigation?.[1]).not.toHaveProperty("deltaMb");
+      // `tier1ReclaimMb` is gone with the delta gate it fed (#11674) — it
+      // reported a number tier 1's dominant lever could never move.
+      expect(mitigation?.[1]).not.toHaveProperty("tier1ReclaimMb");
       expect(mitigation?.[1]).toMatchObject({
-        tier1ReclaimMb: 0,
         systemPressureRemains: false,
       });
     });

--- a/electron/services/__tests__/ProcessMemoryMonitor.test.ts
+++ b/electron/services/__tests__/ProcessMemoryMonitor.test.ts
@@ -1145,6 +1145,38 @@ describe("ProcessMemoryMonitor", () => {
       expect(mockActions.destroyHiddenWebviews).toHaveBeenCalledWith(2);
     });
 
+    it("voids a live reprieve when the tier-2 re-sample fails", async () => {
+      // Earn a reprieve, then blind the next poll's re-sample while it is still
+      // fresh. Not seeing current pressure is not a reason to keep waiting on
+      // an earlier reclaim — the failure path has to fall toward escalation,
+      // not inherit the suppression.
+      let postMitigation = false;
+      // The poll's own read must still succeed — blinding it too would abort
+      // the poll before the gate, testing nothing. Allow that one read, then
+      // fail the pre-sample and the post-settle re-sample behind it.
+      let readsBeforeBlinding = Infinity;
+      mockGetAppMetrics.mockImplementation(() => {
+        if (readsBeforeBlinding <= 0) throw new Error("metrics unavailable");
+        readsBeforeBlinding--;
+        const mb = postMitigation ? 400 - MIN_RECLAIMED_MB : 400;
+        return [makeMetric("Browser", mb * 1024, 100, mb * 1024)];
+      });
+      mockActions.destroyHiddenWebviews = vi.fn().mockImplementation(async (tier) => {
+        if (tier === 1) postMitigation = true;
+        return 0;
+      });
+      stop = startAppMetricsMonitor(mockActions);
+
+      // Stop one poll short of tier-2 eligibility, with the reprieve earned.
+      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2 - 1);
+      expect(mockActions.hibernateIdleProjects).not.toHaveBeenCalled();
+
+      readsBeforeBlinding = 1;
+      await advancePolls(1);
+
+      expect(mockActions.hibernateIdleProjects).toHaveBeenCalledTimes(1);
+    });
+
     it("never lets the unobservable trim earn a reprieve it cannot demonstrate", async () => {
       // The reported bug: a scrollback trim cannot move deltaMb inside the
       // settle window, so tier 1 shows ~0 reclaim however much it did. That
@@ -1342,8 +1374,9 @@ describe("ProcessMemoryMonitor", () => {
 
       expect(mitigation).toBeDefined();
       expect(mitigation?.[1]).not.toHaveProperty("deltaMb");
-      // `tier1ReclaimMb` is gone with the delta gate it fed (#11674) — it
-      // reported a number tier 1's dominant lever could never move.
+      // The tier-2 line no longer republishes tier 1's reclaim (#11674). The
+      // figure still exists as a bounded suppressor, but reporting it here
+      // implied it described this tier, which it never did.
       expect(mitigation?.[1]).not.toHaveProperty("tier1ReclaimMb");
       expect(mitigation?.[1]).toMatchObject({
         systemPressureRemains: false,

--- a/electron/services/__tests__/PtyClient.fabric.test.ts
+++ b/electron/services/__tests__/PtyClient.fabric.test.ts
@@ -784,15 +784,19 @@ describe("PtyClient fabric", () => {
 
       client.pauseAll();
       client.resumeAll();
-      void client.trimState(1000).catch(() => {});
+      void client.trimState(1000, "idle-only").catch(() => {});
 
       for (const child of [defaultShard().child, shardA.child]) {
         expect(messagesOfType(child, "pause-all")).toHaveLength(1);
         expect(messagesOfType(child, "resume-all")).toHaveLength(1);
         const trims = messagesOfType(child, "trim-state");
         expect(trims).toHaveLength(1);
-        expect(trims[0]).toMatchObject({ type: "trim-state", targetLines: 1000 });
-        expect(typeof trims[0].requestId).toBe("string");
+        expect(trims[0]).toEqual({
+          type: "trim-state",
+          targetLines: 1000,
+          scope: "idle-only",
+          requestId: expect.any(String),
+        });
       }
       client.dispose();
     });
@@ -803,7 +807,7 @@ describe("PtyClient fabric", () => {
       const shardA = projectShard("project-a");
       shardA.child.emit("message", { type: "ready" });
 
-      const promise = client.trimState(500);
+      const promise = client.trimState(500, "idle-only");
       const defaultReq = messagesOfType(defaultShard().child, "trim-state")[0];
       const shardAReq = messagesOfType(shardA.child, "trim-state")[0];
       defaultShard().child.emit("message", {
@@ -835,7 +839,7 @@ describe("PtyClient fabric", () => {
       const shardA = projectShard("project-a");
       shardA.child.emit("message", { type: "ready" });
 
-      const promise = client.trimState(500);
+      const promise = client.trimState(500, "idle-only");
       const defaultReq = messagesOfType(defaultShard().child, "trim-state")[0];
       defaultShard().child.emit("message", {
         type: "trim-state-result",
@@ -843,12 +847,39 @@ describe("PtyClient fabric", () => {
         result: { trimmed: 5, skipped: 1 },
       });
 
-      // Let the surviving shard's request time out in the broker.
-      await vi.advanceTimersByTimeAsync(120_000);
+      // Just past the shard broker's 5s default request deadline — advancing
+      // further would drive unrelated shard timers for no added coverage.
+      await vi.advanceTimersByTimeAsync(6_000);
 
       expect(await promise).toEqual({
         trimmed: 5,
         skipped: 1,
+        shardsTotal: 2,
+        shardsFailed: 1,
+      });
+      client.dispose();
+    });
+
+    it("counts an unreachable shard against the total instead of dropping it", async () => {
+      // A shard still booting cannot be sent to, but excluding it from the
+      // denominator would report a complete fan-out that never happened.
+      const client = createFabricClient();
+      client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      const shardA = projectShard("project-a");
+      // Deliberately never ready.
+
+      const promise = client.trimState(500, "idle-only");
+      const defaultReq = messagesOfType(defaultShard().child, "trim-state")[0];
+      defaultShard().child.emit("message", {
+        type: "trim-state-result",
+        requestId: defaultReq.requestId,
+        result: { trimmed: 2, skipped: 0 },
+      });
+
+      expect(messagesOfType(shardA.child, "trim-state")).toHaveLength(0);
+      expect(await promise).toEqual({
+        trimmed: 2,
+        skipped: 0,
         shardsTotal: 2,
         shardsFailed: 1,
       });

--- a/electron/services/__tests__/PtyClient.fabric.test.ts
+++ b/electron/services/__tests__/PtyClient.fabric.test.ts
@@ -777,18 +777,81 @@ describe("PtyClient fabric", () => {
       const client = createFabricClient();
       client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
       const shardA = projectShard("project-a");
+      // trim-state is an RPC now, so it fans out over ready shards (as
+      // get-memory-rollup and get-all-terminals do) — a shard that cannot
+      // reply yet would only contribute a timeout.
+      shardA.child.emit("message", { type: "ready" });
 
       client.pauseAll();
       client.resumeAll();
-      client.trimState(1000);
+      void client.trimState(1000).catch(() => {});
 
       for (const child of [defaultShard().child, shardA.child]) {
         expect(messagesOfType(child, "pause-all")).toHaveLength(1);
         expect(messagesOfType(child, "resume-all")).toHaveLength(1);
-        expect(messagesOfType(child, "trim-state")).toEqual([
-          { type: "trim-state", targetLines: 1000 },
-        ]);
+        const trims = messagesOfType(child, "trim-state");
+        expect(trims).toHaveLength(1);
+        expect(trims[0]).toMatchObject({ type: "trim-state", targetLines: 1000 });
+        expect(typeof trims[0].requestId).toBe("string");
       }
+      client.dispose();
+    });
+
+    it("sums trim-state counts across shards (#11674)", async () => {
+      const client = createFabricClient();
+      client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      const shardA = projectShard("project-a");
+      shardA.child.emit("message", { type: "ready" });
+
+      const promise = client.trimState(500);
+      const defaultReq = messagesOfType(defaultShard().child, "trim-state")[0];
+      const shardAReq = messagesOfType(shardA.child, "trim-state")[0];
+      defaultShard().child.emit("message", {
+        type: "trim-state-result",
+        requestId: defaultReq.requestId,
+        result: { trimmed: 1, skipped: 2 },
+      });
+      shardA.child.emit("message", {
+        type: "trim-state-result",
+        requestId: shardAReq.requestId,
+        result: { trimmed: 3, skipped: 4 },
+      });
+
+      expect(await promise).toEqual({
+        trimmed: 4,
+        skipped: 6,
+        shardsTotal: 2,
+        shardsFailed: 0,
+      });
+      client.dispose();
+    });
+
+    it("keeps a responding shard's counts when a sibling never answers", async () => {
+      // A silent shard must surface as shardsFailed, not fold into `skipped` —
+      // an incomplete fan-out read as "nothing was eligible" is the same class
+      // of unfalsifiable signal #11674 is about.
+      const client = createFabricClient();
+      client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      const shardA = projectShard("project-a");
+      shardA.child.emit("message", { type: "ready" });
+
+      const promise = client.trimState(500);
+      const defaultReq = messagesOfType(defaultShard().child, "trim-state")[0];
+      defaultShard().child.emit("message", {
+        type: "trim-state-result",
+        requestId: defaultReq.requestId,
+        result: { trimmed: 5, skipped: 1 },
+      });
+
+      // Let the surviving shard's request time out in the broker.
+      await vi.advanceTimersByTimeAsync(120_000);
+
+      expect(await promise).toEqual({
+        trimmed: 5,
+        skipped: 1,
+        shardsTotal: 2,
+        shardsFailed: 1,
+      });
       client.dispose();
     });
   });

--- a/electron/services/__tests__/PtyManager.governanceTrim.test.ts
+++ b/electron/services/__tests__/PtyManager.governanceTrim.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { PtyManager } from "../PtyManager.js";
 import { ANALYSIS_SESSION_IDLE_TRIM_MS } from "../../../shared/utils/workerGovernancePolicy.js";
-import { SCROLLBACK_MIN } from "../../../shared/config/scrollback.js";
+import { SCROLLBACK_BACKGROUND, SCROLLBACK_MIN } from "../../../shared/config/scrollback.js";
 import type { AgentState } from "../../../shared/types/agent.js";
 import type { TerminalProcess } from "../pty/TerminalProcess.js";
 import type { TerminalRegistry } from "../pty/TerminalRegistry.js";
@@ -21,13 +21,21 @@ function makeTerminal(
     agentState?: AgentState;
     idleMs?: number;
     scrollback?: number;
+    /** Model an analysis backend that refuses the resize: the cap never moves. */
+    refuseResize?: boolean;
   } = {}
 ): FakeTerminal {
   const at = NOW - (opts.idleMs ?? ANALYSIS_SESSION_IDLE_TRIM_MS * 2);
+  // Mutable so the manager's post-trim re-read sees the effect of its own call,
+  // the way a real TerminalProcess does.
+  let scrollback = opts.scrollback ?? 10_000;
   return {
     id,
-    trimScrollback: vi.fn(),
-    getCurrentScrollback: () => opts.scrollback ?? 10_000,
+    trimScrollback: vi.fn((target: number) => {
+      if (opts.refuseResize) return;
+      if (target < scrollback) scrollback = target;
+    }),
+    getCurrentScrollback: () => scrollback,
     getInfo: () => ({
       agentState: opts.agentState,
       lastInputTime: at,
@@ -92,5 +100,36 @@ describe("PtyManager.trimIdleAnalysisSessions", () => {
     });
     expect(result).toEqual({ trimmed: 1, skipped: 0 });
     expect(terminal.trimScrollback).toHaveBeenCalledWith(2_000);
+  });
+
+  it("counts a refused resize as skipped, not trimmed", () => {
+    // The count is the only evidence main gets that the trim did anything
+    // (#11674), so a backend that declines the resize must not inflate it.
+    const refused = makeTerminal("refused", { refuseResize: true });
+    const manager = managerWith([refused]);
+
+    const result = manager.trimIdleAnalysisSessions({ now: NOW });
+
+    expect(refused.trimScrollback).toHaveBeenCalled();
+    expect(result).toEqual({ trimmed: 0, skipped: 1 });
+  });
+
+  it("reports every terminal as skipped when agents hold them all", () => {
+    // The tier-1 shape from #11674: a machine full of working agents. The pass
+    // must be a no-op that says so, so a zero delta upstream is attributable to
+    // deliberate protection rather than to a lever that failed.
+    const terminals = ["a", "b", "c"].map((id) => makeTerminal(id, { agentState: "working" }));
+    const manager = managerWith(terminals);
+
+    const result = manager.trimIdleAnalysisSessions({
+      now: NOW,
+      targetLines: SCROLLBACK_BACKGROUND,
+    });
+
+    expect(result).toEqual({ trimmed: 0, skipped: terminals.length });
+    for (const terminal of terminals) {
+      expect(terminal.trimScrollback).not.toHaveBeenCalled();
+      expect(terminal.getCurrentScrollback()).toBeGreaterThan(SCROLLBACK_BACKGROUND);
+    }
   });
 });

--- a/electron/services/__tests__/PtyManager.governanceTrim.test.ts
+++ b/electron/services/__tests__/PtyManager.governanceTrim.test.ts
@@ -114,6 +114,27 @@ describe("PtyManager.trimIdleAnalysisSessions", () => {
     expect(result).toEqual({ trimmed: 0, skipped: 1 });
   });
 
+  it("leaves trimScrollback exempting nothing, agents included (#10948)", () => {
+    // The unguarded flatten backs two emergencies: the governor's last lever
+    // before a PTY pause, and the "all"-scoped trim main sends once the host
+    // has already paused. On a fixed heap the active agents ARE the memory, so
+    // adding a governance exemption here reclaims nothing and self-defeats into
+    // the visible pause — the shape that got reverted. This must never grow a
+    // guard just because its guarded sibling did.
+    const working = makeTerminal("working", { agentState: "working" });
+    const waiting = makeTerminal("waiting", { agentState: "waiting" });
+    const busy = makeTerminal("busy", { agentState: "working", idleMs: 0 });
+    const manager = managerWith([working, waiting, busy]);
+
+    const result = manager.trimScrollback(SCROLLBACK_MIN);
+
+    expect(result).toEqual({ trimmed: 3, skipped: 0 });
+    for (const terminal of [working, waiting, busy]) {
+      expect(terminal.trimScrollback).toHaveBeenCalledWith(SCROLLBACK_MIN);
+      expect(terminal.getCurrentScrollback()).toBe(SCROLLBACK_MIN);
+    }
+  });
+
   it("reports every terminal as skipped when agents hold them all", () => {
     // The tier-1 shape from #11674: a machine full of working agents. The pass
     // must be a no-op that says so, so a zero delta upstream is attributable to

--- a/electron/services/pty/PtyEventRouter.ts
+++ b/electron/services/pty/PtyEventRouter.ts
@@ -270,6 +270,10 @@ export function routeHostEvent(event: PtyHostEvent, deps: PtyEventRouterDeps): b
       broker.resolve(event.requestId, event.rollup);
       return true;
 
+    case "trim-state-result":
+      broker.resolve(event.requestId, event.result);
+      return true;
+
     case "terminal-diagnostic-info":
       broker.resolve(event.requestId, event.info);
       return true;

--- a/electron/services/pty/__tests__/PtyEventRouter.test.ts
+++ b/electron/services/pty/__tests__/PtyEventRouter.test.ts
@@ -507,6 +507,22 @@ describe("routeHostEvent", () => {
     );
   });
 
+  it("resolves a trim-state-result to its pending request (#11674)", () => {
+    const { deps, brokerCalls } = makeDeps();
+
+    const handled = routeHostEvent(
+      {
+        type: "trim-state-result",
+        requestId: "trim-7",
+        result: { trimmed: 3, skipped: 4 },
+      } as PtyHostEvent,
+      deps
+    );
+
+    expect(handled).toBe(true);
+    expect(brokerCalls).toEqual([{ requestId: "trim-7", result: { trimmed: 3, skipped: 4 } }]);
+  });
+
   it("logs and returns false for unknown event types", () => {
     const logWarn = vi.fn();
     const { deps } = makeDeps({ logWarn });

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -456,8 +456,10 @@ export async function initGlobalServices(
             }
             return viewsEvicted;
           },
-          trimPtyHostState: () => {
-            getPtyClient()?.trimState(SCROLLBACK_BACKGROUND);
+          trimPtyHostState: async () => {
+            const client = getPtyClient();
+            if (!client) return { trimmed: 0, skipped: 0, shardsTotal: 0, shardsFailed: 0 };
+            return client.trimState(SCROLLBACK_BACKGROUND);
           },
           sampleBlinkMemory: () => {
             if (!windowRegistry) return;

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -459,7 +459,8 @@ export async function initGlobalServices(
           trimPtyHostState: async () => {
             const client = getPtyClient();
             if (!client) return { trimmed: 0, skipped: 0, shardsTotal: 0, shardsFailed: 0 };
-            return client.trimState(SCROLLBACK_BACKGROUND);
+            // Graduated lever: never at the cost of a working agent's history.
+            return client.trimState(SCROLLBACK_BACKGROUND, "idle-only");
           },
           sampleBlinkMemory: () => {
             if (!windowRegistry) return;

--- a/electron/window/perWindowInit.ts
+++ b/electron/window/perWindowInit.ts
@@ -294,10 +294,15 @@ export async function initPerWindowServices(
           }
         }
       }
-      // Fire-and-forget: unlike tier 1 this path makes no escalation decision,
-      // so the trim counts have no consumer here. `.catch()` rather than
-      // try/catch — trimState is async, so a rejection would escape the block.
-      void ptyClient!.trimState(SCROLLBACK_BACKGROUND).catch(() => {
+      // Scope "all": the host only throttles after the governor has paused
+      // every PTY, and at critical utilization it skips its own pre-pause trim
+      // to pause immediately — so this is the last buffer reclaim available,
+      // and sparing the active agents holding the memory would leave nothing
+      // to reclaim (#10948). Fire-and-forget: unlike tier 1 this path makes no
+      // escalation decision, so the counts have no consumer here. `.catch()`
+      // rather than try/catch — trimState is async, so a rejection would
+      // escape the block.
+      void ptyClient!.trimState(SCROLLBACK_BACKGROUND, "all").catch(() => {
         /* non-critical */
       });
     });

--- a/electron/window/perWindowInit.ts
+++ b/electron/window/perWindowInit.ts
@@ -294,11 +294,12 @@ export async function initPerWindowServices(
           }
         }
       }
-      try {
-        ptyClient!.trimState(SCROLLBACK_BACKGROUND);
-      } catch {
+      // Fire-and-forget: unlike tier 1 this path makes no escalation decision,
+      // so the trim counts have no consumer here. `.catch()` rather than
+      // try/catch — trimState is async, so a rejection would escape the block.
+      void ptyClient!.trimState(SCROLLBACK_BACKGROUND).catch(() => {
         /* non-critical */
-      }
+      });
     });
     ptyClient.setPortRefreshCallback((windowId) => {
       // Called with no windowId on a full host restart (refresh every window)

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -312,7 +312,7 @@ export type PtyHostRequest =
       requestId: string;
       preserveSession?: boolean;
     }
-  | { type: "trim-state"; targetLines: number }
+  | { type: "trim-state"; targetLines: number; requestId: string }
   | { type: "set-resource-monitoring"; enabled: boolean }
   | { type: "set-session-persist-suppressed"; suppressed: boolean }
   | { type: "set-resource-profile"; profile: ResourceProfile }
@@ -624,6 +624,7 @@ export type PtyHostEvent =
   | { type: "terminals-by-state"; requestId: string; terminals: PtyHostTerminalInfo[] }
   | { type: "all-terminals"; requestId: string; terminals: PtyHostTerminalInfo[] }
   | { type: "memory-rollup"; requestId: string; rollup: MemoryRollup }
+  | { type: "trim-state-result"; requestId: string; result: TrimStateResult }
   | {
       type: "semantic-search-result";
       requestId: string;
@@ -739,6 +740,31 @@ export type PtyHostResponseEvent = Extract<PtyHostEvent, { requestId: string }>;
  */
 export interface GracefulKillResult {
   sessionId: string | null;
+}
+
+/**
+ * Outcome of one shard's `trim-state` pass. Trimming scrollback only drops JS
+ * references, so the caller's footprint re-sample cannot attribute a delta to it
+ * within any practical settle window (#11674). These counts are the only
+ * evidence the trim ran, and they separate "every terminal was deliberately
+ * protected" from "there was nothing left to trim".
+ */
+export interface TrimStateResult {
+  /** Terminals whose scrollback cap actually moved down. */
+  trimmed: number;
+  /** Terminals the per-session policy protected, or that were already at the floor. */
+  skipped: number;
+}
+
+/** {@link TrimStateResult} summed across shards, with fan-out completeness. */
+export interface TrimStateSummary extends TrimStateResult {
+  shardsTotal: number;
+  /**
+   * Shards that failed or timed out. Non-zero means `trimmed`/`skipped` are a
+   * floor, not a census — an incomplete fan-out must never be read as
+   * "nothing was eligible".
+   */
+  shardsFailed: number;
 }
 
 export function isPtyHostResponseEvent(event: PtyHostEvent): event is PtyHostResponseEvent {

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -312,7 +312,7 @@ export type PtyHostRequest =
       requestId: string;
       preserveSession?: boolean;
     }
-  | { type: "trim-state"; targetLines: number; requestId: string }
+  | { type: "trim-state"; targetLines: number; requestId: string; scope: TrimStateScope }
   | { type: "set-resource-monitoring"; enabled: boolean }
   | { type: "set-session-persist-suppressed"; suppressed: boolean }
   | { type: "set-resource-profile"; profile: ResourceProfile }
@@ -741,6 +741,23 @@ export type PtyHostResponseEvent = Extract<PtyHostEvent, { requestId: string }>;
 export interface GracefulKillResult {
   sessionId: string | null;
 }
+
+/**
+ * Who a `trim-state` pass is allowed to touch.
+ *
+ * `idle-only` applies the governance policy — a terminal with a live agent
+ * keeps its scrollback (which is also its serialize/restore source). This is
+ * for graduated pressure levers like ProcessMemoryMonitor tier 1, which are
+ * redundant with the host's own governor and must not cost more than they
+ * reclaim (#11674).
+ *
+ * `all` exempts nothing. Reserved for the post-pause emergency: once the
+ * governor has already paused every PTY, active agents are the dominant
+ * consumer, and sparing them leaves nothing to reclaim — the self-defeating
+ * shape that got the equivalent exemption reverted from `performPrePauseTrim`
+ * (#10948).
+ */
+export type TrimStateScope = "idle-only" | "all";
 
 /**
  * Outcome of one shard's `trim-state` pass. Trimming scrollback only drops JS

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -762,12 +762,17 @@ export type TrimStateScope = "idle-only" | "all";
 /**
  * Outcome of one shard's `trim-state` pass. Trimming scrollback only drops JS
  * references, so the caller's footprint re-sample cannot attribute a delta to it
- * within any practical settle window (#11674). These counts are the only
- * evidence the trim ran, and they separate "every terminal was deliberately
- * protected" from "there was nothing left to trim".
+ * within any practical settle window (#11674). These counts are what the pass
+ * decided to do, and they separate "every terminal was deliberately protected"
+ * from "there was nothing left to trim".
+ *
+ * They are a record of intent, not of completion: on the worker-backed analysis
+ * path the host lowers its own cap and posts the resize to the worker without
+ * waiting for it, so `trimmed` means the shrink was applied and dispatched, not
+ * that the worker's buffer has already released the lines.
  */
 export interface TrimStateResult {
-  /** Terminals whose scrollback cap actually moved down. */
+  /** Terminals whose scrollback cap moved down. */
   trimmed: number;
   /** Terminals the per-session policy protected, or that were already at the floor. */
   skipped: number;


### PR DESCRIPTION
## Summary

- Tier 1 of the memory-pressure ladder called `PtyManager.trimScrollback()`, an unguarded loop that flattened every terminal's pty-host scrollback to 500 lines with no agent-state or idle check, then used the resulting near-zero RSS delta to authorize the very project-view eviction it existed to prevent.
- Splits the pty-host's `trim-state` handler by a new `scope` field: `idle-only` for `ProcessMemoryMonitor`'s tier 1 (routed through the existing guarded policy), `all` for the post-pause `host-throttled` path (deliberately left unguarded).
- Makes the trim observable (`{trimmed, skipped, shardsTotal, shardsFailed}`) and turns the reclaim measurement into a bounded suppressor of tier-2 escalation instead of an authorizer of it.

Resolves #11674

## The bug

Tier 1 called `PtyManager.trimScrollback()`, an unguarded loop that shrinks every terminal's pty-host scrollback buffer down to 500 lines. No check on agent state, no idle check, unlike its two guarded sibling mechanisms. That buffer is also what `getSerializedStateAsync()` serializes, so it's what a project view replays after eviction.

Tier 1 then re-sampled RSS three seconds later and escalated to tier-2 project-view eviction whenever the delta was under 50MB. But trimming scrollback only drops JS references, so the delta was reliably close to zero. Tier 1 was authorizing the very eviction it existed to prevent.

## Two levers, two scopes

Both of main's pressure entry points converge on one pty-host handler, so the split happens there: `trim-state` now carries a `scope`. `ProcessMemoryMonitor`'s tier 1 sends `idle-only`, which routes through the existing `shouldTrimAnalysisSession` policy, never trimming working, waiting, or directing agent states, and enforcing a 10 minute idle floor. The `host-throttled` listener sends `all`, hitting the original unguarded flatten deliberately.

That second half matters. `canTrim = !isCritical` in `ResourceGovernor` means that at 95% or higher utilization the governor skips its own pre-pause trim and pauses immediately, so main's trim is the only buffer reclaim left on that path. Guarding it uniformly would have recreated the #10948 self-defeat, just after the pause instead of before it. `PtyManager.trimScrollback` stays unguarded on purpose, and now has a test pinning that behavior.

## Making the trim observable

`trim-state` became a request/response RPC, returning `{trimmed, skipped}` aggregated across shards, plus `{shardsTotal, shardsFailed}`, and tier 1 now waits for the response before opening its settle window.

These counts are a record of intent, not completion. The worker-backed analysis path posts the resize onward without waiting for it to finish, and this should be said plainly rather than overclaimed. `shardsTotal` counts every live shard, so an unreachable one can't be misread as "nothing was eligible to trim."

Also removed a dead `global.gc()` timer. The pty-host is forked without `--expose-gc`, so that call was never doing anything.

## The escalation gate

The fix inverts the reclaim measurement from an escalation authorizer into a bounded suppressor. A measured reclaim now holds tier-2 escalation back only while it's still fresh evidence, using a 90 second constant, `TIER1_REPRIEVE_MS`. It's retired once its paired timestamp moves on, and voided if the re-sample fails.

Net effect: a lever whose effect can't be observed earns nothing, rather than being read as license to evict, and a stale reading can no longer gate a present-tense decision. Genuine sustained pressure still escalates as before. The original reporter had it right that eviction under real pressure is defensible. The bug was that nothing survived it, not that eviction happens at all.

## Out of scope

A few things this deliberately doesn't touch:

- `ResourceGovernor.performPrePauseTrim`, untouched, per the #10948 precedent.
- Project-view eviction policy itself, unchanged.
- The geometry-divergence warning in `TerminalReconciliationWatchdog`, left for a separate issue.

Reversibility (growing a trimmed scrollback back via `growScrollback`, which still has no production caller) is also deferred. Growing can't restore lines that were already evicted, and doing it without per-terminal trim provenance risks undoing the governor's intentional emergency trim while host pressure is still live. Worth its own issue.

## Testing

Locally: 203 tests across the six directly affected suites, 42 across the other `PtyManager` suites, and 3,684 across the `shared/utils/`, `electron/services/pty/`, and `electron/pty-host/` test trees, plus a clean `npm run typecheck`. Prettier and eslint clean on all 13 changed files.

No E2E: this is a main/utility-process policy and protocol change with no renderer behavior change.

Known gap, stated honestly: the two production call sites (`globalServicesInit.ts`, `perWindowInit.ts`) aren't themselves behaviorally covered. Removing either call would leave the suite green. Wiring them up means importing the electron/AppLayout module graph, judged not worth it here.