### PR TITLE
feat(ui): carry the toolbar pin affordance into the dock launcher

### DIFF
--- a/e2e/full/panels/core-dock-launcher-search.spec.ts
+++ b/e2e/full/panels/core-dock-launcher-search.spec.ts
@@ -246,11 +246,13 @@ test.describe.serial("Core: Dock launcher search", () => {
       timeout: T_MEDIUM,
     });
 
-    // The regression: ONE outside click must dismiss. Measured off the
-    // popover's own box rather than a fixed point — the launcher anchors
-    // `side="top" align="start"` to the dock's left edge, so any hard-coded
-    // dock coordinate risks landing on the trigger (which toggles by its own
-    // path and would prove nothing about the dismiss layer).
+    // The regression: ONE outside click must dismiss. Aimed relative to the
+    // search box — the launcher anchors `side="top" align="start"` to the
+    // dock's left edge, so a hard-coded dock coordinate risks landing on the
+    // trigger, which toggles by its own path and would prove nothing about the
+    // dismiss layer. `mouse.click`, not a locator click: the popover is modal,
+    // so everything outside it has pointer events disabled and Playwright's
+    // actionability check would retry rather than deliver the event.
     const surface = await window.locator(SEARCH_BOX).boundingBox();
     if (!surface) throw new Error("launcher surface has no box");
     await window.mouse.click(surface.x + surface.width + 240, surface.y);

--- a/e2e/full/panels/core-dock-launcher-search.spec.ts
+++ b/e2e/full/panels/core-dock-launcher-search.spec.ts
@@ -212,4 +212,57 @@ test.describe.serial("Core: Dock launcher search", () => {
       .poll(() => getDockPanelIds(window).then((ids) => ids.length), { timeout: T_MEDIUM })
       .toBe(dockBefore + 1);
   });
+
+  // #11689 — the per-row pin. The unit suite mocks the Popover away, so the one
+  // thing it structurally cannot see is how a nested control's pointer events
+  // interact with the real DismissableLayer: stopping propagation on pointerdown
+  // there costs the layer the event it uses to classify the NEXT outside click,
+  // and the launcher then takes two clicks to dismiss.
+  test("pinning from a row leaves the launcher usable and still dismissable in one click", async () => {
+    const { window, app } = ctx;
+    await ensureWindowFocused(app);
+
+    await openLauncher(window);
+    await searchBox(window).fill("browser");
+
+    const row = window.locator(OPTION).filter({ hasText: "Browser" }).first();
+    const pin = row.locator("button[aria-pressed]");
+    await expect(pin).toHaveAttribute("aria-pressed", "false", { timeout: T_MEDIUM });
+
+    await pin.click();
+
+    // Pinning is a change to the list, not an exit from it: the popover stays
+    // open, the query survives, and focus never left the search box.
+    await expect(searchBox(window)).toBeVisible();
+    await expect(searchBox(window)).toHaveValue("browser");
+    expect(await searchBoxHasFocus(window)).toBe(true);
+    await expect(pin).toHaveAttribute("aria-pressed", "true", { timeout: T_MEDIUM });
+
+    // The point of the affordance: the toolbar button beside the launcher is
+    // how a pin becomes visible. The write is optimistic through an async IPC,
+    // so this waits rather than asserting on the first frame.
+    await expect(window.locator('[aria-label="Open browser"]')).toBeAttached({
+      timeout: T_MEDIUM,
+    });
+
+    // The regression: ONE outside click must dismiss.
+    await window.locator("#dock-container").click({ position: { x: 5, y: 5 } });
+    await expect(searchBox(window)).not.toBeVisible({ timeout: T_MEDIUM });
+
+    // Leave the toolbar as this suite found it — later specs share the window.
+    await openLauncher(window);
+    await searchBox(window).fill("browser");
+    const pinAgain = window
+      .locator(OPTION)
+      .filter({ hasText: "Browser" })
+      .first()
+      .locator("button[aria-pressed]");
+    await expect(pinAgain).toHaveAttribute("aria-pressed", "true", { timeout: T_MEDIUM });
+    await pinAgain.click();
+    await expect(pinAgain).toHaveAttribute("aria-pressed", "false", { timeout: T_MEDIUM });
+    await window.keyboard.press("Escape");
+    await window.keyboard.press("Escape");
+    await expect(searchBox(window)).not.toBeVisible({ timeout: T_MEDIUM });
+    await window.waitForTimeout(T_SETTLE);
+  });
 });

--- a/e2e/full/panels/core-dock-launcher-search.spec.ts
+++ b/e2e/full/panels/core-dock-launcher-search.spec.ts
@@ -225,8 +225,9 @@ test.describe.serial("Core: Dock launcher search", () => {
     await openLauncher(window);
     await searchBox(window).fill("browser");
 
-    const row = window.locator(OPTION).filter({ hasText: "Browser" }).first();
-    const pin = row.locator("button[aria-pressed]");
+    // By the option's own accessible name, anchored at the start — `hasText`
+    // is a substring match and "browser" also ranks File Browser.
+    const pin = window.locator(`${OPTION}[aria-label^="Browser,"] button[aria-pressed]`);
     await expect(pin).toHaveAttribute("aria-pressed", "false", { timeout: T_MEDIUM });
 
     await pin.click();
@@ -245,21 +246,25 @@ test.describe.serial("Core: Dock launcher search", () => {
       timeout: T_MEDIUM,
     });
 
-    // The regression: ONE outside click must dismiss.
-    await window.locator("#dock-container").click({ position: { x: 5, y: 5 } });
+    // The regression: ONE outside click must dismiss. Measured off the
+    // popover's own box rather than a fixed point — the launcher anchors
+    // `side="top" align="start"` to the dock's left edge, so any hard-coded
+    // dock coordinate risks landing on the trigger (which toggles by its own
+    // path and would prove nothing about the dismiss layer).
+    const surface = await window.locator(SEARCH_BOX).boundingBox();
+    if (!surface) throw new Error("launcher surface has no box");
+    await window.mouse.click(surface.x + surface.width + 240, surface.y);
     await expect(searchBox(window)).not.toBeVisible({ timeout: T_MEDIUM });
 
-    // Leave the toolbar as this suite found it — later specs share the window.
+    // Leave the toolbar as this suite found it — the describe block is serial
+    // and later specs share this window.
     await openLauncher(window);
     await searchBox(window).fill("browser");
-    const pinAgain = window
-      .locator(OPTION)
-      .filter({ hasText: "Browser" })
-      .first()
-      .locator("button[aria-pressed]");
+    const pinAgain = window.locator(`${OPTION}[aria-label^="Browser,"] button[aria-pressed]`);
     await expect(pinAgain).toHaveAttribute("aria-pressed", "true", { timeout: T_MEDIUM });
     await pinAgain.click();
     await expect(pinAgain).toHaveAttribute("aria-pressed", "false", { timeout: T_MEDIUM });
+    // Two presses: the first clears the populated query, the second closes.
     await window.keyboard.press("Escape");
     await window.keyboard.press("Escape");
     await expect(searchBox(window)).not.toBeVisible({ timeout: T_MEDIUM });

--- a/shared/types/toolbar.ts
+++ b/shared/types/toolbar.ts
@@ -123,6 +123,34 @@ export function isLauncherPanelButtonId(id: AnyToolbarButtonId): id is LauncherP
 }
 
 /**
+ * Panel-kind id → the toolbar button that kind pins to.
+ *
+ * The two vocabularies are not the same words. A launcher built from
+ * `panelKindRegistry` knows kinds; the toolbar knows button ids; and they agree
+ * on three of four names by coincidence rather than by contract — dev preview is
+ * the kind `dev-preview` and the button `dev-server`. Anything testing
+ * `isLauncherPanelButtonId(kindId)` therefore drops that one row silently, which
+ * is exactly the bug this map exists to make impossible.
+ *
+ * Deliberately a lookup rather than a filter: a kind that is absent here is not
+ * pinnable at all (review, file, diff and every plugin kind have no toolbar
+ * button), so "no entry" and "not pinnable" are the same answer.
+ */
+export const LAUNCHER_PANEL_KIND_TO_BUTTON_ID: Readonly<Record<string, LauncherPanelButtonId>> = {
+  terminal: "terminal",
+  "file-browser": "file-browser",
+  browser: "browser",
+  "dev-preview": "dev-server",
+};
+
+/** The toolbar button a panel kind pins to, or undefined when it has none. */
+export function getLauncherPanelButtonIdForKind(kindId: string): LauncherPanelButtonId | undefined {
+  return Object.prototype.hasOwnProperty.call(LAUNCHER_PANEL_KIND_TO_BUTTON_ID, kindId)
+    ? LAUNCHER_PANEL_KIND_TO_BUTTON_ID[kindId]
+    : undefined;
+}
+
+/**
  * Whether a launcher panel button currently has its own top-level toolbar
  * button.
  *

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -153,7 +153,11 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
   const helpTerminalId = useHelpPanelStore((s) => s.terminalId);
   const agentSettings = useAgentSettingsStore((s) => s.settings);
   const agentAvailability = useCliAvailabilityStore((s) => s.availability);
+  // Both side arrays: either one renders an agent button, so `pinnedCount` has
+  // to count them both or the launcher's Pinned band disagrees with the pin icon
+  // on its own rows.
   const leftButtons = useToolbarPreferencesStore(useShallow((s) => s.layout.leftButtons));
+  const rightButtons = useToolbarPreferencesStore(useShallow((s) => s.layout.rightButtons));
   const setDockDensity = usePreferencesStore((s) => s.setDockDensity);
 
   // Narrow dock subscriptions (#10908). Subscribing to the whole `panelsById`
@@ -291,8 +295,8 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
           availability: agentAvailability?.[id],
         };
       });
-    return sortAgentsByToolbarPin(agents, leftButtons, agentSettings);
-  }, [agentAvailability, agentSettings, leftButtons]);
+    return sortAgentsByToolbarPin(agents, leftButtons, agentSettings, rightButtons);
+  }, [agentAvailability, agentSettings, leftButtons, rightButtons]);
 
   const recipeContext = activeWorktree
     ? {

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -612,12 +612,19 @@ function DockLaunchOption({
   // What the row conveys visually, in one string — the option is what
   // `aria-activedescendant` points at, and its children (the trailing qualifier,
   // the pin's own state) stop being announced with it once the name is stated
-  // explicitly. The warning is deliberately NOT folded in: `title` alongside an
-  // `aria-label` computes as the description, so repeating it here would
-  // announce it twice.
+  // explicitly. The pin verb rides here for the same reason the toolbar
+  // launcher gives its rows an `sr-only` sibling: children of `role="option"`
+  // are presentational, so the pin button's own label never reaches a screen
+  // reader — the phrase states both what Alt+P does and, through the verb,
+  // whether the row is already pinned. `aria-keyshortcuts` stays alongside it as
+  // the machine-readable half. The warning is deliberately NOT folded in:
+  // `title` alongside an `aria-label` computes as the description, so repeating
+  // it here would announce it twice.
   const optionLabel = [
     qualifier ? `${displayName}, ${qualifier}` : displayName,
-    pinTarget?.onToolbar ? "Pinned to toolbar" : undefined,
+    pinTarget
+      ? `Press Alt+P to ${pinTarget.onToolbar ? "unpin from" : "pin to"} toolbar`
+      : undefined,
   ]
     .filter(Boolean)
     .join(". ");

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -58,8 +58,8 @@ const SEARCH_RESULT_CAP = 30;
  * (recipes, the create-recipe cue, plugin panel kinds, non-built-in agents).
  */
 type DockLaunchPinTarget =
-  | { category: "agent"; key: string; id: BuiltInAgentId; name: string; onToolbar: boolean }
-  | { category: "panel"; key: string; id: LauncherPanelButtonId; name: string; onToolbar: boolean };
+  | { category: "agent"; id: BuiltInAgentId; name: string; onToolbar: boolean }
+  | { category: "panel"; id: LauncherPanelButtonId; name: string; onToolbar: boolean };
 
 interface DockLaunchButtonProps {
   agents: ReadonlyArray<DockLaunchAgent>;
@@ -124,7 +124,6 @@ export function DockLaunchButton({
         const id = item.agent.id;
         return {
           category: "agent",
-          key: item.key,
           id,
           name: item.name,
           // The array-aware resolver, not `isAgentToolbarVisible`: an installed
@@ -146,7 +145,6 @@ export function DockLaunchButton({
         if (!id) return null;
         return {
           category: "panel",
-          key: item.key,
           id,
           name: item.name,
           onToolbar: isPanelButtonOnToolbar(id, pinnedButtons, leftButtons, rightButtons),
@@ -158,11 +156,11 @@ export function DockLaunchButton({
     [agentSettings, leftButtons, pinnedButtons, rightButtons]
   );
 
-  // Deliberately undebounced, unlike `LauncherMenuButton`'s `guardPinAction`.
-  // That one exists because a Radix menu item synthesizes a pointer/click pair
-  // that both reach the same handler; here only `click` toggles, and the
-  // keyboard path guards itself on `event.repeat`. A time window would only
-  // ever discard a real second intent — pin, then immediately unpin.
+  // Deliberately undebounced, unlike `LauncherMenuButton`'s `guardPinAction`:
+  // there is nothing here for a time window to swallow. Only `click` toggles —
+  // pointerdown just suppresses focus — and the keyboard path guards itself on
+  // `event.repeat`. A window could therefore only ever discard a real second
+  // intent, which for a toggle means pin followed immediately by unpin.
   const togglePin = useCallback(
     (target: DockLaunchPinTarget) => {
       if (target.category === "agent") {
@@ -611,14 +609,15 @@ function DockLaunchOption({
           ? `${item.scopeLabel} · Overridden by Team`
           : item.scopeLabel
         : "Agent";
-  // Everything the sighted user reads off this row, in one string — the option
-  // is what `aria-activedescendant` points at, and its children (the trailing
-  // qualifier, the pin's own state, the warning tooltip) are not announced with
-  // it once the name is stated explicitly.
+  // What the row conveys visually, in one string — the option is what
+  // `aria-activedescendant` points at, and its children (the trailing qualifier,
+  // the pin's own state) stop being announced with it once the name is stated
+  // explicitly. The warning is deliberately NOT folded in: `title` alongside an
+  // `aria-label` computes as the description, so repeating it here would
+  // announce it twice.
   const optionLabel = [
     qualifier ? `${displayName}, ${qualifier}` : displayName,
-    pinTarget?.onToolbar ? "pinned to toolbar" : undefined,
-    title,
+    pinTarget?.onToolbar ? "Pinned to toolbar" : undefined,
   ]
     .filter(Boolean)
     .join(". ");
@@ -647,10 +646,9 @@ function DockLaunchOption({
         aria-selected={isSelected}
         // Stated, not computed from content: the pin button is a child, so a
         // content-derived name would end every pinnable row with "Pin to
-        // toolbar: X". Everything the row conveys visually is folded back in
-        // here instead, because `aria-activedescendant` announces this node and
-        // nothing else — the destination, the pin state, and the warning that
-        // this row opens Settings rather than launching.
+        // toolbar: X". `title` stays a sibling attribute rather than part of the
+        // name — with an `aria-label` present it computes as the description, so
+        // the warning is announced once and still shows as the mouse tooltip.
         aria-label={optionLabel}
         aria-keyshortcuts={pinTarget ? "Alt+P" : undefined}
         title={title}

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import { useShallow } from "zustand/react/shallow";
 import Fuse, { type IFuseOptions } from "fuse.js";
-import { Plus, SquareTerminal } from "lucide-react";
+import { Pin, PinOff, Plus, SquareTerminal } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { AppPalettePopover } from "@/components/ui/AppPalettePopover";
@@ -10,6 +11,19 @@ import { BrandMark, Workflow } from "@/components/icons";
 import { PanelKindIcon } from "@/components/PanelPalette/PanelKindIcon";
 import { cn } from "@/lib/utils";
 import { isAgentBlocked, isAgentLaunchable } from "@shared/utils/agentAvailability";
+import { isAgentButtonOnToolbar } from "@shared/utils/agentPinned";
+import { isBuiltInAgentId, type BuiltInAgentId } from "@shared/config/agentIds";
+import {
+  getLauncherPanelButtonIdForKind,
+  isPanelButtonOnToolbar,
+  type LauncherPanelButtonId,
+} from "@shared/types/toolbar";
+import { useAgentSettingsStore } from "@/store/agentSettingsStore";
+import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
+import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
+import { dispatchToolbarVisibility } from "@/lib/toolbarVisibilityDispatch";
+import { normalizeKeyForBinding } from "@/services/keybindingUtils";
+import { TOOLBAR_PIN_LABEL, TOOLBAR_UNPIN_LABEL } from "./toolbarMenuStrings";
 import { useSearchablePalette } from "@/hooks/useSearchablePalette";
 import {
   activateCreateRecipeCue,
@@ -36,6 +50,23 @@ const DOCK_LAUNCH_FUSE_OPTIONS: IFuseOptions<DockLaunchItem> = {
 
 /** Ranked results are capped; the browse list always renders in full. */
 const SEARCH_RESULT_CAP = 30;
+
+/**
+ * Swallows the second half of a pointer-then-click pair on one row, and a held
+ * Alt+P. Keyed per target below, not one timestamp for the whole launcher, so
+ * two different rows toggled in quick succession both land.
+ */
+const PIN_ACTION_GUARD_MS = 50;
+
+/**
+ * A row that can be pinned to the toolbar, resolved to the id the write path
+ * actually takes. Agents and panels keep separate stores behind the one
+ * affordance — `null` means the row has no toolbar representation at all
+ * (recipes, the create-recipe cue, plugin panel kinds, non-built-in agents).
+ */
+type DockLaunchPinTarget =
+  | { category: "agent"; key: string; id: BuiltInAgentId; name: string; onToolbar: boolean }
+  | { category: "panel"; key: string; id: LauncherPanelButtonId; name: string; onToolbar: boolean };
 
 interface DockLaunchButtonProps {
   agents: ReadonlyArray<DockLaunchAgent>;
@@ -74,6 +105,110 @@ export function DockLaunchButton({
     activeWorktreeId,
     surface: "dock",
   });
+
+  // Subscribed here rather than threaded down from ContentDock: the launcher
+  // already owns its own model's store reads, and #11691 swaps this component
+  // into the toolbar — where there is no ContentDock to compute props for it.
+  const agentSettings = useAgentSettingsStore((s) => s.settings);
+  const setAgentPinned = useAgentSettingsStore((s) => s.setAgentPinned);
+  const agentAvailability = useCliAvailabilityStore((s) => s.availability);
+  const pinnedButtons = useToolbarPreferencesStore(useShallow((s) => s.layout.pinnedButtons));
+  const leftButtons = useToolbarPreferencesStore(useShallow((s) => s.layout.leftButtons));
+  const rightButtons = useToolbarPreferencesStore(useShallow((s) => s.layout.rightButtons));
+  const setPanelButtonOnToolbar = useToolbarPreferencesStore((s) => s.setPanelButtonOnToolbar);
+  const positionAgentButton = useToolbarPreferencesStore((s) => s.positionAgentButton);
+  const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
+
+  const resolvePinTarget = useCallback(
+    (row: DockLaunchRow): DockLaunchPinTarget | null => {
+      const { item } = row;
+      if (!item) return null;
+
+      if (item.category === "agent") {
+        // Only built-in agents have a toolbar button id to write. A plugin or
+        // user-defined agent is launchable here but can never reach the toolbar.
+        if (!isBuiltInAgentId(item.agent.id)) return null;
+        const id = item.agent.id;
+        return {
+          category: "agent",
+          key: item.key,
+          id,
+          name: item.name,
+          // The array-aware resolver, not `isAgentToolbarVisible`: an installed
+          // agent with no position renders no button, and a pin icon that
+          // claimed otherwise would be describing a button that isn't there.
+          onToolbar: isAgentButtonOnToolbar(
+            agentSettings?.agents?.[id],
+            item.agent.availability,
+            leftButtons.includes(id) || rightButtons.includes(id)
+          ),
+        };
+      }
+
+      if (item.category === "panel") {
+        // Through the kind→button map, never `isLauncherPanelButtonId(kindId)`:
+        // the dev preview kind is `dev-preview` and its button is `dev-server`,
+        // so the direct test drops that row and nothing tells you it did.
+        const id = getLauncherPanelButtonIdForKind(item.kindId);
+        if (!id) return null;
+        return {
+          category: "panel",
+          key: item.key,
+          id,
+          name: item.name,
+          onToolbar: isPanelButtonOnToolbar(id, pinnedButtons, leftButtons, rightButtons),
+        };
+      }
+
+      return null;
+    },
+    [agentSettings, leftButtons, pinnedButtons, rightButtons]
+  );
+
+  // Keyed on the item key rather than the row key, deliberately: the recency
+  // band repeats agents that also appear under Pinned/Other, and those two rows
+  // are one logical target that must not be toggled twice.
+  const lastPinActionAt = useRef(new Map<string, number>());
+  const togglePin = useCallback(
+    (target: DockLaunchPinTarget) => {
+      const now = Date.now();
+      if (now - (lastPinActionAt.current.get(target.key) ?? -Infinity) < PIN_ACTION_GUARD_MS)
+        return;
+      lastPinActionAt.current.set(target.key, now);
+
+      if (target.category === "agent") {
+        // Through the shared dispatcher, not `setAgentPinned` directly: it is
+        // what also gives a newly-pinned agent a toolbar position, and it is
+        // what Settings → Toolbar calls. `onToolbar` is passed explicitly
+        // because the dispatcher's own fallback derives the flip from
+        // `isAgentToolbarVisible` — the predicate this row deliberately isn't
+        // using, which would make the first click a no-op for an installed,
+        // unpositioned agent.
+        dispatchToolbarVisibility(
+          target.id,
+          "left",
+          {
+            agentSettings,
+            agentAvailability,
+            setAgentPinned,
+            toggleButtonVisibility,
+            positionAgentButton,
+          },
+          !target.onToolbar
+        );
+        return;
+      }
+      setPanelButtonOnToolbar(target.id, !target.onToolbar);
+    },
+    [
+      agentAvailability,
+      agentSettings,
+      positionAgentButton,
+      setAgentPinned,
+      setPanelButtonOnToolbar,
+      toggleButtonVisibility,
+    ]
+  );
 
   const fuse = useMemo(
     () => new Fuse(model.searchItems, DOCK_LAUNCH_FUSE_OPTIONS),
@@ -125,6 +260,7 @@ export function DockLaunchButton({
         : -1;
   const selectedRow = activeIndex >= 0 ? results[activeIndex] : undefined;
   const activeDescendant = selectedRow ? getOptionId(selectedRow.rowKey) : undefined;
+  const selectedPinTarget = selectedRow ? resolvePinTarget(selectedRow) : null;
 
   const suppressTooltipDuringFocusRestore = useCallback(() => {
     setTooltipOpen(false);
@@ -279,6 +415,30 @@ export function DockLaunchButton({
       }
 
       if (event.key === "Tab") return;
+
+      // Alt+P pins the selected row. It has to be modified: this is a type-ahead
+      // search box, so a bare "P" is the second letter of "python". Exactly Alt
+      // — Cmd+P, Cmd+Shift+P and Cmd+Alt+P are all taken in
+      // `defaultKeybindings.ts`, and requiring Alt alone leaves every one of
+      // them reaching its own binding. `normalizeKeyForBinding` because macOS
+      // reports Option+P as "π"; the AltGraph test because Windows/Linux AltGr
+      // synthesizes ctrl+alt and must keep producing international characters.
+      const isPinShortcut =
+        event.altKey &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.shiftKey &&
+        !event.nativeEvent.getModifierState?.("AltGraph") &&
+        normalizeKeyForBinding(event.nativeEvent).toLowerCase() === "p";
+      if (isPinShortcut && selectedPinTarget) {
+        event.preventDefault();
+        event.stopPropagation();
+        // Held keys repeat; a pin that flips on every repeat lands wherever the
+        // user happened to let go.
+        if (!event.repeat) togglePin(selectedPinTarget);
+        return;
+      }
+
       // Leave shortcuts alone — swallowing modified keys here would break app
       // keybindings while the launcher is open. Plain typing is still stopped
       // so a letter can't reach the dock's own key handling behind the popover;
@@ -286,7 +446,16 @@ export function DockLaunchButton({
       if (event.metaKey || event.ctrlKey || event.altKey) return;
       event.stopPropagation();
     },
-    [activateRow, results.length, selectedRow, selectNext, selectPrevious, setSelectedIndex]
+    [
+      activateRow,
+      results.length,
+      selectedPinTarget,
+      selectedRow,
+      selectNext,
+      selectPrevious,
+      setSelectedIndex,
+      togglePin,
+    ]
   );
 
   return (
@@ -389,8 +558,10 @@ export function DockLaunchButton({
                   isSelected={index === activeIndex}
                   showBandLabel={row.band !== results[index - 1]?.band}
                   optionId={getOptionId(row.rowKey)}
+                  pinTarget={resolvePinTarget(row)}
                   onHover={setSelectedIndex}
                   onActivate={activateRow}
+                  onTogglePin={togglePin}
                 />
               ))}
             </div>
@@ -407,8 +578,11 @@ interface DockLaunchOptionProps {
   isSelected: boolean;
   showBandLabel: boolean;
   optionId: string;
+  /** Null for rows with no toolbar button to pin — the slot is still reserved. */
+  pinTarget: DockLaunchPinTarget | null;
   onHover: (index: number) => void;
   onActivate: (row: DockLaunchRow) => void;
+  onTogglePin: (target: DockLaunchPinTarget) => void;
 }
 
 function DockLaunchOption({
@@ -417,8 +591,10 @@ function DockLaunchOption({
   isSelected,
   showBandLabel,
   optionId,
+  pinTarget,
   onHover,
   onActivate,
+  onTogglePin,
 }: DockLaunchOptionProps) {
   const { item } = row;
   // A filtered row must carry the same warnings as its unfiltered twin: a
@@ -432,6 +608,20 @@ function DockLaunchOption({
       ? `${unavailableAgent.name} is blocked by endpoint security. Click to configure.`
       : `${unavailableAgent.name} needs setup. Click to configure.`
     : undefined;
+  const displayName = item ? item.name : "Create a recipe";
+  // Where the row lands, or which recipe wins — rendered as the trailing label
+  // and reused as the option's accessible name below.
+  const qualifier = !item
+    ? undefined
+    : item.category === "panel"
+      ? item.location === "dock"
+        ? "Dock"
+        : "Grid"
+      : item.category === "recipe"
+        ? item.isShadowed
+          ? `${item.scopeLabel} · Overridden by Team`
+          : item.scopeLabel
+        : "Agent";
 
   return (
     <>
@@ -446,41 +636,91 @@ function DockLaunchOption({
           {DOCK_LAUNCH_BAND_LABELS[row.band]}
         </div>
       )}
-      <button
-        type="button"
+      {/* A div, not a button: the pin control is a real button and one cannot
+          nest inside another. Same split as ActionPaletteItem, which is where
+          this palette family already solved a secondary action on an option. */}
+      <div
         id={optionId}
         role="option"
         aria-selected={isSelected}
-        tabIndex={-1}
-        title={title}
+        // Stated, not computed from content: the pin button is a child, so a
+        // content-derived name would end every pinnable row with "Pin to
+        // toolbar: X". The destination stays in the name because it is the part
+        // that says where activating lands you.
+        aria-label={qualifier ? `${displayName}, ${qualifier}` : displayName}
         // Keeps DOM focus on the search box when a row is clicked or hovered,
-        // so typing never lands anywhere else.
+        // so typing never lands anywhere else. preventDefault only — stopping
+        // propagation here would hide the pointerdown from Radix's
+        // DismissableLayer, which needs to see it to classify the next outside
+        // click as a dismissal.
         onPointerDown={(event) => event.preventDefault()}
         onPointerEnter={() => onHover(index)}
-        onClick={() => onActivate(row)}
         className={cn(
           PALETTE_ROW_CLASS,
-          "relative w-full flex items-center px-2 py-1.5 rounded-[var(--radius-md)] text-left text-sm",
+          "group relative w-full flex items-center px-2 py-1.5 rounded-[var(--radius-md)] text-left text-sm",
           "hover:bg-overlay-subtle",
           isDimmed && "opacity-70"
         )}
       >
-        <DockLaunchOptionIcon row={row} />
-        <span className="truncate">{item ? item.name : "Create a recipe"}</span>
-        {item && (
-          <span className="ml-auto pl-2 text-[11px] text-text-muted shrink-0">
-            {item.category === "panel"
-              ? item.location === "dock"
-                ? "Dock"
-                : "Grid"
-              : item.category === "recipe"
-                ? item.isShadowed
-                  ? `${item.scopeLabel} · Overridden by Team`
-                  : item.scopeLabel
-                : "Agent"}
-          </span>
-        )}
-      </button>
+        <button
+          type="button"
+          tabIndex={-1}
+          // Stays on the inner button rather than the row: it explains what
+          // activating does, and the row now has a second control that does
+          // something else entirely.
+          title={title}
+          onClick={() => onActivate(row)}
+          className="flex-1 min-w-0 flex items-center bg-transparent border-0 p-0 text-left"
+        >
+          <DockLaunchOptionIcon row={row} />
+          <span className="truncate">{displayName}</span>
+          {qualifier && (
+            <span className="ml-auto pl-2 text-[11px] text-text-muted shrink-0">{qualifier}</span>
+          )}
+        </button>
+
+        {/* The slot is reserved on every row, not just pinnable ones. Opacity
+            hides the control without releasing its box, so a recipe and an agent
+            end their trailing labels on the same edge. */}
+        <span className="ml-1 w-5 shrink-0">
+          {pinTarget && (
+            <button
+              type="button"
+              tabIndex={-1}
+              aria-label={`${pinTarget.onToolbar ? TOOLBAR_UNPIN_LABEL : TOOLBAR_PIN_LABEL}: ${pinTarget.name}`}
+              aria-pressed={pinTarget.onToolbar}
+              aria-keyshortcuts="Alt+P"
+              title={`${pinTarget.onToolbar ? TOOLBAR_UNPIN_LABEL : TOOLBAR_PIN_LABEL} (Alt+P)`}
+              // preventDefault keeps focus on the search box; stopPropagation is
+              // deliberately absent here and present on the click below, so the
+              // pin never reaches `onActivate` while Radix still sees the
+              // pointer sequence it needs.
+              onPointerDown={(event) => event.preventDefault()}
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                onTogglePin(pinTarget);
+              }}
+              className={cn(
+                "inline-flex h-5 w-5 items-center justify-center rounded-[var(--radius-sm)] bg-transparent border-0",
+                "transition-[opacity,color,background-color] hover:bg-overlay-soft hover:text-daintree-text",
+                // Pinned rows read as state markers and stay visible; unpinned
+                // ones are controls that only appear once the row is under the
+                // pointer or the selection.
+                pinTarget.onToolbar
+                  ? "text-daintree-text/70 opacity-100"
+                  : "text-daintree-text/40 opacity-0 group-hover:opacity-100 group-aria-selected:opacity-100"
+              )}
+            >
+              {pinTarget.onToolbar ? (
+                <PinOff className="h-3 w-3" aria-hidden />
+              ) : (
+                <Pin className="h-3 w-3" aria-hidden />
+              )}
+            </button>
+          )}
+        </span>
+      </div>
     </>
   );
 }

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -52,13 +52,6 @@ const DOCK_LAUNCH_FUSE_OPTIONS: IFuseOptions<DockLaunchItem> = {
 const SEARCH_RESULT_CAP = 30;
 
 /**
- * Swallows the second half of a pointer-then-click pair on one row, and a held
- * Alt+P. Keyed per target below, not one timestamp for the whole launcher, so
- * two different rows toggled in quick succession both land.
- */
-const PIN_ACTION_GUARD_MS = 50;
-
-/**
  * A row that can be pinned to the toolbar, resolved to the id the write path
  * actually takes. Agents and panels keep separate stores behind the one
  * affordance — `null` means the row has no toolbar representation at all
@@ -165,17 +158,13 @@ export function DockLaunchButton({
     [agentSettings, leftButtons, pinnedButtons, rightButtons]
   );
 
-  // Keyed on the item key rather than the row key, deliberately: the recency
-  // band repeats agents that also appear under Pinned/Other, and those two rows
-  // are one logical target that must not be toggled twice.
-  const lastPinActionAt = useRef(new Map<string, number>());
+  // Deliberately undebounced, unlike `LauncherMenuButton`'s `guardPinAction`.
+  // That one exists because a Radix menu item synthesizes a pointer/click pair
+  // that both reach the same handler; here only `click` toggles, and the
+  // keyboard path guards itself on `event.repeat`. A time window would only
+  // ever discard a real second intent — pin, then immediately unpin.
   const togglePin = useCallback(
     (target: DockLaunchPinTarget) => {
-      const now = Date.now();
-      if (now - (lastPinActionAt.current.get(target.key) ?? -Infinity) < PIN_ACTION_GUARD_MS)
-        return;
-      lastPinActionAt.current.set(target.key, now);
-
       if (target.category === "agent") {
         // Through the shared dispatcher, not `setAgentPinned` directly: it is
         // what also gives a newly-pinned agent a toolbar position, and it is
@@ -622,6 +611,17 @@ function DockLaunchOption({
           ? `${item.scopeLabel} · Overridden by Team`
           : item.scopeLabel
         : "Agent";
+  // Everything the sighted user reads off this row, in one string — the option
+  // is what `aria-activedescendant` points at, and its children (the trailing
+  // qualifier, the pin's own state, the warning tooltip) are not announced with
+  // it once the name is stated explicitly.
+  const optionLabel = [
+    qualifier ? `${displayName}, ${qualifier}` : displayName,
+    pinTarget?.onToolbar ? "pinned to toolbar" : undefined,
+    title,
+  ]
+    .filter(Boolean)
+    .join(". ");
 
   return (
     <>
@@ -637,17 +637,23 @@ function DockLaunchOption({
         </div>
       )}
       {/* A div, not a button: the pin control is a real button and one cannot
-          nest inside another. Same split as ActionPaletteItem, which is where
-          this palette family already solved a secondary action on an option. */}
+          nest inside another. Activation stays on the option itself rather than
+          moving to an inner button — the row owns its padding and the reserved
+          pin column, and an inner button would only cover its own content box,
+          leaving the rest of a row that highlights as one thing inert. */}
       <div
         id={optionId}
         role="option"
         aria-selected={isSelected}
         // Stated, not computed from content: the pin button is a child, so a
         // content-derived name would end every pinnable row with "Pin to
-        // toolbar: X". The destination stays in the name because it is the part
-        // that says where activating lands you.
-        aria-label={qualifier ? `${displayName}, ${qualifier}` : displayName}
+        // toolbar: X". Everything the row conveys visually is folded back in
+        // here instead, because `aria-activedescendant` announces this node and
+        // nothing else — the destination, the pin state, and the warning that
+        // this row opens Settings rather than launching.
+        aria-label={optionLabel}
+        aria-keyshortcuts={pinTarget ? "Alt+P" : undefined}
+        title={title}
         // Keeps DOM focus on the search box when a row is clicked or hovered,
         // so typing never lands anywhere else. preventDefault only — stopping
         // propagation here would hide the pointerdown from Radix's
@@ -655,6 +661,7 @@ function DockLaunchOption({
         // click as a dismissal.
         onPointerDown={(event) => event.preventDefault()}
         onPointerEnter={() => onHover(index)}
+        onClick={() => onActivate(row)}
         className={cn(
           PALETTE_ROW_CLASS,
           "group relative w-full flex items-center px-2 py-1.5 rounded-[var(--radius-md)] text-left text-sm",
@@ -662,22 +669,11 @@ function DockLaunchOption({
           isDimmed && "opacity-70"
         )}
       >
-        <button
-          type="button"
-          tabIndex={-1}
-          // Stays on the inner button rather than the row: it explains what
-          // activating does, and the row now has a second control that does
-          // something else entirely.
-          title={title}
-          onClick={() => onActivate(row)}
-          className="flex-1 min-w-0 flex items-center bg-transparent border-0 p-0 text-left"
-        >
-          <DockLaunchOptionIcon row={row} />
-          <span className="truncate">{displayName}</span>
-          {qualifier && (
-            <span className="ml-auto pl-2 text-[11px] text-text-muted shrink-0">{qualifier}</span>
-          )}
-        </button>
+        <DockLaunchOptionIcon row={row} />
+        <span className="truncate">{displayName}</span>
+        {qualifier && (
+          <span className="ml-auto pl-2 text-[11px] text-text-muted shrink-0">{qualifier}</span>
+        )}
 
         {/* The slot is reserved on every row, not just pinnable ones. Opacity
             hides the control without releasing its box, so a recipe and an agent
@@ -691,10 +687,12 @@ function DockLaunchOption({
               aria-pressed={pinTarget.onToolbar}
               aria-keyshortcuts="Alt+P"
               title={`${pinTarget.onToolbar ? TOOLBAR_UNPIN_LABEL : TOOLBAR_PIN_LABEL} (Alt+P)`}
-              // preventDefault keeps focus on the search box; stopPropagation is
-              // deliberately absent here and present on the click below, so the
-              // pin never reaches `onActivate` while Radix still sees the
-              // pointer sequence it needs.
+              // preventDefault keeps focus on the search box. stopPropagation
+              // belongs on the click below and nowhere else: the row's own
+              // onClick is an ancestor of this one, so the pin must stop the
+              // click — but stopping the POINTERDOWN would hide it from Radix's
+              // DismissableLayer, which needs to see it to classify the next
+              // outside click as a dismissal.
               onPointerDown={(event) => event.preventDefault()}
               onClick={(event) => {
                 event.preventDefault();

--- a/src/components/Layout/__tests__/ContentDock.portalKeydown.test.tsx
+++ b/src/components/Layout/__tests__/ContentDock.portalKeydown.test.tsx
@@ -80,8 +80,9 @@ vi.mock("@/store/cliAvailabilityStore", () => ({
     selector({ availability: null }),
 }));
 vi.mock("@/store/toolbarPreferencesStore", () => ({
-  useToolbarPreferencesStore: (selector: (s: { layout: { leftButtons: string[] } }) => unknown) =>
-    selector({ layout: { leftButtons: [] } }),
+  useToolbarPreferencesStore: (
+    selector: (s: { layout: { leftButtons: string[]; rightButtons: string[] } }) => unknown
+  ) => selector({ layout: { leftButtons: [], rightButtons: [] } }),
 }));
 vi.mock("@/store/preferencesStore", () => ({
   usePreferencesStore: (selector: (s: { setDockDensity: () => void }) => unknown) =>

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -92,6 +92,41 @@ vi.mock("@/services/ActionService", () => ({
   },
 }));
 
+// Pin state. `dispatchToolbarVisibility` is deliberately NOT mocked — it is the
+// seam Settings → Toolbar shares, and mocking it would let the launcher write
+// the pin any way it liked while the suite still passed.
+let mockAgentSettings: { agents?: Record<string, { pinned?: boolean }> } | null = { agents: {} };
+let mockAgentAvailability: Record<string, string> = {};
+let mockToolbarLayout: {
+  pinnedButtons: Record<string, boolean>;
+  leftButtons: string[];
+  rightButtons: string[];
+} = { pinnedButtons: {}, leftButtons: [], rightButtons: [] };
+const setAgentPinnedMock = vi.fn();
+const setPanelButtonOnToolbarMock = vi.fn();
+const positionAgentButtonMock = vi.fn();
+const toggleButtonVisibilityMock = vi.fn();
+
+vi.mock("@/store/agentSettingsStore", () => ({
+  useAgentSettingsStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ settings: mockAgentSettings, setAgentPinned: setAgentPinnedMock }),
+}));
+
+vi.mock("@/store/cliAvailabilityStore", () => ({
+  useCliAvailabilityStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ availability: mockAgentAvailability }),
+}));
+
+vi.mock("@/store/toolbarPreferencesStore", () => ({
+  useToolbarPreferencesStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      layout: mockToolbarLayout,
+      setPanelButtonOnToolbar: setPanelButtonOnToolbarMock,
+      positionAgentButton: positionAgentButtonMock,
+      toggleButtonVisibility: toggleButtonVisibilityMock,
+    }),
+}));
+
 // Mock UI primitives so the test focuses on this component's behavior, not
 // Radix's pointer-event semantics inside jsdom. Mirrors AgentButton.test.tsx.
 // Radix's real focus/dismiss behaviour (mount autofocus winning the lazy-chunk
@@ -276,6 +311,13 @@ beforeEach(() => {
   popoverOpenAutoFocusSpy = null;
   popoverOpenChangeSpy = null;
   popoverModal = undefined;
+  mockAgentSettings = { agents: {} };
+  mockAgentAvailability = {};
+  mockToolbarLayout = { pinnedButtons: {}, leftButtons: [], rightButtons: [] };
+  setAgentPinnedMock.mockReset();
+  setPanelButtonOnToolbarMock.mockReset();
+  positionAgentButtonMock.mockReset();
+  toggleButtonVisibilityMock.mockReset();
 });
 
 describe("DockLaunchButton", () => {
@@ -1355,6 +1397,250 @@ describe("DockLaunchButton", () => {
 
       expect(selectedOption(container)).toBe(options(container)[0]);
       expect(container.querySelectorAll(SELECTED_OPTION)).toHaveLength(1);
+    });
+  });
+
+  describe("toolbar pin affordance", () => {
+    /** The option whose label text matches, whatever band it landed in. */
+    function rowFor(container: HTMLElement, name: string): HTMLElement {
+      const row = options(container).find((option) =>
+        Array.from(option.querySelectorAll("span")).some((s) => s.textContent === name)
+      );
+      if (!row) throw new Error(`no option row for ${name}`);
+      return row;
+    }
+
+    /** Structural, not by label: the pin is the row's toggle-state control. */
+    function pinControl(row: HTMLElement): HTMLButtonElement | null {
+      return row.querySelector<HTMLButtonElement>("button[aria-pressed]");
+    }
+
+    it("renders each option as a container with sibling buttons, never a nested button", () => {
+      // The structural precondition for a secondary control: a <button> cannot
+      // legally contain another, so the row itself stopped being one.
+      const { container } = renderButton();
+      for (const option of options(container)) {
+        expect(option.tagName).not.toBe("BUTTON");
+        expect(option.closest("button")).toBeNull();
+        expect(option.querySelector("button button")).toBeNull();
+      }
+    });
+
+    it("names each option without absorbing its pin button's label", () => {
+      // The pin is a child of the option, so a content-derived name would end
+      // every pinnable row with "Pin to toolbar: X" — while the destination,
+      // which is what the name is for, got buried in the middle.
+      const { container } = renderButton();
+      const claude = rowFor(container, "Claude").getAttribute("aria-label");
+
+      expect(claude).toContain("Claude");
+      expect(claude).toContain("Agent");
+      expect(claude).not.toContain("Pin");
+      expect(rowFor(container, "Review").getAttribute("aria-label")).toContain("Grid");
+    });
+
+    it("offers a pin on built-in agents and on panels that have a toolbar button", () => {
+      mockRecipes = [{ id: "r-1", name: "My recipe", worktreeId: undefined }];
+      const { container } = renderButton();
+
+      expect(pinControl(rowFor(container, "Claude"))).toBeTruthy();
+      expect(pinControl(rowFor(container, "Terminal"))).toBeTruthy();
+      expect(pinControl(rowFor(container, "Browser"))).toBeTruthy();
+      expect(pinControl(rowFor(container, "File Browser"))).toBeTruthy();
+      // The kind is `dev-preview`, the button is `dev-server`. Testing the id
+      // directly against the toolbar list would drop exactly this row.
+      expect(pinControl(rowFor(container, "Dev Preview"))).toBeTruthy();
+    });
+
+    it("withholds the pin from rows with nothing to pin to", () => {
+      mockRecipes = [{ id: "r-1", name: "My recipe", worktreeId: undefined }];
+      const { container } = renderButton({
+        agents: [{ id: "my-plugin-agent", name: "Plugin agent", availability: "ready" }],
+      });
+
+      expect(pinControl(rowFor(container, "My recipe"))).toBeNull();
+      expect(pinControl(rowFor(container, "Review"))).toBeNull();
+      // Not a built-in agent, so there is no toolbar button id to write.
+      expect(pinControl(rowFor(container, "Plugin agent"))).toBeNull();
+    });
+
+    it("withholds the pin from the create-recipe cue", () => {
+      mockRecipes = [];
+      const { container } = renderButton();
+      expect(pinControl(rowFor(container, "Create a recipe"))).toBeNull();
+    });
+
+    it("reports an installed agent with no toolbar position as unpinned", () => {
+      // Since #11680 an installed CLI no longer implies a toolbar slot, so the
+      // pin has to read the position too or it describes a button that is not
+      // rendered anywhere.
+      const { container } = renderButton();
+      expect(pinControl(rowFor(container, "Claude"))?.getAttribute("aria-pressed")).toBe("false");
+    });
+
+    it("reports an agent positioned on either side as pinned", () => {
+      mockToolbarLayout = { pinnedButtons: {}, leftButtons: [], rightButtons: ["claude"] };
+      const { container } = renderButton();
+      expect(pinControl(rowFor(container, "Claude"))?.getAttribute("aria-pressed")).toBe("true");
+    });
+
+    it("lets an explicit pin outrank a missing position, and an explicit hide outrank one", () => {
+      mockAgentSettings = { agents: { claude: { pinned: true }, gemini: { pinned: false } } };
+      mockToolbarLayout = { pinnedButtons: {}, leftButtons: ["gemini"], rightButtons: [] };
+      const { container } = renderButton();
+
+      expect(pinControl(rowFor(container, "Claude"))?.getAttribute("aria-pressed")).toBe("true");
+      expect(pinControl(rowFor(container, "Gemini"))?.getAttribute("aria-pressed")).toBe("false");
+    });
+
+    it("writes an agent pin through the dispatcher that also gives it a position", () => {
+      const { container } = renderButton();
+      const pin = pinControl(rowFor(container, "Claude"))!;
+      expect(pin.getAttribute("aria-pressed")).toBe("false");
+
+      fireEvent.click(pin);
+
+      // Both halves: a pin with no position renders no button at all.
+      expect(positionAgentButtonMock).toHaveBeenCalledWith("claude");
+      expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", true);
+    });
+
+    it("unpins without asking for a new position", () => {
+      mockToolbarLayout = { pinnedButtons: {}, leftButtons: ["claude"], rightButtons: [] };
+      const { container } = renderButton();
+      const pin = pinControl(rowFor(container, "Claude"))!;
+      expect(pin.getAttribute("aria-pressed")).toBe("true");
+
+      fireEvent.click(pin);
+
+      expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", false);
+      expect(positionAgentButtonMock).not.toHaveBeenCalled();
+    });
+
+    it("writes a panel pin to the toolbar button id, not the panel kind id", () => {
+      const { container } = renderButton();
+      fireEvent.click(pinControl(rowFor(container, "Dev Preview"))!);
+
+      expect(setPanelButtonOnToolbarMock).toHaveBeenCalledWith("dev-server", true);
+      expect(setAgentPinnedMock).not.toHaveBeenCalled();
+    });
+
+    it("inverts whatever the current panel state is", () => {
+      mockToolbarLayout = { pinnedButtons: { browser: true }, leftButtons: [], rightButtons: [] };
+      const { container } = renderButton();
+      const pin = pinControl(rowFor(container, "Browser"))!;
+      expect(pin.getAttribute("aria-pressed")).toBe("true");
+
+      fireEvent.click(pin);
+
+      expect(setPanelButtonOnToolbarMock).toHaveBeenCalledWith("browser", false);
+    });
+
+    it("pins without launching, closing, or clearing the query", () => {
+      const onLaunchAgent = vi.fn();
+      const { container } = renderButton({ onLaunchAgent });
+      fireEvent.change(searchInput(container), { target: { value: "claude" } });
+
+      fireEvent.click(pinControl(rowFor(container, "Claude"))!);
+
+      expect(setAgentPinnedMock).toHaveBeenCalled();
+      expect(onLaunchAgent).not.toHaveBeenCalled();
+      expect(recordActionMruMock).not.toHaveBeenCalled();
+      // Still open, still filtered — pinning is a change to the list, not an
+      // exit from it.
+      expect(searchInput(container).value).toBe("claude");
+    });
+
+    it("keeps focus off the pin and lets Radix see the pointer sequence", () => {
+      const { container } = renderButton();
+      const pin = pinControl(rowFor(container, "Claude"))!;
+
+      // preventDefault keeps DOM focus on the search box...
+      expect(fireEvent.pointerDown(pin)).toBe(false);
+
+      // ...but propagation must NOT be stopped, or Radix's DismissableLayer
+      // stops seeing the pointerdown it needs to classify the next outside
+      // click as a dismissal.
+      const seen = vi.fn();
+      document.addEventListener("pointerdown", seen);
+      fireEvent.pointerDown(pin);
+      document.removeEventListener("pointerdown", seen);
+      expect(seen).toHaveBeenCalled();
+    });
+
+    it("suppresses a repeat toggle of one row but not of a second row", () => {
+      // A pointer/click pair on one row is a single intent; two rows in quick
+      // succession are two.
+      const { container } = renderButton();
+      const claudePin = pinControl(rowFor(container, "Claude"))!;
+
+      fireEvent.click(claudePin);
+      fireEvent.click(claudePin);
+      expect(setAgentPinnedMock).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(pinControl(rowFor(container, "Terminal"))!);
+      expect(setPanelButtonOnToolbarMock).toHaveBeenCalledTimes(1);
+    });
+
+    describe("Alt+P", () => {
+      it("toggles the selected row", () => {
+        const { container } = renderButton();
+        const input = searchInput(container);
+        fireEvent.change(input, { target: { value: "claude" } });
+
+        fireEvent.keyDown(input, { key: "p", code: "KeyP", altKey: true });
+
+        expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", true);
+      });
+
+      it("leaves a bare p to the search box", () => {
+        // The row is a type-ahead field: an unmodified P is the second letter
+        // of "python", not a command.
+        const { container } = renderButton();
+        const input = searchInput(container);
+        fireEvent.change(input, { target: { value: "claude" } });
+
+        fireEvent.keyDown(input, { key: "p", code: "KeyP" });
+
+        expect(setAgentPinnedMock).not.toHaveBeenCalled();
+      });
+
+      it("leaves the app's own Cmd/Ctrl combinations alone", () => {
+        const { container } = renderButton();
+        const input = searchInput(container);
+        fireEvent.change(input, { target: { value: "claude" } });
+
+        fireEvent.keyDown(input, { key: "p", code: "KeyP", metaKey: true });
+        fireEvent.keyDown(input, { key: "p", code: "KeyP", altKey: true, metaKey: true });
+        fireEvent.keyDown(input, { key: "p", code: "KeyP", altKey: true, shiftKey: true });
+        // AltGr on Windows/Linux synthesizes ctrl+alt and must keep producing
+        // international characters.
+        fireEvent.keyDown(input, { key: "p", code: "KeyP", altKey: true, ctrlKey: true });
+
+        expect(setAgentPinnedMock).not.toHaveBeenCalled();
+      });
+
+      it("does not flip repeatedly while the key is held", () => {
+        const { container } = renderButton();
+        const input = searchInput(container);
+        fireEvent.change(input, { target: { value: "claude" } });
+
+        fireEvent.keyDown(input, { key: "p", code: "KeyP", altKey: true, repeat: true });
+
+        expect(setAgentPinnedMock).not.toHaveBeenCalled();
+      });
+
+      it("does nothing when the selected row has nothing to pin", () => {
+        mockRecipes = [{ id: "r-1", name: "My recipe", worktreeId: undefined }];
+        const { container } = renderButton();
+        const input = searchInput(container);
+        fireEvent.change(input, { target: { value: "my recipe" } });
+
+        fireEvent.keyDown(input, { key: "p", code: "KeyP", altKey: true });
+
+        expect(setAgentPinnedMock).not.toHaveBeenCalled();
+        expect(setPanelButtonOnToolbarMock).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -1589,10 +1589,12 @@ describe("DockLaunchButton", () => {
       expect(seen).toHaveBeenCalled();
     });
 
-    it("lets a rapid second click through — pinning then unpinning is two intents", () => {
+    it("does not swallow a second click that lands immediately after the first", () => {
       // No time-window debounce here: only `click` toggles (pointerdown does
       // not), so there is no synthesized pair to swallow, and a window would
       // just make a fast pin-then-unpin depend on how quickly the user moved.
+      // The store mock is not reactive, so both clicks read the same state —
+      // what this pins down is that the second one reaches the write path.
       const { container } = renderButton();
       const pin = pinControl(rowFor(container, "Claude"))!;
 
@@ -1622,37 +1624,40 @@ describe("DockLaunchButton", () => {
       mockToolbarLayout = { pinnedButtons: {}, leftButtons: ["claude"], rightButtons: [] };
       const { container } = renderButton();
 
-      expect(rowFor(container, "Claude").getAttribute("aria-label")).toContain("pinned to toolbar");
-      expect(rowFor(container, "Gemini").getAttribute("aria-label")).not.toContain("pinned");
+      expect(rowFor(container, "Claude").getAttribute("aria-label")).toContain("Pinned to toolbar");
+      expect(rowFor(container, "Gemini").getAttribute("aria-label")).not.toContain("Pinned");
     });
 
-    it("keeps the unavailable-agent warning in the option's name", () => {
-      // Gemini is blocked in the fixture: activating opens Settings instead of
-      // launching, and a row that looks ordinary to a screen reader is exactly
-      // the case the warning exists for.
+    it("leaves the unavailable-agent warning to the description, not the name", () => {
+      // Gemini is blocked in the fixture. `title` beside an `aria-label`
+      // computes as the option's description, so the warning still reaches a
+      // screen reader — putting it in both would announce it twice.
       const { container } = renderButton();
-      expect(rowFor(container, "Gemini").getAttribute("aria-label")).toContain(
-        "blocked by endpoint security"
-      );
+      const row = rowFor(container, "Gemini");
+
+      expect(row.getAttribute("title")).toContain("blocked by endpoint security");
+      expect(row.getAttribute("aria-label")).not.toContain("blocked by endpoint security");
     });
 
-    it("reserves the pin column on rows that cannot be pinned", () => {
-      // Without the reserved slot the trailing qualifier on a recipe would run
-      // 20px further right than the one on an agent, and the list's right edge
-      // would comb.
+    it("keeps the trailing slot on rows that cannot be pinned", () => {
+      // jsdom has no layout, so this checks the structure the alignment rests
+      // on rather than the width: an unpinnable row still ends with the same
+      // slot element, so its qualifier stops where a pinnable row's does.
+      // Dropping the slot for unpinnable rows changes the child count.
       mockRecipes = [{ id: "r-1", name: "My recipe", worktreeId: undefined }];
       const { container } = renderButton();
 
       const pinnable = rowFor(container, "Claude");
       const notPinnable = rowFor(container, "My recipe");
       expect(pinControl(notPinnable)).toBeNull();
-      expect(notPinnable.lastElementChild?.className).toBe(pinnable.lastElementChild?.className);
+      expect(notPinnable.children.length).toBe(pinnable.children.length);
+      expect(notPinnable.lastElementChild?.tagName).toBe(pinnable.lastElementChild?.tagName);
     });
 
-    it("activates from anywhere on the row, including its padding", () => {
-      // The row highlights as one thing, so all of it has to launch — the old
-      // full-width row button did, and a click target narrowed to the label
-      // text would leave the padding and the pin column inert.
+    it("activates from the row itself, not only from an inner control", () => {
+      // The row highlights as one thing, so all of it has to launch. When
+      // activation lived on an inner button it covered only its own content
+      // box, leaving the row's padding and its trailing slot inert.
       const onLaunchAgent = vi.fn();
       const { container } = renderButton({ onLaunchAgent });
 

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -107,25 +107,46 @@ const setPanelButtonOnToolbarMock = vi.fn();
 const positionAgentButtonMock = vi.fn();
 const toggleButtonVisibilityMock = vi.fn();
 
-vi.mock("@/store/agentSettingsStore", () => ({
-  useAgentSettingsStore: (selector: (s: Record<string, unknown>) => unknown) =>
-    selector({ settings: mockAgentSettings, setAgentPinned: setAgentPinnedMock }),
-}));
+// `getState` alongside each selector: the real hooks carry Zustand's static API,
+// and a factory that omits it turns a future `useXStore.getState()` anywhere in
+// this component's import graph into an opaque collection failure. Each state
+// reader is declared INSIDE its factory — `vi.mock` is hoisted above every
+// top-level const, so referencing one at factory-evaluation time is a TDZ error
+// (the `mock*` bindings below are fine because they are only read at call time).
+vi.mock("@/store/agentSettingsStore", () => {
+  const getState = () => ({ settings: mockAgentSettings, setAgentPinned: setAgentPinnedMock });
+  return {
+    useAgentSettingsStore: Object.assign(
+      (selector: (s: ReturnType<typeof getState>) => unknown) => selector(getState()),
+      { getState }
+    ),
+  };
+});
 
-vi.mock("@/store/cliAvailabilityStore", () => ({
-  useCliAvailabilityStore: (selector: (s: Record<string, unknown>) => unknown) =>
-    selector({ availability: mockAgentAvailability }),
-}));
+vi.mock("@/store/cliAvailabilityStore", () => {
+  const getState = () => ({ availability: mockAgentAvailability });
+  return {
+    useCliAvailabilityStore: Object.assign(
+      (selector: (s: ReturnType<typeof getState>) => unknown) => selector(getState()),
+      { getState }
+    ),
+  };
+});
 
-vi.mock("@/store/toolbarPreferencesStore", () => ({
-  useToolbarPreferencesStore: (selector: (s: Record<string, unknown>) => unknown) =>
-    selector({
-      layout: mockToolbarLayout,
-      setPanelButtonOnToolbar: setPanelButtonOnToolbarMock,
-      positionAgentButton: positionAgentButtonMock,
-      toggleButtonVisibility: toggleButtonVisibilityMock,
-    }),
-}));
+vi.mock("@/store/toolbarPreferencesStore", () => {
+  const getState = () => ({
+    layout: mockToolbarLayout,
+    setPanelButtonOnToolbar: setPanelButtonOnToolbarMock,
+    positionAgentButton: positionAgentButtonMock,
+    toggleButtonVisibility: toggleButtonVisibilityMock,
+  });
+  return {
+    useToolbarPreferencesStore: Object.assign(
+      (selector: (s: ReturnType<typeof getState>) => unknown) => selector(getState()),
+      { getState }
+    ),
+  };
+});
 
 // Mock UI primitives so the test focuses on this component's behavior, not
 // Radix's pointer-event semantics inside jsdom. Mirrors AgentButton.test.tsx.
@@ -274,8 +295,8 @@ function renderButton(props: Partial<Parameters<typeof DockLaunchButton>[0]> = {
 const OPTION = '[role="option"]';
 const SELECTED_OPTION = '[role="option"][aria-selected="true"]';
 
-function options(container: HTMLElement): HTMLButtonElement[] {
-  return Array.from(container.querySelectorAll<HTMLButtonElement>(OPTION));
+function options(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(OPTION));
 }
 
 function selectedOption(container: HTMLElement): HTMLElement | null {
@@ -392,11 +413,11 @@ describe("DockLaunchButton", () => {
 
     // The name sits in its own span for truncation, so the warning lives on the
     // row itself.
-    expect(getByText("Claude").closest("button")?.getAttribute("title")).toBeNull();
-    expect(getByText("Gemini").closest("button")?.getAttribute("title")).toBe(
+    expect(getByText("Claude").closest(OPTION)?.getAttribute("title")).toBeNull();
+    expect(getByText("Gemini").closest(OPTION)?.getAttribute("title")).toBe(
       "Gemini is blocked by endpoint security. Click to configure."
     );
-    expect(getByText("Codex").closest("button")?.getAttribute("title")).toBe(
+    expect(getByText("Codex").closest(OPTION)?.getAttribute("title")).toBe(
       "Codex needs setup. Click to configure."
     );
   });
@@ -523,7 +544,7 @@ describe("DockLaunchButton", () => {
       const { container, getByText } = renderButton();
       fireEvent.change(searchInput(container), { target: { value: "gemini" } });
 
-      const row = getByText("Gemini").closest("button");
+      const row = getByText("Gemini").closest(OPTION);
       expect(row?.getAttribute("title")).toContain("blocked by endpoint security");
     });
 
@@ -1568,18 +1589,86 @@ describe("DockLaunchButton", () => {
       expect(seen).toHaveBeenCalled();
     });
 
-    it("suppresses a repeat toggle of one row but not of a second row", () => {
-      // A pointer/click pair on one row is a single intent; two rows in quick
-      // succession are two.
+    it("lets a rapid second click through — pinning then unpinning is two intents", () => {
+      // No time-window debounce here: only `click` toggles (pointerdown does
+      // not), so there is no synthesized pair to swallow, and a window would
+      // just make a fast pin-then-unpin depend on how quickly the user moved.
       const { container } = renderButton();
-      const claudePin = pinControl(rowFor(container, "Claude"))!;
+      const pin = pinControl(rowFor(container, "Claude"))!;
 
-      fireEvent.click(claudePin);
-      fireEvent.click(claudePin);
-      expect(setAgentPinnedMock).toHaveBeenCalledTimes(1);
+      fireEvent.click(pin);
+      fireEvent.click(pin);
 
-      fireEvent.click(pinControl(rowFor(container, "Terminal"))!);
-      expect(setPanelButtonOnToolbarMock).toHaveBeenCalledTimes(1);
+      expect(setAgentPinnedMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("labels the pin control and keeps it out of the tab order", () => {
+      const { container } = renderButton();
+      const pin = pinControl(rowFor(container, "Claude"))!;
+
+      // Named for itself — the option's own label deliberately excludes it, so
+      // this is the only place the control says what it does.
+      expect(pin.getAttribute("aria-label")).toContain("Claude");
+      expect(pin.getAttribute("aria-keyshortcuts")).toBe("Alt+P");
+      expect(pin.getAttribute("title")).toContain("Alt+P");
+      // A second tab stop inside every row would break the palette's keyboard
+      // model, which moves selection rather than focus.
+      expect(pin.tabIndex).toBe(-1);
+    });
+
+    it("says so in the option's own name when a row is pinned", () => {
+      // `aria-activedescendant` announces the option, not its children, so the
+      // pin's state has to reach the name or it is never announced at all.
+      mockToolbarLayout = { pinnedButtons: {}, leftButtons: ["claude"], rightButtons: [] };
+      const { container } = renderButton();
+
+      expect(rowFor(container, "Claude").getAttribute("aria-label")).toContain("pinned to toolbar");
+      expect(rowFor(container, "Gemini").getAttribute("aria-label")).not.toContain("pinned");
+    });
+
+    it("keeps the unavailable-agent warning in the option's name", () => {
+      // Gemini is blocked in the fixture: activating opens Settings instead of
+      // launching, and a row that looks ordinary to a screen reader is exactly
+      // the case the warning exists for.
+      const { container } = renderButton();
+      expect(rowFor(container, "Gemini").getAttribute("aria-label")).toContain(
+        "blocked by endpoint security"
+      );
+    });
+
+    it("reserves the pin column on rows that cannot be pinned", () => {
+      // Without the reserved slot the trailing qualifier on a recipe would run
+      // 20px further right than the one on an agent, and the list's right edge
+      // would comb.
+      mockRecipes = [{ id: "r-1", name: "My recipe", worktreeId: undefined }];
+      const { container } = renderButton();
+
+      const pinnable = rowFor(container, "Claude");
+      const notPinnable = rowFor(container, "My recipe");
+      expect(pinControl(notPinnable)).toBeNull();
+      expect(notPinnable.lastElementChild?.className).toBe(pinnable.lastElementChild?.className);
+    });
+
+    it("activates from anywhere on the row, including its padding", () => {
+      // The row highlights as one thing, so all of it has to launch — the old
+      // full-width row button did, and a click target narrowed to the label
+      // text would leave the padding and the pin column inert.
+      const onLaunchAgent = vi.fn();
+      const { container } = renderButton({ onLaunchAgent });
+
+      fireEvent.click(rowFor(container, "Claude"));
+
+      expect(onLaunchAgent).toHaveBeenCalledWith("claude");
+    });
+
+    it("survives a render before agent settings have hydrated", () => {
+      mockAgentSettings = null;
+      const { container } = renderButton();
+
+      const pin = pinControl(rowFor(container, "Claude"));
+      expect(pin?.getAttribute("aria-pressed")).toBe("false");
+      fireEvent.click(pin!);
+      expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", true);
     });
 
     describe("Alt+P", () => {
@@ -1619,6 +1708,35 @@ describe("DockLaunchButton", () => {
 
         expect(setAgentPinnedMock).not.toHaveBeenCalled();
       });
+
+      it("declines a keystroke that reports AltGraph, whatever else it sets", () => {
+        // Non-US layouts reach a character through AltGr; swallowing it here
+        // would make the affected key untypable while the launcher is open.
+        // Built by hand because `getModifierState` is a prototype method — an
+        // init-dict entry is silently dropped and the key would appear plain.
+        const { container } = renderButton();
+        const input = searchInput(container);
+        fireEvent.change(input, { target: { value: "claude" } });
+
+        const event = new KeyboardEvent("keydown", {
+          key: "p",
+          code: "KeyP",
+          altKey: true,
+          bubbles: true,
+          cancelable: true,
+        });
+        Object.defineProperty(event, "getModifierState", {
+          value: (mod: string) => mod === "AltGraph",
+        });
+        fireEvent(input, event);
+
+        expect(setAgentPinnedMock).not.toHaveBeenCalled();
+      });
+
+      // The physical-key mapping macOS needs (Option+P arrives as "π") belongs
+      // to `normalizeKeyForBinding`, which the launcher calls and which owns
+      // that behaviour under a mocked platform in KeybindingService.test.ts.
+      // Re-asserting it here would only prove jsdom reports a non-Mac platform.
 
       it("does not flip repeatedly while the key is held", () => {
         const { container } = renderButton();

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -1618,14 +1618,31 @@ describe("DockLaunchButton", () => {
       expect(pin.tabIndex).toBe(-1);
     });
 
-    it("says so in the option's own name when a row is pinned", () => {
-      // `aria-activedescendant` announces the option, not its children, so the
-      // pin's state has to reach the name or it is never announced at all.
+    it("names the pin shortcut's effect in the option's own name, flipped by state", () => {
+      // Children of `role="option"` are presentational, so the pin button's own
+      // label never reaches a screen reader — without the verb in the option's
+      // name a user hears only a bare "Alt+P" and cannot tell a pinned row from
+      // an unpinned one.
       mockToolbarLayout = { pinnedButtons: {}, leftButtons: ["claude"], rightButtons: [] };
       const { container } = renderButton();
 
-      expect(rowFor(container, "Claude").getAttribute("aria-label")).toContain("Pinned to toolbar");
-      expect(rowFor(container, "Gemini").getAttribute("aria-label")).not.toContain("Pinned");
+      const pinned = rowFor(container, "Claude").getAttribute("aria-label") ?? "";
+      const unpinned = rowFor(container, "Gemini").getAttribute("aria-label") ?? "";
+
+      expect(pinned).toContain("Press Alt+P to unpin from toolbar");
+      expect(unpinned).toContain("Press Alt+P to pin to toolbar");
+      expect(pinned).not.toContain("pin to toolbar");
+      expect(unpinned).not.toContain("unpin from toolbar");
+    });
+
+    it("leaves the pin phrase off rows that cannot be pinned", () => {
+      // The phrase is a promise about a key that works — a recipe row has no
+      // pin target, so announcing Alt+P there would send the user nowhere.
+      mockRecipes = [{ id: "r-1", name: "My recipe", worktreeId: undefined }];
+      const { container } = renderButton();
+
+      expect(rowFor(container, "My recipe").getAttribute("aria-label")).not.toContain("Alt+P");
+      expect(rowFor(container, "My recipe").getAttribute("aria-keyshortcuts")).toBeNull();
     });
 
     it("leaves the unavailable-agent warning to the description, not the name", () => {

--- a/src/components/Layout/__tests__/LauncherMenuButton.panels.test.tsx
+++ b/src/components/Layout/__tests__/LauncherMenuButton.panels.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
   LAUNCHER_PANEL_BUTTON_IDS,
+  LAUNCHER_PANEL_KIND_TO_BUTTON_ID,
+  getLauncherPanelButtonIdForKind,
   isPanelButtonOnToolbar,
   isLauncherPanelButtonId,
 } from "@shared/types/toolbar";
@@ -51,6 +53,47 @@ describe("isPanelButtonOnToolbar", () => {
     }
     expect(isLauncherPanelButtonId("launcher")).toBe(false);
     expect(isLauncherPanelButtonId("claude")).toBe(false);
+  });
+});
+
+describe("getLauncherPanelButtonIdForKind", () => {
+  it("resolves the dev preview kind to the button id it does not share a name with", () => {
+    // The one pair where the panel-kind vocabulary and the toolbar vocabulary
+    // disagree. A surface testing `isLauncherPanelButtonId(kindId)` instead
+    // drops this row and reports nothing.
+    expect(getLauncherPanelButtonIdForKind("dev-preview")).toBe("dev-server");
+    expect(getLauncherPanelButtonIdForKind("dev-server")).toBeUndefined();
+  });
+
+  it("resolves every mapped kind to an id the toolbar list recognises", () => {
+    // The map is the only thing standing between a launcher row and a write to
+    // a button id nothing renders.
+    for (const kindId of Object.keys(LAUNCHER_PANEL_KIND_TO_BUTTON_ID)) {
+      const buttonId = getLauncherPanelButtonIdForKind(kindId);
+      expect(buttonId).toBeDefined();
+      expect(isLauncherPanelButtonId(buttonId!)).toBe(true);
+    }
+  });
+
+  it("covers every pinnable button id, so no panel row is left unpinnable", () => {
+    const mapped = new Set(Object.values(LAUNCHER_PANEL_KIND_TO_BUTTON_ID));
+    expect([...LAUNCHER_PANEL_BUTTON_IDS].filter((id) => !mapped.has(id))).toEqual([]);
+  });
+
+  it("returns undefined for kinds with no toolbar button", () => {
+    // Panel kinds that ship in the launcher but have no button: they need a
+    // resolver that says so rather than one that throws or guesses.
+    expect(getLauncherPanelButtonIdForKind("review")).toBeUndefined();
+    expect(getLauncherPanelButtonIdForKind("diff")).toBeUndefined();
+    expect(getLauncherPanelButtonIdForKind("file")).toBeUndefined();
+    expect(getLauncherPanelButtonIdForKind("some-plugin-kind")).toBeUndefined();
+  });
+
+  it("does not resolve inherited Object properties as button ids", () => {
+    // A plugin kind is an arbitrary string reaching a plain-object lookup.
+    expect(getLauncherPanelButtonIdForKind("constructor")).toBeUndefined();
+    expect(getLauncherPanelButtonIdForKind("toString")).toBeUndefined();
+    expect(getLauncherPanelButtonIdForKind("__proto__")).toBeUndefined();
   });
 });
 

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -323,10 +323,11 @@ export function useContentGridContext({
   const showProjectPulse = usePreferencesStore((state) => state.showProjectPulse);
   const currentProject = useProjectStore((state) => state.currentProject);
   const isAvailabilityInitialized = useCliAvailabilityStore((s) => s.isInitialized);
-  // `useShallow` is mandatory on the `leftButtons` array slice — a bare
-  // selector returns a new array reference every store tick and would
-  // invalidate this hook's "use memo" block on any unrelated toolbar update.
+  // `useShallow` is mandatory on both side-array slices — a bare selector
+  // returns a new array reference every store tick and would invalidate this
+  // hook's "use memo" block on any unrelated toolbar update.
   const leftButtons = useToolbarPreferencesStore(useShallow((s) => s.layout.leftButtons));
+  const rightButtons = useToolbarPreferencesStore(useShallow((s) => s.layout.rightButtons));
   const agentSettings = useAgentSettingsStore((s) => s.settings);
   // Re-derive grid agents when a plugin loads/unloads mid-session so its agents
   // appear / disappear with current icon/name/color (#9879).
@@ -773,8 +774,15 @@ export function useContentGridContext({
           availability: agentAvailability?.[id],
         };
       });
-    return sortAgentsByToolbarPin(agents, leftButtons, agentSettings);
-  }, [agentAvailability, gridSelectedAgentIds, leftButtons, agentSettings, pluginAgentRegistry]);
+    return sortAgentsByToolbarPin(agents, leftButtons, agentSettings, rightButtons);
+  }, [
+    agentAvailability,
+    gridSelectedAgentIds,
+    leftButtons,
+    rightButtons,
+    agentSettings,
+    pluginAgentRegistry,
+  ]);
 
   const handleGridLaunch = useCallback(
     (agentId: string) => {

--- a/src/lib/__tests__/agentMenuOrder.test.ts
+++ b/src/lib/__tests__/agentMenuOrder.test.ts
@@ -17,7 +17,8 @@ describe("sortAgentsByToolbarPin", () => {
     const { sorted, pinnedCount } = sortAgentsByToolbarPin(
       agents,
       ["codex", "gemini"],
-      settings({})
+      settings({}),
+      []
     );
     expect(sorted.map((a) => a.id)).toEqual(["codex", "gemini", "claude"]);
     expect(pinnedCount).toBe(2);
@@ -28,7 +29,8 @@ describe("sortAgentsByToolbarPin", () => {
     const { sorted, pinnedCount } = sortAgentsByToolbarPin(
       agents,
       ["claude"],
-      settings({ claude: { pinned: true } })
+      settings({ claude: { pinned: true } }),
+      []
     );
     expect(sorted.map((a) => a.id)).toEqual(["claude", "gemini"]);
     expect(pinnedCount).toBe(1);
@@ -39,7 +41,8 @@ describe("sortAgentsByToolbarPin", () => {
     const { sorted, pinnedCount } = sortAgentsByToolbarPin(
       agents,
       ["claude", "gemini"],
-      settings({ claude: { pinned: false } })
+      settings({ claude: { pinned: false } }),
+      []
     );
     expect(sorted.map((a) => a.id)).toEqual(["gemini", "claude"]);
     expect(pinnedCount).toBe(1);
@@ -47,7 +50,7 @@ describe("sortAgentsByToolbarPin", () => {
 
   it("returns pinnedCount 0 when no agents are pinned", () => {
     const agents = [agent("claude", "missing"), agent("gemini", undefined)];
-    const { sorted, pinnedCount } = sortAgentsByToolbarPin(agents, [], settings({}));
+    const { sorted, pinnedCount } = sortAgentsByToolbarPin(agents, [], settings({}), []);
     expect(sorted.map((a) => a.id)).toEqual(["claude", "gemini"]);
     expect(pinnedCount).toBe(0);
   });
@@ -57,7 +60,8 @@ describe("sortAgentsByToolbarPin", () => {
     const { sorted, pinnedCount } = sortAgentsByToolbarPin(
       agents,
       ["gemini", "claude"],
-      settings({})
+      settings({}),
+      []
     );
     // leftButtons reverses the input order — guards against a sort that counts
     // pinned agents correctly but ignores the toolbar ordering.
@@ -65,41 +69,97 @@ describe("sortAgentsByToolbarPin", () => {
     expect(pinnedCount).toBe(2);
   });
 
-  it("orders [inLeftButtons, pinned-absent, unpinned] across all three groups", () => {
+  it("orders [inLeftButtons, explicitly-pinned-absent, unpinned] across all three groups", () => {
     const agents = [
-      agent("gemini", "ready"), // pinned, absent from leftButtons → end of pinned group
+      agent("gemini", "ready"), // explicitly pinned, no position → end of pinned group
       agent("codex", "missing"), // unpinned
-      agent("claude", "ready"), // pinned, leftButtons index 0
+      agent("claude", "ready"), // positioned, leftButtons index 0
     ];
-    const { sorted, pinnedCount } = sortAgentsByToolbarPin(agents, ["claude"], settings({}));
+    const { sorted, pinnedCount } = sortAgentsByToolbarPin(
+      agents,
+      ["claude"],
+      settings({ gemini: { pinned: true } }),
+      []
+    );
     expect(sorted.map((a) => a.id)).toEqual(["claude", "gemini", "codex"]);
     expect(pinnedCount).toBe(2);
   });
 
-  it("places a pinned agent absent from leftButtons at the end of the pinned group", () => {
+  it("places a pinned agent absent from both side arrays at the end of the pinned group", () => {
     const agents = [agent("claude", "ready"), agent("gemini", "ready")];
-    // gemini pinned but not in leftButtons → after claude (index 0), before any unpinned.
-    const { sorted, pinnedCount } = sortAgentsByToolbarPin(agents, ["claude"], settings({}));
+    // gemini pinned but positioned nowhere → after claude (index 0), before any unpinned.
+    const { sorted, pinnedCount } = sortAgentsByToolbarPin(
+      agents,
+      ["claude"],
+      settings({ gemini: { pinned: true } }),
+      []
+    );
     expect(sorted.map((a) => a.id)).toEqual(["claude", "gemini"]);
     expect(pinnedCount).toBe(2);
   });
 
   it("uses the first index for a duplicated id in leftButtons", () => {
     const agents = [agent("claude", "ready"), agent("gemini", "ready")];
-    const { sorted } = sortAgentsByToolbarPin(agents, ["gemini", "claude", "gemini"], settings({}));
+    const { sorted } = sortAgentsByToolbarPin(
+      agents,
+      ["gemini", "claude", "gemini"],
+      settings({}),
+      []
+    );
     expect(sorted.map((a) => a.id)).toEqual(["gemini", "claude"]);
   });
 
-  it("treats a missing settings entry as following availability", () => {
+  it("treats a missing settings entry as following position and availability", () => {
     const agents = [agent("claude", "ready"), agent("gemini", "missing")];
-    const { sorted, pinnedCount } = sortAgentsByToolbarPin(agents, ["claude"], null);
+    const { sorted, pinnedCount } = sortAgentsByToolbarPin(agents, ["claude"], null, []);
     expect(sorted.map((a) => a.id)).toEqual(["claude", "gemini"]);
     expect(pinnedCount).toBe(1);
   });
 
   it("treats undefined availability with no pin as unpinned", () => {
     const agents = [agent("claude", undefined)];
-    const { pinnedCount } = sortAgentsByToolbarPin(agents, [], settings({}));
+    const { pinnedCount } = sortAgentsByToolbarPin(agents, [], settings({}), []);
     expect(pinnedCount).toBe(0);
+  });
+
+  it("leaves an installed agent with no position out of the pinned group", () => {
+    // The #11680 regression this predicate change exists for: installing a CLI
+    // stopped implying a toolbar slot, so grouping on availability alone put an
+    // agent under "Pinned" while its own pin affordance read as unpinned.
+    const agents = [agent("claude", "ready"), agent("gemini", "ready")];
+    const { pinnedCount } = sortAgentsByToolbarPin(agents, [], settings({}), []);
+    expect(pinnedCount).toBe(0);
+  });
+
+  it("counts a position on the right side as pinned", () => {
+    const agents = [agent("claude", "ready"), agent("gemini", "ready")];
+    const { sorted, pinnedCount } = sortAgentsByToolbarPin(agents, [], settings({}), ["gemini"]);
+    expect(sorted.map((a) => a.id)).toEqual(["gemini", "claude"]);
+    expect(pinnedCount).toBe(1);
+  });
+
+  it("orders left-side agents ahead of right-side ones", () => {
+    // `leftButtons` supplies the order; a right-side agent has no index there,
+    // so it sorts to the end of the pinned group rather than interleaving.
+    const agents = [agent("gemini", "ready"), agent("claude", "ready")];
+    const { sorted, pinnedCount } = sortAgentsByToolbarPin(agents, ["claude"], settings({}), [
+      "gemini",
+    ]);
+    expect(sorted.map((a) => a.id)).toEqual(["claude", "gemini"]);
+    expect(pinnedCount).toBe(2);
+  });
+
+  it("never counts a non-built-in agent as pinned, even when positioned", () => {
+    // A plugin or user-defined agent has no toolbar button id to write, so it
+    // cannot be on the toolbar however the arrays read.
+    const agents = [agent("my-plugin-agent", "ready"), agent("claude", "ready")];
+    const { sorted, pinnedCount } = sortAgentsByToolbarPin(
+      agents,
+      ["my-plugin-agent", "claude"],
+      settings({ "my-plugin-agent": { pinned: true } }),
+      []
+    );
+    expect(sorted.map((a) => a.id)).toEqual(["claude", "my-plugin-agent"]);
+    expect(pinnedCount).toBe(1);
   });
 });

--- a/src/lib/agentMenuOrder.ts
+++ b/src/lib/agentMenuOrder.ts
@@ -1,6 +1,7 @@
 import type { AgentSettings } from "@shared/types/agentSettings";
 import type { AgentAvailabilityState } from "@shared/types";
-import { isAgentToolbarVisible } from "@shared/utils/agentPinned";
+import { isAgentButtonOnToolbar } from "@shared/utils/agentPinned";
+import { isBuiltInAgentId } from "@shared/config/agentIds";
 
 /** Minimal shape needed to order an agent against the toolbar pin state. */
 export interface PinnableAgent {
@@ -13,12 +14,22 @@ export interface PinnableAgent {
  * present them: toolbar-pinned agents first (in toolbar `leftButtons` order),
  * then the remaining agents in their incoming order.
  *
- * "Pinned to toolbar" follows the tri-state resolver `isAgentToolbarVisible`
- * (explicit pin wins, then live CLI availability) so the menu grouping always
- * matches what the toolbar actually shows. `leftButtons` supplies the order
- * only — an agent visible in the toolbar but absent from `leftButtons` (e.g.
- * explicitly pinned but never dragged into the rail) sorts to the end of the
- * pinned group via a stable sort.
+ * "Pinned to toolbar" follows `isAgentButtonOnToolbar` — the same resolver the
+ * launcher's pin affordance reads — so the band an agent sits under and the pin
+ * icon on its row can never contradict each other. It deliberately is NOT
+ * `isAgentToolbarVisible`: that one resolves an unset pin to "the binary is
+ * installed", which stopped meaning "has a toolbar button" when #11680 dropped
+ * the `LAUNCHABLE_AGENT_IDS` spread from `DEFAULT_LEFT_BUTTONS`. Under the old
+ * predicate a fresh profile's installed-but-unpositioned agent landed under
+ * "Pinned" wearing an unfilled pin.
+ *
+ * Both side arrays decide the position, because either one renders a button;
+ * `leftButtons` supplies the order only — an agent on the toolbar but absent
+ * from it (explicitly pinned, never positioned) sorts to the end of the pinned
+ * group via a stable sort.
+ *
+ * Only built-in agents can be pinned: a plugin or user-defined agent has no
+ * toolbar button id to write, so it can never be in the pinned group.
  *
  * Returns the concatenated array plus `pinnedCount` so callers can render a
  * separator + labels between the two groups without re-deriving the split.
@@ -26,18 +37,30 @@ export interface PinnableAgent {
 export function sortAgentsByToolbarPin<T extends PinnableAgent>(
   agents: ReadonlyArray<T>,
   leftButtons: readonly string[],
-  agentSettings: AgentSettings | null | undefined
+  agentSettings: AgentSettings | null | undefined,
+  // Required rather than defaulted: a caller that forgets it would silently
+  // demote every right-side agent out of the pinned group, and there is no
+  // value of this argument that is safe to guess.
+  rightButtons: readonly string[]
 ): { sorted: T[]; pinnedCount: number } {
   const order = new Map<string, number>();
   for (let i = 0; i < leftButtons.length; i++) {
     const id = leftButtons[i]!;
     if (!order.has(id)) order.set(id, i);
   }
+  const positioned = new Set<string>([...leftButtons, ...rightButtons]);
 
   const pinned: T[] = [];
   const unpinned: T[] = [];
   for (const agent of agents) {
-    if (isAgentToolbarVisible(agentSettings?.agents?.[agent.id], agent.availability)) {
+    const onToolbar =
+      isBuiltInAgentId(agent.id) &&
+      isAgentButtonOnToolbar(
+        agentSettings?.agents?.[agent.id],
+        agent.availability,
+        positioned.has(agent.id)
+      );
+    if (onToolbar) {
       pinned.push(agent);
     } else {
       unpinned.push(agent);


### PR DESCRIPTION
## Summary

Issue #11689 asked for one searchable launcher in the dock, carrying the full inventory both launchers know about plus the per-row pin affordance the toolbar dropdown already has. #11686 and #11687 had already landed the anchored tier, neutral selection, the 352px width, and the footer removal, so the remaining gap was the pin itself, and the inventory unification that implies. The toolbar's own dropdown is untouched here. Swapping it is #11691.

Resolves #11689

## Changes

1. `DockLaunchOption` moves from `<button role="option">` to `<div role="option">`, because a button can't legally nest the pin button. Activation stays on the option row itself rather than an inner button: the row owns its padding and the reserved pin column, and an inner button would only cover its own content box.
2. The pin writes through `dispatchToolbarVisibility` (agents) and `setPanelButtonOnToolbar` (panels), the same functions Settings > Toolbar already uses, so the two surfaces can't disagree about pin state. `onToolbar` is passed explicitly into the agent dispatch, because its own fallback derives the flip from `isAgentToolbarVisible`, which would make the first click a no-op for an agent that's installed but not yet positioned on the toolbar.
3. New `getLauncherPanelButtonIdForKind` in `shared/types/toolbar.ts`. Three of four panel kinds share an identical name with their toolbar button, but the fourth doesn't: `dev-preview` as a panel kind, `dev-server` as a toolbar button. Testing `isLauncherPanelButtonId(kindId)` directly would have silently dropped that row's pin.
4. `sortAgentsByToolbarPin` now groups on `isAgentButtonOnToolbar` instead of `isAgentToolbarVisible`, takes `rightButtons`, and skips non-built-in agents. Since #11680 dropped agent ids from `DEFAULT_LEFT_BUTTONS`, the old check could sort an installed-but-unpositioned agent into "Pinned" while it displayed an unfilled pin icon, a contradiction. This function is shared by the dock and content grid right-click menus too, so both inherit the corrected grouping for free.
5. `Alt+P` pins the selected row. It has to be a modified combo, not bare `P`: this is a type-ahead search box, and a bare `P` reads as the second letter of "python" mid-search. `Cmd+P`, `Cmd+Shift+P`, and `Cmd+Alt+P` were all already taken, so `Alt+P` was the one left free.

## Notes for reviewers

- The pin button's pointer handling is deliberate: `preventDefault()` on `pointerdown`, `stopPropagation()` only on `click`. Stopping propagation on `pointerdown` would hide the event from Radix's `DismissableLayer`, which needs to see it to classify the next outside click as a dismissal. The toolbar's own `LauncherPinAffordance` does stop propagation on `pointerdown`, but it lives inside a `DropdownMenuContent`, not a Popover. Don't copy that pattern over here.
- The three behaviors #11689 called out as must-survive are intact, still commented at their sites: `activateRow`'s launch-only close-autofocus suppression, clearing the query on every close, and `deferFiltering: false`.

## Testing

Ran 1,811 unit tests locally across the touched modules: launcher, agent ordering, toolbar resolvers, pin-sync integration, the accent guard, keybindings, and the whole Terminal suite for the grid context-menu change. Typecheck, eslint, and prettier all pass on the changed files.

Added one new E2E case, `e2e/full/panels/core-dock-launcher-search.spec.ts`, covering the popover dismissal behavior above, since the unit suite mocks Radix's popover away and can't exercise it structurally. Didn't run that one locally: `full-panels` needs a packaged build and doesn't run on PR CI.