### PR TITLE
Drop the accent from palette selection and field focus

### DIFF
--- a/docs/themes/interaction-state-recipes.md
+++ b/docs/themes/interaction-state-recipes.md
@@ -84,7 +84,7 @@ This document maps each interactive component role to its canonical Tailwind cla
 
 The accent border and the 2px accent rail this recipe used to prescribe were removed in #11686: they put accent on the row, its rail and the focused input at once, breaking the one-load-bearing-signal rule. The palette input's focus lift draws the same `selection-outline` (ring at half strength), so the field and the selected row stay one treatment — change them together.
 
-`palette-row` is a forced-colors hook, not styling. Under `forced-colors: active` the fill is discarded, so `src/index.css` redraws the row from `SelectedItem`/`SelectedItemText`; the marker scopes that to palette rows, since `[role="option"]` is also used by the file pane, the settings selectors and the agent/forge dropdowns.
+`palette-row` is a forced-colors hook, not styling. Under `forced-colors: active` both the fill and the outline are stripped, so `src/index.css` falls back to a 2px `SelectedItem` outline. Deliberately an outline rather than a `SelectedItem` fill: these rows carry independently surfaced children (theme "Active" badges, action category chips, panel-kind icons with inline colour) that the engine maps to the forced palette on their own, and a fill would leave them painting `CanvasText` on `SelectedItem` — a pair with no contrast guarantee. The marker scopes the rule to palette rows, since `[role="option"]` is also used by the file pane, the settings selectors and the agent/forge dropdowns.
 
 ---
 

--- a/docs/themes/interaction-state-recipes.md
+++ b/docs/themes/interaction-state-recipes.md
@@ -34,7 +34,7 @@ This document maps each interactive component role to its canonical Tailwind cla
 "hover:bg-overlay-subtle hover:text-daintree-text";
 ```
 
-**Usage:** For selected state, use `aria-selected:bg-overlay-raised aria-selected:border-overlay` with a `before:` pseudo-element for the 2px accent rail (`aria-selected:before:absolute aria-selected:before:left-0 aria-selected:before:top-2 aria-selected:before:bottom-2 aria-selected:before:w-[2px] aria-selected:before:bg-daintree-accent`). The raised token follows the `bondi.ts` "elevate-to-select for menu/palette rows" rationale (#9727) — `overlay-soft` is sub-threshold on near-white surfaces. Used in `QuickSwitcherItem.tsx`.
+**Usage:** For selected state, use the shared `PALETTE_ROW_CLASS` (`src/components/ui/paletteRowStyles.ts`) rather than respelling it — see [Selected State (List Item)](#selected-state-list-item). The raised token follows the `bondi.ts` "elevate-to-select for menu/palette rows" rationale (#9727) — `overlay-soft` is sub-threshold on near-white surfaces. Used in `QuickSwitcherItem.tsx`.
 
 ---
 
@@ -72,13 +72,19 @@ This document maps each interactive component role to its canonical Tailwind cla
 
 ### Selected State (List Item)
 
-**Role:** Selected list item in a picker. Uses background fill with accent rail via pseudo-element.
+**Role:** Selected list item in a picker. A raised neutral fill plus a neutral hairline — no accent, no rail.
 
 ```tsx
-"aria-selected:bg-overlay-raised aria-selected:border-overlay aria-selected:text-daintree-text aria-selected:before:absolute aria-selected:before:left-0 aria-selected:before:top-2 aria-selected:before:bottom-2 aria-selected:before:w-[2px] aria-selected:before:bg-daintree-accent aria-selected:before:content-['']";
+"palette-row border border-transparent transition-colors aria-selected:bg-overlay-raised aria-selected:border-selection-outline aria-selected:text-daintree-text";
 ```
 
-**Usage:** Selected items do not add hover overlay — the background fill and accent rail provide sufficient state distinction. Unselected items get `hover:bg-overlay-subtle`. Used in `QuickSwitcherItem.tsx`.
+**Usage:** Do not respell this — import `PALETTE_ROW_CLASS` from `src/components/ui/paletteRowStyles.ts`, which 16 palette surfaces already share. Selected items do not add hover overlay; unselected items get `hover:bg-overlay-subtle`.
+
+`selection-outline` is its own semantic token, not a member of the resting border ladder, because it is the row's only non-text indicator and so carries WCAG 1.4.11 alone: `overlay-raised` clears only ~1.1-1.2:1 against the palette surface, far short of 3:1. It is derived from each theme's `text-primary` (42% dark / 53% light) and gated at 3:1 against _both_ the selected fill and the surrounding surface by `getThemeContrastWarnings`. The fill is the binding pair — on dark the row lifts toward the outline, so an outline that looks safe against the surface can still vanish into the row it encloses.
+
+The accent border and the 2px accent rail this recipe used to prescribe were removed in #11686: they put accent on the row, its rail and the focused input at once, breaking the one-load-bearing-signal rule. The palette input's focus lift draws the same `selection-outline` (ring at half strength), so the field and the selected row stay one treatment — change them together.
+
+`palette-row` is a forced-colors hook, not styling. Under `forced-colors: active` the fill is discarded, so `src/index.css` redraws the row from `SelectedItem`/`SelectedItemText`; the marker scopes that to palette rows, since `[role="option"]` is also used by the file pane, the settings selectors and the agent/forge dropdowns.
 
 ---
 

--- a/docs/themes/theme-tokens.md
+++ b/docs/themes/theme-tokens.md
@@ -90,8 +90,11 @@ Dim or disabled icons must use a solid token (`text-text-muted` for disabled/nee
 | `border-strong`      | Focused panel borders               | `white 14%`  | `black 14%`   |
 | `border-divider`     | Structural separators               | `white 5%`   | `black 4%`    |
 | `border-interactive` | Hovered/focused interactive borders | `white 20%`  | `black 10%`   |
+| `selection-outline`  | Palette selected-row hairline       | `text 42%`   | `text 53%`    |
 
 **Polarity pattern:** Dark themes use white-alpha; light themes use black-alpha.
+
+**`selection-outline` is deliberately outside that ladder.** It is derived from `text-primary` rather than the border ink, and sits 2-3x above `border-strong`, because it is the only border in the app that must satisfy WCAG 1.4.11 on its own — the raised fill it encloses clears barely 1.1-1.2:1 against the palette surface, so the outline is the whole non-text indicator. `getThemeContrastWarnings` gates it at 3:1 against both the selected fill and the surrounding surface, so retuning `text-primary` or the fill trips the theme contract rather than silently weakening the indicator. See [interaction-state-recipes.md](./interaction-state-recipes.md#selected-state-list-item).
 
 ## Accent Tokens
 

--- a/e2e/full/platform/core-palette-accessibility.spec.ts
+++ b/e2e/full/platform/core-palette-accessibility.spec.ts
@@ -144,6 +144,14 @@ test.describe.serial("Core: Command Palette Accessibility", () => {
     await expect(options.first()).toBeVisible({ timeout: T_MEDIUM });
     await expect(options.first()).toHaveAttribute("aria-selected", "true");
 
+    // The row's raised fill and neutral outline are both discarded here, so the
+    // system-colour fallback in `index.css` is the only thing still marking the
+    // row. The attribute assertion above cannot see that rule go missing.
+    const selectedOutlineWidth = await options
+      .first()
+      .evaluate((el) => getComputedStyle(el).outlineWidth);
+    expect(selectedOutlineWidth).not.toBe("0px");
+
     const searchInput = window.locator(SEL.panelPalette.searchInput);
     await searchInput.focus();
     await expect(searchInput).toBeFocused({ timeout: T_SHORT });

--- a/shared/theme/__tests__/contrast.test.ts
+++ b/shared/theme/__tests__/contrast.test.ts
@@ -390,36 +390,73 @@ describe("getThemeContrastWarnings", () => {
     }
   });
 
+  // The dark palette surface is the sidebar at 94% over whatever the palette
+  // floats above, so these fixtures pin every backdrop to the sidebar's own
+  // colour to isolate the pair under test from that blend.
+  function makeFlatDarkScheme(overrides: Partial<AppColorSchemeTokens>): AppColorScheme {
+    return makeScheme({
+      "surface-sidebar": "#000000" as AppColorSchemeTokens["surface-sidebar"],
+      "surface-grid": "#000000" as AppColorSchemeTokens["surface-grid"],
+      "surface-canvas": "#000000" as AppColorSchemeTokens["surface-canvas"],
+      "surface-panel": "#000000" as AppColorSchemeTokens["surface-panel"],
+      "surface-panel-elevated": "#000000" as AppColorSchemeTokens["surface-panel-elevated"],
+      ...overrides,
+    });
+  }
+
   it("fails an outline that clears the surrounding surface but not the row fill it encloses", () => {
     // The row lifts towards the outline on dark, so the surface pair is the
     // permissive one — an outline can pass it while vanishing into the fill it
     // actually borders. #5A5A5A is 3.04:1 on black and 1.52:1 on #767676.
-    const scheme = makeScheme({
-      "surface-sidebar": "#000000" as AppColorSchemeTokens["surface-sidebar"],
+    const scheme = makeFlatDarkScheme({
       "overlay-raised": "#767676" as AppColorSchemeTokens["overlay-raised"],
       "selection-outline": "#5A5A5A" as AppColorSchemeTokens["selection-outline"],
     });
-    const warnings = getThemeContrastWarnings(scheme);
-    expect(
-      warnings.filter((w) => w.message.includes("selection-outline against the selected row fill"))
-    ).toHaveLength(1);
-    expect(
-      warnings.filter((w) => w.message.includes("selection-outline against the surrounding"))
-    ).toHaveLength(0);
+    const failure = getThemeContrastWarnings(scheme).find((w) =>
+      w.message.includes("selection-outline against")
+    );
+    expect(failure?.message).toContain("the selected row fill");
+  });
+
+  it("scores the dark palette surface as translucent, not as the solid sidebar", () => {
+    // #5A5A5A clears 3:1 on a solid black sidebar, but the palette floats at 94%
+    // over the app, and admitting 6% of a bright plane behind it drops the pair
+    // below the floor. Scoring only the solid token would call this compliant.
+    const scheme = makeFlatDarkScheme({
+      "surface-panel-elevated": "#FFFFFF" as AppColorSchemeTokens["surface-panel-elevated"],
+      "overlay-raised": "#000000" as AppColorSchemeTokens["overlay-raised"],
+      "selection-outline": "#5A5A5A" as AppColorSchemeTokens["selection-outline"],
+    });
+    const failure = getThemeContrastWarnings(scheme).find((w) =>
+      w.message.includes("selection-outline against")
+    );
+    expect(failure?.message).toContain("the surrounding palette surface");
   });
 
   it("composites an rgba outline over the row fill rather than reading its raw alpha", () => {
     // At face value #FFFFFF would be 21:1 on this fill; at 10% alpha the pixel
     // that actually renders is ~#2C2C2C, which is nowhere near 3:1.
-    const scheme = makeScheme({
-      "surface-sidebar": "#141414" as AppColorSchemeTokens["surface-sidebar"],
+    const scheme = makeFlatDarkScheme({
       "overlay-raised": "#1E1E1E" as AppColorSchemeTokens["overlay-raised"],
       "selection-outline": "rgba(255, 255, 255, 0.1)" as AppColorSchemeTokens["selection-outline"],
     });
-    const warnings = getThemeContrastWarnings(scheme);
-    expect(
-      warnings.filter((w) => w.message.includes("selection-outline against the selected row fill"))
-    ).toHaveLength(1);
+    const failures = getThemeContrastWarnings(scheme).filter((w) =>
+      w.message.includes("selection-outline against")
+    );
+    expect(failures).toHaveLength(1);
+  });
+
+  it("composites an alpha-hex outline instead of reading it as opaque", () => {
+    // `#FFFFFF10` is 6% white. Treating the hex as opaque would score it 21:1
+    // and pass; the pixel that renders is ~#151515 on this fill.
+    const scheme = makeFlatDarkScheme({
+      "overlay-raised": "#0E0E0E" as AppColorSchemeTokens["overlay-raised"],
+      "selection-outline": "#FFFFFF10" as AppColorSchemeTokens["selection-outline"],
+    });
+    const failures = getThemeContrastWarnings(scheme).filter((w) =>
+      w.message.includes("selection-outline against")
+    );
+    expect(failures).toHaveLength(1);
   });
 
   it("reports the palette selection check as unevaluable when the outline is not hex or rgba", () => {

--- a/shared/theme/__tests__/contrast.test.ts
+++ b/shared/theme/__tests__/contrast.test.ts
@@ -412,10 +412,11 @@ describe("getThemeContrastWarnings", () => {
       "overlay-raised": "#767676" as AppColorSchemeTokens["overlay-raised"],
       "selection-outline": "#5A5A5A" as AppColorSchemeTokens["selection-outline"],
     });
-    const failure = getThemeContrastWarnings(scheme).find((w) =>
-      w.message.includes("selection-outline against")
-    );
-    expect(failure?.message).toContain("the selected row fill");
+    const messages = getThemeContrastWarnings(scheme)
+      .filter((w) => w.message.includes("selection-outline against"))
+      .map((w) => w.message);
+    expect(messages.some((m) => m.includes("the selected row fill"))).toBe(true);
+    expect(messages.some((m) => m.includes("the surrounding palette surface"))).toBe(false);
   });
 
   it("scores the dark palette surface as translucent, not as the solid sidebar", () => {
@@ -427,34 +428,34 @@ describe("getThemeContrastWarnings", () => {
       "overlay-raised": "#000000" as AppColorSchemeTokens["overlay-raised"],
       "selection-outline": "#5A5A5A" as AppColorSchemeTokens["selection-outline"],
     });
-    const failure = getThemeContrastWarnings(scheme).find((w) =>
-      w.message.includes("selection-outline against")
-    );
-    expect(failure?.message).toContain("the surrounding palette surface");
+    const messages = getThemeContrastWarnings(scheme)
+      .filter((w) => w.message.includes("selection-outline against"))
+      .map((w) => w.message);
+    expect(messages.some((m) => m.includes("the surrounding palette surface"))).toBe(true);
   });
 
   it("composites an rgba outline over the row fill rather than reading its raw alpha", () => {
-    // At face value #FFFFFF would be 21:1 on this fill; at 10% alpha the pixel
-    // that actually renders is ~#2C2C2C, which is nowhere near 3:1.
+    // Opaque white would score 16.67:1 on this fill and sail through; at 10%
+    // alpha the pixel that actually renders is #353535, which is 1.36:1.
     const scheme = makeFlatDarkScheme({
       "overlay-raised": "#1E1E1E" as AppColorSchemeTokens["overlay-raised"],
       "selection-outline": "rgba(255, 255, 255, 0.1)" as AppColorSchemeTokens["selection-outline"],
     });
     const failures = getThemeContrastWarnings(scheme).filter((w) =>
-      w.message.includes("selection-outline against")
+      w.message.includes("selection-outline against the selected row fill")
     );
     expect(failures).toHaveLength(1);
   });
 
   it("composites an alpha-hex outline instead of reading it as opaque", () => {
-    // `#FFFFFF10` is 6% white. Treating the hex as opaque would score it 21:1
-    // and pass; the pixel that renders is ~#151515 on this fill.
+    // `#FFFFFF10` is 6% white. Read as opaque it would score 19.30:1 and pass;
+    // the pixel that renders is #1D1D1D on this fill.
     const scheme = makeFlatDarkScheme({
       "overlay-raised": "#0E0E0E" as AppColorSchemeTokens["overlay-raised"],
       "selection-outline": "#FFFFFF10" as AppColorSchemeTokens["selection-outline"],
     });
     const failures = getThemeContrastWarnings(scheme).filter((w) =>
-      w.message.includes("selection-outline against")
+      w.message.includes("selection-outline against the selected row fill")
     );
     expect(failures).toHaveLength(1);
   });

--- a/shared/theme/__tests__/contrast.test.ts
+++ b/shared/theme/__tests__/contrast.test.ts
@@ -379,6 +379,64 @@ describe("getThemeContrastWarnings", () => {
     }
   });
 
+  it("produces zero palette selection-outline warnings across all built-in themes", () => {
+    for (const scheme of BUILT_IN_APP_SCHEMES) {
+      const warnings = getThemeContrastWarnings(scheme);
+      const selectionFailures = warnings.filter((w) => w.message.includes("selection-outline"));
+      expect(
+        selectionFailures,
+        `${scheme.id}: selection-outline is the palette row's only non-text indicator and must hit 3:1`
+      ).toHaveLength(0);
+    }
+  });
+
+  it("fails an outline that clears the surrounding surface but not the row fill it encloses", () => {
+    // The row lifts towards the outline on dark, so the surface pair is the
+    // permissive one — an outline can pass it while vanishing into the fill it
+    // actually borders. #5A5A5A is 3.04:1 on black and 1.52:1 on #767676.
+    const scheme = makeScheme({
+      "surface-sidebar": "#000000" as AppColorSchemeTokens["surface-sidebar"],
+      "overlay-raised": "#767676" as AppColorSchemeTokens["overlay-raised"],
+      "selection-outline": "#5A5A5A" as AppColorSchemeTokens["selection-outline"],
+    });
+    const warnings = getThemeContrastWarnings(scheme);
+    expect(
+      warnings.filter((w) => w.message.includes("selection-outline against the selected row fill"))
+    ).toHaveLength(1);
+    expect(
+      warnings.filter((w) => w.message.includes("selection-outline against the surrounding"))
+    ).toHaveLength(0);
+  });
+
+  it("composites an rgba outline over the row fill rather than reading its raw alpha", () => {
+    // At face value #FFFFFF would be 21:1 on this fill; at 10% alpha the pixel
+    // that actually renders is ~#2C2C2C, which is nowhere near 3:1.
+    const scheme = makeScheme({
+      "surface-sidebar": "#141414" as AppColorSchemeTokens["surface-sidebar"],
+      "overlay-raised": "#1E1E1E" as AppColorSchemeTokens["overlay-raised"],
+      "selection-outline": "rgba(255, 255, 255, 0.1)" as AppColorSchemeTokens["selection-outline"],
+    });
+    const warnings = getThemeContrastWarnings(scheme);
+    expect(
+      warnings.filter((w) => w.message.includes("selection-outline against the selected row fill"))
+    ).toHaveLength(1);
+  });
+
+  it("reports the palette selection check as unevaluable when the outline is not hex or rgba", () => {
+    const scheme = makeScheme({
+      "selection-outline":
+        "color-mix(in oklab, #ffffff 42%, transparent)" as AppColorSchemeTokens["selection-outline"],
+    });
+    const warnings = getThemeContrastWarnings(scheme);
+    const unevaluable = warnings.find(
+      (w) =>
+        w.kind === "unevaluable" &&
+        w.message.includes("Cannot evaluate palette selection contrast") &&
+        w.message.includes("selection-outline")
+    );
+    expect(unevaluable).toBeDefined();
+  });
+
   it("emits contrast warning when search-highlight-background rgba is composited over a surface", () => {
     const scheme = makeScheme({
       "search-highlight-text": "#cccccc" as AppColorSchemeTokens["search-highlight-text"],

--- a/shared/theme/contrast.ts
+++ b/shared/theme/contrast.ts
@@ -586,29 +586,74 @@ export function getThemeContrastWarnings(scheme: AppColorScheme): AppThemeValida
 const ACCENT_MIN_CONTRAST = ACCENT_CONTRAST_PAIR.minimum;
 const ACCENT_OUTLINE_MIN_CONTRAST = 3.0;
 
-// What sits behind an unselected palette row. `.surface-overlay` (index.css)
-// resolves to the sidebar on dark and to the elevated panel on light, and rows
-// are transparent until selected, so this is also the unselected row's colour.
-// Deliberately the solid token rather than the dark material's ~94% composite
-// over the canvas: the canvas is the darker plane, so compositing pushes the
-// surface and the fill down together and *raises* the outline's ratio. The
-// solid surface is the conservative end of the range.
-const PALETTE_SURFACE_BY_TYPE = {
-  dark: "surface-sidebar",
-  light: "surface-panel-elevated",
-} as const satisfies Record<AppColorScheme["type"], AppThemeTokenKey>;
+// What sits behind an unselected palette row, per `.surface-overlay`
+// (index.css). Rows are transparent until selected, so this is also the
+// unselected row's colour.
+//
+// Light forces the floating surface opaque, so `surface-panel-elevated` is
+// exact. Dark leaves it at 94% over whatever the palette floats above, and
+// every plane except the grid is *lighter* than the sidebar — so the solid
+// sidebar is the flattering end of the range, not the conservative one. The
+// backdrop isn't knowable here, so we score against all of them and keep the
+// worst: a lighter backdrop lifts the surface and the fill together and closes
+// the gap the outline has to hold.
+const DARK_PALETTE_BACKDROPS: AppThemeTokenKey[] = [
+  "surface-grid",
+  "surface-canvas",
+  "surface-panel",
+  "surface-panel-elevated",
+];
+const DARK_PALETTE_SURFACE_OPACITY = 0.94;
+
+// Every colour the palette surface can actually render as, worst case last.
+function resolvePaletteSurfaces(scheme: AppColorScheme): string[] | null {
+  if (scheme.type === "light") {
+    const elevated = scheme.tokens["surface-panel-elevated"];
+    return isHexColor(elevated) ? [elevated] : null;
+  }
+  const sidebar = scheme.tokens["surface-sidebar"];
+  if (!isHexColor(sidebar)) return null;
+  const surfaces = DARK_PALETTE_BACKDROPS.map((key) => scheme.tokens[key])
+    .filter(isHexColor)
+    .map((backdrop) => blendOverBackground(sidebar, backdrop, DARK_PALETTE_SURFACE_OPACITY));
+  return surfaces.length > 0 ? surfaces : [sidebar];
+}
 
 const SELECTION_OUTLINE_MIN_CONTRAST = 3.0;
 
 // The pixel a token actually paints when it lands on `backdrop`. Tokens reach us
-// either as an opaque hex or as an `rgba()` wash; anything else (a `color-mix()`
-// from a partially-specified import) is not evaluable by this math, and says so
-// rather than guessing.
+// as an opaque hex, an alpha hex (`#RGBA`/`#RRGGBBAA`, which `isHexColor` accepts
+// and `relativeLuminance` would otherwise read as opaque and pass on a ratio the
+// user never sees), or an `rgba()` wash. Anything else — a `color-mix()` from a
+// partially-specified import — is not evaluable by this math, and says so rather
+// than guessing.
 function resolveOverBackdrop(value: string, backdrop: string): string | null {
-  if (isHexColor(value)) return value;
+  if (isHexColor(value)) {
+    const alphaHex = splitHexAlpha(value);
+    return alphaHex ? blendOverBackground(alphaHex.hex, backdrop, alphaHex.opacity) : value;
+  }
   const rgba = parseRgba(value);
   if (!rgba) return null;
   return blendOverBackground(rgba.hex, backdrop, rgba.opacity);
+}
+
+// Splits `#RGBA`/`#RRGGBBAA` into its opaque colour and alpha. Returns null for
+// the 3- and 6-digit forms, which are already opaque.
+function splitHexAlpha(hex: string): { hex: string; opacity: number } | null {
+  const body = hex.slice(1);
+  if (body.length === 4) {
+    return {
+      hex: `#${body.slice(0, 3)}`,
+      opacity: parseInt(body[3]!.repeat(2), 16) / 255,
+    };
+  }
+  if (body.length === 8) {
+    return {
+      hex: `#${body.slice(0, 6)}`,
+      opacity: parseInt(body.slice(6), 16) / 255,
+    };
+  }
+  return null;
 }
 
 // WCAG 1.4.11 for the palette selected row. The raised fill clears barely
@@ -619,48 +664,56 @@ function resolveOverBackdrop(value: string, backdrop: string): string | null {
 // surface can still fail against the row it encloses.
 function getPaletteSelectionWarnings(scheme: AppColorScheme): AppThemeValidationWarning[] {
   const warnings: AppThemeValidationWarning[] = [];
-  const surfaceKey = PALETTE_SURFACE_BY_TYPE[scheme.type];
-  const surface = scheme.tokens[surfaceKey];
   const outlineToken = scheme.tokens["selection-outline"];
   const fillToken = scheme.tokens["overlay-raised"];
 
-  if (!isHexColor(surface)) {
+  const surfaces = resolvePaletteSurfaces(scheme);
+  if (surfaces === null) {
     warnings.push({
       kind: "unevaluable",
-      message: `Cannot evaluate palette selection contrast: ${surfaceKey}="${surface}" is not a hex color`,
+      message: `Cannot evaluate palette selection contrast: the palette surface for a ${scheme.type} theme is not a hex color`,
     });
     return warnings;
   }
 
-  const fill = resolveOverBackdrop(fillToken, surface);
-  if (fill === null) {
-    warnings.push({
-      kind: "unevaluable",
-      message: `Cannot evaluate palette selection contrast: overlay-raised="${fillToken}" is neither hex nor rgba()`,
-    });
-    return warnings;
-  }
+  // Report the worst surface only. Every candidate is the same surface under a
+  // different backdrop, so warning once per plane would be four spellings of one
+  // problem.
+  let worst: { ratio: number; label: string } | null = null;
 
-  const outline = resolveOverBackdrop(outlineToken, fill);
-  if (outline === null) {
-    warnings.push({
-      kind: "unevaluable",
-      message: `Cannot evaluate palette selection contrast: selection-outline="${outlineToken}" is neither hex nor rgba()`,
-    });
-    return warnings;
-  }
-
-  for (const [label, against] of [
-    ["the selected row fill", fill],
-    [`the surrounding ${surfaceKey}`, surface],
-  ] as const) {
-    const ratio = contrastRatio(outline, against);
-    if (ratio < SELECTION_OUTLINE_MIN_CONTRAST) {
+  for (const surface of surfaces) {
+    const fill = resolveOverBackdrop(fillToken, surface);
+    if (fill === null) {
       warnings.push({
-        kind: "low-contrast",
-        message: `selection-outline against ${label} is ${ratio.toFixed(2)}:1; target is ${SELECTION_OUTLINE_MIN_CONTRAST.toFixed(1)}:1 (WCAG 1.4.11 Non-text Contrast)`,
+        kind: "unevaluable",
+        message: `Cannot evaluate palette selection contrast: overlay-raised="${fillToken}" is neither hex nor rgba()`,
       });
+      return warnings;
     }
+
+    const outline = resolveOverBackdrop(outlineToken, fill);
+    if (outline === null) {
+      warnings.push({
+        kind: "unevaluable",
+        message: `Cannot evaluate palette selection contrast: selection-outline="${outlineToken}" is neither hex nor rgba()`,
+      });
+      return warnings;
+    }
+
+    for (const [label, against] of [
+      ["the selected row fill", fill],
+      ["the surrounding palette surface", surface],
+    ] as const) {
+      const ratio = contrastRatio(outline, against);
+      if (!worst || ratio < worst.ratio) worst = { ratio, label };
+    }
+  }
+
+  if (worst && worst.ratio < SELECTION_OUTLINE_MIN_CONTRAST) {
+    warnings.push({
+      kind: "low-contrast",
+      message: `selection-outline against ${worst.label} is ${worst.ratio.toFixed(2)}:1; target is ${SELECTION_OUTLINE_MIN_CONTRAST.toFixed(1)}:1 (WCAG 1.4.11 Non-text Contrast)`,
+    });
   }
 
   return warnings;

--- a/shared/theme/contrast.ts
+++ b/shared/theme/contrast.ts
@@ -566,6 +566,10 @@ export function getThemeContrastWarnings(scheme: AppColorScheme): AppThemeValida
     }
   }
 
+  // Palette selected-row indicator (#11686) — the outline is the whole non-text
+  // signal there, so it carries 1.4.11 on its own.
+  warnings.push(...getPaletteSelectionWarnings(scheme));
+
   // Terminal ANSI / syntax legibility and distinctness — OKLab-based because
   // the terminal background is always dark and WCAG ratios are unreliable there.
   warnings.push(...getTerminalSyntaxWarnings(scheme));
@@ -581,6 +585,86 @@ export function getThemeContrastWarnings(scheme: AppColorScheme): AppThemeValida
 // literal here could silently drift from the pair everything else is derived from.
 const ACCENT_MIN_CONTRAST = ACCENT_CONTRAST_PAIR.minimum;
 const ACCENT_OUTLINE_MIN_CONTRAST = 3.0;
+
+// What sits behind an unselected palette row. `.surface-overlay` (index.css)
+// resolves to the sidebar on dark and to the elevated panel on light, and rows
+// are transparent until selected, so this is also the unselected row's colour.
+// Deliberately the solid token rather than the dark material's ~94% composite
+// over the canvas: the canvas is the darker plane, so compositing pushes the
+// surface and the fill down together and *raises* the outline's ratio. The
+// solid surface is the conservative end of the range.
+const PALETTE_SURFACE_BY_TYPE = {
+  dark: "surface-sidebar",
+  light: "surface-panel-elevated",
+} as const satisfies Record<AppColorScheme["type"], AppThemeTokenKey>;
+
+const SELECTION_OUTLINE_MIN_CONTRAST = 3.0;
+
+// The pixel a token actually paints when it lands on `backdrop`. Tokens reach us
+// either as an opaque hex or as an `rgba()` wash; anything else (a `color-mix()`
+// from a partially-specified import) is not evaluable by this math, and says so
+// rather than guessing.
+function resolveOverBackdrop(value: string, backdrop: string): string | null {
+  if (isHexColor(value)) return value;
+  const rgba = parseRgba(value);
+  if (!rgba) return null;
+  return blendOverBackground(rgba.hex, backdrop, rgba.opacity);
+}
+
+// WCAG 1.4.11 for the palette selected row. The raised fill clears barely
+// 1.1-1.2:1 against the surface in every built-in theme, so it cannot be the
+// indicator; `selection-outline` is, and it has to hold 3:1 against BOTH
+// neighbours it touches. The fill is the binding one — on dark the row lifts
+// *towards* the outline, so the pair that looks safe against the surrounding
+// surface can still fail against the row it encloses.
+function getPaletteSelectionWarnings(scheme: AppColorScheme): AppThemeValidationWarning[] {
+  const warnings: AppThemeValidationWarning[] = [];
+  const surfaceKey = PALETTE_SURFACE_BY_TYPE[scheme.type];
+  const surface = scheme.tokens[surfaceKey];
+  const outlineToken = scheme.tokens["selection-outline"];
+  const fillToken = scheme.tokens["overlay-raised"];
+
+  if (!isHexColor(surface)) {
+    warnings.push({
+      kind: "unevaluable",
+      message: `Cannot evaluate palette selection contrast: ${surfaceKey}="${surface}" is not a hex color`,
+    });
+    return warnings;
+  }
+
+  const fill = resolveOverBackdrop(fillToken, surface);
+  if (fill === null) {
+    warnings.push({
+      kind: "unevaluable",
+      message: `Cannot evaluate palette selection contrast: overlay-raised="${fillToken}" is neither hex nor rgba()`,
+    });
+    return warnings;
+  }
+
+  const outline = resolveOverBackdrop(outlineToken, fill);
+  if (outline === null) {
+    warnings.push({
+      kind: "unevaluable",
+      message: `Cannot evaluate palette selection contrast: selection-outline="${outlineToken}" is neither hex nor rgba()`,
+    });
+    return warnings;
+  }
+
+  for (const [label, against] of [
+    ["the selected row fill", fill],
+    [`the surrounding ${surfaceKey}`, surface],
+  ] as const) {
+    const ratio = contrastRatio(outline, against);
+    if (ratio < SELECTION_OUTLINE_MIN_CONTRAST) {
+      warnings.push({
+        kind: "low-contrast",
+        message: `selection-outline against ${label} is ${ratio.toFixed(2)}:1; target is ${SELECTION_OUTLINE_MIN_CONTRAST.toFixed(1)}:1 (WCAG 1.4.11 Non-text Contrast)`,
+      });
+    }
+  }
+
+  return warnings;
+}
 
 // Structured result describing how an accent override fails its contrast gate, so
 // the theme picker can render a specific, actionable warning instead of a generic

--- a/shared/theme/contrast.ts
+++ b/shared/theme/contrast.ts
@@ -613,10 +613,14 @@ function resolvePaletteSurfaces(scheme: AppColorScheme): string[] | null {
   }
   const sidebar = scheme.tokens["surface-sidebar"];
   if (!isHexColor(sidebar)) return null;
-  const surfaces = DARK_PALETTE_BACKDROPS.map((key) => scheme.tokens[key])
-    .filter(isHexColor)
-    .map((backdrop) => blendOverBackground(sidebar, backdrop, DARK_PALETTE_SURFACE_OPACITY));
-  return surfaces.length > 0 ? surfaces : [sidebar];
+  // The solid sidebar stays in the running: performance mode and
+  // `prefers-contrast: more` both drop the material and render it opaque.
+  return [
+    sidebar,
+    ...DARK_PALETTE_BACKDROPS.map((key) => scheme.tokens[key])
+      .filter(isHexColor)
+      .map((backdrop) => blendOverBackground(sidebar, backdrop, DARK_PALETTE_SURFACE_OPACITY)),
+  ];
 }
 
 const SELECTION_OUTLINE_MIN_CONTRAST = 3.0;
@@ -640,7 +644,10 @@ function resolveOverBackdrop(value: string, backdrop: string): string | null {
 // Splits `#RGBA`/`#RRGGBBAA` into its opaque colour and alpha. Returns null for
 // the 3- and 6-digit forms, which are already opaque.
 function splitHexAlpha(hex: string): { hex: string; opacity: number } | null {
-  const body = hex.slice(1);
+  // `isHexColor` trims before validating, so a padded token reaches us intact —
+  // slicing without trimming would leave the alpha digits unrecognised and the
+  // colour would take the opaque path.
+  const body = hex.trim().slice(1);
   if (body.length === 4) {
     return {
       hex: `#${body.slice(0, 3)}`,
@@ -676,10 +683,12 @@ function getPaletteSelectionWarnings(scheme: AppColorScheme): AppThemeValidation
     return warnings;
   }
 
-  // Report the worst surface only. Every candidate is the same surface under a
-  // different backdrop, so warning once per plane would be four spellings of one
-  // problem.
-  let worst: { ratio: number; label: string } | null = null;
+  // Collapse the backdrops but not the pairs: every candidate surface is the
+  // same surface behind a different plane, so warning per plane would be five
+  // spellings of one problem — but "invisible against the row" and "invisible
+  // against the surface" are separate faults, and reporting only the worse one
+  // would send an author to fix half the problem.
+  const worstByLabel = new Map<string, number>();
 
   for (const surface of surfaces) {
     const fill = resolveOverBackdrop(fillToken, surface);
@@ -705,15 +714,18 @@ function getPaletteSelectionWarnings(scheme: AppColorScheme): AppThemeValidation
       ["the surrounding palette surface", surface],
     ] as const) {
       const ratio = contrastRatio(outline, against);
-      if (!worst || ratio < worst.ratio) worst = { ratio, label };
+      const seen = worstByLabel.get(label);
+      if (seen === undefined || ratio < seen) worstByLabel.set(label, ratio);
     }
   }
 
-  if (worst && worst.ratio < SELECTION_OUTLINE_MIN_CONTRAST) {
-    warnings.push({
-      kind: "low-contrast",
-      message: `selection-outline against ${worst.label} is ${worst.ratio.toFixed(2)}:1; target is ${SELECTION_OUTLINE_MIN_CONTRAST.toFixed(1)}:1 (WCAG 1.4.11 Non-text Contrast)`,
-    });
+  for (const [label, ratio] of worstByLabel) {
+    if (ratio < SELECTION_OUTLINE_MIN_CONTRAST) {
+      warnings.push({
+        kind: "low-contrast",
+        message: `selection-outline against ${label} is ${ratio.toFixed(2)}:1; target is ${SELECTION_OUTLINE_MIN_CONTRAST.toFixed(1)}:1 (WCAG 1.4.11 Non-text Contrast)`,
+      });
+    }
   }
 
   return warnings;

--- a/shared/theme/themes.ts
+++ b/shared/theme/themes.ts
@@ -197,6 +197,16 @@ export function createDaintreeTokens(
     "border-strong": tokens["border-strong"] ?? withAlpha(borderInk, dark ? 0.14 : 0.18),
     "border-divider": tokens["border-divider"] ?? withAlpha(borderInk, dark ? 0.05 : 0.085),
     "border-interactive": tokens["border-interactive"] ?? withAlpha(borderInk, dark ? 0.2 : 0.2),
+    // Driven from `text-primary`, not `borderInk`: this is the one border that
+    // must hit a fixed ratio, and `text-primary` is the only ink already floored
+    // against every surface, so a fraction of it lands predictably in all 14
+    // themes. Light needs the heavier alpha for the same reason the light border
+    // ladder is doubled — the eye's luminance discrimination is compressed near
+    // white, and the outline sits on the raised fill rather than the surface.
+    // Both values are enforced at 3:1 by `getThemeContrastWarnings`; raising the
+    // fill or retuning `text-primary` will trip that rather than fail silently.
+    "selection-outline":
+      tokens["selection-outline"] ?? withAlpha(tokens["text-primary"], dark ? 0.42 : 0.53),
     "accent-foreground": tokens["accent-foreground"] ?? tokens["text-inverse"],
     // RC-4 (engine slice): on light, brighten the accent on hover (mix toward white)
     // so it advances on interaction instead of darkening into the canvas.

--- a/shared/theme/types.ts
+++ b/shared/theme/types.ts
@@ -28,6 +28,14 @@ export const APP_THEME_TOKEN_KEYS = [
   "border-strong",
   "border-divider",
   "border-interactive",
+  // The hairline that marks "this is the row Enter will act on" in the palettes.
+  // Its own key rather than a reuse of `border-strong` because it is the only
+  // border in the app that has to satisfy WCAG 1.4.11 on its own: the raised
+  // fill it sits on clears barely 1.1-1.2:1 against the palette surface, so the
+  // outline is the whole non-text indicator and carries the full 3:1. That puts
+  // it 2-3x above the resting border ladder, which is tuned for separation
+  // rather than for being the sole signal.
+  "selection-outline",
 
   // Accent
   "accent-primary",

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -438,7 +438,7 @@ function ProjectListItem({
  *
  * "Scratch" rides the secondary line rather than a chip: origin has to be
  * unambiguous, but it is not the row's headline, and a pill here would be a
- * second emphasis signal competing with the selection stripe.
+ * second emphasis signal competing with the selected row's own treatment.
  *
  * Action-free on purpose. Rename, save-as-project and delete are browse-mode
  * management — an inline rename editor would have to live inside the array the

--- a/src/components/ThemePalette/ThemePalette.tsx
+++ b/src/components/ThemePalette/ThemePalette.tsx
@@ -41,10 +41,10 @@ function ThemeListItem({
       role="option"
       aria-selected={isSelected}
       className={cn(
-        // Was a hand-rolled copy of the shared row: a visible resting outline,
-        // a JS-ternary selected state and a rail that popped instead of fading.
-        // `PALETTE_ROW_CLASS` is the same visual driven off `aria-selected`, so
-        // this row now matches every other palette in the family.
+        // Was a hand-rolled copy of the shared row: a visible resting outline
+        // and a JS-ternary selected state. `PALETTE_ROW_CLASS` is the same
+        // visual driven off `aria-selected`, so this row now matches every
+        // other palette in the family.
         PALETTE_ROW_CLASS,
         "group w-full text-left px-3 py-2 rounded-[var(--radius-md)] flex items-center gap-3",
         "hover:bg-overlay-subtle"

--- a/src/components/Worktree/QuickCreatePalette.tsx
+++ b/src/components/Worktree/QuickCreatePalette.tsx
@@ -47,8 +47,8 @@ function RecipeListItem({
         id={`quick-create-option-${item.id}`}
         onClick={onClick}
         className={cn(
-          // Was a hand-rolled copy of the shared row, so it kept the neutral
-          // selected border after the family moved to the accent one.
+          // Was a hand-rolled copy of the shared row and drifted out of step
+          // with it; takes the selected treatment from the family now.
           PALETTE_ROW_CLASS,
           "w-full text-left px-3 py-2 rounded-[var(--radius-lg)] flex items-center gap-2",
           "bg-daintree-bg hover:bg-surface"

--- a/src/components/Worktree/WorktreePalette.tsx
+++ b/src/components/Worktree/WorktreePalette.tsx
@@ -26,8 +26,8 @@ function WorktreeListItem({ worktree, isActive, isSelected, onClick }: WorktreeL
         id={`worktree-option-${worktree.id}`}
         onClick={onClick}
         className={cn(
-          // Was a hand-rolled copy of the shared row, so it kept the neutral
-          // selected border after the family moved to the accent one.
+          // Was a hand-rolled copy of the shared row and drifted out of step
+          // with it; takes the selected treatment from the family now.
           PALETTE_ROW_CLASS,
           "group w-full text-left px-3 py-2 rounded-[var(--radius-lg)] flex flex-col gap-0.5",
           "bg-daintree-bg hover:bg-surface"

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -590,14 +590,13 @@ function DefaultKeyboardHints() {
 // `surface-input` fill. Alpha-based, so it reads the same over a dialog and
 // over the dock launcher's popover.
 //
-// The focus lift that pairs with it is accent at /40, the same strength every
-// focus border in the app now carries — this input used to be the one holdout,
-// drawn neutral on the theory that the selection rail should own the region's
-// only accent, which just made the focused element the dimmest thing on the
-// surface. /40 also matches `PALETTE_ROW_CLASS`'s selected outline, so the
-// focused field and the selected row render the same green; change them
-// together. Tailwind needs the variants written out at each use site, so they
-// live inline below.
+// The focus lift that pairs with it draws `selection-outline`, the same token
+// `PALETTE_ROW_CLASS` uses for the selected row, with the ring at half strength
+// so the field reads as the quieter half of one treatment rather than a second
+// colour; change them together. Neutral rather than accent (#11686): the row,
+// its old rail and this field were three accent signals in one focus region.
+// Tailwind needs the variants written out at each use site, so they live inline
+// below.
 const PALETTE_INPUT_SURFACE =
   "bg-overlay-soft border border-[var(--border-overlay)] rounded-[var(--radius-md)]";
 
@@ -624,8 +623,8 @@ AppPaletteDialog.Input = function AppPaletteInput({
         className={cn(
           "flex w-full items-center gap-1.5 pl-2 pr-3 py-1.5",
           PALETTE_INPUT_SURFACE,
-          // Accent focus — see `PALETTE_INPUT_SURFACE`.
-          "focus-within:border-daintree-accent/40 focus-within:ring-1 focus-within:ring-daintree-accent/20"
+          // Neutral focus — see `PALETTE_INPUT_SURFACE`.
+          "focus-within:border-selection-outline focus-within:ring-1 focus-within:ring-selection-outline/50"
         )}
       >
         {inputPrefix}
@@ -651,8 +650,8 @@ AppPaletteDialog.Input = function AppPaletteInput({
         "w-full px-3 py-2 text-sm",
         PALETTE_INPUT_SURFACE,
         "text-daintree-text placeholder:text-text-placeholder",
-        // Accent focus — see `PALETTE_INPUT_SURFACE`.
-        "focus:outline-hidden focus:border-daintree-accent/40 focus:ring-1 focus:ring-daintree-accent/20",
+        // Neutral focus — see `PALETTE_INPUT_SURFACE`.
+        "focus:outline-hidden focus:border-selection-outline focus:ring-1 focus:ring-selection-outline/50",
         className
       )}
       {...props}

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -591,9 +591,10 @@ function DefaultKeyboardHints() {
 // over the dock launcher's popover.
 //
 // The focus lift that pairs with it draws `selection-outline`, the same token
-// `PALETTE_ROW_CLASS` uses for the selected row, with the ring at half strength
-// so the field reads as the quieter half of one treatment rather than a second
-// colour; change them together. Neutral rather than accent (#11686): the row,
+// and the same strength `PALETTE_ROW_CLASS` uses for the selected row, so the
+// focused field and the selected row read as one treatment; the ring is that
+// colour again at half alpha, a halo around the border rather than a second
+// signal. Change them together. Neutral rather than accent (#11686): the row,
 // its old rail and this field were three accent signals in one focus region.
 // Tailwind needs the variants written out at each use site, so they live inline
 // below.

--- a/src/components/ui/paletteRowStyles.ts
+++ b/src/components/ui/paletteRowStyles.ts
@@ -21,22 +21,22 @@ import { cn } from "@/lib/utils";
  * treatment from this.
  */
 export const PALETTE_ROW_CLASS = cn(
-  // `relative` is the rail's containing block; the transparent border reserves
-  // the selected border's width so the row cannot shift when it arrives.
-  "relative border border-transparent transition-colors",
-  // The outline is the rail's own colour at /40 — one anchor drawn twice, not
-  // two signals. It shares that /40 with the palette input's focus border
-  // (`AppPaletteDialog`), so both land on the same rendered green and the
-  // surface reads as one treatment rather than two strengths; change them
-  // together. /25 was tried and sat inside the noise of the neutral border it
-  // replaced. Every theme's accent drives it, so the outline and the rail can
-  // never disagree about what colour "selected" is.
-  "aria-selected:bg-overlay-raised aria-selected:border-daintree-accent/40 aria-selected:text-daintree-text",
-  // The rail is always laid out and only its opacity changes. Toggling
-  // `content` instead gave the pseudo-element nothing to transition from.
-  "before:absolute before:top-2 before:bottom-2 before:left-0 before:w-[2px] before:rounded-r",
-  "before:bg-daintree-accent before:opacity-0 before:transition-opacity before:content-['']",
-  "aria-selected:before:opacity-100"
+  // `palette-row` is not styling — it is the handle the `forced-colors: active`
+  // block in `index.css` needs. There the raised fill is discarded and the row
+  // has to redraw itself from system keywords, and `[role="option"]` is far too
+  // broad a hook: the file pane, the settings selectors and the agent/forge
+  // dropdowns all use it too. The transparent resting border reserves the
+  // selected border's width so the row cannot shift when it arrives.
+  "palette-row border border-transparent transition-colors",
+  // Neutral, not accent (#11686). The fill alone can't be the indicator — it
+  // clears about 1.1-1.2:1 against the palette surface — so `selection-outline`
+  // carries WCAG 1.4.11 at 3:1 for the pair. It is the same token the palette
+  // input's focus border uses (`AppPaletteDialog`), so the focused field and the
+  // selected row are one treatment at two strengths rather than two colours;
+  // change them together. Earlier attempts at a neutral outline failed because
+  // they reused the resting border ladder, which is tuned for separation and
+  // sits inside its own noise when asked to be the only signal.
+  "aria-selected:bg-overlay-raised aria-selected:border-selection-outline aria-selected:text-daintree-text"
 );
 
 /**

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -124,17 +124,6 @@ const DURABLE_ALLOWLIST = new Set([
   // Current worktree card left-edge accent bar (single primary anchor per active focus region)
   "src/components/Worktree/WorktreeCard.tsx",
 
-  // The one definition of the palette selected-row treatment: the left-edge
-  // accent stripe plus the half-strength accent outline that carries the same
-  // anchor around the row (single primary anchor per active focus region).
-  // PilotView, ProjectSwitcherPalette, ResumeSessionsPalette, QuickSwitcherItem,
-  // ActionPaletteItem, DockLaunchButton, PanelPalette, PluginQuickPickDialog,
-  // PromptHistoryPalette, WorktreePalette and QuickCreatePalette all take it
-  // from here rather than spelling it out themselves, which is why none of them
-  // needs a bucket entry for the row treatment. QuickCreatePalette still has one
-  // below, but for an unrelated `checked:bg-daintree-accent` checkbox.
-  "src/components/ui/paletteRowStyles.ts",
-
   // PluginManagerView selected-row left-edge accent stripe in the master-detail
   // list, plus the detail subtab active-tab underline (single primary anchor per
   // active focus region)

--- a/src/config/__tests__/focusRingFallback.contract.test.ts
+++ b/src/config/__tests__/focusRingFallback.contract.test.ts
@@ -377,7 +377,7 @@ const ALLOWLIST: FocusRingAllowlistEntry[] = [
     file: "src/components/ui/AppPaletteDialog.tsx",
     fragment: "focus:outline-hidden focus:border-transparent focus:ring-0",
     reason:
-      "Parent shows focus: the prefixed-input wrapper carries `focus-within:border-daintree-accent focus-within:ring-1`.",
+      "Parent shows focus: the prefixed-input wrapper carries `focus-within:border-selection-outline focus-within:ring-1`.",
   },
   {
     file: "src/components/Settings/ColorSchemePicker.tsx",

--- a/src/index.css
+++ b/src/index.css
@@ -60,6 +60,7 @@
   --color-border-strong: var(--theme-border-strong);
   --color-border-divider: var(--theme-border-divider);
   --color-border-interactive: var(--theme-border-interactive);
+  --color-selection-outline: var(--theme-selection-outline);
   --color-accent-primary: var(--theme-accent-primary);
   --color-accent-hover: var(--theme-accent-hover);
   --color-accent-foreground: var(--theme-accent-foreground);
@@ -2583,6 +2584,23 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
   [data-highlighted] {
     outline: 2px solid Highlight;
     outline-offset: -2px;
+  }
+
+  /* The palette selected row is a raised fill plus a neutral outline, and the
+     fill is discarded here, so it redraws from the system selected-item pair.
+     Scoped to the `.palette-row` marker rather than [role="option"], which the
+     file pane, the settings selectors and the agent/forge dropdowns also use.
+     The descendant rule is load-bearing: children that set their own colour are
+     force-mapped to CanvasText independently of the row, which lands unreadable
+     on a SelectedItem fill. */
+  .palette-row[aria-selected="true"] {
+    background-color: SelectedItem;
+    border-color: SelectedItem;
+  }
+
+  .palette-row[aria-selected="true"],
+  .palette-row[aria-selected="true"] * {
+    color: SelectedItemText;
   }
 
   /* Macro-focus regions use a Tailwind ring (box-shadow) which is removed here.

--- a/src/index.css
+++ b/src/index.css
@@ -2586,21 +2586,20 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
     outline-offset: -2px;
   }
 
-  /* The palette selected row is a raised fill plus a neutral outline, and the
-     fill is discarded here, so it redraws from the system selected-item pair.
-     Scoped to the `.palette-row` marker rather than [role="option"], which the
-     file pane, the settings selectors and the agent/forge dropdowns also use.
-     The descendant rule is load-bearing: children that set their own colour are
-     force-mapped to CanvasText independently of the row, which lands unreadable
-     on a SelectedItem fill. */
+  /* The palette selected row is a raised fill plus a neutral outline, both
+     stripped here, so it falls back to a system outline like the Radix rule
+     above. Deliberately an outline and not a SelectedItem fill: these rows carry
+     independently surfaced children (theme "Active" badges, action category
+     chips, panel-kind icons with inline colour), and the engine maps each of
+     those to the forced palette on its own — a fill would leave them painting
+     CanvasText-on-SelectedItem, a pair with no contrast guarantee. An outline
+     leaves the whole subtree on its Canvas/CanvasText pair and still marks the
+     row. Scoped to the `.palette-row` marker rather than [role="option"], which
+     the file pane, the settings selectors and the agent/forge dropdowns use
+     too. */
   .palette-row[aria-selected="true"] {
-    background-color: SelectedItem;
-    border-color: SelectedItem;
-  }
-
-  .palette-row[aria-selected="true"],
-  .palette-row[aria-selected="true"] * {
-    color: SelectedItemText;
+    outline: 2px solid SelectedItem;
+    outline-offset: -2px;
   }
 
   /* Macro-focus regions use a Tailwind ring (box-shadow) which is removed here.


### PR DESCRIPTION
## Summary

- The palette selected row stacked three accent signals at once: a raised background, a 1px border in the theme accent at 40% alpha, and a 2px accent rail on the leading edge, plus the search input's focus ring used the same accent. That's three signals in one focus region, which breaks our own accent-restraint rule and read far too heavy on small surfaces like the dock launcher.
- The row is now a raised neutral fill plus a neutral hairline, and the input's focus lift draws the same neutral token. No accent border, no accent rail. 16 palette surfaces inherit this from the shared `PALETTE_ROW_CLASS`, so it's one change with a wide blast radius.

Resolves #11686

## Why a new token was needed

No existing neutral token could carry the selection indicator. Measured with our own `shared/theme/contrast.ts` across all 14 built-in themes, `overlay-raised` only clears 1.08 to 1.22:1 against the palette surface, and the whole border ladder tops out around 1.5:1, nowhere near the 3:1 that WCAG 1.4.11 needs. Since the fill can't carry the signal, the outline has to, and it needs to hold 3:1 on its own.

That's why there's a new semantic token, `selection-outline`, derived from each theme's `text-primary` at 42% alpha in dark themes and 53% in light. `text-primary` because it's the only ink already floored against every surface, so a fraction of it lands predictably across all 14 themes.

Worth noting: the accent border it replaces only measured 1.64 to 2.41:1 against the row fill, so the old treatment never actually met 1.4.11 in the first place. The new hairline lands at 3.15 to 3.49:1, just above the floor, so the alphas are the minimum needed to satisfy the constraint rather than a bolder choice. It also replaces a 1px border plus a 2px rail, so it's strictly less ink than before.

## Enforcement

`getThemeContrastWarnings` now checks `selection-outline` at 3:1 against both the selected row's fill and the surrounding palette surface. The fill comparison is the binding one: on dark themes the row's background lifts brighter, closer to the outline color, so an outline that passes against the outer surface can still nearly disappear into the row it's meant to outline. There's a regression test locking that case in.

The dark palette surface is scored the same way the sidebar is: 94% opacity over every plane it can float above, plus the fully solid sidebar color, since performance mode and `prefers-contrast: more` both render it opaque. The worst-case result across all of those is what gets used.

## Forced colors

Under `forced-colors: active` the browser strips both the custom fill and the custom outline, so the selected row falls back to a 2px outline in the system `SelectedItem` color. That rule is scoped to a `.palette-row` marker rather than the generic `[role="option"]` selector, because plenty of unrelated UI uses that role too: the file browser pane, settings dropdown selectors, and the agent/forge provider dropdowns.

The choice is deliberately an outline, not a `SelectedItem` fill. These rows carry independently rendered children (theme "Active" badges, action category chips, panel-kind icons with inline color) that the forced-colors engine remaps to the system palette on its own. Fill the row with `SelectedItem` and those children would render `CanvasText` on top of it, a pairing with no contrast guarantee. The existing forced-colors e2e test now asserts a non-zero outline width, so deleting this rule fails the test rather than silently regressing.

## Also

Dropped the now-stale `paletteRowStyles` entry from the accent-guard allowlist (the stale-entry ratchet would have failed otherwise), and updated `docs/themes/interaction-state-recipes.md`, which still prescribed the accent rail. That's where the drift started.

## Not in this PR

- Light theme palette-format imports (not the built-in themes) compile `overlay-raised` as a CSS `color-mix()`, which the new audit reports as unevaluable rather than crashing. That's honest and non-blocking, and consistent with how the existing code handles other non-hex tokens. Fixing it properly means changing how the light theme derives `overlay-raised`.
- The pre-existing `accent-primary`/`accent-secondary` outline checks treat alpha-hex (`#RRGGBBAA`) colors as opaque, the same false-pass I fixed in the new code. Correcting those would newly warn on users' existing custom themes, so that belongs in its own change.

## Testing

4101 tests pass locally across `shared/theme`, `src/theme`, `src/config`, and every palette component directory. Typecheck is clean. Prettier and eslint are clean on changed files, aside from one pre-existing eslint warning in `accentGuard.contract.test.ts` that's untouched by this change and already present on `develop`.

16 files changed.
