### PR TITLE
feat(ui): scale palette chrome to the weight of the surface

### DIFF
--- a/e2e/screenshots/palette-review.spec.ts
+++ b/e2e/screenshots/palette-review.spec.ts
@@ -395,13 +395,23 @@ test("palette review — every surface in the family", async () => {
     });
 
     // One palette, two hosts: the modal and the dropdown render the same
-    // component and must resolve to the same surface in every theme. Shadow is
-    // deliberately out of the comparison — the modal floats over a scrim and
+    // component and must be cut from the same material in every theme. Shadow
+    // is deliberately out of the comparison — the modal floats over a scrim and
     // carries `shadow-modal`, one step above the dropdown's `shadow-overlay`.
+    //
+    // Width is out of it too, and now carries its own assertion: the ⌘P modal
+    // is the command tier and the title-bar dropdown is anchored, so the same
+    // content deliberately gets a box scaled to how the user reached it.
     if (dropdownSurface && modalSurface) {
-      expect(modalSurface, `palette surface drifted between hosts in "${THEME}"`).toEqual(
-        dropdownSurface
+      const { width: modalWidth, ...modalMaterial } = modalSurface;
+      const { width: dropdownWidth, ...dropdownMaterial } = dropdownSurface;
+      expect(modalMaterial, `palette material drifted between hosts in "${THEME}"`).toEqual(
+        dropdownMaterial
       );
+      expect(
+        parseFloat(modalWidth),
+        `the command-tier modal should be wider than the anchored dropdown in "${THEME}"`
+      ).toBeGreaterThan(parseFloat(dropdownWidth));
     } else if (ONLY.length === 0) {
       stepFailures.push("surface drift check: a project-switcher capture did not run");
     }

--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -396,6 +396,7 @@ export function ActionPalette({
 
   return (
     <SearchablePalette<ActionPaletteItemType>
+      tier="command"
       isOpen={isOpen}
       query={query}
       results={results}

--- a/src/components/Commands/CommandPicker.tsx
+++ b/src/components/Commands/CommandPicker.tsx
@@ -151,6 +151,7 @@ export function CommandPicker({
 
   return (
     <SearchablePalette<CommandManifestEntry>
+      tier="command"
       isOpen={isOpen}
       query={query}
       results={flatCommands}

--- a/src/components/Fleet/FleetPickerPalette.tsx
+++ b/src/components/Fleet/FleetPickerPalette.tsx
@@ -173,7 +173,12 @@ export function FleetPickerPalette({ isOpen, onClose }: FleetPickerPaletteProps)
   const showFooterHint = hasVisibleRows || picker.driftCount > 0;
 
   return (
-    <AppPaletteDialog isOpen={isOpen} onClose={onClose} ariaLabel="Select terminals to arm">
+    <AppPaletteDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      ariaLabel="Select terminals to arm"
+      tier="command"
+    >
       <div className="flex flex-col">
         <div
           className={cn(

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -326,6 +326,7 @@ export function DockLaunchButton({
       </Tooltip>
       <AppPalettePopover.Content
         ariaLabel="Launch"
+        tier="anchored"
         inputRef={inputRef}
         onClearQuery={clearQuery}
         onCloseAutoFocus={suppressTooltipDuringFocusRestore}
@@ -333,9 +334,10 @@ export function DockLaunchButton({
         side="top"
         align="start"
         sideOffset={4}
-        // Width comes from the shell — one `PALETTE_SURFACE_WIDTH` for the whole
-        // family, so the launcher can't drift away from the palettes it sits next
-        // to in the same keyboard reflex.
+        // Width comes from the shell's anchored tier, so the launcher can't
+        // drift away from the other menus it sits next to in the same keyboard
+        // reflex — and doesn't wear a command palette's box for a list of
+        // agents and panels.
         className="p-0"
         // Catch-all behind the input's own handler, for the frame before the
         // shell's refocus lands and for focus legitimately sitting on the
@@ -394,8 +396,6 @@ export function DockLaunchButton({
             </div>
           )}
         </AppPaletteDialog.Body>
-
-        <AppPaletteDialog.Footer />
       </AppPalettePopover.Content>
     </AppPalettePopover>
   );

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -200,12 +200,20 @@ vi.mock("@/components/ui/AppPaletteDialog", () => {
         {children}
       </div>
     ),
-    Footer: () => <div data-testid="dock-launcher-footer" />,
     Empty: ({ query }: { query: string }) => (
       <div data-testid="dock-launcher-empty">{query.trim() ? "no matches" : "nothing"}</div>
     ),
   };
-  return { AppPaletteDialog, PALETTE_SURFACE_WIDTH: "w-[484px]" };
+  return {
+    AppPaletteDialog,
+    PALETTE_SURFACE_WIDTHS: {
+      // Sentinel values, not the production pixels: this mock only has to satisfy
+      // the real AppPalettePopover's width lookup, and copying the shipped
+      // classes here would couple every future resize to six mock factories.
+      anchored: "mock-anchored-width",
+      command: "mock-command-width",
+    },
+  };
 });
 
 import { DockLaunchButton } from "../DockLaunchButton";

--- a/src/components/LogLevelPalette/LogLevelPalette.tsx
+++ b/src/components/LogLevelPalette/LogLevelPalette.tsx
@@ -139,6 +139,7 @@ export function LogLevelPalette({ isOpen, onClose }: LogLevelPaletteProps) {
   if (step === "logger") {
     return (
       <SearchablePalette<LoggerItem>
+        tier="command"
         isOpen={isOpen}
         query={loggerPalette.query}
         results={loggerPalette.results}
@@ -179,6 +180,7 @@ export function LogLevelPalette({ isOpen, onClose }: LogLevelPaletteProps) {
 
   return (
     <SearchablePalette<(typeof LEVEL_OPTIONS)[number]>
+      tier="command"
       isOpen={isOpen}
       query={levelPalette.query}
       results={levelPalette.results}

--- a/src/components/PanelPalette/PanelPalette.tsx
+++ b/src/components/PanelPalette/PanelPalette.tsx
@@ -193,7 +193,7 @@ export function PanelPalette({
       : undefined;
 
   return (
-    <AppPaletteDialog isOpen={isOpen} onClose={onClose} ariaLabel="Panel palette">
+    <AppPaletteDialog isOpen={isOpen} onClose={onClose} ariaLabel="Panel palette" tier="anchored">
       <AppPaletteDialog.Header
         label={showCounter ? `New Panel (${panelCount} / ${hardLimit})` : "New Panel"}
         shortcut={panelPaletteShortcut}

--- a/src/components/PanelPalette/PanelPalette.tsx
+++ b/src/components/PanelPalette/PanelPalette.tsx
@@ -138,7 +138,7 @@ export function PanelPalette({
           <PanelKindIcon iconId={kind.iconId} color={kind.color} size={16} />
         </div>
         <div className="flex-1 min-w-0">
-          <div className="text-sm font-medium text-daintree-text">
+          <div className="text-sm font-medium text-daintree-text truncate">
             <HighlightedText
               text={kind.name}
               indices={findMatchIndices(matchesById.get(kind.id), "name")}

--- a/src/components/Pilot/PilotView.tsx
+++ b/src/components/Pilot/PilotView.tsx
@@ -852,7 +852,7 @@ export function PilotView() {
   const actionLabel = selectedRow === null || (isFilterFocused && showFilterBar) ? null : "Open";
 
   return (
-    <AppPaletteDialog isOpen={isOpen} onClose={close} ariaLabel="All agents">
+    <AppPaletteDialog isOpen={isOpen} onClose={close} ariaLabel="All agents" tier="command">
       <AppPaletteDialog.Header label="All agents" shortcut={pilotShortcut}>
         <AppPaletteDialog.Input
           inputRef={searchRef}

--- a/src/components/Plugin/PluginQuickPickDialog.tsx
+++ b/src/components/Plugin/PluginQuickPickDialog.tsx
@@ -193,6 +193,7 @@ export function PluginQuickPickDialog() {
       resetKeys={[promptId ?? "null"]}
     >
       <SearchablePalette<PluginQuickPickItem>
+        tier="command"
         isOpen={isQuickPick}
         query={query}
         results={results}

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -1210,14 +1210,12 @@ function ScratchSection({
 /**
  * Every hint here is project-only, so a highlighted scratch row drops them
  * rather than naming affordances it doesn't have: ⌘↵ falls back to a plain
- * switch, ⌘⌫ is inert, and a search-mode scratch row carries no context menu.
+ * switch, and a search-mode scratch row carries no context menu.
  */
 function ProjectSwitcherFooter({
-  mode,
   isScratchSelected,
   onOpenPilot,
 }: {
-  mode?: ProjectSwitcherMode;
   isScratchSelected: boolean;
   onOpenPilot: () => void;
 }) {
@@ -1233,24 +1231,23 @@ function ProjectSwitcherFooter({
 
   return (
     // Container-queried rather than fixed: the same footer serves the anchored
-    // dropdown and the wider command-tier modal, and four rails do not fit the
-    // anchored box. They drop by ascending importance — the passive
-    // "Right-click for more" first, then "Remove" — so the Enter action and
-    // "All agents" (the only affordance with no other entry point) survive
-    // longest. Tailwind needs each variant written out, so they are literal.
+    // dropdown and the wider command-tier modal, and the passive "Right-click
+    // for more" does not fit the anchored box — so it drops there and the Enter
+    // action and "All agents" (the only affordance with no other entry point)
+    // survive. Tailwind needs each variant written out, so it is a literal.
+    //
+    // There is deliberately no ⌘⌫ Remove rail. It fit the old single 484px
+    // surface, but the anchored footer is 326px: at its widest — ⌘ held, so the
+    // Enter rail reads "⌘↵ New window" — the two rails measure 251px, and a
+    // Remove rail takes that to 343px, which overflows rather than degrading.
+    // A container query cannot drop it only in the ⌘-held state, and ⌘ held is
+    // exactly when it would be worth reading. The chord itself still works; the
+    // context menu is what names it.
     <div className="@container/switcher-footer w-full flex items-center justify-between gap-3">
-      <div className="flex items-center gap-3 min-w-0">
-        <span className="shrink-0">
-          <kbd className={KBD_CLASS}>{hint.keys}</kbd>
-          <span className="ml-1.5">{hint.label}</span>
-        </span>
-        {mode !== "modal" && !isScratchSelected && (
-          <span className="text-daintree-text/50 shrink-0 @max-[420px]/switcher-footer:hidden">
-            <kbd className={KBD_CLASS}>⌘⌫</kbd>
-            <span className="ml-1.5">Remove</span>
-          </span>
-        )}
-      </div>
+      <span className="shrink-0">
+        <kbd className={KBD_CLASS}>{hint.keys}</kbd>
+        <span className="ml-1.5">{hint.label}</span>
+      </span>
       <div className="flex items-center gap-3 min-w-0">
         {/*
           The switcher answers "which project", so the fleet-wide view belongs
@@ -1569,7 +1566,6 @@ function ProjectPaletteInner({
 
       <AppPaletteDialog.Footer>
         <ProjectSwitcherFooter
-          mode={mode}
           isScratchSelected={activeResult?.kind === "scratch"}
           onOpenPilot={() => {
             onClose();
@@ -1698,8 +1694,8 @@ function DropdownContent({
         // better behaviour and worth adopting — but as its own change, not
         // folded silently into an extraction.
         restoreFocusOnPointerDismiss
-        // Width comes from the shell, so the dropdown and the ⌘P modal of this
-        // same palette resolve to one surface.
+        // Padding only — width comes from the shell's tier above, which is what
+        // splits this box from its ⌘P twin.
         className="p-0"
         data-testid="project-switcher-palette"
         align={dropdownAlign}

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -1232,20 +1232,26 @@ function ProjectSwitcherFooter({
       : { keys: "↵", label: "Switch" };
 
   return (
-    <div className="w-full flex items-center justify-between">
-      <div className="flex items-center gap-3">
-        <span>
+    // Container-queried rather than fixed: the same footer serves the anchored
+    // dropdown and the wider command-tier modal, and four rails do not fit the
+    // anchored box. They drop by ascending importance — the passive
+    // "Right-click for more" first, then "Remove" — so the Enter action and
+    // "All agents" (the only affordance with no other entry point) survive
+    // longest. Tailwind needs each variant written out, so they are literal.
+    <div className="@container/switcher-footer w-full flex items-center justify-between gap-3">
+      <div className="flex items-center gap-3 min-w-0">
+        <span className="shrink-0">
           <kbd className={KBD_CLASS}>{hint.keys}</kbd>
           <span className="ml-1.5">{hint.label}</span>
         </span>
         {mode !== "modal" && !isScratchSelected && (
-          <span className="text-daintree-text/50">
+          <span className="text-daintree-text/50 shrink-0 @max-[420px]/switcher-footer:hidden">
             <kbd className={KBD_CLASS}>⌘⌫</kbd>
             <span className="ml-1.5">Remove</span>
           </span>
         )}
       </div>
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-3 min-w-0">
         {/*
           The switcher answers "which project", so the fleet-wide view belongs
           beside it rather than inside its list: adding a row would put a
@@ -1255,14 +1261,18 @@ function ProjectSwitcherFooter({
         <button
           type="button"
           onClick={onOpenPilot}
-          className="inline-flex items-center text-daintree-text/50 transition-colors duration-150 ease-out hover:text-daintree-text"
+          className="inline-flex items-center shrink-0 text-daintree-text/50 transition-colors duration-150 ease-out hover:text-daintree-text"
           data-testid="project-switcher-open-pilot"
           {...(pilotShortcut ? { "aria-keyshortcuts": pilotShortcut } : {})}
         >
           {pilotShortcut && <KbdChord shortcut={pilotShortcut} />}
           <span className={pilotShortcut ? "ml-1.5" : undefined}>All agents</span>
         </button>
-        {!isScratchSelected && <span className="text-daintree-text/50">Right-click for more</span>}
+        {!isScratchSelected && (
+          <span className="text-daintree-text/50 shrink-0 @max-[520px]/switcher-footer:hidden">
+            Right-click for more
+          </span>
+        )}
       </div>
     </div>
   );

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -1591,7 +1591,15 @@ function ModalContent({
   const listRef = useRef<HTMLDivElement>(null);
 
   return (
-    <AppPaletteDialog isOpen={isOpen} onClose={onClose} ariaLabel="Project switcher">
+    <AppPaletteDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      ariaLabel="Project switcher"
+      // The modal form is the global ⌘P surface, so it takes the command box.
+      // Its dropdown twin below is anchored: same content, same material, a
+      // box scaled to how the user reached it.
+      tier="command"
+    >
       <ProjectPaletteInner
         inputRef={inputRef}
         listRef={listRef}
@@ -1668,6 +1676,10 @@ function DropdownContent({
       <AppPalettePopover.Trigger asChild>{children}</AppPalettePopover.Trigger>
       <AppPalettePopover.Content
         ariaLabel="Project switcher"
+        // Anchored: reached by clicking the title bar, showing the projects
+        // already to hand. The ⌘P modal above renders the same content on the
+        // command tier — same material, a box scaled to the way in.
+        tier="anchored"
         inputRef={inputRef}
         onClearQuery={handleClearQuery}
         onCloseAutoFocus={onDropdownCloseAutoFocus}

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.bulkScratchDelete.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.bulkScratchDelete.test.tsx
@@ -92,7 +92,17 @@ vi.mock("@/components/ui/AppPaletteDialog", () => {
   Dialog.Footer = Footer;
   Dialog.Divider = (props: React.HTMLAttributes<HTMLDivElement>) => <div {...props} />;
 
-  return { AppPaletteDialog: Dialog, KBD_CLASS: "kbd", PALETTE_SURFACE_WIDTH: "w-[484px]" };
+  return {
+    AppPaletteDialog: Dialog,
+    KBD_CLASS: "kbd",
+    PALETTE_SURFACE_WIDTHS: {
+      // Sentinel values, not the production pixels: this mock only has to satisfy
+      // the real AppPalettePopover's width lookup, and copying the shipped
+      // classes here would couple every future resize to six mock factories.
+      anchored: "mock-anchored-width",
+      command: "mock-command-width",
+    },
+  };
 });
 
 vi.mock("@/components/ui/popover", () => ({

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
@@ -112,7 +112,13 @@ vi.mock("@/components/ui/AppPaletteDialog", () => {
   return {
     AppPaletteDialog: Dialog,
     KBD_CLASS: "px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-daintree-border text-daintree-text/60",
-    PALETTE_SURFACE_WIDTH: "w-[484px]",
+    PALETTE_SURFACE_WIDTHS: {
+      // Sentinel values, not the production pixels: this mock only has to satisfy
+      // the real AppPalettePopover's width lookup, and copying the shipped
+      // classes here would couple every future resize to six mock factories.
+      anchored: "mock-anchored-width",
+      command: "mock-command-width",
+    },
   };
 });
 

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -560,11 +560,16 @@ describe("ProjectSwitcherPalette modal mode", () => {
     });
   });
 
-  it("shows Remove hint in dropdown mode footer", () => {
+  it("keeps the footer to the rails the anchored box can actually paint", () => {
+    // A ⌘⌫ Remove rail used to sit here and is deliberately gone: it overflows
+    // the 326px anchored footer whenever ⌘ is held, and a container query that
+    // hid it would hide it in every state the dropdown ever renders. Asserted
+    // as an absence because jsdom evaluates no container query — a presence
+    // assertion here would pass on text no user ever sees.
     render(<ProjectSwitcherPalette {...dropdownProps} results={multiProjects} />);
     const footer = screen.getByTestId("palette-footer");
-    expect(footer.textContent).toContain("Remove");
-    expect(footer.textContent).toContain("Right-click for more");
+    expect(footer.textContent).toContain("Switch");
+    expect(footer.textContent).not.toContain("Remove");
   });
 
   it("shows all projects in dropdown mode including closed ones", () => {
@@ -747,21 +752,26 @@ describe("ProjectSwitcherPalette scratch search rows", () => {
   });
 
   it("drops the project-only shortcut hints while a scratch is highlighted", () => {
+    // Run on the command tier, the only one that actually paints the
+    // context-menu rail — the anchored dropdown's footer is 326px, so the rail
+    // is container-queried away there, and jsdom evaluates no container query,
+    // which would let this pass on text the user never sees.
+    const commandSearchProps = { ...searchProps, mode: "modal" as const };
     const { rerender } = render(
-      <ProjectSwitcherPalette {...searchProps} results={[makeProject({ id: "p1" })]} />
+      <ProjectSwitcherPalette {...commandSearchProps} results={[makeProject({ id: "p1" })]} />
     );
-    expect(screen.getByTestId("palette-footer").textContent).toContain("Remove");
+    expect(screen.getByTestId("palette-footer").textContent).toContain("Right-click for more");
 
     rerender(
       <ProjectSwitcherPalette
-        {...searchProps}
+        {...commandSearchProps}
         results={[makeScratchRow({ id: "s1", name: "Spike notes" })]}
       />
     );
 
-    // ⌘⌫ removes a project and does nothing to a scratch, so advertising it
-    // here would name a key that has no effect on the highlighted row.
-    expect(screen.getByTestId("palette-footer").textContent).not.toContain("Remove");
+    // A search-mode scratch row carries no context menu, so pointing at one
+    // would name an affordance the highlighted row does not have.
+    expect(screen.getByTestId("palette-footer").textContent).not.toContain("Right-click for more");
   });
 });
 

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -89,7 +89,13 @@ vi.mock("@/components/ui/AppPaletteDialog", () => {
   return {
     AppPaletteDialog: Dialog,
     KBD_CLASS: "px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-daintree-border text-daintree-text/60",
-    PALETTE_SURFACE_WIDTH: "w-[484px]",
+    PALETTE_SURFACE_WIDTHS: {
+      // Sentinel values, not the production pixels: this mock only has to satisfy
+      // the real AppPalettePopover's width lookup, and copying the shipped
+      // classes here would couple every future resize to six mock factories.
+      anchored: "mock-anchored-width",
+      command: "mock-command-width",
+    },
   };
 });
 

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.scratchNaming.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.scratchNaming.test.tsx
@@ -105,7 +105,17 @@ vi.mock("@/components/ui/AppPaletteDialog", async () => {
   Dialog.Footer = Footer;
   Dialog.Divider = (props: React.HTMLAttributes<HTMLDivElement>) => <div {...props} />;
 
-  return { AppPaletteDialog: Dialog, KBD_CLASS: "kbd", PALETTE_SURFACE_WIDTH: "w-[484px]" };
+  return {
+    AppPaletteDialog: Dialog,
+    KBD_CLASS: "kbd",
+    PALETTE_SURFACE_WIDTHS: {
+      // Sentinel values, not the production pixels: this mock only has to satisfy
+      // the real AppPalettePopover's width lookup, and copying the shipped
+      // classes here would couple every future resize to six mock factories.
+      anchored: "mock-anchored-width",
+      command: "mock-command-width",
+    },
+  };
 });
 
 vi.mock("@/components/ui/popover", () => ({

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.sortControl.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.sortControl.test.tsx
@@ -83,7 +83,17 @@ vi.mock("@/components/ui/AppPaletteDialog", () => {
   Dialog.Footer = Footer;
   Dialog.Divider = (props: React.HTMLAttributes<HTMLDivElement>) => <div {...props} />;
 
-  return { AppPaletteDialog: Dialog, KBD_CLASS: "kbd", PALETTE_SURFACE_WIDTH: "w-[484px]" };
+  return {
+    AppPaletteDialog: Dialog,
+    KBD_CLASS: "kbd",
+    PALETTE_SURFACE_WIDTHS: {
+      // Sentinel values, not the production pixels: this mock only has to satisfy
+      // the real AppPalettePopover's width lookup, and copying the shipped
+      // classes here would couple every future resize to six mock factories.
+      anchored: "mock-anchored-width",
+      command: "mock-command-width",
+    },
+  };
 });
 
 vi.mock("@/components/ui/popover", () => ({

--- a/src/components/QuickSwitcher/QuickSwitcher.footer.test.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcher.footer.test.tsx
@@ -112,10 +112,14 @@ describe("QuickSwitcher dynamic footer hint", () => {
 
     // Nothing is selected, so there is no action to name — and a footer with
     // nothing contextual to say has no reason to occupy a bordered band.
+    //
+    // Asserted on the contextual text rather than on `kbd` anywhere in the
+    // document: this palette also renders a header shortcut chip, which only
+    // stays invisible here because the keybinding hooks are mocked empty. The
+    // wrapper's own absence is covered directly in AppPaletteDialog.test.tsx.
     expect(screen.queryByText("to select")).toBeNull();
     expect(screen.queryByText("to switch terminal")).toBeNull();
     expect(screen.queryByText("to switch worktree")).toBeNull();
-    expect(document.body.querySelector("kbd")).toBeNull();
   });
 
   it("updates the footer when selection moves between item types", () => {
@@ -165,7 +169,6 @@ describe("QuickSwitcher dynamic footer hint", () => {
     rerender(<QuickSwitcher {...baseProps} results={[]} selectedIndex={-1} />);
     expect(screen.queryByText("to switch terminal")).toBeNull();
     expect(screen.queryByText("to select")).toBeNull();
-    expect(document.body.querySelector("kbd")).toBeNull();
   });
 
   it("wires aria-describedby on each row to the footer hint id", () => {

--- a/src/components/QuickSwitcher/QuickSwitcher.footer.test.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcher.footer.test.tsx
@@ -107,12 +107,15 @@ describe("QuickSwitcher dynamic footer hint", () => {
     expect(screen.queryByText("to switch terminal")).toBeNull();
   });
 
-  it("falls back to default hints when results are empty", () => {
+  it("drops the footer entirely when results are empty", () => {
     renderQuickSwitcher({ results: [], selectedIndex: -1 });
 
-    expect(screen.getByText("to select")).toBeTruthy();
+    // Nothing is selected, so there is no action to name — and a footer with
+    // nothing contextual to say has no reason to occupy a bordered band.
+    expect(screen.queryByText("to select")).toBeNull();
     expect(screen.queryByText("to switch terminal")).toBeNull();
     expect(screen.queryByText("to switch worktree")).toBeNull();
+    expect(document.body.querySelector("kbd")).toBeNull();
   });
 
   it("updates the footer when selection moves between item types", () => {
@@ -139,7 +142,7 @@ describe("QuickSwitcher dynamic footer hint", () => {
     expect(screen.queryByText("to switch terminal")).toBeNull();
   });
 
-  it("restores default hints when results transition from populated to empty", () => {
+  it("removes the footer when results transition from populated to empty", () => {
     const baseProps = {
       isOpen: true,
       query: "",
@@ -161,7 +164,8 @@ describe("QuickSwitcher dynamic footer hint", () => {
 
     rerender(<QuickSwitcher {...baseProps} results={[]} selectedIndex={-1} />);
     expect(screen.queryByText("to switch terminal")).toBeNull();
-    expect(screen.getByText("to select")).toBeTruthy();
+    expect(screen.queryByText("to select")).toBeNull();
+    expect(document.body.querySelector("kbd")).toBeNull();
   });
 
   it("wires aria-describedby on each row to the footer hint id", () => {

--- a/src/components/QuickSwitcher/QuickSwitcher.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcher.tsx
@@ -84,6 +84,7 @@ export function QuickSwitcher({
 
   return (
     <SearchablePalette<QuickSwitcherItemData>
+      tier="command"
       isOpen={isOpen}
       query={query}
       results={results}

--- a/src/components/Terminal/PromptHistoryPalette.tsx
+++ b/src/components/Terminal/PromptHistoryPalette.tsx
@@ -148,6 +148,7 @@ export function PromptHistoryPalette({ onOpenRef, ...props }: PromptHistoryPalet
 
   return (
     <SearchablePalette<PromptHistoryEntry>
+      tier="command"
       isOpen={isOpen}
       query={query}
       results={results}

--- a/src/components/Terminal/ResumeSessionsPalette.tsx
+++ b/src/components/Terminal/ResumeSessionsPalette.tsx
@@ -167,7 +167,7 @@ export function ResumeSessionsPalette() {
   const activeDescendant = selected ? `resume-session-option-${selected.id}` : undefined;
 
   return (
-    <AppPaletteDialog isOpen={isOpen} onClose={close} ariaLabel="Resume session">
+    <AppPaletteDialog isOpen={isOpen} onClose={close} ariaLabel="Resume session" tier="command">
       <AppPaletteDialog.Header label="Resume session" shortcut={shortcut} isLoading={isLoading}>
         <AppPaletteDialog.Input
           inputRef={inputRef}

--- a/src/components/Terminal/SendToAgentPalette.tsx
+++ b/src/components/Terminal/SendToAgentPalette.tsx
@@ -99,6 +99,7 @@ export function SendToAgentPalette({
 
   return (
     <SearchablePalette<SendToAgentItem>
+      tier="anchored"
       isOpen={isOpen}
       query={query}
       results={results}

--- a/src/components/TerminalPalette/NewTerminalPalette.tsx
+++ b/src/components/TerminalPalette/NewTerminalPalette.tsx
@@ -150,7 +150,9 @@ export function NewTerminalPalette({
               >
                 <span className="shrink-0 text-daintree-text/70">{option.icon}</span>
                 <div className="flex-1 min-w-0">
-                  <div className="text-sm font-medium text-daintree-text">{option.label}</div>
+                  <div className="text-sm font-medium text-daintree-text truncate">
+                    {option.label}
+                  </div>
                   <div className="text-xs text-daintree-text/50 truncate">{option.description}</div>
                 </div>
               </button>

--- a/src/components/TerminalPalette/NewTerminalPalette.tsx
+++ b/src/components/TerminalPalette/NewTerminalPalette.tsx
@@ -99,7 +99,12 @@ export function NewTerminalPalette({
   const activeDescendant = selectedOption ? `new-terminal-option-${selectedOption.id}` : undefined;
 
   return (
-    <AppPaletteDialog isOpen={isOpen} onClose={onClose} ariaLabel="New terminal palette">
+    <AppPaletteDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      ariaLabel="New terminal palette"
+      tier="anchored"
+    >
       <AppPaletteDialog.Header label="New terminal" shortcut={newTerminalShortcut}>
         <AppPaletteDialog.Input
           inputRef={inputRef}

--- a/src/components/ThemePalette/ThemePalette.tsx
+++ b/src/components/ThemePalette/ThemePalette.tsx
@@ -184,6 +184,7 @@ export function ThemePalette({ isOpen, onClose }: ThemePaletteProps) {
 
   return (
     <SearchablePalette<AppColorScheme>
+      tier="command"
       isOpen={isOpen}
       query={query}
       results={results}

--- a/src/components/Worktree/QuickCreatePalette.tsx
+++ b/src/components/Worktree/QuickCreatePalette.tsx
@@ -128,6 +128,7 @@ export function QuickCreatePalette({ palette }: QuickCreatePaletteProps) {
 
   return (
     <SearchablePalette<QuickCreateItem>
+      tier="anchored"
       isOpen={palette.isOpen}
       query={palette.query}
       results={palette.results}

--- a/src/components/Worktree/WorktreePalette.tsx
+++ b/src/components/Worktree/WorktreePalette.tsx
@@ -35,11 +35,13 @@ function WorktreeListItem({ worktree, isActive, isSelected, onClick }: WorktreeL
         aria-selected={isSelected}
         role="option"
       >
-        <div className="flex items-center justify-between text-sm">
-          <span className="font-medium text-daintree-text">{worktree.name}</span>
-          <div className="flex items-center gap-2 text-xs text-daintree-text/60">
+        <div className="flex items-center justify-between gap-2 text-sm">
+          {/* Both sides truncate: a long branch name used to have the width to
+              spare, and on the anchored tier it does not. */}
+          <span className="font-medium text-daintree-text truncate">{worktree.name}</span>
+          <div className="flex items-center gap-2 min-w-0 text-xs text-daintree-text/60">
             {worktree.branch && (
-              <span className="font-mono text-daintree-text/70">{worktree.branch}</span>
+              <span className="font-mono text-daintree-text/70 truncate">{worktree.branch}</span>
             )}
             {isActive && (
               <span className="px-1.5 py-0.5 rounded-[var(--radius-md)] bg-[var(--color-state-active)]/15 text-[var(--color-state-active)] text-[11px] font-semibold">

--- a/src/components/Worktree/WorktreePalette.tsx
+++ b/src/components/Worktree/WorktreePalette.tsx
@@ -97,6 +97,7 @@ export function WorktreePalette({
 
   return (
     <SearchablePalette<WorktreeState>
+      tier="anchored"
       isOpen={isOpen}
       query={query}
       results={results}

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -517,6 +517,16 @@ interface AppPaletteFooterProps {
   className?: string;
 }
 
+/**
+ * The values React renders as nothing. `getFooter` returning `[]` from a
+ * `.map()` over zero contextual actions is the realistic case — it is not
+ * nullish, so a plain `== null` guard would draw the band around nothing.
+ */
+function rendersNothing(node: React.ReactNode): boolean {
+  if (node == null || typeof node === "boolean" || node === "") return true;
+  return Array.isArray(node) && node.every(rendersNothing);
+}
+
 AppPaletteDialog.Footer = function AppPaletteFooter({
   children,
   className,
@@ -527,7 +537,7 @@ AppPaletteDialog.Footer = function AppPaletteFooter({
   // to. Returning null rather than an empty wrapper matters because callers
   // render <Footer> unconditionally and pass content that resolves per
   // selection — an empty div would still draw the top border and padding.
-  if (children == null || children === false) return null;
+  if (rendersNothing(children)) return null;
   return (
     <div
       className={cn(

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -41,19 +41,38 @@ import {
 export { KBD_CLASS };
 
 /**
- * One width for the whole palette family. Palettes are opened from the same
- * keyboard reflex and often in sequence, so a per-palette width reads as the
- * surface jumping around rather than as a deliberate size. Popover-hosted
- * palettes take this too, which is what keeps the project switcher identical
- * whether it opens as a dropdown or as a modal.
+ * How much box a palette earns. A launcher hanging off a toolbar button and a
+ * global command palette are not the same kind of surface, and one width in
+ * between served neither: anchored menus sit around 320px, centred command
+ * palettes around 600px.
+ *
+ * Two tiers, not a free width per palette — palettes open from the same
+ * keyboard reflex and often in sequence, so unconstrained per-surface sizing
+ * reads as the box jumping around rather than as a deliberate size.
  */
-export const PALETTE_SURFACE_WIDTH = "w-[484px] max-w-[calc(100vw-2rem)]";
+export type PaletteSurfaceTier = "anchored" | "command";
+
+/**
+ * Tailwind needs each class present in source for the JIT compiler, so these
+ * are whole literal strings — never build one by interpolation. Indexing the
+ * map at runtime is fine; the scanner only reads the text.
+ */
+export const PALETTE_SURFACE_WIDTHS: Record<PaletteSurfaceTier, string> = {
+  anchored: "w-[352px] max-w-[calc(100vw-2rem)]",
+  command: "w-[608px] max-w-[calc(100vw-2rem)]",
+};
 
 export interface AppPaletteDialogProps {
   isOpen: boolean;
   onClose: () => void;
   children: React.ReactNode;
   ariaLabel: string;
+  /**
+   * Which tier of surface this is. Required and never inferred: a picker's
+   * weight is an authoring decision, and a default would quietly hand every
+   * new launcher the command palette's box.
+   */
+  tier: PaletteSurfaceTier;
   /**
    * Extra classes for the palette box — sizing and layout only. The surface
    * itself is NOT overridable from here: `surface-overlay` is a handwritten
@@ -69,6 +88,7 @@ export function AppPaletteDialog({
   onClose,
   children,
   ariaLabel,
+  tier,
   className,
 }: AppPaletteDialogProps) {
   useEscapeStack(isOpen, onClose);
@@ -279,7 +299,7 @@ export function AppPaletteDialog({
           // `shadow-modal` sits one step above the popovers' `shadow-overlay`:
           // same inset top lip, deeper drop, because this one floats over a
           // scrim.
-          PALETTE_SURFACE_WIDTH,
+          PALETTE_SURFACE_WIDTHS[tier],
           "mx-4 surface-overlay shadow-modal rounded-[var(--radius-lg)] overflow-hidden origin-top",
           // Tailwind v4 scale-* emits the individual `scale` property, which
           // `transform` in a transition list does NOT cover — the palette
@@ -501,6 +521,13 @@ AppPaletteDialog.Footer = function AppPaletteFooter({
   children,
   className,
 }: AppPaletteFooterProps) {
+  // No content, no band. A footer earns its border by naming what Enter does
+  // for the current selection; `↑↓ navigate` and `Esc close` are conventions
+  // the surface does not need to restate, so there is no default to fall back
+  // to. Returning null rather than an empty wrapper matters because callers
+  // render <Footer> unconditionally and pass content that resolves per
+  // selection — an empty div would still draw the top border and padding.
+  if (children == null || children === false) return null;
   return (
     <div
       className={cn(
@@ -508,7 +535,7 @@ AppPaletteDialog.Footer = function AppPaletteFooter({
         className
       )}
     >
-      {children ?? <DefaultKeyboardHints />}
+      {children}
     </div>
   );
 };
@@ -525,8 +552,12 @@ export interface PaletteFooterHintsProps {
    * Secondary chips rendered on the trailing edge. They drop in reverse order
    * (last hides first) as the footer narrows, so order them by ascending
    * importance — the most-droppable chip last.
+   *
+   * Optional, and omitting it is the common case: a footer that carries one
+   * contextual action is the shape the family wants. Reach for these only when
+   * the surface has a second thing to say that isn't a navigation convention.
    */
-  hints: PaletteFooterHint[];
+  hints?: PaletteFooterHint[];
 }
 
 function HintChip({ hint, className }: { hint: PaletteFooterHint; className?: string }) {
@@ -552,7 +583,7 @@ const SECONDARY_DROP_CLASSES = [
   "@max-[200px]/palette-footer:hidden",
 ];
 
-export function PaletteFooterHints({ primaryHint, hints }: PaletteFooterHintsProps) {
+export function PaletteFooterHints({ primaryHint, hints = [] }: PaletteFooterHintsProps) {
   return (
     <div className="@container/palette-footer w-full flex items-center justify-between gap-3">
       <HintChip hint={primaryHint} />
@@ -570,18 +601,6 @@ export function PaletteFooterHints({ primaryHint, hints }: PaletteFooterHintsPro
         </div>
       )}
     </div>
-  );
-}
-
-function DefaultKeyboardHints() {
-  return (
-    <PaletteFooterHints
-      primaryHint={{ keys: ["↵"], label: "to select" }}
-      hints={[
-        { keys: ["↑", "↓"], label: "navigate" },
-        { keys: ["Esc"], label: "close" },
-      ]}
-    />
   );
 }
 

--- a/src/components/ui/AppPalettePopover.tsx
+++ b/src/components/ui/AppPalettePopover.tsx
@@ -1,7 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef } from "react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { PALETTE_HEADER_ATTR } from "@/components/ui/paletteHeaderAttr";
-import { PALETTE_SURFACE_WIDTH } from "@/components/ui/AppPaletteDialog";
+import { PALETTE_SURFACE_WIDTHS, type PaletteSurfaceTier } from "@/components/ui/AppPaletteDialog";
 import { cn } from "@/lib/utils";
 import { useUIStore } from "@/store/uiStore";
 
@@ -138,6 +138,13 @@ export interface AppPalettePopoverContentProps extends Omit<
    * the visible header and speech control can target it by the word on screen.
    */
   ariaLabel: string;
+  /**
+   * Which tier of surface this is. Required and never inferred — most anchored
+   * palettes want `"anchored"`, but the tier tracks the palette's weight rather
+   * than its host, so a genuinely global surface that happens to hang off a
+   * button still says so.
+   */
+  tier: PaletteSurfaceTier;
   /** The palette's search box. Focus is driven into it on every open. */
   inputRef: React.RefObject<HTMLInputElement | null>;
   /** Called when the first Escape spends itself clearing a non-empty query. */
@@ -182,6 +189,7 @@ export interface AppPalettePopoverContentProps extends Omit<
 
 function AppPalettePopoverContent({
   ariaLabel,
+  tier,
   inputRef,
   onClearQuery,
   restoreFocusOnPointerDismiss = false,
@@ -347,12 +355,12 @@ function AppPalettePopoverContent({
     // names and data attributes still come through untouched.
     <PopoverContent
       {...props}
-      // The family's one width, carried by the shell rather than restated at
-      // each anchor — an anchored palette and the modal form of the same
-      // palette (the project switcher renders both) have to resolve to the same
-      // surface. `cn` merges, so a palette that genuinely needs another width
-      // can still pass one.
-      className={cn(PALETTE_SURFACE_WIDTH, className)}
+      // The tier's width, carried by the shell rather than restated at each
+      // anchor, and resolved from the same map the modal form reads — a
+      // palette on a given tier is the same box whichever host it opens in.
+      // `cn` merges, so a palette that genuinely needs another width can still
+      // pass one.
+      className={cn(PALETTE_SURFACE_WIDTHS[tier], className)}
       aria-label={ariaLabel}
       // Radix does not set this itself. `aria-modal="false"` is noise, so the
       // non-modal form carries nothing rather than a negation.

--- a/src/components/ui/SearchablePalette.tsx
+++ b/src/components/ui/SearchablePalette.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useMemo, useRef, useCallback } from "react";
-import { AppPaletteDialog, KBD_CLASS, PaletteFooterHints } from "@/components/ui/AppPaletteDialog";
+import {
+  AppPaletteDialog,
+  KBD_CLASS,
+  PaletteFooterHints,
+  type PaletteSurfaceTier,
+} from "@/components/ui/AppPaletteDialog";
 import { PaletteOverflowNotice } from "@/components/ui/PaletteOverflowNotice";
 import { useEscapeStack } from "@/hooks";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
@@ -53,6 +58,12 @@ export interface SearchablePaletteProps<T> {
   shortcut?: string;
   /** ARIA label for the dialog */
   ariaLabel: string;
+  /**
+   * Which tier of surface this is — see `PaletteSurfaceTier`. Required and
+   * never inferred, so a new picker's author has to decide whether it is a
+   * scoped menu or a global command surface rather than inheriting one.
+   */
+  tier: PaletteSurfaceTier;
   /** Placeholder text for search input */
   searchPlaceholder?: string;
   /** ARIA label for the search input */
@@ -98,7 +109,10 @@ export interface SearchablePaletteProps<T> {
    * — see that component for layout details.
    */
   inputPrefix?: React.ReactNode;
-  /** Custom footer content. Omit for default keyboard hints. */
+  /**
+   * Custom footer content. Omit — along with `getFooter` and `getActionLabel`
+   * — for no footer band at all, which is the right answer for most surfaces.
+   */
   footer?: React.ReactNode;
   /**
    * Dynamic footer derived from the currently selected item. Receives `null`
@@ -109,13 +123,13 @@ export interface SearchablePaletteProps<T> {
    */
   getFooter?: (selectedItem: T | null) => React.ReactNode;
   /**
-   * Sugar for the very common case of "I just want to change the verb in the
-   * default footer hint." Returns the verb-noun action label for the current
-   * selection (e.g. `"Switch terminal"`, `"Apply theme"`). The shell composes
-   * the default `↵`/`↑↓`/`Esc` hints around it and lowercases the label for
-   * mid-sentence rendering. Ignored when `footer` or `getFooter` is also set
-   * — those win, in that order. Use a stable reference (module-level fn or
-   * `useCallback`) to avoid recomputing the footer node every render.
+   * Sugar for the common case of "the footer says one thing: what Enter does."
+   * Returns the verb-noun action label for the current selection (e.g.
+   * `"Switch terminal"`, `"Apply theme"`); the shell wraps it in a single `↵`
+   * chip and lowercases the label for mid-sentence rendering. Ignored when
+   * `footer` or `getFooter` is also set — those win, in that order. Use a
+   * stable reference (module-level fn or `useCallback`) to avoid recomputing
+   * the footer node every render.
    */
   getActionLabel?: (selectedItem: T | null) => string;
   /** Additional className for AppPaletteDialog.Body */
@@ -165,6 +179,7 @@ export function SearchablePalette<T>({
   label,
   shortcut,
   ariaLabel,
+  tier,
   searchPlaceholder = "Search",
   searchAriaLabel,
   listId = "searchable-palette-list",
@@ -329,15 +344,10 @@ export function SearchablePalette<T>({
     if (rawActionLabel == null) return null;
     const actionLabel = rawActionLabel.trim() || "Select";
     const phrase = `to ${actionLabel.toLowerCase()}`;
-    return (
-      <PaletteFooterHints
-        primaryHint={{ keys: ["↵"], label: phrase }}
-        hints={[
-          { keys: ["↑", "↓"], label: "navigate" },
-          { keys: ["Esc"], label: "close" },
-        ]}
-      />
-    );
+    // One chip, not three. `getActionLabel` names what Enter does for the
+    // current selection, which is the only thing a footer is for now — the
+    // `↑↓` and `Esc` chips this used to compose were restating conventions.
+    return <PaletteFooterHints primaryHint={{ keys: ["↵"], label: phrase }} />;
   }, [rawActionLabel]);
 
   let footerContent: React.ReactNode;
@@ -360,7 +370,7 @@ export function SearchablePalette<T>({
   const resolvedEmptyContent = emptyContent ?? autoEmptyChip;
 
   return (
-    <AppPaletteDialog isOpen={isOpen} onClose={onClose} ariaLabel={ariaLabel}>
+    <AppPaletteDialog isOpen={isOpen} onClose={onClose} ariaLabel={ariaLabel} tier={tier}>
       <AppPaletteDialog.Header
         label={label}
         shortcut={shortcut}

--- a/src/components/ui/__tests__/AppPaletteDialog.exitAriaModal.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteDialog.exitAriaModal.test.tsx
@@ -36,7 +36,7 @@ vi.stubGlobal(
 
 function renderPalette(isOpen: boolean, ariaLabel = "Test palette") {
   return render(
-    <AppPaletteDialog isOpen={isOpen} onClose={() => {}} ariaLabel={ariaLabel}>
+    <AppPaletteDialog isOpen={isOpen} onClose={() => {}} ariaLabel={ariaLabel} tier="command">
       <input type="text" placeholder="Palette input" />
     </AppPaletteDialog>
   );
@@ -78,10 +78,20 @@ describe("AppPaletteDialog aria-modal during exit window", () => {
     presenceFor = (isOpen) => ({ isVisible: isOpen, shouldRender: true });
     render(
       <>
-        <AppPaletteDialog isOpen={false} onClose={() => {}} ariaLabel="Outgoing palette">
+        <AppPaletteDialog
+          isOpen={false}
+          onClose={() => {}}
+          ariaLabel="Outgoing palette"
+          tier="command"
+        >
           <input type="text" placeholder="Outgoing input" />
         </AppPaletteDialog>
-        <AppPaletteDialog isOpen={true} onClose={() => {}} ariaLabel="Incoming palette">
+        <AppPaletteDialog
+          isOpen={true}
+          onClose={() => {}}
+          ariaLabel="Incoming palette"
+          tier="command"
+        >
           <input type="text" placeholder="Incoming input" />
         </AppPaletteDialog>
       </>

--- a/src/components/ui/__tests__/AppPaletteDialog.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteDialog.test.tsx
@@ -145,9 +145,9 @@ describe("AppPaletteDialog.Footer", () => {
     );
     // Structural, not a class-token match: there is a wrapper and the chip is
     // inside it. What that wrapper is styled with is the shell's business.
-    const band = container.firstChild as HTMLElement;
+    const band = container.firstElementChild;
     expect(band).not.toBeNull();
-    expect(band.contains(getByTestId("chip"))).toBe(true);
+    expect(band!.contains(getByTestId("chip"))).toBe(true);
   });
 });
 

--- a/src/components/ui/__tests__/AppPaletteDialog.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteDialog.test.tsx
@@ -106,43 +106,48 @@ describe("AppPaletteDialog surface tier", () => {
     expect(renderedWidth("anchored")).toBeLessThan(renderedWidth("command"));
   });
 
-  it("keeps the viewport clamp on both tiers", () => {
-    // The tier decides the box; it must not cost the narrow-window guard.
-    for (const tier of ["anchored", "command"] as const) {
-      const { unmount } = render(
-        <AppPaletteDialog isOpen onClose={() => {}} ariaLabel="Tier palette" tier={tier}>
-          <input type="text" placeholder="Palette input" />
-        </AppPaletteDialog>
-      );
-      const dialog = screen.getByRole("dialog", { name: "Tier palette" });
-      expect(dialog.className, `${tier} lost its max-width clamp`).toContain("max-w-[calc(");
-      unmount();
-    }
+  // The issue's second rule: "the tier is explicit, not inferred. A new picker
+  // author has to choose one." Nothing at runtime enforces that — the guard is
+  // the type, so the assertion IS the @ts-expect-error directive. Giving `tier`
+  // a default would make the directive unused and fail the typecheck.
+  it("will not compile without a tier", () => {
+    const element = (
+      // @ts-expect-error tier is required — a palette may not inherit its weight
+      <AppPaletteDialog isOpen onClose={() => {}} ariaLabel="Untiered palette">
+        <input type="text" placeholder="Palette input" />
+      </AppPaletteDialog>
+    );
+    expect(element).toBeTruthy();
   });
 });
 
 describe("AppPaletteDialog.Footer", () => {
-  it("renders no band when it has no contextual content", () => {
+  it("renders no band for content that resolves to nothing for this selection", () => {
     // A footer earns its top border by naming what Enter does. Callers render
     // <Footer> unconditionally with content that resolves per selection, so an
-    // empty wrapper would leave a bordered, padded strip behind.
-    const { container } = render(<AppPaletteDialog.Footer />);
-    expect(container.firstChild).toBeNull();
+    // empty wrapper would leave a bordered, padded strip behind. `[]` is the
+    // realistic non-nullish case: `getFooter={() => actions.map(...)}` with no
+    // contextual actions to offer.
+    for (const empty of [undefined, null, false, "", []] as const) {
+      const { container, unmount } = render(
+        <AppPaletteDialog.Footer>{empty}</AppPaletteDialog.Footer>
+      );
+      expect(container.firstChild, `${JSON.stringify(empty)} drew a band`).toBeNull();
+      unmount();
+    }
   });
 
-  it("renders no band for a footer that resolves to nothing for this selection", () => {
-    const { container } = render(<AppPaletteDialog.Footer>{null}</AppPaletteDialog.Footer>);
-    expect(container.firstChild).toBeNull();
-  });
-
-  it("renders the band once it has something to say", () => {
+  it("wraps the content once it has something to say", () => {
     const { container, getByTestId } = render(
       <AppPaletteDialog.Footer>
         <span data-testid="chip">↵ to open</span>
       </AppPaletteDialog.Footer>
     );
-    expect(getByTestId("chip")).toBeTruthy();
-    expect((container.firstChild as HTMLElement).className).toContain("border-t");
+    // Structural, not a class-token match: there is a wrapper and the chip is
+    // inside it. What that wrapper is styled with is the shell's business.
+    const band = container.firstChild as HTMLElement;
+    expect(band).not.toBeNull();
+    expect(band.contains(getByTestId("chip"))).toBe(true);
   });
 });
 

--- a/src/components/ui/__tests__/AppPaletteDialog.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteDialog.test.tsx
@@ -52,7 +52,12 @@ function renderPalette(props: { isOpen: boolean }) {
   return render(
     <>
       <Dispatcher />
-      <AppPaletteDialog isOpen={props.isOpen} onClose={() => {}} ariaLabel="Test palette">
+      <AppPaletteDialog
+        isOpen={props.isOpen}
+        onClose={() => {}}
+        ariaLabel="Test palette"
+        tier="command"
+      >
         <input type="text" placeholder="Palette input" />
       </AppPaletteDialog>
     </>
@@ -76,12 +81,77 @@ describe("AppPaletteDialog ARIA placement", () => {
   });
 });
 
+describe("AppPaletteDialog surface tier", () => {
+  /** Pull the px value out of whichever `w-[Npx]` class the shell applied. */
+  function renderedWidth(tier: "anchored" | "command"): number {
+    const { unmount } = render(
+      <AppPaletteDialog isOpen onClose={() => {}} ariaLabel="Tier palette" tier={tier}>
+        <input type="text" placeholder="Palette input" />
+      </AppPaletteDialog>
+    );
+    const dialog = screen.getByRole("dialog", { name: "Tier palette" });
+    const match = /(?:^|\s)w-\[(\d+)px\]/.exec(dialog.className);
+    // Unmount before the next tier renders: two live dialogs would stack focus
+    // traps and escape backstops, and `getByRole` would find both.
+    unmount();
+    expect(match, `no w-[Npx] class on the ${tier} surface`).not.toBeNull();
+    return Number(match![1]);
+  }
+
+  it("gives the anchored tier a strictly narrower box than the command tier", () => {
+    // The point of the change: a launcher and a global command palette are not
+    // the same weight of surface. Compares the two rendered widths rather than
+    // asserting either literal, so re-tuning a tier inside its band is not a
+    // test edit.
+    expect(renderedWidth("anchored")).toBeLessThan(renderedWidth("command"));
+  });
+
+  it("keeps the viewport clamp on both tiers", () => {
+    // The tier decides the box; it must not cost the narrow-window guard.
+    for (const tier of ["anchored", "command"] as const) {
+      const { unmount } = render(
+        <AppPaletteDialog isOpen onClose={() => {}} ariaLabel="Tier palette" tier={tier}>
+          <input type="text" placeholder="Palette input" />
+        </AppPaletteDialog>
+      );
+      const dialog = screen.getByRole("dialog", { name: "Tier palette" });
+      expect(dialog.className, `${tier} lost its max-width clamp`).toContain("max-w-[calc(");
+      unmount();
+    }
+  });
+});
+
+describe("AppPaletteDialog.Footer", () => {
+  it("renders no band when it has no contextual content", () => {
+    // A footer earns its top border by naming what Enter does. Callers render
+    // <Footer> unconditionally with content that resolves per selection, so an
+    // empty wrapper would leave a bordered, padded strip behind.
+    const { container } = render(<AppPaletteDialog.Footer />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders no band for a footer that resolves to nothing for this selection", () => {
+    const { container } = render(<AppPaletteDialog.Footer>{null}</AppPaletteDialog.Footer>);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the band once it has something to say", () => {
+    const { container, getByTestId } = render(
+      <AppPaletteDialog.Footer>
+        <span data-testid="chip">↵ to open</span>
+      </AppPaletteDialog.Footer>
+    );
+    expect(getByTestId("chip")).toBeTruthy();
+    expect((container.firstChild as HTMLElement).className).toContain("border-t");
+  });
+});
+
 describe("AppPaletteDialog focus trap", () => {
   function renderTrapPalette() {
     render(
       <>
         <Dispatcher />
-        <AppPaletteDialog isOpen onClose={() => {}} ariaLabel="Trap palette">
+        <AppPaletteDialog isOpen onClose={() => {}} ariaLabel="Trap palette" tier="command">
           <input type="text" placeholder="Palette input" />
           <button type="button">Middle action</button>
           <button type="button">Last action</button>
@@ -136,7 +206,7 @@ describe("AppPaletteDialog Escape yielded by the layer underneath", () => {
   it("closes when a dock popover underneath yields Escape", () => {
     const onClose = vi.fn();
     render(
-      <AppPaletteDialog isOpen onClose={onClose} ariaLabel="Yield palette">
+      <AppPaletteDialog isOpen onClose={onClose} ariaLabel="Yield palette" tier="command">
         <input aria-label="Palette input" />
       </AppPaletteDialog>
     );
@@ -186,7 +256,7 @@ describe("AppPaletteDialog focus restore", () => {
     const onClose = vi.fn();
     animatedPresenceState.shouldRender = false;
     const { rerender } = render(
-      <AppPaletteDialog isOpen onClose={onClose} ariaLabel="Test palette">
+      <AppPaletteDialog isOpen onClose={onClose} ariaLabel="Test palette" tier="command">
         <input type="text" placeholder="Palette input" />
       </AppPaletteDialog>
     );
@@ -194,7 +264,7 @@ describe("AppPaletteDialog focus restore", () => {
 
     animatedPresenceState.shouldRender = true;
     rerender(
-      <AppPaletteDialog isOpen onClose={onClose} ariaLabel="Test palette">
+      <AppPaletteDialog isOpen onClose={onClose} ariaLabel="Test palette" tier="command">
         <input type="text" placeholder="Palette input" />
       </AppPaletteDialog>
     );
@@ -233,7 +303,7 @@ describe("AppPaletteDialog focus restore", () => {
     rerender(
       <>
         <Dispatcher />
-        <AppPaletteDialog isOpen={false} onClose={() => {}} ariaLabel="Test palette">
+        <AppPaletteDialog isOpen={false} onClose={() => {}} ariaLabel="Test palette" tier="command">
           <input type="text" placeholder="Palette input" />
         </AppPaletteDialog>
       </>
@@ -265,7 +335,7 @@ describe("AppPaletteDialog focus restore", () => {
     rerender(
       <>
         <Dispatcher />
-        <AppPaletteDialog isOpen={false} onClose={() => {}} ariaLabel="Test palette">
+        <AppPaletteDialog isOpen={false} onClose={() => {}} ariaLabel="Test palette" tier="command">
           <input type="text" placeholder="Palette input" />
         </AppPaletteDialog>
       </>
@@ -315,7 +385,7 @@ describe("AppPaletteDialog focus restore", () => {
     rerender(
       <>
         <Dispatcher />
-        <AppPaletteDialog isOpen={false} onClose={() => {}} ariaLabel="Test palette">
+        <AppPaletteDialog isOpen={false} onClose={() => {}} ariaLabel="Test palette" tier="command">
           <input type="text" placeholder="Palette input" />
         </AppPaletteDialog>
       </>
@@ -335,7 +405,7 @@ describe("AppPaletteDialog focus restore", () => {
     rerender(
       <>
         <Dispatcher />
-        <AppPaletteDialog isOpen={false} onClose={() => {}} ariaLabel="Test palette">
+        <AppPaletteDialog isOpen={false} onClose={() => {}} ariaLabel="Test palette" tier="command">
           <input type="text" placeholder="Palette input" />
         </AppPaletteDialog>
       </>
@@ -417,7 +487,7 @@ describe("AppPaletteDialog.Body results region (#11431)", () => {
     render(
       <>
         <Dispatcher />
-        <AppPaletteDialog isOpen onClose={() => {}} ariaLabel="Body palette">
+        <AppPaletteDialog isOpen onClose={() => {}} ariaLabel="Body palette" tier="command">
           <AppPaletteDialog.Body
             ariaLabel="Results"
             activeDescendant="option-b"

--- a/src/components/ui/__tests__/AppPalettePopover.test.tsx
+++ b/src/components/ui/__tests__/AppPalettePopover.test.tsx
@@ -4,7 +4,7 @@ import { useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AppPalettePopover } from "../AppPalettePopover";
-import { AppPaletteDialog } from "../AppPaletteDialog";
+import { AppPaletteDialog, type PaletteSurfaceTier } from "../AppPaletteDialog";
 import { useUIStore } from "@/store/uiStore";
 
 /**
@@ -98,6 +98,8 @@ interface HarnessProps {
   withInput?: boolean;
   /** Renders a second stamped header in a portal outside this content's DOM. */
   withNestedPortal?: boolean;
+  /** Overrides the content's surface tier; falls through to `contentOverrides`. */
+  tier?: PaletteSurfaceTier;
 }
 
 function Harness({
@@ -134,6 +136,7 @@ function Harness({
       </AppPalettePopover.Trigger>
       <AppPalettePopover.Content
         ariaLabel="Test palette"
+        tier="command"
         inputRef={inputRef}
         onClearQuery={() => setQuery("")}
         restoreFocusOnPointerDismiss={restoreFocusOnPointerDismiss}
@@ -213,6 +216,33 @@ beforeEach(() => {
   useUIStore.setState({ overlayStack: [] });
 });
 
+describe("AppPalettePopover surface tier", () => {
+  /**
+   * The popover resolves its own width rather than inheriting the modal's, so
+   * the wiring is worth its own coverage: a tier honoured by `AppPaletteDialog`
+   * and dropped here is exactly the drift this shell exists to prevent.
+   */
+  function contentWidth(tier: PaletteSurfaceTier): number {
+    const { unmount } = render(<Harness initialOpen tier={tier} />);
+    const className = typeof contentProps.className === "string" ? contentProps.className : "";
+    unmount();
+    const match = /(?:^|\s)w-\[(\d+)px\]/.exec(className);
+    expect(match, `no w-[Npx] class forwarded for the ${tier} surface`).not.toBeNull();
+    return Number(match![1]);
+  }
+
+  it("forwards a narrower box for the anchored tier than the command tier", () => {
+    expect(contentWidth("anchored")).toBeLessThan(contentWidth("command"));
+  });
+
+  it("keeps tier out of the props handed to Radix", () => {
+    // `tier` is shell vocabulary. Forwarded, it reaches the DOM as an unknown
+    // attribute and React warns on every open.
+    render(<Harness initialOpen tier="anchored" />);
+    expect(contentProps).not.toHaveProperty("tier");
+  });
+});
+
 describe("AppPalettePopover", () => {
   it("forwards the open state and the required modal choice to the popover root", () => {
     const { unmount } = render(<Harness modal={true} open={false} />);
@@ -278,7 +308,12 @@ describe("AppPalettePopover", () => {
     const inputRef = { current: null };
     expect(() =>
       render(
-        <AppPalettePopover.Content ariaLabel="Orphan" inputRef={inputRef} onClearQuery={vi.fn()}>
+        <AppPalettePopover.Content
+          ariaLabel="Orphan"
+          tier="command"
+          inputRef={inputRef}
+          onClearQuery={vi.fn()}
+        >
           <span />
         </AppPalettePopover.Content>
       )

--- a/src/components/ui/__tests__/SearchablePalette.announce.test.tsx
+++ b/src/components/ui/__tests__/SearchablePalette.announce.test.tsx
@@ -70,6 +70,7 @@ function renderPalette(initial: { query: string; results: Item[]; isFiltering: b
     renderItem: (item: Item) => <div key={item.id}>{item.id}</div>,
     label: "Test",
     ariaLabel: "Test palette",
+    tier: "command" as const,
     isFiltering: initial.isFiltering,
   };
   return render(<SearchablePalette<Item> {...props} />);
@@ -104,6 +105,7 @@ describe("SearchablePalette filter-result live announcement", () => {
         renderItem={(item) => <div key={item.id}>{item.id}</div>}
         label="Test"
         ariaLabel="Test palette"
+        tier="command"
         isFiltering={false}
       />
     );
@@ -133,6 +135,7 @@ describe("SearchablePalette filter-result live announcement", () => {
         renderItem={(item) => <div key={item.id}>{item.id}</div>}
         label="Test"
         ariaLabel="Test palette"
+        tier="command"
         isFiltering={false}
       />
     );
@@ -160,6 +163,7 @@ describe("SearchablePalette filter-result live announcement", () => {
         renderItem={(item) => <div key={item.id}>{item.id}</div>}
         label="Test"
         ariaLabel="Test palette"
+        tier="command"
         isFiltering={false}
       />
     );
@@ -187,6 +191,7 @@ describe("SearchablePalette filter-result live announcement", () => {
         renderItem={(item) => <div key={item.id}>{item.id}</div>}
         label="Test"
         ariaLabel="Test palette"
+        tier="command"
         isFiltering={isFiltering}
       />
     );

--- a/src/components/ui/__tests__/SearchablePalette.empty.test.tsx
+++ b/src/components/ui/__tests__/SearchablePalette.empty.test.tsx
@@ -64,6 +64,7 @@ function renderEmpty({
       renderItem={(item) => <div key={item.id}>{item.label}</div>}
       label="Test"
       ariaLabel="Test palette"
+      tier="command"
       emptyShortcut={emptyShortcut}
       emptyEntityName={emptyEntityName}
       emptyContent={emptyContent}

--- a/src/components/ui/__tests__/SearchablePalette.footer.test.tsx
+++ b/src/components/ui/__tests__/SearchablePalette.footer.test.tsx
@@ -77,6 +77,7 @@ function renderPalette({
       )}
       label="Test"
       ariaLabel="Test palette"
+      tier="command"
       footer={footer}
       getFooter={getFooter}
       getActionLabel={getActionLabel}
@@ -129,10 +130,15 @@ describe("SearchablePalette footer", () => {
     expect(getByTestId("static-footer").textContent).toBe("static");
   });
 
-  it("falls back to default keyboard hints when neither prop is provided", () => {
+  it("renders no footer band at all when no footer source is provided", () => {
     renderPalette();
 
-    expect(document.body.textContent).toContain("to select");
+    // Not merely "no hint text": the band itself must be absent. A palette that
+    // has nothing to say about Enter should not spend a bordered strip saying
+    // so, and an empty wrapper would still draw its top border and padding.
+    expect(document.body.querySelector("kbd")).toBeNull();
+    expect(document.body.textContent).not.toContain("to select");
+    expect(document.body.querySelector(".border-t")).toBeNull();
   });
 
   it("does not render an aria-live region for the footer", () => {
@@ -149,7 +155,7 @@ describe("SearchablePalette footer", () => {
     expect(footerContainer?.querySelector("[aria-live]")).toBeNull();
   });
 
-  it("getActionLabel composes a custom verb into the default footer hint", () => {
+  it("getActionLabel composes a custom verb into the footer hint", () => {
     renderPalette({
       selectedIndex: 1,
       getActionLabel: (item) => (item ? `Switch to ${item.label}` : "Switch"),
@@ -157,6 +163,21 @@ describe("SearchablePalette footer", () => {
 
     expect(document.body.textContent).toContain("to switch to bravo");
     expect(document.body.textContent).not.toContain("to select");
+  });
+
+  it("getActionLabel renders one contextual chip, not a navigation lesson", () => {
+    renderPalette({
+      selectedIndex: 1,
+      getActionLabel: (item) => (item ? `Switch to ${item.label}` : "Switch"),
+    });
+
+    // The footer names what Enter does and stops there. `↑↓` and `Esc` are
+    // conventions every picker in the app shares, so restating them per surface
+    // is chrome that teaches nothing.
+    const keys = Array.from(document.body.querySelectorAll("kbd"), (el) => el.textContent);
+    expect(keys).toEqual(["↵"]);
+    expect(document.body.textContent).not.toContain("navigate");
+    expect(document.body.textContent).not.toContain("close");
   });
 
   it("getActionLabel receives null when results are empty", () => {
@@ -192,10 +213,11 @@ describe("SearchablePalette footer", () => {
     expect(document.body.textContent).toContain("to select");
   });
 
-  it("explicit footer={false} suppresses both the action-label path and the default hints", () => {
+  it("explicit footer={false} suppresses the action-label path and renders no band", () => {
     renderPalette({ footer: false, getActionLabel: () => "Switch terminal" });
     expect(document.body.textContent).not.toContain("to switch terminal");
     expect(document.body.textContent).not.toContain("to select");
+    expect(document.body.querySelector(".border-t")).toBeNull();
   });
 
   it("getActionLabel updates when selectedIndex moves to a different item", () => {
@@ -219,6 +241,7 @@ describe("SearchablePalette footer", () => {
         )}
         label="Test"
         ariaLabel="Test palette"
+        tier="command"
         getActionLabel={fn}
       />
     );
@@ -243,6 +266,7 @@ describe("SearchablePalette footer", () => {
         )}
         label="Test"
         ariaLabel="Test palette"
+        tier="command"
         getActionLabel={fn}
       />
     );
@@ -281,6 +305,7 @@ describe("SearchablePalette footer", () => {
           )}
           label="Test"
           ariaLabel="Test palette"
+          tier="command"
           getActionLabel={getActionLabel}
         />
       );
@@ -302,7 +327,7 @@ describe("SearchablePalette footer", () => {
       const initialDialog = document.body.querySelector("[role='dialog']");
       expect(initialDialog).not.toBeNull();
       const initialKbds = Array.from(initialDialog!.querySelectorAll("kbd"));
-      // Footer kbd entries are: "↵", "↑", "↓", "Esc". Grab the primary "↵".
+      // The footer carries exactly one chip now — the "↵" action.
       const initialPrimaryKbd = initialKbds.find((kbd) => kbd.textContent === "↵");
       expect(initialPrimaryKbd).toBeDefined();
 

--- a/src/components/ui/__tests__/SearchablePalette.footer.test.tsx
+++ b/src/components/ui/__tests__/SearchablePalette.footer.test.tsx
@@ -31,6 +31,7 @@ vi.mock("@/store/paletteStore", () => ({
 }));
 
 import { SearchablePalette } from "../SearchablePalette";
+import type { PaletteSurfaceTier } from "../AppPaletteDialog";
 
 interface Item {
   id: string;
@@ -49,6 +50,7 @@ interface RenderArgs {
   footer?: React.ReactNode;
   getFooter?: (selectedItem: Item | null) => React.ReactNode;
   getActionLabel?: (selectedItem: Item | null) => string;
+  tier?: PaletteSurfaceTier;
 }
 
 function renderPalette({
@@ -57,6 +59,7 @@ function renderPalette({
   footer,
   getFooter,
   getActionLabel,
+  tier = "command",
 }: RenderArgs = {}) {
   return render(
     <SearchablePalette<Item>
@@ -77,7 +80,7 @@ function renderPalette({
       )}
       label="Test"
       ariaLabel="Test palette"
-      tier="command"
+      tier={tier}
       footer={footer}
       getFooter={getFooter}
       getActionLabel={getActionLabel}
@@ -130,15 +133,31 @@ describe("SearchablePalette footer", () => {
     expect(getByTestId("static-footer").textContent).toBe("static");
   });
 
+  it("forwards its tier to the shell instead of pinning one", () => {
+    // SearchablePalette renders the dialog itself, so a hardcoded or dropped
+    // tier here would leave the shell's own tier tests green while every
+    // anchored consumer — SendToAgent, Worktree, QuickCreate — silently came
+    // out at command width.
+    const widthFor = (tier: "anchored" | "command") => {
+      const { unmount } = renderPalette({ tier });
+      const dialog = document.body.querySelector("[role='dialog']");
+      const match = /(?:^|\s)w-\[(\d+)px\]/.exec(dialog?.className ?? "");
+      unmount();
+      expect(match, `no w-[Npx] class for the ${tier} tier`).not.toBeNull();
+      return Number(match![1]);
+    };
+
+    expect(widthFor("anchored")).toBeLessThan(widthFor("command"));
+  });
+
   it("renders no footer band at all when no footer source is provided", () => {
     renderPalette();
 
-    // Not merely "no hint text": the band itself must be absent. A palette that
-    // has nothing to say about Enter should not spend a bordered strip saying
-    // so, and an empty wrapper would still draw its top border and padding.
+    // This fixture passes no `shortcut` and no `emptyShortcut`, so the footer
+    // is the palette's only source of `kbd` chips — their absence is the band's
+    // absence. (`AppPaletteDialog.Footer` covers the wrapper itself directly.)
     expect(document.body.querySelector("kbd")).toBeNull();
     expect(document.body.textContent).not.toContain("to select");
-    expect(document.body.querySelector(".border-t")).toBeNull();
   });
 
   it("does not render an aria-live region for the footer", () => {
@@ -217,7 +236,7 @@ describe("SearchablePalette footer", () => {
     renderPalette({ footer: false, getActionLabel: () => "Switch terminal" });
     expect(document.body.textContent).not.toContain("to switch terminal");
     expect(document.body.textContent).not.toContain("to select");
-    expect(document.body.querySelector(".border-t")).toBeNull();
+    expect(document.body.querySelector("kbd")).toBeNull();
   });
 
   it("getActionLabel updates when selectedIndex moves to a different item", () => {

--- a/src/components/ui/__tests__/SearchablePalette.hover.test.tsx
+++ b/src/components/ui/__tests__/SearchablePalette.hover.test.tsx
@@ -61,6 +61,7 @@ function renderPalette(onHoverIndex?: (index: number) => void) {
       )}
       label="Test"
       ariaLabel="Test palette"
+      tier="command"
     />
   );
 }

--- a/src/components/ui/__tests__/SearchablePalette.keyboard.test.tsx
+++ b/src/components/ui/__tests__/SearchablePalette.keyboard.test.tsx
@@ -50,6 +50,7 @@ function renderPalette(overrides: Record<string, unknown> = {}) {
     renderItem: (item: Item) => <div key={item.id}>{item.id}</div>,
     label: "Test",
     ariaLabel: "Test palette",
+    tier: "command" as const,
     ...overrides,
   };
   return render(<SearchablePalette<Item> {...props} />);

--- a/src/components/ui/__tests__/SearchablePalette.loading.test.tsx
+++ b/src/components/ui/__tests__/SearchablePalette.loading.test.tsx
@@ -49,6 +49,7 @@ function renderPalette({ isLoading, results }: { isLoading?: boolean; results: I
       renderItem={(item) => <div key={item.id}>{item.id}</div>}
       label="Test"
       ariaLabel="Test palette"
+      tier="command"
       emptyMessage="No items available"
       isLoading={isLoading}
     />

--- a/src/components/ui/__tests__/SearchablePalette.stale.test.tsx
+++ b/src/components/ui/__tests__/SearchablePalette.stale.test.tsx
@@ -51,6 +51,7 @@ function renderPalette(isFiltering: boolean | undefined) {
       renderItem={(item) => <div key={item.id}>{item.id}</div>}
       label="Test"
       ariaLabel="Test palette"
+      tier="command"
       listId="test-palette-list"
       isFiltering={isFiltering}
     />

--- a/src/components/ui/__tests__/dialogOverlayClearing.test.tsx
+++ b/src/components/ui/__tests__/dialogOverlayClearing.test.tsx
@@ -77,7 +77,7 @@ const harnesses = [
   {
     name: "AppPaletteDialog",
     node: (isOpen: boolean) => (
-      <AppPaletteDialog isOpen={isOpen} onClose={() => {}} ariaLabel="Test palette">
+      <AppPaletteDialog isOpen={isOpen} onClose={() => {}} ariaLabel="Test palette" tier="command">
         <input type="text" placeholder="Palette input" />
       </AppPaletteDialog>
     ),


### PR DESCRIPTION
## Summary

- Every palette in the app rendered at one width (`PALETTE_SURFACE_WIDTH = "w-[484px]"`) with one footer: the same three chips (`↵ to select`, `↑↓ navigate`, `Esc close`) on every surface that didn't override them. A small launcher hanging off a toolbar button got the same box and the same instructional band as a global command palette.
- 484px sits between the two width tiers mature pickers actually use, serving neither. The shell now takes an explicit tier, and the tier decides both the box width and whether a footer band exists at all: `anchored` (352px) for launchers and worktree/panel/project pickers, `command` (608px) for the command palette, resume sessions, fleet picker, pilot, and quick switcher.
- Two rules follow. `DefaultKeyboardHints` is gone: a footer only renders when the surface names what Enter does for the current selection, since `↑↓` and `Esc` are conventions no surface needs to restate. And the tier is required, never inferred, so a new picker's author has to choose one.

Resolves #11687

## Changes

- `PALETTE_SURFACE_WIDTHS: Record<PaletteSurfaceTier, string>` replaces the single width constant, with full literal class strings so Tailwind v4's Oxide scanner emits both.
- `AppPaletteDialog.Footer` now returns `null` for content that renders as nothing, including `[]` (what a `getFooter` mapping zero actions naturally produces), instead of drawing an empty bordered strip.
- `SearchablePalette`'s `getActionLabel` auto-footer narrowed from three chips to the single `↵` chip. `PaletteFooterHints`' secondary `hints` prop is now optional.
- Narrowing to 352px exposed latent overflow: the worktree/panel/new-terminal row name lines now truncate, and the project switcher's four-rail footer got container-query breakpoints so it degrades instead of clipping.
- The six test files that mock `AppPaletteDialog` now export a two-key sentinel tier map, deliberately not the production pixel values, so future width resizes don't couple back into the mocks.
- The shared material is untouched: `surface-overlay`, the motion tiers, the row rhythm, and the header treatment are what make the family read as one system. Only the box scales.
- Surfaces that already pass an explicit `footer`/`getFooter` keep rendering what they pass. Per-surface cleanup is separate work, per the issue.

## Testing

- Typecheck clean.
- 3823 tests across 218 files pass.
- Prettier and eslint clean on all 39 changed files (0 errors).