### PR TITLE
feat(palette): browse the full action inventory from the empty query

### DIFF
--- a/src/ModalHostLayer.tsx
+++ b/src/ModalHostLayer.tsx
@@ -599,7 +599,7 @@ export function ModalHostLayer({
               totalResults={actionPalette.totalResults}
               selectedIndex={actionPalette.selectedIndex}
               isStale={actionPalette.isStale}
-              pinnedCount={actionPalette.pinnedCount}
+              sections={actionPalette.sections}
               close={actionPalette.close}
               setQuery={actionPalette.setQuery}
               setSelectedIndex={actionPalette.setSelectedIndex}

--- a/src/components/ActionPalette/ActionPalette.test.tsx
+++ b/src/components/ActionPalette/ActionPalette.test.tsx
@@ -155,7 +155,9 @@ describe("ActionPalette", () => {
     expect(screen.queryByText("No actions yet")).toBeNull();
   });
 
-  it("shows the empty message when no MRU exists and no query is typed", () => {
+  it("shows the empty message when the registry exposes no eligible actions", () => {
+    // No longer the empty-MRU state — that now browses the whole inventory.
+    // This is the defensive case where there is genuinely nothing to list.
     render(<ActionPalette {...baseProps} />);
     expect(screen.getByText("No actions yet")).toBeTruthy();
   });

--- a/src/components/ActionPalette/ActionPalette.test.tsx
+++ b/src/components/ActionPalette/ActionPalette.test.tsx
@@ -56,7 +56,10 @@ vi.mock("@/hooks/useAnimatedPresence", () => ({
 }));
 
 import { ActionPalette } from "./ActionPalette";
-import type { ActionPaletteItem as ActionPaletteItemType } from "@/hooks/useActionPalette";
+import type {
+  ActionPaletteItem as ActionPaletteItemType,
+  UseActionPaletteReturn,
+} from "@/hooks/useActionPalette";
 import { usePaletteStore } from "@/store/paletteStore";
 
 function makeItem(id: string, title: string): ActionPaletteItemType {
@@ -87,7 +90,7 @@ const baseProps = {
   totalResults: 0,
   selectedIndex: 0,
   isStale: false,
-  pinnedCount: 0,
+  sections: [] as UseActionPaletteReturn["sections"],
   close: noop,
   setQuery: noop,
   setSelectedIndex: noop,
@@ -170,13 +173,32 @@ describe("ActionPalette", () => {
     expect(lastSearchablePaletteProps.current?.isFiltering).toBe(true);
   });
 
-  it("passes a renderBody callback when on the empty-query rail with results", () => {
+  it("passes a renderBody callback when the hook supplies sections", () => {
     render(
       <ActionPalette
         {...baseProps}
         query=""
         results={[makeItem("a.action", "Alpha")]}
         totalResults={1}
+        sections={[{ id: "category:general", label: "General", start: 0, count: 1 }]}
+      />
+    );
+
+    expect(typeof lastSearchablePaletteProps.current?.renderBody).toBe("function");
+  });
+
+  it("keeps the sectioned body while a typed query's results are still catching up", () => {
+    // Filtering lags the input, so the browse rows and their sections are both
+    // still on screen for a frame after the first keystroke. Gating on `query`
+    // would strip the headers off rows that still need them.
+    render(
+      <ActionPalette
+        {...baseProps}
+        query="al"
+        results={[makeItem("a.action", "Alpha")]}
+        totalResults={1}
+        sections={[{ id: "category:general", label: "General", start: 0, count: 1 }]}
+        isStale
       />
     );
 
@@ -368,27 +390,75 @@ describe("ActionPalette", () => {
   });
 
   describe("section header listbox separators", () => {
-    it("renders section headers as aria-disabled options so AT announces them", () => {
+    const THREE_SECTIONS = [
+      { id: "favorites", label: "Favorites", start: 0, count: 1 },
+      { id: "recently-used", label: "Recently used", start: 1, count: 1 },
+      { id: "category:worktree", label: "Worktrees", start: 2, count: 2 },
+    ];
+    const FOUR_ROWS = [
+      makeItem("pinned.alpha", "Alpha"),
+      makeItem("recent.beta", "Beta"),
+      makeItem("browse.gamma", "Gamma"),
+      makeItem("browse.delta", "Delta"),
+    ];
+
+    function renderSectionedBody(props: Partial<typeof baseProps> = {}) {
       render(
         <ActionPalette
           {...baseProps}
-          pinnedCount={1}
-          results={[makeItem("pinned.alpha", "Alpha"), makeItem("recent.beta", "Beta")]}
-          totalResults={2}
+          results={FOUR_ROWS}
+          totalResults={FOUR_ROWS.length}
+          sections={THREE_SECTIONS}
+          {...props}
         />
       );
       const renderBody = lastSearchablePaletteProps.current?.renderBody as
         (() => React.ReactNode) | undefined;
       expect(typeof renderBody).toBe("function");
-      const { container } = render(<>{renderBody!()}</>);
+      return render(<>{renderBody!()}</>).container;
+    }
 
-      const favorites = container.querySelector('[aria-label="Favorites"]');
-      const recent = container.querySelector('[aria-label="Recently used"]');
-      expect(favorites?.getAttribute("role")).toBe("option");
-      expect(favorites?.getAttribute("aria-disabled")).toBe("true");
-      expect(favorites?.getAttribute("aria-selected")).toBe("false");
-      expect(recent?.getAttribute("role")).toBe("option");
-      expect(recent?.getAttribute("aria-disabled")).toBe("true");
+    it("renders every section header as an aria-disabled option so AT announces them", () => {
+      const container = renderSectionedBody();
+
+      for (const { label } of THREE_SECTIONS) {
+        const header = container.querySelector(`[aria-label="${label}"]`);
+        expect(header?.getAttribute("role")).toBe("option");
+        expect(header?.getAttribute("aria-disabled")).toBe("true");
+        expect(header?.getAttribute("aria-selected")).toBe("false");
+      }
+    });
+
+    it("never nests a role=group inside the listbox", () => {
+      // role="group" inside role="listbox" drops its label under Chromium +
+      // VoiceOver, which is why the headers masquerade as inert options.
+      const container = renderSectionedBody();
+      expect(container.querySelectorAll('[role="group"]').length).toBe(0);
+    });
+
+    it("keeps headers out of the navigable rows", () => {
+      const container = renderSectionedBody();
+      const navigable = container.querySelectorAll('[role="option"]:not([aria-disabled="true"])');
+      // Arrow keys walk `results`; the three dividers must not join them.
+      expect(navigable.length).toBe(FOUR_ROWS.length);
+    });
+
+    it("indexes rows against the flat result list, not each section's slice", () => {
+      // The last row is selected, so the highlight must follow its global index
+      // rather than its offset within the final section.
+      const container = renderSectionedBody({ selectedIndex: FOUR_ROWS.length - 1 });
+      const selected = container.querySelectorAll('[aria-selected="true"]');
+      expect(selected.length).toBe(1);
+      expect(selected[0]?.getAttribute("id")).toBe(`action-option-${FOUR_ROWS[3]!.id}`);
+    });
+
+    it("offers the hide control only on Recently used rows", () => {
+      const container = renderSectionedBody();
+      const hideButtons = container.querySelectorAll('[aria-label^="Hide "]');
+      // "Hide from Recently used" against a category row would promise an
+      // eviction that rail can't perform.
+      expect(hideButtons.length).toBe(1);
+      expect(hideButtons[0]?.getAttribute("aria-label")).toContain("Beta");
     });
   });
 });

--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { Fragment, useCallback, useEffect, useId, useRef, useState } from "react";
 import { SearchablePalette } from "@/components/ui/SearchablePalette";
 import { PaletteOverflowNotice } from "@/components/ui/PaletteOverflowNotice";
 import { KBD_CLASS, PaletteFooterHints } from "@/components/ui/AppPaletteDialog";
@@ -14,9 +14,10 @@ import {
 } from "@/lib/animationUtils";
 import { cn } from "@/lib/utils";
 import { ActionPaletteItem } from "./ActionPaletteItem";
-import type {
-  ActionPaletteItem as ActionPaletteItemType,
-  UseActionPaletteReturn,
+import {
+  RECENTLY_USED_SECTION_ID,
+  type ActionPaletteItem as ActionPaletteItemType,
+  type UseActionPaletteReturn,
 } from "@/hooks/useActionPalette";
 
 const SECTION_HEADER_CLASS =
@@ -117,7 +118,7 @@ type ActionPaletteProps = Pick<
   | "totalResults"
   | "selectedIndex"
   | "isStale"
-  | "pinnedCount"
+  | "sections"
   | "close"
   | "setQuery"
   | "setSelectedIndex"
@@ -137,7 +138,7 @@ export function ActionPalette({
   totalResults,
   selectedIndex,
   isStale,
-  pinnedCount,
+  sections,
   close,
   setQuery,
   setSelectedIndex,
@@ -169,7 +170,11 @@ export function ActionPalette({
   // sectioned listbox itself, keyed by `data-action-id` so the divider divs
   // don't throw off the offset.
   const sectionedListRef = useRef<HTMLDivElement>(null);
-  const showSections = !query.trim() && results.length > 0;
+  // Driven by the descriptors rather than by `query`, because filtering lags
+  // the input: the hook only publishes sections alongside the browse rows that
+  // produced them, so this can't sectionize a set of search results (or strip
+  // the headers off a browse list that is still on screen) mid-keystroke.
+  const showSections = sections.length > 0;
 
   useEffect(() => {
     if (!showSections) return;
@@ -182,7 +187,7 @@ export function ActionPalette({
   }, [showSections, selectedIndex, results]);
 
   const renderActionRow = useCallback(
-    (item: ActionPaletteItemType, index: number) => {
+    (item: ActionPaletteItemType, index: number, canHide: boolean) => {
       const isPinned = pinnedActionIds.includes(item.id);
       return (
         <div key={item.id} data-action-id={item.id}>
@@ -195,7 +200,7 @@ export function ActionPalette({
             isPinned={isPinned}
             onPin={pinAction}
             onUnpin={unpinAction}
-            onHide={hideAction}
+            onHide={canHide ? hideAction : undefined}
             footerHintId={footerHintId}
           />
         </div>
@@ -214,8 +219,6 @@ export function ActionPalette({
   );
 
   const renderSectionedBody = useCallback(() => {
-    const pinnedRows = results.slice(0, pinnedCount);
-    const recentRows = results.slice(pinnedCount);
     return (
       <>
         <div
@@ -227,47 +230,41 @@ export function ActionPalette({
           data-stale={isStale ? "true" : undefined}
           aria-busy={isStale || undefined}
         >
-          {pinnedRows.length > 0 && (
-            <>
-              {/*
-                Listbox children must be role="option" or role="group" per ARIA.
-                role="group" inside role="listbox" is broken under Chromium 146 +
-                VoiceOver (label is dropped, "empty group" is announced), so the
-                separator masquerades as a non-interactive option instead — AT
-                announces the section name, arrow keys still skip it because it
-                isn't in `results`.
-              */}
-              <div
-                className={SECTION_HEADER_CLASS}
-                role="option"
-                aria-disabled="true"
-                aria-selected="false"
-                aria-label="Favorites"
-              >
-                Favorites
-              </div>
-              {pinnedRows.map((item, idx) => renderActionRow(item, idx))}
-            </>
-          )}
-          {recentRows.length > 0 && (
-            <>
-              <div
-                className={SECTION_HEADER_CLASS}
-                role="option"
-                aria-disabled="true"
-                aria-selected="false"
-                aria-label="Recently used"
-              >
-                Recently used
-              </div>
-              {recentRows.map((item, idx) => renderActionRow(item, pinnedCount + idx))}
-            </>
-          )}
+          {sections.map((section) => {
+            const canHide = section.id === RECENTLY_USED_SECTION_ID;
+            return (
+              <Fragment key={section.id}>
+                {/*
+                  Listbox children must be role="option" or role="group" per ARIA.
+                  role="group" inside role="listbox" is broken under Chromium 146 +
+                  VoiceOver (label is dropped, "empty group" is announced), so the
+                  separator masquerades as a non-interactive option instead — AT
+                  announces the section name, arrow keys still skip it because it
+                  isn't in `results`.
+                */}
+                <div
+                  className={SECTION_HEADER_CLASS}
+                  role="option"
+                  aria-disabled="true"
+                  aria-selected="false"
+                  aria-label={section.label}
+                >
+                  {section.label}
+                </div>
+                {results
+                  .slice(section.start, section.start + section.count)
+                  // Rows are indexed against `results`, not the slice, so the
+                  // highlight and hover handlers keep addressing the flat list
+                  // the keyboard navigates.
+                  .map((item, idx) => renderActionRow(item, section.start + idx, canHide))}
+              </Fragment>
+            );
+          })}
         </div>
         <PaletteOverflowNotice shown={results.length} total={totalResults} />
       </>
     );
-  }, [results, pinnedCount, isStale, totalResults, renderActionRow]);
+  }, [results, sections, isStale, totalResults, renderActionRow]);
 
   const [activeMode, setActiveMode] = useState<ActionPaletteMode | null>(null);
   // Hold the last rendered chip label across the exit animation so the chip

--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -1,6 +1,5 @@
 import { Fragment, useCallback, useEffect, useId, useRef, useState } from "react";
 import { SearchablePalette } from "@/components/ui/SearchablePalette";
-import { PaletteOverflowNotice } from "@/components/ui/PaletteOverflowNotice";
 import { KBD_CLASS, PaletteFooterHints } from "@/components/ui/AppPaletteDialog";
 import { useAnimatedPresence } from "@/hooks/useAnimatedPresence";
 import { useEffectiveCombo } from "@/hooks/useKeybinding";
@@ -202,11 +201,14 @@ export function ActionPalette({
             onUnpin={unpinAction}
             onHide={canHide ? hideAction : undefined}
             footerHintId={footerHintId}
+            posInSet={index + 1}
+            setSize={results.length}
           />
         </div>
       );
     },
     [
+      results.length,
       pinnedActionIds,
       selectedIndex,
       handleSelect,
@@ -261,10 +263,11 @@ export function ActionPalette({
             );
           })}
         </div>
-        <PaletteOverflowNotice shown={results.length} total={totalResults} />
       </>
     );
-  }, [results, sections, isStale, totalResults, renderActionRow]);
+    // No overflow notice here: the browse rail is uncapped, so `shown` always
+    // equals `total`. The search path keeps its notice via SearchablePalette.
+  }, [results, sections, isStale, renderActionRow]);
 
   const [activeMode, setActiveMode] = useState<ActionPaletteMode | null>(null);
   // Hold the last rendered chip label across the exit animation so the chip

--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -426,6 +426,11 @@ export function ActionPalette({
             onUnpin={unpinAction}
             onHide={hideAction}
             footerHintId={footerHintId}
+            // Redundant on this path — the search body has no headers to throw
+            // the count off — but stated anyway so a row announces the same way
+            // whichever body rendered it.
+            posInSet={index + 1}
+            setSize={results.length}
           />
         );
       }}

--- a/src/components/ActionPalette/ActionPaletteItem.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.tsx
@@ -31,6 +31,10 @@ interface ActionPaletteItemProps {
    * pattern.
    */
   footerHintId?: string;
+  /** 1-based position among the navigable rows. See the ARIA note on the row. */
+  posInSet?: number;
+  /** Total navigable rows, excluding any inert section headers. */
+  setSize?: number;
 }
 
 function ActionPaletteItemInner({
@@ -44,6 +48,8 @@ function ActionPaletteItemInner({
   onUnpin,
   onHide,
   footerHintId,
+  posInSet,
+  setSize,
 }: ActionPaletteItemProps) {
   const categoryColor = ACTION_CATEGORY_COLORS[item.category] ?? ACTION_CATEGORY_DEFAULT_COLOR;
   const [pinRejected, setPinRejected] = useState(false);
@@ -139,6 +145,13 @@ function ActionPaletteItemInner({
       role="option"
       aria-selected={isSelected}
       aria-disabled={!item.enabled}
+      // The sectioned body seeds these because it interleaves inert section
+      // headers among the rows: those headers are role="option" too (role=group
+      // loses its label under Chromium + VoiceOver), so a computed set would
+      // count them and announce "38 of 328" for the 36th real action. Stating
+      // the position explicitly keeps the count over the rows only.
+      aria-posinset={posInSet}
+      aria-setsize={setSize}
       onPointerDown={(e) => e.preventDefault()}
       onPointerMove={handleHover}
     >

--- a/src/config/__tests__/actionCategoryOrder.test.ts
+++ b/src/config/__tests__/actionCategoryOrder.test.ts
@@ -72,23 +72,37 @@ describe("getActionCategoryLabel", () => {
     expect(getActionCategoryLabel("somePlugin")).toBe("Some plugin");
   });
 
-  it("prefers the curated label over the humanized form where they differ", () => {
-    // `devServer` would humanize to "Dev server" too, so pick one where the
-    // curated label is not reachable by the fallback.
-    expect(getActionCategoryLabel("ui")).toBe("User interface");
-    expect(getActionCategoryLabel("ui")).not.toBe(humanizeActionCategory("ui"));
+  it("prefers the curated label over the humanized form", () => {
+    // At least one curated label must be something the fallback could never
+    // produce, or the whole map would be redundant.
+    const curated = ACTION_CATEGORY_ORDER.filter(
+      (c) => getActionCategoryLabel(c) !== humanizeActionCategory(c)
+    );
+    expect(curated.length).toBeGreaterThan(0);
+    for (const category of curated) {
+      expect(getActionCategoryLabel(category)).toBe(ACTION_CATEGORY_LABELS.get(category));
+    }
   });
 
   it("labels every ordered category", () => {
-    const unlabelled = ACTION_CATEGORY_ORDER.filter((c) => ACTION_CATEGORY_LABELS[c] === undefined);
+    const unlabelled = ACTION_CATEGORY_ORDER.filter((c) => !ACTION_CATEGORY_LABELS.has(c));
     expect(unlabelled).toEqual([]);
   });
 
   it("labels no category it does not also order", () => {
-    const unordered = Object.keys(ACTION_CATEGORY_LABELS).filter(
+    const unordered = [...ACTION_CATEGORY_LABELS.keys()].filter(
       (c) => !ACTION_CATEGORY_ORDER.includes(c)
     );
     expect(unordered).toEqual([]);
+  });
+
+  it("survives category names that collide with Object prototype keys", () => {
+    // Plugins choose their own category strings. An object-literal lookup would
+    // hand back an inherited non-string here, which becomes a section label and
+    // throws when React renders it.
+    for (const hostile of ["__proto__", "constructor", "toString", "hasOwnProperty"]) {
+      expect(typeof getActionCategoryLabel(hostile)).toBe("string");
+    }
   });
 
   it("gives every ordered category a distinct label so headers are unambiguous", () => {

--- a/src/config/__tests__/actionCategoryOrder.test.ts
+++ b/src/config/__tests__/actionCategoryOrder.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ACTION_CATEGORY_LABELS,
+  ACTION_CATEGORY_ORDER,
+  getActionCategoryLabel,
+  humanizeActionCategory,
+  orderActionCategories,
+} from "../actionCategoryOrder";
+
+describe("orderActionCategories", () => {
+  it("returns known categories in the curated order regardless of input order", () => {
+    const shuffled = [...ACTION_CATEGORY_ORDER].reverse();
+    expect(orderActionCategories(shuffled)).toEqual([...ACTION_CATEGORY_ORDER]);
+  });
+
+  it("omits known categories that were not supplied", () => {
+    const ordered = orderActionCategories(["git", "worktree"]);
+    expect(ordered).toEqual(["worktree", "git"]);
+  });
+
+  it("appends unknown categories after every known one", () => {
+    const ordered = orderActionCategories(["zzPlugin", "git", "aaPlugin", "worktree"]);
+    const firstUnknown = ordered.indexOf("aaPlugin");
+    const lastKnown = Math.max(ordered.indexOf("git"), ordered.indexOf("worktree"));
+    expect(firstUnknown).toBeGreaterThan(lastKnown);
+  });
+
+  it("sorts unknown categories alphabetically, case-insensitively", () => {
+    const ordered = orderActionCategories(["Zebra", "apple", "Mango"]);
+    expect(ordered).toEqual(["apple", "Mango", "Zebra"]);
+  });
+
+  it("drops no category — an unknown one would take its actions off the browse list", () => {
+    const input = ["worktree", "somePluginThing", "git", "core", "extra", "test"];
+    expect(orderActionCategories(input).slice().sort()).toEqual(input.slice().sort());
+  });
+
+  it("collapses duplicate categories to a single group", () => {
+    expect(orderActionCategories(["git", "git", "plugin", "plugin"])).toEqual(["git", "plugin"]);
+  });
+
+  it("orders a stable result across repeated calls with reshuffled input", () => {
+    const a = orderActionCategories(["ui", "custom", "git", "another"]);
+    const b = orderActionCategories(["another", "git", "custom", "ui"]);
+    expect(a).toEqual(b);
+  });
+});
+
+describe("humanizeActionCategory", () => {
+  it("splits camelCase into sentence case", () => {
+    expect(humanizeActionCategory("pluginTools")).toBe("Plugin tools");
+  });
+
+  it("treats hyphens and underscores as word breaks", () => {
+    expect(humanizeActionCategory("custom-actions")).toBe("Custom actions");
+    expect(humanizeActionCategory("custom_actions")).toBe("Custom actions");
+  });
+
+  it("capitalizes a single lowercase word", () => {
+    expect(humanizeActionCategory("core")).toBe("Core");
+  });
+
+  it("falls back to a generic label for a blank category", () => {
+    expect(humanizeActionCategory("")).toBe("General");
+    expect(humanizeActionCategory("   ")).toBe("General");
+  });
+});
+
+describe("getActionCategoryLabel", () => {
+  it("humanizes categories that have no curated label", () => {
+    expect(getActionCategoryLabel("somePlugin")).toBe("Some plugin");
+  });
+
+  it("prefers the curated label over the humanized form where they differ", () => {
+    // `devServer` would humanize to "Dev server" too, so pick one where the
+    // curated label is not reachable by the fallback.
+    expect(getActionCategoryLabel("ui")).toBe("User interface");
+    expect(getActionCategoryLabel("ui")).not.toBe(humanizeActionCategory("ui"));
+  });
+
+  it("labels every ordered category", () => {
+    const unlabelled = ACTION_CATEGORY_ORDER.filter((c) => ACTION_CATEGORY_LABELS[c] === undefined);
+    expect(unlabelled).toEqual([]);
+  });
+
+  it("labels no category it does not also order", () => {
+    const unordered = Object.keys(ACTION_CATEGORY_LABELS).filter(
+      (c) => !ACTION_CATEGORY_ORDER.includes(c)
+    );
+    expect(unordered).toEqual([]);
+  });
+
+  it("gives every ordered category a distinct label so headers are unambiguous", () => {
+    const labels = ACTION_CATEGORY_ORDER.map(getActionCategoryLabel);
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+});

--- a/src/config/actionCategoryOrder.ts
+++ b/src/config/actionCategoryOrder.ts
@@ -1,0 +1,128 @@
+/**
+ * Browse-order taxonomy for the command palette's empty-query inventory.
+ *
+ * Deliberately separate from `categoryColors.ts`: that map is a visual badge
+ * lookup whose keys have already drifted from the manifest (`agents`/`panels`
+ * plural vs the `agent`/`panel` singular the definitions actually emit), so it
+ * can't serve as the category source of truth.
+ *
+ * `ActionManifestEntry.category` is a plain `string`, not a union — plugins
+ * contribute their own. So the order is a preference, never a filter: anything
+ * unlisted still renders, appended alphabetically after the known set.
+ */
+
+/**
+ * Fixed browse order. Sequenced by task flow rather than by how many actions a
+ * category happens to hold — raw counts overweight low-level terminal and
+ * worktree plumbing and would reshuffle as actions are added. Stability is the
+ * point: a browse list that reorders itself between opens isn't browsable.
+ */
+export const ACTION_CATEGORY_ORDER: readonly string[] = [
+  "worktree",
+  "panel",
+  "git",
+  "project",
+  "forge",
+  "agent",
+  "terminal",
+  "files",
+  "browser",
+  "portal",
+  "recipes",
+  "devServer",
+  "copyTree",
+  "navigation",
+  "app",
+  "ui",
+  "settings",
+  "preferences",
+  "voice",
+  "help",
+  "diagnostics",
+  "logs",
+  "errors",
+  "system",
+  "artifacts",
+  "introspection",
+];
+
+/**
+ * Display labels for the known categories. Plural where the category names a
+ * countable thing the user manipulates ("Worktrees", "Panels"), singular where
+ * it names a surface or subsystem ("Git", "Browser"). Everything else falls
+ * through `humanizeActionCategory`.
+ */
+export const ACTION_CATEGORY_LABELS: Readonly<Record<string, string>> = {
+  worktree: "Worktrees",
+  panel: "Panels",
+  git: "Git",
+  project: "Projects",
+  forge: "Forge",
+  agent: "Agents",
+  terminal: "Terminals",
+  files: "Files",
+  browser: "Browser",
+  portal: "Portal",
+  recipes: "Recipes",
+  devServer: "Dev server",
+  copyTree: "CopyTree",
+  navigation: "Navigation",
+  app: "App",
+  ui: "User interface",
+  settings: "Settings",
+  preferences: "Preferences",
+  voice: "Voice",
+  help: "Help",
+  diagnostics: "Diagnostics",
+  logs: "Logs",
+  errors: "Errors",
+  system: "System",
+  artifacts: "Artifacts",
+  introspection: "Introspection",
+};
+
+const ACTION_CATEGORY_RANK: ReadonlyMap<string, number> = new Map(
+  ACTION_CATEGORY_ORDER.map((category, index) => [category, index])
+);
+
+const FALLBACK_CATEGORY_LABEL = "General";
+
+/**
+ * Sentence-case a category string the label map doesn't cover — a plugin's
+ * category, or one added to the manifest without a label. `pluginTools` becomes
+ * "Plugin tools", `custom-actions` becomes "Custom actions".
+ */
+export function humanizeActionCategory(category: string): string {
+  const words = category
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[-_]+/g, " ")
+    .trim();
+  if (words.length === 0) return FALLBACK_CATEGORY_LABEL;
+  const lowered = words.toLowerCase();
+  return lowered.charAt(0).toUpperCase() + lowered.slice(1);
+}
+
+/** Display label for a category, falling back to a humanized form. */
+export function getActionCategoryLabel(category: string): string {
+  return ACTION_CATEGORY_LABELS[category] ?? humanizeActionCategory(category);
+}
+
+/**
+ * Order the given categories for browsing: the curated sequence first, then
+ * everything else alphabetically. Never drops a category — an unknown one that
+ * fell out of the list would take its actions with it, and the whole point of
+ * the browse section is that the full surface is reachable.
+ */
+export function orderActionCategories(categories: Iterable<string>): string[] {
+  return [...new Set(categories)].sort((a, b) => {
+    const rankA = ACTION_CATEGORY_RANK.get(a);
+    const rankB = ACTION_CATEGORY_RANK.get(b);
+    if (rankA !== undefined && rankB !== undefined) return rankA - rankB;
+    // Known categories always precede unknown ones, so appending a plugin
+    // category can never push a built-in group further down the list.
+    if (rankA !== undefined) return -1;
+    if (rankB !== undefined) return 1;
+    const byLabel = a.toLowerCase().localeCompare(b.toLowerCase());
+    return byLabel !== 0 ? byLabel : a.localeCompare(b);
+  });
+}

--- a/src/config/actionCategoryOrder.ts
+++ b/src/config/actionCategoryOrder.ts
@@ -52,7 +52,7 @@ export const ACTION_CATEGORY_ORDER: readonly string[] = [
  * it names a surface or subsystem ("Git", "Browser"). Everything else falls
  * through `humanizeActionCategory`.
  */
-export const ACTION_CATEGORY_LABELS: Readonly<Record<string, string>> = {
+const ACTION_CATEGORY_LABEL_ENTRIES: Readonly<Record<string, string>> = {
   worktree: "Worktrees",
   panel: "Panels",
   git: "Git",
@@ -81,6 +81,16 @@ export const ACTION_CATEGORY_LABELS: Readonly<Record<string, string>> = {
   introspection: "Introspection",
 };
 
+/**
+ * Held as a Map, not the object literal. Categories are arbitrary strings —
+ * plugins pick their own — and an object lookup for `__proto__` or
+ * `constructor` returns an inherited non-string, which would end up as a
+ * section label and throw when React tried to render it.
+ */
+export const ACTION_CATEGORY_LABELS: ReadonlyMap<string, string> = new Map(
+  Object.entries(ACTION_CATEGORY_LABEL_ENTRIES)
+);
+
 const ACTION_CATEGORY_RANK: ReadonlyMap<string, number> = new Map(
   ACTION_CATEGORY_ORDER.map((category, index) => [category, index])
 );
@@ -104,7 +114,7 @@ export function humanizeActionCategory(category: string): string {
 
 /** Display label for a category, falling back to a humanized form. */
 export function getActionCategoryLabel(category: string): string {
-  return ACTION_CATEGORY_LABELS[category] ?? humanizeActionCategory(category);
+  return ACTION_CATEGORY_LABELS.get(category) ?? humanizeActionCategory(category);
 }
 
 /**

--- a/src/hooks/__tests__/useActionPalette.test.tsx
+++ b/src/hooks/__tests__/useActionPalette.test.tsx
@@ -47,6 +47,7 @@ import { usePaletteStore } from "@/store/paletteStore";
 import { useActionMruStore } from "@/store/actionMruStore";
 import { useActionPrefsStore } from "@/store/actionPrefsStore";
 import { useActionPalette } from "../useActionPalette";
+import { getActionCategoryLabel, orderActionCategories } from "@/config/actionCategoryOrder";
 
 function makeEntry(
   id: string,
@@ -216,22 +217,24 @@ describe("useActionPalette", () => {
     }
     expect(cursor).toBe(results.length);
 
-    // Curated category order puts worktrees ahead of git ahead of terminals,
-    // independent of the order the manifest listed them in.
+    // Category runs follow the shared taxonomy, not the order the manifest
+    // happened to list them in. Derived from the taxonomy rather than spelled
+    // out, so re-curating the order doesn't force an edit here — the config's
+    // own suite owns whether that order is the right one.
+    const shuffledInManifest = ["terminal", "git", "worktree"];
     expect(sections.map((s) => s.id)).toEqual([
       "favorites",
       "recently-used",
-      "category:worktree",
-      "category:git",
-      "category:terminal",
+      ...orderActionCategories(shuffledInManifest).map((c) => `category:${c}`),
     ]);
     expect(sections.map((s) => s.label)).toEqual([
       "Favorites",
       "Recently used",
-      "Worktrees",
-      "Git",
-      "Terminals",
+      ...orderActionCategories(shuffledInManifest).map(getActionCategoryLabel),
     ]);
+    // Sanity: the taxonomy really did reorder them, so the assertion above
+    // isn't trivially comparing the manifest order to itself.
+    expect(orderActionCategories(shuffledInManifest)).not.toEqual(shuffledInManifest);
   });
 
   it("lists every eligible action exactly once across all sections", async () => {
@@ -402,13 +405,16 @@ describe("useActionPalette", () => {
     const disabled = Array.from({ length: 8 }, (_, i) =>
       makeEntry(`disabled.${i}`, `Disabled ${i}`, false)
     );
-    const enabled = Array.from({ length: 7 }, (_, i) =>
+    // Deliberately fewer enabled entries than the cap, so the band has to spill
+    // into disabled ones — otherwise a band of all-enabled rows would satisfy
+    // the assertions no matter how the partition behaved.
+    const enabled = Array.from({ length: 2 }, (_, i) =>
       makeEntry(`enabled.${i}`, `Enabled ${i}`, true)
     );
     listMock.mockReturnValue([...disabled, ...enabled]);
 
-    // Order disabled first in MRU so the partition has to do real work to put
-    // enabled items above them within the 10-slot cap.
+    // Order disabled first in MRU so the partition has to do real work to lift
+    // the enabled entries above them within the cap.
     useActionMruStore
       .getState()
       .hydrateActionMru([...disabled.map((e) => e.id), ...enabled.map((e) => e.id)]);
@@ -423,11 +429,12 @@ describe("useActionPalette", () => {
       expect(result.current.results.length).toBe(disabled.length + enabled.length);
     });
 
-    // Every slot in the capped band goes to an enabled action; no disabled
-    // item displaces one despite leading the MRU order.
     const recents = sectionIds(result.current, "recently-used");
-    expect(recents).toEqual(enabled.slice(0, recents.length).map((e) => e.id));
-    expect(recents.every((id) => id.startsWith("enabled."))).toBe(true);
+    // Both enabled entries lead the band despite trailing in MRU order, and the
+    // remaining slots go to disabled ones — so the band genuinely mixes.
+    expect(recents.slice(0, enabled.length)).toEqual(enabled.map((e) => e.id));
+    expect(recents.length).toBeGreaterThan(enabled.length);
+    expect(recents.slice(enabled.length).every((id) => id.startsWith("disabled."))).toBe(true);
   });
 
   it("treats whitespace-only query as the recently-used branch", async () => {
@@ -440,15 +447,23 @@ describe("useActionPalette", () => {
       result.current.open();
     });
 
+    // Go through a real query first, so the whitespace buffer has to actively
+    // restore the browse rail rather than the assertion passing on a state the
+    // palette never left.
+    act(() => {
+      result.current.setQuery("alpha");
+    });
+
+    await waitFor(() => expect(result.current.sections).toEqual([]), { timeout: 2000 });
+
     act(() => {
       result.current.setQuery("   ");
     });
 
-    await waitFor(() => {
-      expect(result.current.results.length).toBe(2);
-    });
-
-    expect(sectionIds(result.current, "recently-used")).toEqual(["b.action", "a.action"]);
+    await waitFor(
+      () => expect(sectionIds(result.current, "recently-used")).toEqual(["b.action", "a.action"]),
+      { timeout: 2000 }
+    );
   });
 
   it("drops the section grouping once the user starts typing", async () => {
@@ -1301,9 +1316,11 @@ describe("useActionPalette", () => {
     });
 
     it("keeps danger:'confirm' actions off the browse rail but findable by search", async () => {
+      // `git.push` mirrors a real palette-eligible confirm action: all-optional
+      // args, so nothing stops it reaching the palette.
       listMock.mockReturnValue([
-        makeEntry("a.action", "Alpha", true, "worktree"),
-        makeEntry("worktree.delete", "Delete worktree", true, "worktree", "confirm"),
+        makeEntry("git.status", "Status", true, "git"),
+        makeEntry("git.push", "Push", true, "git", "confirm"),
       ]);
 
       const { result } = renderHook(() => useActionPalette());
@@ -1313,12 +1330,17 @@ describe("useActionPalette", () => {
       // Scrolling an inventory isn't naming a destructive action, so the
       // empty-query rail stays confirm-free — as Favorites and Recently used
       // already are.
-      await waitFor(() => expect(browseIds(result.current)).toEqual(["a.action"]));
+      await waitFor(() => expect(browseIds(result.current)).toEqual(["git.status"]));
+      expect(result.current.results.map((r) => r.id)).not.toContain("git.push");
 
-      act(() => result.current.setQuery("delete worktree"));
+      act(() => result.current.setQuery("push"));
 
+      // Typing the name is naming it, so search still reaches it.
       await waitFor(
-        () => expect(result.current.results.map((r) => r.id)).toContain("worktree.delete"),
+        () => {
+          expect(result.current.sections).toEqual([]);
+          expect(result.current.results.map((r) => r.id)).toContain("git.push");
+        },
         { timeout: 2000 }
       );
     });
@@ -1332,13 +1354,16 @@ describe("useActionPalette", () => {
       act(() => result.current.open());
       act(() => result.current.setQuery("alpha"));
 
-      await waitFor(() => expect(result.current.results.length).toBeGreaterThan(0), {
-        timeout: 2000,
-      });
-
-      // Hidden action still surfaces during search — the eviction only applies
-      // to the empty-query "Recently used" rail.
-      expect(result.current.results.map((r) => r.id)).toContain("a.action");
+      // Wait on the search branch specifically — empty sections prove ranking
+      // ran. Waiting on a non-empty result set would already be satisfied by
+      // the browse rail, so the assertion could never fail.
+      await waitFor(
+        () => {
+          expect(result.current.sections).toEqual([]);
+          expect(result.current.results.map((r) => r.id)).toEqual(["a.action"]);
+        },
+        { timeout: 2000 }
+      );
     });
 
     it("reports no sections during typed search even when pinned items are in results", async () => {
@@ -1348,41 +1373,60 @@ describe("useActionPalette", () => {
       const { result } = renderHook(() => useActionPalette());
 
       act(() => result.current.open());
+
+      // The pinned action gives the browse rail a Favorites section, so the
+      // assertion below only means something once it has gone away.
+      await waitFor(() => expect(sectionIds(result.current, "favorites")).toEqual(["a.action"]));
+
       act(() => result.current.setQuery("alpha"));
 
-      await waitFor(() => expect(result.current.results.length).toBeGreaterThan(0), {
-        timeout: 2000,
-      });
-
-      expect(result.current.sections).toEqual([]);
+      await waitFor(
+        () => {
+          expect(result.current.results.map((r) => r.id)).toEqual(["a.action"]);
+          expect(result.current.sections).toEqual([]);
+        },
+        { timeout: 2000 }
+      );
     });
 
-    it("keeps selectedIndex inside results when the list collapses under a query", async () => {
-      const entries = Array.from({ length: 30 }, (_, i) =>
-        makeEntry(`action.${i.toString().padStart(2, "0")}`, `Action ${i}`)
-      );
-      listMock.mockReturnValue(entries);
+    it("exposes an in-range selection when the stored index points past the results", async () => {
+      dispatchMock.mockResolvedValue({ ok: true });
+      listMock.mockReturnValue([
+        makeEntry("a.action", "Alpha", true, "git"),
+        makeEntry("b.action", "Bravo", true, "git"),
+        makeEntry("c.action", "Charlie", true, "git"),
+      ]);
 
       const { result } = renderHook(() => useActionPalette());
 
       act(() => result.current.open());
 
-      await waitFor(() => expect(result.current.results.length).toBe(entries.length));
+      await waitFor(() => expect(result.current.results.length).toBe(3));
 
-      // Select deep in the browse list, then narrow to a much shorter set. The
-      // stored index is reconciled an effect later, so the read must not hand
-      // out an index past the end in the meantime.
-      act(() => result.current.setSelectedIndex(entries.length - 1));
-      act(() => result.current.setQuery("Action 7"));
+      // Drive the stored index out of range without touching `results`, so the
+      // reconcile effect never fires and only the read-time clamp can save it.
+      // Reproduces the render-time window that typing opens for real: results
+      // shrink during render, the index catches up an effect later.
+      act(() => result.current.setSelectedIndex(99));
 
-      await waitFor(() => expect(result.current.results.length).toBeLessThan(entries.length), {
-        timeout: 2000,
-      });
+      expect(result.current.selectedIndex).toBe(0);
+      // Enter must still fire — an out-of-range index would make it a silent
+      // no-op, which is the failure this clamp exists to prevent.
+      act(() => result.current.confirmSelection());
+      expect(dispatchMock).toHaveBeenCalledWith("a.action", {}, { source: "user" });
+    });
 
-      expect(result.current.selectedIndex).toBeGreaterThanOrEqual(0);
-      expect(result.current.selectedIndex).toBeLessThan(result.current.results.length);
-      // The clamped index must name a real row, so Enter can't silently no-op.
-      expect(result.current.results[result.current.selectedIndex]).toBeDefined();
+    it("reports no selection when there is nothing to select", async () => {
+      listMock.mockReturnValue([makeEntry("a.action", "Alpha")]);
+
+      const { result } = renderHook(() => useActionPalette());
+
+      act(() => result.current.open());
+      act(() => result.current.setQuery("nothing-matches-this-xyz"));
+
+      await waitFor(() => expect(result.current.results.length).toBe(0), { timeout: 2000 });
+
+      expect(result.current.selectedIndex).toBe(-1);
     });
 
     it("reopens at the top of the browse rail instead of chasing the last search hit", async () => {

--- a/src/hooks/__tests__/useActionPalette.test.tsx
+++ b/src/hooks/__tests__/useActionPalette.test.tsx
@@ -67,6 +67,25 @@ function makeEntry(
   return { id, title, description: "", category, kind: "command", enabled, danger };
 }
 
+type PaletteLike = {
+  results: { id: string }[];
+  sections: readonly { id: string; label: string; start: number; count: number }[];
+};
+
+/** Ids of the rows a named section covers, or [] when the section isn't rendered. */
+function sectionIds(palette: PaletteLike, sectionId: string): string[] {
+  const section = palette.sections.find((s) => s.id === sectionId);
+  if (!section) return [];
+  return palette.results.slice(section.start, section.start + section.count).map((r) => r.id);
+}
+
+/** Ids of every row below Favorites and Recently used, in render order. */
+function browseIds(palette: PaletteLike): string[] {
+  return palette.sections
+    .filter((s) => s.id.startsWith("category:"))
+    .flatMap((s) => palette.results.slice(s.start, s.start + s.count).map((r) => r.id));
+}
+
 describe("useActionPalette", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -112,7 +131,7 @@ describe("useActionPalette", () => {
     });
   });
 
-  it("returns empty results with empty query and empty MRU so the hint can render", async () => {
+  it("browses the whole inventory with an empty query and empty MRU", async () => {
     listMock.mockReturnValue([
       makeEntry("c.action", "Charlie"),
       makeEntry("a.action", "Alpha"),
@@ -129,12 +148,17 @@ describe("useActionPalette", () => {
       expect(result.current.isOpen).toBe(true);
     });
 
-    expect(result.current.results).toEqual([]);
-    expect(result.current.totalResults).toBe(0);
-    expect(result.current.isShowingRecentlyUsed).toBe(false);
+    // Nothing pinned and nothing used yet, so every action is reachable by
+    // scrolling — sorted by title within its category, not by registry order.
+    await waitFor(() => {
+      expect(browseIds(result.current)).toEqual(["a.action", "b.action", "c.action"]);
+    });
+    expect(sectionIds(result.current, "favorites")).toEqual([]);
+    expect(sectionIds(result.current, "recently-used")).toEqual([]);
+    expect(result.current.totalResults).toBe(3);
   });
 
-  it("surfaces only recently-used actions on the empty query state", async () => {
+  it("puts recently-used actions above the rest of the inventory", async () => {
     listMock.mockReturnValue([
       makeEntry("c.action", "Charlie"),
       makeEntry("a.action", "Alpha"),
@@ -150,11 +174,145 @@ describe("useActionPalette", () => {
     });
 
     await waitFor(() => {
+      expect(result.current.results.length).toBe(3);
+    });
+
+    expect(sectionIds(result.current, "recently-used")).toEqual(["b.action", "c.action"]);
+    // The recents band no longer terminates the list: what wasn't promoted is
+    // still browsable below it.
+    expect(browseIds(result.current)).toEqual(["a.action"]);
+    expect(result.current.results.map((r) => r.id)).toEqual(["b.action", "c.action", "a.action"]);
+  });
+
+  it("labels a section for every run of results, covering them with no gaps or overlaps", async () => {
+    listMock.mockReturnValue([
+      makeEntry("t.one", "Terminal one", true, "terminal"),
+      makeEntry("g.one", "Git one", true, "git"),
+      makeEntry("w.one", "Worktree one", true, "worktree"),
+      makeEntry("p.one", "Pinned one", true, "git"),
+      makeEntry("r.one", "Recent one", true, "terminal"),
+    ]);
+
+    useActionMruStore.getState().hydrateActionMru(["r.one"]);
+    useActionPrefsStore.getState().pinAction("p.one");
+
+    const { result } = renderHook(() => useActionPalette());
+
+    act(() => {
+      result.current.open();
+    });
+
+    await waitFor(() => {
+      expect(result.current.results.length).toBe(5);
+    });
+
+    const { sections, results } = result.current;
+    // Contiguous and total: every row belongs to exactly one section.
+    let cursor = 0;
+    for (const section of sections) {
+      expect(section.start).toBe(cursor);
+      expect(section.count).toBeGreaterThan(0);
+      cursor += section.count;
+    }
+    expect(cursor).toBe(results.length);
+
+    // Curated category order puts worktrees ahead of git ahead of terminals,
+    // independent of the order the manifest listed them in.
+    expect(sections.map((s) => s.id)).toEqual([
+      "favorites",
+      "recently-used",
+      "category:worktree",
+      "category:git",
+      "category:terminal",
+    ]);
+    expect(sections.map((s) => s.label)).toEqual([
+      "Favorites",
+      "Recently used",
+      "Worktrees",
+      "Git",
+      "Terminals",
+    ]);
+  });
+
+  it("lists every eligible action exactly once across all sections", async () => {
+    const entries = [
+      makeEntry("a.action", "Alpha", true, "git"),
+      makeEntry("b.action", "Bravo", true, "terminal"),
+      makeEntry("c.action", "Charlie", true, "git"),
+      makeEntry("d.action", "Delta", true, "worktree"),
+    ];
+    listMock.mockReturnValue(entries);
+
+    // Pin one and recently-use another so both promotion paths are exercised.
+    useActionMruStore.getState().hydrateActionMru(["b.action"]);
+    useActionPrefsStore.getState().pinAction("c.action");
+
+    const { result } = renderHook(() => useActionPalette());
+
+    act(() => {
+      result.current.open();
+    });
+
+    await waitFor(() => {
+      expect(result.current.results.length).toBe(entries.length);
+    });
+
+    const ids = result.current.results.map((r) => r.id);
+    // A duplicated id would collide on React keys, the `action-option-{id}`
+    // DOM id behind aria-activedescendant, and the selection-follow lookup.
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids.slice().sort()).toEqual(entries.map((e) => e.id).sort());
+  });
+
+  it("keeps the browse order fixed when frecency changes", async () => {
+    const entries = [
+      makeEntry("a.action", "Alpha", true, "git"),
+      makeEntry("b.action", "Bravo", true, "git"),
+      makeEntry("c.action", "Charlie", true, "git"),
+    ];
+    listMock.mockReturnValue(entries);
+
+    const { result, rerender } = renderHook(() => useActionPalette());
+
+    act(() => {
+      result.current.open();
+    });
+
+    await waitFor(() => {
+      expect(browseIds(result.current)).toEqual(["a.action", "b.action", "c.action"]);
+    });
+
+    // Using an action promotes it into Recently used, but must not reshuffle
+    // what remains below — a browse list that reorders itself isn't browsable.
+    act(() => {
+      useActionMruStore.getState().recordActionMru("c.action");
+    });
+    rerender();
+
+    await waitFor(() => {
+      expect(sectionIds(result.current, "recently-used")).toEqual(["c.action"]);
+    });
+    expect(browseIds(result.current)).toEqual(["a.action", "b.action"]);
+  });
+
+  it("groups unknown categories after known ones without dropping their actions", async () => {
+    listMock.mockReturnValue([
+      makeEntry("plug.one", "Plugin thing", true, "acmePlugin"),
+      makeEntry("git.one", "Git thing", true, "git"),
+    ]);
+
+    const { result } = renderHook(() => useActionPalette());
+
+    act(() => {
+      result.current.open();
+    });
+
+    await waitFor(() => {
       expect(result.current.results.length).toBe(2);
     });
 
-    expect(result.current.results.map((r) => r.id)).toEqual(["b.action", "c.action"]);
-    expect(result.current.isShowingRecentlyUsed).toBe(true);
+    expect(result.current.sections.map((s) => s.label)).toEqual(["Git", "Acme plugin"]);
+    expect(browseIds(result.current)).toEqual(["git.one", "plug.one"]);
   });
 
   it("keeps disabled MRU actions below enabled MRU actions on the empty state", async () => {
@@ -178,7 +336,11 @@ describe("useActionPalette", () => {
       expect(result.current.results.length).toBe(3);
     });
 
-    expect(result.current.results.map((r) => r.id)).toEqual(["c.action", "a.action", "b.action"]);
+    expect(sectionIds(result.current, "recently-used")).toEqual([
+      "c.action",
+      "a.action",
+      "b.action",
+    ]);
   });
 
   it("ignores stale MRU ids that no longer exist in the action manifest", async () => {
@@ -198,10 +360,10 @@ describe("useActionPalette", () => {
       expect(result.current.results.length).toBe(2);
     });
 
-    expect(result.current.results.map((r) => r.id)).toEqual(["b.action", "a.action"]);
+    expect(sectionIds(result.current, "recently-used")).toEqual(["b.action", "a.action"]);
   });
 
-  it("caps recently-used results at 10 entries", async () => {
+  it("caps the recents band well short of the inventory and browses the overflow", async () => {
     const entries = Array.from({ length: 15 }, (_, i) =>
       makeEntry(`action.${i.toString().padStart(2, "0")}`, `Action ${i}`)
     );
@@ -216,10 +378,24 @@ describe("useActionPalette", () => {
     });
 
     await waitFor(() => {
-      expect(result.current.results.length).toBe(10);
+      expect(result.current.results.length).toBe(entries.length);
     });
 
-    expect(result.current.isShowingRecentlyUsed).toBe(true);
+    const recents = sectionIds(result.current, "recently-used");
+    // The band is a short recall rail, not the whole list — it must leave room
+    // for the categories below it.
+    expect(recents.length).toBeGreaterThan(0);
+    expect(recents.length).toBeLessThan(entries.length / 2);
+    expect(recents).toEqual(entries.slice(0, recents.length).map((e) => e.id));
+
+    // MRU entries past the cap aren't lost — they're browsable below. Compare
+    // as sets: the browse rail is title-sorted, which is not the MRU order.
+    expect(browseIds(result.current).sort()).toEqual(
+      entries
+        .slice(recents.length)
+        .map((e) => e.id)
+        .sort()
+    );
   });
 
   it("does not let disabled MRU entries crowd out enabled ones at the cap boundary", async () => {
@@ -244,14 +420,14 @@ describe("useActionPalette", () => {
     });
 
     await waitFor(() => {
-      expect(result.current.results.length).toBe(10);
+      expect(result.current.results.length).toBe(disabled.length + enabled.length);
     });
 
-    // All 7 enabled entries must appear (no disabled item displaces them),
-    // followed by the first 3 disabled by MRU order.
-    const ids = result.current.results.map((r) => r.id);
-    expect(ids.slice(0, 7)).toEqual(enabled.map((e) => e.id));
-    expect(ids.slice(7)).toEqual(disabled.slice(0, 3).map((e) => e.id));
+    // Every slot in the capped band goes to an enabled action; no disabled
+    // item displaces one despite leading the MRU order.
+    const recents = sectionIds(result.current, "recently-used");
+    expect(recents).toEqual(enabled.slice(0, recents.length).map((e) => e.id));
+    expect(recents.every((id) => id.startsWith("enabled."))).toBe(true);
   });
 
   it("treats whitespace-only query as the recently-used branch", async () => {
@@ -272,11 +448,10 @@ describe("useActionPalette", () => {
       expect(result.current.results.length).toBe(2);
     });
 
-    expect(result.current.results.map((r) => r.id)).toEqual(["b.action", "a.action"]);
-    expect(result.current.isShowingRecentlyUsed).toBe(true);
+    expect(sectionIds(result.current, "recently-used")).toEqual(["b.action", "a.action"]);
   });
 
-  it("clears the recently-used flag once the user starts typing", async () => {
+  it("drops the section grouping once the user starts typing", async () => {
     listMock.mockReturnValue([makeEntry("a.action", "Alpha"), makeEntry("b.action", "Bravo")]);
     useActionMruStore.getState().hydrateActionMru(["a.action"]);
 
@@ -284,13 +459,45 @@ describe("useActionPalette", () => {
 
     act(() => result.current.open());
 
-    await waitFor(() => expect(result.current.isShowingRecentlyUsed).toBe(true));
+    await waitFor(() => expect(result.current.sections.length).toBeGreaterThan(0));
 
     act(() => result.current.setQuery("brav"));
 
-    await waitFor(() => expect(result.current.isShowingRecentlyUsed).toBe(false), {
+    // Ranking replaces grouping: a relevance-ordered list has no stable
+    // category runs to label.
+    await waitFor(() => expect(result.current.sections).toEqual([]), { timeout: 2000 });
+
+    act(() => result.current.setQuery(""));
+
+    await waitFor(() => expect(result.current.sections.length).toBeGreaterThan(0), {
       timeout: 2000,
     });
+  });
+
+  it("caps a typed search while reporting the true match count, and uncaps browsing", async () => {
+    // More actions than the search cap, all matching the same query.
+    const entries = Array.from({ length: 26 }, (_, i) =>
+      makeEntry(`match.${i.toString().padStart(2, "0")}`, `Matchable ${i}`)
+    );
+    listMock.mockReturnValue(entries);
+
+    const { result } = renderHook(() => useActionPalette());
+
+    act(() => result.current.open());
+
+    // The browse rail is the inventory, so it is not capped.
+    await waitFor(() => expect(result.current.results.length).toBe(entries.length));
+
+    act(() => result.current.setQuery("matchable"));
+
+    await waitFor(() => expect(result.current.results.length).toBeLessThan(entries.length), {
+      timeout: 2000,
+    });
+
+    // The cap trims what is rendered but must not falsify the total, or the
+    // "N more results not shown" notice silently stops firing.
+    expect(result.current.totalResults).toBe(entries.length);
+    expect(result.current.results.length).toBeLessThan(result.current.totalResults);
   });
 
   it("records frecency when executeAction is called on enabled item", async () => {
@@ -993,7 +1200,8 @@ describe("useActionPalette", () => {
       });
 
       expect(result.current.results.map((r) => r.id)).toEqual(["a.action", "b.action", "c.action"]);
-      expect(result.current.pinnedCount).toBe(1);
+      expect(sectionIds(result.current, "favorites")).toEqual(["a.action"]);
+      expect(sectionIds(result.current, "recently-used")).toEqual(["b.action", "c.action"]);
     });
 
     it("does not duplicate a pinned id that also appears in MRU", async () => {
@@ -1009,10 +1217,11 @@ describe("useActionPalette", () => {
       await waitFor(() => expect(result.current.results.length).toBe(2));
 
       expect(result.current.results.map((r) => r.id)).toEqual(["a.action", "b.action"]);
-      expect(result.current.pinnedCount).toBe(1);
+      expect(sectionIds(result.current, "favorites")).toEqual(["a.action"]);
+      expect(sectionIds(result.current, "recently-used")).toEqual(["b.action"]);
     });
 
-    it("hides actions from the Recently used rail while keeping them in MRU", async () => {
+    it("hides actions from the Recently used rail while keeping them browsable", async () => {
       listMock.mockReturnValue([
         makeEntry("a.action", "Alpha"),
         makeEntry("b.action", "Bravo"),
@@ -1026,11 +1235,12 @@ describe("useActionPalette", () => {
 
       act(() => result.current.open());
 
-      await waitFor(() => expect(result.current.results.length).toBe(2));
+      await waitFor(() => expect(result.current.results.length).toBe(3));
 
-      const ids = result.current.results.map((r) => r.id);
-      expect(ids).not.toContain("b.action");
-      expect(ids).toEqual(["a.action", "c.action"]);
+      // Hiding demotes an action out of frecency; it doesn't retire it, so it
+      // stays reachable in its category.
+      expect(sectionIds(result.current, "recently-used")).toEqual(["a.action", "c.action"]);
+      expect(browseIds(result.current)).toEqual(["b.action"]);
     });
 
     it("refuses to pin a danger:'confirm' action and returns false", async () => {
@@ -1090,6 +1300,29 @@ describe("useActionPalette", () => {
       expect(ids).toEqual(["a.action"]);
     });
 
+    it("keeps danger:'confirm' actions off the browse rail but findable by search", async () => {
+      listMock.mockReturnValue([
+        makeEntry("a.action", "Alpha", true, "worktree"),
+        makeEntry("worktree.delete", "Delete worktree", true, "worktree", "confirm"),
+      ]);
+
+      const { result } = renderHook(() => useActionPalette());
+
+      act(() => result.current.open());
+
+      // Scrolling an inventory isn't naming a destructive action, so the
+      // empty-query rail stays confirm-free — as Favorites and Recently used
+      // already are.
+      await waitFor(() => expect(browseIds(result.current)).toEqual(["a.action"]));
+
+      act(() => result.current.setQuery("delete worktree"));
+
+      await waitFor(
+        () => expect(result.current.results.map((r) => r.id)).toContain("worktree.delete"),
+        { timeout: 2000 }
+      );
+    });
+
     it("ignores hidden ids during typed search (only the empty-query rail evicts)", async () => {
       listMock.mockReturnValue([makeEntry("a.action", "Alpha"), makeEntry("b.action", "Bravo")]);
       useActionPrefsStore.getState().hideAction("a.action");
@@ -1108,7 +1341,7 @@ describe("useActionPalette", () => {
       expect(result.current.results.map((r) => r.id)).toContain("a.action");
     });
 
-    it("pinnedCount is 0 during typed search even when pinned items are in results", async () => {
+    it("reports no sections during typed search even when pinned items are in results", async () => {
       listMock.mockReturnValue([makeEntry("a.action", "Alpha"), makeEntry("b.action", "Bravo")]);
       useActionPrefsStore.getState().pinAction("a.action");
 
@@ -1121,7 +1354,62 @@ describe("useActionPalette", () => {
         timeout: 2000,
       });
 
-      expect(result.current.pinnedCount).toBe(0);
+      expect(result.current.sections).toEqual([]);
+    });
+
+    it("keeps selectedIndex inside results when the list collapses under a query", async () => {
+      const entries = Array.from({ length: 30 }, (_, i) =>
+        makeEntry(`action.${i.toString().padStart(2, "0")}`, `Action ${i}`)
+      );
+      listMock.mockReturnValue(entries);
+
+      const { result } = renderHook(() => useActionPalette());
+
+      act(() => result.current.open());
+
+      await waitFor(() => expect(result.current.results.length).toBe(entries.length));
+
+      // Select deep in the browse list, then narrow to a much shorter set. The
+      // stored index is reconciled an effect later, so the read must not hand
+      // out an index past the end in the meantime.
+      act(() => result.current.setSelectedIndex(entries.length - 1));
+      act(() => result.current.setQuery("Action 7"));
+
+      await waitFor(() => expect(result.current.results.length).toBeLessThan(entries.length), {
+        timeout: 2000,
+      });
+
+      expect(result.current.selectedIndex).toBeGreaterThanOrEqual(0);
+      expect(result.current.selectedIndex).toBeLessThan(result.current.results.length);
+      // The clamped index must name a real row, so Enter can't silently no-op.
+      expect(result.current.results[result.current.selectedIndex]).toBeDefined();
+    });
+
+    it("reopens at the top of the browse rail instead of chasing the last search hit", async () => {
+      const entries = [
+        makeEntry("a.action", "Alpha", true, "git"),
+        makeEntry("m.action", "Mike", true, "git"),
+        makeEntry("z.action", "Zulu", true, "git"),
+      ];
+      listMock.mockReturnValue(entries);
+
+      const { result } = renderHook(() => useActionPalette());
+
+      act(() => result.current.open());
+      act(() => result.current.setQuery("zulu"));
+
+      await waitFor(() => expect(result.current.results.map((r) => r.id)).toEqual(["z.action"]), {
+        timeout: 2000,
+      });
+
+      act(() => result.current.close());
+      act(() => result.current.open());
+
+      await waitFor(() => expect(result.current.results.length).toBe(entries.length));
+
+      // Without clearing the follow anchor on close, reconciliation would chase
+      // "z.action" into the inventory and land selection at the bottom.
+      expect(result.current.selectedIndex).toBe(0);
     });
   });
 

--- a/src/hooks/__tests__/useSearchablePalette.test.tsx
+++ b/src/hooks/__tests__/useSearchablePalette.test.tsx
@@ -81,6 +81,27 @@ describe("useSearchablePalette", () => {
     expect(result.current.selectedIndex).toBe(1);
   });
 
+  it("keeps the selection anchor consistent across back-to-back updates in one tick", () => {
+    // The index and its anchor id are mirrored in refs that the reconcile
+    // effect trusts to agree. Resolving them through a setState updater would
+    // put those writes in the render phase, where React can re-run or discard
+    // them; two moves in a single tick is the cheap way to prove each write
+    // lands exactly once and in order.
+    const items: PaletteItem[] = ["a", "b", "c"].map((id) => ({ id, name: id }));
+
+    const { result } = renderHook(() =>
+      useSearchablePalette<PaletteItem>({ items, maxResults: 20 })
+    );
+
+    act(() => {
+      result.current.selectNext();
+      result.current.selectNext();
+    });
+
+    expect(result.current.selectedIndex).toBe(2);
+    expect(result.current.results[result.current.selectedIndex]?.id).toBe("c");
+  });
+
   it("steps from the visible row when the stored index is out of range", () => {
     const items: PaletteItem[] = [
       { id: "a", name: "a" },

--- a/src/hooks/__tests__/useSearchablePalette.test.tsx
+++ b/src/hooks/__tests__/useSearchablePalette.test.tsx
@@ -51,6 +51,57 @@ describe("useSearchablePalette", () => {
     expect(result.current.selectedIndex).toBe(-1);
   });
 
+  describe("query-sensitive maxResults", () => {
+    const items: PaletteItem[] = Array.from({ length: 25 }, (_, i) => ({
+      id: `item-${i}`,
+      name: `Item ${i}`,
+    }));
+    // Uncapped while browsing, capped once the user searches.
+    const byQuery = (query: string) => (query.trim() ? 20 : Number.POSITIVE_INFINITY);
+
+    it("applies the limit the function returns for the current query", () => {
+      const { result } = renderHook(() =>
+        useSearchablePalette<PaletteItem>({ items, maxResults: byQuery })
+      );
+
+      expect(result.current.results).toHaveLength(items.length);
+
+      act(() => result.current.setQuery("item"));
+
+      expect(result.current.results).toHaveLength(20);
+      expect(result.current.totalResults).toBe(items.length);
+    });
+
+    it("hands back the filter's own array when nothing is sliced off", () => {
+      // The action palette pairs section descriptors with the exact array its
+      // filter produced, so an untruncated pass must preserve that identity.
+      const filtered: PaletteItem[] = items.slice(0, 3);
+      const { result } = renderHook(() =>
+        useSearchablePalette<PaletteItem>({
+          items,
+          filterFn: () => filtered,
+          maxResults: byQuery,
+        })
+      );
+
+      expect(result.current.results).toBe(filtered);
+    });
+
+    it("copies rather than aliases the filter's array once truncation applies", () => {
+      const filtered: PaletteItem[] = items;
+      const { result } = renderHook(() =>
+        useSearchablePalette<PaletteItem>({
+          items,
+          filterFn: () => filtered,
+          maxResults: 5,
+        })
+      );
+
+      expect(result.current.results).not.toBe(filtered);
+      expect(result.current.results).toHaveLength(5);
+    });
+  });
+
   describe("totalResults", () => {
     it("exposes total count before slicing when results exceed maxResults", () => {
       const items: PaletteItem[] = Array.from({ length: 25 }, (_, i) => ({

--- a/src/hooks/__tests__/useSearchablePalette.test.tsx
+++ b/src/hooks/__tests__/useSearchablePalette.test.tsx
@@ -51,6 +51,55 @@ describe("useSearchablePalette", () => {
     expect(result.current.selectedIndex).toBe(-1);
   });
 
+  it("follows the selected item through a reorder the sampled fingerprint can't see", () => {
+    // Same length, same first/middle/last ids — only the interior moves, which
+    // is exactly what pinning a row does. The change-detection fast path must
+    // not treat that as "nothing moved", or the highlight slides onto whichever
+    // row took the index and Enter runs it instead.
+    const before: PaletteItem[] = ["f", "a", "b", "c", "d", "e", "g"].map((id) => ({
+      id,
+      name: id,
+    }));
+    const after: PaletteItem[] = ["f", "b", "a", "c", "d", "e", "g"].map((id) => ({
+      id,
+      name: id,
+    }));
+
+    const { result, rerender } = renderHook(
+      ({ items }: { items: PaletteItem[] }) =>
+        useSearchablePalette<PaletteItem>({ items, maxResults: 20 }),
+      { initialProps: { items: before } }
+    );
+
+    // Select "b" at index 2.
+    act(() => result.current.setSelectedIndex(2));
+    expect(result.current.results[result.current.selectedIndex]?.id).toBe("b");
+
+    rerender({ items: after });
+
+    expect(result.current.results[result.current.selectedIndex]?.id).toBe("b");
+    expect(result.current.selectedIndex).toBe(1);
+  });
+
+  it("steps from the visible row when the stored index is out of range", () => {
+    const items: PaletteItem[] = [
+      { id: "a", name: "a" },
+      { id: "b", name: "b" },
+    ];
+
+    const { result } = renderHook(() =>
+      useSearchablePalette<PaletteItem>({ items, maxResults: 20 })
+    );
+
+    // Out of range without changing results, so nothing reconciles it. Consumers
+    // clamp this to 0 on read, so ArrowDown has to advance to 1 — computing from
+    // the raw value would wrap to 0 and appear to do nothing.
+    act(() => result.current.setSelectedIndex(99));
+    act(() => result.current.selectNext());
+
+    expect(result.current.selectedIndex).toBe(1);
+  });
+
   describe("query-sensitive maxResults", () => {
     const items: PaletteItem[] = Array.from({ length: 25 }, (_, i) => ({
       id: `item-${i}`,

--- a/src/hooks/useActionPalette.ts
+++ b/src/hooks/useActionPalette.ts
@@ -8,6 +8,7 @@ import { usePaletteStore } from "@/store/paletteStore";
 import { useActionMruStore } from "@/store/actionMruStore";
 import { useActionPrefsStore } from "@/store/actionPrefsStore";
 import { createActionRanker, extractAcronym, rankActionMatches } from "@/lib/actionPaletteSearch";
+import { getActionCategoryLabel, orderActionCategories } from "@/config/actionCategoryOrder";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { isPanelLimitError } from "@/services/actions/definitions/panelLimitError";
 import { useSearchablePalette } from "./useSearchablePalette";
@@ -42,16 +43,33 @@ export interface ActionPaletteItem {
   keywordsLower: readonly string[];
 }
 
+/**
+ * A contiguous labelled run of `results`. Sections are presentation metadata
+ * only — headers never enter `results`, so keyboard navigation stays a flat
+ * walk over the rows and arrow keys skip the dividers for free.
+ */
+export interface ActionPaletteSection {
+  /** Stable identity: `favorites`, `recently-used`, or `category:{raw}`. */
+  readonly id: string;
+  readonly label: string;
+  /** Index into `results` of this section's first row. */
+  readonly start: number;
+  readonly count: number;
+}
+
 export interface UseActionPaletteReturn {
   isOpen: boolean;
   query: string;
   results: ActionPaletteItem[];
   totalResults: number;
+  /** Always within `results`, or -1 when there are none. See the clamp below. */
   selectedIndex: number;
-  isShowingRecentlyUsed: boolean;
   isStale: boolean;
-  /** Count of pinned items at the start of `results`. The remainder is "Recently used". */
-  pinnedCount: number;
+  /**
+   * Section runs covering `results` on the empty-query browse rail. Empty
+   * during a typed search, where ranking replaces grouping.
+   */
+  sections: readonly ActionPaletteSection[];
   open: () => void;
   close: () => void;
   toggle: () => void;
@@ -69,7 +87,29 @@ export interface UseActionPaletteReturn {
 }
 
 const MAX_RESULTS = 20;
-const MAX_MRU_RESULTS = 10;
+const MAX_MRU_RESULTS = 5;
+
+const EMPTY_SECTIONS: readonly ActionPaletteSection[] = [];
+
+/**
+ * Section id of the frecency band. The palette only offers the "Hide from
+ * Recently used" control on these rows — it's the one section the control acts
+ * on, and offering it against a category row would promise an eviction that
+ * surface can't perform.
+ */
+export const RECENTLY_USED_SECTION_ID = "recently-used";
+
+/**
+ * The search path stays capped — ranking past the twentieth match is noise, and
+ * `PaletteOverflowNotice` reports the remainder. The empty-query rail is the
+ * browsable inventory, so capping it would defeat the point; it caps itself at
+ * the number of registered actions.
+ *
+ * Module-level: `useSearchablePalette` reads this inside its filter memo, and a
+ * fresh closure per render would invalidate that memo every time.
+ */
+const resolveMaxResults = (query: string): number =>
+  query.trim() ? MAX_RESULTS : Number.POSITIVE_INFINITY;
 
 export function toActionPaletteItem(entry: ActionManifestEntry): ActionPaletteItem {
   const title =
@@ -163,32 +203,96 @@ export function useActionPalette(): UseActionPaletteReturn {
     return getSortedActionMruList().filter(({ id }) => !confirmDangerIds.has(id));
   }, [getSortedActionMruList, actionUsageEntries, confirmDangerIds]);
 
+  /**
+   * The empty-query rail: Favorites, then a short recents band, then every
+   * remaining action grouped by category. Recall on top, browsing below — a
+   * palette opened to find out what the app can do has somewhere to go.
+   *
+   * Built as one memo so the flat row array and the section runs describing it
+   * are always produced together and can never disagree about an offset.
+   */
+  const browseModel = useMemo(() => {
+    const items: ActionPaletteItem[] = [];
+    const sections: ActionPaletteSection[] = [];
+    const pushSection = (id: string, label: string, rows: ActionPaletteItem[]) => {
+      if (rows.length === 0) return;
+      sections.push({ id, label, start: items.length, count: rows.length });
+      items.push(...rows);
+    };
+
+    // Favorites: ordered by pin time (insertion order), strip danger:"confirm"
+    // and skip ids the action registry no longer exposes.
+    const pinnedItems: ActionPaletteItem[] = [];
+    for (const id of pinnedActionIds) {
+      if (confirmDangerIds.has(id)) continue;
+      const item = itemById.get(id);
+      if (item) pinnedItems.push(item);
+    }
+    pushSection("favorites", "Favorites", pinnedItems);
+
+    // Recently used: filter out pinned ids (so they don't appear in both
+    // sections) and hidden ids (eviction).
+    const enabled: ActionPaletteItem[] = [];
+    const disabled: ActionPaletteItem[] = [];
+    for (const { id } of actionMruList) {
+      if (pinnedSet.has(id) || hiddenSet.has(id)) continue;
+      const item = itemById.get(id);
+      if (!item) continue;
+      if (item.enabled) enabled.push(item);
+      else disabled.push(item);
+    }
+    pushSection(
+      RECENTLY_USED_SECTION_ID,
+      "Recently used",
+      [...enabled, ...disabled].slice(0, MAX_MRU_RESULTS)
+    );
+
+    // Browse: everything not already on screen above. Excluding the promoted
+    // rows keeps every action to exactly one row, which the rest of the palette
+    // depends on — `key`, the `action-option-{id}` DOM id behind
+    // aria-activedescendant, the `data-action-id` scroll lookup and the
+    // selection-follow ref all assume an id identifies one row.
+    //
+    // Only ids actually rendered above are skipped, not every preference id: an
+    // MRU entry past the recents cap, or one hidden from the recents rail, is
+    // still part of the inventory and reappears in its category. Hiding demotes
+    // an action out of frecency; it doesn't retire the action.
+    const promotedIds = new Set(items.map((item) => item.id));
+    const byCategory = new Map<string, ActionPaletteItem[]>();
+    for (const item of allActions) {
+      if (promotedIds.has(item.id)) continue;
+      // danger:"confirm" stays off the empty-query rail, as it already is for
+      // Favorites and Recently used (#7481). Search still surfaces these — a
+      // user who types the name has named the destructive action; one who is
+      // scrolling an inventory has not.
+      if (item.danger === "confirm") continue;
+      const bucket = byCategory.get(item.category);
+      if (bucket) bucket.push(item);
+      else byCategory.set(item.category, [item]);
+    }
+    for (const category of orderActionCategories(byCategory.keys())) {
+      const rows = byCategory.get(category)!;
+      // Sort by title so the inventory reads alphabetically within a group, and
+      // break ties on id: registry insertion order shifts with plugin load
+      // order, and a browse list that reorders between opens isn't browsable.
+      rows.sort((a, b) => a.titleLower.localeCompare(b.titleLower) || a.id.localeCompare(b.id));
+      pushSection(`category:${category}`, getActionCategoryLabel(category), rows);
+    }
+
+    return { items, sections: sections as readonly ActionPaletteSection[] };
+  }, [
+    pinnedActionIds,
+    confirmDangerIds,
+    itemById,
+    actionMruList,
+    pinnedSet,
+    hiddenSet,
+    allActions,
+  ]);
+
   const filterFn = useCallback(
     (items: ActionPaletteItem[], query: string): ActionPaletteItem[] => {
-      if (!query.trim()) {
-        // Favorites: ordered by pin time (insertion order), strip danger:"confirm"
-        // and skip ids the action registry no longer exposes.
-        const pinnedItems: ActionPaletteItem[] = [];
-        for (const id of pinnedActionIds) {
-          if (confirmDangerIds.has(id)) continue;
-          const item = itemById.get(id);
-          if (item) pinnedItems.push(item);
-        }
-
-        // Recently used: filter out pinned ids (so they don't appear in both
-        // sections) and hidden ids (eviction).
-        const enabled: ActionPaletteItem[] = [];
-        const disabled: ActionPaletteItem[] = [];
-        for (const { id } of actionMruList) {
-          if (pinnedSet.has(id) || hiddenSet.has(id)) continue;
-          const item = itemById.get(id);
-          if (!item) continue;
-          if (item.enabled) enabled.push(item);
-          else disabled.push(item);
-        }
-        const recentItems = [...enabled, ...disabled].slice(0, MAX_MRU_RESULTS);
-        return [...pinnedItems, ...recentItems];
-      }
+      if (!query.trim()) return browseModel.items;
 
       const context = actionService.getContext();
       const rankContext = {
@@ -200,16 +304,7 @@ export function useActionPalette(): UseActionPaletteReturn {
         ? rankActions(query, actionMruList, rankContext)
         : rankActionMatches(query, items, actionMruList, rankContext);
     },
-    [
-      pinnedActionIds,
-      confirmDangerIds,
-      itemById,
-      hiddenSet,
-      pinnedSet,
-      allActions,
-      rankActions,
-      actionMruList,
-    ]
+    [browseModel, allActions, rankActions, actionMruList]
   );
 
   const {
@@ -217,7 +312,7 @@ export function useActionPalette(): UseActionPaletteReturn {
     query,
     results,
     totalResults,
-    selectedIndex,
+    selectedIndex: rawSelectedIndex,
     isStale,
     open,
     close,
@@ -229,9 +324,31 @@ export function useActionPalette(): UseActionPaletteReturn {
   } = useSearchablePalette<ActionPaletteItem>({
     items: allActions,
     filterFn,
-    maxResults: MAX_RESULTS,
+    maxResults: resolveMaxResults,
     paletteId: "action",
   });
+
+  // `results` is the browse inventory exactly when it is the array the browse
+  // memo built — `useSearchablePalette` hands back the filter's own array
+  // whenever nothing was sliced off. Identity, not a re-read of `query`, is
+  // what keeps the two in step: filtering runs on the *deferred* query, so a
+  // `query`-based test would label a still-rendering browse list as search
+  // results the moment a key goes down, and vice versa on clearing.
+  const sections = results === browseModel.items ? browseModel.sections : EMPTY_SECTIONS;
+
+  // Results are computed during render but `selectedIndex` is reconciled a
+  // frame later in an effect, so between the two the stored index can point
+  // past the end of a list that just shrank. Typing turns ~300 browse rows into
+  // a handful of matches, which makes that window trivial to hit; clamp on read
+  // so the highlight, aria-activedescendant and Enter all agree on a row that
+  // exists. Resetting from the query setter instead would clobber the
+  // selection-follow ref and land on the wrong row.
+  const selectedIndex =
+    rawSelectedIndex >= 0 && rawSelectedIndex < results.length
+      ? rawSelectedIndex
+      : results.length > 0
+        ? 0
+        : -1;
 
   const executeAction = useCallback(
     (item: ActionPaletteItem) => {
@@ -313,7 +430,9 @@ export function useActionPalette(): UseActionPaletteReturn {
     // text in the input. Wait for the next render; the user's repeat Enter
     // (typically <32ms later) will land on the up-to-date selection.
     if (isStale) return;
-    if (results.length > 0 && selectedIndex >= 0 && selectedIndex < results.length) {
+    // `selectedIndex` is the clamped read above, so it already names a row that
+    // exists whenever there is one.
+    if (selectedIndex >= 0) {
       executeAction(results[selectedIndex]!);
     }
   }, [isStale, results, selectedIndex, executeAction]);
@@ -349,7 +468,7 @@ export function useActionPalette(): UseActionPaletteReturn {
     notify({
       type: "success",
       title: "Hidden from Recently used",
-      message: `'${item.title}' won't appear in the empty-query rail.`,
+      message: `You can still find '${item.title}' by searching or browsing its category.`,
       duration: 30_000,
       urgent: true,
       transient: true,
@@ -360,31 +479,14 @@ export function useActionPalette(): UseActionPaletteReturn {
     });
   }, []);
 
-  // When the query is non-empty, results come from `rankActionMatches` (search
-  // scoring) and the section split doesn't apply. The empty-query branch is the
-  // only path where the first N items are pinned — count them up so consumers
-  // can render the "Favorites" / "Recently used" divider at the right offset.
-  const pinnedCount = useMemo(() => {
-    if (query.trim()) return 0;
-    let count = 0;
-    for (const item of results) {
-      if (pinnedSet.has(item.id)) count++;
-      else break;
-    }
-    return count;
-  }, [query, results, pinnedSet]);
-
-  const isShowingRecentlyUsed = query.trim() === "" && results.length > 0;
-
   return {
     isOpen,
     query,
     results,
     totalResults,
     selectedIndex,
-    isShowingRecentlyUsed,
     isStale,
-    pinnedCount,
+    sections,
     open,
     close,
     toggle,

--- a/src/hooks/useSearchablePalette.ts
+++ b/src/hooks/useSearchablePalette.ts
@@ -185,6 +185,10 @@ export function useSearchablePalette<T>(
   // overwrite the ref before the follow lookup could use the prior ID.
   const selectedItemIdRef = useRef<string | null>(null);
 
+  // Mirrors `selectedIndex` so the reconcile effect can consult the current
+  // selection without taking it as a dependency and re-running on every move.
+  const selectedIndexRef = useRef(0);
+
   const updateSelectedIndex = useCallback(
     (next: number | ((prev: number) => number)): void => {
       setSelectedIndex((prev) => {
@@ -193,6 +197,7 @@ export function useSearchablePalette<T>(
         if (item != null) {
           selectedItemIdRef.current = getItemId(item);
         }
+        selectedIndexRef.current = value;
         return value;
       });
     },
@@ -212,8 +217,20 @@ export function useSearchablePalette<T>(
           ? results.map(getItemId).join(",")
           : `${getItemId(results[0]!)},${getItemId(results[Math.floor(length / 2)]!)},${getItemId(results[length - 1]!)}`;
     const prev = prevResultsRef.current;
-    if (ids === prev.ids && length === prev.length) return;
-    prevResultsRef.current = { ids, length };
+    if (ids === prev.ids && length === prev.length) {
+      // Sampling first/middle/last can't see an interior reorder that keeps all
+      // three in place — pinning a row lifts it above its neighbours and does
+      // exactly that. Trust the fast path only while the anchored row is still
+      // where the selection points; otherwise fall through and follow it, or
+      // the highlight silently slides onto the row that took its index and
+      // Enter runs the wrong action.
+      const anchorId = selectedItemIdRef.current;
+      if (anchorId == null) return;
+      const atSelected = results[selectedIndexRef.current];
+      if (atSelected != null && getItemId(atSelected) === anchorId) return;
+    } else {
+      prevResultsRef.current = { ids, length };
+    }
 
     // Follow the previously selected item to its new index when it's still
     // present and still navigable. This preserves the "type to narrow, glance,
@@ -253,6 +270,7 @@ export function useSearchablePalette<T>(
     // Reset to the first navigable item (not blindly 0) so that
     // palettes with disabled leading items start on the correct row.
     const firstNav = canNavigate && results.length > 0 ? findNavigable(0, 1) : 0;
+    selectedIndexRef.current = firstNav;
     setSelectedIndex(firstNav);
   }, [paletteId, canNavigate, results.length, findNavigable]);
 
@@ -264,6 +282,7 @@ export function useSearchablePalette<T>(
     }
     setQuery("");
     selectedItemIdRef.current = null;
+    selectedIndexRef.current = 0;
     setSelectedIndex(0);
   }, [paletteId]);
 
@@ -275,21 +294,32 @@ export function useSearchablePalette<T>(
     }
   }, [isOpen, open, close]);
 
+  // Stored state can briefly point past a list that just shrank — results are
+  // computed during render, the index is reconciled an effect later. Step from
+  // where the user actually sees the highlight, not from the stale value, or
+  // the first arrow press after a narrowing goes somewhere they didn't ask for.
+  const currentIndex = useCallback(
+    (prev: number) => (prev >= 0 && prev < results.length ? prev : 0),
+    [results.length]
+  );
+
   const selectPrevious = useCallback(() => {
     if (results.length === 0) return;
     updateSelectedIndex((prev) => {
-      const next = prev <= 0 ? results.length - 1 : prev - 1;
+      const from = currentIndex(prev);
+      const next = from <= 0 ? results.length - 1 : from - 1;
       return canNavigate ? findNavigable(next, -1) : next;
     });
-  }, [results.length, canNavigate, findNavigable, updateSelectedIndex]);
+  }, [results.length, canNavigate, findNavigable, updateSelectedIndex, currentIndex]);
 
   const selectNext = useCallback(() => {
     if (results.length === 0) return;
     updateSelectedIndex((prev) => {
-      const next = prev >= results.length - 1 ? 0 : prev + 1;
+      const from = currentIndex(prev);
+      const next = from >= results.length - 1 ? 0 : from + 1;
       return canNavigate ? findNavigable(next, 1) : next;
     });
-  }, [results.length, canNavigate, findNavigable, updateSelectedIndex]);
+  }, [results.length, canNavigate, findNavigable, updateSelectedIndex, currentIndex]);
 
   return {
     isOpen,

--- a/src/hooks/useSearchablePalette.ts
+++ b/src/hooks/useSearchablePalette.ts
@@ -8,7 +8,15 @@ export interface UseSearchablePaletteOptions<T> {
   items: T[];
   fuseOptions?: IFuseOptions<T>;
   filterFn?: (items: T[], query: string) => T[];
-  maxResults?: number;
+  /**
+   * Cap on rendered results. Pass a function to vary the cap by query — the
+   * action palette uncaps its empty-query browse inventory while keeping the
+   * search path at 20. Resolved against the *deferred* query, the same one
+   * `filterFn` sees, so the cap never disagrees with the results it slices.
+   * Use a stable (module-level or memoized) function; an inline arrow
+   * re-runs the filter memo on every render.
+   */
+  maxResults?: number | ((query: string) => number);
   /** Return false to skip item during keyboard navigation (e.g. disabled items) */
   canNavigate?: (item: T) => boolean;
   /** Reset selected index when results change. Default: true */
@@ -122,8 +130,15 @@ export function useSearchablePalette<T>(
       filtered = items;
     }
 
+    const limit = typeof maxResults === "function" ? maxResults(deferredQuery) : maxResults;
+
     return {
-      results: filtered.slice(0, maxResults),
+      // Return `filtered` itself when nothing is cut. Beyond skipping a copy of
+      // a several-hundred-entry list on every render, this preserves the array
+      // identity `filterFn` returned, which lets a caller recognise its own
+      // memoized result set — the action palette pairs its section descriptors
+      // with the exact array that produced them that way.
+      results: filtered.length <= limit ? filtered : filtered.slice(0, limit),
       totalResults: filtered.length,
       matchesById: matches,
     };
@@ -227,11 +242,19 @@ export function useSearchablePalette<T>(
       setLocalIsOpen(true);
     }
     setQuery("");
+    // Drop the follow anchor: an explicit open/close is a fresh start, not a
+    // result-set change to be tracked through. Leaving it set lets the
+    // reconcile effect chase the previously selected id into the next result
+    // set — harmless when that set was a short recents rail, but the action
+    // palette's empty-query inventory contains nearly every action, so the
+    // last search hit is almost always in there and reopening would land
+    // selection deep in the list instead of at the top.
+    selectedItemIdRef.current = null;
     // Reset to the first navigable item (not blindly 0) so that
     // palettes with disabled leading items start on the correct row.
     const firstNav = canNavigate && results.length > 0 ? findNavigable(0, 1) : 0;
-    updateSelectedIndex(firstNav);
-  }, [paletteId, canNavigate, results.length, findNavigable, updateSelectedIndex]);
+    setSelectedIndex(firstNav);
+  }, [paletteId, canNavigate, results.length, findNavigable]);
 
   const close = useCallback(() => {
     if (paletteId != null) {
@@ -240,8 +263,9 @@ export function useSearchablePalette<T>(
       setLocalIsOpen(false);
     }
     setQuery("");
-    updateSelectedIndex(0);
-  }, [paletteId, updateSelectedIndex]);
+    selectedItemIdRef.current = null;
+    setSelectedIndex(0);
+  }, [paletteId]);
 
   const toggle = useCallback(() => {
     if (isOpen) {

--- a/src/hooks/useSearchablePalette.ts
+++ b/src/hooks/useSearchablePalette.ts
@@ -191,15 +191,19 @@ export function useSearchablePalette<T>(
 
   const updateSelectedIndex = useCallback(
     (next: number | ((prev: number) => number)): void => {
-      setSelectedIndex((prev) => {
-        const value = typeof next === "function" ? next(prev) : next;
-        const item = results[value];
-        if (item != null) {
-          selectedItemIdRef.current = getItemId(item);
-        }
-        selectedIndexRef.current = value;
-        return value;
-      });
+      // Resolved against the ref rather than inside a setState updater. An
+      // updater runs during render and React may re-run or discard one while
+      // re-basing work, which would leave these refs describing a selection
+      // that never committed — and the reconcile effect below trusts them to
+      // agree with each other. Every write lands here, so the ref is as current
+      // as the state it mirrors.
+      const value = typeof next === "function" ? next(selectedIndexRef.current) : next;
+      const item = results[value];
+      if (item != null) {
+        selectedItemIdRef.current = getItemId(item);
+      }
+      selectedIndexRef.current = value;
+      setSelectedIndex(value);
     },
     [results, getItemId]
   );


### PR DESCRIPTION
Opening the palette without typing gave you pinned favourites plus up to ten recents and nothing else. Someone who had only ever launched Claude through it saw one row, with no path to the other ~300 registered actions except guessing search terms. That's the recall half of a command palette working fine and the discovery half missing entirely.

Now the empty query renders Favorites, a recents band capped at 5, then the whole inventory grouped by category — Worktrees, Panels, Git, Projects and so on — so the surface is reachable by scrolling.

**How it fits together**

`useActionPalette` builds one memo that produces the flat row array and the section descriptors covering it together, so they can't disagree about an offset. `useSearchablePalette` grew a query-sensitive `maxResults` (`number | (query) => number`): browsing is uncapped, search still caps at 20 and keeps an honest `totalResults`, which is what `PaletteOverflowNotice` reads. Its 13 other callers are untouched.

Sections are paired to results by array identity — the hook returns the filter's own array when nothing is sliced off, so sections can only ever publish alongside the exact rows that produced them. That matters because filtering lags the input; a `query`-based test would strip headers off a browse list still on screen mid-keystroke.

Category order is a hand-picked task-flow sequence in a new `src/config/actionCategoryOrder.ts`, not frequency and not alphabetical, because a browse list that reshuffles between opens isn't browsable. Unknown categories (plugins contribute their own) sort in after the known ones rather than being dropped — dropping one would take its actions off the list. Deliberately separate from `categoryColors.ts`, whose keys have already drifted from the manifest (`agents`/`panels` there vs `agent`/`panel` in the definitions — pre-existing, not touched here).

**ARIA shape is unchanged**

Headers are still sibling `role="option"` + `aria-disabled` rather than `role="group"`, which loses its label under Chromium + VoiceOver. Going from 2 headers to ~28 did surface one thing: with the headers inside the listbox, a computed set counts them, so the 36th action announced as "38 of 328". Rows now carry explicit `aria-posinset`/`aria-setsize` so the count covers only navigable rows.

**Bugs the bigger list made reachable**

The empty-query list now swings ~300 → a handful on typing and back, which turned three latent races into easy ones:

- `selectedIndex` is reconciled an effect after results are computed, so it could point past a list that just shrank — blanking the highlight and making Enter a silent no-op. Clamped on read.
- `close()` wrote the selection-follow anchor from the closing results, so reopening chased the last search hit deep into the inventory instead of starting at the top. The anchor is now dropped on open/close.
- The change-detection fingerprint samples first/middle/last ids, which can't see an interior reorder — exactly what pinning a row does. The highlight slid onto whichever row took the index and Enter ran that one. It now verifies the anchor is still where the selection points.

Selection writes also moved out of the render phase; they were being resolved inside a `setState` updater, which React can re-run or discard while re-basing.

**Two judgement calls worth flagging**

`danger:"confirm"` actions stay off the browse rail. The issue says this population is already filtered that way — it isn't, but the empty-query rail has always been confirm-free via the `#7481` strip, and search still reaches them. Scrolling an inventory isn't naming a destructive action. Related: `worktree.resource.teardown` and `worktree.restartService` are `danger:"confirm"`, palette-runnable, and their dialogs live only at component call sites, so palette dispatch bypasses them. That's pre-existing and reachable by typing today — worth its own issue, not this one.

Hidden actions (evicted from Recently used) **do** appear in browse. Hiding demotes something out of frecency; it doesn't retire it. The undo toast body was retuned to match.

**Testing**

246 tests across the palette suites plus 63 across five sibling palettes that share the generic hook. The test that literally encoded this bug — "returns empty results with empty query and empty MRU" — was rewritten rather than patched. New regression tests cover the clamp, the anchor reset, the fingerprint reorder, and prototype-key category names (`__proto__` as a plugin category returned an inherited non-string that became a section label and threw on render).

Not covered: `e2e/full/platform/core-palette-accessibility.spec.ts` searches the whole list for "Toggle sidebar", so it's now satisfiable by a browse row rather than only a recents row. Left alone rather than shipping an unverified edit to a release-gating spec.

Resolves #11688