### PR TITLE
fix(file-browser): keep the tree put when a folder above the cursor expands

### DIFF
--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -1492,6 +1492,14 @@ export function FileBrowserPane({
           </div>
         )}
         <FileTreeView
+          // Keyed per panel for the same reason the cursor sync above carries
+          // an id: a tab group renders one unkeyed `GridPanel`, so two file
+          // browsers share this instance. Unkeyed, the tree also inherits the
+          // other panel's scroll position and its record of where the cursor
+          // last sat — and a cursor naming the same path in both panels then
+          // reads as one that never moved, so the second panel opens without
+          // revealing it.
+          key={id}
           rows={rows}
           cursorPath={cursorPath}
           // What the other column is showing, so the tree can mark it. Only

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -1492,14 +1492,6 @@ export function FileBrowserPane({
           </div>
         )}
         <FileTreeView
-          // Keyed per panel for the same reason the cursor sync above carries
-          // an id: a tab group renders one unkeyed `GridPanel`, so two file
-          // browsers share this instance. Unkeyed, the tree also inherits the
-          // other panel's scroll position and its record of where the cursor
-          // last sat — and a cursor naming the same path in both panels then
-          // reads as one that never moved, so the second panel opens without
-          // revealing it.
-          key={id}
           rows={rows}
           cursorPath={cursorPath}
           // What the other column is showing, so the tree can mark it. Only

--- a/src/panels/file-browser/FileTreeView.tsx
+++ b/src/panels/file-browser/FileTreeView.tsx
@@ -265,11 +265,12 @@ export function FileTreeView({
     ]
   );
 
-  // Keep the cursor on screen when it moves by keyboard. Runs after commit,
-  // never during render: an abandoned concurrent render would otherwise scroll
-  // for state that never committed, and suppress the scroll on the render that
-  // did. `auto` only scrolls when the row is actually outside the viewport, so
-  // clicking a visible row never yanks the list.
+  // Keep the cursor on screen when it moves. Runs after commit, never during
+  // render: an abandoned concurrent render would otherwise scroll for state
+  // that never committed, and suppress the scroll on the render that did.
+  // `scrollIntoView` leaves an already-visible row alone, so clicking a visible
+  // row never yanks the list; `auto` only picks an instant jump over a smooth
+  // one.
   //
   // Only two changes are worth revealing: the cursor moving to another row, and
   // a cursor that had no row acquiring one — a restored cursor on mount, or a
@@ -279,9 +280,9 @@ export function FileTreeView({
   // and scrolling for that drags the view off the folder the user just opened
   // (#11684). Live refreshes and re-sorts shift indices the same way.
   const previousCursorRef = useRef<{ path: string | null; found: boolean }>({
-    path: cursorPath,
-    // Never found to begin with, so a cursor that already resolves on the first
-    // commit still reads as newly appearing and gets revealed.
+    // Starts unfound so a cursor that already resolves on the first commit
+    // still reads as newly appearing and gets revealed.
+    path: null,
     found: false,
   });
   useEffect(() => {

--- a/src/panels/file-browser/FileTreeView.tsx
+++ b/src/panels/file-browser/FileTreeView.tsx
@@ -271,10 +271,32 @@ export function FileTreeView({
   // did. `auto` only scrolls when the row is actually outside the viewport, so
   // clicking a visible row never yanks the list.
   //
-  // Keyed on the path as well as the index so a restored cursor scrolls on
-  // mount, and so a live update that shifts a row's index re-reveals it.
+  // Only two changes are worth revealing: the cursor moving to another row, and
+  // a cursor that had no row acquiring one — a restored cursor on mount, or a
+  // reveal whose ancestors expand a beat after `cursorPath` lands on the target.
+  // A bare `cursorIndex` change is neither. Expanding a folder resplices `rows`,
+  // so every row below it — including a stationary cursor — takes a new index,
+  // and scrolling for that drags the view off the folder the user just opened
+  // (#11684). Live refreshes and re-sorts shift indices the same way.
+  const previousCursorRef = useRef<{ path: string | null; found: boolean }>({
+    path: cursorPath,
+    // Never found to begin with, so a cursor that already resolves on the first
+    // commit still reads as newly appearing and gets revealed.
+    found: false,
+  });
   useEffect(() => {
-    if (cursorIndex < 0) return;
+    const previous = previousCursorRef.current;
+    const found = cursorIndex >= 0;
+    // Recorded before the early return, and in the effect rather than in render:
+    // an unreachable cursor is still the baseline the next commit compares
+    // against, and only a committed write makes "appeared" mean what it says.
+    previousCursorRef.current = { path: cursorPath, found };
+    if (!found) return;
+
+    const moved = previous.path !== cursorPath;
+    const appeared = !previous.found;
+    if (!moved && !appeared) return;
+
     virtuosoRef.current?.scrollIntoView({ index: cursorIndex, behavior: "auto" });
   }, [cursorIndex, cursorPath]);
 

--- a/src/panels/file-browser/__tests__/FileTreeView.test.tsx
+++ b/src/panels/file-browser/__tests__/FileTreeView.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render } from "@testing-library/react";
-import { forwardRef } from "react";
-import type { ReactNode } from "react";
+import { StrictMode, forwardRef, useImperativeHandle } from "react";
+import type { ForwardedRef, ReactNode } from "react";
 import { UI_INLINE_LOADING_GATE_MS } from "@/lib/animationUtils";
 import { ContextMenuItem } from "@/components/ui/context-menu";
 import { FILE_DRAG_MIME, decodeFileDragPaths } from "@/lib/fileDragPayload";
@@ -19,6 +19,16 @@ vi.mock("@/lib/platform", async (importOriginal) => ({
   isMac: isMacMock,
 }));
 
+/**
+ * Scroll requests the tree makes through Virtuoso's imperative handle. The
+ * stub has to publish a handle for these to be observable at all: without one
+ * the forwarded ref stays null and `virtuosoRef.current?.scrollIntoView(...)`
+ * is swallowed by its own optional chaining.
+ */
+const { scrollIntoViewMock } = vi.hoisted(() => ({
+  scrollIntoViewMock: vi.fn<(location: { index: number; behavior?: string }) => void>(),
+}));
+
 // Render every row: the virtualization itself is not under test, and the row
 // interactions below need real DOM nodes for every item.
 vi.mock("react-virtuoso", () => ({
@@ -28,8 +38,9 @@ vi.mock("react-virtuoso", () => ({
       context: unknown;
       itemContent: (index: number, row: FlatTreeRow, context: unknown) => ReactNode;
     },
-    _ref
+    ref: ForwardedRef<{ scrollIntoView: (location: { index: number }) => void }>
   ) {
+    useImperativeHandle(ref, () => ({ scrollIntoView: scrollIntoViewMock }), []);
     return (
       <div>
         {props.data.map((row, index) => (
@@ -59,6 +70,9 @@ const BASE_PATH = "/repo";
 // One test flips to Ctrl; without this reset it would leak into the rest.
 beforeEach(() => {
   isMacMock.mockReturnValue(true);
+  // Every render with a resolvable cursor scrolls once on mount, so the count
+  // carries into the next test without this.
+  scrollIntoViewMock.mockClear();
 });
 
 function renderTree(overrides: Partial<Parameters<typeof FileTreeView>[0]> = {}) {
@@ -888,5 +902,146 @@ describe("FileTreeView git status markers", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe("FileTreeView cursor reveal", () => {
+  const COLLAPSED: FlatTreeRow[] = [row("src", true), row("README.md")];
+  const EXPANDED: FlatTreeRow[] = [
+    { ...row("src", true), isExpanded: true },
+    { ...row("src/a.ts"), depth: 1 },
+    { ...row("src/b.ts"), depth: 1 },
+    row("README.md"),
+  ];
+
+  function renderCursor(rows: FlatTreeRow[], cursorPath: string | null) {
+    const props = {
+      rows,
+      cursorPath,
+      onSelect: vi.fn(),
+      onToggleExpanded: vi.fn(),
+      basePath: BASE_PATH,
+      label: "Files",
+    };
+    const utils = render(<FileTreeView {...props} />);
+    return {
+      ...utils,
+      /** Commit a new row array, and optionally a moved cursor, as the pane would. */
+      show: (nextRows: FlatTreeRow[], nextCursorPath = cursorPath) =>
+        utils.rerender(<FileTreeView {...props} rows={nextRows} cursorPath={nextCursorPath} />),
+    };
+  }
+
+  it("reveals a restored cursor on mount", () => {
+    // The cursor a restored panel comes back with is off screen as often as
+    // not, so the first commit that resolves it has to scroll.
+    renderCursor(COLLAPSED, "README.md");
+
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ index: 1, behavior: "auto" });
+  });
+
+  it("leaves the view alone when a folder above the cursor expands", () => {
+    // #11684: expanding splices rows in above a stationary cursor, so its index
+    // changes without the cursor having moved. Scrolling for that is what drags
+    // the list away from the folder the user just opened.
+    const { show } = renderCursor(COLLAPSED, "README.md");
+    scrollIntoViewMock.mockClear();
+
+    // The folder flips to expanded while its listing is still in flight...
+    show([{ ...row("src", true), isExpanded: true, isLoading: true }, row("README.md")]);
+    // ...and the children land a beat later, shifting the cursor row down.
+    show(EXPANDED);
+
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+  });
+
+  it("leaves the view alone when a second folder expands below a long first one", () => {
+    // The reported shape: open a folder with a lot of files, then open another.
+    // The first expansion is what makes the tree long enough to scroll at all,
+    // and it puts the most rows between the second folder and the cursor.
+    const srcChildren = Array.from({ length: 40 }, (_, index) => ({
+      ...row(`src/file-${index}.ts`),
+      depth: 1,
+    }));
+    const firstExpanded: FlatTreeRow[] = [
+      { ...row("src", true), isExpanded: true },
+      ...srcChildren,
+      row("lib", true),
+      row("README.md"),
+    ];
+    const bothExpanded: FlatTreeRow[] = [
+      { ...row("src", true), isExpanded: true },
+      ...srcChildren,
+      { ...row("lib", true), isExpanded: true },
+      { ...row("lib/util.ts"), depth: 1 },
+      row("README.md"),
+    ];
+    const { show } = renderCursor(firstExpanded, "README.md");
+    scrollIntoViewMock.mockClear();
+
+    show(bothExpanded);
+
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+  });
+
+  it("reveals the cursor when it moves to another row", () => {
+    // Keyboard navigation still has to keep up with the cursor — the whole
+    // reason the effect exists.
+    const { show } = renderCursor(COLLAPSED, "README.md");
+    scrollIntoViewMock.mockClear();
+
+    show(COLLAPSED, "src");
+
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ index: 0, behavior: "auto" });
+  });
+
+  it("reveals a cursor whose row only appears once its ancestors expand", () => {
+    // The reveal flow sets `cursorPath` to the target before anything expands,
+    // so the row does not exist yet and `cursorPath` never changes again. Only
+    // the row appearing marks the moment there is something to scroll to.
+    const { show } = renderCursor(COLLAPSED, "src/b.ts");
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+
+    show(EXPANDED);
+
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ index: 2, behavior: "auto" });
+  });
+
+  it("re-reveals a cursor whose row disappears and comes back", () => {
+    const { show } = renderCursor(EXPANDED, "src/b.ts");
+    scrollIntoViewMock.mockClear();
+
+    show(COLLAPSED);
+    show(EXPANDED);
+
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("never scrolls while no row is under the cursor", () => {
+    const { show } = renderCursor(COLLAPSED, null);
+
+    show(EXPANDED);
+
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+  });
+
+  it("records the previous cursor after commit rather than during render", () => {
+    // The app renders under StrictMode, which runs each render twice. Tracking
+    // the previous cursor in render instead of in the effect would let the
+    // second pass mark it already seen, and the mount reveal would be lost.
+    render(
+      <StrictMode>
+        <FileTreeView
+          rows={COLLAPSED}
+          cursorPath="README.md"
+          onSelect={vi.fn()}
+          onToggleExpanded={vi.fn()}
+          basePath={BASE_PATH}
+          label="Files"
+        />
+      </StrictMode>
+    );
+
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/panels/file-browser/__tests__/FileTreeView.test.tsx
+++ b/src/panels/file-browser/__tests__/FileTreeView.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render } from "@testing-library/react";
 import { StrictMode, forwardRef, useImperativeHandle } from "react";
 import type { ForwardedRef, ReactNode } from "react";
+import type { VirtuosoHandle } from "react-virtuoso";
 import { UI_INLINE_LOADING_GATE_MS } from "@/lib/animationUtils";
 import { ContextMenuItem } from "@/components/ui/context-menu";
 import { FILE_DRAG_MIME, decodeFileDragPaths } from "@/lib/fileDragPayload";
@@ -24,21 +25,34 @@ vi.mock("@/lib/platform", async (importOriginal) => ({
  * stub has to publish a handle for these to be observable at all: without one
  * the forwarded ref stays null and `virtuosoRef.current?.scrollIntoView(...)`
  * is swallowed by its own optional chaining.
+ *
+ * Typed from `VirtuosoHandle` rather than by hand so a signature change in the
+ * library fails here instead of letting the double drift out of step with what
+ * it stands in for.
  */
 const { scrollIntoViewMock } = vi.hoisted(() => ({
-  scrollIntoViewMock: vi.fn<(location: { index: number; behavior?: string }) => void>(),
+  scrollIntoViewMock: vi.fn<VirtuosoHandle["scrollIntoView"]>(),
 }));
 
 // Render every row: the virtualization itself is not under test, and the row
 // interactions below need real DOM nodes for every item.
-vi.mock("react-virtuoso", () => ({
+//
+// Spread over the real module so the one export this file replaces doesn't
+// take the rest of them down with it — a partial factory turns any future
+// `react-virtuoso` import in the tree into a collection-time failure.
+//
+// The handle stays deliberately minimal. If production starts reaching for
+// `scrollToIndex` or `getState`, that should fail loudly here rather than be
+// swallowed by a no-op the double was never asked to model.
+vi.mock("react-virtuoso", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-virtuoso")>()),
   Virtuoso: forwardRef(function VirtuosoStub(
     props: {
       data: FlatTreeRow[];
       context: unknown;
       itemContent: (index: number, row: FlatTreeRow, context: unknown) => ReactNode;
     },
-    ref: ForwardedRef<{ scrollIntoView: (location: { index: number }) => void }>
+    ref: ForwardedRef<Pick<VirtuosoHandle, "scrollIntoView">>
   ) {
     useImperativeHandle(ref, () => ({ scrollIntoView: scrollIntoViewMock }), []);
     return (
@@ -906,13 +920,38 @@ describe("FileTreeView git status markers", () => {
 });
 
 describe("FileTreeView cursor reveal", () => {
-  const COLLAPSED: FlatTreeRow[] = [row("src", true), row("README.md")];
-  const EXPANDED: FlatTreeRow[] = [
+  const COLLAPSED: FlatTreeRow[] = [row("src", true), row("lib", true), row("README.md")];
+  const SRC_EXPANDED: FlatTreeRow[] = [
     { ...row("src", true), isExpanded: true },
     { ...row("src/a.ts"), depth: 1 },
     { ...row("src/b.ts"), depth: 1 },
+    row("lib", true),
     row("README.md"),
   ];
+  const BOTH_EXPANDED: FlatTreeRow[] = [
+    { ...row("src", true), isExpanded: true },
+    { ...row("src/a.ts"), depth: 1 },
+    { ...row("src/b.ts"), depth: 1 },
+    { ...row("lib", true), isExpanded: true },
+    { ...row("lib/util.ts"), depth: 1 },
+    row("README.md"),
+  ];
+
+  /**
+   * Which rows the tree asked Virtuoso to reveal, resolved back through the
+   * rows it was rendering. The invariant is *which row* got revealed — the
+   * number its position happened to carry is an implementation detail, and
+   * asserting it would only restate the fixture.
+   */
+  function revealedPaths(rows: FlatTreeRow[]): (string | undefined)[] {
+    return scrollIntoViewMock.mock.calls.map(([location]) => {
+      if (typeof location !== "object" || location === null || !("index" in location)) {
+        return undefined;
+      }
+      const { index } = location;
+      return typeof index === "number" ? rows[index]?.path : undefined;
+    });
+  }
 
   function renderCursor(rows: FlatTreeRow[], cursorPath: string | null) {
     const props = {
@@ -926,8 +965,12 @@ describe("FileTreeView cursor reveal", () => {
     const utils = render(<FileTreeView {...props} />);
     return {
       ...utils,
-      /** Commit a new row array, and optionally a moved cursor, as the pane would. */
-      show: (nextRows: FlatTreeRow[], nextCursorPath = cursorPath) =>
+      /**
+       * Commit a new tree the way the pane does. Both arguments are required:
+       * defaulting the cursor would silently restore it from the first render
+       * rather than from the last commit.
+       */
+      show: (nextRows: FlatTreeRow[], nextCursorPath: string | null) =>
         utils.rerender(<FileTreeView {...props} rows={nextRows} cursorPath={nextCursorPath} />),
     };
   }
@@ -937,62 +980,48 @@ describe("FileTreeView cursor reveal", () => {
     // not, so the first commit that resolves it has to scroll.
     renderCursor(COLLAPSED, "README.md");
 
-    expect(scrollIntoViewMock).toHaveBeenCalledWith({ index: 1, behavior: "auto" });
+    expect(revealedPaths(COLLAPSED)).toEqual(["README.md"]);
   });
 
-  it("leaves the view alone when a folder above the cursor expands", () => {
+  it("leaves the view alone while folders above the cursor expand", () => {
     // #11684: expanding splices rows in above a stationary cursor, so its index
     // changes without the cursor having moved. Scrolling for that is what drags
-    // the list away from the folder the user just opened.
+    // the list away from the folder the user just opened — and it compounds,
+    // because opening one big folder is what makes the tree long enough to
+    // scroll before the next folder is opened at all.
     const { show } = renderCursor(COLLAPSED, "README.md");
     scrollIntoViewMock.mockClear();
 
     // The folder flips to expanded while its listing is still in flight...
-    show([{ ...row("src", true), isExpanded: true, isLoading: true }, row("README.md")]);
-    // ...and the children land a beat later, shifting the cursor row down.
-    show(EXPANDED);
+    show(
+      [
+        { ...row("src", true), isExpanded: true, isLoading: true },
+        row("lib", true),
+        row("README.md"),
+      ],
+      "README.md"
+    );
+    // ...its children land a beat later, shifting the cursor row down...
+    show(SRC_EXPANDED, "README.md");
+    // ...and a second folder opens below the first, shifting it again.
+    show(BOTH_EXPANDED, "README.md");
 
     expect(scrollIntoViewMock).not.toHaveBeenCalled();
   });
 
-  it("leaves the view alone when a second folder expands below a long first one", () => {
-    // The reported shape: open a folder with a lot of files, then open another.
-    // The first expansion is what makes the tree long enough to scroll at all,
-    // and it puts the most rows between the second folder and the cursor.
-    const srcChildren = Array.from({ length: 40 }, (_, index) => ({
-      ...row(`src/file-${index}.ts`),
-      depth: 1,
-    }));
-    const firstExpanded: FlatTreeRow[] = [
-      { ...row("src", true), isExpanded: true },
-      ...srcChildren,
-      row("lib", true),
-      row("README.md"),
-    ];
-    const bothExpanded: FlatTreeRow[] = [
-      { ...row("src", true), isExpanded: true },
-      ...srcChildren,
-      { ...row("lib", true), isExpanded: true },
-      { ...row("lib/util.ts"), depth: 1 },
-      row("README.md"),
-    ];
-    const { show } = renderCursor(firstExpanded, "README.md");
+  it("reveals the cursor when it moves to a row holding the same position", () => {
+    // Sorting the same two rows the other way round moves the cursor to a
+    // different file that lands on the index the old one just vacated. What
+    // makes this a move is the path, so keying off the index alone would miss
+    // it entirely.
+    const ascending = [row("a.ts"), row("b.ts")];
+    const descending = [row("b.ts"), row("a.ts")];
+    const { show } = renderCursor(ascending, "a.ts");
     scrollIntoViewMock.mockClear();
 
-    show(bothExpanded);
+    show(descending, "b.ts");
 
-    expect(scrollIntoViewMock).not.toHaveBeenCalled();
-  });
-
-  it("reveals the cursor when it moves to another row", () => {
-    // Keyboard navigation still has to keep up with the cursor — the whole
-    // reason the effect exists.
-    const { show } = renderCursor(COLLAPSED, "README.md");
-    scrollIntoViewMock.mockClear();
-
-    show(COLLAPSED, "src");
-
-    expect(scrollIntoViewMock).toHaveBeenCalledWith({ index: 0, behavior: "auto" });
+    expect(revealedPaths(descending)).toEqual(["b.ts"]);
   });
 
   it("reveals a cursor whose row only appears once its ancestors expand", () => {
@@ -1002,33 +1031,42 @@ describe("FileTreeView cursor reveal", () => {
     const { show } = renderCursor(COLLAPSED, "src/b.ts");
     expect(scrollIntoViewMock).not.toHaveBeenCalled();
 
-    show(EXPANDED);
+    show(SRC_EXPANDED, "src/b.ts");
 
-    expect(scrollIntoViewMock).toHaveBeenCalledWith({ index: 2, behavior: "auto" });
+    expect(revealedPaths(SRC_EXPANDED)).toEqual(["src/b.ts"]);
   });
 
   it("re-reveals a cursor whose row disappears and comes back", () => {
-    const { show } = renderCursor(EXPANDED, "src/b.ts");
+    const { show } = renderCursor(SRC_EXPANDED, "src/b.ts");
     scrollIntoViewMock.mockClear();
 
-    show(COLLAPSED);
-    show(EXPANDED);
+    // Collapsing the branch takes the row away — nothing to reveal.
+    show(COLLAPSED, "src/b.ts");
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
 
-    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+    show(SRC_EXPANDED, "src/b.ts");
+
+    expect(revealedPaths(SRC_EXPANDED)).toEqual(["src/b.ts"]);
   });
 
-  it("never scrolls while no row is under the cursor", () => {
-    const { show } = renderCursor(COLLAPSED, null);
+  it("does not reveal a cursor that moves to a path with no row", () => {
+    // Re-rooting leaves the cursor naming a path this tree cannot show. The
+    // move is real, but there is no row to scroll to, so the reachability
+    // check has to win over it.
+    const { show } = renderCursor(COLLAPSED, "README.md");
+    scrollIntoViewMock.mockClear();
 
-    show(EXPANDED);
+    show(COLLAPSED, "somewhere/else.ts");
 
     expect(scrollIntoViewMock).not.toHaveBeenCalled();
   });
 
-  it("records the previous cursor after commit rather than during render", () => {
-    // The app renders under StrictMode, which runs each render twice. Tracking
-    // the previous cursor in render instead of in the effect would let the
-    // second pass mark it already seen, and the mount reveal would be lost.
+  it("reveals a restored cursor exactly once under StrictMode replay", () => {
+    // The app mounts under StrictMode, which runs each render twice and replays
+    // effects. Two calls would mean the replay duplicated the request; zero
+    // would mean the mount reveal was suppressed — which is what tracking the
+    // previous cursor during render instead of after commit would cause, since
+    // the second render pass would have already marked it seen.
     render(
       <StrictMode>
         <FileTreeView
@@ -1042,6 +1080,6 @@ describe("FileTreeView cursor reveal", () => {
       </StrictMode>
     );
 
-    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+    expect(revealedPaths(COLLAPSED)).toEqual(["README.md"]);
   });
 });

--- a/src/panels/file-browser/__tests__/FileTreeView.test.tsx
+++ b/src/panels/file-browser/__tests__/FileTreeView.test.tsx
@@ -986,9 +986,8 @@ describe("FileTreeView cursor reveal", () => {
   it("leaves the view alone while folders above the cursor expand", () => {
     // #11684: expanding splices rows in above a stationary cursor, so its index
     // changes without the cursor having moved. Scrolling for that is what drags
-    // the list away from the folder the user just opened — and it compounds,
-    // because opening one big folder is what makes the tree long enough to
-    // scroll before the next folder is opened at all.
+    // the list away from the folder the user just opened, and each further
+    // expansion shifts the same cursor again.
     const { show } = renderCursor(COLLAPSED, "README.md");
     scrollIntoViewMock.mockClear();
 


### PR DESCRIPTION
Resolves #11684

## The problem

`cursorIndex` is derived from the row array, so expanding a folder changed it even though `cursorPath` never moved. The scroll-into-view effect keyed on that index then revealed the cursor row wherever it had just been pushed to — which is how expanding a folder near the top could snap the list to a selection far below it. It compounds: opening one big folder is what makes the tree long enough to scroll before the next folder is opened at all.

## The fix

Reveal the cursor only when there's a reason to:

- **it moved** — `cursorPath` changed (keyboard nav, or the pane rehoming a cursor out of a branch it just collapsed)
- **it appeared** — the row went from absent to present under an unchanged path: a restored cursor on mount, and the reveal flow, where `cursorPath` lands on the target a beat before its ancestors expand

A bare index change is neither, so a resplice under a stationary cursor no longer scrolls. The previous cursor rides a ref written inside the effect rather than during render, so it holds the last *committed* answer.

## Trade-offs worth knowing

- A cursor that stays present no longer re-reveals when only its index shifts — including on re-sort and on lazy hydration of a restored expansion. That follows the issue's own line that a pure index shift under a stationary cursor isn't worth revealing, but it is a real behaviour change.
- Two file browsers in one tab group share a component instance, so if their cursors name the same path, switching between them won't re-reveal. Narrow, and the old behaviour there only worked by accident of the bug. Fixing it properly needs panel identity to move above the tree hook — `key`ing the tree was tried and reverted, because remounting it drops keyboard focus on every tab switch.

## Tests

The `react-virtuoso` stub dropped its forwarded ref, so `virtuosoRef.current` was always null and every scroll call in this suite was silently swallowed — no test could observe scrolling at all. It now publishes a typed imperative handle, and the suite asserts which *row* got revealed rather than the index it happened to sit at.

Seven cases cover mount restore, expand-above-cursor (including the async child arrival and a second folder opening after the first), a move that keeps the same index, reveal-on-appear, disappear-and-return, a move to a path with no row, and StrictMode replay. Reverting the production change fails three of them.

Verified locally: 177 tests across `FileTreeView.test.tsx` and `FileBrowserPane.test.tsx`, plus lint, format and typecheck on the changed files.