### PR TITLE
fix(main): bound the agent compile cache

### DIFF
--- a/electron/services/AgentCompileCacheCleanupService.ts
+++ b/electron/services/AgentCompileCacheCleanupService.ts
@@ -81,55 +81,90 @@ interface VersionDir {
   mtimeMs: number;
 }
 
+/**
+ * Why a directory was or was not admitted. A three-way status rather than a
+ * boolean because "vanished" must not be conflated with "too big": treating a
+ * concurrently-removed directory as over budget would latch the budget pass and
+ * evict every older cache behind it.
+ */
+type MeasurementStatus = "fits" | "too-big" | "gone";
+
 interface Measurement {
   bytes: number;
   entries: number;
   inspected: number;
-  /** False when the directory blew a budget or could not be measured. */
-  fits: boolean;
+  status: MeasurementStatus;
+}
+
+interface Discovery {
+  versionDirs: VersionDir[];
+  /** Agent directories that hold no version directories at all. */
+  emptyAgentDirs: string[];
 }
 
 function isNodeError(err: unknown): err is NodeJS.ErrnoException {
   return err instanceof Error && "code" in err;
 }
 
-/** Immediate real subdirectories of `dir`; `[]` when it cannot be read. */
+/**
+ * Immediate real subdirectories of `dir`; `[]` when it cannot be read. An
+ * absent directory is the ordinary case and stays quiet, but a genuinely
+ * unreadable one is logged — otherwise an EACCES on a 9 GB cache would report
+ * a clean sweep forever.
+ */
 async function listSubdirectories(dir: string): Promise<string[]> {
   const names: string[] = [];
   try {
     const handle = await fs.opendir(dir);
     for await (const entry of handle) {
-      // isDirectory() is false for symlinks, so a symlinked directory is never
-      // followed — the cache holds no symlinks, and following one would put
-      // `fs.rm` outside the cache root.
+      // isDirectory() is false for a symlink, so a symlinked entry is never
+      // descended into — following one would put `fs.rm` outside the cache.
       if (entry.isDirectory()) names.push(entry.name);
     }
-  } catch {
-    // Absent or unreadable root/agent directory — nothing to reclaim here.
+  } catch (error) {
+    if (!isNodeError(error) || (error.code !== "ENOENT" && error.code !== "ENOTDIR")) {
+      logError(`[AgentCompileCacheCleanup] Failed to read ${dir}`, error);
+    }
     return [];
   }
   return names;
 }
 
-/** Every version directory under every agent directory, with its own mtime. */
-async function discoverVersionDirs(root: string): Promise<VersionDir[]> {
-  const found: VersionDir[] = [];
+/**
+ * Every version directory under every agent directory, with its own mtime.
+ *
+ * A relocated cache root (a symlink onto another volume) is followed
+ * deliberately: the spawn path writes through that same symlink, so refusing
+ * to sweep it would leave the cache unbounded for exactly the users who moved
+ * it. Everything *below* the root must be a real directory, re-checked with
+ * `lstat` here so an entry swapped for a symlink between listing and stat is
+ * not handed to `fs.rm`.
+ */
+async function discoverVersionDirs(root: string): Promise<Discovery> {
+  const versionDirs: VersionDir[] = [];
+  const emptyAgentDirs: string[] = [];
   // Every agent directory is swept, not just the ones currently in
   // NODE_COMPILE_CACHE_AGENTS: dropping an agent from that allowlist would
   // otherwise strand its cache forever.
   for (const agentName of await listSubdirectories(root)) {
     const agentDir = path.join(root, agentName);
-    for (const versionName of await listSubdirectories(agentDir)) {
+    const versionNames = await listSubdirectories(agentDir);
+    if (versionNames.length === 0) {
+      emptyAgentDirs.push(agentDir);
+      continue;
+    }
+    for (const versionName of versionNames) {
       const versionDir = path.join(agentDir, versionName);
       try {
-        const stats = await fs.stat(versionDir);
-        found.push({ path: versionDir, agentDir, mtimeMs: stats.mtimeMs });
+        const stats = await fs.lstat(versionDir);
+        if (!stats.isDirectory()) continue;
+        versionDirs.push({ path: versionDir, agentDir, mtimeMs: stats.mtimeMs });
       } catch {
         // Vanished or unreadable between listing and stat — skip it.
       }
     }
   }
-  return found;
+  return { versionDirs, emptyAgentDirs };
 }
 
 /**
@@ -138,6 +173,10 @@ async function discoverVersionDirs(root: string): Promise<VersionDir[]> {
  * directory), so this never recurses; an unexpected subdirectory is
  * unmeasurable and reported as not fitting, which evicts the directory rather
  * than let an unmeasured subtree escape the budget.
+ *
+ * Only a vanished blob (`ENOENT`) may be skipped. Any other stat failure means
+ * the directory's true size is unknown, and treating unknown as zero would let
+ * an arbitrarily large unreadable blob sit inside the budget.
  */
 async function measureVersionDir(
   dir: string,
@@ -147,31 +186,37 @@ async function measureVersionDir(
   let bytes = 0;
   let entries = 0;
   let inspected = 0;
+  const tooBig = (): Measurement => ({ bytes, entries, inspected, status: "too-big" });
 
   try {
     const handle = await fs.opendir(dir);
     for await (const entry of handle) {
-      if (!entry.isFile()) return { bytes, entries, inspected, fits: false };
+      if (!entry.isFile()) return tooBig();
       entries += 1;
-      if (entries > remainingEntries) return { bytes, entries, inspected, fits: false };
-      let size = 0;
+      if (entries > remainingEntries) return tooBig();
+      inspected += 1;
+      let stats;
       try {
-        const stats = await fs.lstat(path.join(dir, entry.name));
-        inspected += 1;
-        size = stats.size;
-      } catch {
-        // A blob that vanished mid-measure contributes nothing; the directory
-        // is still measurable.
-        continue;
+        stats = await fs.lstat(path.join(dir, entry.name));
+      } catch (error) {
+        if (isNodeError(error) && error.code === "ENOENT") continue;
+        return tooBig();
       }
-      bytes += size;
-      if (bytes > remainingBytes) return { bytes, entries, inspected, fits: false };
+      if (!stats.isFile()) return tooBig();
+      bytes += stats.size;
+      if (bytes > remainingBytes) return tooBig();
     }
-  } catch {
-    return { bytes, entries, inspected, fits: false };
+  } catch (error) {
+    // The directory itself disappearing is not evidence that it was too big —
+    // reporting it as such would latch the budget pass and evict every older
+    // cache behind it.
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return { bytes, entries, inspected, status: "gone" };
+    }
+    return tooBig();
   }
 
-  return { bytes, entries, inspected, fits: true };
+  return { bytes, entries, inspected, status: "fits" };
 }
 
 /** Best-effort recursive removal. Returns false (logged) on failure. */
@@ -184,6 +229,21 @@ async function removeVersionDir(dir: string, reason: string): Promise<boolean> {
   } catch (error) {
     logError(`[AgentCompileCacheCleanup] Failed to remove ${dir} (${reason})`, error);
     return false;
+  }
+}
+
+/**
+ * Drop agent directories that hold nothing. ENOTEMPTY just means a live agent
+ * repopulated one mid-sweep, which is not a failure.
+ */
+async function removeEmptyAgentDirs(agentDirs: Iterable<string>): Promise<void> {
+  for (const agentDir of agentDirs) {
+    try {
+      await fs.rmdir(agentDir);
+    } catch (error) {
+      if (isNodeError(error) && (error.code === "ENOTEMPTY" || error.code === "ENOENT")) continue;
+      logError(`[AgentCompileCacheCleanup] Failed to remove empty agent dir ${agentDir}`, error);
+    }
   }
 }
 
@@ -205,11 +265,17 @@ export async function runAgentCompileCacheCleanup(
     entriesInspected: 0,
   };
 
-  const versionDirs = await discoverVersionDirs(root);
+  const { versionDirs, emptyAgentDirs } = await discoverVersionDirs(root);
   result.candidates = versionDirs.length;
-  if (versionDirs.length === 0) return result;
 
-  const touchedAgentDirs = new Set<string>();
+  // An agent directory left behind with no version directories is pure dead
+  // weight — no sweep would otherwise ever visit it.
+  const touchedAgentDirs = new Set<string>(emptyAgentDirs);
+  if (versionDirs.length === 0) {
+    await removeEmptyAgentDirs(touchedAgentDirs);
+    return result;
+  }
+
   const expiredBefore = now - policy.ttlMs;
   const survivors: VersionDir[] = [];
 
@@ -243,7 +309,10 @@ export async function runAgentCompileCacheCleanup(
         remainingEntries
       );
       result.entriesInspected += measurement.inspected;
-      if (measurement.fits) {
+      // Already gone (a concurrent sweep, or the user clearing the cache):
+      // nothing to reclaim and, critically, no reason to latch.
+      if (measurement.status === "gone") continue;
+      if (measurement.status === "fits") {
         remainingBytes -= measurement.bytes;
         remainingEntries -= measurement.entries;
         continue;
@@ -260,16 +329,7 @@ export async function runAgentCompileCacheCleanup(
     }
   }
 
-  // An agent directory emptied by this sweep is itself dead weight. ENOTEMPTY
-  // just means a live agent repopulated it, which is not a failure.
-  for (const agentDir of touchedAgentDirs) {
-    try {
-      await fs.rmdir(agentDir);
-    } catch (error) {
-      if (isNodeError(error) && (error.code === "ENOTEMPTY" || error.code === "ENOENT")) continue;
-      logError(`[AgentCompileCacheCleanup] Failed to remove empty agent dir ${agentDir}`, error);
-    }
-  }
+  await removeEmptyAgentDirs(touchedAgentDirs);
 
   if (result.expiredRemoved > 0 || result.budgetRemoved > 0 || result.failed > 0) {
     logInfo(

--- a/electron/services/AgentCompileCacheCleanupService.ts
+++ b/electron/services/AgentCompileCacheCleanupService.ts
@@ -148,6 +148,15 @@ async function discoverVersionDirs(root: string): Promise<Discovery> {
   // otherwise strand its cache forever.
   for (const agentName of await listSubdirectories(root)) {
     const agentDir = path.join(root, agentName);
+    // Re-check the agent component too, not just the version directory below
+    // it: an agent directory swapped for a symlink after the root listing would
+    // otherwise be an intermediate path component that both `lstat` and
+    // `fs.rm` follow straight out of the cache.
+    try {
+      if (!(await fs.lstat(agentDir)).isDirectory()) continue;
+    } catch {
+      continue;
+    }
     const versionNames = await listSubdirectories(agentDir);
     if (versionNames.length === 0) {
       emptyAgentDirs.push(agentDir);
@@ -159,8 +168,13 @@ async function discoverVersionDirs(root: string): Promise<Discovery> {
         const stats = await fs.lstat(versionDir);
         if (!stats.isDirectory()) continue;
         versionDirs.push({ path: versionDir, agentDir, mtimeMs: stats.mtimeMs });
-      } catch {
-        // Vanished or unreadable between listing and stat — skip it.
+      } catch (error) {
+        // A vanished entry is ordinary churn, but an unreadable one hides a
+        // whole cache directory from the sweep — say so rather than let a
+        // multi-gigabyte tree go silently unreclaimed.
+        if (!isNodeError(error) || error.code !== "ENOENT") {
+          logError(`[AgentCompileCacheCleanup] Failed to stat ${versionDir}`, error);
+        }
       }
     }
   }

--- a/electron/services/AgentCompileCacheCleanupService.ts
+++ b/electron/services/AgentCompileCacheCleanupService.ts
@@ -1,0 +1,306 @@
+/**
+ * Bounds the per-agent V8 compile cache that Node-based agent CLIs write to
+ * `<userData>/agent-compile-cache/<agentId>/<nodeVersionDir>/` (#11699).
+ *
+ * Node has no eviction of its own — every runtime it has ever run under keeps a
+ * directory forever, and the runtime currently in use gains a full fresh blob
+ * set each time the agent CLI updates. One report reached 9.3 GB across 890K
+ * files. Both halves need answering, so the sweep runs two passes:
+ *
+ *   Pass 1 (TTL): a version directory whose own mtime predates
+ *   `AGENT_COMPILE_CACHE_TTL_MS` is removed outright. Node writes blobs
+ *   directly into that directory, so its mtime tracks the last compile under
+ *   that runtime — one `stat` stands in for walking its contents.
+ *
+ *   Pass 2 (budget): survivors are ranked newest-first and admitted while they
+ *   fit the root-wide byte and entry budgets. The first directory that does not
+ *   fit is removed along with every older one, without measuring those. This is
+ *   deliberately a newest-prefix policy, not an optimal packing: finding a
+ *   smaller older directory that would fit means sizing the whole tree, which
+ *   is the cost the mtime signal exists to avoid.
+ *
+ * Bounded work is the point. Measuring stops the moment a budget is exceeded,
+ * so a sweep inspects at most roughly `AGENT_COMPILE_CACHE_MAX_ENTRIES` files
+ * however large the cache has grown. `fs.rm` still traverses what it deletes,
+ * but that work buys back the disk.
+ *
+ * Every deletion is isolated and best-effort. Windows can refuse a blob a live
+ * agent still holds open (`EBUSY`/`EPERM`); that directory is counted, logged,
+ * and left for the next sweep rather than aborting the pass. Deleting a cache
+ * is always safe — Node silently recompiles on a miss, so the worst case of
+ * over-eviction is one slower agent launch, never incorrect behaviour.
+ *
+ * Silent by design: reclamation is not something the user needs to act on, so
+ * this logs a summary and never calls `notify()` — matching `ScratchCleanupService`
+ * and the log prunes.
+ */
+import fs from "fs/promises";
+import path from "path";
+import { app } from "electron";
+import { logError, logInfo } from "../utils/logger.js";
+import {
+  AGENT_COMPILE_CACHE_TTL_MS,
+  AGENT_COMPILE_CACHE_MAX_BYTES,
+  AGENT_COMPILE_CACHE_MAX_ENTRIES,
+} from "../../shared/config/agentCompileCache.js";
+import { getAgentCompileCacheRoot } from "./agentCompileCachePaths.js";
+
+export interface AgentCompileCacheCleanupPolicy {
+  ttlMs: number;
+  maxBytes: number;
+  maxEntries: number;
+}
+
+export interface AgentCompileCacheCleanupResult {
+  /** Version directories discovered across every agent. */
+  candidates: number;
+  /** Removed by the TTL pass. */
+  expiredRemoved: number;
+  /** Removed by the budget pass. */
+  budgetRemoved: number;
+  /** Directories whose removal failed (logged, not rethrown). */
+  failed: number;
+  /**
+   * Files stat'd while measuring. The headline bounded-work figure: it stays
+   * near the entry budget no matter how many files the cache actually holds,
+   * because TTL-evicted directories are never opened and measuring stops at
+   * the first budget overrun.
+   */
+  entriesInspected: number;
+}
+
+export const DEFAULT_AGENT_COMPILE_CACHE_POLICY: AgentCompileCacheCleanupPolicy = {
+  ttlMs: AGENT_COMPILE_CACHE_TTL_MS,
+  maxBytes: AGENT_COMPILE_CACHE_MAX_BYTES,
+  maxEntries: AGENT_COMPILE_CACHE_MAX_ENTRIES,
+};
+
+interface VersionDir {
+  path: string;
+  agentDir: string;
+  mtimeMs: number;
+}
+
+interface Measurement {
+  bytes: number;
+  entries: number;
+  inspected: number;
+  /** False when the directory blew a budget or could not be measured. */
+  fits: boolean;
+}
+
+function isNodeError(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error && "code" in err;
+}
+
+/** Immediate real subdirectories of `dir`; `[]` when it cannot be read. */
+async function listSubdirectories(dir: string): Promise<string[]> {
+  const names: string[] = [];
+  try {
+    const handle = await fs.opendir(dir);
+    for await (const entry of handle) {
+      // isDirectory() is false for symlinks, so a symlinked directory is never
+      // followed — the cache holds no symlinks, and following one would put
+      // `fs.rm` outside the cache root.
+      if (entry.isDirectory()) names.push(entry.name);
+    }
+  } catch {
+    // Absent or unreadable root/agent directory — nothing to reclaim here.
+    return [];
+  }
+  return names;
+}
+
+/** Every version directory under every agent directory, with its own mtime. */
+async function discoverVersionDirs(root: string): Promise<VersionDir[]> {
+  const found: VersionDir[] = [];
+  // Every agent directory is swept, not just the ones currently in
+  // NODE_COMPILE_CACHE_AGENTS: dropping an agent from that allowlist would
+  // otherwise strand its cache forever.
+  for (const agentName of await listSubdirectories(root)) {
+    const agentDir = path.join(root, agentName);
+    for (const versionName of await listSubdirectories(agentDir)) {
+      const versionDir = path.join(agentDir, versionName);
+      try {
+        const stats = await fs.stat(versionDir);
+        found.push({ path: versionDir, agentDir, mtimeMs: stats.mtimeMs });
+      } catch {
+        // Vanished or unreadable between listing and stat — skip it.
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Size one version directory, stopping as soon as it cannot fit the remaining
+ * budget. The layout is flat (Node writes blobs directly into the version
+ * directory), so this never recurses; an unexpected subdirectory is
+ * unmeasurable and reported as not fitting, which evicts the directory rather
+ * than let an unmeasured subtree escape the budget.
+ */
+async function measureVersionDir(
+  dir: string,
+  remainingBytes: number,
+  remainingEntries: number
+): Promise<Measurement> {
+  let bytes = 0;
+  let entries = 0;
+  let inspected = 0;
+
+  try {
+    const handle = await fs.opendir(dir);
+    for await (const entry of handle) {
+      if (!entry.isFile()) return { bytes, entries, inspected, fits: false };
+      entries += 1;
+      if (entries > remainingEntries) return { bytes, entries, inspected, fits: false };
+      let size = 0;
+      try {
+        const stats = await fs.lstat(path.join(dir, entry.name));
+        inspected += 1;
+        size = stats.size;
+      } catch {
+        // A blob that vanished mid-measure contributes nothing; the directory
+        // is still measurable.
+        continue;
+      }
+      bytes += size;
+      if (bytes > remainingBytes) return { bytes, entries, inspected, fits: false };
+    }
+  } catch {
+    return { bytes, entries, inspected, fits: false };
+  }
+
+  return { bytes, entries, inspected, fits: true };
+}
+
+/** Best-effort recursive removal. Returns false (logged) on failure. */
+async function removeVersionDir(dir: string, reason: string): Promise<boolean> {
+  try {
+    // `force` absorbs the already-gone race; the retries cover a Windows lock
+    // held briefly by an agent that is still writing.
+    await fs.rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    return true;
+  } catch (error) {
+    logError(`[AgentCompileCacheCleanup] Failed to remove ${dir} (${reason})`, error);
+    return false;
+  }
+}
+
+/**
+ * Sweep the agent compile cache. Returns a summary for tests; production
+ * callers go through {@link requestAgentCompileCacheCleanup}. `root` and
+ * `policy` are injectable so tests drive real temp directories with tiny budgets.
+ */
+export async function runAgentCompileCacheCleanup(
+  now: number = Date.now(),
+  root: string = getAgentCompileCacheRoot(app.getPath("userData")),
+  policy: AgentCompileCacheCleanupPolicy = DEFAULT_AGENT_COMPILE_CACHE_POLICY
+): Promise<AgentCompileCacheCleanupResult> {
+  const result: AgentCompileCacheCleanupResult = {
+    candidates: 0,
+    expiredRemoved: 0,
+    budgetRemoved: 0,
+    failed: 0,
+    entriesInspected: 0,
+  };
+
+  const versionDirs = await discoverVersionDirs(root);
+  result.candidates = versionDirs.length;
+  if (versionDirs.length === 0) return result;
+
+  const touchedAgentDirs = new Set<string>();
+  const expiredBefore = now - policy.ttlMs;
+  const survivors: VersionDir[] = [];
+
+  // Pass 1: TTL. An expired directory is removed without ever being opened,
+  // which is what keeps a 890K-file cache cheap to reclaim.
+  for (const versionDir of versionDirs) {
+    if (versionDir.mtimeMs >= expiredBefore) {
+      survivors.push(versionDir);
+      continue;
+    }
+    if (await removeVersionDir(versionDir.path, "expired")) {
+      result.expiredRemoved += 1;
+      touchedAgentDirs.add(versionDir.agentDir);
+    } else {
+      result.failed += 1;
+    }
+  }
+
+  // Pass 2: budget. Newest first, so the caches most likely to be hit again
+  // are the ones retained.
+  survivors.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  let remainingBytes = policy.maxBytes;
+  let remainingEntries = policy.maxEntries;
+  let overBudget = false;
+
+  for (const versionDir of survivors) {
+    if (!overBudget) {
+      const measurement = await measureVersionDir(
+        versionDir.path,
+        remainingBytes,
+        remainingEntries
+      );
+      result.entriesInspected += measurement.inspected;
+      if (measurement.fits) {
+        remainingBytes -= measurement.bytes;
+        remainingEntries -= measurement.entries;
+        continue;
+      }
+      // This directory does not fit, so neither can anything older: every
+      // remaining candidate is removed unmeasured.
+      overBudget = true;
+    }
+    if (await removeVersionDir(versionDir.path, "over-budget")) {
+      result.budgetRemoved += 1;
+      touchedAgentDirs.add(versionDir.agentDir);
+    } else {
+      result.failed += 1;
+    }
+  }
+
+  // An agent directory emptied by this sweep is itself dead weight. ENOTEMPTY
+  // just means a live agent repopulated it, which is not a failure.
+  for (const agentDir of touchedAgentDirs) {
+    try {
+      await fs.rmdir(agentDir);
+    } catch (error) {
+      if (isNodeError(error) && (error.code === "ENOTEMPTY" || error.code === "ENOENT")) continue;
+      logError(`[AgentCompileCacheCleanup] Failed to remove empty agent dir ${agentDir}`, error);
+    }
+  }
+
+  if (result.expiredRemoved > 0 || result.budgetRemoved > 0 || result.failed > 0) {
+    logInfo(
+      `[AgentCompileCacheCleanup] sweep complete: ${result.expiredRemoved} expired, ` +
+        `${result.budgetRemoved} over-budget, ${result.failed} failed, ` +
+        `${result.entriesInspected} entries inspected of ${result.candidates} directories`
+    );
+  }
+
+  return result;
+}
+
+let inFlight: Promise<AgentCompileCacheCleanupResult> | null = null;
+
+/**
+ * Single-flight entry point. Startup, the four-hour periodic tick, and the
+ * disk-critical edge can all fire this; without coalescing, two sweeps would
+ * race to delete the same directories and each count the other's work as a
+ * failure.
+ */
+export function requestAgentCompileCacheCleanup(): Promise<AgentCompileCacheCleanupResult> {
+  if (inFlight) return inFlight;
+  inFlight = runAgentCompileCacheCleanup().finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
+}
+
+/** Fire-and-forget boot entry point. Never throws into the deferred queue. */
+export function initializeAgentCompileCacheCleanup(): void {
+  requestAgentCompileCacheCleanup().catch((err) => {
+    logError("[AgentCompileCacheCleanup] sweep threw", err);
+  });
+}

--- a/electron/services/PeriodicCleanupService.ts
+++ b/electron/services/PeriodicCleanupService.ts
@@ -22,6 +22,7 @@
 import { app, powerMonitor } from "electron";
 import { runScratchCleanup } from "./ScratchCleanupService.js";
 import { runAssistantScratchCleanup } from "./AssistantScratchService.js";
+import { requestAgentCompileCacheCleanup } from "./AgentCompileCacheCleanupService.js";
 import {
   pruneOldLogs,
   pruneHeapSnapshotsAsync,
@@ -104,6 +105,13 @@ class PeriodicCleanupService {
       await runAssistantScratchCleanup();
     } catch (err) {
       logError("[PeriodicCleanup] assistant scratch cleanup threw", err);
+    }
+    try {
+      // Agent compile caches grow only while agents run, so a long session is
+      // exactly when they outgrow their budget between boots (#11699).
+      await requestAgentCompileCacheCleanup();
+    } catch (err) {
+      logError("[PeriodicCleanup] agent compile cache cleanup threw", err);
     }
     try {
       // Re-read retention each pass — the user may change it mid-session.

--- a/electron/services/__tests__/AgentCompileCacheCleanupService.test.ts
+++ b/electron/services/__tests__/AgentCompileCacheCleanupService.test.ts
@@ -1,0 +1,352 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  app: { getPath: vi.fn(() => path.join(os.tmpdir(), "unused-userdata")) },
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  logInfo: vi.fn(),
+  logError: vi.fn(),
+}));
+
+import {
+  runAgentCompileCacheCleanup,
+  requestAgentCompileCacheCleanup,
+  type AgentCompileCacheCleanupPolicy,
+} from "../AgentCompileCacheCleanupService.js";
+
+const NOW = 1_700_000_000_000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Budgets large enough that only the TTL pass can evict. */
+const TTL_ONLY: AgentCompileCacheCleanupPolicy = {
+  ttlMs: 30 * DAY_MS,
+  maxBytes: Number.MAX_SAFE_INTEGER,
+  maxEntries: Number.MAX_SAFE_INTEGER,
+};
+
+let root: string;
+
+/**
+ * Seed one version directory with `fileCount` blobs of `fileSize` bytes, then
+ * backdate its mtime. Backdating happens last because writing a blob bumps the
+ * containing directory's mtime — the very signal the TTL pass reads.
+ */
+async function seedVersionDir(
+  agentId: string,
+  versionName: string,
+  opts: { ageDays: number; fileCount?: number; fileSize?: number }
+): Promise<string> {
+  const dir = path.join(root, agentId, versionName);
+  await fs.mkdir(dir, { recursive: true });
+  const fileCount = opts.fileCount ?? 1;
+  const fileSize = opts.fileSize ?? 16;
+  for (let i = 0; i < fileCount; i += 1) {
+    await fs.writeFile(path.join(dir, `blob-${i}`), Buffer.alloc(fileSize, 1));
+  }
+  const mtime = new Date(NOW - opts.ageDays * DAY_MS);
+  await fs.utimes(dir, mtime, mtime);
+  return dir;
+}
+
+async function exists(target: string): Promise<boolean> {
+  try {
+    await fs.stat(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-compile-cache-"));
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+describe("runAgentCompileCacheCleanup discovery", () => {
+  it("reports nothing to do when the cache root does not exist", async () => {
+    const result = await runAgentCompileCacheCleanup(
+      NOW,
+      path.join(root, "never-created"),
+      TTL_ONLY
+    );
+    expect(result.candidates).toBe(0);
+    expect(result.expiredRemoved).toBe(0);
+    expect(result.budgetRemoved).toBe(0);
+    expect(result.failed).toBe(0);
+  });
+
+  it("ignores loose files sitting directly under the root and under an agent dir", async () => {
+    await seedVersionDir("claude", "v26.0.0-arm64-abc-501", { ageDays: 1 });
+    await fs.writeFile(path.join(root, "stray.txt"), "x");
+    await fs.writeFile(path.join(root, "claude", "stray.txt"), "x");
+
+    const result = await runAgentCompileCacheCleanup(NOW, root, TTL_ONLY);
+
+    expect(result.candidates).toBe(1);
+    expect(await exists(path.join(root, "stray.txt"))).toBe(true);
+  });
+
+  it("sweeps agent directories that are no longer in the injection allowlist", async () => {
+    // A retired agent id must not strand its cache forever.
+    await seedVersionDir("retired-agent", "v22.0.0-x64-abc-501", { ageDays: 90 });
+
+    const result = await runAgentCompileCacheCleanup(NOW, root, TTL_ONLY);
+
+    expect(result.expiredRemoved).toBe(1);
+    expect(await exists(path.join(root, "retired-agent"))).toBe(false);
+  });
+});
+
+describe("runAgentCompileCacheCleanup TTL pass", () => {
+  it("removes an expired version directory and keeps a fresh sibling", async () => {
+    const stale = await seedVersionDir("claude", "v22.0.0-arm64-old-501", { ageDays: 90 });
+    const fresh = await seedVersionDir("claude", "v26.0.0-arm64-new-501", { ageDays: 1 });
+
+    const result = await runAgentCompileCacheCleanup(NOW, root, TTL_ONLY);
+
+    expect(result.expiredRemoved).toBe(1);
+    expect(await exists(stale)).toBe(false);
+    expect(await exists(fresh)).toBe(true);
+  });
+
+  it("evicts an expired directory without stat-ing any of the blobs inside it", async () => {
+    await seedVersionDir("claude", "v22.0.0-arm64-old-501", { ageDays: 90, fileCount: 25 });
+
+    const result = await runAgentCompileCacheCleanup(NOW, root, TTL_ONLY);
+
+    // The whole point of the mtime signal: expired directories cost one stat,
+    // not one per blob.
+    expect(result.expiredRemoved).toBe(1);
+    expect(result.entriesInspected).toBe(0);
+  });
+
+  it("spans agents, evicting stale directories under each independently", async () => {
+    const staleClaude = await seedVersionDir("claude", "v20-old", { ageDays: 90 });
+    const freshClaude = await seedVersionDir("claude", "v26-new", { ageDays: 2 });
+    const staleGemini = await seedVersionDir("gemini", "v20-old", { ageDays: 90 });
+
+    const result = await runAgentCompileCacheCleanup(NOW, root, TTL_ONLY);
+
+    expect(result.candidates).toBe(3);
+    expect(result.expiredRemoved).toBe(2);
+    expect(await exists(staleClaude)).toBe(false);
+    expect(await exists(staleGemini)).toBe(false);
+    expect(await exists(freshClaude)).toBe(true);
+  });
+
+  it("removes an agent directory once its last version directory is gone", async () => {
+    await seedVersionDir("gemini", "v20-old", { ageDays: 90 });
+
+    await runAgentCompileCacheCleanup(NOW, root, TTL_ONLY);
+
+    expect(await exists(path.join(root, "gemini"))).toBe(false);
+  });
+
+  it("leaves an agent directory that still holds a surviving version directory", async () => {
+    await seedVersionDir("claude", "v20-old", { ageDays: 90 });
+    await seedVersionDir("claude", "v26-new", { ageDays: 1 });
+
+    await runAgentCompileCacheCleanup(NOW, root, TTL_ONLY);
+
+    expect(await exists(path.join(root, "claude"))).toBe(true);
+  });
+});
+
+describe("runAgentCompileCacheCleanup budget pass", () => {
+  const byteBudget = (maxBytes: number): AgentCompileCacheCleanupPolicy => ({
+    ttlMs: 30 * DAY_MS,
+    maxBytes,
+    maxEntries: Number.MAX_SAFE_INTEGER,
+  });
+
+  it("evicts a fresh directory that alone exceeds the byte budget", async () => {
+    // The runtime currently in use is not exempt from the cap — this is the
+    // half of #11699 that a TTL alone cannot bound.
+    const fresh = await seedVersionDir("claude", "v26-new", {
+      ageDays: 0,
+      fileCount: 4,
+      fileSize: 100,
+    });
+
+    const result = await runAgentCompileCacheCleanup(NOW, root, byteBudget(150));
+
+    expect(result.expiredRemoved).toBe(0);
+    expect(result.budgetRemoved).toBe(1);
+    expect(await exists(fresh)).toBe(false);
+  });
+
+  it("retains the newest directories that fit and drops the rest", async () => {
+    // Each directory is 200 bytes; a 500-byte budget fits exactly two.
+    const newest = await seedVersionDir("claude", "v26", {
+      ageDays: 1,
+      fileCount: 2,
+      fileSize: 100,
+    });
+    const middle = await seedVersionDir("claude", "v24", {
+      ageDays: 2,
+      fileCount: 2,
+      fileSize: 100,
+    });
+    const oldest = await seedVersionDir("claude", "v22", {
+      ageDays: 3,
+      fileCount: 2,
+      fileSize: 100,
+    });
+
+    const result = await runAgentCompileCacheCleanup(NOW, root, byteBudget(500));
+
+    expect(result.budgetRemoved).toBe(1);
+    expect(await exists(newest)).toBe(true);
+    expect(await exists(middle)).toBe(true);
+    expect(await exists(oldest)).toBe(false);
+  });
+
+  it("ranks by recency across agents, not within each agent", async () => {
+    const newestOverall = await seedVersionDir("gemini", "v26", {
+      ageDays: 1,
+      fileCount: 2,
+      fileSize: 100,
+    });
+    const olderOtherAgent = await seedVersionDir("claude", "v22", {
+      ageDays: 5,
+      fileCount: 2,
+      fileSize: 100,
+    });
+
+    await runAgentCompileCacheCleanup(NOW, root, byteBudget(250));
+
+    expect(await exists(newestOverall)).toBe(true);
+    expect(await exists(olderOtherAgent)).toBe(false);
+  });
+
+  it("stops measuring once the budget is spent, leaving older blobs un-stat'd", async () => {
+    // 3 blobs fit the budget; the two older directories hold 50 blobs each and
+    // must be deleted without being measured.
+    await seedVersionDir("claude", "v26", { ageDays: 1, fileCount: 3, fileSize: 10 });
+    await seedVersionDir("claude", "v24", { ageDays: 2, fileCount: 50, fileSize: 10 });
+    await seedVersionDir("claude", "v22", { ageDays: 3, fileCount: 50, fileSize: 10 });
+
+    const result = await runAgentCompileCacheCleanup(NOW, root, byteBudget(30));
+
+    expect(result.budgetRemoved).toBe(2);
+    // 103 blobs exist. Bounded work means inspecting the 3 that fit plus at
+    // most the overrun that proved the next directory did not.
+    expect(result.entriesInspected).toBeLessThan(20);
+  });
+
+  it("counts files toward the entry budget independently of their size", async () => {
+    const policy: AgentCompileCacheCleanupPolicy = {
+      ttlMs: 30 * DAY_MS,
+      maxBytes: Number.MAX_SAFE_INTEGER,
+      maxEntries: 3,
+    };
+    const newest = await seedVersionDir("claude", "v26", {
+      ageDays: 1,
+      fileCount: 2,
+      fileSize: 1,
+    });
+    const older = await seedVersionDir("claude", "v22", {
+      ageDays: 2,
+      fileCount: 40,
+      fileSize: 1,
+    });
+
+    const result = await runAgentCompileCacheCleanup(NOW, root, policy);
+
+    expect(result.budgetRemoved).toBe(1);
+    expect(await exists(newest)).toBe(true);
+    expect(await exists(older)).toBe(false);
+  });
+
+  it("evicts a version directory holding an unexpected nested subdirectory", async () => {
+    // The flat layout is what makes the directory measurable; anything nested
+    // is unmeasurable and must not escape the budget by being skipped.
+    const dir = await seedVersionDir("claude", "v26", { ageDays: 1, fileCount: 1, fileSize: 1 });
+    await fs.mkdir(path.join(dir, "unexpected"));
+
+    const result = await runAgentCompileCacheCleanup(
+      NOW,
+      root,
+      byteBudget(Number.MAX_SAFE_INTEGER)
+    );
+
+    expect(result.budgetRemoved).toBe(1);
+    expect(await exists(dir)).toBe(false);
+  });
+
+  it("leaves everything in place when the whole cache fits", async () => {
+    const a = await seedVersionDir("claude", "v26", { ageDays: 1, fileCount: 2, fileSize: 10 });
+    const b = await seedVersionDir("claude", "v22", { ageDays: 2, fileCount: 2, fileSize: 10 });
+
+    const result = await runAgentCompileCacheCleanup(NOW, root, byteBudget(10_000));
+
+    expect(result.expiredRemoved).toBe(0);
+    expect(result.budgetRemoved).toBe(0);
+    expect(await exists(a)).toBe(true);
+    expect(await exists(b)).toBe(true);
+  });
+});
+
+describe("runAgentCompileCacheCleanup failure isolation", () => {
+  it("counts a failed removal and still evicts the other candidates", async () => {
+    const doomed = await seedVersionDir("claude", "v20-locked", { ageDays: 90 });
+    const alsoDoomed = await seedVersionDir("claude", "v21-old", { ageDays: 90 });
+
+    const realRm = fs.rm;
+    vi.spyOn(fs, "rm").mockImplementation(async (target, options) => {
+      if (target === doomed) {
+        // Stand in for a Windows lock on a blob a live agent still holds open.
+        const err: NodeJS.ErrnoException = new Error("EBUSY: resource busy or locked");
+        err.code = "EBUSY";
+        throw err;
+      }
+      return realRm(target as string, options);
+    });
+
+    const result = await runAgentCompileCacheCleanup(NOW, root, TTL_ONLY);
+
+    expect(result.failed).toBe(1);
+    expect(result.expiredRemoved).toBe(1);
+    expect(await exists(doomed)).toBe(true);
+    expect(await exists(alsoDoomed)).toBe(false);
+  });
+
+  it("is idempotent — a second sweep over the reclaimed tree does nothing", async () => {
+    await seedVersionDir("claude", "v20-old", { ageDays: 90 });
+    await seedVersionDir("claude", "v26-new", { ageDays: 1 });
+
+    const first = await runAgentCompileCacheCleanup(NOW, root, TTL_ONLY);
+    const second = await runAgentCompileCacheCleanup(NOW, root, TTL_ONLY);
+
+    expect(first.expiredRemoved).toBe(1);
+    expect(second.expiredRemoved).toBe(0);
+    expect(second.failed).toBe(0);
+    expect(second.candidates).toBe(1);
+  });
+});
+
+describe("requestAgentCompileCacheCleanup", () => {
+  it("coalesces overlapping callers onto one sweep, then allows a later one", async () => {
+    // Startup, the periodic tick, and the disk-critical edge can all fire at
+    // once; two concurrent sweeps would race to delete the same directories
+    // and each count the other's work as a failure.
+    const a = requestAgentCompileCacheCleanup();
+    const b = requestAgentCompileCacheCleanup();
+    expect(a).toBe(b);
+
+    await a;
+
+    const c = requestAgentCompileCacheCleanup();
+    expect(c).not.toBe(a);
+    await c;
+  });
+});

--- a/electron/services/__tests__/AgentCompileCacheCleanupService.test.ts
+++ b/electron/services/__tests__/AgentCompileCacheCleanupService.test.ts
@@ -100,6 +100,26 @@ describe("runAgentCompileCacheCleanup discovery", () => {
     expect(await exists(path.join(root, "claude", "stray.txt"))).toBe(true);
   });
 
+  it("never descends through a symlinked agent directory", async () => {
+    // The sweep deletes recursively, so an agent entry that is a symlink must
+    // never become an intermediate path component — it would take `fs.rm`
+    // straight out of the cache root.
+    const outside = path.join(root, "..", `outside-${path.basename(root)}`);
+    await fs.mkdir(path.join(outside, "v20-old"), { recursive: true });
+    const ancient = new Date(NOW - 400 * DAY_MS);
+    await fs.utimes(path.join(outside, "v20-old"), ancient, ancient);
+    await fs.symlink(outside, path.join(root, "claude"));
+
+    try {
+      const result = await runAgentCompileCacheCleanup(NOW, root, TTL_ONLY);
+
+      expect(result.candidates).toBe(0);
+      expect(await exists(path.join(outside, "v20-old"))).toBe(true);
+    } finally {
+      await fs.rm(outside, { recursive: true, force: true });
+    }
+  });
+
   it("sweeps agent directories that are no longer in the injection allowlist", async () => {
     // A retired agent id must not strand its cache forever.
     await seedVersionDir("retired-agent", "v22.0.0-x64-abc-501", { ageDays: 90 });

--- a/electron/services/__tests__/AgentCompileCacheCleanupService.test.ts
+++ b/electron/services/__tests__/AgentCompileCacheCleanupService.test.ts
@@ -2,10 +2,13 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+import { app } from "electron";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("electron", () => ({
-  app: { getPath: vi.fn(() => path.join(os.tmpdir(), "unused-userdata")) },
+  // Per-process so a concurrent suite cannot target the same tree; individual
+  // tests that exercise the default root point this at their own temp dir.
+  app: { getPath: vi.fn(() => path.join(os.tmpdir(), `unused-userdata-${process.pid}`)) },
 }));
 
 vi.mock("../../utils/logger.js", () => ({
@@ -18,6 +21,7 @@ import {
   requestAgentCompileCacheCleanup,
   type AgentCompileCacheCleanupPolicy,
 } from "../AgentCompileCacheCleanupService.js";
+import { AGENT_COMPILE_CACHE_TTL_DAYS } from "../../../shared/config/agentCompileCache.js";
 
 const NOW = 1_700_000_000_000;
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -93,6 +97,7 @@ describe("runAgentCompileCacheCleanup discovery", () => {
 
     expect(result.candidates).toBe(1);
     expect(await exists(path.join(root, "stray.txt"))).toBe(true);
+    expect(await exists(path.join(root, "claude", "stray.txt"))).toBe(true);
   });
 
   it("sweeps agent directories that are no longer in the injection allowlist", async () => {
@@ -153,11 +158,40 @@ describe("runAgentCompileCacheCleanup TTL pass", () => {
 
   it("leaves an agent directory that still holds a surviving version directory", async () => {
     await seedVersionDir("claude", "v20-old", { ageDays: 90 });
-    await seedVersionDir("claude", "v26-new", { ageDays: 1 });
+    const fresh = await seedVersionDir("claude", "v26-new", { ageDays: 1 });
 
     await runAgentCompileCacheCleanup(NOW, root, TTL_ONLY);
 
+    expect(await exists(fresh)).toBe(true);
     expect(await exists(path.join(root, "claude"))).toBe(true);
+  });
+
+  it("removes an agent directory that holds no version directories at all", async () => {
+    // Nothing else in the sweep would ever visit it.
+    await fs.mkdir(path.join(root, "orphan"), { recursive: true });
+
+    const result = await runAgentCompileCacheCleanup(NOW, root, TTL_ONLY);
+
+    expect(result.candidates).toBe(0);
+    expect(await exists(path.join(root, "orphan"))).toBe(false);
+  });
+
+  it("applies the TTL derived from the shared policy when none is injected", async () => {
+    // Exercises DEFAULT_AGENT_COMPILE_CACHE_POLICY rather than an injected one:
+    // ages are derived from the exported constant, so a swapped or mis-wired
+    // field fails here instead of passing silently.
+    const stale = await seedVersionDir("claude", "v20-old", {
+      ageDays: AGENT_COMPILE_CACHE_TTL_DAYS + 5,
+    });
+    const fresh = await seedVersionDir("claude", "v26-new", {
+      ageDays: AGENT_COMPILE_CACHE_TTL_DAYS - 5,
+    });
+
+    const result = await runAgentCompileCacheCleanup(NOW, root);
+
+    expect(result.expiredRemoved).toBe(1);
+    expect(await exists(stale)).toBe(false);
+    expect(await exists(fresh)).toBe(true);
   });
 });
 
@@ -238,9 +272,11 @@ describe("runAgentCompileCacheCleanup budget pass", () => {
     const result = await runAgentCompileCacheCleanup(NOW, root, byteBudget(30));
 
     expect(result.budgetRemoved).toBe(2);
-    // 103 blobs exist. Bounded work means inspecting the 3 that fit plus at
-    // most the overrun that proved the next directory did not.
-    expect(result.entriesInspected).toBeLessThan(20);
+    // 103 blobs exist, but the count is deterministic: v26's 3 blobs exactly
+    // fill the 30-byte budget, v24's first blob proves the zero remainder is
+    // blown, and v22 is never opened. Every blob is the same size, so readdir
+    // order cannot change this.
+    expect(result.entriesInspected).toBe(4);
   });
 
   it("counts files toward the entry budget independently of their size", async () => {
@@ -281,6 +317,130 @@ describe("runAgentCompileCacheCleanup budget pass", () => {
 
     expect(result.budgetRemoved).toBe(1);
     expect(await exists(dir)).toBe(false);
+  });
+
+  it("does not evict older caches when the newest directory vanishes mid-sweep", async () => {
+    // A directory disappearing is not evidence that it was too big. Conflating
+    // the two would latch the budget pass and wipe every older cache behind it.
+    const vanishing = await seedVersionDir("claude", "v26", {
+      ageDays: 1,
+      fileCount: 1,
+      fileSize: 10,
+    });
+    const older = await seedVersionDir("claude", "v22", { ageDays: 2, fileCount: 1, fileSize: 10 });
+
+    const realOpendir = fs.opendir;
+    vi.spyOn(fs, "opendir").mockImplementation(async (target, options) => {
+      if (target === vanishing) {
+        const err: NodeJS.ErrnoException = new Error("ENOENT: no such file or directory");
+        err.code = "ENOENT";
+        throw err;
+      }
+      return realOpendir(target as string, options);
+    });
+
+    const result = await runAgentCompileCacheCleanup(NOW, root, byteBudget(10_000));
+
+    expect(result.budgetRemoved).toBe(0);
+    expect(await exists(older)).toBe(true);
+  });
+
+  it("evicts a directory whose blob size cannot be read rather than counting it as zero", async () => {
+    // An unreadable blob of unknown size must not be treated as free, or an
+    // arbitrarily large one sits inside the budget forever.
+    const unreadable = await seedVersionDir("claude", "v26", {
+      ageDays: 1,
+      fileCount: 1,
+      fileSize: 10,
+    });
+    const older = await seedVersionDir("claude", "v22", { ageDays: 2, fileCount: 1, fileSize: 10 });
+
+    const realLstat = fs.lstat;
+    vi.spyOn(fs, "lstat").mockImplementation(async (target, options) => {
+      if (typeof target === "string" && target.startsWith(unreadable + path.sep)) {
+        const err: NodeJS.ErrnoException = new Error("EACCES: permission denied");
+        err.code = "EACCES";
+        throw err;
+      }
+      return realLstat(target as string, options);
+    });
+
+    const result = await runAgentCompileCacheCleanup(NOW, root, byteBudget(10_000));
+
+    expect(result.budgetRemoved).toBeGreaterThanOrEqual(1);
+    expect(await exists(unreadable)).toBe(false);
+    // The unmeasurable directory latches the pass, so the older one goes too.
+    expect(await exists(older)).toBe(false);
+  });
+
+  it("applies the TTL first and budgets only the survivors", async () => {
+    // A regression that stopped after the TTL pass, or that charged the expired
+    // directory's bytes against the survivor budget, would fail here.
+    const expired = await seedVersionDir("claude", "v18", {
+      ageDays: 90,
+      fileCount: 50,
+      fileSize: 100,
+    });
+    const newest = await seedVersionDir("claude", "v26", {
+      ageDays: 1,
+      fileCount: 2,
+      fileSize: 100,
+    });
+    const middle = await seedVersionDir("claude", "v24", {
+      ageDays: 2,
+      fileCount: 2,
+      fileSize: 100,
+    });
+    const oldestFresh = await seedVersionDir("claude", "v22", {
+      ageDays: 3,
+      fileCount: 2,
+      fileSize: 100,
+    });
+
+    const result = await runAgentCompileCacheCleanup(NOW, root, byteBudget(500));
+
+    expect(result.expiredRemoved).toBe(1);
+    expect(result.budgetRemoved).toBe(1);
+    expect(await exists(expired)).toBe(false);
+    expect(await exists(newest)).toBe(true);
+    expect(await exists(middle)).toBe(true);
+    expect(await exists(oldestFresh)).toBe(false);
+  });
+
+  it("counts a failed over-budget removal and still removes the rest", async () => {
+    const newest = await seedVersionDir("claude", "v26", {
+      ageDays: 1,
+      fileCount: 1,
+      fileSize: 100,
+    });
+    const locked = await seedVersionDir("claude", "v24", {
+      ageDays: 2,
+      fileCount: 1,
+      fileSize: 100,
+    });
+    const oldest = await seedVersionDir("claude", "v22", {
+      ageDays: 3,
+      fileCount: 1,
+      fileSize: 100,
+    });
+
+    const realRm = fs.rm;
+    vi.spyOn(fs, "rm").mockImplementation(async (target, options) => {
+      if (target === locked) {
+        const err: NodeJS.ErrnoException = new Error("EPERM: operation not permitted");
+        err.code = "EPERM";
+        throw err;
+      }
+      return realRm(target as string, options);
+    });
+
+    const result = await runAgentCompileCacheCleanup(NOW, root, byteBudget(100));
+
+    expect(result.failed).toBe(1);
+    expect(result.budgetRemoved).toBe(1);
+    expect(await exists(newest)).toBe(true);
+    expect(await exists(locked)).toBe(true);
+    expect(await exists(oldest)).toBe(false);
   });
 
   it("leaves everything in place when the whole cache fits", async () => {
@@ -339,14 +499,26 @@ describe("requestAgentCompileCacheCleanup", () => {
     // Startup, the periodic tick, and the disk-critical edge can all fire at
     // once; two concurrent sweeps would race to delete the same directories
     // and each count the other's work as a failure.
-    const a = requestAgentCompileCacheCleanup();
-    const b = requestAgentCompileCacheCleanup();
-    expect(a).toBe(b);
+    //
+    // Counting sweeps rather than comparing promise identity: an
+    // implementation that returned distinct promises while running one sweep
+    // would still be correct, and one that returned the cached promise while
+    // secretly starting a second sweep would not.
+    const userData = path.join(root, "userdata");
+    await fs.mkdir(path.join(userData, "agent-compile-cache", "claude"), { recursive: true });
+    vi.mocked(app.getPath).mockReturnValue(userData);
 
-    await a;
+    let sweeps = 0;
+    const realOpendir = fs.opendir;
+    vi.spyOn(fs, "opendir").mockImplementation(async (target, options) => {
+      if (target === path.join(userData, "agent-compile-cache")) sweeps += 1;
+      return realOpendir(target as string, options);
+    });
 
-    const c = requestAgentCompileCacheCleanup();
-    expect(c).not.toBe(a);
-    await c;
+    await Promise.all([requestAgentCompileCacheCleanup(), requestAgentCompileCacheCleanup()]);
+    expect(sweeps).toBe(1);
+
+    await requestAgentCompileCacheCleanup();
+    expect(sweeps).toBe(2);
   });
 });

--- a/electron/services/__tests__/PeriodicCleanupService.test.ts
+++ b/electron/services/__tests__/PeriodicCleanupService.test.ts
@@ -10,6 +10,7 @@ const mockApp = vi.hoisted(() => ({
 
 const mockRunScratchCleanup = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const mockRunAssistantScratchCleanup = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockRequestAgentCompileCacheCleanup = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const mockPruneOldLogs = vi.hoisted(() => vi.fn());
 const mockPruneHeapSnapshotsAsync = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const mockPruneAuditByRetention = vi.hoisted(() => vi.fn());
@@ -34,6 +35,10 @@ vi.mock("../ScratchCleanupService.js", () => ({
 
 vi.mock("../AssistantScratchService.js", () => ({
   runAssistantScratchCleanup: mockRunAssistantScratchCleanup,
+}));
+
+vi.mock("../AgentCompileCacheCleanupService.js", () => ({
+  requestAgentCompileCacheCleanup: mockRequestAgentCompileCacheCleanup,
 }));
 
 vi.mock("../../utils/logger.js", () => ({
@@ -63,6 +68,7 @@ describe("PeriodicCleanupService", () => {
     mockApp.getPath.mockImplementation((name: string) => `/fake/${name}`);
     mockRunScratchCleanup.mockResolvedValue(undefined);
     mockRunAssistantScratchCleanup.mockResolvedValue(undefined);
+    mockRequestAgentCompileCacheCleanup.mockResolvedValue(undefined);
     mockPruneHeapSnapshotsAsync.mockResolvedValue(undefined);
     mockStoreGet.mockImplementation(storeGetByKey);
   });
@@ -75,6 +81,7 @@ describe("PeriodicCleanupService", () => {
   function expectNoRoutinesRan() {
     expect(mockRunScratchCleanup).not.toHaveBeenCalled();
     expect(mockRunAssistantScratchCleanup).not.toHaveBeenCalled();
+    expect(mockRequestAgentCompileCacheCleanup).not.toHaveBeenCalled();
     expect(mockPruneOldLogs).not.toHaveBeenCalled();
     expect(mockPruneHeapSnapshotsAsync).not.toHaveBeenCalled();
   }
@@ -82,6 +89,7 @@ describe("PeriodicCleanupService", () => {
   function expectAllRoutinesRan() {
     expect(mockRunScratchCleanup).toHaveBeenCalledTimes(1);
     expect(mockRunAssistantScratchCleanup).toHaveBeenCalledTimes(1);
+    expect(mockRequestAgentCompileCacheCleanup).toHaveBeenCalledTimes(1);
     expect(mockPruneOldLogs).toHaveBeenCalledTimes(1);
     expect(mockPruneHeapSnapshotsAsync).toHaveBeenCalledTimes(1);
   }
@@ -155,6 +163,17 @@ describe("PeriodicCleanupService", () => {
     expect(mockRunScratchCleanup).toHaveBeenCalledTimes(1);
     expect(mockRunAssistantScratchCleanup).toHaveBeenCalledTimes(1);
     expect(mockPruneOldLogs).toHaveBeenCalledTimes(1);
+    service.dispose();
+  });
+
+  it("isolates a failing compile-cache sweep from the routines that follow it", async () => {
+    mockRequestAgentCompileCacheCleanup.mockRejectedValue(new Error("EBUSY"));
+    const service = new PeriodicCleanupService();
+    await service.tick();
+
+    expect(mockRequestAgentCompileCacheCleanup).toHaveBeenCalledTimes(1);
+    expect(mockPruneOldLogs).toHaveBeenCalledTimes(1);
+    expect(mockPruneHeapSnapshotsAsync).toHaveBeenCalledTimes(1);
     service.dispose();
   });
 

--- a/electron/services/__tests__/agentCompileCachePaths.test.ts
+++ b/electron/services/__tests__/agentCompileCachePaths.test.ts
@@ -1,0 +1,49 @@
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { getAgentCompileCacheDir, getAgentCompileCacheRoot } from "../agentCompileCachePaths.js";
+
+const USER_DATA = path.join(path.sep, "tmp", "userdata");
+
+describe("getAgentCompileCacheRoot", () => {
+  it("resolves under the supplied userData path rather than a process global", () => {
+    const a = getAgentCompileCacheRoot(path.join(path.sep, "one"));
+    const b = getAgentCompileCacheRoot(path.join(path.sep, "two"));
+    expect(a).not.toBe(b);
+    expect(path.dirname(a)).toBe(path.join(path.sep, "one"));
+    expect(path.dirname(b)).toBe(path.join(path.sep, "two"));
+  });
+});
+
+describe("getAgentCompileCacheDir", () => {
+  it("nests the agent id directly beneath the cache root", () => {
+    const dir = getAgentCompileCacheDir(USER_DATA, "claude");
+    expect(dir).not.toBeNull();
+    expect(path.dirname(dir!)).toBe(getAgentCompileCacheRoot(USER_DATA));
+    expect(path.basename(dir!)).toBe("claude");
+  });
+
+  it.each([
+    ["parent traversal", ".."],
+    ["nested traversal", path.join("..", "..", "etc")],
+    ["traversal through a valid segment", path.join("claude", "..", "..", "escape")],
+    ["separator-bearing id", path.join("claude", "nested")],
+    ["empty id", ""],
+  ])("returns null for %s", (_label, agentId) => {
+    expect(getAgentCompileCacheDir(USER_DATA, agentId)).toBeNull();
+  });
+
+  it("returns null for an id that resolves to the root itself", () => {
+    expect(getAgentCompileCacheDir(USER_DATA, ".")).toBeNull();
+  });
+
+  it("keeps every accepted id strictly inside the root", () => {
+    const root = getAgentCompileCacheRoot(USER_DATA);
+    for (const agentId of ["claude", "gemini", "agent.with.dots", "agent-with-dash"]) {
+      const dir = getAgentCompileCacheDir(USER_DATA, agentId);
+      expect(dir).not.toBeNull();
+      expect(dir!.startsWith(root + path.sep)).toBe(true);
+    }
+  });
+});

--- a/electron/services/__tests__/agentCompileCachePaths.test.ts
+++ b/electron/services/__tests__/agentCompileCachePaths.test.ts
@@ -44,6 +44,7 @@ describe("getAgentCompileCacheDir", () => {
     ["a trailing forward slash", "claude/"],
     ["a trailing backslash", "claude\\"],
     ["an embedded NUL", "claude\0evil"],
+    ["a Windows drive-relative id", "C:claude"],
   ])("returns null for %s", (_label, agentId) => {
     expect(getAgentCompileCacheDir(USER_DATA, agentId)).toBeNull();
   });

--- a/electron/services/__tests__/agentCompileCachePaths.test.ts
+++ b/electron/services/__tests__/agentCompileCachePaths.test.ts
@@ -30,12 +30,22 @@ describe("getAgentCompileCacheDir", () => {
     ["traversal through a valid segment", path.join("claude", "..", "..", "escape")],
     ["separator-bearing id", path.join("claude", "nested")],
     ["empty id", ""],
+    ["the current directory", "."],
   ])("returns null for %s", (_label, agentId) => {
     expect(getAgentCompileCacheDir(USER_DATA, agentId)).toBeNull();
   });
 
-  it("returns null for an id that resolves to the root itself", () => {
-    expect(getAgentCompileCacheDir(USER_DATA, ".")).toBeNull();
+  // These all normalize to the same immediate child as a bare `claude`, so a
+  // containment-only check would accept them and let one agent own several
+  // spellings of its cache directory.
+  it.each([
+    ["a leading current-dir segment", "./claude"],
+    ["an absolute id", "/claude"],
+    ["a trailing forward slash", "claude/"],
+    ["a trailing backslash", "claude\\"],
+    ["an embedded NUL", "claude\0evil"],
+  ])("returns null for %s", (_label, agentId) => {
+    expect(getAgentCompileCacheDir(USER_DATA, agentId)).toBeNull();
   });
 
   it("keeps every accepted id strictly inside the root", () => {

--- a/electron/services/agentCompileCachePaths.ts
+++ b/electron/services/agentCompileCachePaths.ts
@@ -31,8 +31,10 @@ export function getAgentCompileCacheDir(userDataPath: string, agentId: string): 
   // Reject on the RAW id, before normalization: `./claude`, `/claude` and
   // `claude/` all normalize to the same immediate child as `claude`, so a
   // containment check alone would silently accept several spellings of one
-  // agent — different ids mapping to one cache directory.
-  if (/[/\\\0]/.test(agentId) || agentId === "." || agentId === "..") return null;
+  // agent — different ids mapping to one cache directory. The colon covers
+  // Windows drive-relative ids like `C:claude`, which is not a portable
+  // directory component at all.
+  if (/[/\\:\0]/.test(agentId) || agentId === "." || agentId === "..") return null;
   const root = path.normalize(getAgentCompileCacheRoot(userDataPath));
   const candidate = path.normalize(path.join(root, agentId));
   if (!candidate.startsWith(root + path.sep)) return null;

--- a/electron/services/agentCompileCachePaths.ts
+++ b/electron/services/agentCompileCachePaths.ts
@@ -1,0 +1,36 @@
+/**
+ * Path accessors for the per-agent compile cache.
+ *
+ * Imports `node:path` and nothing else. `buildTerminalEnv` — the sole writer —
+ * runs in the pty-host UtilityProcess where `electron` is unavailable, so this
+ * module must never reach for `app.getPath`. Callers supply the userData root:
+ * Main from `app.getPath("userData")`, the pty-host from `DAINTREE_USER_DATA`
+ * (forwarded from that same value in `PtyHostLifecycle`, so the two agree).
+ */
+import path from "node:path";
+import { AGENT_COMPILE_CACHE_DIRNAME } from "../../shared/config/agentCompileCache.js";
+
+export function getAgentCompileCacheRoot(userDataPath: string): string {
+  return path.join(userDataPath, AGENT_COMPILE_CACHE_DIRNAME);
+}
+
+/**
+ * Resolve one agent's cache directory, or `null` when `agentId` is not a plain
+ * directory name. Agent ids reach the spawn path from plugin manifests and
+ * persisted launch config, so they are treated as untrusted.
+ *
+ * The check is that the result is an *immediate* child of the root, which is
+ * stricter than `getScratchDir`'s containment test and necessarily so:
+ * containment alone accepts `claude/nested` and `/etc/passwd`, both of which
+ * land inside the root while putting the cleanup sweep's per-agent assumptions
+ * (one level of agent dirs, one level of version dirs) out of step with the
+ * write path.
+ */
+export function getAgentCompileCacheDir(userDataPath: string, agentId: string): string | null {
+  if (typeof agentId !== "string" || agentId.length === 0) return null;
+  const root = path.normalize(getAgentCompileCacheRoot(userDataPath));
+  const candidate = path.normalize(path.join(root, agentId));
+  if (!candidate.startsWith(root + path.sep)) return null;
+  if (path.dirname(candidate) !== root) return null;
+  return candidate;
+}

--- a/electron/services/agentCompileCachePaths.ts
+++ b/electron/services/agentCompileCachePaths.ts
@@ -28,6 +28,11 @@ export function getAgentCompileCacheRoot(userDataPath: string): string {
  */
 export function getAgentCompileCacheDir(userDataPath: string, agentId: string): string | null {
   if (typeof agentId !== "string" || agentId.length === 0) return null;
+  // Reject on the RAW id, before normalization: `./claude`, `/claude` and
+  // `claude/` all normalize to the same immediate child as `claude`, so a
+  // containment check alone would silently accept several spellings of one
+  // agent — different ids mapping to one cache directory.
+  if (/[/\\\0]/.test(agentId) || agentId === "." || agentId === "..") return null;
   const root = path.normalize(getAgentCompileCacheRoot(userDataPath));
   const candidate = path.normalize(path.join(root, agentId));
   if (!candidate.startsWith(root + path.sep)) return null;

--- a/electron/services/pty/terminalSpawn.ts
+++ b/electron/services/pty/terminalSpawn.ts
@@ -18,6 +18,7 @@ import {
 } from "../PtyPool.js";
 import { markHostPerformance } from "../../utils/hostPerformance.js";
 import { PERF_MARKS } from "../../../shared/perf/marks.js";
+import { getAgentCompileCacheDir } from "../agentCompileCachePaths.js";
 
 // Agent CLIs that ship as Node binaries and benefit from V8 bytecode
 // caching across launches. Codex is a Rust binary and would silently
@@ -118,6 +119,8 @@ export function buildTerminalEnv(
   // version + V8 flags so a single dir is safe across runtime upgrades.
   // Only set when DAINTREE_USER_DATA is available (production) and the
   // caller has not provided an explicit override via intentionalEnv.
+  // Node never evicts what it writes here — `AgentCompileCacheCleanupService`
+  // in Main bounds the tree (#11699).
   const userData = process.env.DAINTREE_USER_DATA;
   const launchAgentId = options.launchAgentId;
   if (
@@ -126,7 +129,8 @@ export function buildTerminalEnv(
     NODE_COMPILE_CACHE_AGENTS.has(launchAgentId) &&
     mergedEnv.NODE_COMPILE_CACHE === undefined
   ) {
-    mergedEnv.NODE_COMPILE_CACHE = path.join(userData, "agent-compile-cache", launchAgentId);
+    const cacheDir = getAgentCompileCacheDir(userData, launchAgentId);
+    if (cacheDir) mergedEnv.NODE_COMPILE_CACHE = cacheDir;
   }
 
   return ensureUtf8Locale(mergedEnv);

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -893,32 +893,48 @@ describe("initGlobalServices task ordering", () => {
     expect(spy).toHaveBeenCalled();
   });
 
-  it("reclaims the agent compile cache on the disk-critical edge only (#11699)", async () => {
+  /**
+   * Register a fresh disk-space monitor and return the options IT was given.
+   * Clearing the monitor ref first is load-bearing: the task short-circuits on
+   * an already-installed monitor, so without this a later test reads an
+   * earlier test's callback out of the mock instead of its own.
+   */
+  async function captureDiskMonitorOptions(): Promise<{
+    onCriticalChange: (isCritical: boolean) => void;
+  }> {
+    const { setStopDiskSpaceMonitor } = await import("../serviceRefs.js");
     const { startDiskSpaceMonitor } = await import("../../services/DiskSpaceMonitor.js");
+    const startSpy = startDiskSpaceMonitor as ReturnType<typeof vi.fn>;
+    setStopDiskSpaceMonitor(null);
+    startSpy.mockClear();
+
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+    const monitorRun = registeredTaskRuns.get("disk-space-monitor");
+    expect(monitorRun).toBeDefined();
+    await monitorRun!();
+
+    expect(startSpy).toHaveBeenCalledTimes(1);
+    return startSpy.mock.calls[0][0];
+  }
+
+  it("reclaims the agent compile cache on the disk-critical edge only (#11699)", async () => {
     const { requestAgentCompileCacheCleanup } =
       await import("../../services/AgentCompileCacheCleanupService.js");
     const requestSpy = requestAgentCompileCacheCleanup as ReturnType<typeof vi.fn>;
     requestSpy.mockClear();
 
-    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
-    await initGlobalServices(fakeRegistry);
+    const monitorOptions = await captureDiskMonitorOptions();
 
-    const monitorRun = registeredTaskRuns.get("disk-space-monitor");
-    expect(monitorRun).toBeDefined();
-    await monitorRun!();
-
-    const monitorArgs = (startDiskSpaceMonitor as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0];
-    expect(monitorArgs?.onCriticalChange).toBeTypeOf("function");
-
-    monitorArgs.onCriticalChange(false);
+    // Recovering from pressure must not start a sweep.
+    monitorOptions.onCriticalChange(false);
     expect(requestSpy).not.toHaveBeenCalled();
 
-    monitorArgs.onCriticalChange(true);
+    monitorOptions.onCriticalChange(true);
     expect(requestSpy).toHaveBeenCalledTimes(1);
   });
 
   it("logs but does not reject when the disk-critical compile cache sweep fails", async () => {
-    const { startDiskSpaceMonitor } = await import("../../services/DiskSpaceMonitor.js");
     const { requestAgentCompileCacheCleanup } =
       await import("../../services/AgentCompileCacheCleanupService.js");
     const { logError } = await import("../../utils/logger.js");
@@ -926,24 +942,20 @@ describe("initGlobalServices task ordering", () => {
     const logErrorSpy = logError as ReturnType<typeof vi.fn>;
     requestSpy.mockClear();
     logErrorSpy.mockClear();
-    requestSpy.mockRejectedValueOnce(new Error("EBUSY"));
+    const sweepError = new Error("EBUSY");
+    requestSpy.mockRejectedValueOnce(sweepError);
 
-    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
-    await initGlobalServices(fakeRegistry);
-    const monitorRun = registeredTaskRuns.get("disk-space-monitor");
-    await monitorRun!();
+    const monitorOptions = await captureDiskMonitorOptions();
+    // The callback is synchronous fire-and-forget, so the rejection has to be
+    // caught at the call site or it escapes as an unhandled rejection.
+    monitorOptions.onCriticalChange(true);
 
-    const monitorArgs = (startDiskSpaceMonitor as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0];
-    // The callback is synchronous and fire-and-forget: a rejected sweep must be
-    // caught here or it surfaces as an unhandled rejection.
-    expect(() => monitorArgs.onCriticalChange(true)).not.toThrow();
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(logErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("agent compile cache cleanup threw"),
-      expect.any(Error)
-    );
+    await vi.waitFor(() => {
+      expect(logErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("agent compile cache cleanup threw"),
+        sweepError
+      );
+    });
   });
 
   it("prune-old-logs task invokes pruneOldLogsAsync with retentionDays from privacy settings", async () => {

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -194,12 +194,23 @@ vi.mock("../../services/TrashedPidTracker.js", () => ({
   initializeTrashedPidCleanup: vi.fn(),
 }));
 
+// `runScratchCleanup`/`runAssistantScratchCleanup` are also imported by
+// globalServicesInit for the disk-critical edge. A factory that omits them
+// throws only when that edge is actually exercised, so they must be present
+// for the onCriticalChange tests below.
 vi.mock("../../services/ScratchCleanupService.js", () => ({
   initializeScratchCleanup: vi.fn(),
+  runScratchCleanup: vi.fn(async () => {}),
 }));
 
 vi.mock("../../services/AssistantScratchService.js", () => ({
   startAssistantScratchCleanup: vi.fn(async () => {}),
+  runAssistantScratchCleanup: vi.fn(async () => {}),
+}));
+
+vi.mock("../../services/AgentCompileCacheCleanupService.js", () => ({
+  initializeAgentCompileCacheCleanup: vi.fn(),
+  requestAgentCompileCacheCleanup: vi.fn(async () => {}),
 }));
 
 // GpuCrashMonitorService is NOT a deferred task — it stays eager pre-window in
@@ -801,6 +812,7 @@ describe("initGlobalServices task ordering", () => {
     expect(registeredTaskNames).toContain("trashed-pid-cleanup");
     expect(registeredTaskNames).toContain("scratch-cleanup");
     expect(registeredTaskNames).toContain("assistant-scratch-cleanup");
+    expect(registeredTaskNames).toContain("agent-compile-cache-cleanup");
     // GpuCrashMonitor is intentionally NOT a deferred task — it must stay
     // eager in main.ts so the child-process-gone listener installs before
     // GPU process spawn. Deferring it would silently drop startup-window
@@ -859,6 +871,79 @@ describe("initGlobalServices task ordering", () => {
     expect(trashedSpy).toHaveBeenCalled();
     expect(scratchSpy).toHaveBeenCalled();
     expect(assistantSpy).toHaveBeenCalled();
+  });
+
+  it("defers the agent compile cache sweep rather than running it during init (#11699)", async () => {
+    const { initializeAgentCompileCacheCleanup } =
+      await import("../../services/AgentCompileCacheCleanupService.js");
+    const spy = initializeAgentCompileCacheCleanup as ReturnType<typeof vi.fn>;
+    spy.mockClear();
+
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    // The first sweep on an affected install can delete gigabytes, so it must
+    // not run on the boot-critical path.
+    expect(spy).not.toHaveBeenCalled();
+
+    const run = registeredTaskRuns.get("agent-compile-cache-cleanup");
+    expect(run).toBeDefined();
+    await run!();
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("reclaims the agent compile cache on the disk-critical edge only (#11699)", async () => {
+    const { startDiskSpaceMonitor } = await import("../../services/DiskSpaceMonitor.js");
+    const { requestAgentCompileCacheCleanup } =
+      await import("../../services/AgentCompileCacheCleanupService.js");
+    const requestSpy = requestAgentCompileCacheCleanup as ReturnType<typeof vi.fn>;
+    requestSpy.mockClear();
+
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    const monitorRun = registeredTaskRuns.get("disk-space-monitor");
+    expect(monitorRun).toBeDefined();
+    await monitorRun!();
+
+    const monitorArgs = (startDiskSpaceMonitor as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0];
+    expect(monitorArgs?.onCriticalChange).toBeTypeOf("function");
+
+    monitorArgs.onCriticalChange(false);
+    expect(requestSpy).not.toHaveBeenCalled();
+
+    monitorArgs.onCriticalChange(true);
+    expect(requestSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs but does not reject when the disk-critical compile cache sweep fails", async () => {
+    const { startDiskSpaceMonitor } = await import("../../services/DiskSpaceMonitor.js");
+    const { requestAgentCompileCacheCleanup } =
+      await import("../../services/AgentCompileCacheCleanupService.js");
+    const { logError } = await import("../../utils/logger.js");
+    const requestSpy = requestAgentCompileCacheCleanup as ReturnType<typeof vi.fn>;
+    const logErrorSpy = logError as ReturnType<typeof vi.fn>;
+    requestSpy.mockClear();
+    logErrorSpy.mockClear();
+    requestSpy.mockRejectedValueOnce(new Error("EBUSY"));
+
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+    const monitorRun = registeredTaskRuns.get("disk-space-monitor");
+    await monitorRun!();
+
+    const monitorArgs = (startDiskSpaceMonitor as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0];
+    // The callback is synchronous and fire-and-forget: a rejected sweep must be
+    // caught here or it surfaces as an unhandled rejection.
+    expect(() => monitorArgs.onCriticalChange(true)).not.toThrow();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(logErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("agent compile cache cleanup threw"),
+      expect.any(Error)
+    );
   });
 
   it("prune-old-logs task invokes pruneOldLogsAsync with retentionDays from privacy settings", async () => {

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -42,6 +42,10 @@ import {
 
 import { startDiskSpaceMonitor } from "../services/DiskSpaceMonitor.js";
 import { runScratchCleanup } from "../services/ScratchCleanupService.js";
+import {
+  initializeAgentCompileCacheCleanup,
+  requestAgentCompileCacheCleanup,
+} from "../services/AgentCompileCacheCleanupService.js";
 import { runAssistantScratchCleanup } from "../services/AssistantScratchService.js";
 import { getPeriodicCleanupService } from "../services/PeriodicCleanupService.js";
 import {
@@ -365,6 +369,13 @@ export async function initGlobalServices(
               });
               runAssistantScratchCleanup().catch((err) => {
                 logError("[DiskSpaceMonitor] assistant scratch cleanup threw", err);
+              });
+              // The agent compile cache is itself a plausible cause of the
+              // pressure — it reached 9.3 GB unbounded in #11699 — so it is
+              // worth reclaiming on the critical edge rather than waiting for
+              // the next idle tick.
+              requestAgentCompileCacheCleanup().catch((err) => {
+                logError("[DiskSpaceMonitor] agent compile cache cleanup threw", err);
               });
               try {
                 const retentionDays = store.get("privacy")?.logRetentionDays ?? 30;
@@ -1113,6 +1124,13 @@ export async function initGlobalServices(
   // `child-process-gone` listener BEFORE the GPU process spawns (first
   // window creation), or startup-window GPU crashes are silently dropped.
   // It stays as an eager pre-window call in main.ts.
+  registerDeferredTask({
+    name: "agent-compile-cache-cleanup",
+    // Fire-and-forget: the first sweep on an affected install may delete
+    // gigabytes, which must not serialize the rest of the deferred queue.
+    run: () => initializeAgentCompileCacheCleanup(),
+  });
+
   registerDeferredTask({
     name: "trashed-pid-cleanup",
     run: async () => {

--- a/shared/config/agentCompileCache.ts
+++ b/shared/config/agentCompileCache.ts
@@ -1,0 +1,47 @@
+/**
+ * Location and retention policy for the per-agent V8 compile caches written by
+ * Node-based agent CLIs (`NODE_COMPILE_CACHE`).
+ *
+ * Shared because the write path and the reclaim path live in different
+ * processes: `buildTerminalEnv` runs in the pty-host UtilityProcess, while the
+ * cleanup sweep runs in Main. Both must agree on the directory name or the
+ * sweep would silently prune nothing.
+ *
+ * Deliberately import-free so the pty-host can read it without dragging in
+ * `electron` (which does not exist there).
+ */
+
+/** Directory under userData holding one subdirectory per agent id. */
+export const AGENT_COMPILE_CACHE_DIRNAME = "agent-compile-cache";
+
+/**
+ * A Node-version subdirectory is evicted once its own mtime is older than this.
+ * Node writes every blob for a given runtime directly into that directory, so
+ * the directory's mtime tracks the last time the runtime compiled anything —
+ * a usable freshness signal that costs one `stat` instead of walking the
+ * hundreds of thousands of blobs inside. Matches `SCRATCH_CLEANUP_TTL_DAYS` so
+ * the two disk-reclamation policies age work out on the same schedule.
+ */
+export const AGENT_COMPILE_CACHE_TTL_DAYS = 30;
+
+/** TTL in milliseconds, for direct comparison against `stat().mtimeMs`. */
+export const AGENT_COMPILE_CACHE_TTL_MS = AGENT_COMPILE_CACHE_TTL_DAYS * 24 * 60 * 60 * 1000;
+
+/**
+ * Ceiling on the retained cache across every agent, not per agent. A per-agent
+ * reservation would let the total scale with the agent roster, which is exactly
+ * how the unbounded growth in #11699 went unnoticed.
+ *
+ * The reported pathological cache averaged ~550 MB per Node-version directory,
+ * so 1 GiB retains roughly the two most recent useful generations.
+ */
+export const AGENT_COMPILE_CACHE_MAX_BYTES = 1024 * 1024 * 1024;
+
+/**
+ * Companion ceiling on retained file count, also root-wide. Bytes alone do not
+ * capture the cost of the reported 890K-file cache: inode pressure, slow
+ * backup/indexing passes, and expensive directory walks are driven by count,
+ * not size. It doubles as the bound on sweep work — the cap pass stops
+ * measuring once this many entries have been admitted.
+ */
+export const AGENT_COMPILE_CACHE_MAX_ENTRIES = 100_000;


### PR DESCRIPTION
## Summary

- When Daintree spawns a Node-based agent CLI (Claude, Gemini), it sets `NODE_COMPILE_CACHE` to a per-agent directory under the app's user data folder (`electron/services/pty/terminalSpawn.ts`). Node never evicts entries from that cache, and nothing in this codebase read, sized, or pruned it. One reporter measured 9.3 GB across 890,589 files in 17 Node-version subdirectories, and packaged installs hit this silently with no UI visibility.
- Adds a new `AgentCompileCacheCleanupService` that bounds the cache with a TTL pass plus a budget pass, wired to boot, the periodic cleanup tick, and disk-critical pressure.
- Moves the cache path logic into an Electron-free helper, since the actual writer process is the pty-host UtilityProcess, which has no `app.getPath`.

Resolves #11699

## How it works

`AgentCompileCacheCleanupService` runs two passes:

1. **TTL pass**: any Node-version subdirectory whose own mtime is older than 30 days gets removed outright. Node writes blobs directly into that directory, so its mtime tracks the last compile under that runtime, meaning one `stat` call replaces walking every blob inside.
2. **Budget pass**: survivors get ranked newest-first and admitted while they fit a root-wide 1 GiB / 100,000-entry ceiling. The first directory that doesn't fit gets removed along with every older one, unmeasured. That's a deliberate newest-prefix eviction, not optimal bin-packing: finding a smaller older directory that would still fit means sizing the whole tree, which is exactly the cost the mtime signal exists to avoid.

TTL alone wouldn't have fixed the reported bug. The Node version currently in use gets a full fresh set of blobs on every agent-CLI update, so it always looks fresh under the TTL check while still growing without bound. The budget pass is what actually bounds that case.

The service is wired to three triggers, coalesced through a single-flight wrapper so they can't race each other: a boot-time deferred task (`agent-compile-cache-cleanup`), the existing 4-hour `PeriodicCleanupService` tick, and the disk-critical pressure edge in `globalServicesInit` (worth wiring separately, since the compile cache itself can be the thing causing the pressure). It stays silent per the project's `notify()` gate: reclaim runs log, they never toast.

The cache path logic moved into `electron/services/agentCompileCachePaths.ts`, which has no Electron dependency, because the writer process is the pty-host UtilityProcess, where `app.getPath` doesn't exist. `PtyHostLifecycle` already forwards `DAINTREE_USER_DATA` set from `app.getPath("userData")` (unchanged by this PR), so the main process and the pty-host provably resolve to the same cache root.

Deleting a compile cache is always safe: Node just recompiles silently on a miss, so the worst case of over-eviction is one slower agent launch, never incorrect behavior. Every deletion is isolated per-directory and best-effort, since on Windows a live agent can be holding a blob file open, and that shouldn't take down the rest of the sweep.

Deliberately not implemented: detecting which Node versions are still installed, which the original issue raised as an option. Cross-manager detection across nvm, fnm, volta, asdf, and Homebrew is fragile and not worth it. Deleting the cache for a Node version that's still in use just costs one recompile, not correctness.

## Changes

- `shared/config/agentCompileCache.ts` (new)
- `electron/services/agentCompileCachePaths.ts` (new)
- `electron/services/AgentCompileCacheCleanupService.ts` (new)
- `electron/services/pty/terminalSpawn.ts`
- `electron/services/PeriodicCleanupService.ts`
- `electron/window/globalServicesInit.ts`
- 2 new test files, 2 updated test files

## Testing

- 1741 tests pass locally: the 5 branch specs plus every consumer of the edited module, including the full `electron/services/pty/__tests__` suite and the `PtyManager` suites.
- Prettier clean on all 10 files.
- One pre-existing eslint warning at `terminalSpawn.ts:177`, outside this diff and unrelated.

