### PR TITLE
feat(toolbar): declare button groups instead of deriving dividers

### DIFF
--- a/e2e/full/presets/preset-tray-default.spec.ts
+++ b/e2e/full/presets/preset-tray-default.spec.ts
@@ -75,10 +75,10 @@ function launchEnv(): Record<string, string> {
 
 test.describe.serial("Presets: Tray Default Launch (101–106)", () => {
   // The open tray is the top-level role=menu that carries the always-present
-  // "Manage Agents" item (the nested preset SubContent never has it). Radix's
+  // "Manage agents" item (the nested preset SubContent never has it). Radix's
   // DropdownMenuContent has no accessible name, so identify it by that item
   // rather than by role+name.
-  const trayMenu = () => ctx.window.locator('[role="menu"]').filter({ hasText: "Manage Agents" });
+  const trayMenu = () => ctx.window.locator('[role="menu"]').filter({ hasText: "Manage agents" });
   const submenuContent = () => ctx.window.locator('[data-testid="submenu-content"]');
   const claudeSubmenuTrigger = () =>
     trayMenu().locator('[data-testid="submenu-trigger"]', { hasText: "Claude" });

--- a/src/components/Layout/LauncherMenuButton.tsx
+++ b/src/components/Layout/LauncherMenuButton.tsx
@@ -56,11 +56,7 @@ import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
-import {
-  TOOLBAR_CUSTOMIZE_LABEL,
-  TOOLBAR_PIN_LABEL,
-  TOOLBAR_UNPIN_LABEL,
-} from "./toolbarMenuStrings";
+import { TOOLBAR_PIN_LABEL, TOOLBAR_UNPIN_LABEL } from "./toolbarMenuStrings";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 
 import { useKeybindingDisplay } from "@/hooks";
@@ -1017,7 +1013,7 @@ export function LauncherMenuButton({
           {needsSetup.length > 0 && (
             <>
               <DropdownMenuSeparator />
-              <DropdownMenuLabel>Needs Setup</DropdownMenuLabel>
+              <DropdownMenuLabel>Needs setup</DropdownMenuLabel>
               {needsSetup.map((row) => (
                 <DropdownMenuItem
                   key={`setup-${row.id}`}
@@ -1039,7 +1035,7 @@ export function LauncherMenuButton({
           {showFallback && (
             <>
               <DropdownMenuSeparator />
-              <DropdownMenuLabel>Available Agents</DropdownMenuLabel>
+              <DropdownMenuLabel>Available agents</DropdownMenuLabel>
               {fallbackSetup.map((row) => (
                 <DropdownMenuItem
                   key={`fallback-${row.id}`}
@@ -1056,29 +1052,33 @@ export function LauncherMenuButton({
                   </span>
                 </DropdownMenuItem>
               ))}
+              {/*
+                Setup belongs to the empty state, not the footer (#11681). It
+                only helps when nothing is installed, and as a permanent third
+                row it was a second exit competing with `Manage agents` — which
+                already reaches the same settings.
+              */}
+              <DropdownMenuItem onSelect={handleOpenAgentSetupWizard} className="h-7">
+                <Plug className="mr-2 h-3.5 w-3.5" />
+                Set up agents
+              </DropdownMenuItem>
             </>
           )}
 
+          {/*
+            `Customize toolbar…` used to sit here too, sharing the `Settings2`
+            glyph with `Manage agents` so the two read as the same destination —
+            and `ToolbarContextMenuItems` already offers it on this button's
+            right click, where a global toolbar control belongs.
+          */}
           <DropdownMenuSeparator />
           <DropdownMenuActionItem actionId="panel.palette" className="h-7">
             <SquareMenu className="mr-2 h-3.5 w-3.5 text-text-secondary" />
             More panels…
           </DropdownMenuActionItem>
           <DropdownMenuItem onSelect={handleManageAgents} className="h-7">
-            <Settings2 className="mr-2 h-3.5 w-3.5 text-text-muted" />
-            Manage Agents
-          </DropdownMenuItem>
-          <DropdownMenuActionItem
-            actionId="app.settings.openTab"
-            args={{ tab: "toolbar" }}
-            className="h-7"
-          >
-            <Settings2 className="mr-2 h-3.5 w-3.5 text-text-muted" />
-            {TOOLBAR_CUSTOMIZE_LABEL}
-          </DropdownMenuActionItem>
-          <DropdownMenuItem onSelect={handleOpenAgentSetupWizard} className="h-7">
-            <Plug className="mr-2 h-3.5 w-3.5" />
-            Set Up Agents
+            <Settings2 className="mr-2 h-3.5 w-3.5 text-text-secondary" />
+            Manage agents
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -30,7 +30,12 @@ import {
 import { Spinner } from "@/components/ui/Spinner";
 import { FolderTree, Folders } from "@/components/icons";
 import { buildPluginToolbarMeta } from "./pluginToolbarMeta";
-import { TOOLBAR_BUTTON_METADATA, isToolbarButtonVisible } from "./toolbarButtonMetadata";
+import {
+  TOOLBAR_BUTTON_METADATA,
+  getToolbarButtonGroup,
+  isToolbarButtonVisible,
+} from "./toolbarButtonMetadata";
+import { getToolbarDividerAfterIds, orderToolbarButtonsByGroup } from "./toolbarButtonGrouping";
 import { ToolbarContextMenuItems } from "./ToolbarContextMenuItems";
 import { cn } from "@/lib/utils";
 import { shortcutHintStore } from "@/store/shortcutHintStore";
@@ -87,7 +92,7 @@ import { activeWorkspaceIdentity, branchChipState } from "@/lib/workspaceIdentit
 import { usePreferencesStore, useToolbarPreferencesStore, useVoiceRecordingStore } from "@/store";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
-import type { ToolbarButtonId, AnyToolbarButtonId } from "@/../../shared/types/toolbar";
+import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
 import { usePluginToolbarButtons } from "@/hooks/usePluginToolbarButtons";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
@@ -125,16 +130,6 @@ import {
   isBuiltInAgentId,
   type BuiltInAgentId,
 } from "@shared/config/agentIds";
-
-// Carries `agent-tray`'s old membership forward under the merged id, so the
-// divider between the agent and non-agent runs lands exactly where it does
-// today. The launcher now holds panels too, which makes that grouping only
-// approximately right — #11681 replaces this predicate flip with declared group
-// data and owns the fix.
-const AGENT_TOOLBAR_IDS = new Set<ToolbarButtonId>([
-  "launcher",
-  ...(LAUNCHABLE_AGENT_IDS as unknown as ToolbarButtonId[]),
-]);
 
 type OverflowMenuMeta = { label: string; icon: React.ComponentType<{ className?: string }> };
 
@@ -1388,6 +1383,13 @@ export function Toolbar({
     toolbarLayout.rightButtons.includes("launcher") &&
     !toolbarLayout.leftButtons.includes("launcher");
 
+  // Declared group per button, resolved against the live plugin registry so a
+  // contribution is classified by membership rather than by parsing its id.
+  const resolveToolbarGroup = useCallback(
+    (id: AnyToolbarButtonId) => getToolbarButtonGroup(id, pluginConfigs.has(id)),
+    [pluginConfigs]
+  );
+
   const effectiveLeftButtons = useMemo(() => {
     // Dedupe defensively so a persisted list holding a repeated id never
     // renders duplicate pills (#10937) — the store also heals this, this is
@@ -1395,8 +1397,10 @@ export function Toolbar({
     const positioned = Array.from(new Set(toolbarLayout.leftButtons));
 
     if (!launcherOnRight && unpositionedAgentPins.length > 0) {
-      // Beside the launcher they were pinned out of, in registry order, so the
-      // brand marks stay contiguous rather than scattering to the end of the row.
+      // Right after the launcher they were pinned out of, so they lead the
+      // agent run in registry order rather than trailing the positioned ones.
+      // Grouping below is what keeps the brand marks contiguous; this only
+      // decides their order within that group.
       const launcherIndex = positioned.indexOf("launcher");
       positioned.splice(
         launcherIndex === -1 ? positioned.length : launcherIndex + 1,
@@ -1405,14 +1409,21 @@ export function Toolbar({
       );
     }
 
-    return positioned.filter((id) =>
-      isToolbarButtonVisible(
-        id,
-        pinnedButtons,
-        effectiveAgentSettings,
-        agentAvailability,
-        pluginConfigs.has(id)
-      )
+    // Grouped, not persisted order (#11681): the divider marks a group
+    // boundary, so the groups have to actually be contiguous. Ordering here
+    // rather than at the render loop means overflow, keyboard roving, and the
+    // DOM all see the same canonical sequence.
+    return orderToolbarButtonsByGroup(
+      positioned.filter((id) =>
+        isToolbarButtonVisible(
+          id,
+          pinnedButtons,
+          effectiveAgentSettings,
+          agentAvailability,
+          pluginConfigs.has(id)
+        )
+      ),
+      resolveToolbarGroup
     );
   }, [
     toolbarLayout.leftButtons,
@@ -1422,6 +1433,7 @@ export function Toolbar({
     effectiveAgentSettings,
     agentAvailability,
     pluginConfigs,
+    resolveToolbarGroup,
   ]);
 
   const effectiveRightButtons = useMemo(() => {
@@ -1558,10 +1570,17 @@ export function Toolbar({
     visibleSet: Set<AnyToolbarButtonId>
   ) => {
     const available = buttonIds.filter((id) => buttonRegistry[id]?.isAvailable);
-    const visible = available.filter((id) => visibleSet.has(id));
-    const elements: React.ReactNode[] = [];
+    // `buttonIds` arrives already grouped, so a divider belongs after every
+    // visible button whose declared group differs from the next visible one
+    // (#11681). Overflow-hidden buttons stay mounted for measurement but are
+    // excluded, so an evicted button never strands a divider.
+    const dividerAfter = getToolbarDividerAfterIds(
+      available,
+      (id) => visibleSet.has(id),
+      resolveToolbarGroup
+    );
 
-    // Render all available items (visible + hidden for measurement)
+    const elements: React.ReactNode[] = [];
     for (const id of available) {
       const isVisible = visibleSet.has(id);
       elements.push(
@@ -1577,32 +1596,13 @@ export function Toolbar({
           {buttonRegistry[id]!.render()}
         </div>
       );
-    }
-
-    // Insert group dividers between agent and non-agent visible items
-    const withDividers: React.ReactNode[] = [];
-    let visibleIdx = 0;
-    for (const el of elements) {
-      withDividers.push(el);
-      const key = (el as React.ReactElement).key as string;
-      if (visibleSet.has(key as AnyToolbarButtonId)) {
-        if (
-          visibleIdx < visible.length - 1 &&
-          AGENT_TOOLBAR_IDS.has(visible[visibleIdx] as ToolbarButtonId) !==
-            AGENT_TOOLBAR_IDS.has(visible[visibleIdx + 1] as ToolbarButtonId)
-        ) {
-          withDividers.push(
-            <div
-              key={`group-divider-${visibleIdx}`}
-              className={toolbarDividerClass}
-              aria-hidden="true"
-            />
-          );
-        }
-        visibleIdx++;
+      if (isVisible && dividerAfter.has(id)) {
+        elements.push(
+          <div key={`group-divider-${id}`} className={toolbarDividerClass} aria-hidden="true" />
+        );
       }
     }
-    return withDividers;
+    return elements;
   };
 
   const pluginTrayGroups = useMemo(

--- a/src/components/Layout/__tests__/LauncherMenuButton.test.tsx
+++ b/src/components/Layout/__tests__/LauncherMenuButton.test.tsx
@@ -972,19 +972,44 @@ describe("LauncherMenuButton", () => {
     );
   });
 
-  it("leaves Manage agents as the footer's only settings exit", () => {
+  it("leaves the footer at its two entries, with one settings exit", () => {
     const availability = { claude: "ready" } as unknown as CliAvailability;
     mockSettings = settingsWith({ claude: { pinned: true } });
 
-    const { container } = render(<LauncherMenuButton agentAvailability={availability} />);
-    const items = Array.from(container.querySelectorAll('[role="menuitem"]')).map(
-      (el) => el.textContent ?? ""
-    );
+    const { getByTestId } = render(<LauncherMenuButton agentAvailability={availability} />);
 
-    // The two other exits are gone: customize lives on the right click, and
-    // setup only appears when nothing is installed (#11681).
-    expect(items.filter((text) => text.includes("Manage agents"))).toHaveLength(1);
-    expect(items.some((text) => text.includes("Set up agents"))).toBe(false);
+    // Everything after the last separator is the footer. Counting the nodes
+    // rather than matching labels means a third exit sneaking back in fails
+    // here even if it is worded differently (#11681).
+    const dropdown = getByTestId("dropdown-content");
+    const children = Array.from(dropdown.children);
+    const lastSeparator = children.map((el) => el.tagName).lastIndexOf("HR");
+    expect(lastSeparator).toBeGreaterThan(-1);
+
+    const footer = children.slice(lastSeparator + 1);
+    expect(footer).toHaveLength(2);
+    expect(footer[0]!.textContent).toContain("More panels");
+    expect(footer[1]!.textContent).toContain("Manage agents");
+  });
+
+  it("keeps the setup wizard out of the loading and needs-setup states", () => {
+    // Still probing: nothing is known yet, so offering setup would be noise.
+    mockHasRealData = false;
+    const { container: loading } = render(
+      <LauncherMenuButton agentAvailability={{} as unknown as CliAvailability} />
+    );
+    expect(loading.textContent).not.toContain("Set up agents");
+
+    // Installed but unauthenticated agents get their own per-agent rows, which
+    // are a better route than the blanket wizard.
+    mockHasRealData = true;
+    const { container: needsSetup } = render(
+      <LauncherMenuButton
+        agentAvailability={{ codex: "installed" } as unknown as CliAvailability}
+      />
+    );
+    expect(needsSetup.textContent).toContain("Needs setup");
+    expect(needsSetup.textContent).not.toContain("Set up agents");
   });
 
   it("renders Set up agents only in the nothing-installed empty state", () => {

--- a/src/components/Layout/__tests__/LauncherMenuButton.test.tsx
+++ b/src/components/Layout/__tests__/LauncherMenuButton.test.tsx
@@ -592,9 +592,9 @@ describe("LauncherMenuButton", () => {
 
   it("renders the plus trigger with accessible label", () => {
     // Scoped to the trigger, not the whole tree: a bare `getAllByTestId` also
-    // matches the footer's "Set Up Agents" Plug glyph, so it stayed green with
-    // the trigger icon removed entirely. The plus is the point of #11680 — a
-    // plug reads as connections, not as "make me a new thing".
+    // matches the "Set up agents" Plug glyph, so it stayed green with the
+    // trigger icon removed entirely. The plus is the point of #11680 — a plug
+    // reads as connections, not as "make me a new thing".
     const { getByLabelText } = render(<LauncherMenuButton />);
     const trigger = getByLabelText("Launcher");
     expect(trigger).toBeTruthy();
@@ -801,7 +801,7 @@ describe("LauncherMenuButton", () => {
     expect(getByTestId("launcher-pin-claude").getAttribute("data-pinned")).toBe("false");
   });
 
-  it("only puts installed-but-unauth agents in Needs Setup (missing agents are hidden)", () => {
+  it("only puts installed-but-unauth agents in Needs setup (missing agents are hidden)", () => {
     const availability = {
       claude: "ready",
       gemini: "missing",
@@ -814,7 +814,7 @@ describe("LauncherMenuButton", () => {
     );
 
     const labels = getAllByTestId("menu-label").map((el) => el.textContent);
-    expect(labels).toContain("Needs Setup");
+    expect(labels).toContain("Needs setup");
 
     const setupItems = Array.from(container.querySelectorAll('[role="menuitem"]')).filter(
       (el) =>
@@ -822,11 +822,11 @@ describe("LauncherMenuButton", () => {
         !el.textContent.includes("Manage") &&
         !el.textContent.includes("Customize")
     );
-    // Only codex (installed) belongs in Needs Setup. Gemini (missing) must NOT appear.
+    // Only codex (installed) belongs in Needs setup. Gemini (missing) must NOT appear.
     expect(setupItems.length).toBe(1);
     expect(setupItems[0]!.textContent).toContain("Codex");
     const allText = container.textContent ?? "";
-    expect(allText).not.toMatch(/Needs Setup[\s\S]*Gemini/);
+    expect(allText).not.toMatch(/Needs setup[\s\S]*Gemini/);
   });
 
   it("dispatches settings with subtab when a Needs-Setup row is clicked", () => {
@@ -841,7 +841,7 @@ describe("LauncherMenuButton", () => {
     );
     // Sanity check: this must be the Needs-Setup branch, not the fallback.
     const labels = getAllByTestId("menu-label").map((el) => el.textContent);
-    expect(labels).toContain("Needs Setup");
+    expect(labels).toContain("Needs setup");
 
     const setupItem = Array.from(container.querySelectorAll('[role="menuitem"]')).find((el) =>
       el.textContent?.includes("Gemini")
@@ -855,24 +855,24 @@ describe("LauncherMenuButton", () => {
     );
   });
 
-  it("shows Customize Toolbar footer", () => {
+  // #11681: the customize entry left this menu — it duplicated the right-click
+  // `ToolbarContextMenuItems` entry on this same button, and shared the
+  // `Settings2` glyph with `Manage agents` so the two read as one destination.
+  it("does not duplicate the right-click Customize toolbar entry in the menu", () => {
     const availability = { claude: "ready" } as unknown as CliAvailability;
     mockSettings = settingsWith({ claude: { pinned: true } });
 
-    const { container } = render(<LauncherMenuButton agentAvailability={availability} />);
-    const footer = Array.from(container.querySelectorAll('[role="menuitem"]')).find((el) =>
+    const { getByTestId } = render(<LauncherMenuButton agentAvailability={availability} />);
+
+    const dropdown = getByTestId("dropdown-content");
+    const inDropdown = Array.from(dropdown.querySelectorAll('[role="menuitem"]')).find((el) =>
       el.textContent?.includes(TOOLBAR_CUSTOMIZE_LABEL)
     );
-    expect(footer).toBeTruthy();
-    fireEvent.click(footer!);
-    // The Customize entry routes through DropdownMenuActionItem, so the
-    // source is whatever the wrapping DropdownMenu provides ("menu" when
-    // Radix primitives load, "user" when the fallback path is taken).
-    const calls = dispatchMock.mock.calls.filter(
-      ([id, args]: unknown[]) =>
-        id === "app.settings.openTab" && JSON.stringify(args) === JSON.stringify({ tab: "toolbar" })
-    );
-    expect(calls.length).toBeGreaterThan(0);
+    expect(inDropdown).toBeUndefined();
+
+    // Still reachable on the right click of this same button, which is the
+    // single home the entry keeps.
+    expect(getByTestId("context-menu-content").textContent).toContain(TOOLBAR_CUSTOMIZE_LABEL);
   });
 
   it("shows loading placeholder when availability is undefined", () => {
@@ -909,7 +909,7 @@ describe("LauncherMenuButton", () => {
     expect(getByTestId("launcher-fallback-gemini")).toBeTruthy();
     expect(getByTestId("launcher-fallback-codex")).toBeTruthy();
     const labels = getAllByTestId("menu-label").map((el) => el.textContent);
-    expect(labels).toContain("Available Agents");
+    expect(labels).toContain("Available agents");
   });
 
   it("triggers a refresh when the dropdown opens", () => {
@@ -955,13 +955,13 @@ describe("LauncherMenuButton", () => {
     expect(refreshAvailabilityMock).toHaveBeenCalledTimes(1);
   });
 
-  it("renders a Manage Agents… footer that opens the agents settings tab", () => {
+  it("renders a Manage agents footer that opens the agents settings tab", () => {
     const availability = { claude: "ready" } as unknown as CliAvailability;
     mockSettings = settingsWith({ claude: { pinned: true } });
 
     const { container } = render(<LauncherMenuButton agentAvailability={availability} />);
     const manage = Array.from(container.querySelectorAll('[role="menuitem"]')).find((el) =>
-      el.textContent?.includes("Manage Agents")
+      el.textContent?.includes("Manage agents")
     );
     expect(manage).toBeTruthy();
     fireEvent.click(manage!);
@@ -972,14 +972,33 @@ describe("LauncherMenuButton", () => {
     );
   });
 
-  it("renders a Set Up Agents footer that dispatches the wizard custom event", () => {
+  it("leaves Manage agents as the footer's only settings exit", () => {
     const availability = { claude: "ready" } as unknown as CliAvailability;
     mockSettings = settingsWith({ claude: { pinned: true } });
+
+    const { container } = render(<LauncherMenuButton agentAvailability={availability} />);
+    const items = Array.from(container.querySelectorAll('[role="menuitem"]')).map(
+      (el) => el.textContent ?? ""
+    );
+
+    // The two other exits are gone: customize lives on the right click, and
+    // setup only appears when nothing is installed (#11681).
+    expect(items.filter((text) => text.includes("Manage agents"))).toHaveLength(1);
+    expect(items.some((text) => text.includes("Set up agents"))).toBe(false);
+  });
+
+  it("renders Set up agents only in the nothing-installed empty state", () => {
+    mockHasRealData = true;
+    const availability = {
+      claude: "missing",
+      gemini: "missing",
+      codex: "missing",
+    } as unknown as CliAvailability;
 
     const dispatchSpy = vi.spyOn(window, "dispatchEvent");
     const { container } = render(<LauncherMenuButton agentAvailability={availability} />);
     const setup = Array.from(container.querySelectorAll('[role="menuitem"]')).find((el) =>
-      el.textContent?.includes("Set Up Agents")
+      el.textContent?.includes("Set up agents")
     );
     expect(setup).toBeTruthy();
     fireEvent.click(setup!);

--- a/src/components/Layout/__tests__/Toolbar.layout.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.layout.test.ts
@@ -90,8 +90,11 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
     // still wired to that declared-group algorithm rather than deriving
     // boundaries locally, which this file (a source scan) is the only place
     // that can check.
-    it("resolves each button's group from the declared resolver", () => {
-      expect(source).toContain("getToolbarButtonGroup");
+    it("resolves each button's group against the live plugin registry", () => {
+      // The membership argument is what keeps a contribution from inheriting a
+      // built-in's placement — a bare `getToolbarButtonGroup(id)` would compile
+      // and silently misplace every promoted plugin button.
+      expect(source).toMatch(/getToolbarButtonGroup\(\s*id,\s*pluginConfigs\.has\(id\)\s*\)/);
     });
 
     it("no longer derives boundaries from an agent/non-agent predicate", () => {
@@ -102,8 +105,12 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
       expect(source).toContain("orderToolbarButtonsByGroup");
     });
 
-    it("places dividers via the pure grouping helper", () => {
-      expect(source).toContain("getToolbarDividerAfterIds");
+    it("places dividers from the visible set, not from every available button", () => {
+      // Passing `() => true` here would restore a divider after an
+      // overflow-evicted button.
+      expect(source).toMatch(
+        /getToolbarDividerAfterIds\(\s*available,\s*\(id\) => visibleSet\.has\(id\),/
+      );
     });
 
     it("has renderLeftButtons helper that inserts group dividers", () => {

--- a/src/components/Layout/__tests__/Toolbar.layout.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.layout.test.ts
@@ -84,9 +84,26 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
     });
   });
 
-  describe("Agent/tool button group divider — issue #2879", () => {
-    it("defines AGENT_TOOLBAR_IDS constant for group boundary detection", () => {
-      expect(source).toContain("AGENT_TOOLBAR_IDS");
+  describe("Agent/tool button group divider — issues #2879, #11681", () => {
+    // The divider positions themselves are covered for real in
+    // toolbarButtonGrouping.test.ts — these only assert that Toolbar.tsx is
+    // still wired to that declared-group algorithm rather than deriving
+    // boundaries locally, which this file (a source scan) is the only place
+    // that can check.
+    it("resolves each button's group from the declared resolver", () => {
+      expect(source).toContain("getToolbarButtonGroup");
+    });
+
+    it("no longer derives boundaries from an agent/non-agent predicate", () => {
+      expect(source).not.toContain("AGENT_TOOLBAR_IDS");
+    });
+
+    it("orders the left buttons by declared group before rendering", () => {
+      expect(source).toContain("orderToolbarButtonsByGroup");
+    });
+
+    it("places dividers via the pure grouping helper", () => {
+      expect(source).toContain("getToolbarDividerAfterIds");
     });
 
     it("has renderLeftButtons helper that inserts group dividers", () => {

--- a/src/components/Layout/__tests__/toolbarButtonGrouping.test.ts
+++ b/src/components/Layout/__tests__/toolbarButtonGrouping.test.ts
@@ -67,13 +67,23 @@ describe("orderToolbarButtonsByGroup", () => {
     expect(orderToolbarButtonsByGroup([], resolve)).toEqual([]);
   });
 
-  it("sorts plugin contributions into the trailing utilities group", () => {
-    const ordered = orderToolbarButtonsByGroup(
-      ["my-plugin.action", "terminal", "claude"],
-      resolveWithPlugins(new Set(["my-plugin.action"]))
-    );
+  it("sorts by live registry membership, not by the id alone", () => {
+    // `settings` is unclassified (utilities) and `terminal` is a declared
+    // panel, so panels normally win the lead regardless of input order.
+    const ids: AnyToolbarButtonId[] = ["settings", "terminal"];
+    expect(orderToolbarButtonsByGroup(ids, resolveWithPlugins(new Set()))).toEqual([
+      "terminal",
+      "settings",
+    ]);
 
-    expect(ordered).toEqual(["claude", "terminal", "my-plugin.action"]);
+    // Flagging `terminal` as a live contribution demotes it to utilities, where
+    // it shares a group with `settings` and the input order stands. The same
+    // ids, a different result — so the membership argument genuinely reaches
+    // the ordering and the plugin branch can't be dropped.
+    expect(orderToolbarButtonsByGroup(ids, resolveWithPlugins(new Set(["terminal"])))).toEqual([
+      "settings",
+      "terminal",
+    ]);
   });
 });
 

--- a/src/components/Layout/__tests__/toolbarButtonGrouping.test.ts
+++ b/src/components/Layout/__tests__/toolbarButtonGrouping.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from "vitest";
+import type { AnyToolbarButtonId } from "@shared/types/toolbar";
+import {
+  getGroupedInsertionIndex,
+  getToolbarDividerAfterIds,
+  orderToolbarButtonsByGroup,
+  type ResolveToolbarButtonGroup,
+} from "../toolbarButtonGrouping";
+import { getToolbarButtonGroup } from "../toolbarButtonMetadata";
+
+// The real resolver, with nothing registered as a plugin contribution. Tests
+// that care about plugin classification pass their own membership set.
+const resolve: ResolveToolbarButtonGroup = (id) => getToolbarButtonGroup(id);
+
+const resolveWithPlugins =
+  (pluginIds: Set<string>): ResolveToolbarButtonGroup =>
+  (id) =>
+    getToolbarButtonGroup(id, pluginIds.has(id));
+
+const visibleOnly =
+  (visible: AnyToolbarButtonId[]) =>
+  (id: AnyToolbarButtonId): boolean =>
+    visible.includes(id);
+
+describe("orderToolbarButtonsByGroup", () => {
+  it("moves an interleaved layout into launcher, agents, panels, utilities order", () => {
+    const ordered = orderToolbarButtonsByGroup(
+      ["terminal", "claude", "launcher", "settings", "file-browser", "codex"],
+      resolve
+    );
+
+    expect(ordered).toEqual([
+      "launcher",
+      "claude",
+      "codex",
+      "terminal",
+      "file-browser",
+      "settings",
+    ]);
+  });
+
+  it("preserves the user's relative order inside each group", () => {
+    const ordered = orderToolbarButtonsByGroup(
+      ["codex", "terminal", "claude", "file-browser"],
+      resolve
+    );
+
+    // codex before claude, terminal before file-browser — as the user had them.
+    expect(ordered).toEqual(["codex", "claude", "terminal", "file-browser"]);
+  });
+
+  it("keeps every input id exactly once", () => {
+    const input: AnyToolbarButtonId[] = ["settings", "claude", "browser", "launcher", "dev-server"];
+
+    const ordered = orderToolbarButtonsByGroup(input, resolve);
+
+    expect([...ordered].sort()).toEqual([...input].sort());
+  });
+
+  it("is idempotent — regrouping an already grouped list changes nothing", () => {
+    const once = orderToolbarButtonsByGroup(["terminal", "claude", "launcher"], resolve);
+
+    expect(orderToolbarButtonsByGroup(once, resolve)).toEqual(once);
+  });
+
+  it("returns an empty list unchanged", () => {
+    expect(orderToolbarButtonsByGroup([], resolve)).toEqual([]);
+  });
+
+  it("sorts plugin contributions into the trailing utilities group", () => {
+    const ordered = orderToolbarButtonsByGroup(
+      ["my-plugin.action", "terminal", "claude"],
+      resolveWithPlugins(new Set(["my-plugin.action"]))
+    );
+
+    expect(ordered).toEqual(["claude", "terminal", "my-plugin.action"]);
+  });
+});
+
+describe("getToolbarDividerAfterIds", () => {
+  it("marks the last visible member of each group but never the final one", () => {
+    const ordered: AnyToolbarButtonId[] = ["launcher", "claude", "codex", "terminal", "settings"];
+
+    const dividerAfter = getToolbarDividerAfterIds(ordered, () => true, resolve);
+
+    // launcher│agents│panels│utilities — three boundaries, no trailing divider.
+    expect([...dividerAfter]).toEqual(["launcher", "codex", "terminal"]);
+  });
+
+  it("draws nothing when every visible button shares one group", () => {
+    const dividerAfter = getToolbarDividerAfterIds(
+      ["claude", "codex", "gemini"],
+      () => true,
+      resolve
+    );
+
+    expect(dividerAfter.size).toBe(0);
+  });
+
+  it("moves the divider to the last still-visible member when one overflows", () => {
+    const ordered: AnyToolbarButtonId[] = ["launcher", "claude", "codex", "terminal"];
+
+    // codex was evicted into the overflow menu.
+    const dividerAfter = getToolbarDividerAfterIds(
+      ordered,
+      visibleOnly(["launcher", "claude", "terminal"]),
+      resolve
+    );
+
+    expect(dividerAfter.has("claude")).toBe(true);
+    expect(dividerAfter.has("codex")).toBe(false);
+  });
+
+  it("collapses to one divider when an entire middle group overflows", () => {
+    const ordered: AnyToolbarButtonId[] = ["launcher", "claude", "codex", "terminal"];
+
+    const dividerAfter = getToolbarDividerAfterIds(
+      ordered,
+      visibleOnly(["launcher", "terminal"]),
+      resolve
+    );
+
+    expect([...dividerAfter]).toEqual(["launcher"]);
+  });
+
+  it("draws no divider when only one button is visible", () => {
+    const dividerAfter = getToolbarDividerAfterIds(
+      ["launcher", "claude", "terminal"],
+      visibleOnly(["claude"]),
+      resolve
+    );
+
+    expect(dividerAfter.size).toBe(0);
+  });
+
+  it("draws no divider when nothing is visible", () => {
+    const dividerAfter = getToolbarDividerAfterIds(
+      ["launcher", "claude", "terminal"],
+      () => false,
+      resolve
+    );
+
+    expect(dividerAfter.size).toBe(0);
+  });
+
+  it("never marks a hidden button, so an evicted id cannot strand a divider", () => {
+    const ordered: AnyToolbarButtonId[] = ["launcher", "claude", "terminal"];
+
+    const dividerAfter = getToolbarDividerAfterIds(
+      ordered,
+      visibleOnly(["launcher", "claude"]),
+      resolve
+    );
+
+    expect(dividerAfter.has("terminal")).toBe(false);
+    // agents is now the trailing visible group, so its boundary disappears too.
+    expect([...dividerAfter]).toEqual(["launcher"]);
+  });
+});
+
+describe("getGroupedInsertionIndex", () => {
+  it("anchors after the preceding same-group peer in the stored array", () => {
+    // Stored order is interleaved; the projection the user saw is grouped.
+    const raw: AnyToolbarButtonId[] = ["terminal", "claude", "file-browser"];
+    const projected: AnyToolbarButtonId[] = ["claude", "codex", "terminal", "file-browser"];
+
+    const index = getGroupedInsertionIndex(raw, projected, "codex", resolve);
+
+    // Straight after `claude` in the raw array, so grouping yields claude→codex.
+    expect(index).toBe(2);
+    const spliced = [...raw];
+    spliced.splice(index, 0, "codex");
+    expect(orderToolbarButtonsByGroup(spliced, resolve)).toEqual(projected);
+  });
+
+  it("anchors before the following peer when the button was dropped first in its group", () => {
+    const raw: AnyToolbarButtonId[] = ["terminal", "claude"];
+    const projected: AnyToolbarButtonId[] = ["codex", "claude", "terminal"];
+
+    const index = getGroupedInsertionIndex(raw, projected, "codex", resolve);
+
+    expect(index).toBe(1);
+    const spliced = [...raw];
+    spliced.splice(index, 0, "codex");
+    expect(orderToolbarButtonsByGroup(spliced, resolve)).toEqual(projected);
+  });
+
+  it("appends when the button has no peers in its group", () => {
+    const raw: AnyToolbarButtonId[] = ["claude", "codex"];
+    const projected: AnyToolbarButtonId[] = ["claude", "codex", "terminal"];
+
+    expect(getGroupedInsertionIndex(raw, projected, "terminal", resolve)).toBe(raw.length);
+  });
+
+  it("round-trips the drop position through a legacy interleaved array", () => {
+    const raw: AnyToolbarButtonId[] = ["terminal", "claude", "settings", "codex"];
+    // The user dropped `gemini` between claude and codex in the grouped column.
+    const projected: AnyToolbarButtonId[] = ["claude", "gemini", "codex", "terminal", "settings"];
+
+    const index = getGroupedInsertionIndex(raw, projected, "gemini", resolve);
+    const spliced = [...raw];
+    spliced.splice(index, 0, "gemini");
+
+    expect(orderToolbarButtonsByGroup(spliced, resolve)).toEqual(projected);
+  });
+});

--- a/src/components/Layout/__tests__/toolbarButtonMetadata.test.ts
+++ b/src/components/Layout/__tests__/toolbarButtonMetadata.test.ts
@@ -1,8 +1,17 @@
 // @vitest-environment jsdom
 import { describe, it, expect } from "vitest";
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
-import { TOOLBAR_BUTTON_METADATA, isToolbarButtonVisible } from "../toolbarButtonMetadata";
-import { TOOLBAR_BUTTON_PRIORITIES, type AnyToolbarButtonId } from "@shared/types/toolbar";
+import {
+  TOOLBAR_BUTTON_GROUP_ORDER,
+  TOOLBAR_BUTTON_METADATA,
+  getToolbarButtonGroup,
+  isToolbarButtonVisible,
+} from "../toolbarButtonMetadata";
+import {
+  LAUNCHER_PANEL_BUTTON_IDS,
+  TOOLBAR_BUTTON_PRIORITIES,
+  type AnyToolbarButtonId,
+} from "@shared/types/toolbar";
 
 // IDs that intentionally have no entry in TOOLBAR_BUTTON_METADATA. The fixed
 // titlebar buttons (sidebar-toggle, assistant-toggle, portal-toggle) are
@@ -136,5 +145,50 @@ describe("isToolbarButtonVisible", () => {
         { "daintree-assistant": "ready" } as never
       )
     ).toBe(false);
+  });
+});
+
+describe("getToolbarButtonGroup (#11681)", () => {
+  it("puts every built-in agent in the agents group", () => {
+    for (const id of BUILT_IN_AGENT_IDS) {
+      expect(getToolbarButtonGroup(id as AnyToolbarButtonId)).toBe("agents");
+    }
+  });
+
+  it("classifies the launcher and every launcher panel button", () => {
+    expect(getToolbarButtonGroup("launcher")).toBe("launcher");
+    // Read off the launcher's own list rather than a copy, so a panel button
+    // added there can't silently fall through to `utilities`.
+    for (const id of LAUNCHER_PANEL_BUTTON_IDS) {
+      expect(getToolbarButtonGroup(id)).toBe("panels");
+    }
+  });
+
+  it("trails unclassified built-ins into utilities rather than calling them panels", () => {
+    for (const id of ["plugin-tray", "settings", "notification-center", "copy-tree"] as const) {
+      expect(getToolbarButtonGroup(id)).toBe("utilities");
+    }
+  });
+
+  it("routes a registered plugin contribution to utilities by registry membership", () => {
+    const pluginId = "my-plugin.action" as AnyToolbarButtonId;
+    expect(getToolbarButtonGroup(pluginId, true)).toBe("utilities");
+    // Agent classification wins over the plugin flag — a contribution can't
+    // impersonate an agent by claiming an agent id.
+    expect(getToolbarButtonGroup(BUILT_IN_AGENT_IDS[0] as AnyToolbarButtonId, true)).toBe("agents");
+  });
+
+  it("does not inherit a group from Object.prototype for a prototype-shaped id", () => {
+    // The lookup is a Map, so these resolve to the fallback instead of picking
+    // up an inherited member.
+    for (const id of ["constructor", "__proto__", "toString"] as unknown as AnyToolbarButtonId[]) {
+      expect(getToolbarButtonGroup(id)).toBe("utilities");
+    }
+  });
+
+  it("declares a group for every id the metadata registry knows", () => {
+    for (const id of Object.keys(TOOLBAR_BUTTON_METADATA) as AnyToolbarButtonId[]) {
+      expect(TOOLBAR_BUTTON_GROUP_ORDER).toContain(getToolbarButtonGroup(id));
+    }
   });
 });

--- a/src/components/Layout/__tests__/toolbarButtonMetadata.test.ts
+++ b/src/components/Layout/__tests__/toolbarButtonMetadata.test.ts
@@ -7,11 +7,7 @@ import {
   getToolbarButtonGroup,
   isToolbarButtonVisible,
 } from "../toolbarButtonMetadata";
-import {
-  LAUNCHER_PANEL_BUTTON_IDS,
-  TOOLBAR_BUTTON_PRIORITIES,
-  type AnyToolbarButtonId,
-} from "@shared/types/toolbar";
+import { TOOLBAR_BUTTON_PRIORITIES, type AnyToolbarButtonId } from "@shared/types/toolbar";
 
 // IDs that intentionally have no entry in TOOLBAR_BUTTON_METADATA. The fixed
 // titlebar buttons (sidebar-toggle, assistant-toggle, portal-toggle) are
@@ -155,27 +151,25 @@ describe("getToolbarButtonGroup (#11681)", () => {
     }
   });
 
-  it("classifies the launcher and every launcher panel button", () => {
-    expect(getToolbarButtonGroup("launcher")).toBe("launcher");
-    // Read off the launcher's own list rather than a copy, so a panel button
-    // added there can't silently fall through to `utilities`.
-    for (const id of LAUNCHER_PANEL_BUTTON_IDS) {
-      expect(getToolbarButtonGroup(id)).toBe("panels");
-    }
+  it("falls back rather than throwing on an id it has never heard of", () => {
+    expect(getToolbarButtonGroup("not-a-real-button" as AnyToolbarButtonId)).toBe("utilities");
   });
 
-  it("trails unclassified built-ins into utilities rather than calling them panels", () => {
-    for (const id of ["plugin-tray", "settings", "notification-center", "copy-tree"] as const) {
-      expect(getToolbarButtonGroup(id)).toBe("utilities");
-    }
+  it("lets the plugin flag override a declared built-in group", () => {
+    // The same id resolves differently depending on whether the caller says it
+    // is a live contribution — so the `isPluginContribution` branch is load
+    // bearing and can't be dropped without this failing. A plugin that shadows
+    // a built-in id must not inherit that built-in's placement.
+    const declared = getToolbarButtonGroup("terminal");
+    expect(getToolbarButtonGroup("terminal", true)).not.toBe(declared);
+    expect(getToolbarButtonGroup("terminal", true)).toBe("utilities");
   });
 
-  it("routes a registered plugin contribution to utilities by registry membership", () => {
-    const pluginId = "my-plugin.action" as AnyToolbarButtonId;
-    expect(getToolbarButtonGroup(pluginId, true)).toBe("utilities");
-    // Agent classification wins over the plugin flag — a contribution can't
-    // impersonate an agent by claiming an agent id.
-    expect(getToolbarButtonGroup(BUILT_IN_AGENT_IDS[0] as AnyToolbarButtonId, true)).toBe("agents");
+  it("classifies an agent id as an agent even when flagged as a contribution", () => {
+    // Agent dispatch runs first, so a contribution can't impersonate an agent
+    // by claiming an agent id.
+    const agentId = BUILT_IN_AGENT_IDS[0] as AnyToolbarButtonId;
+    expect(getToolbarButtonGroup(agentId, true)).toBe(getToolbarButtonGroup(agentId));
   });
 
   it("does not inherit a group from Object.prototype for a prototype-shaped id", () => {
@@ -186,9 +180,17 @@ describe("getToolbarButtonGroup (#11681)", () => {
     }
   });
 
-  it("declares a group for every id the metadata registry knows", () => {
-    for (const id of Object.keys(TOOLBAR_BUTTON_METADATA) as AnyToolbarButtonId[]) {
-      expect(TOOLBAR_BUTTON_GROUP_ORDER).toContain(getToolbarButtonGroup(id));
+  it("orders every declared group, so no button can resolve to an unplaced one", () => {
+    // Guards the coupling between the resolver and the order array: a group
+    // added to one but not the other would silently render out of sequence.
+    const declared = new Set(
+      (Object.keys(TOOLBAR_BUTTON_METADATA) as AnyToolbarButtonId[]).map((id) =>
+        getToolbarButtonGroup(id)
+      )
+    );
+    expect(declared.size).toBeGreaterThan(1);
+    for (const group of declared) {
+      expect(TOOLBAR_BUTTON_GROUP_ORDER.indexOf(group)).toBeGreaterThanOrEqual(0);
     }
   });
 });

--- a/src/components/Layout/toolbarButtonGrouping.ts
+++ b/src/components/Layout/toolbarButtonGrouping.ts
@@ -64,9 +64,19 @@ export function getToolbarDividerAfterIds(
  * Settings shows the grouped projection but `moveButton` splices into the
  * stored array, so a projected index can't be passed through directly. Only the
  * order relative to the button's own group peers survives grouping, so anchor
- * on those: after the preceding peer when there is one, otherwise before the
- * following peer. With no peers at all the position is unobservable once
+ * on those: after the nearest preceding peer, otherwise before the nearest
+ * following one. With no peers at all the position is unobservable once
  * grouped, so appending is as correct as anything else.
+ *
+ * Each direction keeps scanning outward past peers the stored array no longer
+ * holds. The projection is a snapshot taken at drag start while the stored
+ * array is read at drop, and the two can diverge mid-drag — the side arrays
+ * reconcile last-writer-wins across project views, so a sibling view's write
+ * can drop a peer underneath an open drag.
+ *
+ * Assumes `activeId` is absent from `rawTargetIds` (it is — this only runs for
+ * a cross-side move) and that neither list repeats an id (the store sanitizes
+ * on every write, and the render boundary dedupes again).
  */
 export function getGroupedInsertionIndex(
   rawTargetIds: readonly AnyToolbarButtonId[],
@@ -75,18 +85,18 @@ export function getGroupedInsertionIndex(
   resolveGroup: ResolveToolbarButtonGroup
 ): number {
   const group = resolveGroup(activeId);
-  const peers = projectedTargetIds.filter((id) => id !== activeId && resolveGroup(id) === group);
   const droppedAt = projectedTargetIds.indexOf(activeId);
+  const peers = projectedTargetIds.filter((id) => id !== activeId && resolveGroup(id) === group);
 
-  const previousPeer = peers.filter((id) => projectedTargetIds.indexOf(id) < droppedAt).pop();
-  if (previousPeer !== undefined) {
-    const at = rawTargetIds.indexOf(previousPeer);
+  const preceding = peers.filter((id) => projectedTargetIds.indexOf(id) < droppedAt);
+  for (let i = preceding.length - 1; i >= 0; i--) {
+    const at = rawTargetIds.indexOf(preceding[i]!);
     if (at !== -1) return at + 1;
   }
 
-  const nextPeer = peers.find((id) => projectedTargetIds.indexOf(id) > droppedAt);
-  if (nextPeer !== undefined) {
-    const at = rawTargetIds.indexOf(nextPeer);
+  const following = peers.filter((id) => projectedTargetIds.indexOf(id) > droppedAt);
+  for (const peer of following) {
+    const at = rawTargetIds.indexOf(peer);
     if (at !== -1) return at;
   }
 

--- a/src/components/Layout/toolbarButtonGrouping.ts
+++ b/src/components/Layout/toolbarButtonGrouping.ts
@@ -1,0 +1,94 @@
+import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
+import { TOOLBAR_BUTTON_GROUP_ORDER, type ToolbarButtonGroup } from "./toolbarButtonMetadata";
+
+/**
+ * Resolves a button's declared group. Callers bind the plugin-registry lookup
+ * so this module stays pure and directly unit-testable — `Toolbar.tsx` has too
+ * many IPC dependencies to render in jsdom, so the divider algorithm can only
+ * be covered for real if it lives outside the component.
+ */
+export type ResolveToolbarButtonGroup = (id: AnyToolbarButtonId) => ToolbarButtonGroup;
+
+/**
+ * Stable-partition button ids into `TOOLBAR_BUTTON_GROUP_ORDER`, preserving the
+ * user's relative order inside each group (#11681).
+ *
+ * The persisted side arrays let a user interleave groups freely. Grouping at
+ * render rather than rewriting what is stored keeps the fix working for every
+ * existing profile — including one a stale cross-view write re-interleaves —
+ * without a migration and without teaching the store what a group is.
+ */
+export function orderToolbarButtonsByGroup(
+  ids: readonly AnyToolbarButtonId[],
+  resolveGroup: ResolveToolbarButtonGroup
+): AnyToolbarButtonId[] {
+  const buckets = new Map<ToolbarButtonGroup, AnyToolbarButtonId[]>(
+    TOOLBAR_BUTTON_GROUP_ORDER.map((group) => [group, []])
+  );
+  for (const id of ids) {
+    buckets.get(resolveGroup(id))!.push(id);
+  }
+  return TOOLBAR_BUTTON_GROUP_ORDER.flatMap((group) => buckets.get(group)!);
+}
+
+/**
+ * Ids that a divider follows, given already-grouped ids and which of them are
+ * visible.
+ *
+ * Only visible buttons count: an overflow-evicted button stays mounted for
+ * measurement but must not leave a divider behind, and when a whole group
+ * overflows the boundary collapses to a single divider between the groups that
+ * remain. Walking the visible subsequence handles both — and, because the input
+ * is grouped, its adjacent pairs differ exactly at the real group boundaries.
+ * Never emits a trailing divider.
+ */
+export function getToolbarDividerAfterIds(
+  orderedIds: readonly AnyToolbarButtonId[],
+  isVisible: (id: AnyToolbarButtonId) => boolean,
+  resolveGroup: ResolveToolbarButtonGroup
+): Set<AnyToolbarButtonId> {
+  const visible = orderedIds.filter(isVisible);
+  const dividerAfter = new Set<AnyToolbarButtonId>();
+  for (let i = 0; i < visible.length - 1; i++) {
+    if (resolveGroup(visible[i]!) !== resolveGroup(visible[i + 1]!)) {
+      dividerAfter.add(visible[i]!);
+    }
+  }
+  return dividerAfter;
+}
+
+/**
+ * Where to splice `activeId` into a raw (possibly interleaved) side array so
+ * that grouping the result reproduces the position the user dropped it at.
+ *
+ * Settings shows the grouped projection but `moveButton` splices into the
+ * stored array, so a projected index can't be passed through directly. Only the
+ * order relative to the button's own group peers survives grouping, so anchor
+ * on those: after the preceding peer when there is one, otherwise before the
+ * following peer. With no peers at all the position is unobservable once
+ * grouped, so appending is as correct as anything else.
+ */
+export function getGroupedInsertionIndex(
+  rawTargetIds: readonly AnyToolbarButtonId[],
+  projectedTargetIds: readonly AnyToolbarButtonId[],
+  activeId: AnyToolbarButtonId,
+  resolveGroup: ResolveToolbarButtonGroup
+): number {
+  const group = resolveGroup(activeId);
+  const peers = projectedTargetIds.filter((id) => id !== activeId && resolveGroup(id) === group);
+  const droppedAt = projectedTargetIds.indexOf(activeId);
+
+  const previousPeer = peers.filter((id) => projectedTargetIds.indexOf(id) < droppedAt).pop();
+  if (previousPeer !== undefined) {
+    const at = rawTargetIds.indexOf(previousPeer);
+    if (at !== -1) return at + 1;
+  }
+
+  const nextPeer = peers.find((id) => projectedTargetIds.indexOf(id) > droppedAt);
+  if (nextPeer !== undefined) {
+    const at = rawTargetIds.indexOf(nextPeer);
+    if (at !== -1) return at;
+  }
+
+  return rawTargetIds.length;
+}

--- a/src/components/Layout/toolbarButtonMetadata.ts
+++ b/src/components/Layout/toolbarButtonMetadata.ts
@@ -126,6 +126,63 @@ export const TOOLBAR_BUTTON_METADATA: Partial<Record<AnyToolbarButtonId, Toolbar
 };
 
 /**
+ * Left-toolbar groups, in the order they render (#11681).
+ *
+ * A divider is drawn wherever the group changes, so this array is the single
+ * source of both the ordering and the separator positions. It replaces the
+ * old `AGENT_TOOLBAR_IDS` predicate, which described an agent/non-agent flip
+ * rather than a group: once a user reordered the toolbar, that flip landed
+ * dividers in arbitrary positions and could split the agent brand marks.
+ *
+ * `utilities` trails deliberately. Any built-in a user drags onto the left
+ * side — settings, notifications, copy-tree — plus every plugin contribution
+ * lands there, and calling those "panels" would be a lie. On a normal layout
+ * the group is empty and the row reads `[launcher] │ [agents] │ [panels]`.
+ */
+export const TOOLBAR_BUTTON_GROUP_ORDER = ["launcher", "agents", "panels", "utilities"] as const;
+
+export type ToolbarButtonGroup = (typeof TOOLBAR_BUTTON_GROUP_ORDER)[number];
+
+/**
+ * A `Map`, not an object literal, because `getToolbarButtonGroup` looks up ids
+ * that include plugin contributions — bracket-indexing a plain object with a
+ * key the registry supplies would inherit `Object.prototype` members.
+ */
+const BUILT_IN_TOOLBAR_GROUPS: ReadonlyMap<AnyToolbarButtonId, ToolbarButtonGroup> = new Map<
+  AnyToolbarButtonId,
+  ToolbarButtonGroup
+>([
+  ["launcher", "launcher"],
+  ["terminal", "panels"],
+  ["file-browser", "panels"],
+  ["browser", "panels"],
+  ["dev-server", "panels"],
+]);
+
+/**
+ * Canonical resolver for which left-toolbar group a button belongs to (#11681).
+ *
+ * Declared data, never derived from position: the group is a pure function of
+ * the id and must stay that way. It is deliberately absent from `ToolbarLayout`
+ * and `ToolbarPinnedState` — the side arrays reconcile last-writer-wins across
+ * project views, so making array position carry meaning beyond display order
+ * reopens the data loss #11667/#11671 had to unpick.
+ *
+ * Dispatch order mirrors `isToolbarButtonVisible` below: agent ids first,
+ * registered plugin contributions second (registry membership is the
+ * discriminator, never string-parsing the dotted id), then the built-in table,
+ * and finally the trailing `utilities` fallback for anything unclassified.
+ */
+export function getToolbarButtonGroup(
+  buttonId: AnyToolbarButtonId,
+  isPluginContribution = false
+): ToolbarButtonGroup {
+  if (isBuiltInAgentId(buttonId)) return "agents";
+  if (isPluginContribution) return "utilities";
+  return BUILT_IN_TOOLBAR_GROUPS.get(buttonId) ?? "utilities";
+}
+
+/**
  * Canonical resolver for whether a button gets its own top-level toolbar slot.
  * Both `Toolbar.tsx` and `ToolbarSettingsTab.tsx` consume this so they can
  * never disagree (#7666).

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -45,9 +45,14 @@ import { LAUNCHABLE_AGENT_IDS, isBuiltInAgentId } from "@shared/config/agentIds"
 import { isAgentButtonOnToolbar } from "../../../shared/utils/agentPinned";
 import {
   TOOLBAR_BUTTON_METADATA,
+  getToolbarButtonGroup,
   isToolbarButtonVisible,
   type ToolbarButtonMetadata,
 } from "@/components/Layout/toolbarButtonMetadata";
+import {
+  getGroupedInsertionIndex,
+  orderToolbarButtonsByGroup,
+} from "@/components/Layout/toolbarButtonGrouping";
 import { getAgentConfig } from "@/config/agents";
 import { usePluginToolbarButtons } from "@/hooks/usePluginToolbarButtons";
 import { DEFAULT_PLUGIN_ICON } from "@/components/icons/pluginIconRegistry";
@@ -323,7 +328,6 @@ export function ToolbarSettingsTab() {
   const [dragState, setDragState] = useState<SideLists | null>(null);
   const [activeId, setActiveId] = useState<AnyToolbarButtonId | null>(null);
 
-  const liveLeft = dragState?.left ?? layout.leftButtons;
   const liveRight = dragState?.right ?? layout.rightButtons;
 
   const sensors = useSensors(
@@ -334,6 +338,22 @@ export function ToolbarSettingsTab() {
   );
 
   const { buttonIds: pluginButtonIds, configs: pluginConfigs } = usePluginToolbarButtons();
+
+  const resolveGroup = useCallback(
+    (id: AnyToolbarButtonId) => getToolbarButtonGroup(id, pluginConfigs.has(id)),
+    [pluginConfigs]
+  );
+
+  // The left toolbar renders its buttons grouped (#11681), so this column has
+  // to show the same order — otherwise it would invite the user to arrange a
+  // row the toolbar will never draw. The right side has no groups and stays in
+  // persisted order.
+  const groupedLeft = useMemo(
+    () => orderToolbarButtonsByGroup(layout.leftButtons, resolveGroup),
+    [layout.leftButtons, resolveGroup]
+  );
+
+  const liveLeft = dragState?.left ?? groupedLeft;
 
   const allMetadata = useMemo(
     () =>
@@ -410,7 +430,7 @@ export function ToolbarSettingsTab() {
 
   const handleDragStart = (event: DragStartEvent) => {
     setActiveId(toButtonId(event.active.id));
-    setDragState({ left: layout.leftButtons, right: layout.rightButtons });
+    setDragState({ left: groupedLeft, right: layout.rightButtons });
   };
 
   // Speculatively relocate the dragged button across columns so the target's
@@ -422,7 +442,7 @@ export function ToolbarSettingsTab() {
     const activeButtonId = toButtonId(active.id);
 
     setDragState((prev) => {
-      const base = prev ?? { left: layout.leftButtons, right: layout.rightButtons };
+      const base = prev ?? { left: groupedLeft, right: layout.rightButtons };
       const activeContainer = findContainer(active.id, base);
       const overContainer = findContainer(over.id, base);
       if (!activeContainer || !overContainer || activeContainer === overContainer) {
@@ -442,14 +462,22 @@ export function ToolbarSettingsTab() {
         newIndex = overIndex >= 0 ? overIndex + (isAfterOver ? 1 : 0) : overItems.length;
       }
 
+      const relocated = [
+        ...overItems.slice(0, newIndex),
+        activeButtonId,
+        ...overItems.slice(newIndex),
+      ];
+
       return {
         ...base,
         [activeContainer]: base[activeContainer].filter((id) => id !== activeButtonId),
-        [overContainer]: [
-          ...overItems.slice(0, newIndex),
-          activeButtonId,
-          ...overItems.slice(newIndex),
-        ],
+        // Regroup the left column live so the gap opens where the button will
+        // actually land — dropping a panel among the agents snaps it into the
+        // panel block during the drag rather than jumping after the release.
+        [overContainer]:
+          overContainer === "left"
+            ? orderToolbarButtonsByGroup(relocated, resolveGroup)
+            : relocated,
       };
     });
   };
@@ -468,7 +496,7 @@ export function ToolbarSettingsTab() {
       return;
     }
 
-    const live = dragState ?? { left: layout.leftButtons, right: layout.rightButtons };
+    const live = dragState ?? { left: groupedLeft, right: layout.rightButtons };
     const overContainer = findContainer(over.id, live);
     const originalContainer: ToolbarSide | null = layout.leftButtons.includes(activeButtonId)
       ? "left"
@@ -495,7 +523,13 @@ export function ToolbarSettingsTab() {
       }
       const reordered = arrayMove(items, oldIndex, newIndex);
       if (overContainer === "left") {
-        setLeftButtons(reordered);
+        // Regroup before writing: a drag across a group boundary snaps back
+        // into the button's own group, and a drop that only crossed a boundary
+        // therefore changes nothing — skip the write rather than churn persist.
+        const grouped = orderToolbarButtonsByGroup(reordered, resolveGroup);
+        if (grouped.some((id, i) => id !== groupedLeft[i])) {
+          setLeftButtons(grouped);
+        }
       } else {
         setRightButtons(reordered);
       }
@@ -503,11 +537,17 @@ export function ToolbarSettingsTab() {
       // Cross-side move — `onDragOver` already relocated the item into the
       // target list at its drop position, so its index in `dragState` IS the
       // final target index. Re-running `arrayMove` here would invert it.
-      const toIndex = live[overContainer].indexOf(activeButtonId);
-      if (toIndex === -1) {
+      if (live[overContainer].indexOf(activeButtonId) === -1) {
         clearDrag();
         return;
       }
+      // `moveButton` splices into the stored array, which may still be
+      // interleaved, so a grouped index can't be handed over directly —
+      // translate it into one that survives grouping (#11681).
+      const toIndex =
+        overContainer === "left"
+          ? getGroupedInsertionIndex(layout.leftButtons, live.left, activeButtonId, resolveGroup)
+          : live[overContainer].indexOf(activeButtonId);
       moveButton(activeButtonId, originalContainer, overContainer, toIndex);
     }
 
@@ -565,7 +605,7 @@ export function ToolbarSettingsTab() {
       <SettingsSection
         icon={LayoutGrid}
         title="Toolbar buttons"
-        description="Drag to reorder within a side or move a button between the left and right groups. Toggle to show or hide."
+        description="Drag to reorder within a side or move a button between the left and right groups. Left-side buttons stay grouped as launcher, agents, then panels, so dragging one across a boundary snaps it back into its own group. Toggle to show or hide."
       >
         <DndContext
           sensors={sensors}

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -527,7 +527,9 @@ export function ToolbarSettingsTab() {
         // into the button's own group, and a drop that only crossed a boundary
         // therefore changes nothing — skip the write rather than churn persist.
         const grouped = orderToolbarButtonsByGroup(reordered, resolveGroup);
-        if (grouped.some((id, i) => id !== groupedLeft[i])) {
+        const unchanged =
+          grouped.length === groupedLeft.length && grouped.every((id, i) => id === groupedLeft[i]);
+        if (!unchanged) {
           setLeftButtons(grouped);
         }
       } else {
@@ -605,7 +607,7 @@ export function ToolbarSettingsTab() {
       <SettingsSection
         icon={LayoutGrid}
         title="Toolbar buttons"
-        description="Drag to reorder within a side or move a button between the left and right groups. Left-side buttons stay grouped as launcher, agents, then panels, so dragging one across a boundary snaps it back into its own group. Toggle to show or hide."
+        description="Drag to reorder within a side or move a button between the left and right groups. Left-side buttons stay grouped as launcher, agents, panels, then everything else, so dragging one across a boundary snaps it back into its own group. Toggle to show or hide."
       >
         <DndContext
           sensors={sensors}

--- a/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
@@ -437,8 +437,13 @@ describe("ToolbarSettingsTab — drag reordering and cross-side moves", () => {
   });
 
   function fire(name: string, event: unknown) {
+    // Assert the handler exists before invoking it: optional chaining would
+    // silently no-op if the component stopped wiring it, quietly turning every
+    // negative assertion below into a test that proves nothing.
+    const handler = dnd.props?.[name];
+    expect(typeof handler).toBe("function");
     act(() => {
-      dnd.props?.[name]?.(event);
+      handler!(event);
     });
   }
 
@@ -484,7 +489,42 @@ describe("ToolbarSettingsTab — drag reordering and cross-side moves", () => {
     fire("onDragEnd", { active: { id: "launcher" }, over: { id: "terminal" } });
 
     expect(setLeftButtonsMock).not.toHaveBeenCalled();
+    expect(setRightButtonsMock).not.toHaveBeenCalled();
     expect(moveButtonMock).not.toHaveBeenCalled();
+  });
+
+  it("regroups the left column live during a cross-side drag", () => {
+    mockToolbarState = makeToolbarState({
+      leftButtons: ["launcher", "claude", "gemini"],
+      rightButtons: ["terminal"],
+      pinnedButtons: {},
+    });
+
+    const { container } = render(<ToolbarSettingsTab />);
+
+    // Drop the panel into the middle of the agent block. The preview must show
+    // it after the agents, not where the pointer is — otherwise the gap opens
+    // somewhere the button will never land.
+    fire("onDragStart", { active: { id: "terminal" } });
+    fire("onDragOver", {
+      active: { id: "terminal", rect: { current: { translated: { right: 0 } } } },
+      over: { id: "gemini", rect: { left: 0, width: 100 } },
+    });
+
+    const order = Array.from(container.querySelectorAll('[role="switch"]'))
+      .map((el) => el.getAttribute("aria-label"))
+      .filter((label) => label?.startsWith("Toggle "))
+      // The DragOverlay renders its own card for the button under the cursor,
+      // always last and only while a drag is in flight. The right column is
+      // empty at this point, so what remains is the left column.
+      .slice(0, -1);
+
+    expect(order).toEqual([
+      "Toggle Launcher visibility",
+      "Toggle Claude agent visibility",
+      "Toggle Gemini agent visibility",
+      "Toggle Terminal visibility",
+    ]);
   });
 
   it("translates a right-to-left drop into an index that survives grouping", () => {

--- a/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
@@ -445,12 +445,71 @@ describe("ToolbarSettingsTab — drag reordering and cross-side moves", () => {
   it("commits a same-side reorder via setLeftButtons (not moveButton)", () => {
     render(<ToolbarSettingsTab />);
 
-    // Drag "launcher" (index 0) onto "terminal" (index 3) within the left side.
-    fire("onDragEnd", { active: { id: "launcher" }, over: { id: "terminal" } });
+    // Drag "claude" onto "gemini" — both agents, so the reorder is legal.
+    fire("onDragEnd", { active: { id: "claude" }, over: { id: "gemini" } });
 
     expect(setLeftButtonsMock).toHaveBeenCalledTimes(1);
-    expect(setLeftButtonsMock).toHaveBeenCalledWith(["claude", "gemini", "terminal", "launcher"]);
+    expect(setLeftButtonsMock).toHaveBeenCalledWith(["launcher", "gemini", "claude", "terminal"]);
     expect(moveButtonMock).not.toHaveBeenCalled();
+  });
+
+  // #11681
+  it("shows the left column in canonical group order for a legacy interleaved array", () => {
+    mockToolbarState = makeToolbarState({
+      leftButtons: ["terminal", "claude", "launcher", "gemini"],
+      rightButtons: [],
+      pinnedButtons: {},
+    });
+
+    const { container } = render(<ToolbarSettingsTab />);
+    // Only the side-column switches — the panel section below renders its own
+    // "Show … in toolbar" switches regardless of array membership.
+    const order = Array.from(container.querySelectorAll('[role="switch"]'))
+      .map((el) => el.getAttribute("aria-label"))
+      .filter((label) => label?.startsWith("Toggle "));
+
+    expect(order).toEqual([
+      "Toggle Launcher visibility",
+      "Toggle Claude agent visibility",
+      "Toggle Gemini agent visibility",
+      "Toggle Terminal visibility",
+    ]);
+  });
+
+  it("snaps a cross-group drag back into its own group, writing nothing", () => {
+    render(<ToolbarSettingsTab />);
+
+    // Drag the launcher past the agents onto "terminal". Grouping puts it back
+    // at the head, so the effective order is unchanged and no write is needed.
+    fire("onDragEnd", { active: { id: "launcher" }, over: { id: "terminal" } });
+
+    expect(setLeftButtonsMock).not.toHaveBeenCalled();
+    expect(moveButtonMock).not.toHaveBeenCalled();
+  });
+
+  it("translates a right-to-left drop into an index that survives grouping", () => {
+    mockToolbarState = makeToolbarState({
+      // Stored interleaved: the panel sits ahead of the agent.
+      leftButtons: ["terminal", "claude"],
+      rightButtons: ["codex"],
+      pinnedButtons: {},
+    });
+
+    render(<ToolbarSettingsTab />);
+
+    // The column shows ["claude", "terminal"]; drop codex onto terminal's
+    // leading half, i.e. between claude and terminal in the grouped view.
+    fire("onDragStart", { active: { id: "codex" } });
+    fire("onDragOver", {
+      active: { id: "codex", rect: { current: { translated: { right: 0 } } } },
+      over: { id: "terminal", rect: { left: 0, width: 100 } },
+    });
+    fire("onDragEnd", { active: { id: "codex" }, over: { id: "terminal" } });
+
+    // Index 2 in the *stored* array — right after its group peer `claude` —
+    // which grouping renders as claude → codex → terminal. The projected
+    // index (1) would have landed it before claude.
+    expect(moveButtonMock).toHaveBeenCalledWith("codex", "right", "left", 2);
   });
 
   it("commits a cross-side move after the hovered item (right edge past midpoint)", () => {


### PR DESCRIPTION
## Summary

The left toolbar used to draw a divider wherever two adjacent visible buttons disagreed on an agent vs non-agent predicate. That's a predicate flip, not a group, so once a user reordered the toolbar the dividers landed in arbitrary positions and could split the coloured agent brand marks. Each button now declares a group, and the left side renders in canonical group order, so a divider always marks a real boundary.

Resolves #11681

## Changes

- New `getToolbarButtonGroup(id, isPluginContribution)` resolver in `src/components/Layout/toolbarButtonMetadata.ts`, mirroring the existing `isToolbarButtonVisible` dispatch shape: agent ids first, registry membership second, then a Map, then a fallback. Groups are launcher, agents, panels, utilities.
- New pure module `src/components/Layout/toolbarButtonGrouping.ts` holding the stable partition, the divider placement, and the drag index translation. `Toolbar.tsx` can't render in jsdom, so the algorithm needed to live outside the component to get real unit tests.
- `Toolbar.tsx` now orders `effectiveLeftButtons` by declared group before overflow runs, so overflow, keyboard roving order, and the DOM all agree. `AGENT_TOOLBAR_IDS` is gone.
- Settings > Toolbar shows the same grouped projection, so it never invites the user to arrange a row the toolbar won't draw. A drag across a group boundary snaps back into the button's own group.
- Agent tray footer trimmed to one entry, `Manage agents`. `Customize toolbar…` was a duplicate of the right-click entry on that same button and shared the Settings2 glyph with `Manage agents`. `Set up agents` moved into the nothing-installed empty state.
- Sentence-cased the Title Case labels in that menu.

A note for the reviewer: the group is a pure code-level lookup, deliberately never persisted into `ToolbarLayout` or `ToolbarPinnedState`. Those side arrays reconcile last-writer-wins across project views, so letting array position carry meaning beyond display order would reopen the data loss that #11667 and #11671 had to unpick. Grouping at render also means the fix applies to every existing profile with no migration.

Scoped this to today's toolbar rather than waiting on #11680. That issue's own body already buckets terminal, file-browser, browser, and dev-server as "Panels", so the mapping matches where it's heading. When the unified launcher lands, only the `agent-tray` to launcher declaration needs swapping.

## Testing

446 targeted tests pass: toolbar grouping, metadata, layout, keyboard, overflow, responsive, agent-registry, agent tray, toolbar context menu, toolbar settings tab, `useToolbarOverflow`, `LauncherQuickActions`, `agentPinSync`, `toolbarPreferencesStore`. New `toolbarButtonGrouping.test.ts` covers the partition, divider placement under overflow, and the drag index round-trip.

Two known limitations, both pre-existing and untouched by this change:

- The overflow width budget still doesn't count divider width. This change makes it strictly smaller though: the old predicate could emit an unbounded number of dividers on an alternating layout, and the declared groups cap it at three. A real fix needs a circular width/divider calculation and belongs in its own issue.
- Cross-side drag position still freezes at the first container crossed (control flow in `handleDragOver`).
