### PR TITLE
fix(plugin): deliver capability consent prompts to the app renderer

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -1035,6 +1035,11 @@ export const CHANNELS = {
   // typed event bus. Distinct from the per-tool plugin-MCP consent above —
   // this gates first use of a host capability (shell:exec, fs:*-write, git:write).
   PLUGIN_CAPABILITY_RESOLVE_CONSENT: "plugin-capability:resolve-consent",
+  // Receipt for that push (#11708), sent when the prompt is enqueued rather
+  // than when it is answered. A push into a renderer with no listener is a
+  // silent no-op, so without an explicit receipt an undeliverable prompt is
+  // indistinguishable from an ignored one until the five-minute timeout.
+  PLUGIN_CAPABILITY_ACKNOWLEDGE_CONSENT: "plugin-capability:acknowledge-consent",
 
   // Plugin managed-process channels (#9234) — child processes spawned by a
   // plugin via `host.process.spawn` (gated on `shell:exec`). `list` is the

--- a/electron/ipc/handlers/__tests__/pluginCapability.test.ts
+++ b/electron/ipc/handlers/__tests__/pluginCapability.test.ts
@@ -1,26 +1,67 @@
 // @vitest-environment node
+import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-interface FakeWebContents {
+/**
+ * These tests model Daintree's BrowserWindow/WebContentsView split, which the
+ * pre-#11708 fixture did not: it returned a single `{ webContents }` object, so
+ * "the window's webContents" and "the renderer running the app" were the same
+ * object by construction and the routing bug could not be expressed, let alone
+ * caught. Worse, `getAppWebContents()` falls back to `win.webContents` when no
+ * app view is registered, so a fixture that skips registration passes
+ * identically before and after the fix.
+ *
+ * So: a distinct shell WebContents and app-view WebContents, wired through the
+ * REAL `webContentsRegistry`. Asserting the shell is never sent to is what makes
+ * these tests fail against the old implementation.
+ */
+
+interface FakeWebContents extends EventEmitter {
   id: number;
+  destroyed: boolean;
   isDestroyed: () => boolean;
   send: ReturnType<typeof vi.fn>;
-  once: ReturnType<typeof vi.fn>;
-  removeListener: ReturnType<typeof vi.fn>;
+  destroy: () => void;
 }
 
-function makeFakeWindow(id: number): { webContents: FakeWebContents; isDestroyed: () => boolean } {
-  const wc: FakeWebContents = {
-    id,
-    isDestroyed: () => false,
-    send: vi.fn(),
-    once: vi.fn(),
-    removeListener: vi.fn(),
+let nextWebContentsId = 100;
+
+function makeWebContents(): FakeWebContents {
+  const wc = new EventEmitter() as FakeWebContents;
+  wc.id = nextWebContentsId++;
+  wc.destroyed = false;
+  wc.isDestroyed = () => wc.destroyed;
+  wc.send = vi.fn();
+  wc.destroy = () => {
+    wc.destroyed = true;
+    wc.emit("destroyed");
   };
-  return { webContents: wc, isDestroyed: () => false };
+  return wc;
 }
 
-let focusedWindow: ReturnType<typeof makeFakeWindow> | null = null;
+interface Harness {
+  win: { id: number; webContents: FakeWebContents; isDestroyed: () => boolean };
+  /** The BrowserWindow's own renderer — `about:blank`, no preload, no listener. */
+  shellWebContents: FakeWebContents;
+  /** The WebContentsView actually running the React app. */
+  appView: { webContents: FakeWebContents };
+  appWebContents: FakeWebContents;
+}
+
+let nextWindowId = 1;
+
+function makeHarness(): Harness {
+  const shellWebContents = makeWebContents();
+  const appWebContents = makeWebContents();
+  return {
+    win: { id: nextWindowId++, webContents: shellWebContents, isDestroyed: () => false },
+    shellWebContents,
+    appView: { webContents: appWebContents },
+    appWebContents,
+  };
+}
+
+let harness: Harness | null = null;
 
 vi.mock("electron", () => ({
   app: {
@@ -29,120 +70,144 @@ vi.mock("electron", () => ({
   },
   ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
   BrowserWindow: {
-    getFocusedWindow: () => focusedWindow,
-    getAllWindows: () => (focusedWindow ? [focusedWindow] : []),
+    getFocusedWindow: () => harness?.win ?? null,
+    getAllWindows: () => (harness ? [harness.win] : []),
+    fromWebContents: () => null,
   },
+  // The real webContentsRegistry imports both of these at module scope.
+  WebContentsView: vi.fn(),
+  webContents: { fromId: vi.fn(() => null) },
 }));
 
 vi.mock("../../../window/windowRef.js", () => ({
-  getMainWindow: () => focusedWindow,
+  getMainWindow: () => harness?.win ?? null,
 }));
 
 import {
+  handleAcknowledgeConsent,
   handleResolveConsent,
   registerPluginCapabilityHandlers,
   _resetCapabilityConsentBridgeForTest,
 } from "../pluginCapability.js";
+import { registerAppView, unregisterAppView } from "../../../window/webContentsRegistry.js";
 import {
   getPluginCapabilityConsentService,
   _resetPluginCapabilityServicesForTest,
 } from "../../../services/plugin-capability/instances.js";
-import { PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS } from "../../../../shared/types/pluginCapabilityConsent.js";
+import {
+  PLUGIN_CAPABILITY_CONSENT_DELIVERY_TIMEOUT_MS,
+  PLUGIN_CAPABILITY_CONSENT_RESEND_INTERVAL_MS,
+  PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS,
+} from "../../../../shared/types/pluginCapabilityConsent.js";
 import type { IpcContext } from "../../types.js";
 
 function ctx(webContentsId: number): IpcContext {
   return { event: {} as never, webContentsId, senderWindow: null, projectId: null };
 }
 
+/** Start a gated call and capture its settlement without an unhandled rejection. */
+function startGatedCall(): Promise<{ ok: true } | { ok: false; err: Error }> {
+  return getPluginCapabilityConsentService()
+    .ensureAllowed("acme.x", "Acme", "shell:exec", ["shell:exec"])
+    .then(
+      () => ({ ok: true }) as const,
+      (err: Error) => ({ ok: false, err }) as const
+    );
+}
+
+/** The requestId of the Nth push made to a given WebContents. */
+function pushedRequestId(wc: FakeWebContents, callIndex = 0): string {
+  const call = wc.send.mock.calls[callIndex] as [string, { payload: { requestId: string } }];
+  return call[1].payload.requestId;
+}
+
 beforeEach(() => {
-  focusedWindow = makeFakeWindow(7);
-  // Install the bridge directly (mirrors registerPluginCapabilityHandlers).
+  harness = makeHarness();
+  registerAppView(harness.win as never, harness.appView as never);
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
   getPluginCapabilityConsentService();
 });
 
 afterEach(() => {
   _resetCapabilityConsentBridgeForTest();
   _resetPluginCapabilityServicesForTest();
-  focusedWindow = null;
+  if (harness) unregisterAppView(harness.win as never);
+  harness = null;
+  vi.restoreAllMocks();
 });
 
-describe("pluginCapability consent bridge", () => {
-  it("pushes a consent-request to the focused window and ignores a reply from a different sender", async () => {
-    // Wire the real bridge onto the service via the handler's install path.
-    const { registerPluginCapabilityHandlers } = await import("../pluginCapability.js");
+describe("pluginCapability consent bridge — routing (#11708)", () => {
+  it("pushes the prompt to the app view's renderer, never the BrowserWindow shell", async () => {
     const dispose = registerPluginCapabilityHandlers();
+    const settled = startGatedCall();
 
-    const decisionPromise = getPluginCapabilityConsentService().ensureAllowed(
-      "acme.x",
-      "Acme",
-      "shell:exec",
-      ["shell:exec"]
-    );
-
-    // The bridge pushed exactly one consent-request to the focused window.
-    const send = focusedWindow!.webContents.send;
-    expect(send).toHaveBeenCalledTimes(1);
-    const pushed = send.mock.calls[0][1] as {
+    // The app renderer got it...
+    expect(harness!.appWebContents.send).toHaveBeenCalledTimes(1);
+    const pushed = harness!.appWebContents.send.mock.calls[0][1] as {
       name: string;
       payload: { requestId: string; capability: string };
     };
     expect(pushed.name).toBe("plugin-capability:consent-request");
     expect(pushed.payload.capability).toBe("shell:exec");
-    const requestId = pushed.payload.requestId;
 
-    // A reply from the WRONG WebContents must not settle the prompt.
-    await handleResolveConsent(ctx(999), { requestId, decision: "approved-and-pin" });
+    // ...and the shell — an `about:blank` document with no preload bridge — did
+    // not. This is the assertion that fails against the pre-#11708 code.
+    expect(harness!.shellWebContents.send).not.toHaveBeenCalled();
 
-    // The correct sender settles it.
-    await handleResolveConsent(ctx(7), { requestId, decision: "approved-and-pin" });
-    await expect(decisionPromise).resolves.toBeUndefined();
+    await handleAcknowledgeConsent(ctx(harness!.appWebContents.id), {
+      requestId: pushed.payload.requestId,
+    });
+    await handleResolveConsent(ctx(harness!.appWebContents.id), {
+      requestId: pushed.payload.requestId,
+      decision: "approved-once",
+    });
+    await expect(settled).resolves.toEqual({ ok: true });
 
     dispose();
   });
 
-  it("is a no-op for an unknown requestId", async () => {
-    await expect(
-      handleResolveConsent(ctx(7), { requestId: "does-not-exist", decision: "rejected" })
-    ).resolves.toBeUndefined();
-  });
+  it("pins the response to the app view, so the shell's id cannot answer", async () => {
+    const dispose = registerPluginCapabilityHandlers();
+    const settled = startGatedCall();
+    const requestId = pushedRequestId(harness!.appWebContents);
 
-  it("settles an abandoned prompt as a timeout denial and ignores a late reply (#10841)", async () => {
+    // The shell webContents is a real, live WebContents in production — it just
+    // isn't the one holding the dialog. It must not be able to approve.
+    await handleAcknowledgeConsent(ctx(harness!.shellWebContents.id), { requestId });
+    await handleResolveConsent(ctx(harness!.shellWebContents.id), {
+      requestId,
+      decision: "approved-and-pin",
+    });
+
+    await handleResolveConsent(ctx(harness!.appWebContents.id), {
+      requestId,
+      decision: "rejected",
+    });
+    const outcome = await settled;
+    expect(outcome.ok).toBe(false);
+
+    dispose();
+  });
+});
+
+describe("pluginCapability consent bridge — delivery acknowledgement (#11708)", () => {
+  it("settles undeliverable well before the decision timeout when nothing acknowledges", async () => {
     vi.useFakeTimers();
     try {
       const dispose = registerPluginCapabilityHandlers();
+      const settled = startGatedCall();
 
-      const decisionPromise = getPluginCapabilityConsentService().ensureAllowed(
-        "acme.x",
-        "Acme",
-        "shell:exec",
-        ["shell:exec"]
-      );
-      // Surface the rejection synchronously so an unhandled rejection isn't
-      // flagged while we advance the fake clock.
-      const settled = decisionPromise.then(
-        () => ({ ok: true }) as const,
-        (err: Error) => ({ ok: false, err }) as const
-      );
+      await vi.advanceTimersByTimeAsync(PLUGIN_CAPABILITY_CONSENT_DELIVERY_TIMEOUT_MS);
 
-      const requestId = (
-        focusedWindow!.webContents.send.mock.calls[0][1] as {
-          payload: { requestId: string };
-        }
-      ).payload.requestId;
-
-      await vi.advanceTimersByTimeAsync(PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS);
-
-      // The gating call fails closed (PERMISSION_REQUIRED) rather than hanging.
       const outcome = await settled;
       expect(outcome.ok).toBe(false);
       if (!outcome.ok) {
+        // Fails closed, but does not claim the user refused.
         expect(outcome.err.message).toContain("PERMISSION_REQUIRED");
+        expect(outcome.err.message).toContain("could not present");
+        expect(outcome.err.message).not.toContain("was denied");
       }
-      // The destroyed listener was torn down on settle.
-      expect(focusedWindow!.webContents.removeListener).toHaveBeenCalled();
-
-      // A late reply for the timed-out request is a no-op (pending entry gone).
-      await handleResolveConsent(ctx(7), { requestId, decision: "approved-and-pin" });
 
       dispose();
     } finally {
@@ -150,39 +215,294 @@ describe("pluginCapability consent bridge", () => {
     }
   });
 
-  it("times out even when only a wrong-sender reply ever arrives (#10841)", async () => {
+  it("gives up on delivery far sooner than the five-minute decision window", () => {
+    // The original bug held the plugin for the full decision timeout before
+    // reporting a denial. Delivery failure must be detected in a fraction of it.
+    expect(PLUGIN_CAPABILITY_CONSENT_DELIVERY_TIMEOUT_MS).toBeLessThan(
+      PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS / 10
+    );
+    expect(PLUGIN_CAPABILITY_CONSENT_RESEND_INTERVAL_MS).toBeLessThan(
+      PLUGIN_CAPABILITY_CONSENT_DELIVERY_TIMEOUT_MS
+    );
+  });
+
+  it("re-pushes an unacknowledged prompt, then stops once it is acknowledged", async () => {
     vi.useFakeTimers();
     try {
       const dispose = registerPluginCapabilityHandlers();
+      const settled = startGatedCall();
+      const requestId = pushedRequestId(harness!.appWebContents);
 
-      const decisionPromise = getPluginCapabilityConsentService().ensureAllowed(
-        "acme.x",
-        "Acme",
-        "shell:exec",
-        ["shell:exec"]
-      );
-      const settled = decisionPromise.then(
-        () => ({ ok: true }) as const,
-        (err: Error) => ({ ok: false, err }) as const
-      );
+      expect(harness!.appWebContents.send).toHaveBeenCalledTimes(1);
 
-      const requestId = (
-        focusedWindow!.webContents.send.mock.calls[0][1] as {
-          payload: { requestId: string };
-        }
-      ).payload.requestId;
+      // A renderer mid-cold-start isn't listening yet; the re-push is what lets
+      // it receive the prompt once React mounts instead of losing it.
+      await vi.advanceTimersByTimeAsync(PLUGIN_CAPABILITY_CONSENT_RESEND_INTERVAL_MS);
+      expect(harness!.appWebContents.send).toHaveBeenCalledTimes(2);
+      // Same request, not a second dialog.
+      expect(pushedRequestId(harness!.appWebContents, 1)).toBe(requestId);
 
-      // A reply from the wrong WebContents is ignored and must NOT settle or
-      // disarm the timer — otherwise the prompt would hang forever.
-      await handleResolveConsent(ctx(999), { requestId, decision: "approved-and-pin" });
+      await handleAcknowledgeConsent(ctx(harness!.appWebContents.id), { requestId });
 
+      const callsAtAck = harness!.appWebContents.send.mock.calls.length;
+      await vi.advanceTimersByTimeAsync(PLUGIN_CAPABILITY_CONSENT_RESEND_INTERVAL_MS * 3);
+      expect(harness!.appWebContents.send).toHaveBeenCalledTimes(callsAtAck);
+
+      await handleResolveConsent(ctx(harness!.appWebContents.id), {
+        requestId,
+        decision: "approved-once",
+      });
+      await expect(settled).resolves.toEqual({ ok: true });
+
+      dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("starts the five-minute decision clock only after acknowledgement", async () => {
+    vi.useFakeTimers();
+    try {
+      const dispose = registerPluginCapabilityHandlers();
+      const settled = startGatedCall();
+      const requestId = pushedRequestId(harness!.appWebContents);
+
+      // Acknowledge late — the user's full decision window should start here,
+      // not at push time, so a slow delivery doesn't eat into their time.
+      await vi.advanceTimersByTimeAsync(PLUGIN_CAPABILITY_CONSENT_RESEND_INTERVAL_MS);
+      await handleAcknowledgeConsent(ctx(harness!.appWebContents.id), { requestId });
+
+      await vi.advanceTimersByTimeAsync(PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS - 1);
+      await handleResolveConsent(ctx(harness!.appWebContents.id), {
+        requestId,
+        decision: "approved-and-pin",
+      });
+
+      await expect(settled).resolves.toEqual({ ok: true });
+      dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reports an acknowledged-but-unanswered prompt as a timeout, not a denial", async () => {
+    vi.useFakeTimers();
+    try {
+      const dispose = registerPluginCapabilityHandlers();
+      const settled = startGatedCall();
+      const requestId = pushedRequestId(harness!.appWebContents);
+
+      await handleAcknowledgeConsent(ctx(harness!.appWebContents.id), { requestId });
       await vi.advanceTimersByTimeAsync(PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS);
 
       const outcome = await settled;
       expect(outcome.ok).toBe(false);
       if (!outcome.ok) {
-        expect(outcome.err.message).toContain("PERMISSION_REQUIRED");
+        expect(outcome.err.message).toContain("timed out");
+        expect(outcome.err.message).not.toContain("was denied");
+        expect(outcome.err.message).not.toContain("could not present");
       }
+
+      // A reply arriving after the request is gone is a no-op.
+      await handleResolveConsent(ctx(harness!.appWebContents.id), {
+        requestId,
+        decision: "approved-and-pin",
+      });
+
+      dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("ignores an acknowledgement from a different sender and still fails delivery", async () => {
+    vi.useFakeTimers();
+    try {
+      const dispose = registerPluginCapabilityHandlers();
+      const settled = startGatedCall();
+      const requestId = pushedRequestId(harness!.appWebContents);
+
+      // A sibling renderer must not be able to vouch for delivery on behalf of
+      // the renderer that was actually targeted.
+      await handleAcknowledgeConsent(ctx(9999), { requestId });
+      await vi.advanceTimersByTimeAsync(PLUGIN_CAPABILITY_CONSENT_DELIVERY_TIMEOUT_MS);
+
+      const outcome = await settled;
+      expect(outcome.ok).toBe(false);
+      if (!outcome.ok) expect(outcome.err.message).toContain("could not present");
+
+      dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("treats a decision arriving before the acknowledgement as proof of delivery", async () => {
+    vi.useFakeTimers();
+    try {
+      const dispose = registerPluginCapabilityHandlers();
+      const settled = startGatedCall();
+      const requestId = pushedRequestId(harness!.appWebContents);
+
+      // The reply itself proves the prompt was displayed and answered, so it
+      // must settle rather than being overtaken by the delivery deadline.
+      await handleResolveConsent(ctx(harness!.appWebContents.id), {
+        requestId,
+        decision: "approved-once",
+      });
+      await expect(settled).resolves.toEqual({ ok: true });
+
+      // The delivery timer was disarmed with everything else.
+      await vi.advanceTimersByTimeAsync(PLUGIN_CAPABILITY_CONSENT_DELIVERY_TIMEOUT_MS * 2);
+      dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("pluginCapability consent bridge — unpromptable states (#11708)", () => {
+  it("fails fast as undeliverable when there is no window to prompt in", async () => {
+    const dispose = registerPluginCapabilityHandlers();
+    unregisterAppView(harness!.win as never);
+    const saved = harness;
+    harness = null; // no focused window, no primary window
+
+    const outcome = await startGatedCall();
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.err.message).toContain("could not present");
+      expect(outcome.err.message).not.toContain("was denied");
+    }
+
+    harness = saved;
+    dispose();
+  });
+
+  it("fails as undeliverable when the push itself throws", async () => {
+    const dispose = registerPluginCapabilityHandlers();
+    harness!.appWebContents.send.mockImplementation(() => {
+      throw new Error("render frame was disposed");
+    });
+
+    const outcome = await startGatedCall();
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) expect(outcome.err.message).toContain("could not present");
+
+    dispose();
+  });
+
+  it("fails as undeliverable when the target renderer is destroyed before acknowledging", async () => {
+    const dispose = registerPluginCapabilityHandlers();
+    const settled = startGatedCall();
+
+    harness!.appWebContents.destroy();
+
+    const outcome = await settled;
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) expect(outcome.err.message).toContain("could not present");
+
+    dispose();
+  });
+
+  it("fails as undeliverable when the renderer is destroyed after acknowledging", async () => {
+    const dispose = registerPluginCapabilityHandlers();
+    const settled = startGatedCall();
+    const requestId = pushedRequestId(harness!.appWebContents);
+
+    await handleAcknowledgeConsent(ctx(harness!.appWebContents.id), { requestId });
+    // The dialog the user was looking at went away with the renderer — they
+    // never answered it, so this is still not a denial.
+    harness!.appWebContents.destroy();
+
+    const outcome = await settled;
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) expect(outcome.err.message).toContain("could not present");
+
+    dispose();
+  });
+
+  it("settles pending prompts as undeliverable when the handlers are torn down", async () => {
+    const dispose = registerPluginCapabilityHandlers();
+    const settled = startGatedCall();
+
+    dispose();
+
+    const outcome = await settled;
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) expect(outcome.err.message).toContain("could not present");
+  });
+});
+
+describe("pluginCapability consent bridge — decisions", () => {
+  it("persists the grant on approve-and-pin so a second call never prompts", async () => {
+    const dispose = registerPluginCapabilityHandlers();
+    const first = startGatedCall();
+    const requestId = pushedRequestId(harness!.appWebContents);
+
+    await handleAcknowledgeConsent(ctx(harness!.appWebContents.id), { requestId });
+    await handleResolveConsent(ctx(harness!.appWebContents.id), {
+      requestId,
+      decision: "approved-and-pin",
+    });
+    await expect(first).resolves.toEqual({ ok: true });
+
+    const pushesAfterGrant = harness!.appWebContents.send.mock.calls.length;
+    await expect(startGatedCall()).resolves.toEqual({ ok: true });
+    expect(harness!.appWebContents.send).toHaveBeenCalledTimes(pushesAfterGrant);
+
+    dispose();
+  });
+
+  it("still says the plugin was denied when the user actually rejects", async () => {
+    const dispose = registerPluginCapabilityHandlers();
+    const settled = startGatedCall();
+    const requestId = pushedRequestId(harness!.appWebContents);
+
+    await handleAcknowledgeConsent(ctx(harness!.appWebContents.id), { requestId });
+    await handleResolveConsent(ctx(harness!.appWebContents.id), {
+      requestId,
+      decision: "rejected",
+    });
+
+    const outcome = await settled;
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.err.message).toContain("was denied");
+      expect(outcome.err.message).not.toContain("could not present");
+      expect(outcome.err.message).not.toContain("timed out");
+    }
+
+    dispose();
+  });
+
+  it("is a no-op for an unknown requestId on both reply channels", async () => {
+    await expect(
+      handleResolveConsent(ctx(harness!.appWebContents.id), {
+        requestId: "does-not-exist",
+        decision: "rejected",
+      })
+    ).resolves.toBeUndefined();
+    await expect(
+      handleAcknowledgeConsent(ctx(harness!.appWebContents.id), { requestId: "does-not-exist" })
+    ).resolves.toBeUndefined();
+  });
+
+  it("ignores a reply from a different sender and keeps waiting", async () => {
+    vi.useFakeTimers();
+    try {
+      const dispose = registerPluginCapabilityHandlers();
+      const settled = startGatedCall();
+      const requestId = pushedRequestId(harness!.appWebContents);
+      await handleAcknowledgeConsent(ctx(harness!.appWebContents.id), { requestId });
+
+      // Must not settle, and must not disarm the decision clock either.
+      await handleResolveConsent(ctx(9999), { requestId, decision: "approved-and-pin" });
+
+      await vi.advanceTimersByTimeAsync(PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS);
+      const outcome = await settled;
+      expect(outcome.ok).toBe(false);
+      if (!outcome.ok) expect(outcome.err.message).toContain("timed out");
 
       dispose();
     } finally {

--- a/electron/ipc/handlers/__tests__/pluginCapability.test.ts
+++ b/electron/ipc/handlers/__tests__/pluginCapability.test.ts
@@ -186,6 +186,13 @@ describe("pluginCapability consent bridge — routing (#11708)", () => {
     });
     const outcome = await settled;
     expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      // The shell's attempt neither approved nor changed how the real answer is
+      // reported — this is the app view's rejection, not a delivery failure.
+      expect(outcome.err.message).toContain("was denied");
+      expect(outcome.err.message).not.toContain("could not present");
+      expect(outcome.err.message).not.toContain("timed out");
+    }
 
     dispose();
   });
@@ -352,9 +359,73 @@ describe("pluginCapability consent bridge — delivery acknowledgement (#11708)"
       });
       await expect(settled).resolves.toEqual({ ok: true });
 
-      // The delivery timer was disarmed with everything else.
-      await vi.advanceTimersByTimeAsync(PLUGIN_CAPABILITY_CONSENT_DELIVERY_TIMEOUT_MS * 2);
+      // Every timer the request owned is gone. Asserting the count directly
+      // matters: a leaked timer would just fire against a deleted map entry and
+      // no-op, so advancing the clock alone proves nothing.
+      expect(vi.getTimerCount()).toBe(0);
       dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("settles undeliverable when a re-push throws after the first push succeeded", async () => {
+    vi.useFakeTimers();
+    try {
+      const dispose = registerPluginCapabilityHandlers();
+      const settled = startGatedCall();
+      expect(harness!.appWebContents.send).toHaveBeenCalledTimes(1);
+
+      // The renderer can go away between the initial push and a retry; the
+      // retry's failure path is separate code from the initial one.
+      harness!.appWebContents.send.mockImplementation(() => {
+        throw new Error("render frame was disposed");
+      });
+      await vi.advanceTimersByTimeAsync(PLUGIN_CAPABILITY_CONSENT_RESEND_INTERVAL_MS);
+
+      const outcome = await settled;
+      expect(outcome.ok).toBe(false);
+      if (!outcome.ok) expect(outcome.err.message).toContain("could not present");
+      // Settled on the retry, not by waiting out the delivery deadline.
+      expect(vi.getTimerCount()).toBe(0);
+
+      dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps concurrent prompts for different capabilities independent", async () => {
+    vi.useFakeTimers();
+    try {
+      const dispose = registerPluginCapabilityHandlers();
+      const service = getPluginCapabilityConsentService();
+      const shell = service
+        .ensureAllowed("acme.x", "Acme", "shell:exec", ["shell:exec", "git:write"])
+        .then(
+          () => ({ ok: true }) as const,
+          (err: Error) => ({ ok: false, err }) as const
+        );
+      const git = service.ensureAllowed("acme.x", "Acme", "git:write", ["shell:exec", "git:write"]);
+      git.catch(() => {});
+
+      expect(harness!.appWebContents.send).toHaveBeenCalledTimes(2);
+      const shellId = pushedRequestId(harness!.appWebContents, 0);
+      const gitId = pushedRequestId(harness!.appWebContents, 1);
+      expect(shellId).not.toBe(gitId);
+
+      // Answering one must not settle or disturb the other.
+      await handleAcknowledgeConsent(ctx(harness!.appWebContents.id), { requestId: shellId });
+      await handleResolveConsent(ctx(harness!.appWebContents.id), {
+        requestId: shellId,
+        decision: "approved-once",
+      });
+      await expect(shell).resolves.toEqual({ ok: true });
+
+      // Tearing down settles everything still pending.
+      dispose();
+      await expect(git).rejects.toThrow(/could not present/);
+      expect(vi.getTimerCount()).toBe(0);
     } finally {
       vi.useRealTimers();
     }

--- a/electron/ipc/handlers/pluginCapability.preload.ts
+++ b/electron/ipc/handlers/pluginCapability.preload.ts
@@ -2,6 +2,7 @@ import type { IpcInvokeMap } from "../../types/index.js";
 
 export const PLUGIN_CAPABILITY_METHOD_CHANNELS = {
   resolveConsent: "plugin-capability:resolve-consent",
+  acknowledgeConsent: "plugin-capability:acknowledge-consent",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof PLUGIN_CAPABILITY_METHOD_CHANNELS;

--- a/electron/ipc/handlers/pluginCapability.ts
+++ b/electron/ipc/handlers/pluginCapability.ts
@@ -10,9 +10,13 @@ import type {
   PluginCapabilityConsentRequest,
 } from "../../services/plugin-capability/PluginCapabilityConsentService.js";
 import { getMainWindow } from "../../window/windowRef.js";
+import { getAppWebContents } from "../../window/webContentsRegistry.js";
 import {
+  PLUGIN_CAPABILITY_CONSENT_DELIVERY_TIMEOUT_MS,
+  PLUGIN_CAPABILITY_CONSENT_RESEND_INTERVAL_MS,
   PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS,
-  type PluginCapabilityConsentDecision,
+  type PluginCapabilityAcknowledgeConsentInput,
+  type PluginCapabilityConsentOutcome,
   type PluginCapabilityResolveConsentInput,
 } from "../../../shared/types/pluginCapabilityConsent.js";
 
@@ -24,12 +28,36 @@ import {
 // initiating renderer to pin to — so the prompt is sent to the focused window,
 // falling back to the primary window. The renderer replies via
 // `plugin-capability:resolve-consent`, correlated by `requestId`.
+//
+// Which WebContents *inside* that window matters (#11708). The BrowserWindow is
+// only a shell — it stays at `about:blank` with no preload attached — while the
+// React app lives in a child WebContentsView registered through
+// `webContentsRegistry`. Pushing to `win.webContents` therefore delivered every
+// prompt into an empty document: `send()` to a listener-less renderer neither
+// throws nor logs, so the failure was invisible until the five-minute timeout
+// fired and reported itself to the plugin as a user denial. `getAppWebContents`
+// is the established lookup for "the renderer actually running the app".
+//
+// Because that class of failure is silent by construction, routing correctly is
+// not enough to *know* it worked. The renderer acknowledges receipt as soon as
+// it enqueues the prompt, and the bridge re-pushes until that receipt arrives —
+// which also covers a cold project switch, where the app view is registered
+// before React has mounted the consent listener. An unacknowledged prompt
+// settles `undeliverable` in seconds instead of failing closed as a denial the
+// user never made.
 
 interface PendingConsent {
-  resolve: (decision: PluginCapabilityConsentDecision) => void;
+  resolve: (outcome: PluginCapabilityConsentOutcome) => void;
+  /** Response sender pin — only this WebContents may acknowledge or answer. */
   webContentsId: number;
   cleanup: () => void;
-  timer: ReturnType<typeof setTimeout>;
+  /** Re-push tick; cleared on receipt. Null once acknowledged. */
+  resendTimer: ReturnType<typeof setInterval> | null;
+  /** Deadline for the receipt; cleared on receipt. Null once acknowledged. */
+  deliveryTimer: ReturnType<typeof setTimeout> | null;
+  /** Five-minute decision clock; armed only once delivery is proven. */
+  decisionTimer: ReturnType<typeof setTimeout> | null;
+  acknowledged: boolean;
 }
 
 const pendingConsents = new Map<string, PendingConsent>();
@@ -44,25 +72,39 @@ function resolvePromptWindow(): BrowserWindow | null {
   return null;
 }
 
-function settleConsent(requestId: string, decision: PluginCapabilityConsentDecision): void {
+/**
+ * The single terminal path for a pending prompt. Drops the entry first so any
+ * re-entrant or late event (a re-push tick, a destroy signal, a straggling
+ * reply) becomes a no-op, then disarms every timer the entry owns — which of
+ * the three are live depends on whether delivery was ever acknowledged.
+ */
+function settleConsent(requestId: string, outcome: PluginCapabilityConsentOutcome): void {
   const pending = pendingConsents.get(requestId);
   if (!pending) return;
   pendingConsents.delete(requestId);
-  clearTimeout(pending.timer);
+  if (pending.resendTimer) clearInterval(pending.resendTimer);
+  if (pending.deliveryTimer) clearTimeout(pending.deliveryTimer);
+  if (pending.decisionTimer) clearTimeout(pending.decisionTimer);
   pending.cleanup();
-  pending.resolve(decision);
+  pending.resolve(outcome);
 }
 
 const consentBridge: PluginCapabilityConsentBridge = (request: PluginCapabilityConsentRequest) => {
   const win = resolvePromptWindow();
-  const wc = win?.webContents;
+  // The app renderer is the window's registered WebContentsView, not the
+  // BrowserWindow shell — see the note above (#11708).
+  const wc = win ? getAppWebContents(win) : null;
   if (!wc || wc.isDestroyed()) {
-    // Fail closed: no window to surface a prompt, so no one can approve.
-    return Promise.resolve("rejected");
+    // Fail closed, but say so honestly: there is no surface to prompt on, which
+    // is not the same as a user refusing.
+    return Promise.resolve("undeliverable");
   }
-  return new Promise<PluginCapabilityConsentDecision>((resolve) => {
+  return new Promise<PluginCapabilityConsentOutcome>((resolve) => {
     const requestId = randomUUID();
-    const onDestroyed = () => settleConsent(requestId, "rejected");
+    // A renderer that goes away can no longer show or answer the prompt. Before
+    // acknowledgement that is a delivery failure; after it, the dialog the user
+    // was looking at vanished — neither is a decision they made.
+    const onDestroyed = () => settleConsent(requestId, "undeliverable");
     const cleanup = () => {
       try {
         wc.removeListener("destroyed", onDestroyed);
@@ -70,15 +112,8 @@ const consentBridge: PluginCapabilityConsentBridge = (request: PluginCapabilityC
         // best-effort — the WebContents may already be torn down
       }
     };
-    // Safety net: an abandoned prompt settles itself as "timeout" so the gating
-    // promise never hangs and the pending entry is freed (#10841).
-    const timer = setTimeout(
-      () => settleConsent(requestId, "timeout"),
-      PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS
-    );
-    pendingConsents.set(requestId, { resolve, webContentsId: wc.id, cleanup, timer });
-    wc.once("destroyed", onDestroyed);
-    try {
+
+    const push = () => {
       wc.send(CHANNELS.EVENTS_PUSH, {
         name: "plugin-capability:consent-request",
         payload: {
@@ -89,8 +124,50 @@ const consentBridge: PluginCapabilityConsentBridge = (request: PluginCapabilityC
           declaredCapabilities: request.declaredCapabilities,
         },
       });
+    };
+
+    // Re-push the same prompt to the same renderer until it acknowledges. This
+    // is what carries a prompt across a cold project switch: the app view is
+    // registered before React mounts the consent listener, so the first push
+    // can land in a renderer that is not listening yet. The renderer keys on
+    // `requestId` and re-acknowledges rather than queueing a second dialog.
+    const resendTimer = setInterval(() => {
+      const pending = pendingConsents.get(requestId);
+      if (!pending || pending.acknowledged) return;
+      if (wc.isDestroyed()) {
+        settleConsent(requestId, "undeliverable");
+        return;
+      }
+      try {
+        push();
+      } catch {
+        settleConsent(requestId, "undeliverable");
+      }
+    }, PLUGIN_CAPABILITY_CONSENT_RESEND_INTERVAL_MS);
+
+    // No receipt in time: the prompt is not on screen anywhere, so fail now
+    // rather than holding the plugin for the full five-minute decision window.
+    const deliveryTimer = setTimeout(() => {
+      console.warn(
+        `[plugin-capability] No renderer acknowledged the consent prompt for plugin "${request.pluginId}" capability "${request.capability}" within ${PLUGIN_CAPABILITY_CONSENT_DELIVERY_TIMEOUT_MS}ms — treating it as undeliverable`
+      );
+      settleConsent(requestId, "undeliverable");
+    }, PLUGIN_CAPABILITY_CONSENT_DELIVERY_TIMEOUT_MS);
+
+    pendingConsents.set(requestId, {
+      resolve,
+      webContentsId: wc.id,
+      cleanup,
+      resendTimer,
+      deliveryTimer,
+      decisionTimer: null,
+      acknowledged: false,
+    });
+    wc.once("destroyed", onDestroyed);
+    try {
+      push();
     } catch {
-      settleConsent(requestId, "rejected");
+      settleConsent(requestId, "undeliverable");
     }
   });
 };
@@ -102,12 +179,54 @@ function ensureConsentBridge(): void {
   getPluginCapabilityConsentService().setConsentBridge(consentBridge);
 }
 
-/** Test-only: drop installed-bridge state and reject any pending prompts. */
+/** Test-only: drop installed-bridge state and fail any pending prompts closed. */
 export function _resetCapabilityConsentBridgeForTest(): void {
   for (const requestId of [...pendingConsents.keys()]) {
-    settleConsent(requestId, "rejected");
+    settleConsent(requestId, "undeliverable");
   }
   consentBridgeInstalled = false;
+}
+
+/**
+ * Renderer receipt for a `plugin-capability:consent-request` push (#11708).
+ * Proves the prompt reached a renderer that can display it, which the push
+ * itself cannot: `send()` into a listener-less document is a silent no-op.
+ *
+ * Stops the re-push loop and hands the request over to the five-minute decision
+ * clock, which deliberately starts here rather than at push time — a prompt
+ * that took two seconds to land should still get the full window to answer in.
+ * Sender-pinned like the decision reply, and one-shot: duplicate receipts (the
+ * renderer re-acknowledges a re-push it already holds) are no-ops rather than
+ * re-arming the clock.
+ */
+export async function handleAcknowledgeConsent(
+  ctx: IpcContext,
+  input: PluginCapabilityAcknowledgeConsentInput
+): Promise<void> {
+  const pending = pendingConsents.get(input.requestId);
+  if (!pending) return;
+  if (ctx.webContentsId !== pending.webContentsId) {
+    console.warn(
+      `[plugin-capability] Ignoring consent receipt from unexpected sender ${ctx.webContentsId} (expected ${pending.webContentsId}, requestId=${input.requestId})`
+    );
+    return;
+  }
+  if (pending.acknowledged) return;
+  pending.acknowledged = true;
+  if (pending.resendTimer) {
+    clearInterval(pending.resendTimer);
+    pending.resendTimer = null;
+  }
+  if (pending.deliveryTimer) {
+    clearTimeout(pending.deliveryTimer);
+    pending.deliveryTimer = null;
+  }
+  // Safety net: an abandoned prompt settles itself as "timeout" so the gating
+  // promise never hangs and the pending entry is freed (#10841).
+  pending.decisionTimer = setTimeout(
+    () => settleConsent(input.requestId, "timeout"),
+    PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS
+  );
 }
 
 /**
@@ -115,6 +234,10 @@ export function _resetCapabilityConsentBridgeForTest(): void {
  * consent is dropped (resolving the bridge promise) only when the responding
  * WebContents is the one the prompt was sent to — a sibling window cannot answer
  * another window's prompt.
+ *
+ * A decision arriving before the receipt is itself proof of delivery, so it
+ * settles normally; `settleConsent` disarms the delivery and re-push timers
+ * whether or not they were ever superseded.
  */
 export async function handleResolveConsent(
   ctx: IpcContext,
@@ -137,6 +260,11 @@ export const pluginCapabilityNamespace = defineIpcNamespace({
     resolveConsent: op(PLUGIN_CAPABILITY_METHOD_CHANNELS.resolveConsent, handleResolveConsent, {
       withContext: true,
     }),
+    acknowledgeConsent: op(
+      PLUGIN_CAPABILITY_METHOD_CHANNELS.acknowledgeConsent,
+      handleAcknowledgeConsent,
+      { withContext: true }
+    ),
   },
 });
 
@@ -146,14 +274,15 @@ export function registerPluginCapabilityHandlers(): () => void {
   return () => {
     unregister();
     // Tear down the consent bridge so a re-registration reinstalls cleanly and
-    // no stale prompt resolves against a torn-down renderer. Pending prompts are
-    // rejected (fail closed) rather than left dangling.
+    // no stale prompt resolves against a torn-down renderer. Pending prompts
+    // fail closed rather than being left dangling — as "undeliverable", since
+    // the surface was pulled out from under them and no user ever answered.
     if (consentBridgeInstalled) {
       getPluginCapabilityConsentService().setConsentBridge(null);
       consentBridgeInstalled = false;
     }
     for (const requestId of [...pendingConsents.keys()]) {
-      settleConsent(requestId, "rejected");
+      settleConsent(requestId, "undeliverable");
     }
   };
 }

--- a/electron/ipc/handlers/pluginCapability.ts
+++ b/electron/ipc/handlers/pluginCapability.ts
@@ -184,6 +184,12 @@ export function _resetCapabilityConsentBridgeForTest(): void {
   for (const requestId of [...pendingConsents.keys()]) {
     settleConsent(requestId, "undeliverable");
   }
+  // Detach from the service too, mirroring the disposer. Clearing only the flag
+  // would leave the service holding a bridge that a later disposer then skips
+  // detaching, because the flag says it was never installed.
+  if (consentBridgeInstalled) {
+    getPluginCapabilityConsentService().setConsentBridge(null);
+  }
   consentBridgeInstalled = false;
 }
 

--- a/electron/services/plugin-capability/PluginCapabilityConsentService.ts
+++ b/electron/services/plugin-capability/PluginCapabilityConsentService.ts
@@ -41,7 +41,7 @@ export type PluginCapabilityConsentBridge = (
  */
 export class PluginCapabilityConsentService {
   private bridge: PluginCapabilityConsentBridge | null = null;
-  private readonly inFlight = new Map<string, Promise<PluginCapabilityConsentDecision>>();
+  private readonly inFlight = new Map<string, Promise<PluginCapabilityConsentOutcome>>();
 
   constructor(private readonly consentStore: PluginCapabilityConsentStore) {}
 
@@ -108,7 +108,7 @@ export class PluginCapabilityConsentService {
       // level, not warn: unlike an abandoned dialog this is a Daintree-side
       // delivery failure, not a user behaviour (#11708).
       console.error(
-        `[PluginCapabilityConsentService] could not present the consent prompt for plugin "${pluginId}" capability "${capability}" — no renderer acknowledged it`
+        `[PluginCapabilityConsentService] could not present the consent prompt for plugin "${pluginId}" capability "${capability}" — it never reached a renderer, or the renderer holding it went away before answering`
       );
       throw new Error(
         `${PLUGIN_CAPABILITY_DENIED_PREFIX}: Daintree could not present the "${capability}" capability consent prompt for plugin "${pluginId}"`
@@ -158,7 +158,14 @@ export class PluginCapabilityConsentService {
     if (existing) return existing;
 
     const bridge = this.bridge;
-    const promise = bridge({ pluginId, pluginDisplayName, capability, declaredCapabilities })
+    // Invoke through an async wrapper so a bridge that throws *synchronously*
+    // becomes a rejection the `.catch` below can classify. Calling it bare would
+    // let that throw escape `requestOutcome` entirely, and the gated call would
+    // reject with a raw error instead of a `PERMISSION_REQUIRED:` one — still
+    // closed, but outside the contract plugins are told to expect.
+    const invoke = async () =>
+      bridge({ pluginId, pluginDisplayName, capability, declaredCapabilities });
+    const promise = invoke()
       .catch((err) => {
         console.error("[PluginCapabilityConsentService] Consent bridge threw:", err);
         return "undeliverable" as PluginCapabilityConsentOutcome;

--- a/electron/services/plugin-capability/PluginCapabilityConsentService.ts
+++ b/electron/services/plugin-capability/PluginCapabilityConsentService.ts
@@ -1,5 +1,5 @@
 import type { BuiltInPluginCapability } from "../../../shared/types/plugin.js";
-import type { PluginCapabilityConsentDecision } from "../../../shared/types/pluginCapabilityConsent.js";
+import type { PluginCapabilityConsentOutcome } from "../../../shared/types/pluginCapabilityConsent.js";
 import type { PluginCapabilityConsentStore } from "./PluginCapabilityConsentStore.js";
 
 /** Prefix on the thrown error so `useHostChannel` discriminates a denial. */
@@ -21,7 +21,7 @@ export interface PluginCapabilityConsentRequest {
 /** Bridge that owns the consent UI surface (renderer dialog). */
 export type PluginCapabilityConsentBridge = (
   request: PluginCapabilityConsentRequest
-) => Promise<PluginCapabilityConsentDecision>;
+) => Promise<PluginCapabilityConsentOutcome>;
 
 /**
  * Orchestrates just-in-time consent for a single plugin host capability
@@ -72,7 +72,15 @@ export class PluginCapabilityConsentService {
   /**
    * Gate a gated host capability call. Resolves silently when the capability is
    * already granted or the user approves; throws a `PERMISSION_REQUIRED:` error
-   * when the user rejects or no consent bridge is installed.
+   * otherwise.
+   *
+   * Every failure path fails closed, but they no longer speak with one voice
+   * (#11708). Only an actual refusal says the plugin "was denied": a prompt that
+   * expired unanswered says it timed out, and a prompt that never reached a
+   * renderer says Daintree could not present it. Reporting an undelivered prompt
+   * as a denial was the misleading half of the original bug — it sent plugin
+   * authors looking for a user who had refused, and a manifest problem that
+   * didn't exist.
    */
   async ensureAllowed(
     pluginId: string,
@@ -82,25 +90,40 @@ export class PluginCapabilityConsentService {
   ): Promise<void> {
     if (this.consentStore.hasGrant({ pluginId, capability })) return;
 
-    const decision = await this.requestDecision(
+    const outcome = await this.requestOutcome(
       pluginId,
       pluginDisplayName,
       capability,
       declaredCapabilities
     );
 
-    if (decision === "approved-and-pin") {
+    if (outcome === "approved-and-pin") {
       this.consentStore.grant({ pluginId, capability });
       return;
     }
-    if (decision === "approved-once") return;
+    if (outcome === "approved-once") return;
 
-    if (decision === "timeout") {
+    if (outcome === "undeliverable") {
+      // The prompt never reached a renderer that could show it. Logged at error
+      // level, not warn: unlike an abandoned dialog this is a Daintree-side
+      // delivery failure, not a user behaviour (#11708).
+      console.error(
+        `[PluginCapabilityConsentService] could not present the consent prompt for plugin "${pluginId}" capability "${capability}" — no renderer acknowledged it`
+      );
+      throw new Error(
+        `${PLUGIN_CAPABILITY_DENIED_PREFIX}: Daintree could not present the "${capability}" capability consent prompt for plugin "${pluginId}"`
+      );
+    }
+
+    if (outcome === "timeout") {
       // Fail closed exactly like "rejected", but log distinctly so an abandoned
       // dialog is diagnosable in the operator logs rather than reading as a
       // deliberate refusal (#10841).
       console.warn(
         `[PluginCapabilityConsentService] consent prompt timed out for plugin "${pluginId}" capability "${capability}"`
+      );
+      throw new Error(
+        `${PLUGIN_CAPABILITY_DENIED_PREFIX}: the "${capability}" capability consent prompt for plugin "${pluginId}" timed out`
       );
     }
 
@@ -110,20 +133,25 @@ export class PluginCapabilityConsentService {
   }
 
   /**
-   * Resolve the user's decision for a `(pluginId, capability)`, coalescing
-   * concurrent first-use requests onto one in-flight prompt. Re-checks the grant
-   * store after awaiting a coalesced prompt so a sibling call that just got
+   * Resolve the outcome for a `(pluginId, capability)`, coalescing concurrent
+   * first-use requests onto one in-flight prompt. Re-checks the grant store
+   * after awaiting a coalesced prompt so a sibling call that just got
    * `approved-and-pin` lets the rest through without a second decision.
+   *
+   * Both non-decision paths — no bridge installed, and a bridge that throws —
+   * are delivery failures rather than refusals, so they resolve `undeliverable`
+   * (#11708). The fail-closed guarantee is unchanged; only the reported reason
+   * differs.
    */
-  private requestDecision(
+  private requestOutcome(
     pluginId: string,
     pluginDisplayName: string,
     capability: BuiltInPluginCapability,
     declaredCapabilities: readonly BuiltInPluginCapability[]
-  ): Promise<PluginCapabilityConsentDecision> {
+  ): Promise<PluginCapabilityConsentOutcome> {
     if (this.bridge === null) {
       // Fail closed — no UI to approve through.
-      return Promise.resolve("rejected");
+      return Promise.resolve("undeliverable");
     }
     const key = JSON.stringify([pluginId, capability]);
     const existing = this.inFlight.get(key);
@@ -133,7 +161,7 @@ export class PluginCapabilityConsentService {
     const promise = bridge({ pluginId, pluginDisplayName, capability, declaredCapabilities })
       .catch((err) => {
         console.error("[PluginCapabilityConsentService] Consent bridge threw:", err);
-        return "rejected" as PluginCapabilityConsentDecision;
+        return "undeliverable" as PluginCapabilityConsentOutcome;
       })
       .finally(() => {
         this.inFlight.delete(key);

--- a/electron/services/plugin-capability/__tests__/PluginCapabilityConsentService.test.ts
+++ b/electron/services/plugin-capability/__tests__/PluginCapabilityConsentService.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { PluginCapabilityConsentService } from "../PluginCapabilityConsentService.js";
 import { PluginCapabilityConsentStore } from "../PluginCapabilityConsentStore.js";
-import type { PluginCapabilityConsentDecision } from "../../../../shared/types/pluginCapabilityConsent.js";
+import type {
+  PluginCapabilityConsentDecision,
+  PluginCapabilityConsentOutcome,
+} from "../../../../shared/types/pluginCapabilityConsent.js";
 
 function makeService() {
   let config: Record<string, unknown> = {};
@@ -18,13 +21,19 @@ function makeService() {
 const CAPS = ["shell:exec"] as const;
 
 describe("PluginCapabilityConsentService", () => {
-  it("denies (fail-closed) when no consent bridge is installed", async () => {
+  it("fails closed as undeliverable when no consent bridge is installed", async () => {
     const { service, store } = makeService();
-    await expect(service.ensureAllowed("acme.x", "Acme", "shell:exec", CAPS)).rejects.toThrow(
-      /PERMISSION_REQUIRED/
-    );
-    // A denial must not leave a grant behind.
-    expect(store.hasGrant({ pluginId: "acme.x", capability: "shell:exec" })).toBe(false);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      // No bridge means no UI at all — fail closed, but don't attribute it to a
+      // user who was never asked (#11708).
+      await expect(service.ensureAllowed("acme.x", "Acme", "shell:exec", CAPS)).rejects.toThrow(
+        /PERMISSION_REQUIRED.*could not present.*shell:exec/
+      );
+      expect(store.hasGrant({ pluginId: "acme.x", capability: "shell:exec" })).toBe(false);
+    } finally {
+      error.mockRestore();
+    }
   });
 
   it("short-circuits without prompting once a capability is granted", async () => {
@@ -80,7 +89,7 @@ describe("PluginCapabilityConsentService", () => {
     try {
       service.setConsentBridge(async () => "timeout");
       await expect(service.ensureAllowed("acme.x", "Acme", "shell:exec", CAPS)).rejects.toThrow(
-        /PERMISSION_REQUIRED.*shell:exec/
+        /PERMISSION_REQUIRED.*shell:exec.*timed out/
       );
       // A timed-out prompt must not leave a grant behind.
       expect(store.hasGrant({ pluginId: "acme.x", capability: "shell:exec" })).toBe(false);
@@ -91,14 +100,56 @@ describe("PluginCapabilityConsentService", () => {
     }
   });
 
-  it("treats a thrown bridge as a rejection (fail-closed)", async () => {
-    const { service } = makeService();
-    service.setConsentBridge(async () => {
-      throw new Error("renderer blew up");
-    });
-    await expect(service.ensureAllowed("acme.x", "Acme", "shell:exec", CAPS)).rejects.toThrow(
-      /PERMISSION_REQUIRED/
-    );
+  it("treats a thrown bridge as undeliverable (fail-closed)", async () => {
+    const { service, store } = makeService();
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      service.setConsentBridge(async () => {
+        throw new Error("renderer blew up");
+      });
+      await expect(service.ensureAllowed("acme.x", "Acme", "shell:exec", CAPS)).rejects.toThrow(
+        /PERMISSION_REQUIRED.*could not present/
+      );
+      expect(store.hasGrant({ pluginId: "acme.x", capability: "shell:exec" })).toBe(false);
+    } finally {
+      error.mockRestore();
+    }
+  });
+
+  it("reports undeliverable, timeout and rejection as three distinguishable failures (#11708)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const messageFor = async (outcome: PluginCapabilityConsentOutcome): Promise<string> => {
+        const { service } = makeService();
+        service.setConsentBridge(async () => outcome);
+        try {
+          await service.ensureAllowed("acme.x", "Acme", "shell:exec", CAPS);
+          throw new Error(`expected ${outcome} to fail closed`);
+        } catch (err) {
+          return (err as Error).message;
+        }
+      };
+
+      const undeliverable = await messageFor("undeliverable");
+      const timedOut = await messageFor("timeout");
+      const rejected = await messageFor("rejected");
+
+      // All fail closed behind the prefix the SDK discriminates on...
+      for (const message of [undeliverable, timedOut, rejected]) {
+        expect(message).toContain("PERMISSION_REQUIRED");
+      }
+      // ...but a plugin author reading the error can tell what actually
+      // happened. Conflating these was the misleading half of #11708: an
+      // undelivered prompt was reported as an explicit refusal.
+      expect(new Set([undeliverable, timedOut, rejected]).size).toBe(3);
+      expect(undeliverable).not.toContain("was denied");
+      expect(timedOut).not.toContain("was denied");
+      expect(rejected).toContain("was denied");
+    } finally {
+      warn.mockRestore();
+      error.mockRestore();
+    }
   });
 
   it("coalesces concurrent first-use calls for the same (plugin, capability) onto one prompt", async () => {

--- a/electron/services/plugin-capability/__tests__/PluginCapabilityConsentService.test.ts
+++ b/electron/services/plugin-capability/__tests__/PluginCapabilityConsentService.test.ts
@@ -116,6 +116,83 @@ describe("PluginCapabilityConsentService", () => {
     }
   });
 
+  it("classifies a synchronously thrown bridge as undeliverable, not a raw error", async () => {
+    const { service, store } = makeService();
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      // Deliberately NOT async: this throws before any promise exists, so a
+      // bare `bridge(...).catch(...)` would let it escape unclassified and the
+      // plugin would see an error without the prefix the SDK keys on.
+      service.setConsentBridge(() => {
+        throw new Error("no window ref");
+      });
+      await expect(service.ensureAllowed("acme.x", "Acme", "shell:exec", CAPS)).rejects.toThrow(
+        /PERMISSION_REQUIRED.*could not present/
+      );
+      expect(store.hasGrant({ pluginId: "acme.x", capability: "shell:exec" })).toBe(false);
+
+      // The failed attempt must not poison the coalescing map — a later call
+      // still gets to prompt.
+      const bridge = vi.fn(async () => "approved-once" as PluginCapabilityConsentOutcome);
+      service.setConsentBridge(bridge);
+      await expect(
+        service.ensureAllowed("acme.x", "Acme", "shell:exec", CAPS)
+      ).resolves.toBeUndefined();
+      expect(bridge).toHaveBeenCalledTimes(1);
+    } finally {
+      error.mockRestore();
+    }
+  });
+
+  it.each(["undeliverable", "timeout", "rejected"] as const)(
+    "coalesces concurrent callers onto one prompt and gives them all the same %s failure",
+    async (outcome) => {
+      const { service, store } = makeService();
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const error = vi.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        let release!: (o: PluginCapabilityConsentOutcome) => void;
+        const bridge = vi.fn(
+          () =>
+            new Promise<PluginCapabilityConsentOutcome>((resolve) => {
+              release = resolve;
+            })
+        );
+        service.setConsentBridge(bridge);
+
+        const calls = [
+          service.ensureAllowed("acme.x", "Acme", "shell:exec", CAPS),
+          service.ensureAllowed("acme.x", "Acme", "shell:exec", CAPS),
+          service.ensureAllowed("acme.x", "Acme", "shell:exec", CAPS),
+        ].map((p) =>
+          p.then(
+            () => null,
+            (err: Error) => err.message
+          )
+        );
+        expect(bridge).toHaveBeenCalledTimes(1);
+
+        release(outcome);
+        const messages = await Promise.all(calls);
+
+        // Every waiter fails closed, with the same reason — a coalesced caller
+        // must not be told a different story from the one that raised the prompt.
+        expect(messages.every((m) => m !== null)).toBe(true);
+        expect(new Set(messages).size).toBe(1);
+        expect(store.hasGrant({ pluginId: "acme.x", capability: "shell:exec" })).toBe(false);
+
+        // A settled failure must not linger in the in-flight map and suppress
+        // the next prompt.
+        release = () => {};
+        void service.ensureAllowed("acme.x", "Acme", "shell:exec", CAPS).catch(() => {});
+        expect(bridge).toHaveBeenCalledTimes(2);
+      } finally {
+        warn.mockRestore();
+        error.mockRestore();
+      }
+    }
+  );
+
   it("reports undeliverable, timeout and rejection as three distinguishable failures (#11708)", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const error = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -538,6 +538,9 @@ export interface GeneratedElectronAPI {
     ): Promise<IpcInvokeMap["plugin:validate-action-ids"]["result"]>;
   };
   pluginCapability: {
+    acknowledgeConsent(
+      ...args: IpcInvokeMap["plugin-capability:acknowledge-consent"]["args"]
+    ): Promise<IpcInvokeMap["plugin-capability:acknowledge-consent"]["result"]>;
     resolveConsent(
       ...args: IpcInvokeMap["plugin-capability:resolve-consent"]["args"]
     ): Promise<IpcInvokeMap["plugin-capability:resolve-consent"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -944,6 +944,10 @@ export interface GeneratedIpcInvokeMap {
     ];
     result: void;
   };
+  "plugin-capability:acknowledge-consent": {
+    args: [input: import("../pluginCapabilityConsent.js").PluginCapabilityAcknowledgeConsentInput];
+    result: void;
+  };
   "plugin-capability:resolve-consent": {
     args: [input: import("../pluginCapabilityConsent.js").PluginCapabilityResolveConsentInput];
     result: void;

--- a/shared/types/pluginCapabilityConsent.ts
+++ b/shared/types/pluginCapabilityConsent.ts
@@ -64,11 +64,13 @@ export type PluginCapabilityConsentDecision =
 
 /**
  * What the main-process consent bridge resolves with — every
- * {@link PluginCapabilityConsentDecision} plus `undeliverable`, which means the
- * prompt never reached a renderer that could display it (#11708): no window to
- * host it, the target view was destroyed mid-flight, the push threw, the
- * handler was torn down, or no receipt acknowledgement arrived within
- * {@link PLUGIN_CAPABILITY_CONSENT_DELIVERY_TIMEOUT_MS}.
+ * {@link PluginCapabilityConsentDecision} plus `undeliverable`, which covers
+ * every way a prompt can fail to *reach and stay in front of* a user (#11708):
+ * no window to host it, no receipt acknowledgement within
+ * {@link PLUGIN_CAPABILITY_CONSENT_DELIVERY_TIMEOUT_MS}, the push threw, the
+ * handler was torn down, or the renderer holding it was destroyed — before or
+ * after acknowledging. The last case did display a dialog, but it vanished
+ * unanswered, so it is grouped here rather than with the decisions.
  *
  * The split exists because `webContents.send()` to a document with no listener
  * is a silent no-op — nothing throws and nothing logs — so before #11708 an
@@ -89,11 +91,17 @@ export type PluginCapabilityConsentOutcome = PluginCapabilityConsentDecision | "
  * main-process bridge and the renderer confirm store arm an independent timer at
  * this duration.
  *
- * As with the MCP timeout, the clock starts when the prompt is *acknowledged as
- * delivered*, not when the dialog becomes visible — a queued prompt shares this
- * window rather than getting its own per-display clock. The timeout is an
- * abandonment backstop, and the rare queued-then-expired case fails closed
- * (denied), the safe direction.
+ * As with the MCP timeout, the clock starts when the prompt is raised, not when
+ * the dialog becomes visible — a queued prompt shares this window rather than
+ * getting its own per-display clock. The timeout is an abandonment backstop, and
+ * the rare queued-then-expired case fails closed (denied), the safe direction.
+ *
+ * Main and the renderer arm this independently and from slightly different
+ * origins: the renderer at enqueue, main once delivery is acknowledged. The
+ * renderer therefore expires first, by however long delivery took (bounded by
+ * {@link PLUGIN_CAPABILITY_CONSENT_DELIVERY_TIMEOUT_MS}), and its `"timeout"`
+ * reply settles main's copy. That ordering is deliberate — a decision reply
+ * beats a main-side guess — and the skew is immaterial against five minutes.
  */
 export const PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS = 5 * 60 * 1000;
 

--- a/shared/types/pluginCapabilityConsent.ts
+++ b/shared/types/pluginCapabilityConsent.ts
@@ -54,9 +54,32 @@ export interface PluginCapabilityConsentRecord {
  * `rejected` (the gated call still throws `PERMISSION_REQUIRED:`) but is
  * distinguished for diagnostics so a walked-away dialog reads differently from a
  * deliberate refusal in the logs.
+ *
+ * Every member of this union describes something that happened *in the dialog*.
+ * A prompt that never reached a renderer at all is not a decision — see
+ * {@link PluginCapabilityConsentOutcome}.
  */
 export type PluginCapabilityConsentDecision =
   "approved-once" | "approved-and-pin" | "rejected" | "timeout";
+
+/**
+ * What the main-process consent bridge resolves with — every
+ * {@link PluginCapabilityConsentDecision} plus `undeliverable`, which means the
+ * prompt never reached a renderer that could display it (#11708): no window to
+ * host it, the target view was destroyed mid-flight, the push threw, the
+ * handler was torn down, or no receipt acknowledgement arrived within
+ * {@link PLUGIN_CAPABILITY_CONSENT_DELIVERY_TIMEOUT_MS}.
+ *
+ * The split exists because `webContents.send()` to a document with no listener
+ * is a silent no-op — nothing throws and nothing logs — so before #11708 an
+ * undeliverable prompt was indistinguishable from a user who sat on the dialog
+ * for five minutes, and both surfaced to the plugin as "was denied". The
+ * renderer never produces this value; it is minted only by the bridge.
+ *
+ * All outcomes still fail closed: the gated host call throws
+ * `PERMISSION_REQUIRED:` regardless. Only the wording and the timing differ.
+ */
+export type PluginCapabilityConsentOutcome = PluginCapabilityConsentDecision | "undeliverable";
 
 /**
  * How long a pushed plugin-capability consent prompt may stay unanswered before
@@ -66,12 +89,43 @@ export type PluginCapabilityConsentDecision =
  * main-process bridge and the renderer confirm store arm an independent timer at
  * this duration.
  *
- * As with the MCP timeout, the clock starts when the prompt is raised, not when
- * the dialog becomes visible — a queued prompt shares this window rather than
- * getting its own per-display clock. The timeout is an abandonment backstop, and
- * the rare queued-then-expired case fails closed (denied), the safe direction.
+ * As with the MCP timeout, the clock starts when the prompt is *acknowledged as
+ * delivered*, not when the dialog becomes visible — a queued prompt shares this
+ * window rather than getting its own per-display clock. The timeout is an
+ * abandonment backstop, and the rare queued-then-expired case fails closed
+ * (denied), the safe direction.
  */
 export const PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * How long the bridge waits for a renderer to acknowledge receipt of a pushed
+ * consent prompt before settling it `undeliverable` (#11708).
+ *
+ * This is a *delivery* bound, not a decision bound: it only has to cover the
+ * gap between the push and the consent hook's `useEffect` running in the target
+ * renderer. It is generous enough to absorb a cold project switch, whose React
+ * boot `ProjectViewSwitchController` documents at ~1.5-4s, plus slack for the
+ * Efficiency resource profile — and the bridge re-pushes every
+ * {@link PLUGIN_CAPABILITY_CONSENT_RESEND_INTERVAL_MS} within the window, so a
+ * renderer that mounts late still gets the prompt rather than losing it.
+ *
+ * Once a receipt lands, {@link PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS} takes over
+ * and the user gets the full five minutes to decide.
+ */
+export const PLUGIN_CAPABILITY_CONSENT_DELIVERY_TIMEOUT_MS = 10 * 1000;
+
+/**
+ * How often the bridge re-pushes an unacknowledged consent prompt to the same
+ * target renderer, until either a receipt arrives or
+ * {@link PLUGIN_CAPABILITY_CONSENT_DELIVERY_TIMEOUT_MS} elapses (#11708).
+ *
+ * The target is resolved once and never re-resolved, so re-pushes cannot drift
+ * to a different window or invalidate the response sender pin. The renderer
+ * de-duplicates by `requestId` and simply re-acknowledges a prompt it already
+ * holds, so a re-push that races a receipt is a no-op rather than a second
+ * dialog.
+ */
+export const PLUGIN_CAPABILITY_CONSENT_RESEND_INTERVAL_MS = 2 * 1000;
 
 /**
  * Display-safe consent prompt pushed from main to the renderer over the typed
@@ -91,6 +145,22 @@ export interface PluginCapabilityConsentRequestEvent {
   capability: BuiltInPluginCapability;
   /** Plugin's manifest `capabilities[]` list — surfaced for transparency. */
   declaredCapabilities: readonly BuiltInPluginCapability[];
+}
+
+/**
+ * Renderer → main receipt for a `plugin-capability:consent-request` push
+ * (#11708). Sent as soon as the prompt is enqueued into the dialog FIFO, well
+ * before the user decides — it answers "did this reach a renderer that can show
+ * it", which a bare `webContents.send()` cannot, since a push into a document
+ * with no listener neither throws nor logs.
+ *
+ * Until this arrives the bridge treats the prompt as undelivered and re-pushes;
+ * after it arrives the five-minute decision clock starts. Acknowledgements are
+ * sender-pinned exactly like the decision reply, so a sibling window cannot
+ * acknowledge another window's prompt.
+ */
+export interface PluginCapabilityAcknowledgeConsentInput {
+  requestId: string;
 }
 
 /** Renderer → main reply to a `plugin-capability:consent-request` push. */

--- a/src/hooks/__tests__/usePluginCapabilityConsentBridge.test.tsx
+++ b/src/hooks/__tests__/usePluginCapabilityConsentBridge.test.tsx
@@ -124,6 +124,23 @@ describe("usePluginCapabilityConsentBridge", () => {
     expect(acknowledgeConsent).toHaveBeenCalledTimes(2);
   });
 
+  it("ignores a re-push that arrives after the user already answered (#11708)", async () => {
+    render(<Harness />);
+    act(() => listener!(request("req-1")));
+    act(() => usePluginCapabilityConfirmStore.getState().resolveCurrent("approved-once"));
+    await waitFor(() => expect(resolveConsent).toHaveBeenCalled());
+
+    // A retry main had already put on the wire before it settled. Both this
+    // hook's record and the store's resolver are gone by now, so nothing but
+    // the retained id stops it becoming a fresh dialog for a dead request —
+    // one the consent dialog would refuse to act on twice, stranding it.
+    act(() => listener!(request("req-1")));
+
+    expect(usePluginCapabilityConfirmStore.getState().current).toBeNull();
+    expect(usePluginCapabilityConfirmStore.getState().queue).toHaveLength(0);
+    expect(resolveConsent).toHaveBeenCalledTimes(1);
+  });
+
   it("survives a remount with a prompt still in flight (#11708)", async () => {
     const { unmount } = render(<Harness />);
     act(() => listener!(request("req-1")));

--- a/src/hooks/__tests__/usePluginCapabilityConsentBridge.test.tsx
+++ b/src/hooks/__tests__/usePluginCapabilityConsentBridge.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, act, waitFor } from "@testing-library/react";
+import type { PluginCapabilityConsentRequestEvent } from "@shared/types/pluginCapabilityConsent";
+
+import { usePluginCapabilityConsentBridge } from "../usePluginCapabilityConsentBridge";
+import {
+  usePluginCapabilityConfirmStore,
+  __resetPluginCapabilityConfirmStoreForTesting,
+} from "@/store/pluginCapabilityConfirmStore";
+
+type Listener = (payload: PluginCapabilityConsentRequestEvent) => void;
+
+function Harness() {
+  usePluginCapabilityConsentBridge();
+  return null;
+}
+
+function request(requestId: string): PluginCapabilityConsentRequestEvent {
+  return {
+    requestId,
+    pluginId: "acme.x",
+    pluginDisplayName: "Acme",
+    capability: "fs:project-write",
+    declaredCapabilities: ["fs:project-write"],
+  };
+}
+
+let listener: Listener | null = null;
+let unsubscribe: ReturnType<typeof vi.fn>;
+let acknowledgeConsent: ReturnType<typeof vi.fn>;
+let resolveConsent: ReturnType<typeof vi.fn>;
+/** What the store held at the moment each acknowledgement was sent. */
+let queuedAtAck: Array<string | undefined>;
+
+beforeEach(() => {
+  listener = null;
+  queuedAtAck = [];
+  unsubscribe = vi.fn();
+  acknowledgeConsent = vi.fn(() => {
+    queuedAtAck.push(usePluginCapabilityConfirmStore.getState().current?.requestId);
+    return Promise.resolve();
+  });
+  resolveConsent = vi.fn(() => Promise.resolve());
+  (window as unknown as { electron: unknown }).electron = {
+    events: {
+      on: vi.fn((name: string, cb: Listener) => {
+        if (name === "plugin-capability:consent-request") listener = cb;
+        return unsubscribe;
+      }),
+    },
+    pluginCapability: { acknowledgeConsent, resolveConsent },
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  __resetPluginCapabilityConfirmStoreForTesting();
+  vi.restoreAllMocks();
+});
+
+describe("usePluginCapabilityConsentBridge", () => {
+  it("acknowledges receipt only after the prompt is queued for display (#11708)", async () => {
+    render(<Harness />);
+    act(() => listener!(request("req-1")));
+
+    // Main takes the acknowledgement as proof the prompt is displayable, so it
+    // must not be sent before the dialog store actually owns the request.
+    expect(acknowledgeConsent).toHaveBeenCalledTimes(1);
+    expect(acknowledgeConsent).toHaveBeenCalledWith({ requestId: "req-1" });
+    expect(queuedAtAck).toEqual(["req-1"]);
+  });
+
+  it("forwards the user's decision back to main", async () => {
+    render(<Harness />);
+    act(() => listener!(request("req-1")));
+
+    act(() => usePluginCapabilityConfirmStore.getState().resolveCurrent("approved-and-pin"));
+
+    await waitFor(() =>
+      expect(resolveConsent).toHaveBeenCalledWith({
+        requestId: "req-1",
+        decision: "approved-and-pin",
+      })
+    );
+  });
+
+  it("re-acknowledges a re-pushed prompt instead of queueing it twice (#11708)", async () => {
+    render(<Harness />);
+    act(() => listener!(request("req-1")));
+    // Main re-pushes an unacknowledged prompt, so a re-push can cross the
+    // acknowledgement on the wire and arrive for a request already queued.
+    act(() => listener!(request("req-1")));
+
+    expect(acknowledgeConsent).toHaveBeenCalledTimes(2);
+
+    // Exactly one dialog: the second push must not enqueue a duplicate.
+    const { current, queue } = usePluginCapabilityConfirmStore.getState();
+    expect(current?.requestId).toBe("req-1");
+    expect(queue).toHaveLength(0);
+
+    // And critically, nothing was resolved. Re-enqueueing would hit the store's
+    // duplicate guard, which resolves "rejected" — surfacing to the plugin as a
+    // denial the user never made, which is the bug this whole path fixes.
+    expect(resolveConsent).not.toHaveBeenCalled();
+
+    act(() => usePluginCapabilityConfirmStore.getState().resolveCurrent("approved-once"));
+    await waitFor(() =>
+      expect(resolveConsent).toHaveBeenCalledWith({ requestId: "req-1", decision: "approved-once" })
+    );
+    expect(resolveConsent).toHaveBeenCalledTimes(1);
+  });
+
+  it("queues a genuinely different prompt rather than de-duplicating it", async () => {
+    render(<Harness />);
+    act(() => listener!(request("req-1")));
+    act(() => listener!(request("req-2")));
+
+    const { current, queue } = usePluginCapabilityConfirmStore.getState();
+    expect(current?.requestId).toBe("req-1");
+    expect(queue.map((item) => item.requestId)).toEqual(["req-2"]);
+    expect(acknowledgeConsent).toHaveBeenCalledTimes(2);
+  });
+
+  it("unsubscribes from the push on unmount", () => {
+    const { unmount } = render(<Harness />);
+    unmount();
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/usePluginCapabilityConsentBridge.test.tsx
+++ b/src/hooks/__tests__/usePluginCapabilityConsentBridge.test.tsx
@@ -44,15 +44,19 @@ beforeEach(() => {
     return Promise.resolve();
   });
   resolveConsent = vi.fn(() => Promise.resolve());
-  (window as unknown as { electron: unknown }).electron = {
-    events: {
-      on: vi.fn((name: string, cb: Listener) => {
-        if (name === "plugin-capability:consent-request") listener = cb;
-        return unsubscribe;
-      }),
+  Object.defineProperty(window, "electron", {
+    configurable: true,
+    writable: true,
+    value: {
+      events: {
+        on: vi.fn((name: string, cb: Listener) => {
+          if (name === "plugin-capability:consent-request") listener = cb;
+          return unsubscribe;
+        }),
+      },
+      pluginCapability: { acknowledgeConsent, resolveConsent },
     },
-    pluginCapability: { acknowledgeConsent, resolveConsent },
-  };
+  });
 });
 
 afterEach(() => {

--- a/src/hooks/__tests__/usePluginCapabilityConsentBridge.test.tsx
+++ b/src/hooks/__tests__/usePluginCapabilityConsentBridge.test.tsx
@@ -124,6 +124,50 @@ describe("usePluginCapabilityConsentBridge", () => {
     expect(acknowledgeConsent).toHaveBeenCalledTimes(2);
   });
 
+  it("survives a remount with a prompt still in flight (#11708)", async () => {
+    const { unmount } = render(<Harness />);
+    act(() => listener!(request("req-1")));
+    unmount();
+
+    // The dedupe Set dies with the effect, but the store's resolver map does
+    // not — so a re-push after a remount reaches a store that already knows the
+    // request. It must share that prompt, not treat it as a collision and
+    // resolve "rejected", which would reach the plugin as a phantom denial.
+    render(<Harness />);
+    act(() => listener!(request("req-1")));
+
+    expect(resolveConsent).not.toHaveBeenCalled();
+    expect(usePluginCapabilityConfirmStore.getState().queue).toHaveLength(0);
+
+    act(() => usePluginCapabilityConfirmStore.getState().resolveCurrent("approved-and-pin"));
+    await waitFor(() =>
+      expect(resolveConsent).toHaveBeenCalledWith({
+        requestId: "req-1",
+        decision: "approved-and-pin",
+      })
+    );
+  });
+
+  it("handles a rejected reply IPC instead of leaking an unhandled rejection", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    acknowledgeConsent.mockRejectedValue(new Error("channel gone"));
+    resolveConsent.mockRejectedValue(new Error("channel gone"));
+
+    render(<Harness />);
+    act(() => listener!(request("req-1")));
+    act(() => usePluginCapabilityConfirmStore.getState().resolveCurrent("approved-once"));
+
+    // Both replies are fire-and-forget; a teardown-time rejection on either must
+    // be consumed rather than surfacing as an unrelated renderer error.
+    await waitFor(() => expect(warn).toHaveBeenCalledTimes(2));
+    expect(warn.mock.calls.map((c) => String(c[0]))).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("failed to acknowledge"),
+        expect.stringContaining("failed to deliver decision"),
+      ])
+    );
+  });
+
   it("unsubscribes from the push on unmount", () => {
     const { unmount } = render(<Harness />);
     unmount();

--- a/src/hooks/usePluginCapabilityConsentBridge.ts
+++ b/src/hooks/usePluginCapabilityConsentBridge.ts
@@ -18,11 +18,15 @@ import { requestPluginCapabilityConsent } from "@/store/pluginCapabilityConfirmS
  */
 export function usePluginCapabilityConsentBridge(): void {
   useEffect(() => {
-    // Prompts already handed to the store. Main re-pushes an unacknowledged
-    // prompt, so a re-push can race the acknowledgement it crossed on the wire;
-    // re-enqueueing it would hit the store's duplicate guard, which resolves
-    // "rejected" and would surface as a denial the user never made. Re-ack
-    // instead — the request is in the queue, which is all main is asking about.
+    // Every prompt this mount has handed to the store, kept for the mount's
+    // lifetime rather than cleared on settle. Main re-pushes an unacknowledged
+    // prompt, and a re-push already on the wire can arrive *after* the user has
+    // answered — by which point both this Set and the store's resolver map
+    // would have forgotten the id, so it would enqueue a fresh dialog for a
+    // request main has already settled. The consent dialog refuses to act twice
+    // on one requestId, so that phantom would sit there unanswerable until its
+    // own five-minute timer. Consent prompts are first-use-per-capability, so
+    // retaining ids costs nothing worth reclaiming.
     const enqueued = new Set<string>();
 
     return window.electron.events.on("plugin-capability:consent-request", (payload) => {
@@ -52,7 +56,6 @@ export function usePluginCapabilityConsentBridge(): void {
       acknowledge();
 
       void decided.then((decision) => {
-        enqueued.delete(requestId);
         return window.electron.pluginCapability
           .resolveConsent({ requestId, decision })
           .catch((err: unknown) =>

--- a/src/hooks/usePluginCapabilityConsentBridge.ts
+++ b/src/hooks/usePluginCapabilityConsentBridge.ts
@@ -4,22 +4,48 @@ import { requestPluginCapabilityConsent } from "@/store/pluginCapabilityConfirmS
 /**
  * Wires main-process just-in-time capability consent prompts into the renderer
  * dialog queue (#10524). Subscribes to the `plugin-capability:consent-request`
- * push (sent to the focused window by main), enqueues each prompt through the
- * FIFO consent store, and replies with the user's decision via
- * `plugin-capability:resolve-consent`.
+ * push, enqueues each prompt through the FIFO consent store, and replies with
+ * the user's decision via `plugin-capability:resolve-consent`.
+ *
+ * Also acknowledges receipt the moment a prompt is enqueued (#11708). Main
+ * cannot otherwise tell that the push arrived — sending to a renderer with no
+ * listener is a silent no-op — so without this it re-pushes until it gives up
+ * and reports the capability as undeliverable. The acknowledgement is what
+ * starts the user's five-minute decision window.
  *
  * Mounted once near the app root alongside the consent dialog. The store's
  * resolver map serialises concurrent prompts, so this hook only forwards.
  */
 export function usePluginCapabilityConsentBridge(): void {
   useEffect(() => {
+    // Prompts already handed to the store. Main re-pushes an unacknowledged
+    // prompt, so a re-push can race the acknowledgement it crossed on the wire;
+    // re-enqueueing it would hit the store's duplicate guard, which resolves
+    // "rejected" and would surface as a denial the user never made. Re-ack
+    // instead — the request is in the queue, which is all main is asking about.
+    const enqueued = new Set<string>();
+
     return window.electron.events.on("plugin-capability:consent-request", (payload) => {
-      void requestPluginCapabilityConsent(payload).then((decision) =>
-        window.electron.pluginCapability.resolveConsent({
-          requestId: payload.requestId,
-          decision,
-        })
-      );
+      const { requestId } = payload;
+      const acknowledge = () =>
+        void window.electron.pluginCapability.acknowledgeConsent({ requestId });
+
+      if (enqueued.has(requestId)) {
+        acknowledge();
+        return;
+      }
+      enqueued.add(requestId);
+
+      // Enqueue before acknowledging: the acknowledgement asserts the prompt is
+      // queued for display, and requestPluginCapabilityConsent's executor runs
+      // synchronously, so it genuinely is by the time we send.
+      const decided = requestPluginCapabilityConsent(payload);
+      acknowledge();
+
+      void decided.then((decision) => {
+        enqueued.delete(requestId);
+        return window.electron.pluginCapability.resolveConsent({ requestId, decision });
+      });
     });
   }, []);
 }

--- a/src/hooks/usePluginCapabilityConsentBridge.ts
+++ b/src/hooks/usePluginCapabilityConsentBridge.ts
@@ -27,8 +27,17 @@ export function usePluginCapabilityConsentBridge(): void {
 
     return window.electron.events.on("plugin-capability:consent-request", (payload) => {
       const { requestId } = payload;
-      const acknowledge = () =>
-        void window.electron.pluginCapability.acknowledgeConsent({ requestId });
+      // Both replies are fire-and-forget, but their rejections still have to be
+      // consumed — during renderer teardown the IPC call can reject, and an
+      // unhandled rejection there would surface as a renderer error unrelated to
+      // anything the user did.
+      const acknowledge = () => {
+        window.electron.pluginCapability
+          .acknowledgeConsent({ requestId })
+          .catch((err: unknown) =>
+            console.warn(`[plugin-capability] failed to acknowledge ${requestId}:`, err)
+          );
+      };
 
       if (enqueued.has(requestId)) {
         acknowledge();
@@ -44,7 +53,14 @@ export function usePluginCapabilityConsentBridge(): void {
 
       void decided.then((decision) => {
         enqueued.delete(requestId);
-        return window.electron.pluginCapability.resolveConsent({ requestId, decision });
+        return window.electron.pluginCapability
+          .resolveConsent({ requestId, decision })
+          .catch((err: unknown) =>
+            // Main keeps waiting and will eventually report a timeout. Nothing
+            // useful to retry against a renderer that is going away, but the
+            // divergence between "user decided" and "main heard" is worth a log.
+            console.warn(`[plugin-capability] failed to deliver decision for ${requestId}:`, err)
+          );
       });
     });
   }, []);

--- a/src/store/__tests__/pluginCapabilityConfirmStore.test.ts
+++ b/src/store/__tests__/pluginCapabilityConfirmStore.test.ts
@@ -50,15 +50,20 @@ describe("pluginCapabilityConfirmStore", () => {
     await expect(p2).resolves.toBe("rejected");
   });
 
-  it("rejects a duplicate requestId without disturbing the live prompt", async () => {
+  it("shares one prompt between repeat requests for the same requestId (#11708)", async () => {
     const p1 = requestPluginCapabilityConsent(req("dup"));
     const dup = requestPluginCapabilityConsent(req("dup"));
-    await expect(dup).resolves.toBe("rejected");
-    // The original is still pending and current.
-    expect(usePluginCapabilityConfirmStore.getState().current?.requestId).toBe("dup");
 
+    // Main re-pushes an unacknowledged prompt, so the same id can legitimately
+    // arrive twice. It must not queue a second dialog...
+    expect(usePluginCapabilityConfirmStore.getState().current?.requestId).toBe("dup");
+    expect(usePluginCapabilityConfirmStore.getState().queue).toHaveLength(0);
+
+    // ...and must not settle early. Resolving a repeat as "rejected" would
+    // reach the plugin as a denial the user never made.
     usePluginCapabilityConfirmStore.getState().resolveCurrent("approved-and-pin");
     await expect(p1).resolves.toBe("approved-and-pin");
+    await expect(dup).resolves.toBe("approved-and-pin");
   });
 
   it("drop rejects a queued request and removes it from the queue", async () => {

--- a/src/store/__tests__/pluginCapabilityConfirmStore.test.ts
+++ b/src/store/__tests__/pluginCapabilityConfirmStore.test.ts
@@ -128,18 +128,20 @@ describe("pluginCapabilityConfirmStore", () => {
       }
     });
 
-    it("reset clears pending timers so they never fire into a cleared store", async () => {
+    it("reset settles pending prompts fail-closed and clears their timers", async () => {
       vi.useFakeTimers();
       try {
         const p = requestPluginCapabilityConsent(req("r1"));
         __resetPluginCapabilityConfirmStoreForTesting();
 
+        // Settling is the contract: this promise gates a plugin's host call, so
+        // leaving it pending would hang that call rather than fail it closed.
+        await expect(p).resolves.toBe("rejected");
+
         await vi.advanceTimersByTimeAsync(PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS * 2);
-        // The promise stays unsettled (the timer was cleared); no leaked timer
-        // re-enqueued or re-settled anything.
+        // No leaked timer re-enqueued or re-settled anything.
         expect(usePluginCapabilityConfirmStore.getState().current).toBeNull();
         expect(vi.getTimerCount()).toBe(0);
-        void p;
       } finally {
         vi.useRealTimers();
       }

--- a/src/store/pluginCapabilityConfirmStore.ts
+++ b/src/store/pluginCapabilityConfirmStore.ts
@@ -94,7 +94,14 @@ export const usePluginCapabilityConfirmStore = create<
   },
 
   reset: () => {
-    for (const { timer } of resolvers.values()) clearTimeout(timer);
+    // Settle every waiter before dropping it. Clearing the map alone left the
+    // gating promises pending forever, and `requestPluginCapabilityConsent`
+    // documents that its promise always settles. "rejected" is the fail-closed
+    // direction, matching drop().
+    for (const { timer, resolve } of resolvers.values()) {
+      clearTimeout(timer);
+      resolve("rejected");
+    }
     resolvers.clear();
     set({ queue: [], current: null });
   },

--- a/src/store/pluginCapabilityConfirmStore.ts
+++ b/src/store/pluginCapabilityConfirmStore.ts
@@ -29,6 +29,8 @@ interface PluginCapabilityConfirmActions {
 
 interface PendingResolver {
   resolve: (decision: PluginCapabilityConsentDecision) => void;
+  /** Kept so a repeat request for the same id can share this outcome. */
+  promise: Promise<PluginCapabilityConsentDecision>;
   timer: ReturnType<typeof setTimeout>;
 }
 
@@ -102,33 +104,40 @@ export const usePluginCapabilityConfirmStore = create<
  * Push a consent prompt into the queue and return a Promise that resolves with
  * the user's decision. The returned Promise never rejects — callers branch on
  * the discriminated decision value.
+ *
+ * A `requestId` already in flight returns that request's existing promise rather
+ * than queueing a second dialog. Main deliberately re-pushes an unacknowledged
+ * prompt (#11708), so a repeat is the *same* request arriving twice, not a
+ * collision — ids are main-minted UUIDs. Treating a repeat as an error and
+ * resolving it "rejected", as this did before, surfaced to the plugin as a user
+ * denial that never happened, which is the very failure mode #11708 exists to
+ * remove.
  */
 export function requestPluginCapabilityConsent(
   item: Omit<PendingPluginCapabilityConsent, "enqueuedAt">
 ): Promise<PluginCapabilityConsentDecision> {
-  return new Promise((resolve) => {
-    if (resolvers.has(item.requestId)) {
-      console.warn(
-        `[PluginCapabilityConfirmStore] duplicate requestId rejected: ${item.requestId}`
-      );
-      resolve("rejected");
-      return;
-    }
-    const { requestId } = item;
-    // Safety net: an abandoned dialog settles itself as "timeout" so the gating
-    // promise never hangs and the stale prompt is evicted from the store. The
-    // resolver is pre-deleted before delegating state cleanup to drop(), which
-    // then finds no resolver and only advances the queue (#10841).
-    const timer = setTimeout(() => {
-      const entry = resolvers.get(requestId);
-      if (!entry) return;
-      resolvers.delete(requestId);
-      entry.resolve("timeout");
-      usePluginCapabilityConfirmStore.getState().drop(requestId);
-    }, PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS);
-    resolvers.set(requestId, { resolve, timer });
-    usePluginCapabilityConfirmStore.getState().enqueue({ ...item, enqueuedAt: Date.now() });
+  const { requestId } = item;
+  const existing = resolvers.get(requestId);
+  if (existing) return existing.promise;
+
+  let settle!: (decision: PluginCapabilityConsentDecision) => void;
+  const promise = new Promise<PluginCapabilityConsentDecision>((resolve) => {
+    settle = resolve;
   });
+  // Safety net: an abandoned dialog settles itself as "timeout" so the gating
+  // promise never hangs and the stale prompt is evicted from the store. The
+  // resolver is pre-deleted before delegating state cleanup to drop(), which
+  // then finds no resolver and only advances the queue (#10841).
+  const timer = setTimeout(() => {
+    const entry = resolvers.get(requestId);
+    if (!entry) return;
+    resolvers.delete(requestId);
+    entry.resolve("timeout");
+    usePluginCapabilityConfirmStore.getState().drop(requestId);
+  }, PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS);
+  resolvers.set(requestId, { resolve: settle, promise, timer });
+  usePluginCapabilityConfirmStore.getState().enqueue({ ...item, enqueuedAt: Date.now() });
+  return promise;
 }
 
 /** Test-only escape hatch — resets store and clears the resolver map. */


### PR DESCRIPTION
## Summary

- Plugin capability consent prompts (`fs:project-write`, `fs:user-data-write`, `shell:exec`, `git:write`, `agent:input`) never reached the app UI. Every plugin waited the full five-minute timeout and was then told the user denied the request, even though no prompt was ever shown.
- Root cause: `electron/ipc/handlers/pluginCapability.ts` sent `plugin-capability:consent-request` through `win.webContents`, the bare `BrowserWindow` shell that stays at `about:blank` with no preload. The real listener lives in a child `WebContentsView`, and `webContents.send()` into a listener-less document neither throws nor logs.
- Fixed by routing through the app view, proving delivery instead of assuming it, and splitting the failure into three honest outcomes instead of one false "denied."

Resolves #11708

## Root cause

The consent bridge picked the focused (or primary) `BrowserWindow` and sent the request to `win.webContents`. That's always the shell, not the React app. The app, along with `usePluginCapabilityConsentBridge`, runs in a separate `WebContentsView` registered through `electron/window/webContentsRegistry.ts`. Sending into the shell silently goes nowhere: no error, no log. The only thing that ever noticed was `PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS` (five minutes), and when it fired, the error path reported it to the plugin as an explicit `PERMISSION_REQUIRED: ... was denied`, an outcome that never actually happened.

This was the last IPC handler in the tree still routing to the shell. `getAppWebContents()` in `webContentsRegistry.ts` exists specifically for this split and is already used at 15+ other call sites.

## The fix

1. Route the consent request through `getAppWebContents(win)` instead of `win.webContents`.
2. Prove delivery instead of assuming it. The renderer acknowledges receipt on a new `plugin-capability:acknowledge-consent` channel as soon as the prompt is enqueued, and main re-pushes the prompt every 2 seconds until that acknowledgement lands. That re-push is what carries a prompt across a cold project switch, where the app view gets registered before React has mounted the listener. No acknowledgement within 10 seconds means the request is undeliverable, so a plugin now fails in seconds instead of being held for five minutes.
3. Split the outcomes. `undeliverable`, `timeout`, and `rejected` now produce three distinct messages. All three keep the `PERMISSION_REQUIRED:` prefix the plugin SDK greps for, and all three still fail closed. Only an actual user rejection now says the plugin "was denied."

Also fixed while in here: the renderer's consent store used to resolve a repeat of the same `requestId` as a rejection. Now that main re-pushes prompts deliberately, that could have manufactured the exact phantom denial this PR fixes, so repeats now share the in-flight prompt instead of re-resolving it. Resetting the store also settles any pending prompts instead of leaving their gating promises hanging.

## Changes

- `electron/ipc/handlers/pluginCapability.ts`: route consent requests via `getAppWebContents(win)`, add the acknowledgement/re-push/undeliverable flow, and split outcome error messages.
- `electron/ipc/handlers/pluginCapability.preload.ts`, `electron/ipc/channels.ts`, `shared/types/ipc/generated*.ts`: new `plugin-capability:acknowledge-consent` channel.
- `shared/types/pluginCapabilityConsent.ts`: shared types for the new consent flow and outcomes.
- `electron/services/plugin/PluginCapabilityConsentService.ts`: distinguish `undeliverable` / `timeout` / `rejected` outcomes.
- `src/hooks/usePluginCapabilityConsentBridge.ts`: send the acknowledgement on receipt.
- `src/store/pluginCapabilityConfirmStore.ts`: dedupe repeat `requestId`s against the in-flight prompt; settle pending prompts on reset.

## Testing

The old bridge test fixture returned a single `{ webContents }` object, so the shell and the app renderer were the same object by construction, meaning the bug could not be expressed in a test. On top of that, `getAppWebContents()` falls back to `win.webContents` when no app view is registered, so a fixture that skips registration passed identically before and after the fix. The suite (`electron/ipc/handlers/__tests__/pluginCapability.test.ts`) now models a real `BrowserWindow`/`WebContentsView` split wired through the actual `webContentsRegistry`. Verified by experiment: reverting the one-line routing fix fails 11 of 18 bridge tests.

## Verification

- 237 targeted tests pass: the bridge, the consent service and store, `webContentsRegistry`, the renderer hook and store, and the `PluginService` host FS/git/agent suites that sit behind this gate.
- `npm run typecheck` is clean.
- Lint ratchet is down 10 warnings.
- `check:ipc` and `check:ipc-renderer` both match.

## Follow-ups (out of scope, flagged by the maintainer in the issue thread)

- `PluginCapabilityConsentRequest` still carries no project or worktree identity, so a prompt routes to the focused window rather than the project that raised it.
- `ProjectViewSwitchController`'s `registerAppView()` ordering during a cold switch is unchanged. The acknowledgement and re-push make that path safe without touching switch architecture.
- The Plugin Manager's Permissions tab still has no manual-grant control.