### PR TITLE
fix(ui): mark the current project in the switcher

### DIFF
--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -217,7 +217,7 @@ interface ProjectListItemProps {
  */
 function StatusDot({ status }: { status: ProjectRowStatus }) {
   return (
-    <div className="w-1.5 shrink-0">
+    <div className="w-1.5 shrink-0" data-testid="workspace-status-slot">
       {!status.isDormantFallback && (
         <div
           className={cn("w-1.5 h-1.5 rounded-full", ROW_DOT_CLASS[status.tone])}
@@ -342,20 +342,24 @@ function ProjectListItem({
           >
             {project.name}
           </span>
-          {isProjectNotificationsMuted && (
-            <BellOff
-              className="w-3.5 h-3.5 text-daintree-text/40 shrink-0 ml-1"
-              aria-label="Notifications muted for this project"
-            />
-          )}
           {/*
            * The band header above says which row this is, but a screen reader
            * arrowing straight onto the option may never hear the group boundary
            * — and `aria-current` itself goes unannounced inside a listbox often
            * enough that it can't be the only carrier. In the name it is always
            * read, and one extra word on one row is a cheap way to be sure.
+           *
+           * Directly after the name, before the bell: the name is what it
+           * qualifies, and read after the muted-notifications label it would
+           * attach itself to the wrong noun.
            */}
           {project.isActive && <span className="sr-only">, current</span>}
+          {isProjectNotificationsMuted && (
+            <BellOff
+              className="w-3.5 h-3.5 text-daintree-text/40 shrink-0 ml-1"
+              aria-label="Notifications muted for this project"
+            />
+          )}
         </div>
 
         {/*
@@ -482,9 +486,9 @@ function ProjectListItem({
  * selection, so it carries the shared `project-option-` id the scroll query and
  * `aria-activedescendant` resolve against, and stays out of the tab order.
  *
- * "Scratch" rides the secondary line rather than a chip: origin has to be
- * unambiguous, but it is not the row's headline, and a pill here would be a
- * second emphasis signal competing with the selected row's own treatment.
+ * "Scratch" trails the name as plain muted text rather than a chip: origin has
+ * to be unambiguous, but a pill here would be a second emphasis signal
+ * competing with the selected row's own treatment.
  *
  * Action-free on purpose. Rename, save-as-project and delete are browse-mode
  * management — an inline rename editor would have to live inside the array the
@@ -1151,12 +1155,12 @@ function ScratchSection({
                           scratch.isActive ? "bg-overlay-subtle" : "hover:bg-overlay-subtle"
                         )}
                         role="option"
-                        // This list has no roving cursor of its own, so
-                        // `aria-selected` here has only ever meant "the scratch
-                        // you're in" and stays. `aria-current` names that
-                        // directly, matching how the ranked rows above say it.
+                        // No `aria-current` here, unlike the ranked rows above.
+                        // This list has no roving cursor, so `aria-selected` is
+                        // not spoken for — it has only ever meant "the scratch
+                        // you're in", which is the same fact. Saying it twice
+                        // would have a reader announce one state as two.
                         aria-selected={scratch.isActive}
-                        aria-current={scratch.isActive ? "true" : undefined}
                       >
                         <StatusDot status={status} />
                         <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] bg-tint/[0.04] text-muted-foreground shrink-0">

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -343,11 +343,11 @@ function ProjectListItem({
             {project.name}
           </span>
           {/*
-           * The band header above says which row this is, but a screen reader
-           * arrowing straight onto the option may never hear the group boundary
-           * — and `aria-current` itself goes unannounced inside a listbox often
-           * enough that it can't be the only carrier. In the name it is always
-           * read, and one extra word on one row is a cheap way to be sure.
+           * Said in the name, not just in `aria-current`. In browse the band
+           * header carries it, but search drops the bands entirely — and even
+           * in browse a reader arrowing straight onto the option may never hear
+           * the group boundary, while `aria-current` itself goes unannounced
+           * inside a listbox often enough that it can't be the only carrier.
            *
            * Directly after the name, before the bell: the name is what it
            * qualifies, and read after the muted-notifications label it would
@@ -355,10 +355,18 @@ function ProjectListItem({
            */}
           {project.isActive && <span className="sr-only">, current</span>}
           {isProjectNotificationsMuted && (
-            <BellOff
-              className="w-3.5 h-3.5 text-daintree-text/40 shrink-0 ml-1"
-              aria-label="Notifications muted for this project"
-            />
+            <>
+              {/*
+               * The icon's label is concatenated straight onto whatever
+               * precedes it, so without this the name runs together as
+               * "Payments, currentNotifications muted…".
+               */}
+              <span className="sr-only">, </span>
+              <BellOff
+                className="w-3.5 h-3.5 text-daintree-text/40 shrink-0 ml-1"
+                aria-label="Notifications muted for this project"
+              />
+            </>
           )}
         </div>
 

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -50,7 +50,7 @@ import {
   getScratchRowStatus,
   ROW_DOT_CLASS,
   ROW_TONE_CLASS,
-  type ProjectRowTone,
+  type ProjectRowStatus,
 } from "@/lib/projectRowStatus";
 import { useEffectiveCombo } from "@/hooks/useKeybinding";
 import { useModifierKeys } from "@/hooks/useModifierKeys";
@@ -209,9 +209,23 @@ interface ProjectListItemProps {
  * The dot repeats the status line's tone rather than encoding anything on its
  * own — status must never be colour-only, and the sentence beside it already
  * carries the meaning for anyone who can't separate these hues.
+ *
+ * A row with nothing to report draws no dot, only the slot that reserves its
+ * width (#11692). The slot is what keeps the tiles and names in one column: an
+ * omitted dot would pull every quiet row 14px left of the busy ones, and a list
+ * that is mostly quiet would read as the ragged edge rather than the tidy one.
  */
-function StatusDot({ tone }: { tone: ProjectRowTone }) {
-  return <div className={cn("w-1.5 h-1.5 rounded-full shrink-0", ROW_DOT_CLASS[tone])} />;
+function StatusDot({ status }: { status: ProjectRowStatus }) {
+  return (
+    <div className="w-1.5 shrink-0">
+      {!status.isDormantFallback && (
+        <div
+          className={cn("w-1.5 h-1.5 rounded-full", ROW_DOT_CLASS[status.tone])}
+          data-testid="workspace-status-dot"
+        />
+      )}
+    </div>
+  );
 }
 
 /** Matches the resolution of the wait ages on screen — they change by the minute. */
@@ -272,11 +286,21 @@ function ProjectListItem({
       id={`project-option-${project.id}`}
       role="option"
       aria-selected={isSelected}
+      // Where you are, on its own channel from where Enter goes. `aria-selected`
+      // is spoken for — it is the one authority on the Enter target
+      // (`PALETTE_ROW_CLASS`) — so the current project rides `aria-current`
+      // instead, the same way every other surface in the app marks its active
+      // row. Support for the bare attribute inside a listbox is uneven enough
+      // that the accessible name says it too (see below).
+      aria-current={project.isActive ? "true" : undefined}
       className={cn(
         PALETTE_ROW_CLASS,
-        "group w-full flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] text-left cursor-pointer",
+        "group w-full flex items-center gap-2 px-3 py-1 rounded-[var(--radius-md)] text-left cursor-pointer",
         project.isActive
-          ? "text-daintree-text"
+          ? // Hover still has to answer: the band wash used to sit under this
+            // row permanently, which both marked it and made it look hovered
+            // already, so pointing at it said nothing back.
+            "text-daintree-text hover:bg-overlay-subtle"
           : project.isMissing
             ? // A missing project stays dimmed while selected: the row's own
               // brightness is what says the folder is gone, and restoring it
@@ -291,7 +315,7 @@ function ProjectListItem({
       onPointerEnter={onHoverProject ? (e) => onHoverProject(project.id, e.pointerType) : undefined}
       onPointerLeave={onHoverProjectEnd ? (e) => onHoverProjectEnd(e.pointerType) : undefined}
     >
-      <StatusDot tone={status.tone} />
+      <StatusDot status={status} />
 
       <div
         className={cn(
@@ -324,18 +348,40 @@ function ProjectListItem({
               aria-label="Notifications muted for this project"
             />
           )}
+          {/*
+           * The band header above says which row this is, but a screen reader
+           * arrowing straight onto the option may never hear the group boundary
+           * — and `aria-current` itself goes unannounced inside a listbox often
+           * enough that it can't be the only carrier. In the name it is always
+           * read, and one extra word on one row is a cheap way to be sure.
+           */}
+          {project.isActive && <span className="sr-only">, current</span>}
         </div>
 
-        <div className="flex items-center gap-1 min-w-0 mt-0.5">
-          <span className={cn("truncate text-[11px] leading-none", ROW_TONE_CLASS[status.tone])}>
-            {status.text}
-          </span>
-          {status.pathHint && (
-            <span className="truncate text-[11px] leading-none text-daintree-text/50 shrink">
-              {`· ${status.pathHint}`}
-            </span>
-          )}
-        </div>
+        {/*
+         * The second line is earned, not standing. It says what the row is
+         * doing, and "Opened 13h ago" is not that — repeated down twenty rows
+         * it was most of the palette's height and none of its meaning (#11692).
+         * A path hint is the exception: it disambiguates two projects with the
+         * same folder name, so it belongs to identity rather than status and
+         * survives on its own.
+         */}
+        {(!status.isDormantFallback || status.pathHint) && (
+          <div className="flex items-center gap-1 min-w-0 mt-0.5">
+            {!status.isDormantFallback && (
+              <span
+                className={cn("truncate text-[11px] leading-none", ROW_TONE_CLASS[status.tone])}
+              >
+                {status.text}
+              </span>
+            )}
+            {status.pathHint && (
+              <span className="truncate text-[11px] leading-none text-daintree-text/50 shrink">
+                {status.isDormantFallback ? status.pathHint : `· ${status.pathHint}`}
+              </span>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );
@@ -460,36 +506,45 @@ function ScratchListItem({
       id={`project-option-${scratch.id}`}
       role="option"
       aria-selected={isSelected}
+      // Same split the project rows draw: `aria-selected` is the Enter target,
+      // `aria-current` is the workspace you are in. A ranked scratch has no
+      // band header to place it, so the accessible name carries the word too.
+      aria-current={scratch.isActive ? "true" : undefined}
       className={cn(
         PALETTE_ROW_CLASS,
-        "group w-full flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] text-left cursor-pointer",
+        "group w-full flex items-center gap-2 px-3 py-1 rounded-[var(--radius-md)] text-left cursor-pointer",
         scratch.isActive
           ? "text-daintree-text hover:bg-overlay-subtle"
           : "text-daintree-text/70 hover:bg-overlay-subtle hover:text-daintree-text"
       )}
       onClick={() => onSelect(scratch)}
     >
-      <StatusDot tone={status.tone} />
+      <StatusDot status={status} />
 
       <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] bg-tint/[0.04] text-muted-foreground shrink-0">
         <FileText className="h-4 w-4" aria-hidden="true" />
       </div>
       <div className="flex-1 min-w-0">
-        <div className="truncate text-sm font-semibold leading-tight">{scratch.name}</div>
         {/*
-         * Origin trails the status rather than leading it. In the ranked list a
+         * Origin rides the name, not the status line. In the ranked list a
          * scratch sits among projects with no section header to place it, so
-         * "Scratch" still has to be on the row — but what the row is doing
-         * outranks what kind of thing it is.
+         * "Scratch" has to be on the row somewhere — and it answers what the
+         * row *is*, which belongs beside the name. Parked on the status line it
+         * also held that line open on a scratch with nothing to report, which
+         * is the second line #11692 is trying to give back.
          */}
-        <div className="flex items-center gap-1 min-w-0 mt-0.5">
-          <span className={cn("truncate text-[11px] leading-none", ROW_TONE_CLASS[status.tone])}>
-            {status.text}
-          </span>
-          <span className="truncate text-[11px] leading-none text-daintree-text/50 shrink-0">
-            · Scratch
-          </span>
+        <div className="flex items-baseline gap-1 min-w-0">
+          <span className="truncate text-sm font-semibold leading-tight">{scratch.name}</span>
+          <span className="text-[11px] leading-none text-daintree-text/50 shrink-0">· Scratch</span>
+          {scratch.isActive && <span className="sr-only">, current</span>}
         </div>
+        {!status.isDormantFallback && (
+          <div
+            className={cn("truncate text-[11px] leading-none mt-0.5", ROW_TONE_CLASS[status.tone])}
+          >
+            {status.text}
+          </div>
+        )}
       </div>
     </div>
   );
@@ -497,7 +552,7 @@ function ScratchListItem({
 
 interface ProjectSection {
   key: ProjectSectionKey;
-  label: string | null;
+  label: string;
   items: ProjectSwitcherProjectRow[];
 }
 
@@ -514,9 +569,11 @@ const OTHER_PROJECTS_SORT_OPTIONS: Record<
 };
 
 /**
- * The Other band's header, which doubles as its sort control (#11455). Every
- * row in the band prints a timestamp, so an unlabelled frecency order reads as
- * broken — the control's first job is naming the order, changing it second.
+ * The Other band's header, which doubles as its sort control (#11455). The
+ * band is the residual catch-all, so its order is the one thing a reader can't
+ * infer from the rows — the control's first job is naming that order, changing
+ * it second. More so since the rows stopped printing their opened times
+ * (#11692): there is now nothing else on screen hinting at how they are sorted.
  *
  * Two structural constraints shape the markup:
  *
@@ -766,40 +823,34 @@ function ProjectListContent({
           </div>
         ) : sections ? (
           sections.map((section, sectionIdx) => {
-            const isActiveSection = section.key === "current";
             const isLast = sectionIdx === sections.length - 1;
             const headerId = `project-section-${section.key}`;
 
             // Bands wrap options, so they can't be bare `div`s inside the
-            // listbox: a labelled band is a `group` named by its own visible
-            // header, and an unlabelled one flattens away so its rows stay
-            // owned by the listbox (an unnamed `group` is an ARIA violation).
+            // listbox: each is a `group` named by its own visible header. Every
+            // band carries one now that `current` is labelled (#11692), which
+            // is also what keeps this legal — an unnamed `group` is an ARIA
+            // violation, so a band without a header would have to flatten away.
             return (
               <div key={section.key} role="presentation">
                 {sectionIdx > 0 && <AppPaletteDialog.Divider />}
                 <div
-                  role={section.label ? "group" : "presentation"}
-                  aria-labelledby={section.label ? headerId : undefined}
-                  className={cn(
-                    "px-2 py-1.5",
-                    sectionIdx === 0 && "pt-2",
-                    isLast && "pb-2",
-                    isActiveSection && "bg-overlay-subtle"
-                  )}
+                  role="group"
+                  aria-labelledby={headerId}
+                  className={cn("px-2 py-1.5", sectionIdx === 0 && "pt-2", isLast && "pb-2")}
                 >
-                  {section.label &&
-                    (section.key === "other" ? (
-                      <OtherProjectsHeader
-                        headerId={headerId}
-                        label={section.label}
-                        itemCount={section.items.length}
-                        onReturnFocus={onReturnFocus}
-                      />
-                    ) : (
-                      <div id={headerId} className={cn(PALETTE_SECTION_LABEL_CLASS, "px-3 py-1")}>
-                        {section.label}
-                      </div>
-                    ))}
+                  {section.key === "other" ? (
+                    <OtherProjectsHeader
+                      headerId={headerId}
+                      label={section.label}
+                      itemCount={section.items.length}
+                      onReturnFocus={onReturnFocus}
+                    />
+                  ) : (
+                    <div id={headerId} className={cn(PALETTE_SECTION_LABEL_CLASS, "px-3 py-1")}>
+                      {section.label}
+                    </div>
+                  )}
                   {section.items.map(renderItem)}
                 </div>
               </div>
@@ -1096,31 +1147,46 @@ function ScratchSection({
                         type="button"
                         onClick={() => onSelect?.(scratch)}
                         className={cn(
-                          "w-full flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors",
+                          "w-full flex items-center gap-2 px-3 py-1 rounded-[var(--radius-md)] text-left transition-colors",
                           scratch.isActive ? "bg-overlay-subtle" : "hover:bg-overlay-subtle"
                         )}
                         role="option"
+                        // This list has no roving cursor of its own, so
+                        // `aria-selected` here has only ever meant "the scratch
+                        // you're in" and stays. `aria-current` names that
+                        // directly, matching how the ranked rows above say it.
                         aria-selected={scratch.isActive}
+                        aria-current={scratch.isActive ? "true" : undefined}
                       >
-                        <StatusDot tone={status.tone} />
+                        <StatusDot status={status} />
                         <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] bg-tint/[0.04] text-muted-foreground shrink-0">
                           <FileText className="h-4 w-4" aria-hidden="true" />
                         </div>
                         <div className="flex-1 min-w-0">
-                          <div className="text-sm font-medium truncate">{scratch.name}</div>
+                          <div className="text-sm font-medium truncate leading-tight">
+                            {scratch.name}
+                          </div>
                           {/*
                            * No origin hint here — the section header already
                            * says "Scratch", so repeating it on every row would
                            * be chrome naming what the reader just read.
+                           *
+                           * The status line is conditional for the same reason
+                           * it is on a project row (#11692); the cleanup
+                           * countdown below is not, because a scratch about to
+                           * be deleted is exactly the row that has something to
+                           * report even when nothing is running.
                            */}
-                          <div
-                            className={cn(
-                              "text-[11px] leading-none truncate mt-0.5",
-                              ROW_TONE_CLASS[status.tone]
-                            )}
-                          >
-                            {status.text}
-                          </div>
+                          {!status.isDormantFallback && (
+                            <div
+                              className={cn(
+                                "text-[11px] leading-none truncate mt-0.5",
+                                ROW_TONE_CLASS[status.tone]
+                              )}
+                            >
+                              {status.text}
+                            </div>
+                          )}
                           {countdown && (
                             <div
                               className="text-[11px] leading-none text-daintree-text/40 mt-0.5 truncate"

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -357,9 +357,13 @@ describe("ProjectSwitcherPalette status dot", () => {
     expect(screen.queryByTestId("workspace-status-dot")).toBeNull();
   });
 
-  // The dot's width is reserved whether or not it draws, so a mostly-quiet list
-  // keeps one column of tiles rather than two.
-  it("holds the indicator column open on an unmarked row", () => {
+  /*
+   * Structural only — jsdom does no layout, so this pins that the slot element
+   * survives on a quiet row, not that it still measures 6px. What it rules out
+   * is the tempting simplification: dropping the whole slot instead of just its
+   * dot, which would pull every quiet row's tile left of the busy ones.
+   */
+  it("keeps the indicator slot on an unmarked row and empties it instead", () => {
     render(
       <ProjectSwitcherPalette
         {...baseProps}
@@ -370,17 +374,14 @@ describe("ProjectSwitcherPalette status dot", () => {
       />
     );
 
+    const slotIn = (row: HTMLElement) => row.querySelector("[data-testid='workspace-status-slot']");
     const busy = screen.getByRole("option", { name: /Busy/ });
     const quiet = screen.getByRole("option", { name: /Quiet/ });
-    // Same number of leading children before the identity tile: the quiet row
-    // drops the dot inside its slot, not the slot itself.
-    expect(quiet.children.length).toBe(busy.children.length);
-    expect(
-      busy.firstElementChild!.querySelector("[data-testid='workspace-status-dot']")
-    ).toBeTruthy();
-    expect(
-      quiet.firstElementChild!.querySelector("[data-testid='workspace-status-dot']")
-    ).toBeNull();
+
+    expect(slotIn(busy)).toBeTruthy();
+    expect(slotIn(quiet)).toBeTruthy();
+    expect(slotIn(busy)!.querySelector("[data-testid='workspace-status-dot']")).toBeTruthy();
+    expect(slotIn(quiet)!.querySelector("[data-testid='workspace-status-dot']")).toBeNull();
   });
 });
 
@@ -411,6 +412,9 @@ describe("ProjectSwitcherPalette status conveyance", () => {
     const row = screen.getByText("Directory not found").closest('[role="option"]');
     expect(row).toBeTruthy();
     expect(row!.getAttribute("aria-disabled")).toBeNull();
+    // A folder that has gone missing is the loudest thing a row can report, so
+    // it keeps both the line and the mark the quiet rows gave up.
+    expect(screen.getByTestId("workspace-status-dot")).toBeTruthy();
     fireEvent.click(row!);
     expect(onSelect).toHaveBeenCalled();
   });
@@ -504,6 +508,32 @@ describe("ProjectSwitcherPalette current-project marker", () => {
     expect(current.getAttribute("aria-current")).toBe("true");
     // Only the one row says it — the word is a marker, not decoration.
     expect(screen.queryByRole("option", { name: /Other Project, current/ })).toBeNull();
+  });
+
+  // The two changes meet on this row: the project you are in is usually the one
+  // with nothing running, so the marker has to survive the collapse that takes
+  // its status line and dot away.
+  it("still marks the current project when it is the quietest row in the list", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...modalProps}
+        results={[
+          makeProject({
+            id: "active",
+            name: "Active Project",
+            isActive: true,
+            section: "current",
+            lastOpened: Date.now() - 2 * 3600000,
+          }),
+        ]}
+      />
+    );
+
+    const row = screen.getByRole("option", { name: /Active Project, current/ });
+    expect(row.getAttribute("aria-current")).toBe("true");
+    expect(within(row).queryByTestId("workspace-status-dot")).toBeNull();
+    expect(screen.queryByText(/^Opened /)).toBeNull();
+    expect(screen.getByRole("group", { name: "Current project" })).toBeTruthy();
   });
 
   // The header is chrome, not a row. Arrow keys walk `results`, and a label
@@ -1080,12 +1110,17 @@ describe("ProjectSwitcherPalette scratch status treatment", () => {
     expect(screen.getByText("· Scratch")).toBeTruthy();
   });
 
-  it("marks the scratch you are in without claiming the Enter target", () => {
+  // The lone ranked result is also the cursor, so this is the both-at-once
+  // case: the two attributes describe different facts that happen to coincide,
+  // and each still has to be stated.
+  it("marks the scratch you are in even while it is also the Enter target", () => {
     render(<ProjectSwitcherPalette {...rankedProps({ isActive: true })} />);
 
-    const row = screen.getByRole("option", { name: /Spike notes/ });
+    // Queried by accessible name, not textContent — that is what proves the
+    // hidden word actually names the option rather than just sitting in it.
+    const row = screen.getByRole("option", { name: /Spike notes.*current/ });
     expect(row.getAttribute("aria-current")).toBe("true");
-    expect(row.textContent).toContain(", current");
+    expect(row.getAttribute("aria-selected")).toBe("true");
   });
 
   it("keeps the cleanup countdown beside the status line", () => {
@@ -1125,13 +1160,17 @@ describe("ProjectSwitcherPalette scratch status treatment", () => {
     expect(screen.getByTestId("scratch-cleanup-countdown")).toBeTruthy();
   });
 
-  it("marks the pinned scratch you are in", () => {
+  // This list has no roving cursor, so `aria-selected` is free to mean "the one
+  // you're in" and says it alone — a second attribute for the same fact would
+  // have a reader announce one state as two.
+  it("marks the pinned scratch you are in without doubling the signal", () => {
     render(<ProjectSwitcherPalette {...browseProps({ isActive: true })} />);
 
     const row = within(screen.getByRole("listbox", { name: "Scratch workspaces" })).getByRole(
       "option"
     );
-    expect(row.getAttribute("aria-current")).toBe("true");
+    expect(row.getAttribute("aria-selected")).toBe("true");
+    expect(row.getAttribute("aria-current")).toBeNull();
   });
 
   // The tick lives at the palette level, not inside the project list. Moved

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -258,22 +258,49 @@ describe("ProjectSwitcherPalette secondary text waterfall", () => {
     expect(screen.getByText("2 agents running")).toBeTruthy();
   });
 
-  it("labels the relative time as an opened time when nothing is running", () => {
+  // A row with nothing running has nothing to report, and twenty of those in a
+  // row were most of the palette's height and none of its meaning (#11692).
+  it("gives a row with nothing to report no second line at all", () => {
     const twoHoursAgo = Date.now() - 2 * 3600000;
     render(
       <ProjectSwitcherPalette {...baseProps} results={[makeProject({ lastOpened: twoHoursAgo })]} />
     );
-    expect(screen.getByText("Opened 2h ago")).toBeTruthy();
+    expect(screen.queryByText(/^Opened /)).toBeNull();
+    expect(screen.queryByText("Not opened yet")).toBeNull();
   });
 
-  it("names the state, not the path, when the project was never opened", () => {
+  it("stays silent rather than echoing a path for a never-opened project", () => {
     render(
       <ProjectSwitcherPalette
         {...baseProps}
         results={[makeProject({ path: "/home/user/my-project", displayPath: "my-project" })]}
       />
     );
-    expect(screen.getByText("Not opened yet")).toBeTruthy();
+    expect(screen.queryByText("Not opened yet")).toBeNull();
+    // The name is still the row — silence removes the status line, not the row.
+    expect(screen.getByRole("option", { name: /Test Project/ })).toBeTruthy();
+  });
+
+  // The hint tells two same-named folders apart, so it is identity rather than
+  // status: it outlives the line the dormant row no longer draws.
+  it("keeps the disambiguating path on a row that has gone quiet", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...baseProps}
+        results={[
+          makeProject({
+            lastOpened: Date.now() - 2 * 3600000,
+            displayPath: "payments/api",
+          }),
+        ]}
+      />
+    );
+
+    const hint = screen.getByText("payments/api");
+    expect(hint).toBeTruthy();
+    // No orphaned separator: the "·" only joins the hint to a status sentence,
+    // and there is no sentence here to join it to.
+    expect(hint.textContent).not.toContain("·");
   });
 
   it("shows 'Suspended to free memory' for an auto-parked closed project", () => {
@@ -289,9 +316,11 @@ describe("ProjectSwitcherPalette secondary text waterfall", () => {
     // The parked label wins over the plain time-ago for an auto-closed project.
     expect(screen.getByText("Suspended to free memory")).toBeTruthy();
     expect(screen.queryByText(/Opened 2h ago/)).toBeNull();
+    // Muted, but still a fact the row earned — it keeps its line and its mark.
+    expect(screen.getByTestId("workspace-status-dot")).toBeTruthy();
   });
 
-  it("shows the opened time (not the parked label) for a closed project without the marker", () => {
+  it("says nothing at all for a closed project without the parked marker", () => {
     const twoHoursAgo = Date.now() - 2 * 3600000;
     render(
       <ProjectSwitcherPalette
@@ -299,8 +328,59 @@ describe("ProjectSwitcherPalette secondary text waterfall", () => {
         results={[makeProject({ status: "closed", lastOpened: twoHoursAgo })]}
       />
     );
-    expect(screen.getByText("Opened 2h ago")).toBeTruthy();
+    // Closed on its own is not a reason: without the auto-park marker the row
+    // falls through to the opened-time fallback, which no longer prints.
     expect(screen.queryByText("Suspended to free memory")).toBeNull();
+    expect(screen.queryByText(/^Opened /)).toBeNull();
+  });
+});
+
+/**
+ * The leading dot marks rows that have something to say. It used to sit on
+ * every row as a hollow ring, which made the most common mark in the list the
+ * one carrying no information — and left it competing with the filled dots that
+ * do (#11692).
+ */
+describe("ProjectSwitcherPalette status dot", () => {
+  it("marks a row with something to report and leaves a quiet one unmarked", () => {
+    const { rerender } = render(
+      <ProjectSwitcherPalette {...baseProps} results={[makeProject({ waitingAgentCount: 1 })]} />
+    );
+    expect(screen.getByTestId("workspace-status-dot")).toBeTruthy();
+
+    rerender(
+      <ProjectSwitcherPalette
+        {...baseProps}
+        results={[makeProject({ lastOpened: Date.now() - 2 * 3600000 })]}
+      />
+    );
+    expect(screen.queryByTestId("workspace-status-dot")).toBeNull();
+  });
+
+  // The dot's width is reserved whether or not it draws, so a mostly-quiet list
+  // keeps one column of tiles rather than two.
+  it("holds the indicator column open on an unmarked row", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...baseProps}
+        results={[
+          makeProject({ id: "busy", name: "Busy", waitingAgentCount: 1 }),
+          makeProject({ id: "quiet", name: "Quiet", lastOpened: Date.now() - 2 * 3600000 }),
+        ]}
+      />
+    );
+
+    const busy = screen.getByRole("option", { name: /Busy/ });
+    const quiet = screen.getByRole("option", { name: /Quiet/ });
+    // Same number of leading children before the identity tile: the quiet row
+    // drops the dot inside its slot, not the slot itself.
+    expect(quiet.children.length).toBe(busy.children.length);
+    expect(
+      busy.firstElementChild!.querySelector("[data-testid='workspace-status-dot']")
+    ).toBeTruthy();
+    expect(
+      quiet.firstElementChild!.querySelector("[data-testid='workspace-status-dot']")
+    ).toBeNull();
   });
 });
 
@@ -372,6 +452,67 @@ describe("ProjectSwitcherPalette clone repo button", () => {
   it("does not render Clone Repository button when onCloneRepo is not provided", () => {
     render(<ProjectSwitcherPalette {...baseProps} results={[makeProject()]} />);
     expect(screen.queryByTestId("project-clone-button")).toBeNull();
+  });
+});
+
+/**
+ * Two things in this list need telling apart: where you are, and where Enter
+ * would take you (#11692). They ride separate channels on purpose —
+ * `aria-selected` is the sole authority on the Enter target, so "current" is
+ * said with a band header, `aria-current`, and a word in the accessible name.
+ */
+describe("ProjectSwitcherPalette current-project marker", () => {
+  const currentAndOther = [
+    makeProject({ id: "active", name: "Active Project", isActive: true, section: "current" }),
+    makeProject({ id: "other", name: "Other Project", section: "other" }),
+  ];
+
+  it("separates where you are from where Enter goes", () => {
+    // The hook preselects the first switchable row, so the cursor is on a row
+    // the current marker must not also claim.
+    render(<ProjectSwitcherPalette {...modalProps} results={currentAndOther} selectedIndex={1} />);
+
+    const current = screen.getByRole("option", { name: /Active Project/ });
+    const cursor = screen.getByRole("option", { name: /Other Project/ });
+
+    expect(current.getAttribute("aria-current")).toBe("true");
+    expect(current.getAttribute("aria-selected")).toBe("false");
+    expect(cursor.getAttribute("aria-selected")).toBe("true");
+    expect(cursor.getAttribute("aria-current")).toBeNull();
+  });
+
+  it("names the band the current project sits in", () => {
+    render(<ProjectSwitcherPalette {...modalProps} results={currentAndOther} />);
+
+    const band = screen.getByRole("group", { name: "Current project" });
+    expect(within(band).getByRole("option", { name: /Active Project/ })).toBeTruthy();
+    // The band holds only the current project — the rest of the list is
+    // elsewhere, which is what makes the header true.
+    expect(within(band).getAllByRole("option")).toHaveLength(1);
+  });
+
+  // Bands are browse-only, so search leaves the header behind. The row still
+  // has to say it — `aria-current` alone goes unannounced inside a listbox
+  // often enough that the accessible name has to carry the word too.
+  it("keeps saying it in search, where there is no band to say it for the row", () => {
+    render(
+      <ProjectSwitcherPalette {...modalProps} query="proj" rankedSearch results={currentAndOther} />
+    );
+
+    expect(screen.queryByRole("group", { name: "Current project" })).toBeNull();
+    const current = screen.getByRole("option", { name: /Active Project, current/ });
+    expect(current.getAttribute("aria-current")).toBe("true");
+    // Only the one row says it — the word is a marker, not decoration.
+    expect(screen.queryByRole("option", { name: /Other Project, current/ })).toBeNull();
+  });
+
+  // The header is chrome, not a row. Arrow keys walk `results`, and a label
+  // that registered as an option would put a dead stop in that walk.
+  it("does not add the header to the option count", () => {
+    render(<ProjectSwitcherPalette {...modalProps} results={currentAndOther} />);
+
+    const list = screen.getByRole("listbox", { name: "Workspaces" });
+    expect(within(list).getAllByRole("option")).toHaveLength(currentAndOther.length);
   });
 });
 
@@ -914,16 +1055,37 @@ describe("ProjectSwitcherPalette scratch status treatment", () => {
 
   // In the ranked list a scratch sits among projects with no section header to
   // place it, so losing the origin would make it indistinguishable from one.
-  it("keeps the scratch origin legible in search once status takes the line", () => {
+  // It rides the name because it answers what the row *is*, and because parked
+  // on the status line it held that line open on a scratch with nothing to
+  // report — the second line #11692 hands back.
+  it("keeps the scratch origin legible beside the name", () => {
     render(<ProjectSwitcherPalette {...rankedProps({ activeAgentCount: 1 })} />);
 
-    const line = screen.getByText("Agent running").parentElement!;
-    // Order matters: the origin trails the status, and the separator is what
-    // keeps them one readable line rather than two adjacent labels.
-    expect(Array.from(line.children).map((el) => el.textContent!.trim())).toEqual([
-      "Agent running",
+    const nameLine = screen.getByText("Spike notes").parentElement!;
+    expect(Array.from(nameLine.children).map((el) => el.textContent!.trim())).toEqual([
+      "Spike notes",
       "· Scratch",
     ]);
+    // The status keeps its own line rather than sharing the name's.
+    expect(nameLine.textContent).not.toContain("Agent running");
+    expect(screen.getByText("Agent running")).toBeTruthy();
+  });
+
+  it("gives a quiet scratch one line without losing what it is", () => {
+    render(<ProjectSwitcherPalette {...rankedProps({ lastOpened: Date.now() - 2 * 3600_000 })} />);
+
+    expect(screen.queryByText(/^Opened /)).toBeNull();
+    expect(screen.queryByTestId("workspace-status-dot")).toBeNull();
+    // Provenance is identity, not status — it survives the collapse.
+    expect(screen.getByText("· Scratch")).toBeTruthy();
+  });
+
+  it("marks the scratch you are in without claiming the Enter target", () => {
+    render(<ProjectSwitcherPalette {...rankedProps({ isActive: true })} />);
+
+    const row = screen.getByRole("option", { name: /Spike notes/ });
+    expect(row.getAttribute("aria-current")).toBe("true");
+    expect(row.textContent).toContain(", current");
   });
 
   it("keeps the cleanup countdown beside the status line", () => {
@@ -945,10 +1107,31 @@ describe("ProjectSwitcherPalette scratch status treatment", () => {
     expect(screen.queryByLabelText("Idle")).toBeNull();
   });
 
-  it("falls back to the opened time when the scratch has no activity", () => {
+  it("stays quiet in the pinned section when the scratch has no activity", () => {
     render(<ProjectSwitcherPalette {...browseProps({ lastOpened: Date.now() - 2 * 3600_000 })} />);
 
-    expect(screen.getByText(/^Opened /)).toBeTruthy();
+    expect(screen.queryByText(/^Opened /)).toBeNull();
+    expect(screen.queryByTestId("workspace-status-dot")).toBeNull();
+    expect(screen.getByText("Spike notes")).toBeTruthy();
+  });
+
+  // Cleanup is the one thing a dormant scratch still has to say: it is about to
+  // be deleted, which is exactly the report an idle row can owe you.
+  it("keeps the cleanup countdown on a scratch that is otherwise quiet", () => {
+    const lastOpened = Date.now() - (SCRATCH_CLEANUP_TTL_MS - 2 * 24 * 3600_000);
+    render(<ProjectSwitcherPalette {...browseProps({ lastOpened })} />);
+
+    expect(screen.queryByText(/^Opened /)).toBeNull();
+    expect(screen.getByTestId("scratch-cleanup-countdown")).toBeTruthy();
+  });
+
+  it("marks the pinned scratch you are in", () => {
+    render(<ProjectSwitcherPalette {...browseProps({ isActive: true })} />);
+
+    const row = within(screen.getByRole("listbox", { name: "Scratch workspaces" })).getByRole(
+      "option"
+    );
+    expect(row.getAttribute("aria-current")).toBe("true");
   });
 
   // The tick lives at the palette level, not inside the project list. Moved

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from "vitest";
 import { render, screen, within, fireEvent, act } from "@testing-library/react";
 
 const originalScrollIntoView = Element.prototype.scrollIntoView;
@@ -138,6 +138,7 @@ import type {
   SearchableScratch,
 } from "@/hooks/useProjectSwitcherPalette";
 import { SCRATCH_CLEANUP_TTL_MS } from "@shared/config/scratchCleanup";
+import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 
 const { ProjectSwitcherPalette } = await import("../ProjectSwitcherPalette");
 
@@ -466,6 +467,12 @@ describe("ProjectSwitcherPalette clone repo button", () => {
  * said with a band header, `aria-current`, and a word in the accessible name.
  */
 describe("ProjectSwitcherPalette current-project marker", () => {
+  // The override map is module state on a real store — left set, it would mute
+  // every later fixture that reuses the default project id.
+  afterEach(() => {
+    useProjectSettingsStore.setState({ notificationOverridesByProjectId: {} });
+  });
+
   const currentAndOther = [
     makeProject({ id: "active", name: "Active Project", isActive: true, section: "current" }),
     makeProject({ id: "other", name: "Other Project", section: "other" }),
@@ -534,6 +541,45 @@ describe("ProjectSwitcherPalette current-project marker", () => {
     expect(within(row).queryByTestId("workspace-status-dot")).toBeNull();
     expect(screen.queryByText(/^Opened /)).toBeNull();
     expect(screen.getByRole("group", { name: "Current project" })).toBeTruthy();
+  });
+
+  /*
+   * The row's name is assembled from adjacent nodes, and a labelled icon
+   * concatenates straight onto whatever precedes it — so a muted current
+   * project once named as "…, currentNotifications muted…". Both markers have
+   * to survive together, separated, in either order of arrival.
+   */
+  it.each([
+    [false, false],
+    [true, false],
+    [false, true],
+    [true, true],
+  ])("keeps the name readable with isActive=%s muted=%s", (isActive, muted) => {
+    useProjectSettingsStore.setState({
+      notificationOverridesByProjectId: muted
+        ? { "proj-1": { completedEnabled: false, waitingEnabled: false } }
+        : {},
+    });
+
+    render(
+      <ProjectSwitcherPalette
+        {...modalProps}
+        results={[
+          makeProject({ name: "Payments", isActive, section: isActive ? "current" : "other" }),
+        ]}
+      />
+    );
+
+    // Asserted against the accessible NAME, not textContent — the bell is an
+    // SVG carrying an aria-label, so it contributes nothing to the latter and
+    // the run-together bug is invisible there.
+    const marked = screen.queryByRole("option", { name: /Payments, current\b/ }) !== null;
+    expect(marked).toBe(isActive);
+    // A word ending immediately before the bell's label means the two fused
+    // into one — "Payments, currentNotifications muted…". A punctuated join is
+    // fine; the name-computation polyfill trims each node, so the separator
+    // reliably survives as the comma rather than as the space after it.
+    expect(screen.queryByRole("option", { name: /[A-Za-z]Notifications muted/ })).toBeNull();
   });
 
   // The header is chrome, not a row. Arrow keys walk `results`, and a label
@@ -668,11 +714,15 @@ describe("ProjectSwitcherPalette modal mode", () => {
       .map((el) => el.textContent?.trim())
       .filter(
         (text): text is string =>
-          text === "Pinned" || text === "Running" || text === "Other projects"
+          text === "Current project" ||
+          text === "Pinned" ||
+          text === "Running" ||
+          text === "Other projects"
       );
-    // Pinned above Running: an explicit pin outranks the operational fact
-    // that something is executing.
-    expect(headers[0]).toBe("Pinned");
+    // The band you are in leads, then Pinned above Running: an explicit pin
+    // outranks the operational fact that something is executing.
+    expect(headers[0]).toBe("Current project");
+    expect(headers[1]).toBe("Pinned");
     expect(headers).toContain("Running");
     expect(headers).toContain("Other projects");
   });
@@ -815,12 +865,15 @@ describe("ProjectSwitcherPalette scratch search rows", () => {
     ];
     render(<ProjectSwitcherPalette {...searchProps} results={rows} selectedIndex={0} />);
 
-    expect(screen.getByRole("option", { name: /Spike one/ }).getAttribute("aria-selected")).toBe(
-      "true"
-    );
-    expect(screen.getByRole("option", { name: /Spike two/ }).getAttribute("aria-selected")).toBe(
-      "false"
-    );
+    const cursor = screen.getByRole("option", { name: /Spike one/ });
+    const active = screen.getByRole("option", { name: /Spike two/ });
+
+    expect(cursor.getAttribute("aria-selected")).toBe("true");
+    expect(active.getAttribute("aria-selected")).toBe("false");
+    // The other half of the same contract: the row Enter would act on is not
+    // the one you are in, and each says only its own fact (#11692).
+    expect(active.getAttribute("aria-current")).toBe("true");
+    expect(cursor.getAttribute("aria-current")).toBeNull();
   });
 
   it("keeps a scratch row out of the tab order so the arrow keys stay in charge", () => {

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.sortControl.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.sortControl.test.tsx
@@ -211,8 +211,9 @@ function sortMode(): OtherProjectsSortMode {
 describe("Other projects sort control (#11455)", () => {
   it("names the order the band is currently in", () => {
     renderPalette(4);
-    // The control's first job is naming the order — every row shows a
-    // timestamp, so an unlabelled frecency sort reads as broken.
+    // The control's first job is naming the order. The band is the residual
+    // catch-all, and since its rows stopped printing opened times (#11692)
+    // there is nothing else on screen hinting at how they are sorted.
     expect(trigger().textContent).toContain("Most used");
     expect(trigger().getAttribute("aria-label")).toContain("Most used");
   });

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -128,9 +128,9 @@ export const PROJECT_SECTION_LABELS: Record<ProjectSectionKey, string> = {
 
 /**
  * Rows the Other band needs before its sort control is worth advertising
- * (#11455). Below this the order is self-evident from the rows themselves, so
- * the control would be chrome naming something nobody asked about. The
- * preference still applies — only the visible affordance is gated.
+ * (#11455). Below this there is too little order to be worth naming, so the
+ * control would be chrome answering a question nobody asked. The preference
+ * still applies — only the visible affordance is gated.
  */
 export const OTHER_PROJECTS_SORT_CONTROL_MIN_ROWS = 4;
 
@@ -644,7 +644,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     if (!isOpen) return;
     // Pull a fresh agent-status snapshot on open so rows show live status
     // immediately instead of waiting for the next passive broadcast, which
-    // would otherwise leave them falling back to a stale relative timestamp.
+    // would otherwise leave a busy project rendering as a silent, idle row.
     //
     // Both stores are awaited because the pull covers scratch rows too (#11518)
     // — the push channel is best-effort, so this is the only guaranteed
@@ -707,8 +707,9 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         });
       })
       .catch(() => {
-        // Project load or stats refresh failed; rows fall back to the relative
-        // timestamp. This background freshness pull must never surface an error.
+        // Project load or stats refresh failed; rows just render without a
+        // status line. This background freshness pull must never surface an
+        // error.
       });
   }, [isOpen, loadProjects, loadScratches]);
 

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -101,17 +101,24 @@ export const PROJECT_SECTION_ORDER = [
 export type ProjectSectionKey = (typeof PROJECT_SECTION_ORDER)[number];
 
 /**
- * Header text per band. `current` is deliberately unlabelled.
+ * Header text per band.
+ *
+ * `current` went unlabelled while the keyboard cursor was the loudest thing on
+ * the surface — position alone read as "you are here" next to an accent-painted
+ * row. Once the cursor calmed to a neutral fill (#11686) the two stopped being
+ * telling apart, and the band that says where you are is the one that has to
+ * say so out loud (#11692). "Current project", not "Current": the word on its
+ * own could be read as the current *selection*, which is the other signal.
  *
  * "Other projects", not "Recent" or "Frequent": the band is the residual
  * catch-all — frecency-ordered, holding never-opened projects and acknowledged
  * completions alike — so any label naming a sort order would be a lie the row
- * timestamps immediately expose. "Running" requires live agents; projects with
+ * contents immediately expose. "Running" requires live agents; projects with
  * only bare processes fall through to Pinned/Other, where their status line
  * still says "Process running".
  */
-export const PROJECT_SECTION_LABELS: Record<ProjectSectionKey, string | null> = {
-  current: null,
+export const PROJECT_SECTION_LABELS: Record<ProjectSectionKey, string> = {
+  current: "Current project",
   attention: "Needs attention",
   pinned: "Pinned",
   running: "Running",

--- a/src/lib/__tests__/projectRowStatus.test.ts
+++ b/src/lib/__tests__/projectRowStatus.test.ts
@@ -345,6 +345,7 @@ describe("getProjectRowStatus", () => {
 
     expect(status.text).toMatch(/^Opened /);
     expect(status.tone).toBe("muted");
+    expect(status.isDormantFallback).toBe(true);
   });
 
   it("names the next step for a never-opened project instead of echoing its path", () => {
@@ -366,6 +367,57 @@ describe("getProjectRowStatus", () => {
       getProjectRowStatus(project({ displayPath: "payments/api", waitingAgentCount: 1 }), NOW)
         .pathHint
     ).toBe("payments/api");
+  });
+
+  // The flag decides whether a row keeps its second line at all, so what it
+  // must NOT catch matters more than what it does. "Agent finished" and
+  // "Suspended to free memory" are muted too — a tone check would take them
+  // down with the timestamps, which is the bug this field exists to avoid.
+  it("flags only the opened-time fallback, never the other muted states", () => {
+    const dormant = [
+      project({ lastOpened: NOW - 2 * 3600_000 }),
+      project({ lastOpened: 0 }),
+      // Closed, but swept by nothing — no auto-park marker, so it falls all the
+      // way through to the fallback.
+      project({ status: "closed", lastOpened: NOW - 2 * 3600_000 }),
+    ];
+    for (const row of dormant) {
+      expect(getProjectRowStatus(row, NOW).isDormantFallback).toBe(true);
+    }
+
+    const reportable = [
+      project({ status: "closed", autoParkedAt: NOW - 1000, lastOpened: NOW - 5000 }),
+      project({ completedAgentCount: 1, latestCompletionAt: NOW - 2 * 3600_000 }),
+      project({ isMissing: true }),
+      project({ waitingAgentCount: 1 }),
+      project({ activeAgentCount: 1 }),
+      project({ processCount: 1 }),
+    ];
+    for (const row of reportable) {
+      const status = getProjectRowStatus(row, NOW);
+      expect(status.isDormantFallback).toBeUndefined();
+      // Guards the pairing the switcher relies on: anything unflagged still has
+      // a sentence to print, so hiding the flagged ones can't blank a row.
+      expect(status.text.length).toBeGreaterThan(0);
+    }
+
+    // Two of the reportable rows are muted. If that stopped being true the test
+    // above would pass while proving nothing.
+    expect(getProjectRowStatus(reportable[0]!, NOW).tone).toBe("muted");
+    expect(getProjectRowStatus(reportable[1]!, NOW).tone).toBe("muted");
+  });
+
+  // The hint disambiguates two projects sharing a folder name, so it is part of
+  // the row's identity rather than its status — it has to survive the flag that
+  // takes the status line away.
+  it("keeps the path hint on a dormant project", () => {
+    const status = getProjectRowStatus(
+      project({ displayPath: "payments/api", lastOpened: NOW - 2 * 3600_000 }),
+      NOW
+    );
+
+    expect(status.isDormantFallback).toBe(true);
+    expect(status.pathHint).toBe("payments/api");
   });
 });
 
@@ -400,6 +452,10 @@ describe("getScratchRowStatus", () => {
 
     expect(scratchStatus.text).toBe(projectStatus.text);
     expect(scratchStatus.tone).toBe(projectStatus.tone);
+    // Shared core, shared verdict on whether the line is worth showing — a
+    // scratch and a project holding the same activity must not disagree about
+    // which of them gets a second line.
+    expect(scratchStatus.isDormantFallback).toBe(projectStatus.isDormantFallback);
   });
 
   it("falls back to the opened time when nothing is running", () => {
@@ -407,10 +463,14 @@ describe("getScratchRowStatus", () => {
 
     expect(status.text).toMatch(/^Opened /);
     expect(status.tone).toBe("muted");
+    expect(status.isDormantFallback).toBe(true);
   });
 
   it("names the never-opened state rather than showing a bare age", () => {
-    expect(getScratchRowStatus(scratch({ lastOpened: 0 }), NOW).text).toBe("Not opened yet");
+    const status = getScratchRowStatus(scratch({ lastOpened: 0 }), NOW);
+
+    expect(status.text).toBe("Not opened yet");
+    expect(status.isDormantFallback).toBe(true);
   });
 
   // A scratch path is a UUID under the app's own directory, so a fragment of

--- a/src/lib/projectRowStatus.ts
+++ b/src/lib/projectRowStatus.ts
@@ -35,6 +35,11 @@ export const ROW_DOT_CLASS: Record<ProjectRowTone, string> = {
   review: "bg-activity-completed",
   working: "bg-activity-active animate-activity-pulse",
   running: "bg-status-success",
+  // Hollow, because "finished" and "suspended" are settled states rather than
+  // live ones. It used to sit on every dormant row too, which made a ring the
+  // most common mark in the list and left it competing with the filled dots
+  // that mean something — dormant rows draw no dot at all now (#11692), so the
+  // ring is back to marking the two muted states that earned a line.
   muted: "border border-daintree-text/20",
 };
 
@@ -57,6 +62,16 @@ export interface ProjectRowStatus {
    * every row a second line of chrome it doesn't need.
    */
   pathHint?: string;
+  /**
+   * Set only by the opened-time fallback — the line a row shows when it has
+   * nothing else to say (#11692). Callers use it to drop both the status line
+   * and the leading dot, so an ordinary row is one line with no mark on it.
+   *
+   * Deliberately not derived from `tone`. `muted` also carries "Agent finished
+   * · 2h ago" and "Suspended to free memory", which are facts a row earned and
+   * keeps — a tone check would silently delete them along with the timestamps.
+   */
+  isDormantFallback?: true;
 }
 
 /** Compact duration for a wait that is already minutes old. Sub-minute reads as "just now". */
@@ -242,17 +257,20 @@ function getWorkspaceActivityStatus(
 }
 
 /**
- * Dormant fallback shared by both kinds.
+ * Dormant fallback shared by both kinds, flagged so callers can decline it.
  *
  * "Opened", explicitly: the browse band is frecency-ordered, so a bare "13h ago"
  * read as a sort key it isn't. The verb turns it back into what it is — one
- * useful fact about the row.
+ * useful fact about the row. Still the weakest thing a row can say, though, and
+ * on twenty rows at once it is twenty timestamps nobody reads; the switcher
+ * takes the flag and shows nothing (#11692). The text stays here because a
+ * surface with room for it should still say it the same way.
  */
 function getOpenedStatus(lastOpened: number): WorkspaceActivityStatus {
   if (lastOpened > 0) {
-    return { text: `Opened ${formatTimeAgo(lastOpened)}`, tone: "muted" };
+    return { text: `Opened ${formatTimeAgo(lastOpened)}`, tone: "muted", isDormantFallback: true };
   }
-  return { text: "Not opened yet", tone: "muted" };
+  return { text: "Not opened yet", tone: "muted", isDormantFallback: true };
 }
 
 /** The one status line a project row shows. */

--- a/src/lib/projectRowStatus.ts
+++ b/src/lib/projectRowStatus.ts
@@ -57,9 +57,11 @@ export interface ProjectRowStatus {
   tone: ProjectRowTone;
   /**
    * Disambiguating path fragment, present only when this project's folder name
-   * collides with another registered project's. Rendered as a trailing segment
-   * so identical-looking monorepo siblings can be told apart without giving
-   * every row a second line of chrome it doesn't need.
+   * collides with another registered project's, so identical-looking monorepo
+   * siblings can be told apart without giving every row a second line of chrome
+   * it doesn't need. Trails the status sentence where there is one, and stands
+   * alone on a row that has gone quiet — it describes which project this is,
+   * not what it is doing, so it outlives the status line.
    */
   pathHint?: string;
   /**

--- a/src/lib/projectRowStatus.ts
+++ b/src/lib/projectRowStatus.ts
@@ -275,7 +275,7 @@ function getOpenedStatus(lastOpened: number): WorkspaceActivityStatus {
   return { text: "Not opened yet", tone: "muted", isDormantFallback: true };
 }
 
-/** The one status line a project row shows. */
+/** The one status line a project row has to show, if it shows one at all. */
 export function getProjectRowStatus(
   project: SearchableProject,
   nowMs: number = Date.now()
@@ -303,7 +303,8 @@ export function getProjectRowStatus(
 }
 
 /**
- * The one status line a scratch row shows (#11518).
+ * The one status line a scratch row has to show, if it shows one at all
+ * (#11518).
  *
  * Same activity sentences and tones a project gets — the point of the shared
  * core — minus the states a scratch has no concept of. There is no `isMissing`


### PR DESCRIPTION
## Summary

- #11686 removed the accent color from the project switcher's selected/cursor row. That also stripped the marker off the CURRENT project's row, so "where I am" and "where Enter goes" rendered at the same visual weight.
- This PR gives the current row its own quiet marker, collapses ordinary rows to one line, and only draws the leading status dot when a row has something to report.
- Rows also lost a bit of vertical padding, since the issue's real complaint is a switcher that runs close to a thousand pixels tall.

Resolves #11692

## Changes

**1. Label the current band.** The `current` band was unlabelled on purpose; it's now a properly named ARIA group like every other band, labelled "Current project." The active row gets `aria-current="true"` plus a visually-hidden `, current` suffix on its accessible name, since `aria-current` alone often goes unannounced inside a listbox, and search mode drops the group bands entirely. `aria-selected` is untouched, it stays the only thing that tells you where Enter lands. The band's background wash is gone too: it used the same token as the hover state on ordinary rows, so the current row read as permanently hovered, which was half the original confusion.

**2. Collapse ordinary rows to one line.** New `isDormantFallback` field on `ProjectRowStatus`, set only by the opened-time fallback path in `getOpenedStatus()`. It's deliberately not keyed off a `muted` tone, since that tone also carries facts a row has earned and should keep, like "Agent finished 2h ago" or "Suspended to free memory." A disambiguating path hint survives the collapse too, since it describes which project a row is rather than what it's doing.

**3. Status dot only when there's something to say.** It used to render as a hollow ring on every idle row. Now it's only drawn when a row has something to report, with a placeholder slot holding its width open so a mostly-quiet list keeps one consistent column of icons rather than two. The ring still shows for the two muted states that earned a status line.

**4. Tighter row padding.** Not explicit in the issue, but implied by it: `py-2` down to `py-1`, uniformly across all rows, never conditionally (conditional padding would shift rows under the pointer every time an agent's status changes). The identity tile fixes row height, so hiding the second line alone wouldn't have shortened the list at all.

Out of scope: the palette footer (#11690) and the shared cursor treatment in `paletteRowStyles.ts`. The behavior where Enter skips the active row and lands on the next enabled one is unchanged.

## Testing

- 532 tests pass across the full covering set: `projectRowStatus`, `projectSwitcherSearch`, all five `ProjectSwitcherPalette` suites, the three `ProjectSwitcher` suites, `scratchCleanupCountdown`, all three `useProjectSwitcherPalette` hook suites, and the five action-definition suites that reference the palette.
- Both CI-only contract scanners, `accentGuard` and `colorSystem`, run explicitly and pass. The marker uses only neutral tokens, so no allowlist entry was needed.
- Prettier clean, zero eslint errors on all six changed files.
- Three rounds of review found no blocking or medium findings. One caught a real accessibility defect: a labelled SVG was concatenating onto the preceding text in the accessible name, so a muted current project announced as "Payments, currentNotifications muted...". Fixed, and now covered across all four active x muted combinations.

Files changed:
- `src/lib/projectRowStatus.ts`
- `src/hooks/useProjectSwitcherPalette.ts`
- `src/components/Project/ProjectSwitcherPalette.tsx`
- `src/lib/__tests__/projectRowStatus.test.ts`
- `src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx`
- `src/components/Project/__tests__/ProjectSwitcherPalette.sortControl.test.tsx`