### PR TITLE
feat(ui): name and undo a keyboard-hidden sidebar

### DIFF
--- a/src/services/actions/__tests__/keyboardLayoutChangeFeedback.test.ts
+++ b/src/services/actions/__tests__/keyboardLayoutChangeFeedback.test.ts
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ActionSource } from "@shared/types/actions";
+
+interface CapturedNotify {
+  type?: string;
+  title?: string;
+  message?: string;
+  priority?: string;
+  urgent?: boolean;
+  transient?: boolean;
+  duration?: number;
+  context?: unknown;
+  action?: { label: string; onClick: () => void };
+}
+
+const notifyMock = vi.fn<(payload: CapturedNotify) => string>(() => "toast-1");
+vi.mock("@/lib/notify", () => ({
+  notify: (payload: CapturedNotify) => notifyMock(payload),
+}));
+
+const getEffectiveCombo = vi.fn<(actionId: string) => string | undefined>(() => "Cmd+B");
+const getDisplayCombo = vi.fn<(actionId: string) => string>(() => "⌘B");
+vi.mock("@/services/KeybindingService", () => ({
+  keybindingService: {
+    getEffectiveCombo: (actionId: string) => getEffectiveCombo(actionId),
+    getDisplayCombo: (actionId: string) => getDisplayCombo(actionId),
+  },
+}));
+
+import {
+  KEYBOARD_LAYOUT_CONFIRMATION_LIMIT,
+  keyboardLayoutBindingKey,
+  usePreferencesStore,
+} from "@/store/preferencesStore";
+import { notifyUndoableKeyboardLayoutChange } from "../keyboardLayoutChangeFeedback";
+
+const ACTION_ID = "nav.toggleSidebar";
+
+function fire(overrides: Partial<Parameters<typeof notifyUndoableKeyboardLayoutChange>[0]> = {}) {
+  notifyUndoableKeyboardLayoutChange({
+    actionId: ACTION_ID,
+    dispatchSource: "keybinding",
+    changed: true,
+    title: "Sidebar hidden",
+    message: (displayCombo) => `${displayCombo} toggles the sidebar`,
+    onUndo: () => {},
+    ...overrides,
+  });
+}
+
+function confirmations(): Record<string, number> {
+  return usePreferencesStore.getState().keyboardLayoutConfirmationsByBinding;
+}
+
+function lastPayload(): CapturedNotify {
+  const call = notifyMock.mock.calls.at(-1);
+  if (!call) throw new Error("notify was not called");
+  return call[0];
+}
+
+beforeEach(() => {
+  notifyMock.mockClear().mockReturnValue("toast-1");
+  getEffectiveCombo.mockReset().mockReturnValue("Cmd+B");
+  getDisplayCombo.mockReset().mockReturnValue("⌘B");
+  usePreferencesStore.setState({ keyboardLayoutConfirmationsByBinding: {} });
+});
+
+describe("notifyUndoableKeyboardLayoutChange", () => {
+  it("announces a keyboard-driven change and offers a way back", () => {
+    fire();
+
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+    expect(lastPayload().action?.label).toBe("Undo");
+  });
+
+  it("attributes the change to the live display combo, not a hard-coded one", () => {
+    getDisplayCombo.mockReturnValue("⌃⇧S");
+    fire();
+
+    expect(lastPayload().message).toContain("⌃⇧S");
+  });
+
+  it("routes to a shape that actually surfaces a toast", () => {
+    fire();
+    const payload = lastPayload();
+
+    // A transient toast skips the inbox, so "low" priority (what any passive
+    // eventKind resolves to) or a `context` both collapse it into a silent
+    // drop. Asserted as the invariant rather than the literal field values.
+    expect(payload.transient).toBe(true);
+    expect(payload.priority).not.toBe("low");
+    expect(payload.context).toBeUndefined();
+  });
+
+  it.each<ActionSource | undefined>(["user", "menu", "context-menu", "agent", "plugin", undefined])(
+    "stays silent for %s dispatch, which needs no attribution",
+    (dispatchSource) => {
+      fire({ dispatchSource });
+
+      expect(notifyMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it("stays silent when the dispatch changed nothing", () => {
+    // Covers the show direction and every downstream guard that turns the
+    // toggle into a no-op — the caller reports an observed transition.
+    fire({ changed: false });
+
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("stays silent when the action has no binding to name", () => {
+    getEffectiveCombo.mockReturnValue(undefined);
+    fire();
+
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("stops announcing once the binding has been confirmed enough times", () => {
+    for (let i = 0; i < KEYBOARD_LAYOUT_CONFIRMATION_LIMIT; i++) {
+      fire();
+    }
+    expect(notifyMock).toHaveBeenCalledTimes(KEYBOARD_LAYOUT_CONFIRMATION_LIMIT);
+
+    notifyMock.mockClear();
+    fire();
+
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("gives a rebound shortcut a fresh allowance", () => {
+    for (let i = 0; i < KEYBOARD_LAYOUT_CONFIRMATION_LIMIT; i++) {
+      fire();
+    }
+    notifyMock.mockClear();
+
+    getEffectiveCombo.mockReturnValue("Cmd+Shift+S");
+    fire();
+
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("supersedes the old combo's tally instead of accumulating one key per rebind", () => {
+    fire();
+    getEffectiveCombo.mockReturnValue("Cmd+Shift+S");
+    fire();
+
+    expect(Object.keys(confirmations())).toEqual([
+      keyboardLayoutBindingKey(ACTION_ID, "Cmd+Shift+S"),
+    ]);
+  });
+
+  it("spends no allowance on a toast that never surfaced", () => {
+    // Notification settings and rate limiting both drop the toast and return an
+    // empty id. Counting those would retire the affordance unseen.
+    notifyMock.mockReturnValue("");
+    fire();
+
+    expect(confirmations()).toEqual({});
+  });
+
+  it("treats Undo as proof the keypress was a slip and restores the allowance", () => {
+    fire();
+    expect(confirmations()).not.toEqual({});
+
+    lastPayload().action?.onClick();
+
+    expect(confirmations()).toEqual({});
+  });
+
+  it("runs the inverse exactly once however often Undo is clicked", () => {
+    const onUndo = vi.fn();
+    fire({ onUndo });
+
+    const undo = lastPayload().action;
+    undo?.onClick();
+    undo?.onClick();
+
+    expect(onUndo).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears familiarity before running the inverse, so a re-hide is announced again", () => {
+    fire();
+    lastPayload().action?.onClick();
+    notifyMock.mockClear();
+
+    fire();
+
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/actions/__tests__/keyboardLayoutChangeFeedback.test.ts
+++ b/src/services/actions/__tests__/keyboardLayoutChangeFeedback.test.ts
@@ -101,6 +101,10 @@ describe("notifyUndoableKeyboardLayoutChange", () => {
     const { duration } = lastPayload();
     expect(duration).toBeGreaterThan(0);
     expect(Number.isFinite(duration)).toBe(true);
+    // Being transient, this toast writes no inbox row, so it is the only
+    // chance to reach the Undo — it may never dip under the documented
+    // accessibility floor for an info toast.
+    expect(duration).toBeGreaterThanOrEqual(6000);
   });
 
   it.each<ActionSource | undefined>(["user", "menu", "context-menu", "agent", "plugin", undefined])(

--- a/src/services/actions/__tests__/keyboardLayoutChangeFeedback.test.ts
+++ b/src/services/actions/__tests__/keyboardLayoutChangeFeedback.test.ts
@@ -93,6 +93,16 @@ describe("notifyUndoableKeyboardLayoutChange", () => {
     expect(payload.context).toBeUndefined();
   });
 
+  it("stays time-bound, rather than inheriting the sticky default for action toasts", () => {
+    // notify() makes action-bearing toasts stick forever (duration 0) unless
+    // the caller sets one, which would leave a permanent "Sidebar hidden" bar.
+    fire();
+
+    const { duration } = lastPayload();
+    expect(duration).toBeGreaterThan(0);
+    expect(Number.isFinite(duration)).toBe(true);
+  });
+
   it.each<ActionSource | undefined>(["user", "menu", "context-menu", "agent", "plugin", undefined])(
     "stays silent for %s dispatch, which needs no attribution",
     (dispatchSource) => {
@@ -181,12 +191,51 @@ describe("notifyUndoableKeyboardLayoutChange", () => {
   });
 
   it("clears familiarity before running the inverse, so a re-hide is announced again", () => {
-    fire();
+    // Ordering matters: the inverse may itself re-enter this module, so the
+    // allowance has to be restored by the time onUndo observes it.
+    let seenDuringUndo: Record<string, number> | undefined;
+    fire({ onUndo: () => (seenDuringUndo = { ...confirmations() }) });
+
     lastPayload().action?.onClick();
-    notifyMock.mockClear();
 
+    expect(seenDuringUndo).toEqual({});
+  });
+
+  it("ignores an Undo once a later change has superseded the notice", () => {
+    // Hide, show, hide again — all inside the 5s window. The first toast's
+    // Undo would now reverse the user's most recent, deliberate press.
+    const staleUndo = vi.fn();
+    fire({ onUndo: staleUndo });
+    const stale = lastPayload().action;
     fire();
 
-    expect(notifyMock).toHaveBeenCalledTimes(1);
+    stale?.onClick();
+
+    expect(staleUndo).not.toHaveBeenCalled();
+  });
+
+  it("still supersedes when the later change was too familiar to announce", () => {
+    const staleUndo = vi.fn();
+    fire({ onUndo: staleUndo });
+    const stale = lastPayload().action;
+    // Exhaust the allowance so the newest hide is silent but still real.
+    usePreferencesStore.setState({
+      keyboardLayoutConfirmationsByBinding: {
+        [keyboardLayoutBindingKey(ACTION_ID, "Cmd+B")]: KEYBOARD_LAYOUT_CONFIRMATION_LIMIT,
+      },
+    });
+    fire();
+
+    stale?.onClick();
+
+    expect(staleUndo).not.toHaveBeenCalled();
+  });
+
+  it("never lets a broken notification break the change that already happened", () => {
+    notifyMock.mockImplementation(() => {
+      throw new Error("toaster exploded");
+    });
+
+    expect(() => fire()).not.toThrow();
   });
 });

--- a/src/services/actions/definitions/__tests__/navigationActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/navigationActions.adversarial.test.ts
@@ -3,16 +3,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ActionContext, ActionSource } from "@shared/types/actions";
 import type { ActionCallbacks, ActionRegistry, AnyActionDefinition } from "../../actionTypes";
 
-const notifyLayoutChange =
-  vi.fn<
-    (change: { changed: boolean; onUndo: () => void; dispatchSource?: ActionSource }) => void
-  >();
+interface LayoutChange {
+  actionId: string;
+  changed: boolean;
+  title: string;
+  message: (displayCombo: string) => string;
+  onUndo: () => void;
+  dispatchSource?: ActionSource;
+}
+
+const notifyLayoutChange = vi.fn<(change: LayoutChange) => void>();
 vi.mock("../../keyboardLayoutChangeFeedback", () => ({
-  notifyUndoableKeyboardLayoutChange: (change: {
-    changed: boolean;
-    onUndo: () => void;
-    dispatchSource?: ActionSource;
-  }) => notifyLayoutChange(change),
+  notifyUndoableKeyboardLayoutChange: (change: LayoutChange) => notifyLayoutChange(change),
 }));
 
 import { useFocusStore } from "@/store/focusStore";
@@ -199,6 +201,33 @@ describe("nav.toggleSidebar keyboard feedback (issue #11704)", () => {
 
     expect(useFocusStore.getState().gestureSidebarHidden).toBe(false);
     expect(callbacks.onToggleSidebar).toHaveBeenCalledTimes(2);
+  });
+
+  it("announces under the toggle's own identity, so familiarity is keyed correctly", async () => {
+    const { actions, callbacks } = setupActions();
+    toggleOnDispatch(callbacks);
+
+    await runToggle(actions, "keybinding");
+
+    const change = notifyLayoutChange.mock.calls[0]![0]!;
+    expect(change.actionId).toBe("nav.toggleSidebar");
+    expect(change.title).toBe("Sidebar hidden");
+    // The combo is resolved live rather than hard-coded, so a rebind still
+    // names the key the user actually pressed.
+    expect(change.message("⌃⇧S")).toContain("⌃⇧S");
+  });
+
+  it("undo restores the sidebar even when an overlay swallows the toggle event", async () => {
+    // The toast is dismissed by the click either way, so a swallowed event
+    // would leave the sidebar hidden with the promised way back gone.
+    const { actions, callbacks } = setupActions();
+    toggleOnDispatch(callbacks);
+    await runToggle(actions, "keybinding");
+
+    callbacks.onToggleSidebar.mockImplementation(() => {});
+    notifyLayoutChange.mock.calls[0]![0]!.onUndo();
+
+    expect(useFocusStore.getState().gestureSidebarHidden).toBe(false);
   });
 
   it("undo does nothing if the sidebar is already back", async () => {

--- a/src/services/actions/definitions/__tests__/navigationActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/navigationActions.adversarial.test.ts
@@ -1,6 +1,21 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ActionContext, ActionSource } from "@shared/types/actions";
 import type { ActionCallbacks, ActionRegistry, AnyActionDefinition } from "../../actionTypes";
+
+const notifyLayoutChange =
+  vi.fn<
+    (change: { changed: boolean; onUndo: () => void; dispatchSource?: ActionSource }) => void
+  >();
+vi.mock("../../keyboardLayoutChangeFeedback", () => ({
+  notifyUndoableKeyboardLayoutChange: (change: {
+    changed: boolean;
+    onUndo: () => void;
+    dispatchSource?: ActionSource;
+  }) => notifyLayoutChange(change),
+}));
+
+import { useFocusStore } from "@/store/focusStore";
 import { registerNavigationActions } from "../navigationActions";
 
 function setupActions() {
@@ -28,6 +43,8 @@ const dispatchSpy = vi.fn<(event: Event) => boolean>(() => true);
 
 beforeEach(() => {
   dispatchSpy.mockReset().mockReturnValue(true);
+  notifyLayoutChange.mockReset();
+  useFocusStore.setState({ gestureSidebarHidden: false });
   Object.defineProperty(globalThis.window, "dispatchEvent", {
     value: dispatchSpy,
     configurable: true,
@@ -108,5 +125,92 @@ describe("navigationActions adversarial", () => {
   it("registers exactly 7 navigation actions", () => {
     const { actions } = setupActions();
     expect(actions.size).toBe(7);
+  });
+});
+
+describe("nav.toggleSidebar keyboard feedback (issue #11704)", () => {
+  /** Mimics AppLayout's listener: flips the store while the event dispatches. */
+  function toggleOnDispatch(callbacks: { onToggleSidebar: ReturnType<typeof vi.fn> }) {
+    callbacks.onToggleSidebar.mockImplementation(() => {
+      const { gestureSidebarHidden } = useFocusStore.getState();
+      useFocusStore.setState({ gestureSidebarHidden: !gestureSidebarHidden });
+    });
+  }
+
+  async function runToggle(actions: ActionRegistry, source: ActionSource | undefined) {
+    const def = actions.get("nav.toggleSidebar")!() as AnyActionDefinition;
+    await def.run(undefined, { dispatchSource: source } as ActionContext);
+  }
+
+  it("reports the hide direction as the change worth announcing", async () => {
+    const { actions, callbacks } = setupActions();
+    toggleOnDispatch(callbacks);
+
+    await runToggle(actions, "keybinding");
+
+    expect(notifyLayoutChange.mock.calls[0]![0]!.changed).toBe(true);
+  });
+
+  it("reports the show direction as nothing to announce", async () => {
+    const { actions, callbacks } = setupActions();
+    toggleOnDispatch(callbacks);
+    useFocusStore.setState({ gestureSidebarHidden: true });
+
+    await runToggle(actions, "keybinding");
+
+    expect(notifyLayoutChange.mock.calls[0]![0]!.changed).toBe(false);
+  });
+
+  it("reports no change when a guard swallowed the toggle", async () => {
+    // AppLayout drops the event when an overlay is open or no workspace is
+    // mounted; the store never moves, so the observed transition is the guard.
+    const { actions, callbacks } = setupActions();
+    callbacks.onToggleSidebar.mockImplementation(() => {});
+
+    await runToggle(actions, "keybinding");
+
+    expect(notifyLayoutChange.mock.calls[0]![0]!.changed).toBe(false);
+  });
+
+  it("forwards the dispatch source so non-keyboard paths can be filtered out", async () => {
+    const { actions, callbacks } = setupActions();
+    toggleOnDispatch(callbacks);
+
+    await runToggle(actions, "user");
+
+    expect(notifyLayoutChange.mock.calls[0]![0]!.dispatchSource).toBe("user");
+  });
+
+  it("tolerates a context with no dispatch source", async () => {
+    const { actions, callbacks } = setupActions();
+    toggleOnDispatch(callbacks);
+
+    await expect(runToggle(actions, undefined)).resolves.not.toThrow();
+    expect(notifyLayoutChange.mock.calls[0]![0]!.dispatchSource).toBeUndefined();
+  });
+
+  it("undo toggles back through the same path, keeping AppLayout's guards", async () => {
+    const { actions, callbacks } = setupActions();
+    toggleOnDispatch(callbacks);
+    await runToggle(actions, "keybinding");
+    expect(useFocusStore.getState().gestureSidebarHidden).toBe(true);
+
+    notifyLayoutChange.mock.calls[0]![0]!.onUndo();
+
+    expect(useFocusStore.getState().gestureSidebarHidden).toBe(false);
+    expect(callbacks.onToggleSidebar).toHaveBeenCalledTimes(2);
+  });
+
+  it("undo does nothing if the sidebar is already back", async () => {
+    const { actions, callbacks } = setupActions();
+    toggleOnDispatch(callbacks);
+    await runToggle(actions, "keybinding");
+    // The user reached for the toolbar button before the toast lapsed.
+    useFocusStore.setState({ gestureSidebarHidden: false });
+
+    notifyLayoutChange.mock.calls[0]![0]!.onUndo();
+
+    expect(useFocusStore.getState().gestureSidebarHidden).toBe(false);
+    expect(callbacks.onToggleSidebar).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/actions/definitions/navigationActions.ts
+++ b/src/services/actions/definitions/navigationActions.ts
@@ -34,10 +34,18 @@ export function registerNavigationActions(
         onUndo: () => {
           // The user may have brought it back themselves while the toast was up.
           if (!useFocusStore.getState().gestureSidebarHidden) return;
-          // Back out through the same event, so AppLayout re-applies its guards,
-          // its resize suppression and the live sidebar width — rather than
-          // writing the focus store here with panel state we'd have to guess.
+          // Back out through the same event, so AppLayout re-applies its resize
+          // suppression and the live sidebar width — rather than writing the
+          // focus store here with panel state we'd have to guess.
           callbacks.onToggleSidebar();
+          // That event is dropped while an overlay is open, and the toast is
+          // dismissed by the click either way. Undo is a promise the user
+          // already accepted, so restore directly rather than leave them with
+          // the sidebar still gone and the way back retired. Safe to pass no
+          // panel state: revealing keeps whatever the store already held.
+          if (useFocusStore.getState().gestureSidebarHidden) {
+            useFocusStore.getState().setSidebarGestureHidden(false);
+          }
         },
       });
     },

--- a/src/services/actions/definitions/navigationActions.ts
+++ b/src/services/actions/definitions/navigationActions.ts
@@ -1,4 +1,6 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
+import { notifyUndoableKeyboardLayoutChange } from "../keyboardLayoutChangeFeedback";
+import { useFocusStore } from "@/store/focusStore";
 
 export function registerNavigationActions(
   actions: ActionRegistry,
@@ -13,8 +15,31 @@ export function registerNavigationActions(
     danger: "safe",
     scope: "renderer",
     nonRepeatable: true,
-    run: async () => {
+    run: async (_args, ctx) => {
+      // Read the store across the callback rather than predicting the outcome:
+      // the toggle travels through a synchronous window event to AppLayout,
+      // which drops it when an overlay is open or no workspace is mounted. An
+      // observed false → true transition is the only proof the sidebar actually
+      // went away, and it costs nothing to re-derive those guards here.
+      const wasHidden = useFocusStore.getState().gestureSidebarHidden;
       callbacks.onToggleSidebar();
+      const isHidden = useFocusStore.getState().gestureSidebarHidden;
+
+      notifyUndoableKeyboardLayoutChange({
+        actionId: "nav.toggleSidebar",
+        dispatchSource: ctx?.dispatchSource,
+        changed: !wasHidden && isHidden,
+        title: "Sidebar hidden",
+        message: (displayCombo) => `${displayCombo} toggles the sidebar`,
+        onUndo: () => {
+          // The user may have brought it back themselves while the toast was up.
+          if (!useFocusStore.getState().gestureSidebarHidden) return;
+          // Back out through the same event, so AppLayout re-applies its guards,
+          // its resize suppression and the live sidebar width — rather than
+          // writing the focus store here with panel state we'd have to guess.
+          callbacks.onToggleSidebar();
+        },
+      });
     },
   }));
 

--- a/src/services/actions/definitions/navigationActions.ts
+++ b/src/services/actions/definitions/navigationActions.ts
@@ -1,6 +1,7 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import { notifyUndoableKeyboardLayoutChange } from "../keyboardLayoutChangeFeedback";
 import { useFocusStore } from "@/store/focusStore";
+import { suppressSidebarResizes } from "@/lib/sidebarToggle";
 
 export function registerNavigationActions(
   actions: ActionRegistry,
@@ -44,6 +45,9 @@ export function registerNavigationActions(
           // the sidebar still gone and the way back retired. Safe to pass no
           // panel state: revealing keeps whatever the store already held.
           if (useFocusStore.getState().gestureSidebarHidden) {
+            // Take the resize lock AppLayout would have taken, or the width
+            // animates without it and the terminals re-fit every frame.
+            suppressSidebarResizes();
             useFocusStore.getState().setSidebarGestureHidden(false);
           }
         },

--- a/src/services/actions/keyboardLayoutChangeFeedback.ts
+++ b/src/services/actions/keyboardLayoutChangeFeedback.ts
@@ -1,0 +1,100 @@
+import type { ActionId, ActionSource } from "@shared/types/actions";
+import { notify } from "@/lib/notify";
+import { keybindingService } from "@/services/KeybindingService";
+import {
+  KEYBOARD_LAYOUT_CONFIRMATION_LIMIT,
+  keyboardLayoutBindingKey,
+  usePreferencesStore,
+} from "@/store/preferencesStore";
+
+export interface UndoableKeyboardLayoutChange {
+  /** The action whose binding caused the change; also the familiarity key. */
+  actionId: ActionId;
+  /** `ctx.dispatchSource` for the dispatch that ran. */
+  dispatchSource: ActionSource | undefined;
+  /**
+   * Whether the dispatch actually performed the surprising direction of the
+   * change. Callers should pass an *observed* before/after transition rather
+   * than their intent, so a dispatch some downstream guard turned into a no-op
+   * reports `false` without the caller re-deriving that guard.
+   */
+  changed: boolean;
+  /** Past-tense name for what happened, e.g. "Sidebar hidden". */
+  title: string;
+  /** Built from the live display combo, so a rebound key attributes correctly. */
+  message: (displayCombo: string) => string;
+  /** The inverse of the change. Invoked at most once. */
+  onUndo: () => void;
+}
+
+/**
+ * Announce a layout change big enough to be alarming when it arrives
+ * unannounced, and offer a time-bound way back (#11704).
+ *
+ * Only bare keypresses get this. Menu items, the command palette and toolbar
+ * buttons all name themselves at the moment of the click, and an agent or
+ * plugin dispatch has nobody at the keyboard to inform — a keypress is the one
+ * path where a whole region of the app can vanish with nothing connecting it to
+ * what the user just did.
+ *
+ * Fires on one direction only. Callers own the asymmetry via `changed`: hiding
+ * something is the surprise, bringing it back is self-evidently what happened.
+ */
+export function notifyUndoableKeyboardLayoutChange(change: UndoableKeyboardLayoutChange): void {
+  const { actionId, dispatchSource, changed, title, message, onUndo } = change;
+
+  if (dispatchSource !== "keybinding") return;
+  if (!changed) return;
+
+  // No binding means no combo to attribute the change to, which is the whole
+  // point of the notice.
+  const combo = keybindingService.getEffectiveCombo(actionId);
+  if (!combo) return;
+
+  const key = keyboardLayoutBindingKey(actionId, combo);
+  if (
+    (usePreferencesStore.getState().keyboardLayoutConfirmationsByBinding[key] ?? 0) >=
+    KEYBOARD_LAYOUT_CONFIRMATION_LIMIT
+  ) {
+    return;
+  }
+
+  let undoFired = false;
+
+  // eslint-disable-next-line no-restricted-syntax -- notify-event-kind: ok — a transient toast cannot carry context (notify() drops the event whenever the origin surface is visible, and the inbox fallback it needs is exactly what transient skips), and no EVENT_POLICY kind describes an attribution notice.
+  const notificationId = notify({
+    type: "info",
+    title,
+    message: message(keybindingService.getDisplayCombo(actionId)),
+    duration: 5000,
+    // Explicit, because a passive eventKind would resolve this to "low" and
+    // route it to the inbox only — a silent no-op for a toast whose whole job
+    // is to be seen right now.
+    priority: "high",
+    // Time-bound Undo, so it has to surface during quiet hours too; otherwise
+    // the recovery path is gone before the user has read the notice.
+    urgent: true,
+    // The change is already on screen and the toolbar button is the durable way
+    // back, so once the Undo lapses an inbox row would carry a stale action and
+    // nothing worth reading.
+    transient: true,
+    action: {
+      label: "Undo",
+      onClick: () => {
+        if (undoFired) return;
+        undoFired = true;
+        // Reaching for Undo is the evidence that this keypress was a slip, so
+        // the binding goes back to announcing itself.
+        usePreferencesStore.getState().clearKeyboardLayoutConfirmations(actionId);
+        onUndo();
+      },
+    },
+  });
+
+  // Count it only once it actually surfaced. A toast dropped by the user's
+  // notification settings or by rate limiting teaches nobody, and spending an
+  // allowance on it would retire the affordance unseen.
+  if (notificationId) {
+    usePreferencesStore.getState().recordKeyboardLayoutConfirmation(actionId, combo);
+  }
+}

--- a/src/services/actions/keyboardLayoutChangeFeedback.ts
+++ b/src/services/actions/keyboardLayoutChangeFeedback.ts
@@ -77,7 +77,7 @@ export function notifyUndoableKeyboardLayoutChange(change: UndoableKeyboardLayou
 
     announce({ actionId, combo, title, message, onUndo, sequenceAtAnnouncement });
   } catch (error) {
-    logWarn("Failed to announce a keyboard layout change", error);
+    logWarn("Failed to announce a keyboard layout change", { error });
   }
 }
 

--- a/src/services/actions/keyboardLayoutChangeFeedback.ts
+++ b/src/services/actions/keyboardLayoutChangeFeedback.ts
@@ -6,6 +6,15 @@ import {
   keyboardLayoutBindingKey,
   usePreferencesStore,
 } from "@/store/preferencesStore";
+import { logWarn } from "@/utils/logger";
+
+/**
+ * Bumped for every change reported here, announced or not. An Undo belongs to
+ * the transition that produced it: once a later change has landed, the older
+ * toast's Undo would reverse something the user has done since, so it goes
+ * inert rather than silently rolling back the wrong thing.
+ */
+let changeSequence = 0;
 
 export interface UndoableKeyboardLayoutChange {
   /** The action whose binding caused the change; also the familiarity key. */
@@ -46,19 +55,49 @@ export function notifyUndoableKeyboardLayoutChange(change: UndoableKeyboardLayou
   if (dispatchSource !== "keybinding") return;
   if (!changed) return;
 
-  // No binding means no combo to attribute the change to, which is the whole
-  // point of the notice.
-  const combo = keybindingService.getEffectiveCombo(actionId);
-  if (!combo) return;
+  changeSequence += 1;
+  const sequenceAtAnnouncement = changeSequence;
 
-  const key = keyboardLayoutBindingKey(actionId, combo);
-  if (
-    (usePreferencesStore.getState().keyboardLayoutConfirmationsByBinding[key] ?? 0) >=
-    KEYBOARD_LAYOUT_CONFIRMATION_LIMIT
-  ) {
-    return;
+  // The change itself has already happened by the time we get here, so nothing
+  // below may throw into the caller: a failed notice would turn a completed
+  // toggle into a failed action. Same reasoning as `emitShortcutHint`.
+  try {
+    // No binding means no combo to attribute the change to, which is the whole
+    // point of the notice.
+    const combo = keybindingService.getEffectiveCombo(actionId);
+    if (!combo) return;
+
+    const key = keyboardLayoutBindingKey(actionId, combo);
+    if (
+      (usePreferencesStore.getState().keyboardLayoutConfirmationsByBinding[key] ?? 0) >=
+      KEYBOARD_LAYOUT_CONFIRMATION_LIMIT
+    ) {
+      return;
+    }
+
+    announce({ actionId, combo, title, message, onUndo, sequenceAtAnnouncement });
+  } catch (error) {
+    logWarn("Failed to announce a keyboard layout change", error);
   }
+}
 
+interface Announcement {
+  actionId: ActionId;
+  combo: string;
+  title: string;
+  message: (displayCombo: string) => string;
+  onUndo: () => void;
+  sequenceAtAnnouncement: number;
+}
+
+function announce({
+  actionId,
+  combo,
+  title,
+  message,
+  onUndo,
+  sequenceAtAnnouncement,
+}: Announcement): void {
   let undoFired = false;
 
   // eslint-disable-next-line no-restricted-syntax -- notify-event-kind: ok — a transient toast cannot carry context (notify() drops the event whenever the origin surface is visible, and the inbox fallback it needs is exactly what transient skips), and no EVENT_POLICY kind describes an attribution notice.
@@ -82,6 +121,9 @@ export function notifyUndoableKeyboardLayoutChange(change: UndoableKeyboardLayou
       label: "Undo",
       onClick: () => {
         if (undoFired) return;
+        // Something changed again after this notice went up, so this Undo would
+        // roll back the newer change rather than the one it named.
+        if (sequenceAtAnnouncement !== changeSequence) return;
         undoFired = true;
         // Reaching for Undo is the evidence that this keypress was a slip, so
         // the binding goes back to announcing itself.

--- a/src/services/actions/keyboardLayoutChangeFeedback.ts
+++ b/src/services/actions/keyboardLayoutChangeFeedback.ts
@@ -105,7 +105,11 @@ function announce({
     type: "info",
     title,
     message: message(keybindingService.getDisplayCombo(actionId)),
-    duration: 5000,
+    // `transient` writes no inbox row, so this toast is the only window the
+    // Undo ever gets. Matches the palette's hide-action toast — the other
+    // transient undo — rather than the 6s info floor, because a user who just
+    // slipped mid-work needs time to notice the change and reach the action.
+    duration: 30_000,
     // Explicit, because a passive eventKind would resolve this to "low" and
     // route it to the inbox only — a silent no-op for a toast whose whole job
     // is to be seen right now.

--- a/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
@@ -171,6 +171,26 @@ describe("preferencesStore cross-view write merge (#11351)", () => {
     });
   });
 
+  // Taking the higher count unconditionally would resurrect a tally another
+  // view had just cleared, permanently silencing a notice the user asked for.
+  it("does not resurrect a sibling's Undo when writing an unrelated preference", async () => {
+    const backing = installLocalStorage({});
+    const { usePreferencesStore: store } = await import("../preferencesStore");
+
+    store.getState().recordKeyboardLayoutConfirmation("nav.toggleSidebar", "Cmd+B");
+
+    // A sibling view's user clicked Undo, clearing the key on disk.
+    const disk = readBlob(backing);
+    disk.state.keyboardLayoutConfirmationsByBinding = {};
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    // This view still holds the tally, and writes something else entirely.
+    store.getState().setDockDensity("compact");
+
+    const written = readBlob(backing);
+    expect(written.state.keyboardLayoutConfirmationsByBinding).toEqual({});
+  });
+
   it("lets Undo clear a binding even when a sibling raced its count higher", async () => {
     const backing = installLocalStorage({});
     const { usePreferencesStore: store } = await import("../preferencesStore");

--- a/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
@@ -20,6 +20,7 @@ describe("preferencesStore cross-view write merge (#11351)", () => {
       reduceAnimations?: boolean;
       dockDensity?: string;
       hasSeenActionPalettePrefixHint?: boolean;
+      keyboardLayoutConfirmationsByBinding?: Record<string, number>;
       [key: string]: unknown;
     };
   };
@@ -132,8 +133,7 @@ describe("preferencesStore cross-view write merge (#11351)", () => {
 
     // Sibling view confirms a different shortcut.
     const disk = readBlob(backing);
-    const confirmations =
-      (disk.state.keyboardLayoutConfirmationsByBinding as Record<string, number> | undefined) ?? {};
+    const confirmations = disk.state.keyboardLayoutConfirmationsByBinding ?? {};
     confirmations["nav.toggleFocusMode@Cmd+K"] = 2;
     disk.state.keyboardLayoutConfirmationsByBinding = confirmations;
     backing.set(STORAGE_KEY, JSON.stringify(disk));

--- a/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
@@ -147,9 +147,50 @@ describe("preferencesStore cross-view write merge (#11351)", () => {
     });
   });
 
-  // The generic scalar tests above pass even if this specific field is dropped
-  // from the merge, which would silently make the sort mode the one preference
-  // a stale sibling view can clobber (#11455).
+  // A stale view incrementing the SAME binding is the case last-writer-wins
+  // gets wrong: writing its own 2 over a sibling's 3 would hand back an
+  // allowance the user already spent, and the notice would return (#11704).
+  it("never lowers a sibling's confirmation count for the same binding", async () => {
+    const backing = installLocalStorage({});
+    const { usePreferencesStore: store } = await import("../preferencesStore");
+
+    // This view hydrated at 1.
+    store.getState().recordKeyboardLayoutConfirmation("nav.toggleSidebar", "Cmd+B");
+
+    // A sibling view raced ahead to the limit.
+    const disk = readBlob(backing);
+    disk.state.keyboardLayoutConfirmationsByBinding = { "nav.toggleSidebar@Cmd+B": 3 };
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    // This view, still holding 1, records again.
+    store.getState().recordKeyboardLayoutConfirmation("nav.toggleSidebar", "Cmd+B");
+
+    const written = readBlob(backing);
+    expect(written.state.keyboardLayoutConfirmationsByBinding).toEqual({
+      "nav.toggleSidebar@Cmd+B": 3,
+    });
+  });
+
+  it("lets Undo clear a binding even when a sibling raced its count higher", async () => {
+    const backing = installLocalStorage({});
+    const { usePreferencesStore: store } = await import("../preferencesStore");
+
+    store.getState().recordKeyboardLayoutConfirmation("nav.toggleSidebar", "Cmd+B");
+
+    const disk = readBlob(backing);
+    disk.state.keyboardLayoutConfirmationsByBinding = { "nav.toggleSidebar@Cmd+B": 3 };
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    // The user here was surprised, so the notice must come back for them.
+    store.getState().clearKeyboardLayoutConfirmations("nav.toggleSidebar");
+
+    const written = readBlob(backing);
+    expect(written.state.keyboardLayoutConfirmationsByBinding).toEqual({});
+  });
+
+  // Dropping this field from the merge would let a stale view resurrect a
+  // tally the user just cleared with Undo, silencing the notice they were
+  // still relying on (#11704).
   it("keeps a sibling's sort mode when this view changes an unrelated scalar", async () => {
     const backing = installLocalStorage({});
     const { usePreferencesStore: store } = await import("../preferencesStore");

--- a/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
@@ -121,6 +121,32 @@ describe("preferencesStore cross-view write merge (#11351)", () => {
     expect(written.state.reduceAnimations).toBe(true); // sibling's change survived
   });
 
+  // Dropping this field from the merge would let a stale view resurrect a
+  // tally the user just cleared with Undo, silencing the notice they were
+  // still relying on (#11704).
+  it("keeps a sibling's shortcut confirmation and carries an Undo deletion through", async () => {
+    const backing = installLocalStorage({});
+    const { usePreferencesStore: store } = await import("../preferencesStore");
+
+    store.getState().recordKeyboardLayoutConfirmation("nav.toggleSidebar", "Cmd+B");
+
+    // Sibling view confirms a different shortcut.
+    const disk = readBlob(backing);
+    const confirmations =
+      (disk.state.keyboardLayoutConfirmationsByBinding as Record<string, number> | undefined) ?? {};
+    confirmations["nav.toggleFocusMode@Cmd+K"] = 2;
+    disk.state.keyboardLayoutConfirmationsByBinding = confirmations;
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    // This view's user reaches for Undo, which clears only its own entry.
+    store.getState().clearKeyboardLayoutConfirmations("nav.toggleSidebar");
+
+    const written = readBlob(backing);
+    expect(written.state.keyboardLayoutConfirmationsByBinding).toEqual({
+      "nav.toggleFocusMode@Cmd+K": 2,
+    });
+  });
+
   // The generic scalar tests above pass even if this specific field is dropped
   // from the merge, which would silently make the sort mode the one preference
   // a stale sibling view can clobber (#11455).

--- a/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
@@ -208,9 +208,9 @@ describe("preferencesStore cross-view write merge (#11351)", () => {
     expect(written.state.keyboardLayoutConfirmationsByBinding).toEqual({});
   });
 
-  // Dropping this field from the merge would let a stale view resurrect a
-  // tally the user just cleared with Undo, silencing the notice they were
-  // still relying on (#11704).
+  // The generic scalar tests above pass even if this specific field is dropped
+  // from the merge, which would silently make the sort mode the one preference
+  // a stale sibling view can clobber (#11455).
   it("keeps a sibling's sort mode when this view changes an unrelated scalar", async () => {
     const backing = installLocalStorage({});
     const { usePreferencesStore: store } = await import("../preferencesStore");

--- a/src/store/__tests__/preferencesStore.test.ts
+++ b/src/store/__tests__/preferencesStore.test.ts
@@ -956,14 +956,13 @@ describe("preferencesStore migration", () => {
 
       store.getState().recordKeyboardLayoutConfirmation("nav.toggleSidebar", "Cmd+B");
 
-      const written = JSON.parse(storage[STORAGE_KEY]!) as {
-        version: number;
-        state: Record<string, unknown>;
-      };
+      const written: { version?: number; state?: Record<string, unknown> } = JSON.parse(
+        storage[STORAGE_KEY]!
+      );
       // Greater-than, not equality against the configured version: comparing a
       // written value to the same option that wrote it passes at any version.
       expect(written.version).toBeGreaterThan(15);
-      expect(written.state.keyboardLayoutConfirmationsByBinding).toEqual({ [KEY]: 1 });
+      expect(written.state?.keyboardLayoutConfirmationsByBinding).toEqual({ [KEY]: 1 });
     });
 
     it("replaces a non-record blob rather than letting it reach live state", async () => {

--- a/src/store/__tests__/preferencesStore.test.ts
+++ b/src/store/__tests__/preferencesStore.test.ts
@@ -960,7 +960,9 @@ describe("preferencesStore migration", () => {
         version: number;
         state: Record<string, unknown>;
       };
-      expect(written.version).toBe(store.persist.getOptions().version);
+      // Greater-than, not equality against the configured version: comparing a
+      // written value to the same option that wrote it passes at any version.
+      expect(written.version).toBeGreaterThan(15);
       expect(written.state.keyboardLayoutConfirmationsByBinding).toEqual({ [KEY]: 1 });
     });
 

--- a/src/store/__tests__/preferencesStore.test.ts
+++ b/src/store/__tests__/preferencesStore.test.ts
@@ -919,27 +919,49 @@ describe("preferencesStore migration", () => {
       expect(migrated?.dockDensity).toBe("compact");
     });
 
-    it("drops counts that would silence a binding the user never confirmed", async () => {
-      // A hand-edited or corrupt value breaks both ways: a non-number would nag
-      // forever, an oversized one retires the notice unseen.
+    it("drops corrupt counts rather than silencing a binding the user never confirmed", async () => {
+      // Clamping an oversized value would land it on exactly the limit, which
+      // retires the notice for someone who never saw it. Dropping the entry
+      // costs one extra toast instead — the recoverable direction.
       setStoredState(
         {
           keyboardLayoutConfirmationsByBinding: {
             [KEY]: 999,
             "nav.toggleFocusMode@Cmd+K": "yes",
             "nav.quickSwitcher@Cmd+P": 0,
+            "nav.focusRegion.next@Cmd+1": -2,
+            "nav.focusRegion.prev@Cmd+2": 1.5,
           },
         },
         16
       );
-      const mod = await import("../preferencesStore");
-      const store = mod.usePreferencesStore;
+      const store = await loadStore();
 
       await vi.waitFor(() => {
-        expect(store.getState().keyboardLayoutConfirmationsByBinding).toEqual({
-          [KEY]: mod.KEYBOARD_LAYOUT_CONFIRMATION_LIMIT,
-        });
+        expect(store.getState().keyboardLayoutConfirmationsByBinding).toEqual({});
       });
+    });
+
+    it("keeps a hydrated in-range count, so the sanitizer isn't just wiping the field", async () => {
+      setStoredState({ keyboardLayoutConfirmationsByBinding: { [KEY]: 2 } }, 16);
+      const store = await loadStore();
+
+      expect(store.getState().keyboardLayoutConfirmationsByBinding).toEqual({ [KEY]: 2 });
+    });
+
+    it("hydrates a v15 blob and rewrites it at the current version", async () => {
+      setStoredState({ dockDensity: "compact" }, 15);
+      const store = await loadStore();
+      expect(store.getState().keyboardLayoutConfirmationsByBinding).toEqual({});
+
+      store.getState().recordKeyboardLayoutConfirmation("nav.toggleSidebar", "Cmd+B");
+
+      const written = JSON.parse(storage[STORAGE_KEY]!) as {
+        version: number;
+        state: Record<string, unknown>;
+      };
+      expect(written.version).toBe(store.persist.getOptions().version);
+      expect(written.state.keyboardLayoutConfirmationsByBinding).toEqual({ [KEY]: 1 });
     });
 
     it("replaces a non-record blob rather than letting it reach live state", async () => {

--- a/src/store/__tests__/preferencesStore.test.ts
+++ b/src/store/__tests__/preferencesStore.test.ts
@@ -858,6 +858,98 @@ describe("preferencesStore migration", () => {
     });
   });
 
+  describe("keyboardLayoutConfirmationsByBinding (v16 migration, issue #11704)", () => {
+    const KEY = "nav.toggleSidebar@Cmd+B";
+
+    it("starts empty so a fresh install still gets told what its shortcut did", async () => {
+      const store = await loadStore();
+      expect(store.getState().keyboardLayoutConfirmationsByBinding).toEqual({});
+    });
+
+    it("counts each confirmation up to the limit and then holds", async () => {
+      const mod = await import("../preferencesStore");
+      const store = mod.usePreferencesStore;
+      const limit = mod.KEYBOARD_LAYOUT_CONFIRMATION_LIMIT;
+
+      for (let i = 0; i < limit + 2; i++) {
+        store.getState().recordKeyboardLayoutConfirmation("nav.toggleSidebar", "Cmd+B");
+      }
+
+      expect(store.getState().keyboardLayoutConfirmationsByBinding[KEY]).toBe(limit);
+    });
+
+    it("keeps one entry per action so rebinding cannot accumulate stale tallies", async () => {
+      const store = await loadStore();
+      store.getState().recordKeyboardLayoutConfirmation("nav.toggleSidebar", "Cmd+B");
+      store.getState().recordKeyboardLayoutConfirmation("nav.toggleSidebar", "Cmd+Shift+S");
+
+      expect(Object.keys(store.getState().keyboardLayoutConfirmationsByBinding)).toEqual([
+        "nav.toggleSidebar@Cmd+Shift+S",
+      ]);
+    });
+
+    it("clearing one action leaves other actions' tallies alone", async () => {
+      const store = await loadStore();
+      store.getState().recordKeyboardLayoutConfirmation("nav.toggleSidebar", "Cmd+B");
+      store.getState().recordKeyboardLayoutConfirmation("nav.toggleFocusMode", "Cmd+K");
+
+      store.getState().clearKeyboardLayoutConfirmations("nav.toggleSidebar");
+
+      expect(store.getState().keyboardLayoutConfirmationsByBinding).toEqual({
+        "nav.toggleFocusMode@Cmd+K": 1,
+      });
+    });
+
+    it("survives a reload, or the toast returns on every app start", async () => {
+      const first = await loadStore();
+      first.getState().recordKeyboardLayoutConfirmation("nav.toggleSidebar", "Cmd+B");
+
+      vi.resetModules();
+      _resetPersistedStoreRegistryForTests();
+      const reloaded = await loadStore();
+
+      expect(reloaded.getState().keyboardLayoutConfirmationsByBinding[KEY]).toBe(1);
+    });
+
+    it("supplies the field in the migration itself, not only in the sanitizer", async () => {
+      const store = await loadStore();
+      const migrated = await store.persist.getOptions().migrate?.({ dockDensity: "compact" }, 15);
+
+      expect(migrated?.keyboardLayoutConfirmationsByBinding).toEqual({});
+      expect(migrated?.dockDensity).toBe("compact");
+    });
+
+    it("drops counts that would silence a binding the user never confirmed", async () => {
+      // A hand-edited or corrupt value breaks both ways: a non-number would nag
+      // forever, an oversized one retires the notice unseen.
+      setStoredState(
+        {
+          keyboardLayoutConfirmationsByBinding: {
+            [KEY]: 999,
+            "nav.toggleFocusMode@Cmd+K": "yes",
+            "nav.quickSwitcher@Cmd+P": 0,
+          },
+        },
+        16
+      );
+      const mod = await import("../preferencesStore");
+      const store = mod.usePreferencesStore;
+
+      await vi.waitFor(() => {
+        expect(store.getState().keyboardLayoutConfirmationsByBinding).toEqual({
+          [KEY]: mod.KEYBOARD_LAYOUT_CONFIRMATION_LIMIT,
+        });
+      });
+    });
+
+    it("replaces a non-record blob rather than letting it reach live state", async () => {
+      setStoredState({ keyboardLayoutConfirmationsByBinding: "corrupt" }, 16);
+      const store = await loadStore();
+
+      expect(store.getState().keyboardLayoutConfirmationsByBinding).toEqual({});
+    });
+  });
+
   describe("hasSeenActionPalettePrefixHint (v15 migration)", () => {
     it("starts unseen so a fresh install still gets taught the prefixes", async () => {
       const store = await loadStore();

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -341,17 +341,46 @@ function normalizeSkipMap(value: unknown): Record<string, boolean> {
 }
 
 /**
- * Coerce the confirmation tallies to whole counts within the real range. Zero
- * and below carry no information the absent key doesn't, so they're dropped
- * rather than stored — which also keeps the record sparse over time.
+ * Keep only whole counts inside the real range. Out-of-range values are dropped
+ * rather than clamped: clamping an oversized one would land on exactly the
+ * limit and silence a binding the user never confirmed, which is the single
+ * failure this notice can't recover from. Erring toward showing it again costs
+ * one toast. `Number.isInteger` also rejects NaN, Infinity and fractions.
  */
 function normalizeConfirmationMap(value: unknown): Record<string, number> {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return {};
   const result: Record<string, number> = {};
   for (const [key, entry] of Object.entries(value)) {
-    if (typeof entry !== "number" || !Number.isFinite(entry)) continue;
-    const clamped = Math.min(Math.floor(entry), KEYBOARD_LAYOUT_CONFIRMATION_LIMIT);
-    if (clamped > 0) result[key] = clamped;
+    if (typeof entry !== "number" || !Number.isInteger(entry)) continue;
+    if (entry < 1 || entry > KEYBOARD_LAYOUT_CONFIRMATION_LIMIT) continue;
+    result[key] = entry;
+  }
+  return result;
+}
+
+/**
+ * Counter-aware merge for the confirmation tallies. The generic
+ * `mergeRecordByWriterDelta` is last-writer-wins per key, which is wrong for a
+ * count two project views both increment: a view still holding 1 would write it
+ * over a sibling's 3 and reopen an allowance the user had already spent. Take
+ * the higher count instead, and keep the writer-delta rule for deletions so an
+ * Undo still clears the key rather than losing to a sibling's stale tally.
+ */
+function mergeConfirmationCounts(
+  baseline: Record<string, number>,
+  incoming: Record<string, number>,
+  onDisk: Record<string, number>
+): Record<string, number> {
+  const result: Record<string, number> = {};
+  for (const [key, incomingCount] of Object.entries(incoming)) {
+    const diskCount = onDisk[key];
+    result[key] = diskCount === undefined ? incomingCount : Math.max(incomingCount, diskCount);
+  }
+  for (const [key, diskCount] of Object.entries(onDisk)) {
+    if (key in incoming) continue;
+    // Held at hydration and gone now → this writer's Undo cleared it.
+    if (key in baseline) continue;
+    result[key] = diskCount;
   }
   return result;
 }
@@ -524,11 +553,9 @@ function mergePreferencesPersistedWrite({
         inc.hasSeenActionPalettePrefixHint,
         disk.hasSeenActionPalettePrefixHint
       ),
-      // Per-binding keys, so the same rule as the two id-keyed maps: a view
-      // that confirmed one shortcut must not wipe a sibling's tally for
-      // another. Undo deletes its key, which the writer-delta diff carries
-      // through as a deletion rather than resurrecting the stale count.
-      keyboardLayoutConfirmationsByBinding: mergeRecordByWriterDelta(
+      // Counts rather than independent values, so this one needs the
+      // counter-aware merge — see {@link mergeConfirmationCounts}.
+      keyboardLayoutConfirmationsByBinding: mergeConfirmationCounts(
         base.keyboardLayoutConfirmationsByBinding,
         inc.keyboardLayoutConfirmationsByBinding,
         disk.keyboardLayoutConfirmationsByBinding

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -371,15 +371,28 @@ function mergeConfirmationCounts(
   incoming: Record<string, number>,
   onDisk: Record<string, number>
 ): Record<string, number> {
+  // Map lookups rather than `in`/bracket reads, which see the prototype chain —
+  // the same reason `mergeRecordByWriterDelta` builds Maps from `Object.entries`.
+  const baselineMap = new Map(Object.entries(baseline));
+  const incomingMap = new Map(Object.entries(incoming));
+  const onDiskMap = new Map(Object.entries(onDisk));
   const result: Record<string, number> = {};
-  for (const [key, incomingCount] of Object.entries(incoming)) {
-    const diskCount = onDisk[key];
+
+  for (const [key, incomingCount] of incomingMap) {
+    const diskCount = onDiskMap.get(key);
+    if (baselineMap.get(key) === incomingCount) {
+      // This writer didn't touch the key, so the sibling's value stands —
+      // including its absence, which is a sibling's Undo that must survive.
+      if (diskCount !== undefined) result[key] = diskCount;
+      continue;
+    }
+    // This writer counted up. Never let its total lower a sibling's.
     result[key] = diskCount === undefined ? incomingCount : Math.max(incomingCount, diskCount);
   }
-  for (const [key, diskCount] of Object.entries(onDisk)) {
-    if (key in incoming) continue;
+  for (const [key, diskCount] of onDiskMap) {
+    if (incomingMap.has(key)) continue;
     // Held at hydration and gone now → this writer's Undo cleared it.
-    if (key in baseline) continue;
+    if (baselineMap.has(key)) continue;
     result[key] = diskCount;
   }
   return result;

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -151,6 +151,32 @@ interface PreferencesState {
    */
   hasSeenActionPalettePrefixHint: boolean;
   markActionPalettePrefixHintSeen: () => void;
+  /**
+   * How many times a keyboard-dispatched layout change has been announced and
+   * left standing, keyed {@link keyboardLayoutBindingKey}. Each confirmation
+   * that actually surfaced counts up; using its Undo clears the action's entry,
+   * because taking the change back is evidence the keypress was a slip rather
+   * than a habit. At {@link KEYBOARD_LAYOUT_CONFIRMATION_LIMIT} the toast stops
+   * firing for that binding, so someone who hits the shortcut on purpose fifty
+   * times a day isn't told what their own key does fifty times (#11704).
+   *
+   * Keyed by combo, not by action alone: the message names the combo, so a
+   * rebind is a new thing to learn and earns a fresh allowance.
+   */
+  keyboardLayoutConfirmationsByBinding: Record<string, number>;
+  recordKeyboardLayoutConfirmation: (actionId: string, combo: string) => void;
+  clearKeyboardLayoutConfirmations: (actionId: string) => void;
+}
+
+/** Confirmations of one binding before it stops announcing itself (#11704). */
+export const KEYBOARD_LAYOUT_CONFIRMATION_LIMIT = 3;
+
+/**
+ * Storage key for a keyboard layout-change confirmation count. Mirrors
+ * `shortcutHintStore`'s `actionId@…` convention.
+ */
+export function keyboardLayoutBindingKey(actionId: string, combo: string): string {
+  return `${actionId}@${combo}`;
 }
 
 function isDockDensity(value: unknown): value is DockDensity {
@@ -226,6 +252,12 @@ function sanitizePersistedPreferences(
     sanitized.hasSeenActionPalettePrefixHint = false;
   }
 
+  // A corrupt count breaks in both directions: a NaN would nag forever, and an
+  // oversized one would silence a binding the user never confirmed.
+  sanitized.keyboardLayoutConfirmationsByBinding = normalizeConfirmationMap(
+    sanitized.keyboardLayoutConfirmationsByBinding
+  );
+
   return sanitized;
 }
 
@@ -252,6 +284,7 @@ type PreferencesPersistedState = Pick<
   | "skipPushConfirmByWorktreePath"
   | "fileBrowserAlwaysHiddenPatterns"
   | "hasSeenActionPalettePrefixHint"
+  | "keyboardLayoutConfirmationsByBinding"
 >;
 
 const PREFERENCES_PERSISTED_DEFAULTS: PreferencesPersistedState = {
@@ -276,6 +309,7 @@ const PREFERENCES_PERSISTED_DEFAULTS: PreferencesPersistedState = {
   skipPushConfirmByWorktreePath: {},
   fileBrowserAlwaysHiddenPatterns: [...DEFAULT_FILE_BROWSER_ALWAYS_HIDDEN],
   hasSeenActionPalettePrefixHint: false,
+  keyboardLayoutConfirmationsByBinding: {},
 };
 
 function coerceBool(value: unknown, fallback: boolean): boolean {
@@ -302,6 +336,22 @@ function normalizeSkipMap(value: unknown): Record<string, boolean> {
   const result: Record<string, boolean> = {};
   for (const [key, entry] of Object.entries(value)) {
     if (typeof entry === "boolean") result[key] = entry;
+  }
+  return result;
+}
+
+/**
+ * Coerce the confirmation tallies to whole counts within the real range. Zero
+ * and below carry no information the absent key doesn't, so they're dropped
+ * rather than stored — which also keeps the record sparse over time.
+ */
+function normalizeConfirmationMap(value: unknown): Record<string, number> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return {};
+  const result: Record<string, number> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry !== "number" || !Number.isFinite(entry)) continue;
+    const clamped = Math.min(Math.floor(entry), KEYBOARD_LAYOUT_CONFIRMATION_LIMIT);
+    if (clamped > 0) result[key] = clamped;
   }
   return result;
 }
@@ -350,6 +400,9 @@ function toPreferencesPersisted(
     hasSeenActionPalettePrefixHint: coerceBool(
       raw.hasSeenActionPalettePrefixHint,
       d.hasSeenActionPalettePrefixHint
+    ),
+    keyboardLayoutConfirmationsByBinding: normalizeConfirmationMap(
+      raw.keyboardLayoutConfirmationsByBinding
     ),
   };
 }
@@ -471,6 +524,15 @@ function mergePreferencesPersistedWrite({
         inc.hasSeenActionPalettePrefixHint,
         disk.hasSeenActionPalettePrefixHint
       ),
+      // Per-binding keys, so the same rule as the two id-keyed maps: a view
+      // that confirmed one shortcut must not wipe a sibling's tally for
+      // another. Undo deletes its key, which the writer-delta diff carries
+      // through as a deletion rather than resurrecting the stale count.
+      keyboardLayoutConfirmationsByBinding: mergeRecordByWriterDelta(
+        base.keyboardLayoutConfirmationsByBinding,
+        inc.keyboardLayoutConfirmationsByBinding,
+        disk.keyboardLayoutConfirmationsByBinding
+      ),
     },
   };
 }
@@ -546,13 +608,45 @@ export const usePreferencesStore = create<PreferencesState>()(
         set({ fileBrowserAlwaysHiddenPatterns: [...DEFAULT_FILE_BROWSER_ALWAYS_HIDDEN] }),
       hasSeenActionPalettePrefixHint: false,
       markActionPalettePrefixHintSeen: () => set({ hasSeenActionPalettePrefixHint: true }),
+      keyboardLayoutConfirmationsByBinding: {},
+      recordKeyboardLayoutConfirmation: (actionId, combo) =>
+        set((state) => {
+          const key = keyboardLayoutBindingKey(actionId, combo);
+          const current = state.keyboardLayoutConfirmationsByBinding[key] ?? 0;
+          if (current >= KEYBOARD_LAYOUT_CONFIRMATION_LIMIT) return state;
+          // One entry per action: a rebind supersedes the old combo's tally
+          // instead of leaving it to accumulate in persisted JSON forever.
+          const prefix = `${actionId}@`;
+          const next: Record<string, number> = {};
+          for (const [existing, count] of Object.entries(
+            state.keyboardLayoutConfirmationsByBinding
+          )) {
+            if (!existing.startsWith(prefix)) next[existing] = count;
+          }
+          next[key] = current + 1;
+          return { keyboardLayoutConfirmationsByBinding: next };
+        }),
+      clearKeyboardLayoutConfirmations: (actionId) =>
+        set((state) => {
+          const prefix = `${actionId}@`;
+          const next: Record<string, number> = {};
+          let removed = false;
+          for (const [existing, count] of Object.entries(
+            state.keyboardLayoutConfirmationsByBinding
+          )) {
+            if (existing.startsWith(prefix)) removed = true;
+            else next[existing] = count;
+          }
+          if (!removed) return state;
+          return { keyboardLayoutConfirmationsByBinding: next };
+        }),
     }),
     {
       name: "daintree-preferences",
       storage: createSafeJSONStorage<PreferencesPersistedState>({
         mergeOnWrite: mergePreferencesPersistedWrite,
       }),
-      version: 15,
+      version: 16,
       // Explicit persisted subset — matches the pre-existing default (setters are
       // dropped by JSON serialization); named so the write merge (#11351) has a
       // typed persisted shape to reconcile.
@@ -578,6 +672,7 @@ export const usePreferencesStore = create<PreferencesState>()(
         skipPushConfirmByWorktreePath: state.skipPushConfirmByWorktreePath,
         fileBrowserAlwaysHiddenPatterns: state.fileBrowserAlwaysHiddenPatterns,
         hasSeenActionPalettePrefixHint: state.hasSeenActionPalettePrefixHint,
+        keyboardLayoutConfirmationsByBinding: state.keyboardLayoutConfirmationsByBinding,
       }),
       // Runs on every hydration (unlike `migrate`, which Zustand skips when the
       // persisted version matches). Closed-set normalisation lives here so a
@@ -699,6 +794,14 @@ export const usePreferencesStore = create<PreferencesState>()(
             persisted.hasSeenActionPalettePrefixHint = false;
           }
         }
+        if (version < 16 && isRecord(persisted)) {
+          // Nobody has confirmed a keyboard layout change before this shipped,
+          // so everyone starts with the full allowance rather than inheriting
+          // silence from an absent key (#11704).
+          if (!isRecord(persisted.keyboardLayoutConfirmationsByBinding)) {
+            persisted.keyboardLayoutConfirmationsByBinding = {};
+          }
+        }
         return persisted as PreferencesState;
       },
     }
@@ -709,5 +812,5 @@ registerPersistedStore({
   storeId: "preferencesStore",
   store: usePreferencesStore,
   persistedStateType:
-    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; showAgentTaskTitles: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; diffViewType: DiffViewType; diffWrapLines: boolean; diffIgnoreWhitespace: boolean; diffShowFileList: boolean; diffFullFile: boolean; diffFontSize: DiffFontSize; markdownWrapLines: boolean; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>; skipPushConfirmByWorktreePath: Record<string, boolean>; deletedWorktreeCleanupSeconds: DeletedWorktreeCleanupSeconds; projectSwitcherOtherSortMode: OtherProjectsSortMode; fileBrowserAlwaysHiddenPatterns: string[]; hasSeenActionPalettePrefixHint: boolean }",
+    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; showAgentTaskTitles: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; diffViewType: DiffViewType; diffWrapLines: boolean; diffIgnoreWhitespace: boolean; diffShowFileList: boolean; diffFullFile: boolean; diffFontSize: DiffFontSize; markdownWrapLines: boolean; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>; skipPushConfirmByWorktreePath: Record<string, boolean>; deletedWorktreeCleanupSeconds: DeletedWorktreeCleanupSeconds; projectSwitcherOtherSortMode: OtherProjectsSortMode; fileBrowserAlwaysHiddenPatterns: string[]; hasSeenActionPalettePrefixHint: boolean; keyboardLayoutConfirmationsByBinding: Record<string, number> }",
 });


### PR DESCRIPTION
## Summary

Cmd+B sits next to Cmd+V, the most repeated chord in the app, so brushing B mid-paste hides the worktree sidebar. As #11704 puts it, the hidden sidebar isn't really the problem: the missing attribution is. A whole region disappears with nothing connecting it to the keys just pressed, and no way to take it back.

`nav.toggleSidebar` now announces itself when it came from a keypress: a 5s toast naming the combo that did it, with an Undo.

Resolves #11704

## How it works

**Only when it's actually surprising.** The notice fires on the hide direction only, since bringing the sidebar back is self-evidently what happened. It fires only for `dispatchSource === "keybinding"`; menu items, the command palette, and the toolbar button all name themselves at the moment of the click, and an agent or plugin dispatch has nobody at the keyboard to tell.

**Derived, not predicted.** `run()` reads `gestureSidebarHidden` before and after the (synchronous) toggle event and reports the observed transition. `AppLayout` drops that event when an overlay is open or no workspace is mounted, so reading the real transition respects both guards without re-deriving either.

**It stops nagging.** Someone who hits Cmd+B fifty times a day shouldn't be told what their own shortcut does fifty times. A persisted per-binding tally retires the notice after three hides the user left standing. Reaching for Undo clears it (taking the change back is the evidence the keypress was a slip), and rebinding earns a fresh allowance, since the message names the combo and a new one has to be learned.

**Undo goes back the way it came.** It re-enters the same toggle event so `AppLayout` reapplies its resize suppression and live sidebar width, falling back to a direct restore (still taking the resize lock) if an overlay swallows the event. The toast is dismissed by the click either way, so it must not leave the user with the sidebar gone and the way back retired. It's one-shot, no-ops if the sidebar is already back, and goes inert once a later change has superseded the notice it named.

`layoutUndoStore` is deliberately untouched: that's the Cmd+Z panel-grid timeline, and sidebar visibility isn't part of it. `AppLayout.tsx` is untouched too.

## Design notes

- The `notify()` call carries an explicit `priority: "high"` and no `context`. A passive `eventKind` resolves to `"low"`, and `transient` plus `context` both collapse the toast into a silent drop, a bug class this repo has hit twice.
- Confirmation tallies merge with a counter-aware three-way merge rather than the generic last-writer-wins one, so a stale project view can't write its lower count over a sibling's and reopen a spent allowance, and a sibling's Undo survives an unrelated write instead of being resurrected.
- Corrupt persisted counts are dropped rather than clamped. Clamping an oversized value would land it exactly on the limit and silence a binding nobody confirmed. Erring toward showing the notice again costs one toast.

## Follow-up

`nav.toggleSidebar` is also a native menu accelerator (`electron/menu.ts`), which fires when a guest webview or DevTools has focus. The renderer never sees that keystroke, and the menu path dispatches as `source: "menu"`, so the notice doesn't appear there. Fixing it means threading Electron's `triggeredByAccelerator` through the menu to IPC to renderer contract, which changes source attribution for every action, so it belongs in its own change. The reported scenario (pasting into agent terminals) is renderer-owned and covered here.

## Testing

- New `src/services/actions/__tests__/keyboardLayoutChangeFeedback.test.ts` (22 tests): direction asymmetry, every non-keyboard dispatch source, the familiarity limit and its reset, rebinding, supersession, one-shot Undo, no allowance spent on a toast that never surfaced, and a broken notification not failing the toggle.
- Extended `navigationActions.adversarial.test.ts`, `preferencesStore.test.ts` (v16 migration, sanitizer, end-to-end v15 hydration), and `preferencesStore.crossViewMerge.test.ts` (same-binding counter merge, Undo vs a racing sibling).
- Local: 89 test files / 1955 tests pass; `tsc --noEmit` clean; eslint on changed files leaves the ratchet unmoved (23 warnings on base, 23 on branch).
