### PR TITLE
feat(pilot): order fleet overview project groups by recency

### DIFF
--- a/src/components/Pilot/PilotView.tsx
+++ b/src/components/Pilot/PilotView.tsx
@@ -539,8 +539,8 @@ export function PilotView() {
    * this surface exists to give, so it has to stay true: an agent that blocks
    * while you are looking at the list has to rise to where the ranking says it
    * belongs, not sit below every idle agent until you close and reopen. Group
-   * order follows workspace recency and holds still on its own, so what moves
-   * under the pointer is a row within its project.
+   * order is workspace recency, which no amount of agent state can move — but a
+   * switch elsewhere can, which is why the hold has to cover whole groups too.
    *
    * The misclick this used to guard against is real but pointer-only. Selection
    * is keyed by `rowId` (#11071), so a re-rank cannot make Enter commit a row

--- a/src/components/Pilot/PilotView.tsx
+++ b/src/components/Pilot/PilotView.tsx
@@ -497,6 +497,9 @@ export function PilotView() {
       map.set(project.id, {
         kind: "project",
         name: project.name,
+        // Required on both workspace types, unlike the fields around it, so it
+        // is assigned rather than spread in on a check.
+        lastOpened: project.lastOpened,
         ...(project.emoji ? { emoji: project.emoji } : {}),
         ...(project.color ? { color: project.color } : {}),
         ...(project.lastCompletionSeenAt !== undefined
@@ -508,6 +511,7 @@ export function PilotView() {
       map.set(scratch.id, {
         kind: "scratch",
         name: scratch.name,
+        lastOpened: scratch.lastOpened,
         ...(scratch.lastCompletionSeenAt !== undefined
           ? { lastCompletionSeenAt: scratch.lastCompletionSeenAt }
           : {}),
@@ -531,10 +535,12 @@ export function PilotView() {
   /**
    * Position, held only while the pointer is genuinely working the list.
    *
-   * Ordering is derived from live agent state and the ranking IS the answer
+   * Row order is derived from live agent state and the ranking IS the answer
    * this surface exists to give, so it has to stay true: an agent that blocks
    * while you are looking at the list has to rise to where the ranking says it
-   * belongs, not sit below every idle agent until you close and reopen.
+   * belongs, not sit below every idle agent until you close and reopen. Group
+   * order follows workspace recency and holds still on its own, so what moves
+   * under the pointer is a row within its project.
    *
    * The misclick this used to guard against is real but pointer-only. Selection
    * is keyed by `rowId` (#11071), so a re-rank cannot make Enter commit a row

--- a/src/components/Pilot/__tests__/PilotView.test.tsx
+++ b/src/components/Pilot/__tests__/PilotView.test.tsx
@@ -93,6 +93,25 @@ function seedViewWorkspace(id: string | null): void {
   (window as { __DAINTREE_INITIAL_PROJECT__?: unknown }).__DAINTREE_INITIAL_PROJECT__ = { id };
 }
 
+/**
+ * The two workspace stores, with explicit opening times.
+ *
+ * Group order is workspace MRU, so a fixture that left these out would fall
+ * through to the name tiebreak and prove nothing about the rule under test.
+ * The default below reproduces that old alphabetical order deliberately, so
+ * only the tests that care about recency have to think about it.
+ */
+function seedWorkspaceOpenings(daintreeOpened: number, spikeOpened: number): void {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test carrier: only id/name/lastOpened are read
+  useProjectStore.setState({
+    projects: [{ id: "p1", name: "daintree", lastOpened: daintreeOpened }],
+  } as Partial<ReturnType<typeof useProjectStore.getState>>);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test carrier: only id/name/lastOpened are read
+  useScratchStore.setState({
+    scratches: [{ id: "s1", name: "spike", lastOpened: spikeOpened }],
+  } as Partial<ReturnType<typeof useScratchStore.getState>>);
+}
+
 beforeEach(() => {
   vi.useFakeTimers();
   vi.setSystemTime(NOW);
@@ -100,14 +119,7 @@ beforeEach(() => {
   seedViewWorkspace(null);
   seed(null);
   usePilotStore.setState({ isOpen: true });
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test carrier: only id/name are read
-  useProjectStore.setState({ projects: [{ id: "p1", name: "daintree" }] } as Partial<
-    ReturnType<typeof useProjectStore.getState>
-  >);
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test carrier: only id/name are read
-  useScratchStore.setState({ scratches: [{ id: "s1", name: "spike" }] } as Partial<
-    ReturnType<typeof useScratchStore.getState>
-  >);
+  seedWorkspaceOpenings(NOW, NOW - 60_000);
 });
 
 afterEach(() => {
@@ -409,21 +421,23 @@ describe("PilotView", () => {
     expect(screen.getByText("2 agents need you")).toBeTruthy();
   });
 
-  it("groups rows under their project, most urgent project first", () => {
+  it("groups rows under their project, most recently opened first", () => {
+    seedWorkspaceOpenings(NOW - 60_000, NOW);
     seed([
-      run({ runId: "w", workspaceId: "p1", agentState: "working", since: NOW - 10_000 }),
       run({
         runId: "b",
-        workspaceId: "s1",
+        workspaceId: "p1",
         agentState: "waiting",
         waitingReason: "error",
         since: NOW - 60_000,
       }),
+      run({ runId: "w", workspaceId: "s1", agentState: "working", since: NOW - 10_000 }),
     ]);
     render(<PilotView />);
 
     const headers = screen.getAllByTestId("pilot-group-header").map((h) => h.textContent ?? "");
-    // "spike" holds the blocked run, so it leads despite "daintree" sorting first.
+    // "spike" was opened last, so it leads even though "daintree" sorts first
+    // alphabetically AND is the one holding the blocked run.
     expect(headers[0]).toContain("spike");
     expect(headers[1]).toContain("daintree");
   });
@@ -1379,38 +1393,30 @@ describe("PilotView", () => {
       // The group half of the re-sort has its own branch, so a hold that kept
       // rows in place while letting entire projects jump under the pointer
       // would otherwise pass everything above.
-      const seedProjects = (spikeBlocked: boolean) => {
-        seed([
-          run({ runId: "a", workspaceId: "p1", agentState: "working", title: "in daintree" }),
-          spikeBlocked
-            ? run({
-                runId: "b",
-                workspaceId: "s1",
-                agentState: "waiting",
-                waitingReason: "error",
-                title: "in spike",
-                since: NOW,
-              })
-            : run({ runId: "b", workspaceId: "s1", agentState: "working", title: "in spike" }),
-        ]);
-      };
+      seed([
+        run({ runId: "a", workspaceId: "p1", agentState: "working", title: "in daintree" }),
+        run({ runId: "b", workspaceId: "s1", agentState: "working", title: "in spike" }),
+      ]);
       // Read through the rows rather than the header text: one row per project
       // means row order IS group order, and the workspace-name lookup does not
       // survive the microtask flush this test needs (the name loaders resolve
       // against no IPC host and empty their stores).
-      seedProjects(false);
       render(<PilotView />);
       expect(order()).toEqual(["in daintree", "in spike"]);
 
       fireEvent.pointerMove(screen.getAllByTestId("pilot-row")[0]!);
-      act(() => seedProjects(true));
+      // Let those mount-time loaders settle first, since they empty both stores:
+      // the switch below has to be seeded on top of that, not before it.
       await vi.advanceTimersByTimeAsync(0);
+      // Switching to the scratch elsewhere makes it the most recently opened,
+      // which is the only thing that reorders groups now.
+      act(() => seedWorkspaceOpenings(NOW - 60_000, NOW));
       expect(order()).toEqual(["in daintree", "in spike"]);
 
       fireEvent.pointerLeave(document.getElementById("pilot-agent-list")!);
 
-      // The project holding the blocked agent leads the moment the pointer
-      // stops protecting the position it was aimed at.
+      // The newly opened project leads the moment the pointer stops protecting
+      // the position it was aimed at.
       expect(order()).toEqual(["in spike", "in daintree"]);
     });
 

--- a/src/components/Pilot/__tests__/pilotRows.test.ts
+++ b/src/components/Pilot/__tests__/pilotRows.test.ts
@@ -213,13 +213,13 @@ describe("buildPilotGroups", () => {
     expect(alpha.rows.map((r) => r.run.runId).sort()).toEqual(["a", "c"]);
   });
 
-  it("orders projects by their worst band, not alphabetically", () => {
+  it("orders projects by last opened, not by worst band", () => {
     const groups = buildPilotGroups(
       [
-        run({ runId: "w", workspaceId: "aaa", agentState: "working", since: NOW }),
+        run({ runId: "w", workspaceId: "fresh", agentState: "working", since: NOW }),
         run({
           runId: "b",
-          workspaceId: "zzz",
+          workspaceId: "stale",
           agentState: "waiting",
           waitingReason: "error",
           since: NOW,
@@ -227,17 +227,76 @@ describe("buildPilotGroups", () => {
       ],
       ctx({
         workspaces: new Map([
-          ["aaa", { kind: "project", name: "aaa" }],
-          ["zzz", { kind: "project", name: "zzz" }],
+          // Named so that the old band rule and a bare name fallback would BOTH
+          // put "aaa" first. Only recency lifts the just-opened project over it.
+          ["fresh", { kind: "project", name: "zzz", lastOpened: NOW }],
+          ["stale", { kind: "project", name: "aaa", lastOpened: NOW - 3_600_000 }],
         ]),
       })
     );
 
-    // "zzz" holds a blocked run, so it outranks "aaa" despite sorting later.
-    expect(groups[0]!.name).toBe("zzz");
+    expect(groups.map((g) => g.name)).toEqual(["zzz", "aaa"]);
   });
 
-  it("falls back to alphabetical when two projects are equally urgent", () => {
+  it("puts the project just opened above another project's waiting agents", () => {
+    // The reported case (#11678): the current project held one working agent and
+    // rendered below a project holding four waiting ones, because waiting
+    // outranked everything at group level. Only the opening times differ between
+    // the two calls, so the flip is proof recency is what decides.
+    const fleet = (groundwork: number, pixel: number) =>
+      buildPilotGroups(
+        [
+          run({ runId: "gt", workspaceId: "gt", agentState: "working", since: NOW }),
+          ...["a", "b", "c", "d"].map((id) =>
+            run({
+              runId: `px-${id}`,
+              workspaceId: "px",
+              agentState: "waiting",
+              since: NOW - 600_000,
+            })
+          ),
+        ],
+        ctx({
+          currentWorkspaceId: "gt",
+          workspaces: new Map([
+            ["gt", { kind: "project", name: "Groundwork Terrain", lastOpened: groundwork }],
+            ["px", { kind: "project", name: "Pixel Reconstruct", lastOpened: pixel }],
+          ]),
+        })
+      ).map((g) => g.name);
+
+    expect(fleet(NOW, NOW - 86_400_000)).toEqual(["Groundwork Terrain", "Pixel Reconstruct"]);
+    expect(fleet(NOW - 86_400_000, NOW)).toEqual(["Pixel Reconstruct", "Groundwork Terrain"]);
+  });
+
+  it("orders a mixed fleet strictly newest-opened first", () => {
+    const groups = buildPilotGroups(
+      [
+        run({
+          runId: "a",
+          workspaceId: "old",
+          agentState: "waiting",
+          waitingReason: "error",
+          since: NOW,
+        }),
+        run({ runId: "b", workspaceId: "mid", agentState: "working", since: NOW }),
+        run({ runId: "c", workspaceId: "new", agentState: "exited" }),
+      ],
+      ctx({
+        workspaces: new Map([
+          // Both name and band run opposite to the opening times, so neither can
+          // be what produces the expected order.
+          ["old", { kind: "project", name: "aaa", lastOpened: NOW - 86_400_000 }],
+          ["mid", { kind: "scratch", name: "mmm", lastOpened: NOW - 3_600_000 }],
+          ["new", { kind: "project", name: "zzz", lastOpened: NOW }],
+        ]),
+      })
+    );
+
+    expect(groups.map((g) => g.name)).toEqual(["zzz", "mmm", "aaa"]);
+  });
+
+  it("breaks an equal last-opened tie by name", () => {
     const groups = buildPilotGroups(
       [
         run({ runId: "b", workspaceId: "p2", agentState: "working", since: NOW }),
@@ -245,8 +304,8 @@ describe("buildPilotGroups", () => {
       ],
       ctx({
         workspaces: new Map([
-          ["p1", { kind: "project", name: "beta" }],
-          ["p2", { kind: "project", name: "alpha" }],
+          ["p1", { kind: "project", name: "beta", lastOpened: NOW }],
+          ["p2", { kind: "project", name: "alpha", lastOpened: NOW }],
         ]),
       })
     );
@@ -254,10 +313,28 @@ describe("buildPilotGroups", () => {
     expect(groups.map((g) => g.name)).toEqual(["alpha", "beta"]);
   });
 
-  it("does not let activity times reorder two equally quiet projects", () => {
-    // The tiebreak used to be recency, so the order changed between every
-    // opening and spatial memory never formed. Same fleet, only the timestamps
-    // swapped: the order has to be the same both times.
+  it("sinks a workspace it cannot date below every dated one, without dropping it", () => {
+    // A run whose workspace has left the store still has to render. Ranking it
+    // is a separate question: an absent opening time is not evidence of a recent
+    // one, so it settles at the bottom rather than displacing a real history.
+    // Named so a name fallback would put the unknown group first instead.
+    const groups = buildPilotGroups(
+      [
+        run({ runId: "orphan", workspaceId: "gone", agentState: "waiting", since: NOW }),
+        run({ runId: "known", workspaceId: "p1", agentState: "working", since: NOW }),
+      ],
+      ctx({
+        workspaces: new Map([["p1", { kind: "project", name: "zzz", lastOpened: NOW - 600_000 }]]),
+      })
+    );
+
+    expect(groups.map((g) => g.name)).toEqual(["zzz", "Unknown workspace"]);
+    expect(groups[1]!.rows.map((r) => r.run.runId)).toEqual(["orphan"]);
+  });
+
+  it("does not let run activity times reorder project groups", () => {
+    // Group order is workspace recency, which only a switch advances. An agent
+    // starting or blocking must not reshuffle the projects under the cursor.
     const quiet = (aSince: number, bSince: number) =>
       buildPilotGroups(
         [
@@ -266,104 +343,20 @@ describe("buildPilotGroups", () => {
         ],
         ctx({
           workspaces: new Map([
-            ["p1", { kind: "project", name: "beta" }],
-            ["p2", { kind: "project", name: "alpha" }],
+            ["p1", { kind: "project", name: "beta", lastOpened: NOW }],
+            ["p2", { kind: "project", name: "alpha", lastOpened: NOW - 600_000 }],
           ]),
         })
       ).map((g) => g.name);
 
-    expect(quiet(NOW - 600_000, NOW)).toEqual(quiet(NOW, NOW - 600_000));
+    expect(quiet(NOW - 600_000, NOW)).toEqual(["beta", "alpha"]);
+    expect(quiet(NOW, NOW - 600_000)).toEqual(["beta", "alpha"]);
   });
 
-  it("puts the longest-standing demand first among equally urgent projects", () => {
-    // The anti-starvation rule the rows already follow, now applied a level up:
-    // a stream of fresh blocks must never bury the one stuck for forty minutes.
-    const groups = buildPilotGroups(
-      [
-        run({
-          runId: "fresh",
-          workspaceId: "p1",
-          agentState: "waiting",
-          waitingReason: "error",
-          since: NOW - 60_000,
-        }),
-        run({
-          runId: "stale",
-          workspaceId: "p2",
-          agentState: "waiting",
-          waitingReason: "error",
-          since: NOW - 40 * 60_000,
-        }),
-      ],
-      ctx({
-        workspaces: new Map([
-          // Named so alphabetical order would give the opposite answer.
-          ["p1", { kind: "project", name: "aaa" }],
-          ["p2", { kind: "project", name: "zzz" }],
-        ]),
-      })
-    );
-
-    expect(groups.map((g) => g.name)).toEqual(["zzz", "aaa"]);
-  });
-
-  it("dates a project by its oldest demand, not by its oldest run", () => {
-    // A project whose blocked agent is fresh must not inherit urgency from a
-    // long-running working agent sitting beside it.
-    const groups = buildPilotGroups(
-      [
-        run({
-          runId: "old-work",
-          workspaceId: "p1",
-          agentState: "working",
-          since: NOW - 3_600_000,
-        }),
-        run({
-          runId: "fresh-block",
-          workspaceId: "p1",
-          agentState: "waiting",
-          waitingReason: "error",
-          since: NOW - 1_000,
-        }),
-        run({
-          runId: "older-block",
-          workspaceId: "p2",
-          agentState: "waiting",
-          waitingReason: "error",
-          since: NOW - 60_000,
-        }),
-      ],
-      ctx({
-        workspaces: new Map([
-          ["p1", { kind: "project", name: "aaa" }],
-          ["p2", { kind: "project", name: "zzz" }],
-        ]),
-      })
-    );
-
-    expect(groups.map((g) => g.name)).toEqual(["zzz", "aaa"]);
-  });
-
-  it("sorts a demand of unknown age behind one it can actually date", () => {
-    // An unknown age is not evidence of urgency — treating it as infinitely old
-    // would let a pre-detection boot window outrank a genuine wait.
-    const groups = buildPilotGroups(
-      [
-        run({ runId: "undated", workspaceId: "p1", agentState: "waiting" }),
-        run({ runId: "dated", workspaceId: "p2", agentState: "waiting", since: NOW - 1_000 }),
-      ],
-      ctx({
-        workspaces: new Map([
-          ["p1", { kind: "project", name: "aaa" }],
-          ["p2", { kind: "project", name: "zzz" }],
-        ]),
-      })
-    );
-
-    expect(groups.map((g) => g.name)).toEqual(["zzz", "aaa"]);
-  });
-
-  it("gives the current workspace primacy only among equally quiet projects", () => {
+  it("does not use the current workspace to break an equal-recency tie", () => {
+    // Being the workspace asking is not evidence of recency — `lastOpened`
+    // already carries that, and under write suppression a switch can leave it
+    // unmoved, so context must not buy a position the timestamp does not.
     const groups = buildPilotGroups(
       [
         run({ runId: "a", workspaceId: "p1", agentState: "working", since: NOW }),
@@ -372,41 +365,15 @@ describe("buildPilotGroups", () => {
       ctx({
         currentWorkspaceId: "p2",
         workspaces: new Map([
-          ["p1", { kind: "project", name: "alpha" }],
-          ["p2", { kind: "project", name: "zeta" }],
+          ["p1", { kind: "project", name: "alpha", lastOpened: NOW }],
+          ["p2", { kind: "project", name: "zeta", lastOpened: NOW }],
         ]),
       })
     );
 
-    // Alphabetically last, but it is the workspace this view already owns and
-    // neither project has anything urgent to say.
-    expect(groups.map((g) => g.name)).toEqual(["zeta", "alpha"]);
-  });
-
-  it("never lets the current workspace outrank another project's demand", () => {
-    // Context above severity would bury a blocked agent somewhere else, which is
-    // the exact failure the band ordering exists to prevent.
-    const groups = buildPilotGroups(
-      [
-        run({ runId: "a", workspaceId: "p1", agentState: "working", since: NOW }),
-        run({
-          runId: "b",
-          workspaceId: "p2",
-          agentState: "waiting",
-          waitingReason: "error",
-          since: NOW,
-        }),
-      ],
-      ctx({
-        currentWorkspaceId: "p1",
-        workspaces: new Map([
-          ["p1", { kind: "project", name: "here" }],
-          ["p2", { kind: "project", name: "elsewhere" }],
-        ]),
-      })
-    );
-
-    expect(groups.map((g) => g.name)).toEqual(["elsewhere", "here"]);
+    expect(groups.map((g) => g.name)).toEqual(["alpha", "zeta"]);
+    // Still marked as the current workspace — it just does not buy position.
+    expect(groups.find((g) => g.name === "zeta")!.isCurrent).toBe(true);
   });
 
   it("orders two identically named projects the same way whatever order they arrive in", () => {
@@ -418,8 +385,8 @@ describe("buildPilotGroups", () => {
         runs,
         ctx({
           workspaces: new Map([
-            ["p1", { kind: "project", name: "same" }],
-            ["p2", { kind: "project", name: "same" }],
+            ["p1", { kind: "project", name: "same", lastOpened: NOW }],
+            ["p2", { kind: "project", name: "same", lastOpened: NOW }],
           ]),
         })
       ).map((g) => g.workspaceId);

--- a/src/components/Pilot/__tests__/pilotRows.test.ts
+++ b/src/components/Pilot/__tests__/pilotRows.test.ts
@@ -216,21 +216,21 @@ describe("buildPilotGroups", () => {
   it("orders projects by last opened, not by worst band", () => {
     const groups = buildPilotGroups(
       [
-        run({ runId: "w", workspaceId: "fresh", agentState: "working", since: NOW }),
         run({
           runId: "b",
-          workspaceId: "stale",
+          workspaceId: "aa-stale",
           agentState: "waiting",
           waitingReason: "error",
           since: NOW,
         }),
+        run({ runId: "w", workspaceId: "zz-fresh", agentState: "working", since: NOW }),
       ],
       ctx({
         workspaces: new Map([
-          // Named so that the old band rule and a bare name fallback would BOTH
-          // put "aaa" first. Only recency lifts the just-opened project over it.
-          ["fresh", { kind: "project", name: "zzz", lastOpened: NOW }],
-          ["stale", { kind: "project", name: "aaa", lastOpened: NOW - 3_600_000 }],
+          // Name, band, arrival order and workspace id would ALL put the stale
+          // project first. Only recency lifts the just-opened one over it.
+          ["aa-stale", { kind: "project", name: "aaa", lastOpened: NOW - 3_600_000 }],
+          ["zz-fresh", { kind: "project", name: "zzz", lastOpened: NOW }],
         ]),
       })
     );
@@ -299,8 +299,10 @@ describe("buildPilotGroups", () => {
   it("breaks an equal last-opened tie by name", () => {
     const groups = buildPilotGroups(
       [
-        run({ runId: "b", workspaceId: "p2", agentState: "working", since: NOW }),
+        // Arrival order and workspace id both favour "beta", so only the name
+        // tiebreak can produce the expected order.
         run({ runId: "a", workspaceId: "p1", agentState: "working", since: NOW }),
+        run({ runId: "b", workspaceId: "p2", agentState: "working", since: NOW }),
       ],
       ctx({
         workspaces: new Map([
@@ -335,16 +337,18 @@ describe("buildPilotGroups", () => {
   it("does not let run activity times reorder project groups", () => {
     // Group order is workspace recency, which only a switch advances. An agent
     // starting or blocking must not reshuffle the projects under the cursor.
-    const quiet = (aSince: number, bSince: number) =>
+    // Name, arrival order and workspace id all favour "alpha", so only recency
+    // can put "beta" first — and it has to do so whichever way the runs age.
+    const quiet = (betaSince: number, alphaSince: number) =>
       buildPilotGroups(
         [
-          run({ runId: "a", workspaceId: "p1", agentState: "working", since: aSince }),
-          run({ runId: "b", workspaceId: "p2", agentState: "working", since: bSince }),
+          run({ runId: "b", workspaceId: "a-quiet", agentState: "working", since: alphaSince }),
+          run({ runId: "a", workspaceId: "z-busy", agentState: "working", since: betaSince }),
         ],
         ctx({
           workspaces: new Map([
-            ["p1", { kind: "project", name: "beta", lastOpened: NOW }],
-            ["p2", { kind: "project", name: "alpha", lastOpened: NOW - 600_000 }],
+            ["z-busy", { kind: "project", name: "beta", lastOpened: NOW }],
+            ["a-quiet", { kind: "project", name: "alpha", lastOpened: NOW - 600_000 }],
           ]),
         })
       ).map((g) => g.name);
@@ -353,20 +357,50 @@ describe("buildPilotGroups", () => {
     expect(quiet(NOW, NOW - 600_000)).toEqual(["beta", "alpha"]);
   });
 
+  it("treats an unusable opening time as undateable instead of breaking the order", () => {
+    // `Infinity - Infinity` is NaN, and a NaN comparator result reads as "these
+    // two are equal" against everything it touches, so the sort quietly stops
+    // being transitive and the same fleet opens two different ways.
+    const fleet = (runs: Parameters<typeof buildPilotGroups>[0]) =>
+      buildPilotGroups(
+        runs,
+        ctx({
+          workspaces: new Map([
+            ["w-inf", { kind: "project", name: "aaa", lastOpened: Number.POSITIVE_INFINITY }],
+            ["w-nan", { kind: "project", name: "bbb", lastOpened: Number.NaN }],
+            ["w-real", { kind: "project", name: "zzz", lastOpened: NOW }],
+          ]),
+        })
+      ).map((g) => g.name);
+
+    const runs = [
+      run({ runId: "a", workspaceId: "w-inf", agentState: "working", since: NOW }),
+      run({ runId: "b", workspaceId: "w-nan", agentState: "working", since: NOW }),
+      run({ runId: "c", workspaceId: "w-real", agentState: "working", since: NOW }),
+    ];
+
+    // The one real timestamp leads despite sorting last by name, and the two
+    // unusable ones settle by name the same way whichever order they arrive in.
+    expect(fleet(runs)).toEqual(["zzz", "aaa", "bbb"]);
+    expect(fleet([...runs].reverse())).toEqual(["zzz", "aaa", "bbb"]);
+  });
+
   it("does not use the current workspace to break an equal-recency tie", () => {
     // Being the workspace asking is not evidence of recency — `lastOpened`
     // already carries that, and under write suppression a switch can leave it
     // unmoved, so context must not buy a position the timestamp does not.
     const groups = buildPilotGroups(
       [
-        run({ runId: "a", workspaceId: "p1", agentState: "working", since: NOW }),
-        run({ runId: "b", workspaceId: "p2", agentState: "working", since: NOW }),
+        // Being current, arriving first and holding the lower workspace id all
+        // point at "zeta", so only the name tiebreak explains the result.
+        run({ runId: "b", workspaceId: "a-here", agentState: "working", since: NOW }),
+        run({ runId: "a", workspaceId: "z-there", agentState: "working", since: NOW }),
       ],
       ctx({
-        currentWorkspaceId: "p2",
+        currentWorkspaceId: "a-here",
         workspaces: new Map([
-          ["p1", { kind: "project", name: "alpha", lastOpened: NOW }],
-          ["p2", { kind: "project", name: "zeta", lastOpened: NOW }],
+          ["z-there", { kind: "project", name: "alpha", lastOpened: NOW }],
+          ["a-here", { kind: "project", name: "zeta", lastOpened: NOW }],
         ]),
       })
     );

--- a/src/components/Pilot/pilotRows.ts
+++ b/src/components/Pilot/pilotRows.ts
@@ -58,7 +58,7 @@ export interface PilotProjectGroup {
   rows: PilotRow[];
   /** Runs in this project that constitute a demand on the user. */
   demandCount: number;
-  /** Worst band present, which is what orders the group against its siblings. */
+  /** Worst band present, which headlines the group. Group ORDER is workspace recency. */
   topBand: FleetBand;
 }
 
@@ -93,6 +93,11 @@ export interface PilotWorkspaceMeta {
    * seen and stop counting as a hand-back — see `bandForRun`.
    */
   lastCompletionSeenAt?: number;
+  /**
+   * When the workspace was last switched to, which is what orders the groups.
+   * Absent means no opening was ever recorded, which sorts last.
+   */
+  lastOpened?: number;
 }
 
 export interface PilotRowContext {
@@ -136,53 +141,25 @@ function narrowGroup(group: PilotProjectGroup, rows: PilotRow[]): PilotProjectGr
 }
 
 /**
- * Oldest still-outstanding demand in a project, or undefined when it has none.
- *
- * The group-level counterpart of {@link compareWithinBand}'s anti-starvation
- * rule, which is the point: a project whose block has been standing for forty
- * minutes stops being displaced by one that only just started asking.
- *
- * Not identical to it, deliberately. `compareWithinBand` ranks rows inside ONE
- * band; this takes the oldest demand of ANY kind, so a long-unread completion
- * can date a project whose worst band is a fresh question. That is the right
- * reading of "oldest outstanding demand" — a review nobody has looked at in two
- * hours is outstanding — but it does mean the two are not the same function.
- *
- * A demand with no `since` contributes nothing rather than counting as
- * infinitely old — an unknown age is not evidence of urgency.
- */
-function oldestDemand(rows: readonly PilotRow[]): number | undefined {
-  let oldest: number | undefined;
-  for (const row of rows) {
-    if (!isDemandBand(row.band)) continue;
-    const since = row.run.since;
-    if (since === undefined) continue;
-    if (oldest === undefined || since < oldest) oldest = since;
-  }
-  return oldest;
-}
-
-/**
  * Group every run under the project that owns it.
  *
- * Project is the primary axis because that is the unit the user thinks in.
- * Ordering is by SEVERITY, never by how many agents a project holds: a project
- * running eight idle agents would otherwise bury one holding a single blocked
- * agent, which is the documented failure mode of count-based ranking in
- * operator tools. Volume is reported as a count on the header instead, where it
- * informs without competing for position.
+ * Project is the primary axis because that is the unit the user thinks in, and
+ * groups read in workspace MRU order: newest `lastOpened` first, a workspace
+ * with no recorded opening last, then name and id to settle the rest. Severity
+ * never lifts one project above another — a blocked agent in a project left an
+ * hour ago does not outrank the one being worked in now. Worst band and volume
+ * are reported on the header instead, where they inform without competing for
+ * position.
  *
- * Ties break on the oldest outstanding demand, NOT on recency. Recency changed
- * between every single opening, so the group order was never the same twice and
- * spatial memory never formed — and it inverted the anti-starvation rule the
- * rows themselves already follow. Quiet projects, which have no demand to date,
- * fall back to the workspace this view already owns and then to name, so their
- * order is fixed for as long as they stay quiet and only genuinely demanding
- * projects float.
+ * This is not the recency #11626 rejected. That ordering read `latestActivity`,
+ * which moves while the palette is open, so groups reshuffled between openings
+ * the user had not caused and spatial memory never formed. `lastOpened` only
+ * advances when a workspace is actually switched to, so the order holds still
+ * until the user is the one who changed it.
  *
- * The current workspace is deliberately NOT pinned above severity: putting
- * context first would bury a blocked agent in another project, which is the
- * exact failure the band ordering exists to prevent.
+ * Severity and anti-starvation stay the ROW rule inside each group: worst band
+ * first, then oldest `since`. A project's demands still surface at the top of
+ * its own rows — they just no longer move the project itself.
  */
 export function buildPilotGroups(
   runs: readonly FleetRunRow[],
@@ -195,7 +172,7 @@ export function buildPilotGroups(
     else byWorkspace.set(run.workspaceId, [run]);
   }
 
-  const groups: Array<PilotProjectGroup & { oldestDemand: number | undefined }> = [];
+  const groups: Array<PilotProjectGroup & { lastOpened: number }> = [];
   for (const [workspaceId, workspaceRuns] of byWorkspace) {
     const meta = ctx.workspaces.get(workspaceId);
     // A run whose workspace has been removed from the store still has to render
@@ -263,28 +240,17 @@ export function buildPilotGroups(
       rows,
       demandCount: rows.filter((r) => isDemandBand(r.band)).length,
       topBand: rows[0]?.band ?? "idle",
-      oldestDemand: oldestDemand(rows),
+      lastOpened: meta?.lastOpened ?? 0,
     });
   }
 
   groups.sort((a, b) => {
-    const byBand = rank(a.topBand) - rank(b.topBand);
-    if (byBand !== 0) return byBand;
+    const byRecency = b.lastOpened - a.lastOpened;
+    if (byRecency !== 0) return byRecency;
 
-    // Both sides share a top band here, so testing either one answers for the
-    // pair. A demand band ranks by how long it has been outstanding; anything
-    // else has no urgency to compare and gives primacy to the workspace this
-    // view is already in, where opening a run costs no switch.
-    if (isDemandBand(a.topBand)) {
-      const ao = a.oldestDemand;
-      const bo = b.oldestDemand;
-      if (ao !== undefined && bo !== undefined && ao !== bo) return ao - bo;
-      if (ao === undefined && bo !== undefined) return 1;
-      if (bo === undefined && ao !== undefined) return -1;
-    } else if (a.isCurrent !== b.isCurrent) {
-      return a.isCurrent ? -1 : 1;
-    }
-
+    // Equal recency means MRU has nothing left to say, so what settles the pair
+    // is stable identity rather than agent state — a group must not change
+    // place because a run inside it started or blocked.
     const byName = a.name.localeCompare(b.name);
     if (byName !== 0) return byName;
     // Workspace id last, so the comparator is a TRUE total order. Two projects
@@ -295,7 +261,7 @@ export function buildPilotGroups(
     return a.workspaceId < b.workspaceId ? -1 : 1;
   });
 
-  return groups.map(({ oldestDemand: _oldest, ...group }) => group);
+  return groups.map(({ lastOpened: _lastOpened, ...group }) => group);
 }
 
 /**

--- a/src/components/Pilot/pilotRows.ts
+++ b/src/components/Pilot/pilotRows.ts
@@ -94,8 +94,10 @@ export interface PilotWorkspaceMeta {
    */
   lastCompletionSeenAt?: number;
   /**
-   * When the workspace was last switched to, which is what orders the groups.
-   * Absent means no opening was ever recorded, which sorts last.
+   * When the workspace was last switched to or away from, which is what orders
+   * the groups. Leaving a project stamps it too, a millisecond behind the one
+   * being entered, so the pair either side of a switch stays adjacent at the
+   * top. Anything but a finite positive number sorts as undateable.
    */
   lastOpened?: number;
 }
@@ -141,21 +143,39 @@ function narrowGroup(group: PilotProjectGroup, rows: PilotRow[]): PilotProjectGr
 }
 
 /**
+ * An opening time reduced to something the comparator can total-order on.
+ *
+ * Anything that is not a finite positive number — absent metadata, a corrupt
+ * row, an infinity that would subtract to `NaN` — collapses to 0 and ranks as
+ * undateable. A `NaN` reaching the comparator is the reason this exists: it
+ * compares equal to every timestamp it meets, so the sort would silently stop
+ * being transitive and the same fleet could open two different ways.
+ */
+function openedAt(value: number | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+/**
  * Group every run under the project that owns it.
  *
  * Project is the primary axis because that is the unit the user thinks in, and
- * groups read in workspace MRU order: newest `lastOpened` first, a workspace
- * with no recorded opening last, then name and id to settle the rest. Severity
- * never lifts one project above another — a blocked agent in a project left an
- * hour ago does not outrank the one being worked in now. Worst band and volume
- * are reported on the header instead, where they inform without competing for
- * position.
+ * groups read in workspace MRU order: newest `lastOpened` first, then name and
+ * id to settle the rest. Severity never lifts one project above another — a
+ * blocked agent in a project left an hour ago does not outrank the one being
+ * worked in now (#11678).
  *
  * This is not the recency #11626 rejected. That ordering read `latestActivity`,
  * which moves while the palette is open, so groups reshuffled between openings
- * the user had not caused and spatial memory never formed. `lastOpened` only
- * advances when a workspace is actually switched to, so the order holds still
- * until the user is the one who changed it.
+ * the user had not caused and spatial memory never formed. `lastOpened` moves
+ * only when the user switches workspace, so the order holds still across
+ * openings and changes only where they changed it themselves.
+ *
+ * A workspace this view cannot date sorts LAST, not first. Ranking an anomaly
+ * above everything is the worse failure here: the two name stores hydrate on
+ * separate promises, so a half-loaded palette would open with its unresolved
+ * groups on top and watch them drop as the names land — the unstable order
+ * again, through the back door. An undateable group still renders and still
+ * filters; it just does not outrank a workspace with a real history.
  *
  * Severity and anti-starvation stay the ROW rule inside each group: worst band
  * first, then oldest `since`. A project's demands still surface at the top of
@@ -240,7 +260,7 @@ export function buildPilotGroups(
       rows,
       demandCount: rows.filter((r) => isDemandBand(r.band)).length,
       topBand: rows[0]?.band ?? "idle",
-      lastOpened: meta?.lastOpened ?? 0,
+      lastOpened: openedAt(meta?.lastOpened),
     });
   }
 

--- a/src/components/Pilot/pilotRows.ts
+++ b/src/components/Pilot/pilotRows.ts
@@ -58,7 +58,12 @@ export interface PilotProjectGroup {
   rows: PilotRow[];
   /** Runs in this project that constitute a demand on the user. */
   demandCount: number;
-  /** Worst band present, which headlines the group. Group ORDER is workspace recency. */
+  /**
+   * Worst band among the rows below, recomputed rather than inherited whenever
+   * the group is narrowed. A derived summary of the group's contents only —
+   * group ORDER is workspace recency, and the header draws identity, not
+   * severity.
+   */
   topBand: FleetBand;
 }
 
@@ -94,10 +99,11 @@ export interface PilotWorkspaceMeta {
    */
   lastCompletionSeenAt?: number;
   /**
-   * When the workspace was last switched to or away from, which is what orders
-   * the groups. Leaving a project stamps it too, a millisecond behind the one
-   * being entered, so the pair either side of a switch stays adjacent at the
-   * top. Anything but a finite positive number sorts as undateable.
+   * When the workspace was last switched to, which is what orders the groups.
+   * A project-to-project switch also stamps the project being LEFT, a
+   * millisecond behind, so that pair stays adjacent at the top; switches
+   * involving a scratch stamp only the one being entered. Anything but a
+   * finite positive number sorts as undateable.
    */
   lastOpened?: number;
 }


### PR DESCRIPTION
The fleet overview palette (⌥⌘O) ordered project groups by severity band, so the project you just opened sank below any project holding a waiting agent. The reported case: `Groundwork Terrain` is current with one working agent and rendered below `Pixel Reconstruct`, which held four waiting ones.

Groups now read most-recently-opened first, using the `lastOpened` each `Project` and `Scratch` already carries — the same field `getMruProjects()` sorts the switcher palette on. Row order inside each group is untouched: worst band first, then oldest `since` for anti-starvation.

**What changed**

- `buildPilotGroups()`'s group comparator reduces to `lastOpened` desc → name → `workspaceId`. The band / oldest-demand / current-workspace chain is gone rather than kept below recency — leaving it would have resurrected the old policy in exactly the degenerate case where metadata is missing, which is the worst place for it to reappear silently.
- `oldestDemand()` is deleted; the group sort was its only caller. Its three tests went with it. The row-level anti-starvation rule it mirrored is still covered in `fleetAttention.test.ts` and by the intra-group ordering test.
- `PilotWorkspaceMeta` gains an optional `lastOpened`, populated in `PilotView` from `project.lastOpened` / `scratch.lastOpened`.
- `openedAt()` normalizes the timestamp before it reaches the comparator. `Infinity - Infinity` is `NaN`, and a `NaN` comparator result reads as "equal" to every group it meets — the sort would have quietly stopped being transitive and the same fleet could open two different ways. Anything not a finite positive number now sorts as undateable.
- The doc comment above `buildPilotGroups()` argued against recency ordering (from #11626); it now states the new rule and why this isn't the thing #11626 rejected. That rejection was about `latestActivity`, which moves while the palette is open. `lastOpened` moves only when you switch workspace, so the order holds still across openings.

**Undateable workspaces sort last, not first**

A run whose workspace has left the store still renders — dropping it would hide a live agent because a lookup missed — but it doesn't outrank a workspace with real history. Sorting unknowns first was considered and rejected: `loadProjects()` and `loadScratches()` hydrate on separate promises, so a half-loaded palette would open with its unresolved groups on top and drop them as the names land, which is the unstable ordering #11626 was written against arriving through the back door.

**Known gap, not fixed here**

Switching to a scratch stamps its `lastOpened` and broadcasts `SCRATCH_ON_SWITCH`, but the renderer's listener only updates `currentScratch` — it never upserts into `state.scratches`, which is the array Pilot reads. Projects don't have this hole because their switch broadcasts replace the row. In practice Pilot remounts on every open and calls `loadScratches()`, so it only bites if Pilot stays open while another window switches scratch. Pre-existing and out of scope here.

Also worth noting: `topBand` and `demandCount` on `PilotProjectGroup` now have no production reader — `demandCount` already didn't, and the group sort was `topBand`'s last one. Both are still computed and tested. Left alone rather than removed as an unrelated API change.

**Testing**

`npx vitest run src/components/Pilot/__tests__/ src/lib/__tests__/fleetAttention.test.ts src/lib/__tests__/projectSwitcherSearch.test.ts` — 225 pass. `tsc --noEmit` clean, eslint and prettier clean on the changed files.

The ordering fixtures are arranged so name, band, arrival order and workspace id would each give a different answer than recency, so a test that passes is actually testing the rule it names. The regression test for the reported case flips only the two timestamps and asserts the order flips with them.

Resolves #11678