### PR TITLE
fix(ui): stop palette footers restating what every user already knows

### DIFF
--- a/e2e/full/panels/core-palette-specialized.spec.ts
+++ b/e2e/full/panels/core-palette-specialized.spec.ts
@@ -80,6 +80,43 @@ test.describe.serial("Core: Specialized Command Palettes", () => {
     await resetToApp(ctx.window);
   });
 
+  // ── Action Palette prefix hint ─────────────────────────────
+  //
+  // Must stay the FIRST test in this serial suite. The prefix row gets one
+  // showing per profile and is spent by the first action-palette open that
+  // renders it, so any earlier test reaching for `Cmd+Shift+P` consumes it and
+  // leaves this asserting an empty footer.
+
+  test("prefix discoverability row is taught once and then retires", async () => {
+    const { window } = ctx;
+    await ensureWindowFocused(ctx.app);
+
+    await window.keyboard.press(`${mod}+Shift+P`);
+    const actionInput = window.locator(SEL.actionPalette.searchInput);
+    await expect(actionInput).toBeFocused({ timeout: T_MEDIUM });
+
+    const row = window.locator(SEL.palettePrefix.discoverabilityRow);
+    await expect(row).toBeVisible({ timeout: T_MEDIUM });
+
+    await actionInput.fill("toggle");
+    await expect(row).toHaveCount(0, { timeout: T_MEDIUM });
+
+    // Typing doesn't spend the hint — only closing the palette does, so the row
+    // is still there for the rest of this opening.
+    await actionInput.fill("");
+    await expect(row).toBeVisible({ timeout: T_MEDIUM });
+
+    await window.keyboard.press("Escape");
+    await expect(window.locator(SEL.actionPalette.dialog)).not.toBeVisible({ timeout: T_MEDIUM });
+
+    await window.keyboard.press(`${mod}+Shift+P`);
+    await expect(actionInput).toBeFocused({ timeout: T_MEDIUM });
+    await expect(row).toHaveCount(0, { timeout: T_MEDIUM });
+
+    await window.keyboard.press("Escape");
+    await expect(window.locator(SEL.actionPalette.dialog)).not.toBeVisible({ timeout: T_MEDIUM });
+  });
+
   // ── Panel Palette (Cmd+N) ─────────────────────────────────
 
   test("panel palette opens via shortcut with first option selected", async () => {
@@ -420,21 +457,6 @@ test.describe.serial("Core: Specialized Command Palettes", () => {
         count--;
       }
     });
-  });
-
-  test("prefix discoverability row shows on empty query and hides once typing starts", async () => {
-    const { window } = ctx;
-    await ensureWindowFocused(ctx.app);
-
-    await window.keyboard.press(`${mod}+Shift+P`);
-    const actionInput = window.locator(SEL.actionPalette.searchInput);
-    await expect(actionInput).toBeFocused({ timeout: T_MEDIUM });
-
-    const row = window.locator(SEL.palettePrefix.discoverabilityRow);
-    await expect(row).toBeVisible({ timeout: T_MEDIUM });
-
-    await actionInput.fill("toggle");
-    await expect(row).toHaveCount(0, { timeout: T_MEDIUM });
   });
 
   test("typing '>' shows the commands mode chip and backspace removes it", async () => {

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -499,7 +499,9 @@ export const SEL = {
     rows: "#searchable-palette-list > div",
   },
   palettePrefix: {
-    // Footer affordance listing the @/#/:/> prefixes; rendered only on empty query.
+    // Footer affordance listing the @/#/:/> prefixes. Empty query only, and
+    // only until the first action-palette opening that showed it closes — it
+    // teaches once per profile, then retires (#11690).
     discoverabilityRow: '[aria-label="Prefix shortcuts"]',
     // Mode chip (e.g. "Commands") rendered as the action-palette input prefix.
     modeChip: '[role="dialog"][aria-label="Command palette"] [role="status"][aria-live="polite"]',

--- a/src/components/ActionPalette/ActionPalette.test.tsx
+++ b/src/components/ActionPalette/ActionPalette.test.tsx
@@ -429,9 +429,22 @@ describe("ActionPalette", () => {
 
     it("does not spend the hint on an opening that never showed the row", () => {
       // Opened straight into a query — the row never rendered, so closing has
-      // nothing to consume and the next empty open still teaches.
+      // nothing to consume and the next empty open still teaches. The closed
+      // render drops the query because production `close()` resets it: the
+      // palette then satisfies the row's query/mode predicate while invisible,
+      // which is exactly the state that must not bank an exposure.
       const { rerender } = render(<ActionPalette {...baseProps} query="al" />);
-      rerender(<ActionPalette {...baseProps} query="al" isOpen={false} />);
+      rerender(<ActionPalette {...baseProps} query="" isOpen={false} />);
+      expect(seen()).toBe(false);
+    });
+
+    it("does not spend the hint while sitting closed between openings", () => {
+      // `useKeepMounted` keeps this component mounted after its first open, so
+      // it goes on rendering with an empty query and no mode — the row's own
+      // conditions — long after the palette is off screen.
+      usePreferencesStore.setState({ hasSeenActionPalettePrefixHint: false });
+      const { rerender } = render(<ActionPalette {...baseProps} isOpen={false} />);
+      rerender(<ActionPalette {...baseProps} isOpen={false} />);
       expect(seen()).toBe(false);
     });
 

--- a/src/components/ActionPalette/ActionPalette.test.tsx
+++ b/src/components/ActionPalette/ActionPalette.test.tsx
@@ -61,6 +61,7 @@ import type {
   UseActionPaletteReturn,
 } from "@/hooks/useActionPalette";
 import { usePaletteStore } from "@/store/paletteStore";
+import { usePreferencesStore } from "@/store/preferencesStore";
 
 function makeItem(id: string, title: string): ActionPaletteItemType {
   return {
@@ -144,10 +145,15 @@ describe("ActionPalette", () => {
   beforeEach(() => {
     lastSearchablePaletteProps.current = null;
     usePaletteStore.setState({ activePaletteId: "action" });
+    // Real store, not a mock: the prefix hint's whole behaviour is that a
+    // render writes state a later render reads, so a non-reactive fixture would
+    // only ever prove the selector was called.
+    usePreferencesStore.setState({ hasSeenActionPalettePrefixHint: false });
   });
 
   afterEach(() => {
     usePaletteStore.setState({ activePaletteId: null });
+    usePreferencesStore.setState({ hasSeenActionPalettePrefixHint: false });
   });
 
   it("does not render the empty message when a typed query has zero matches", () => {
@@ -359,6 +365,9 @@ describe("ActionPalette", () => {
   });
 
   describe("prefix discoverability footer", () => {
+    const prefixRow = () => screen.queryByLabelText("Prefix shortcuts");
+    const seen = () => usePreferencesStore.getState().hasSeenActionPalettePrefixHint;
+
     it("renders the prefix table in the default empty-query footer", () => {
       render(<ActionPalette {...baseProps} />);
       // One chip per prefix — labels are lowercased for mid-sentence rendering.
@@ -378,16 +387,59 @@ describe("ActionPalette", () => {
           totalResults={1}
         />
       );
-      expect(screen.queryByText("worktrees")).toBeNull();
+      expect(prefixRow()).toBeNull();
     });
 
     it("hides the prefix table while a mode chip is active", () => {
       render(<ActionPalette {...baseProps} />);
       // Sanity: prefix row visible before any prefix is typed.
-      expect(screen.getByText("worktrees")).toBeTruthy();
+      expect(prefixRow()).toBeTruthy();
       fireKey(">");
       // Activating commands mode replaces the row with the mode-scoped hint.
-      expect(screen.queryByText("worktrees")).toBeNull();
+      expect(prefixRow()).toBeNull();
+    });
+
+    it("keeps the row for the whole opening when a query is typed and cleared", () => {
+      const { rerender } = render(<ActionPalette {...baseProps} />);
+      rerender(<ActionPalette {...baseProps} query="al" />);
+      expect(prefixRow()).toBeNull();
+      // Typing is not what spends the hint — only closing the palette is, so
+      // clearing the buffer inside the same opening brings the row back.
+      rerender(<ActionPalette {...baseProps} query="" />);
+      expect(prefixRow()).toBeTruthy();
+      expect(seen()).toBe(false);
+    });
+
+    it("retires the row once the opening that showed it closes", () => {
+      const { rerender } = render(<ActionPalette {...baseProps} />);
+      expect(prefixRow()).toBeTruthy();
+
+      rerender(<ActionPalette {...baseProps} isOpen={false} />);
+      expect(seen()).toBe(true);
+
+      rerender(<ActionPalette {...baseProps} isOpen />);
+      expect(prefixRow()).toBeNull();
+    });
+
+    it("suppresses the row for a user who has already seen it", () => {
+      usePreferencesStore.setState({ hasSeenActionPalettePrefixHint: true });
+      render(<ActionPalette {...baseProps} />);
+      expect(prefixRow()).toBeNull();
+    });
+
+    it("does not spend the hint on an opening that never showed the row", () => {
+      // Opened straight into a query — the row never rendered, so closing has
+      // nothing to consume and the next empty open still teaches.
+      const { rerender } = render(<ActionPalette {...baseProps} query="al" />);
+      rerender(<ActionPalette {...baseProps} query="al" isOpen={false} />);
+      expect(seen()).toBe(false);
+    });
+
+    it("keeps the scope-exit hint but not the close convention in commands mode", () => {
+      render(<ActionPalette {...baseProps} />);
+      fireKey(">");
+      expect(screen.getByText("exit scope")).toBeTruthy();
+      expect(screen.queryByText("close")).toBeNull();
     });
   });
 

--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -333,10 +333,12 @@ export function ActionPalette({
         if (route.mode) setActiveMode(route.mode);
         return;
       }
-      // Atomic hand-off — `openPalette` replaces `activePaletteId` directly,
-      // so the action palette unmounts as the target mounts. No `close()`
+      // Atomic hand-off — `openPalette` replaces `activePaletteId` directly, so
+      // this palette's `isOpen` goes false as the target mounts. No `close()`
       // call needed; an explicit close would briefly null the mutex and
-      // teardown focus restoration via the palette-to-palette guard.
+      // teardown focus restoration via the palette-to-palette guard. The
+      // component itself stays mounted (`useKeepMounted`) and only its dialog
+      // exits, which is what lets the prefix-hint close effect still run.
       usePaletteStore.getState().openPalette(route.paletteId);
     },
     [activeMode, query]
@@ -354,10 +356,14 @@ export function ActionPalette({
   // this component subscribes to it; observing `isOpen` rather than wrapping
   // `close()` catches every exit, including the prefix hand-off that swaps
   // palettes through `paletteStore` without calling it.
+  // `isOpen` gates the exposure too, not just the spend. The component stays
+  // mounted between openings (`useKeepMounted`) and `close()` resets the query,
+  // so a closed palette otherwise satisfies the predicate and would bank an
+  // exposure the user never saw.
   const prefixHintShownRef = useRef(false);
   useEffect(() => {
-    if (showPrefixHints) prefixHintShownRef.current = true;
-  }, [showPrefixHints]);
+    if (isOpen && showPrefixHints) prefixHintShownRef.current = true;
+  }, [isOpen, showPrefixHints]);
   useEffect(() => {
     if (isOpen || !prefixHintShownRef.current) return;
     prefixHintShownRef.current = false;

--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -5,6 +5,7 @@ import { useAnimatedPresence } from "@/hooks/useAnimatedPresence";
 import { useEffectiveCombo } from "@/hooks/useKeybinding";
 import { useActionPrefsStore } from "@/store/actionPrefsStore";
 import { usePaletteStore, type PaletteId } from "@/store/paletteStore";
+import { usePreferencesStore } from "@/store/preferencesStore";
 import {
   UI_PALETTE_ENTER_DURATION,
   UI_PALETTE_EXIT_DURATION,
@@ -55,10 +56,15 @@ function looksLikePath(query: string): boolean {
   return /[/\\]/.test(query) || /^[.~]/.test(query);
 }
 
-// Compact prefix table surfaced in the default empty-query footer so users can
-// discover the mode-routing characters without having to type one first. Drops
-// out as soon as a query or mode is active so it never competes with the
-// primary "↵ to {action}" hint.
+// Compact prefix table surfaced in the empty-query footer so users can discover
+// the mode-routing characters without having to type one first. Drops out as
+// soon as a query or mode is active so it never competes with the primary
+// "↵ to {action}" hint.
+//
+// Teaching content rather than chrome, so it gets one showing and then retires
+// (#11690) — see `hasSeenActionPalettePrefixHint`. The empty-query browse rail
+// covers what actions exist; this covers the input grammar that hands search to
+// another palette, which nothing else states.
 function PrefixDiscoverabilityRow() {
   return (
     <div
@@ -158,6 +164,8 @@ export function ActionPalette({
 
   const actionPaletteShortcut = useEffectiveCombo("action.palette.open");
   const pinnedActionIds = useActionPrefsStore((state) => state.pinnedActionIds);
+  const hasSeenPrefixHint = usePreferencesStore((state) => state.hasSeenActionPalettePrefixHint);
+  const markPrefixHintSeen = usePreferencesStore((state) => state.markActionPalettePrefixHintSeen);
   // Stable id wraps the rendered footer hint and gets pointed at by every
   // option's aria-describedby — mirrors QuickSwitcher.tsx so screen readers
   // announce what Enter does for each row.
@@ -334,6 +342,28 @@ export function ActionPalette({
     [activeMode, query]
   );
 
+  // Mirror showSections (`!query.trim()`) so a whitespace-only buffer collapses
+  // to the same default state instead of diverging between the sectioned MRU
+  // body and the prefix-hint footer. The seen flag is an extra clause, not a
+  // replacement: within its one showing the row still comes and goes with the
+  // query, so typing and clearing brings it back.
+  const showPrefixHints = !hasSeenPrefixHint && activeMode === null && !query.trim();
+
+  // Consumed by an opening that actually showed the row, and only once it
+  // closes. Marking on open would clear the flag under the user mid-read, since
+  // this component subscribes to it; observing `isOpen` rather than wrapping
+  // `close()` catches every exit, including the prefix hand-off that swaps
+  // palettes through `paletteStore` without calling it.
+  const prefixHintShownRef = useRef(false);
+  useEffect(() => {
+    if (showPrefixHints) prefixHintShownRef.current = true;
+  }, [showPrefixHints]);
+  useEffect(() => {
+    if (isOpen || !prefixHintShownRef.current) return;
+    prefixHintShownRef.current = false;
+    markPrefixHintSeen();
+  }, [isOpen, markPrefixHintSeen]);
+
   const getFooter = useCallback(
     (selectedItem: ActionPaletteItemType | null): React.ReactNode => {
       let body: React.ReactNode;
@@ -344,44 +374,24 @@ export function ActionPalette({
         body = (
           <PaletteFooterHints
             primaryHint={{ keys: ["↵"], label: "to run command" }}
-            hints={[
-              { keys: ["⌫"], label: "exit scope" },
-              { keys: ["Esc"], label: "close" },
-            ]}
+            // Backspace keeps its chip: inside a mode it pops the scope rather
+            // than deleting a character, which is the one thing here a user
+            // can't infer from every other list they've used.
+            hints={[{ keys: ["⌫"], label: "exit scope" }]}
           />
         );
       } else if (results.length === 0 && looksLikePath(query)) {
         // Default empty-mode hint: surface the projects prefix when the query
         // resembles a path or filename. Per-query-shape only — no auto-routing.
-        body = (
-          <PaletteFooterHints
-            primaryHint={{ keys: ["/"], label: "search projects" }}
-            hints={[
-              { keys: ["↑", "↓"], label: "navigate" },
-              { keys: ["Esc"], label: "close" },
-            ]}
-          />
-        );
+        body = <PaletteFooterHints primaryHint={{ keys: ["/"], label: "search projects" }} />;
       } else {
         // Default footer mirrors SearchablePalette's getActionLabel composition
         // so we keep that affordance while still owning the wrapper id used by
         // aria-describedby.
         const phrase = `to ${(selectedItem?.title ?? "Run action").trim().toLowerCase()}`;
-        body = (
-          <PaletteFooterHints
-            primaryHint={{ keys: ["↵"], label: phrase }}
-            hints={[
-              { keys: ["↑", "↓"], label: "navigate" },
-              { keys: ["Esc"], label: "close" },
-            ]}
-          />
-        );
+        body = <PaletteFooterHints primaryHint={{ keys: ["↵"], label: phrase }} />;
       }
 
-      // Mirror showSections (`!query.trim()`) so a whitespace-only buffer
-      // collapses to the same default state instead of diverging between the
-      // sectioned MRU body and the prefix-hint footer.
-      const showPrefixHints = activeMode === null && !query.trim();
       return (
         <div id={footerHintId} className="@container/palette-footer w-full flex flex-col gap-1.5">
           {body}
@@ -389,7 +399,7 @@ export function ActionPalette({
         </div>
       );
     },
-    [activeMode, query, results.length, footerHintId]
+    [activeMode, query, results.length, footerHintId, showPrefixHints]
   );
 
   const chipNode = chipShouldRender ? <ModeChip label={chipLabel} isVisible={chipVisible} /> : null;

--- a/src/components/PanelPalette/PanelPalette.tsx
+++ b/src/components/PanelPalette/PanelPalette.tsx
@@ -242,10 +242,6 @@ export function PanelPalette({
             keys: ["↵"],
             label: selectedKind ? `to create ${selectedKind.name.toLowerCase()}` : "to create",
           }}
-          hints={[
-            { keys: ["↑", "↓"], label: "navigate" },
-            { keys: ["Esc"], label: "close" },
-          ]}
         />
       </AppPaletteDialog.Footer>
     </AppPaletteDialog>

--- a/src/components/Pilot/PilotView.tsx
+++ b/src/components/Pilot/PilotView.tsx
@@ -360,9 +360,13 @@ function RunRow({
 }
 
 /**
- * `actionLabel` is null when nothing is listed, and the key hints go with it —
- * a footer offering "↵ Open" over a loading or empty list is chrome promising
- * a key that visibly does nothing.
+ * `actionLabel` is null when nothing is listed, and the hint goes with it — a
+ * footer offering "↵ Open" over a loading or empty list is chrome promising a
+ * key that visibly does nothing.
+ *
+ * What Enter does to the highlighted row is the whole of the left edge. Arrow
+ * keys moving a selection is a convention every list already teaches, so the
+ * footer no longer spends a slot restating it.
  *
  * `onShowDemand` turns the demand sentence into the control it was already
  * implying. "2 agents need you" stated a fact the surface gave no way to act
@@ -385,16 +389,10 @@ function PilotFooter({
     <div className="flex w-full items-center justify-between gap-3">
       <div className="flex items-center gap-3">
         {actionLabel !== null && (
-          <>
-            <span>
-              <kbd className={KBD_CLASS}>↵</kbd>
-              <span className="ml-1.5">{actionLabel}</span>
-            </span>
-            <span className="text-daintree-text/50">
-              <kbd className={KBD_CLASS}>↑↓</kbd>
-              <span className="ml-1.5">Navigate</span>
-            </span>
-          </>
+          <span>
+            <kbd className={KBD_CLASS}>↵</kbd>
+            <span className="ml-1.5">{actionLabel}</span>
+          </span>
         )}
       </div>
       {summary &&

--- a/src/components/Pilot/PilotView.tsx
+++ b/src/components/Pilot/PilotView.tsx
@@ -1061,11 +1061,11 @@ export function PilotView() {
             demandCount={needsYou}
             onShowDemand={() => {
               setBandFilter("needs-you");
-              // The footer advertises the list's keys, and this button leaves
-              // focus on itself — where the body's handler bails on events that
-              // did not come from the scroller, so the arrows it is advertising
-              // do nothing. The Clear-filter button in the empty state already
-              // makes exactly this handoff.
+              // This button leaves focus on itself, where the body's handler
+              // bails on events that did not come from the scroller — so the
+              // arrows stop moving the selection until focus goes back. The
+              // Clear-filter button in the empty state already makes exactly
+              // this handoff.
               searchRef.current?.focus();
             }}
           />

--- a/src/components/Pilot/__tests__/PilotView.test.tsx
+++ b/src/components/Pilot/__tests__/PilotView.test.tsx
@@ -749,7 +749,6 @@ describe("PilotView", () => {
       expect(fireEvent.keyDown(search, { key: "ArrowDown" })).toBe(true);
       expect(fireEvent.keyDown(search, { key: "Enter" })).toBe(true);
       expect(screen.queryByText("Open")).toBeNull();
-      expect(screen.queryByText("Navigate")).toBeNull();
     });
 
     it("keeps the highlight on its row when the list shrinks underneath it", async () => {
@@ -1134,9 +1133,9 @@ describe("PilotView", () => {
     });
 
     it("hands focus back to the search box after applying its filter", () => {
-      // The footer goes on advertising "↑↓ Navigate" while focus sits on the
-      // button, where the body's handler bails on events that did not come from
-      // the scroller — so the arrows it names do nothing at all.
+      // While focus sits on the button the body's handler bails on events that
+      // did not come from the scroller, so the arrow keys do nothing at all —
+      // focus has to go back for the list to be navigable again.
       seed([
         run({ runId: "a", agentState: "waiting", title: "one", since: NOW - 60_000 }),
         run({ runId: "b", agentState: "waiting", title: "two", since: NOW - 30_000 }),

--- a/src/components/Plugin/PluginQuickPickDialog.tsx
+++ b/src/components/Plugin/PluginQuickPickDialog.tsx
@@ -178,11 +178,10 @@ export function PluginQuickPickDialog() {
   const footer = canSelectMany ? (
     <PaletteFooterHints
       primaryHint={{ keys: ["⌘", "↵"], label: `confirm ${checkedIds.size} selected` }}
-      hints={[
-        { keys: ["↵"], label: "toggle" },
-        { keys: ["↑", "↓"], label: "navigate" },
-        { keys: ["Esc"], label: "close" },
-      ]}
+      // Enter earns its chip here and only here: in a multi-select list it
+      // toggles the row instead of confirming, so the palette's usual primary
+      // key does something else. Navigation and close stay unstated.
+      hints={[{ keys: ["↵"], label: "toggle" }]}
     />
   ) : undefined;
 

--- a/src/components/QuickSwitcher/QuickSwitcher.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcher.tsx
@@ -66,13 +66,7 @@ export function QuickSwitcher({
       const label = getQuickSwitcherActionLabel(item);
       return (
         <div id={footerHintId} className="w-full">
-          <PaletteFooterHints
-            primaryHint={{ keys: ["↵"], label }}
-            hints={[
-              { keys: ["↑", "↓"], label: "navigate" },
-              { keys: ["Esc"], label: "close" },
-            ]}
-          />
+          <PaletteFooterHints primaryHint={{ keys: ["↵"], label }} />
         </div>
       );
     },

--- a/src/components/Terminal/PromptHistoryPalette.tsx
+++ b/src/components/Terminal/PromptHistoryPalette.tsx
@@ -128,13 +128,7 @@ export function PromptHistoryPalette({ onOpenRef, ...props }: PromptHistoryPalet
   const footer = (
     <div className="flex items-center gap-3 w-full">
       <div className="flex-1 min-w-0">
-        <PaletteFooterHints
-          primaryHint={{ keys: ["↵"], label: "to recall" }}
-          hints={[
-            { keys: ["↑", "↓"], label: "navigate" },
-            { keys: ["Esc"], label: "close" },
-          ]}
-        />
+        <PaletteFooterHints primaryHint={{ keys: ["↵"], label: "to recall" }} />
       </div>
       <button
         type="button"

--- a/src/components/Terminal/ResumeSessionsPalette.tsx
+++ b/src/components/Terminal/ResumeSessionsPalette.tsx
@@ -233,10 +233,6 @@ export function ResumeSessionsPalette() {
             keys: ["↵"],
             label: selected ? `to resume ${selected.name.toLowerCase()}` : "to resume",
           }}
-          hints={[
-            { keys: ["↑", "↓"], label: "navigate" },
-            { keys: ["Esc"], label: "close" },
-          ]}
         />
       </AppPaletteDialog.Footer>
     </AppPaletteDialog>

--- a/src/components/TerminalPalette/NewTerminalPalette.tsx
+++ b/src/components/TerminalPalette/NewTerminalPalette.tsx
@@ -167,10 +167,6 @@ export function NewTerminalPalette({
             keys: ["↵"],
             label: selectedOption ? `to launch ${selectedOption.label.toLowerCase()}` : "to launch",
           }}
-          hints={[
-            { keys: ["↑", "↓"], label: "navigate" },
-            { keys: ["Esc"], label: "close" },
-          ]}
         />
       </AppPaletteDialog.Footer>
     </AppPaletteDialog>

--- a/src/components/Worktree/QuickCreatePalette.tsx
+++ b/src/components/Worktree/QuickCreatePalette.tsx
@@ -190,9 +190,11 @@ export function QuickCreatePalette({ palette }: QuickCreatePaletteProps) {
         ) : undefined
       }
       footer={
+        // No `Esc cancel` chip. Escape closes the palette but the pending
+        // `worktree.createWithRecipe` keeps running — there is no abort path —
+        // so naming it "cancel" promised something the key doesn't do.
         <PaletteFooterHints
           primaryHint={{ keys: ["↵"], label: palette.isPending ? "creating…" : "to create" }}
-          hints={[{ keys: ["Esc"], label: "cancel" }]}
         />
       }
     />

--- a/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
@@ -19,6 +19,7 @@ describe("preferencesStore cross-view write merge (#11351)", () => {
       showProjectPulse?: boolean;
       reduceAnimations?: boolean;
       dockDensity?: string;
+      hasSeenActionPalettePrefixHint?: boolean;
       [key: string]: unknown;
     };
   };
@@ -155,6 +156,26 @@ describe("preferencesStore cross-view write merge (#11351)", () => {
     const written = readBlob(backing);
     expect(written.state.projectSwitcherOtherSortMode).toBe("alphabetical");
     expect(written.state.reduceAnimations).toBe(true);
+  });
+
+  it("does not re-teach the palette prefix hint a sibling view already spent", async () => {
+    const backing = installLocalStorage({});
+    const { usePreferencesStore: store } = await import("../preferencesStore");
+
+    store.getState().setDockDensity("normal");
+
+    // Another project view showed the hint and retired it.
+    const disk = readBlob(backing);
+    disk.state.hasSeenActionPalettePrefixHint = true;
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    // This view still holds the pre-hydration `false`. Without the writer-delta
+    // guard its unrelated write would hand the user the hint a second time.
+    store.getState().setDockDensity("compact");
+
+    const written = readBlob(backing);
+    expect(written.state.hasSeenActionPalettePrefixHint).toBe(true);
+    expect(written.state.dockDensity).toBe("compact");
   });
 
   it("does not resurrect a recipe entry this view cleared, and keeps a sibling's", async () => {

--- a/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
@@ -158,7 +158,11 @@ describe("preferencesStore cross-view write merge (#11351)", () => {
     expect(written.state.reduceAnimations).toBe(true);
   });
 
-  it("does not re-teach the palette prefix hint a sibling view already spent", async () => {
+  // Disk convergence only. Like every other field here, a sibling's live state
+  // is not pushed across views — an already-hydrated view can still show the
+  // hint once before it reloads. What must not happen is that view's write
+  // erasing the record, sending the hint back to every view on next launch.
+  it("keeps a sibling's spent prefix hint on disk through an unrelated write", async () => {
     const backing = installLocalStorage({});
     const { usePreferencesStore: store } = await import("../preferencesStore");
 

--- a/src/store/__tests__/preferencesStore.test.ts
+++ b/src/store/__tests__/preferencesStore.test.ts
@@ -885,21 +885,21 @@ describe("preferencesStore migration", () => {
       // Hydration sanitizes too, so a blob-in/state-out test passes even with
       // the migration branch deleted. Drive `migrate` directly to pin it.
       const store = await loadStore();
-      const migrated = store.persist
-        .getOptions()
-        .migrate?.({ dockDensity: "compact" }, 14) as Record<string, unknown>;
+      // Awaited rather than asserted: `migrate` is typed `S | Promise<S>`, and
+      // awaiting narrows it without an unsafe cast.
+      const migrated = await store.persist.getOptions().migrate?.({ dockDensity: "compact" }, 14);
 
-      expect(migrated.hasSeenActionPalettePrefixHint).toBe(false);
-      expect(migrated.dockDensity).toBe("compact");
+      expect(migrated?.hasSeenActionPalettePrefixHint).toBe(false);
+      expect(migrated?.dockDensity).toBe("compact");
     });
 
     it("does not re-teach a user who already dismissed it before the upgrade", async () => {
       const store = await loadStore();
-      const migrated = store.persist
+      const migrated = await store.persist
         .getOptions()
-        .migrate?.({ hasSeenActionPalettePrefixHint: true }, 14) as Record<string, unknown>;
+        .migrate?.({ hasSeenActionPalettePrefixHint: true }, 14);
 
-      expect(migrated.hasSeenActionPalettePrefixHint).toBe(true);
+      expect(migrated?.hasSeenActionPalettePrefixHint).toBe(true);
     });
 
     it("treats a corrupt value as unseen rather than as truthy", async () => {

--- a/src/store/__tests__/preferencesStore.test.ts
+++ b/src/store/__tests__/preferencesStore.test.ts
@@ -857,4 +857,57 @@ describe("preferencesStore migration", () => {
       expect(store.getState().projectSwitcherOtherSortMode).toBe("mostUsed");
     });
   });
+
+  describe("hasSeenActionPalettePrefixHint (v15 migration)", () => {
+    it("starts unseen so a fresh install still gets taught the prefixes", async () => {
+      const store = await loadStore();
+      expect(store.getState().hasSeenActionPalettePrefixHint).toBe(false);
+    });
+
+    it("only ever moves forward — marking twice is the same as marking once", async () => {
+      const store = await loadStore();
+      store.getState().markActionPalettePrefixHintSeen();
+      store.getState().markActionPalettePrefixHintSeen();
+      expect(store.getState().hasSeenActionPalettePrefixHint).toBe(true);
+    });
+
+    it("survives a reload, or the hint would return on every app start", async () => {
+      const first = await loadStore();
+      first.getState().markActionPalettePrefixHintSeen();
+
+      vi.resetModules();
+      _resetPersistedStoreRegistryForTests();
+      const reloaded = await loadStore();
+      expect(reloaded.getState().hasSeenActionPalettePrefixHint).toBe(true);
+    });
+
+    it("supplies the field in the migration itself, not only in the sanitizer", async () => {
+      // Hydration sanitizes too, so a blob-in/state-out test passes even with
+      // the migration branch deleted. Drive `migrate` directly to pin it.
+      const store = await loadStore();
+      const migrated = store.persist
+        .getOptions()
+        .migrate?.({ dockDensity: "compact" }, 14) as Record<string, unknown>;
+
+      expect(migrated.hasSeenActionPalettePrefixHint).toBe(false);
+      expect(migrated.dockDensity).toBe("compact");
+    });
+
+    it("does not re-teach a user who already dismissed it before the upgrade", async () => {
+      const store = await loadStore();
+      const migrated = store.persist
+        .getOptions()
+        .migrate?.({ hasSeenActionPalettePrefixHint: true }, 14) as Record<string, unknown>;
+
+      expect(migrated.hasSeenActionPalettePrefixHint).toBe(true);
+    });
+
+    it("treats a corrupt value as unseen rather than as truthy", async () => {
+      // A hand-edited string is truthy, which would silently retire the hint
+      // for someone who never saw it.
+      setStoredState({ hasSeenActionPalettePrefixHint: "yes" }, 15);
+      const store = await loadStore();
+      expect(store.getState().hasSeenActionPalettePrefixHint).toBe(false);
+    });
+  });
 });

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -141,6 +141,16 @@ interface PreferencesState {
   fileBrowserAlwaysHiddenPatterns: string[];
   setFileBrowserAlwaysHiddenPatterns: (patterns: string[]) => void;
   resetFileBrowserAlwaysHiddenPatterns: () => void;
+  /**
+   * Whether the action palette's prefix table (`>` `@` `#` `:` `/`) has already
+   * had its one showing. Teaching content, not a setting — it earns a first
+   * opening and then stops being chrome every later open has to scroll past
+   * (#11690). Deliberately monotonic `false → true`: a view count would lose
+   * concurrent increments across project views, where this only ever converges
+   * on "seen".
+   */
+  hasSeenActionPalettePrefixHint: boolean;
+  markActionPalettePrefixHintSeen: () => void;
 }
 
 function isDockDensity(value: unknown): value is DockDensity {
@@ -210,6 +220,12 @@ function sanitizePersistedPreferences(
   }
   sanitized.skipPushConfirmByWorktreePath = validatedSkip;
 
+  // A non-boolean here would be truthy for any hand-edited string, retiring the
+  // hint for a user who never saw it.
+  if (typeof sanitized.hasSeenActionPalettePrefixHint !== "boolean") {
+    sanitized.hasSeenActionPalettePrefixHint = false;
+  }
+
   return sanitized;
 }
 
@@ -235,6 +251,7 @@ type PreferencesPersistedState = Pick<
   | "lastSelectedWorktreeRecipeIdByProject"
   | "skipPushConfirmByWorktreePath"
   | "fileBrowserAlwaysHiddenPatterns"
+  | "hasSeenActionPalettePrefixHint"
 >;
 
 const PREFERENCES_PERSISTED_DEFAULTS: PreferencesPersistedState = {
@@ -258,6 +275,7 @@ const PREFERENCES_PERSISTED_DEFAULTS: PreferencesPersistedState = {
   lastSelectedWorktreeRecipeIdByProject: {},
   skipPushConfirmByWorktreePath: {},
   fileBrowserAlwaysHiddenPatterns: [...DEFAULT_FILE_BROWSER_ALWAYS_HIDDEN],
+  hasSeenActionPalettePrefixHint: false,
 };
 
 function coerceBool(value: unknown, fallback: boolean): boolean {
@@ -328,6 +346,10 @@ function toPreferencesPersisted(
     skipPushConfirmByWorktreePath: normalizeSkipMap(raw.skipPushConfirmByWorktreePath),
     fileBrowserAlwaysHiddenPatterns: sanitizeAlwaysHiddenPatterns(
       raw.fileBrowserAlwaysHiddenPatterns
+    ),
+    hasSeenActionPalettePrefixHint: coerceBool(
+      raw.hasSeenActionPalettePrefixHint,
+      d.hasSeenActionPalettePrefixHint
     ),
   };
 }
@@ -441,6 +463,14 @@ function mergePreferencesPersistedWrite({
         inc.fileBrowserAlwaysHiddenPatterns,
         disk.fileBrowserAlwaysHiddenPatterns
       ),
+      // A view that hydrated before a sibling marked the hint seen still holds
+      // `false`; without the writer-delta guard its next unrelated preference
+      // write would hand the user the hint a second time.
+      hasSeenActionPalettePrefixHint: pickFieldByWriterDelta(
+        base.hasSeenActionPalettePrefixHint,
+        inc.hasSeenActionPalettePrefixHint,
+        disk.hasSeenActionPalettePrefixHint
+      ),
     },
   };
 }
@@ -514,13 +544,15 @@ export const usePreferencesStore = create<PreferencesState>()(
         set({ fileBrowserAlwaysHiddenPatterns: sanitizeAlwaysHiddenPatterns(patterns) }),
       resetFileBrowserAlwaysHiddenPatterns: () =>
         set({ fileBrowserAlwaysHiddenPatterns: [...DEFAULT_FILE_BROWSER_ALWAYS_HIDDEN] }),
+      hasSeenActionPalettePrefixHint: false,
+      markActionPalettePrefixHintSeen: () => set({ hasSeenActionPalettePrefixHint: true }),
     }),
     {
       name: "daintree-preferences",
       storage: createSafeJSONStorage<PreferencesPersistedState>({
         mergeOnWrite: mergePreferencesPersistedWrite,
       }),
-      version: 14,
+      version: 15,
       // Explicit persisted subset — matches the pre-existing default (setters are
       // dropped by JSON serialization); named so the write merge (#11351) has a
       // typed persisted shape to reconcile.
@@ -545,6 +577,7 @@ export const usePreferencesStore = create<PreferencesState>()(
         lastSelectedWorktreeRecipeIdByProject: state.lastSelectedWorktreeRecipeIdByProject,
         skipPushConfirmByWorktreePath: state.skipPushConfirmByWorktreePath,
         fileBrowserAlwaysHiddenPatterns: state.fileBrowserAlwaysHiddenPatterns,
+        hasSeenActionPalettePrefixHint: state.hasSeenActionPalettePrefixHint,
       }),
       // Runs on every hydration (unlike `migrate`, which Zustand skips when the
       // persisted version matches). Closed-set normalisation lives here so a
@@ -658,6 +691,14 @@ export const usePreferencesStore = create<PreferencesState>()(
             persisted.projectSwitcherOtherSortMode = DEFAULT_OTHER_PROJECTS_SORT_MODE;
           }
         }
+        if (version < 15 && isRecord(persisted)) {
+          // Existing users have never been shown the decaying prefix hint, so
+          // they get their one showing on the next action-palette open rather
+          // than inheriting "seen" from an absent key.
+          if (typeof persisted.hasSeenActionPalettePrefixHint !== "boolean") {
+            persisted.hasSeenActionPalettePrefixHint = false;
+          }
+        }
         return persisted as PreferencesState;
       },
     }
@@ -668,5 +709,5 @@ registerPersistedStore({
   storeId: "preferencesStore",
   store: usePreferencesStore,
   persistedStateType:
-    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; showAgentTaskTitles: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; diffViewType: DiffViewType; diffWrapLines: boolean; diffIgnoreWhitespace: boolean; diffShowFileList: boolean; diffFullFile: boolean; diffFontSize: DiffFontSize; markdownWrapLines: boolean; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>; skipPushConfirmByWorktreePath: Record<string, boolean>; deletedWorktreeCleanupSeconds: DeletedWorktreeCleanupSeconds; projectSwitcherOtherSortMode: OtherProjectsSortMode; fileBrowserAlwaysHiddenPatterns: string[] }",
+    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; showAgentTaskTitles: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; diffViewType: DiffViewType; diffWrapLines: boolean; diffIgnoreWhitespace: boolean; diffShowFileList: boolean; diffFullFile: boolean; diffFontSize: DiffFontSize; markdownWrapLines: boolean; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>; skipPushConfirmByWorktreePath: Record<string, boolean>; deletedWorktreeCleanupSeconds: DeletedWorktreeCleanupSeconds; projectSwitcherOtherSortMode: OtherProjectsSortMode; fileBrowserAlwaysHiddenPatterns: string[]; hasSeenActionPalettePrefixHint: boolean }",
 });


### PR DESCRIPTION
## Summary
- Palette footers across the app spent most of their width restating conventions every command palette user already knows (`↑↓ navigate`, `Esc close`), crowding out the one hint that actually earns its space: the contextual `↵ to resume claude` / `↵ to switch worktree` hint.
- This strips the convention chips from every hand-composed palette footer and turns the action palette's routing prefix table from permanent chrome into a hint that teaches once and retires.
- Follows #11687, which built the tiered `PaletteFooterHints` component and already made this call for `SearchablePalette`'s `getActionLabel` sugar, plus #11688's empty-query browse rail. Six palettes riding that sugar were already correct and needed no change.

Resolves #11690

## Changes
- Dropped the `↑↓ navigate` / `Esc close` chips from all nine hand-composed footers: `ActionPalette` (three branches), `ResumeSessionsPalette`, `QuickSwitcher`, `NewTerminalPalette`, `PanelPalette`, `PromptHistoryPalette`, and `PilotView`'s hand-rolled variant.
- Kept the two chips that name a genuine second action rather than a convention: `⌫ exit scope` in the action palette's commands mode (Backspace at caret 0 pops the scope instead of deleting text), and `↵ toggle` in the multi-select plugin quick pick (plain Enter toggles a row while ⌘↵ confirms).
- Dropped `QuickCreatePalette`'s `Esc cancel` chip. Escape closes the palette, but the pending `worktree.createWithRecipe` call keeps running with no abort path, so the chip promised an abort that never existed.
- The action palette's `>` `@` `#` `:` `/` prefix table is real teaching content, the only surface that states the input grammar handing search off to another palette, so it stays in the footer but now shows once. It's backed by a new persisted `hasSeenActionPalettePrefixHint` flag in `preferencesStore`, marked on the close of an opening that actually rendered it. Marking on open would clear it while the user is mid-read; observing `isOpen` rather than wrapping `close()` also catches the prefix hand-off, which swaps palettes through `paletteStore` without calling close.
- Left `FleetPickerContent`'s footer alone. It's a multi-select checklist where Space is the only way to toggle a row, so both its chips are load bearing.

## Testing
- 472 unit tests pass across 20 files: every palette footer surface, both preferences store suites, and the accent/`colorSystem` contract tests.
- Rewrote `ActionPalette`'s prefix discoverability tests around the first-run lifecycle: shown while unseen, suppressed once seen, survives type-then-clear within one opening, spent on close, and not spent by an opening that never rendered it.
- Added preferences store coverage for the default value, action idempotence, reload persistence, the v15 migration (both an absent flag and an explicit `true`), and corrupt-value handling, plus a cross-view merge test proving a stale sibling write can't erase a spent hint from disk.
- Deleted a `PilotView` assertion that went vacuous once the Navigate chip never renders.
- Moved the E2E prefix-row test to the head of its serial suite with a comment explaining why: three earlier tests open the action palette and would otherwise spend the hint before the assertion runs.

## Known limitation
The flag converges on disk, not across live renderer contexts. Each project view is its own `WebContentsView` with its own Zustand instance, so a view that was already open when a sibling spends the hint can still show it once more before it reloads. That matches how every other field in `preferencesStore` behaves; a broadcast channel for one teaching hint would be disproportionate.