### PR TITLE
fix(terminal): stop CodeMirror pasting dropped file contents

### DIFF
--- a/src/components/Terminal/hooks/__tests__/useEditorDomHandlers.liveEditor.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useEditorDomHandlers.liveEditor.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, cleanup } from "@testing-library/react";
+import { EditorState } from "@codemirror/state";
+import type { Extension } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: { getState: () => ({ setPreferredTerminalFocusTarget: vi.fn() }) },
+}));
+
+vi.mock("@/store/terminalInputStore", () => ({
+  useTerminalInputStore: { getState: () => ({ isVoiceSubmitting: () => false }) },
+}));
+
+const { useEditorDomHandlers } = await import("../useEditorDomHandlers");
+
+type Params = Parameters<typeof useEditorDomHandlers>[0];
+
+// Named for the ordinary test tier rather than `.integration.`, which
+// `vitest.config.ts` excludes — a regression test for #11710 that CI never runs
+// is worth nothing. Driven through a real EditorView because what the fix turns
+// on is not the predicate's return value but what CodeMirror does with it: the
+// built-in drop handler this defers to is reached through the same dispatch
+// table, and only a live view puts the two in their production ordering.
+const views: EditorView[] = [];
+
+function mountEditor(extensions: Extension[]) {
+  const parent = document.createElement("div");
+  document.body.appendChild(parent);
+  const view = new EditorView({
+    parent,
+    state: EditorState.create({ doc: "", extensions }),
+  });
+  views.push(view);
+  return { view, parent };
+}
+
+function params(): Params {
+  return {
+    latestRef: { current: null },
+    editorViewRef: { current: null },
+    isComposingRef: { current: false },
+    handledEnterRef: { current: false },
+    lastEnterKeydownNewlineRef: { current: false },
+    submitAfterCompositionRef: { current: false },
+    applyAutocompleteSelection: vi.fn(() => true),
+    sendFromEditor: vi.fn(),
+    rootRef: { current: null },
+    setActiveCompletionContext: vi.fn(),
+  };
+}
+
+function hookExtension(): Extension {
+  const { result } = renderHook(() => useEditorDomHandlers(params()));
+  return result.current;
+}
+
+/** Stubbed rather than spied: jsdom finishes a real read across later tasks, so
+ * an unsuppressed one would reach CodeMirror's insert after the test that
+ * provoked it has already torn its editor down. */
+function watchFileReads() {
+  return vi.spyOn(FileReader.prototype, "readAsText").mockImplementation(() => {});
+}
+
+function fileDrop() {
+  const event = new Event("drop", { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "dataTransfer", {
+    value: {
+      types: ["Files", "text/plain"],
+      files: [new File(["secret contents"], "notes.txt", { type: "text/plain" })],
+      getData: vi.fn(() => ""),
+    },
+  });
+  return event;
+}
+
+function textDrop() {
+  const event = new Event("drop", { bubbles: true, cancelable: true });
+  // Resolving to an empty string keeps CodeMirror short of `dropText`, which
+  // needs `posAtCoords` and therefore a layout jsdom does not have. The call
+  // itself is the signal: reaching it means the built-in was not suppressed.
+  const getData = vi.fn(() => "");
+  Object.defineProperty(event, "dataTransfer", {
+    value: { types: ["text/plain"], files: [], getData },
+  });
+  return { event, getData };
+}
+
+afterEach(() => {
+  cleanup();
+  for (const view of views.splice(0)) view.destroy();
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("useEditorDomHandlers installed in a live editor", () => {
+  it("keeps a dropped file out of the document instead of reading it as text", () => {
+    const readAsText = watchFileReads();
+    const { view } = mountEditor([hookExtension()]);
+    const event = fileDrop();
+
+    view.contentDOM.dispatchEvent(event);
+
+    expect(readAsText).not.toHaveBeenCalled();
+    expect(view.state.doc.toString()).toBe("");
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  // The control for the assertion above: without the extension the same drop
+  // does reach CodeMirror's FileReader, so a green result there is the fix
+  // working rather than jsdom failing to deliver the event at all.
+  it("reads the file without the extension, proving the drop is delivered", () => {
+    const readAsText = watchFileReads();
+    const { view } = mountEditor([]);
+
+    view.contentDOM.dispatchEvent(fileDrop());
+
+    expect(readAsText).toHaveBeenCalledTimes(1);
+  });
+
+  it("still lets CodeMirror handle a text-only drop", () => {
+    const { view } = mountEditor([hookExtension()]);
+    const { event, getData } = textDrop();
+
+    view.contentDOM.dispatchEvent(event);
+
+    expect(getData).toHaveBeenCalledWith("Text");
+    // CodeMirror declines the empty text itself. Had the handler claimed the
+    // drag, the event would have come back prevented instead.
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  // The chip is inserted by a React handler on an ancestor of the content DOM,
+  // so claiming the drop here has to stop at preventing the default.
+  it("lets a claimed file drop reach the ancestor that inserts the chip", () => {
+    watchFileReads();
+    const { view, parent } = mountEditor([hookExtension()]);
+    const ancestor = vi.fn();
+    parent.addEventListener("drop", ancestor);
+
+    view.contentDOM.dispatchEvent(fileDrop());
+
+    expect(ancestor).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Terminal/hooks/__tests__/useEditorDomHandlers.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useEditorDomHandlers.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { FILE_DRAG_MIME } from "@/lib/fileDragPayload";
+
+type DropHandler = (event: Event, view: unknown) => boolean;
+
+// The extension factory is stubbed to hand its argument straight back, so the
+// hook's return value *is* the handler map CodeMirror would call. That keeps
+// this suite on the classification each drag flavour gets, and off CodeMirror's
+// private plugin shape, which carries no compatibility promise across 6.x.
+// What the classification then costs CodeMirror is a live-editor question, and
+// `useEditorDomHandlers.liveEditor.test.ts` answers it there.
+const factory = { calls: 0 };
+
+vi.mock("@codemirror/view", () => ({
+  EditorView: {
+    domEventHandlers: (handlers: Record<string, DropHandler>) => {
+      factory.calls++;
+      return handlers;
+    },
+  },
+}));
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: { getState: () => ({ setPreferredTerminalFocusTarget: vi.fn() }) },
+}));
+
+vi.mock("@/store/terminalInputStore", () => ({
+  useTerminalInputStore: { getState: () => ({ isVoiceSubmitting: () => false }) },
+}));
+
+const { useEditorDomHandlers } = await import("../useEditorDomHandlers");
+
+type Params = Parameters<typeof useEditorDomHandlers>[0];
+
+function params(): Params {
+  return {
+    latestRef: { current: null },
+    editorViewRef: { current: null },
+    isComposingRef: { current: false },
+    handledEnterRef: { current: false },
+    lastEnterKeydownNewlineRef: { current: false },
+    submitAfterCompositionRef: { current: false },
+    applyAutocompleteSelection: vi.fn(() => true),
+    sendFromEditor: vi.fn(),
+    rootRef: { current: null },
+    setActiveCompletionContext: vi.fn(),
+  };
+}
+
+function registersDrop(value: unknown): value is { drop: DropHandler } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "drop" in value &&
+    typeof value.drop === "function"
+  );
+}
+
+/** Narrowed rather than asserted, so a stub that stopped handing the map back
+ * fails here instead of quietly turning every case below into a no-op. */
+function dropHandlerOf(extension: unknown): DropHandler {
+  if (!registersDrop(extension)) throw new Error("the hook registered no drop handler");
+  return extension.drop;
+}
+
+/** Only `dataTransfer.types` is populated: anything the handler read beyond it
+ * would mean it had started duplicating the chip path it exists to defer to. */
+function dropEvent(types: readonly string[] | null) {
+  const event = new Event("drop", { bubbles: true, cancelable: true });
+  const stopPropagation = vi.spyOn(event, "stopPropagation");
+  Object.defineProperty(event, "dataTransfer", {
+    value: types === null ? null : { types },
+  });
+  return { event, stopPropagation };
+}
+
+function renderHandlers() {
+  const { result, rerender } = renderHook((p: Params) => useEditorDomHandlers(p), {
+    initialProps: params(),
+  });
+  return { result, rerender };
+}
+
+/** Does CodeMirror's own drop handling get retired for this drag? */
+function claimed(types: readonly string[] | null): boolean {
+  const { result } = renderHandlers();
+  const { event } = dropEvent(types);
+  return dropHandlerOf(result.current)(event, {});
+}
+
+beforeEach(() => {
+  factory.calls = 0;
+});
+
+describe("useEditorDomHandlers drop", () => {
+  it("leaves a drag with no dataTransfer to CodeMirror", () => {
+    expect(claimed(null)).toBe(false);
+  });
+
+  it("claims an OS file drop so CodeMirror never reads it as text", () => {
+    expect(claimed(["Files"])).toBe(true);
+  });
+
+  // Finder ships a file drag with a text flavour attached. Falling through on
+  // the text flavour would leave CodeMirror's FileReader branch to run, which
+  // is #11710 itself.
+  it("claims a file drop that also carries a text flavour", () => {
+    expect(claimed(["Files", "text/plain"])).toBe(true);
+  });
+
+  // Guards the gate against narrowing to `dataTransfer.files`, which an in-app
+  // drag never populates (#11576).
+  it("claims an in-app file drag", () => {
+    expect(claimed([FILE_DRAG_MIME])).toBe(true);
+  });
+
+  it("leaves a selection drag inside the editor to CodeMirror", () => {
+    expect(claimed(["text/plain"])).toBe(false);
+  });
+
+  // Separate from the case above: a gate that claimed anything carrying more
+  // than one flavour would pass that one and fail this.
+  it("leaves an external text or link drop to CodeMirror", () => {
+    expect(claimed(["text/plain", "text/uri-list"])).toBe(false);
+  });
+
+  // The chip is produced by `useDragDrop`, wired above the content DOM. Halting
+  // propagation here would claim the drop and then insert nothing.
+  it("lets a claimed drop keep bubbling to the wrapper that inserts the chip", () => {
+    const { result } = renderHandlers();
+    const { event, stopPropagation } = dropEvent(["Files"]);
+
+    dropHandlerOf(result.current)(event, {});
+
+    expect(stopPropagation).not.toHaveBeenCalled();
+  });
+});
+
+describe("useEditorDomHandlers", () => {
+  // `useEditorFactory` builds the editor state under an effect keyed on
+  // terminalId alone, so an extension rebuilt on any other change is handed to
+  // an editor that never installs it — the handlers would silently go stale.
+  it("hands back the extension it built at mount after an unrelated rerender", () => {
+    const { result, rerender } = renderHandlers();
+    const first = result.current;
+
+    rerender(params());
+
+    expect(result.current).toBe(first);
+    expect(factory.calls).toBe(1);
+  });
+});

--- a/src/components/Terminal/hooks/useEditorDomHandlers.ts
+++ b/src/components/Terminal/hooks/useEditorDomHandlers.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef } from "react";
 import { EditorView as EditorViewFacet } from "@codemirror/view";
 import type { EditorView } from "@codemirror/view";
+import { hasFileDrag } from "@/lib/fileDragPayload";
 import { useTerminalInputStore } from "@/store/terminalInputStore";
 import { usePanelStore } from "@/store/panelStore";
 import { isEnterLikeLineBreakInputEvent } from "../hybridInputEvents";
@@ -63,6 +64,17 @@ export function useEditorDomHandlers({
           // of focus events from re-renders does not churn subscribers.
           usePanelStore.getState().setPreferredTerminalFocusTarget("hybridInput");
           return false;
+        },
+        drop: (event) => {
+          if (!event.dataTransfer) return false;
+          // CodeMirror reads a dropped file with a FileReader and dispatches its
+          // text, which lands alongside the `@file` chip `useDragDrop` inserts
+          // when the same drop reaches the wrapper (#11710). Claiming the event
+          // retires that branch — a true return only prevents the default, so
+          // the drop still bubbles and the chip path stays the sole producer.
+          // Drags carrying no file stay CodeMirror's: dropping text still
+          // inserts text, and moving a selection within the input still moves.
+          return hasFileDrag(event.dataTransfer.types);
         },
         beforeinput: (event) => {
           const latest = latestRef.current;


### PR DESCRIPTION
## Summary

Dropping a file from the OS onto the hybrid terminal input inserted the correct `@file` reference chip, but it also pasted the raw text of the file into the prompt. This fixes that by stopping CodeMirror's own drop handler from ever running.

Resolves #11710

## Root cause

CodeMirror 6 ships a built-in drop handler that reads `event.dataTransfer.files` with `FileReader.readAsText` and dispatches the text. Verified in the installed `@codemirror/view` 6.43.6 package, `dist/index.js` line 5094.

Our chip inserter, `useDragDrop.ts`, is a React `onDrop` handler on an ancestor wrapper element. CodeMirror installs its own listener directly on `contentDOM`, so it always fires first and starts the file read. The chip lands, then the `FileReader` resolves later and dumps the raw text in after it.

A previous fix for #11576 didn't cover this. That fix stopped duplicate inserts for in-app drags by never putting `text/plain` on the `DataTransfer`, so CodeMirror's text branch no-opped. A real OS file drop always populates `dataTransfer.files` natively, which the app can't suppress, so #11576 couldn't structurally reach this case.

## Fix

Register a `drop` handler in the hybrid input's existing `EditorView.domEventHandlers` facet that returns `hasFileDrag(event.dataTransfer.types)`.

CodeMirror runs every extension-registered handler before its own built-ins (`computeHandlers`, `dist/index.js` lines 4685-4709), and the first truthy return calls `preventDefault()` and stops the chain (`runHandlers`, lines 4551-4564), so the built-in file read never happens. Returning `true` doesn't stop propagation, so the drop still bubbles up to `useDragDrop`, which remains the sole chip producer and is untouched by this change.

The fix gates on `hasFileDrag` rather than `files.length` so the in-app file drag from #11576 is covered on the same terms, and so a plain text or link drop still falls through to CodeMirror's native text handling unchanged.

## Changes

- `src/components/Terminal/hooks/useEditorDomHandlers.ts`: register the `drop` handler that short-circuits CodeMirror's built-in file read.

## Tests

Two new test files.

`useEditorDomHandlers.test.ts` covers drag-flavour classification (OS files, Finder's `Files` plus `text/plain`, in-app MIME type, text-only, text plus `uri-list`, null `dataTransfer`), plus a memo-identity invariant that `useEditorFactory`'s install-once effect depends on.

`useEditorDomHandlers.liveEditor.test.ts` mounts a real `EditorView` and proves the suppression at the point where CodeMirror actually dispatches, including a no-extension control case so a green result can't just mean jsdom never delivered the drop event.

### Notes for reviewers

No e2e spec was added. There's no existing e2e coverage of file drops, PR CI runs no e2e suite, and this worktree has no build artifacts, so an unrunnable spec would have landed straight in the release gate unvalidated. The live-editor test covers the CodeMirror dispatch ordering instead.

Dropping a file onto the expanded editor already showed a not-allowed cursor, because `useFileDropGuard` sets `dropEffect` to `none` for unclaimed drags, but it still pasted raw contents. Now it does nothing, which matches the affordance. Making the expanded editor a real drop surface is separate pre-existing work, out of scope here.

## Testing

- 1317 tests pass across the Terminal hooks, Terminal components, and `fileDragPayload` suites
- `tsc --noEmit` clean
- `prettier` clean
- `eslint` adds zero new warnings against the existing lint ratchet baseline
