### PR TITLE
fix(terminal): keep bottom-pinned viewport pinned on rows-only resize

### DIFF
--- a/e2e/full/terminal/core-terminal-rows-resize-pin.spec.ts
+++ b/e2e/full/terminal/core-terminal-rows-resize-pin.spec.ts
@@ -32,11 +32,18 @@ type TerminalScrollHooks = {
 };
 
 /**
- * Long enough for the animation frame that carries xterm's queued viewport
- * sync, short enough to stay inside the reconciliation watchdog's 3s sweep —
- * which measures the LIVE container and would undo the simulated grid below.
+ * Let xterm's queued refresh callback — and therefore its viewport sync — run.
+ * Two frames: the first drains the callback the resize queued, the second lets
+ * anything that callback itself scheduled land before we read.
  */
-const SYNC_FRAME_MS = 250;
+async function waitForFrames(page: Page): Promise<void> {
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      })
+  );
+}
 
 function panelId(): string {
   if (!terminalPanelId) throw new Error("Could not resolve terminal panel ID");
@@ -146,7 +153,7 @@ test.describe.serial("Core: Terminal rows-only resize keeps the viewport pinned"
     // therefore run the very invalidation under test — priming afterwards is
     // what guarantees the target shrink below starts from a primed cache.
     const baselineGrid = await simulateResize(window, outputBox.width, outputBox.height);
-    await window.waitForTimeout(SYNC_FRAME_MS);
+    await waitForFrames(window);
     const baseline = await getScrollState(window);
     expect(baseline.cols).toBe(baselineGrid.cols);
     expect(baseline.baseY).toBeGreaterThan(0);
@@ -161,10 +168,10 @@ test.describe.serial("Core: Terminal rows-only resize keeps the viewport pinned"
     expect(scrolledUp.viewportY, "the -40 leg did not move off bottom").toBeLessThan(
       scrolledUp.baseY
     );
-    await window.waitForTimeout(SYNC_FRAME_MS);
+    await waitForFrames(window);
 
     const scrolledBack = await scrollLines(window, 40);
-    await window.waitForTimeout(SYNC_FRAME_MS);
+    await waitForFrames(window);
     const primed = await getScrollState(window);
     expect(primed.viewportY, "the +40 leg did not return to bottom").toBe(primed.baseY);
     expect(primed.isUserScrolledBack).toBe(false);
@@ -178,7 +185,11 @@ test.describe.serial("Core: Terminal rows-only resize keeps the viewport pinned"
     // font metric, so this shrinks by exactly one row on any platform.
     const rowPx = Math.ceil(outputBox.height / baseline.rows) + 1;
     await simulateResize(window, outputBox.width, outputBox.height - rowPx);
-    await window.waitForTimeout(SYNC_FRAME_MS);
+    // Wait for FRAMES, not wall clock. xterm's corrective sync rides an
+    // animation frame; a host-side timer that expires first would snapshot a
+    // scrollable still holding BOTH its old position and old maximum, which
+    // reads as "pinned" and would pass with the fix removed.
+    await waitForFrames(window);
 
     // ONE snapshot: the shrunken grid must still be the live grid at the moment
     // the pin is judged. Asserting these separately, or polling for eventual
@@ -191,6 +202,14 @@ test.describe.serial("Core: Terminal rows-only resize keeps the viewport pinned"
       `rows did not shrink (watchdog may have reconciled): ${detail}`
     ).toBeLessThan(baseline.rows);
     expect(after.rows, `degenerate grid: ${detail}`).toBeGreaterThan(1);
+
+    // Proof the sync actually ran: fewer rows over the same scrollback means a
+    // shorter viewport and therefore MORE room to scroll. Without this the
+    // pinned check could pass on a scrollable that never moved at all.
+    expect(
+      after.maxScrollTop ?? 0,
+      `viewport sync never applied the new dimensions: ${detail}`
+    ).toBeGreaterThan(baseline.maxScrollTop ?? 0);
 
     // The logical half holds with or without the fix; the visual half is what
     // regressed, and the two disagreeing IS the defect.

--- a/e2e/full/terminal/core-terminal-rows-resize-pin.spec.ts
+++ b/e2e/full/terminal/core-terminal-rows-resize-pin.spec.ts
@@ -1,0 +1,168 @@
+import { test, expect, type Page } from "@playwright/test";
+import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
+import { createFixtureRepo } from "../../helpers/fixtures";
+import { openAndOnboardProject } from "../../helpers/project";
+import { waitForTerminalText, runTerminalCommand } from "../../helpers/terminal";
+import { getGridPanelIds, getPanelById, openTerminal } from "../../helpers/panels";
+import { T_LONG, T_SETTLE } from "../../helpers/timeouts";
+
+let ctx: AppContext;
+let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
+let terminalPanelId: string | undefined;
+
+type TerminalScrollState = {
+  viewportY: number;
+  baseY: number;
+  isUserScrolledBack: boolean;
+  cols: number;
+  rows: number;
+  scrollTop: number | null;
+  maxScrollTop: number | null;
+};
+
+type TerminalScrollHooks = {
+  __daintreeGetTerminalScrollState?: (panelId: string) => TerminalScrollState | null;
+  __daintreeScrollTerminalLines?: (panelId: string, lines: number) => TerminalScrollState | null;
+  __daintreeSimulateTerminalResize?: (
+    panelId: string,
+    width: number,
+    height: number
+  ) => { cols: number; rows: number } | null;
+};
+
+function panelId(): string {
+  if (!terminalPanelId) throw new Error("Could not resolve terminal panel ID");
+  return terminalPanelId;
+}
+
+async function getScrollState(page: Page): Promise<TerminalScrollState> {
+  const state = await page.evaluate((id) => {
+    const hooks = window as unknown as TerminalScrollHooks;
+    return hooks.__daintreeGetTerminalScrollState?.(id) ?? null;
+  }, panelId());
+  if (!state) throw new Error("Terminal scroll state unavailable");
+  return state;
+}
+
+async function scrollLines(page: Page, lines: number): Promise<void> {
+  await page.evaluate(
+    ({ id, lineCount }) => {
+      const hooks = window as unknown as TerminalScrollHooks;
+      hooks.__daintreeScrollTerminalLines?.(id, lineCount);
+    },
+    { id: panelId(), lineCount: lines }
+  );
+}
+
+async function simulateResize(
+  page: Page,
+  width: number,
+  height: number
+): Promise<{ cols: number; rows: number } | null> {
+  return page.evaluate(
+    ({ id, w, h }) => {
+      const hooks = window as unknown as TerminalScrollHooks;
+      return hooks.__daintreeSimulateTerminalResize?.(id, w, h) ?? null;
+    },
+    { id: panelId(), w: width, h: height }
+  );
+}
+
+/**
+ * The viewport is where the buffer says it is. `viewportY >= baseY` alone
+ * cannot answer this — a rows-only resize leaves it true while the scrollable
+ * element is still parked rows higher, which is the whole of #11709.
+ */
+function isVisuallyPinned(state: TerminalScrollState): boolean {
+  if (state.scrollTop === null || state.maxScrollTop === null) return false;
+  return Math.abs(state.maxScrollTop - state.scrollTop) < 1;
+}
+
+test.describe.serial("Core: Terminal rows-only resize keeps the viewport pinned", () => {
+  test.beforeAll(async () => {
+    terminalPanelId = undefined;
+    ({ dir: fixtureDir, cleanup: fixtureCleanup } = createFixtureRepo({
+      name: "rows-resize-pin",
+    }));
+    ctx = await launchApp();
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Rows Resize Pin");
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
+  });
+
+  test("a rows-only shrink does not strand a bottom-pinned viewport in scrollback", async () => {
+    const { window } = ctx;
+
+    await openTerminal(window);
+    await expect
+      .poll(() => getGridPanelIds(window).then((ids) => ids.length), {
+        timeout: T_LONG,
+        intervals: [100, 250, 500],
+      })
+      .toBeGreaterThan(0);
+    const ids = await getGridPanelIds(window);
+    terminalPanelId = ids[ids.length - 1];
+    const panel = await getPanelById(window, panelId());
+    await expect(panel).toBeVisible({ timeout: T_LONG });
+
+    // Real scrollback to scroll through — without it ybase stays 0 and the
+    // resize has no lines to spill, so there is nothing to get stranded above.
+    await runTerminalCommand(
+      window,
+      panel,
+      `node -e "for(let i=1;i<=200;i++) console.log('ROWPIN_'+i)"`
+    );
+    await waitForTerminalText(panel, "ROWPIN_200", T_LONG);
+    await window.waitForTimeout(T_SETTLE);
+
+    // Prime xterm's cached viewport position the only way that matters: a real
+    // scroll round-trip. An un-primed cache self-heals on the next sync, which
+    // is exactly why this bug only ever showed up intermittently.
+    await scrollLines(window, -40);
+    await window.waitForTimeout(T_SETTLE);
+    await scrollLines(window, 40);
+    await window.waitForTimeout(T_SETTLE);
+
+    const before = await getScrollState(window);
+    expect(before.baseY).toBeGreaterThan(0);
+    expect(before.viewportY).toBe(before.baseY);
+    // Guard the fixture itself: if the terminal is not visually pinned before
+    // the resize, the assertion after it would prove nothing either way.
+    expect(isVisuallyPinned(before), `not pinned before resize: ${JSON.stringify(before)}`).toBe(
+      true
+    );
+
+    const box = await panel.boundingBox();
+    if (!box) throw new Error("Terminal panel has no layout box");
+
+    // Same width, shorter box — what growing the hybrid input does. Columns
+    // must not move, or this exercises the column-reflow path (#11316) instead.
+    await simulateResize(window, box.width, box.height);
+    await window.waitForTimeout(T_SETTLE);
+    const baseline = await getScrollState(window);
+
+    await simulateResize(window, box.width, box.height - 3 * before.rows);
+    await window.waitForTimeout(T_SETTLE);
+
+    const after = await getScrollState(window);
+    expect(after.cols, `columns moved — not a rows-only resize: ${JSON.stringify(after)}`).toBe(
+      baseline.cols
+    );
+    expect(after.rows, `rows did not shrink: ${JSON.stringify(after)}`).toBeLessThan(baseline.rows);
+
+    // The logical half passes with or without the fix; it is the visual half
+    // that regresses, and the two disagreeing is the defect itself.
+    expect(after.isUserScrolledBack).toBe(false);
+    expect(after.viewportY).toBe(after.baseY);
+    await expect
+      .poll(async () => isVisuallyPinned(await getScrollState(window)), {
+        timeout: T_LONG,
+        intervals: [100, 250, 500],
+      })
+      .toBe(true);
+  });
+});

--- a/e2e/full/terminal/core-terminal-rows-resize-pin.spec.ts
+++ b/e2e/full/terminal/core-terminal-rows-resize-pin.spec.ts
@@ -31,6 +31,13 @@ type TerminalScrollHooks = {
   ) => { cols: number; rows: number } | null;
 };
 
+/**
+ * Long enough for the animation frame that carries xterm's queued viewport
+ * sync, short enough to stay inside the reconciliation watchdog's 3s sweep —
+ * which measures the LIVE container and would undo the simulated grid below.
+ */
+const SYNC_FRAME_MS = 250;
+
 function panelId(): string {
   if (!terminalPanelId) throw new Error("Could not resolve terminal panel ID");
   return terminalPanelId;
@@ -39,40 +46,50 @@ function panelId(): string {
 async function getScrollState(page: Page): Promise<TerminalScrollState> {
   const state = await page.evaluate((id) => {
     const hooks = window as unknown as TerminalScrollHooks;
-    return hooks.__daintreeGetTerminalScrollState?.(id) ?? null;
+    if (!hooks.__daintreeGetTerminalScrollState) throw new Error("scroll-state hook missing");
+    return hooks.__daintreeGetTerminalScrollState(id);
   }, panelId());
   if (!state) throw new Error("Terminal scroll state unavailable");
   return state;
 }
 
-async function scrollLines(page: Page, lines: number): Promise<void> {
-  await page.evaluate(
+async function scrollLines(page: Page, lines: number): Promise<TerminalScrollState> {
+  const state = await page.evaluate(
     ({ id, lineCount }) => {
       const hooks = window as unknown as TerminalScrollHooks;
-      hooks.__daintreeScrollTerminalLines?.(id, lineCount);
+      if (!hooks.__daintreeScrollTerminalLines) throw new Error("scroll-lines hook missing");
+      return hooks.__daintreeScrollTerminalLines(id, lineCount);
     },
     { id: panelId(), lineCount: lines }
   );
+  if (!state) throw new Error("Terminal scroll state unavailable after scroll");
+  return state;
 }
 
 async function simulateResize(
   page: Page,
   width: number,
   height: number
-): Promise<{ cols: number; rows: number } | null> {
-  return page.evaluate(
+): Promise<{ cols: number; rows: number }> {
+  const grid = await page.evaluate(
     ({ id, w, h }) => {
       const hooks = window as unknown as TerminalScrollHooks;
-      return hooks.__daintreeSimulateTerminalResize?.(id, w, h) ?? null;
+      if (!hooks.__daintreeSimulateTerminalResize) throw new Error("resize hook missing");
+      return hooks.__daintreeSimulateTerminalResize(id, w, h);
     },
     { id: panelId(), w: width, h: height }
   );
+  // A converged resize returns null — the grid did not move, which is a valid
+  // outcome for the baseline call below.
+  return grid ?? (await getScrollState(page));
 }
 
 /**
- * The viewport is where the buffer says it is. `viewportY >= baseY` alone
- * cannot answer this — a rows-only resize leaves it true while the scrollable
- * element is still parked rows higher, which is the whole of #11709.
+ * Is the viewport where the buffer says it is? `viewportY >= baseY` cannot
+ * answer this: a rows-only resize leaves it true while the scrollable element
+ * is still parked rows higher, which is the whole of #11709. Null metrics mean
+ * the private shape is gone — treated as NOT pinned so the guard fails loudly
+ * rather than passing vacuously.
  */
 function isVisuallyPinned(state: TerminalScrollState): boolean {
   if (state.scrollTop === null || state.maxScrollTop === null) return false;
@@ -109,8 +126,8 @@ test.describe.serial("Core: Terminal rows-only resize keeps the viewport pinned"
     const panel = await getPanelById(window, panelId());
     await expect(panel).toBeVisible({ timeout: T_LONG });
 
-    // Real scrollback to scroll through — without it ybase stays 0 and the
-    // resize has no lines to spill, so there is nothing to get stranded above.
+    // Real scrollback to scroll through — without it ybase stays 0, the resize
+    // has no lines to spill, and there is nothing to get stranded above.
     await runTerminalCommand(
       window,
       panel,
@@ -119,50 +136,66 @@ test.describe.serial("Core: Terminal rows-only resize keeps the viewport pinned"
     await waitForTerminalText(panel, "ROWPIN_200", T_LONG);
     await window.waitForTimeout(T_SETTLE);
 
+    // The box the ResizeObserver actually watches, not the padded panel — the
+    // simulated resizes below have to speak the same geometry the watchdog
+    // compares against, or it reconciles them away mid-test.
+    const outputBox = await panel.locator('[aria-label="Terminal output"]').boundingBox();
+    if (!outputBox) throw new Error("Terminal output box has no layout");
+
+    // Establish the baseline grid FIRST. This call can itself move the grid and
+    // therefore run the very invalidation under test — priming afterwards is
+    // what guarantees the target shrink below starts from a primed cache.
+    const baselineGrid = await simulateResize(window, outputBox.width, outputBox.height);
+    await window.waitForTimeout(SYNC_FRAME_MS);
+    const baseline = await getScrollState(window);
+    expect(baseline.cols).toBe(baselineGrid.cols);
+    expect(baseline.baseY).toBeGreaterThan(0);
+    // Cross-layer sanity: with scrollback present the scrollable must have room
+    // to move, or the "visually pinned" check below could pass on a 0/0 shape.
+    expect(baseline.maxScrollTop ?? 0).toBeGreaterThan(0);
+
     // Prime xterm's cached viewport position the only way that matters: a real
     // scroll round-trip. An un-primed cache self-heals on the next sync, which
-    // is exactly why this bug only ever showed up intermittently.
-    await scrollLines(window, -40);
-    await window.waitForTimeout(T_SETTLE);
-    await scrollLines(window, 40);
-    await window.waitForTimeout(T_SETTLE);
+    // is exactly why this bug only ever appeared intermittently.
+    const scrolledUp = await scrollLines(window, -40);
+    expect(scrolledUp.viewportY, "the -40 leg did not move off bottom").toBeLessThan(
+      scrolledUp.baseY
+    );
+    await window.waitForTimeout(SYNC_FRAME_MS);
 
-    const before = await getScrollState(window);
-    expect(before.baseY).toBeGreaterThan(0);
-    expect(before.viewportY).toBe(before.baseY);
-    // Guard the fixture itself: if the terminal is not visually pinned before
-    // the resize, the assertion after it would prove nothing either way.
-    expect(isVisuallyPinned(before), `not pinned before resize: ${JSON.stringify(before)}`).toBe(
+    const scrolledBack = await scrollLines(window, 40);
+    await window.waitForTimeout(SYNC_FRAME_MS);
+    const primed = await getScrollState(window);
+    expect(primed.viewportY, "the +40 leg did not return to bottom").toBe(primed.baseY);
+    expect(primed.isUserScrolledBack).toBe(false);
+    expect(isVisuallyPinned(primed), `not pinned before resize: ${JSON.stringify(primed)}`).toBe(
       true
     );
+    expect(scrolledBack.baseY).toBe(primed.baseY);
 
-    const box = await panel.boundingBox();
-    if (!box) throw new Error("Terminal panel has no layout box");
+    // Same width, one row shorter — what growing the hybrid input does. Derive
+    // the row height from the box actually being divided rather than assuming a
+    // font metric, so this shrinks by exactly one row on any platform.
+    const rowPx = Math.ceil(outputBox.height / baseline.rows) + 1;
+    await simulateResize(window, outputBox.width, outputBox.height - rowPx);
+    await window.waitForTimeout(SYNC_FRAME_MS);
 
-    // Same width, shorter box — what growing the hybrid input does. Columns
-    // must not move, or this exercises the column-reflow path (#11316) instead.
-    await simulateResize(window, box.width, box.height);
-    await window.waitForTimeout(T_SETTLE);
-    const baseline = await getScrollState(window);
-
-    await simulateResize(window, box.width, box.height - 3 * before.rows);
-    await window.waitForTimeout(T_SETTLE);
-
+    // ONE snapshot: the shrunken grid must still be the live grid at the moment
+    // the pin is judged. Asserting these separately, or polling for eventual
+    // success, would accept a watchdog repair as if it were the fix.
     const after = await getScrollState(window);
-    expect(after.cols, `columns moved — not a rows-only resize: ${JSON.stringify(after)}`).toBe(
-      baseline.cols
-    );
-    expect(after.rows, `rows did not shrink: ${JSON.stringify(after)}`).toBeLessThan(baseline.rows);
+    const detail = JSON.stringify({ baseline, after });
+    expect(after.cols, `columns moved — not a rows-only resize: ${detail}`).toBe(baseline.cols);
+    expect(
+      after.rows,
+      `rows did not shrink (watchdog may have reconciled): ${detail}`
+    ).toBeLessThan(baseline.rows);
+    expect(after.rows, `degenerate grid: ${detail}`).toBeGreaterThan(1);
 
-    // The logical half passes with or without the fix; it is the visual half
-    // that regresses, and the two disagreeing is the defect itself.
-    expect(after.isUserScrolledBack).toBe(false);
-    expect(after.viewportY).toBe(after.baseY);
-    await expect
-      .poll(async () => isVisuallyPinned(await getScrollState(window)), {
-        timeout: T_LONG,
-        intervals: [100, 250, 500],
-      })
-      .toBe(true);
+    // The logical half holds with or without the fix; the visual half is what
+    // regressed, and the two disagreeing IS the defect.
+    expect(after.isUserScrolledBack, detail).toBe(false);
+    expect(after.viewportY, detail).toBe(after.baseY);
+    expect(isVisuallyPinned(after), `viewport stranded above bottom: ${detail}`).toBe(true);
   });
 });

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -2945,6 +2945,25 @@ if (typeof window !== "undefined" && window.__DAINTREE_E2E_MODE__ === true) {
     viewportY: number;
     baseY: number;
     isUserScrolledBack: boolean;
+    cols: number;
+    rows: number;
+    // Where the viewport ACTUALLY sits, versus the furthest it can go. The
+    // logical fields above cannot see #11709 at all: a rows-only resize leaves
+    // them reporting "at bottom" while the scrollable element is still parked
+    // rows higher, and it is that stale offset which later drags the buffer
+    // back into scrollback. xterm's scrollable element is not a natively
+    // scrolling node, so its own state is the only reading that means anything.
+    scrollTop: number | null;
+    maxScrollTop: number | null;
+  };
+
+  type XtermScrollableForE2E = {
+    _viewport?: {
+      _scrollableElement?: {
+        getScrollPosition?: () => { scrollTop?: number };
+        getScrollDimensions?: () => { height?: number; scrollHeight?: number };
+      };
+    };
   };
 
   const readTerminalScrollSnapshotForE2E = (
@@ -2953,10 +2972,33 @@ if (typeof window !== "undefined" && window.__DAINTREE_E2E_MODE__ === true) {
     const managed = terminalInstanceService.getInstanceForE2E(panelId);
     if (!managed) return null;
     const buffer = managed.terminal.buffer.active;
+    const finite = (value: unknown): number | null =>
+      typeof value === "number" && Number.isFinite(value) ? value : null;
+
+    let scrollTop: number | null = null;
+    let maxScrollTop: number | null = null;
+    try {
+      const scrollable = (
+        managed.terminal as typeof managed.terminal & { _core?: XtermScrollableForE2E }
+      )._core?._viewport?._scrollableElement;
+      scrollTop = finite(scrollable?.getScrollPosition?.().scrollTop);
+      const dimensions = scrollable?.getScrollDimensions?.();
+      const height = finite(dimensions?.height);
+      const scrollHeight = finite(dimensions?.scrollHeight);
+      maxScrollTop =
+        height !== null && scrollHeight !== null ? Math.max(0, scrollHeight - height) : null;
+    } catch {
+      // Private shape absent — the assertions that need it will see null.
+    }
+
     return {
       viewportY: buffer.viewportY,
       baseY: buffer.baseY,
       isUserScrolledBack: managed.isUserScrolledBack,
+      cols: managed.terminal.cols,
+      rows: managed.terminal.rows,
+      scrollTop,
+      maxScrollTop,
     };
   };
 

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -66,6 +66,54 @@ export function getXtermCellDimensions(
   return null;
 }
 
+/** Narrow structural type for the private viewport scroll cache we invalidate. */
+interface XtermCoreViewportSync {
+  _viewport?: {
+    _latestYDisp?: number;
+    queueSync?: (ydisp?: number) => void;
+  };
+}
+
+/**
+ * Drop xterm's cached viewport scroll position so the queued sync re-reads the
+ * buffer.
+ *
+ * `Viewport._sync` skips its corrective `setScrollPosition` whenever the ydisp
+ * it is handed equals the cached `_latestYDisp` — and the resize path hands it
+ * exactly that cached value, because `bufferService.onResize` calls
+ * `queueSync()` with no argument. Once a real scroll has primed the cache to a
+ * number, the comparison is identity-true and the DOM stays parked at the
+ * pre-resize pixel offset while the buffer's ybase/ydisp have already advanced.
+ * The viewport then sits rows above the bottom even though every logical flag
+ * still reports "at bottom" (#11709).
+ *
+ * Clearing the cache makes the pending `_sync` fall through to its
+ * `buffer.ydisp` default, which is the same self-healing path an un-primed
+ * viewport already takes — and it is xterm's own idiom for an untrustworthy
+ * cached position (`Viewport`'s `onBufferActivate` handler does this verbatim).
+ *
+ * Deliberately NOT an absolute `_core.scrollToBottom(true)`: that runs before
+ * the scrollable element has adopted the post-resize dimensions, so its target
+ * is clamped to `scrollHeight - height` a row short, and the synchronous scroll
+ * event that follows reports a negative delta — which scrolls the terminal off
+ * the bottom rather than pinning it there. `_sync` avoids that by setting the
+ * dimensions before the position.
+ *
+ * Upstream tracking: no public API invalidates this cache on resize, and no
+ * public path reaches `Viewport.scrollToLine(line, true)`. Drop this when one
+ * exists.
+ */
+function invalidateXtermViewportScrollCache(terminal: Terminal): void {
+  try {
+    const viewport = (terminal as Terminal & { _core?: XtermCoreViewportSync })._core?._viewport;
+    if (typeof viewport?.queueSync !== "function") return;
+    viewport._latestYDisp = undefined;
+    viewport.queueSync();
+  } catch {
+    // Private shape absent or changed — the public pin above still stands.
+  }
+}
+
 /**
  * A container dimension as `FitAddon` sees it: whole CSS pixels, clamped at zero.
  *
@@ -667,10 +715,20 @@ export class TerminalResizeController {
    * back. Guarded exactly like `commitResize` (`latestWasAtBottom &&
    * !isUserScrolledBack`); `scrollToBottom` sets ydisp=ybase synchronously, so
    * it is a no-op when already pinned.
+   *
+   * A ROW-count resize misses in the opposite way (#11709): xterm advances
+   * ybase and ydisp together as lines spill into scrollback, so the buffer
+   * stays logically pinned and that relative delta is zero, while the DOM keeps
+   * its pre-resize scroll offset. Both calls are needed — the public one
+   * repairs the buffer, which a stale-cache sync would otherwise faithfully
+   * follow back into scrollback; the invalidation repairs the DOM — and in this
+   * order, since the public call can emit an `onScroll` that re-primes the very
+   * cache being cleared.
    */
   private pinToBottomAfterResize(managed: ManagedTerminal): void {
     if (managed.latestWasAtBottom && !managed.isUserScrolledBack) {
       managed.terminal.scrollToBottom();
+      invalidateXtermViewportScrollCache(managed.terminal);
     }
   }
 

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -133,11 +133,20 @@ function invalidateXtermViewportScrollCache(terminal: Terminal): void {
  * against, so forcing a sync against a stale one lands the target a row short,
  * and the scroll event that follows reports a negative delta: it would drag
  * the buffer back into scrollback and mark it user-scrolled, which is the
- * failure this whole helper exists to prevent. Skip until the renderer catches
- * up; every path that reveals a pane re-runs the pin against a live renderer.
+ * failure this whole helper exists to prevent.
  *
- * Half a cell of tolerance separates "adopted" (a rounding delta) from "stale"
- * (at least one whole row behind).
+ * Skipping leaves a pane that was resized while paused with the same stale
+ * cache it has on the unfixed build — no repair, but no new damage either, and
+ * nothing re-pins it on reveal (`applyDeferredResize` early-returns once the
+ * logical grid already matches, and the watchdog sees no divergence to fix).
+ * Repairing that case needs a deferred retry this deliberately does not carry.
+ *
+ * Half a cell of tolerance separates "adopted" from "stale". Both renderers
+ * keep the residue far below it: the DOM renderer derives `css.cell.height` by
+ * dividing `css.canvas.height` by the row count, so the two agree exactly, and
+ * the WebGL renderer's independent derivation differs only by the sub-pixel
+ * rounding in its `Math.round(device / dpr)`. A stale canvas is at least one
+ * whole row out.
  */
 function rendererHasAdoptedRowCount(
   core: XtermCoreViewportSync | undefined,

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -68,6 +68,14 @@ export function getXtermCellDimensions(
 
 /** Narrow structural type for the private viewport scroll cache we invalidate. */
 interface XtermCoreViewportSync {
+  _renderService?: {
+    dimensions?: {
+      css?: {
+        canvas?: { height?: number };
+        cell?: { height?: number };
+      };
+    };
+  };
   _viewport?: {
     _latestYDisp?: number;
     queueSync?: (ydisp?: number) => void;
@@ -105,13 +113,49 @@ interface XtermCoreViewportSync {
  */
 function invalidateXtermViewportScrollCache(terminal: Terminal): void {
   try {
-    const viewport = (terminal as Terminal & { _core?: XtermCoreViewportSync })._core?._viewport;
+    const core = (terminal as Terminal & { _core?: XtermCoreViewportSync })._core;
+    const viewport = core?._viewport;
     if (typeof viewport?.queueSync !== "function") return;
+    if (!rendererHasAdoptedRowCount(core, terminal.rows)) return;
     viewport._latestYDisp = undefined;
     viewport.queueSync();
   } catch {
     // Private shape absent or changed — the public pin above still stands.
   }
+}
+
+/**
+ * Whether the renderer's canvas already describes `rows`.
+ *
+ * A paused renderer — a backgrounded or occluded pane — defers adopting a
+ * resize to an idle task, so its canvas height still measures the OLD row
+ * count. `_sync` divides that height into the scroll maximum it clamps
+ * against, so forcing a sync against a stale one lands the target a row short,
+ * and the scroll event that follows reports a negative delta: it would drag
+ * the buffer back into scrollback and mark it user-scrolled, which is the
+ * failure this whole helper exists to prevent. Skip until the renderer catches
+ * up; every path that reveals a pane re-runs the pin against a live renderer.
+ *
+ * Half a cell of tolerance separates "adopted" (a rounding delta) from "stale"
+ * (at least one whole row behind).
+ */
+function rendererHasAdoptedRowCount(
+  core: XtermCoreViewportSync | undefined,
+  rows: number
+): boolean {
+  const css = core?._renderService?.dimensions?.css;
+  const canvasHeight = css?.canvas?.height;
+  const cellHeight = css?.cell?.height;
+  if (
+    typeof canvasHeight !== "number" ||
+    typeof cellHeight !== "number" ||
+    !Number.isFinite(canvasHeight) ||
+    !Number.isFinite(cellHeight) ||
+    cellHeight <= 0
+  ) {
+    return false;
+  }
+  return Math.abs(canvasHeight - rows * cellHeight) < cellHeight / 2;
 }
 
 /**
@@ -719,11 +763,12 @@ export class TerminalResizeController {
    * A ROW-count resize misses in the opposite way (#11709): xterm advances
    * ybase and ydisp together as lines spill into scrollback, so the buffer
    * stays logically pinned and that relative delta is zero, while the DOM keeps
-   * its pre-resize scroll offset. Both calls are needed — the public one
-   * repairs the buffer, which a stale-cache sync would otherwise faithfully
-   * follow back into scrollback; the invalidation repairs the DOM — and in this
-   * order, since the public call can emit an `onScroll` that re-primes the very
-   * cache being cleared.
+   * its pre-resize scroll offset. The two calls repair different halves and
+   * neither subsumes the other: the public one restores follow-bottom whenever
+   * the buffer is genuinely off-bottom — a state the invalidation alone would
+   * faithfully sync the DOM *to* — and the invalidation restores the DOM when
+   * the buffer was pinned all along. The order matters: the public call can
+   * emit an `onScroll` that re-primes the very cache being cleared.
    */
   private pinToBottomAfterResize(managed: ManagedTerminal): void {
     if (managed.latestWasAtBottom && !managed.isUserScrolledBack) {

--- a/src/services/terminal/__tests__/TerminalListenerInstaller.test.ts
+++ b/src/services/terminal/__tests__/TerminalListenerInstaller.test.ts
@@ -706,6 +706,52 @@ describe("installTerminalBoundListeners", () => {
     });
   });
 
+  describe("onScroll suppression vs unseen-output clearing", () => {
+    // Why the resize re-pin in TerminalResizeController deliberately does NOT
+    // wrap itself in _suppressScrollTracking (#11709): suppression is not free,
+    // it costs the clearUnseen side effect, and the corrective viewport sync
+    // that follows a rows-only resize emits no second event to restore it.
+    function installAtBottom(suppress: boolean) {
+      const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
+      const terminal = makeMockTerminal(captured);
+      const managed = makeMockManaged();
+      const deps = makeDeps();
+
+      managed.terminal = terminal as unknown as ManagedTerminal["terminal"];
+      managed.isUserScrolledBack = true;
+      managed.latestWasAtBottom = false;
+      managed._suppressScrollTracking = suppress;
+      installTerminalBoundListeners(
+        terminal as unknown as Parameters<typeof installTerminalBoundListeners>[0],
+        managed,
+        "t1",
+        deps
+      );
+      // baseY === viewportY === 0 from the mock: an at-bottom scroll.
+      captured.onScroll?.();
+      return { managed, deps };
+    }
+
+    it("clears unseen output when tracking is not suppressed", () => {
+      const { managed, deps } = installAtBottom(false);
+
+      expect(managed.latestWasAtBottom).toBe(true);
+      expect(managed.isUserScrolledBack).toBe(false);
+      expect(deps.clearUnseen).toHaveBeenCalledWith("t1", false);
+    });
+
+    it("keeps tracking position but skips clearUnseen when suppressed", () => {
+      const { managed, deps } = installAtBottom(true);
+
+      // latestWasAtBottom updates ahead of the suppression return, so a
+      // suppressed scroll still reports position...
+      expect(managed.latestWasAtBottom).toBe(true);
+      // ...but the scroll-intent bookkeeping and unseen clearing are skipped.
+      expect(managed.isUserScrolledBack).toBe(true);
+      expect(deps.clearUnseen).not.toHaveBeenCalled();
+    });
+  });
+
   describe("wheel amplification for mouse-tracking TUIs", () => {
     // Wire a real host > xterm element pair so the capture-phase amplifier can
     // intercept a physical wheel and re-dispatch synthetic reports onto the

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -3142,7 +3142,13 @@ describe("TerminalResizeController", () => {
     const BASELINE_HEIGHT = 600;
     const BASELINE_ROWS = BASELINE_HEIGHT / CELL.height;
 
-    function makeManagedWithViewport(primedYDisp = 42) {
+    /**
+     * @param rendererRows the row count the renderer's canvas currently
+     * measures. Defaults to tracking the terminal (an unpaused renderer that
+     * adopted the resize); pass a fixed number to model a PAUSED renderer whose
+     * canvas still describes the pre-resize size.
+     */
+    function makeManagedWithViewport(primedYDisp = 42, rendererRows?: () => number) {
       const managed = createManagedTerminal();
       // The shared fixture's rows (24) do not correspond to its lastHeight
       // (600px / 20px = 30). Align them, or "one row shorter" is a grow.
@@ -3151,13 +3157,27 @@ describe("TerminalResizeController", () => {
       const observed: Array<{ by: string; latestYDisp: number | undefined }> = [];
       const viewport = {
         _latestYDisp: primedYDisp as number | undefined,
-        queueSync: vi.fn(() => {
+        // Mirrors xterm: a queueSync CARRYING a ydisp writes it back into the
+        // cache, which would re-prime what we just cleared. Emulating that is
+        // what makes a `queueSync(staleYDisp)` regression observable here.
+        queueSync: vi.fn((ydisp?: number) => {
+          if (ydisp !== undefined) viewport._latestYDisp = ydisp;
           observed.push({ by: "queueSync", latestYDisp: viewport._latestYDisp });
         }),
       };
+      const rowsForCanvas = rendererRows ?? (() => managed.terminal.rows);
       Object.assign(managed.terminal, {
         _core: {
-          _renderService: { dimensions: { css: { cell: CELL } } },
+          _renderService: {
+            dimensions: {
+              css: {
+                cell: CELL,
+                get canvas() {
+                  return { height: rowsForCanvas() * CELL.height };
+                },
+              },
+            },
+          },
           _viewport: viewport,
         },
         scrollToBottom: vi.fn(() => {
@@ -3204,6 +3224,23 @@ describe("TerminalResizeController", () => {
       expect(observed[1]?.latestYDisp).toBeUndefined();
       expect(viewport._latestYDisp).toBeUndefined();
       expect(viewport.queueSync).toHaveBeenCalledTimes(1);
+      // No argument: passing one writes it straight back into the cache, which
+      // would restore the stale value the clear above just removed.
+      expect(viewport.queueSync).toHaveBeenCalledWith();
+    });
+
+    it("completes the resize when queueSync throws", () => {
+      const { managed, viewport } = makeManagedWithViewport();
+      viewport.queueSync.mockImplementation(() => {
+        throw new Error("viewport disposed mid-resize");
+      });
+      const controller = makeCtl(managed);
+
+      // The DOM repair is best-effort; a disposed or renamed internal must not
+      // take the resize (or the PTY notification) down with it.
+      expect(() => shrinkOneRow(controller)).not.toThrow();
+      expect(managed.terminal.scrollToBottom).toHaveBeenCalledOnce();
+      expect(resizeMock).toHaveBeenCalled();
     });
 
     it("leaves a deliberately scrolled-back viewport's cache alone", () => {
@@ -3218,6 +3255,23 @@ describe("TerminalResizeController", () => {
       expect(observed).toEqual([]);
       expect(viewport._latestYDisp).toBe(42);
       expect(viewport.queueSync).not.toHaveBeenCalled();
+    });
+
+    it("holds off while a paused renderer's canvas still measures the old row count", () => {
+      // A backgrounded pane defers its renderer resize to an idle task, so the
+      // canvas height _sync clamps against is a row (or more) too tall. Forcing
+      // the sync there lands short and the resulting scroll event drags the
+      // buffer back — the exact failure this repairs. Freeze the canvas at the
+      // pre-resize row count to model that.
+      const { managed, viewport, observed } = makeManagedWithViewport(42, () => BASELINE_ROWS);
+      const controller = makeCtl(managed);
+
+      shrinkOneRow(controller);
+
+      // The public pin is unconditional; only the DOM-side repair waits.
+      expect(observed.map((o) => o.by)).toEqual(["scrollToBottom"]);
+      expect(viewport.queueSync).not.toHaveBeenCalled();
+      expect(viewport._latestYDisp).toBe(42);
     });
 
     it("still pins when the private viewport shape is missing", () => {

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -3124,4 +3124,114 @@ describe("TerminalResizeController", () => {
       expect(controller.isResizeLocked("term-1")).toBe(false);
     });
   });
+
+  describe("viewport scroll-cache invalidation after a re-pin (#11709)", () => {
+    /**
+     * A managed terminal whose `_core` carries the private viewport shape, and
+     * which records the cached `_latestYDisp` each collaborator OBSERVES rather
+     * than only that it was called. Ordering is the contract under test: the
+     * public pin has to run while the cache is still primed, and the queued sync
+     * has to run after it was cleared.
+     */
+    /**
+     * A container whose width divides to exactly the fixture's 80 columns, so
+     * the shrink below moves rows and ONLY rows — the condition under which
+     * xterm's reflow never runs and the relative pin has a zero delta.
+     */
+    const ROWS_ONLY_WIDTH = SCROLLBAR_PX + 80 * CELL.width;
+    const BASELINE_HEIGHT = 600;
+    const BASELINE_ROWS = BASELINE_HEIGHT / CELL.height;
+
+    function makeManagedWithViewport(primedYDisp = 42) {
+      const managed = createManagedTerminal();
+      // The shared fixture's rows (24) do not correspond to its lastHeight
+      // (600px / 20px = 30). Align them, or "one row shorter" is a grow.
+      managed.terminal.rows = BASELINE_ROWS;
+      managed.latestRows = BASELINE_ROWS;
+      const observed: Array<{ by: string; latestYDisp: number | undefined }> = [];
+      const viewport = {
+        _latestYDisp: primedYDisp as number | undefined,
+        queueSync: vi.fn(() => {
+          observed.push({ by: "queueSync", latestYDisp: viewport._latestYDisp });
+        }),
+      };
+      Object.assign(managed.terminal, {
+        _core: {
+          _renderService: { dimensions: { css: { cell: CELL } } },
+          _viewport: viewport,
+        },
+        scrollToBottom: vi.fn(() => {
+          observed.push({ by: "scrollToBottom", latestYDisp: viewport._latestYDisp });
+        }),
+      });
+      return { managed, viewport, observed };
+    }
+
+    function makeCtl(managed: ReturnType<typeof createManagedTerminal>) {
+      return new TerminalResizeController({
+        getInstance: vi.fn(() => managed),
+        dataBuffer: {
+          flushForTerminal: vi.fn(),
+          resetForTerminal: vi.fn(),
+          getQueuedBytes: vi.fn(() => 0),
+          resumeFlush: vi.fn(),
+        } as any,
+      });
+    }
+
+    /** A rows-only shrink: same width, one cell row shorter. */
+    const shrinkOneRow = (controller: TerminalResizeController) =>
+      controller.resize("term-1", ROWS_ONLY_WIDTH, BASELINE_HEIGHT - CELL.height);
+
+    it("clears the primed cache and re-queues a sync, in that order, after a rows-only shrink", () => {
+      const { managed, viewport, observed } = makeManagedWithViewport();
+      const colsBefore = managed.terminal.cols;
+      const controller = makeCtl(managed);
+
+      const result = shrinkOneRow(controller);
+
+      // Rows-only: the column count is untouched, so xterm's reflow never runs
+      // and the relative pin below has a zero delta to apply.
+      expect(result?.cols).toBe(colsBefore);
+      expect(result?.rows).toBe(BASELINE_ROWS - 1);
+
+      // The public pin must observe the cache STILL primed — it can emit an
+      // onScroll that re-primes, so clearing first would be undone.
+      expect(observed.map((o) => o.by)).toEqual(["scrollToBottom", "queueSync"]);
+      expect(observed[0]?.latestYDisp).toBe(42);
+      // ...and the queued sync must observe it cleared, which is what makes
+      // `_sync` fall through to buffer.ydisp instead of skipping.
+      expect(observed[1]?.latestYDisp).toBeUndefined();
+      expect(viewport._latestYDisp).toBeUndefined();
+      expect(viewport.queueSync).toHaveBeenCalledTimes(1);
+    });
+
+    it("leaves a deliberately scrolled-back viewport's cache alone", () => {
+      const { managed, viewport, observed } = makeManagedWithViewport();
+      managed.isUserScrolledBack = true;
+      const controller = makeCtl(managed);
+
+      shrinkOneRow(controller);
+
+      // The guard owns both halves: no pin, no invalidation, and the user's own
+      // scroll position stays cached.
+      expect(observed).toEqual([]);
+      expect(viewport._latestYDisp).toBe(42);
+      expect(viewport.queueSync).not.toHaveBeenCalled();
+    });
+
+    it("still pins when the private viewport shape is missing", () => {
+      // createManagedTerminal() has no `_core._viewport` — the shape xterm would
+      // present before open(), and the shape every other suite's mock has. The
+      // fix must degrade to the public pin rather than throw through the resize.
+      const managed = createManagedTerminal();
+      Object.assign(managed.terminal, {
+        _core: { _renderService: { dimensions: { css: { cell: CELL } } } },
+      });
+      const controller = makeCtl(managed);
+
+      expect(() => shrinkOneRow(controller)).not.toThrow();
+      expect(managed.terminal.scrollToBottom).toHaveBeenCalledOnce();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Fixes an intermittent bug where a bottom-pinned agent terminal jumped into scrollback while typing in the hybrid input box. Growing that input box only shrinks the terminal's height, producing a rows-only resize (columns unchanged).
- Traced the root cause into the vendored `@xterm/xterm` 6.1.0-beta.290 source: xterm's own re-pin call and its viewport sync both silently no-op on this path once a prior real scroll has primed a cache.
- Adds a cache invalidation after the existing re-pin call, gated on the renderer having adopted the new row count, plus a Playwright spec and unit tests that pin down the ordering.

Resolves #11709

## Root cause

Two things compound in the vendored xterm source:

1. On a rows shrink, xterm's `Buffer.ts` advances `ybase` and `ydisp` together, so a pinned terminal stays logically pinned. The existing re-pin call therefore always sees a relative delta of exactly zero. `Terminal.scrollToBottom()` is public and takes no argument, so it can only ever take that relative branch.
2. xterm's `Viewport._sync` skips its corrective `setScrollPosition` call whenever the `ydisp` it's handed equals the cached `_latestYDisp`. The resize path hands it exactly that cached value, because `bufferService.onResize` calls `queueSync()` with no argument. Once a prior real scroll has primed the cache with a number, the comparison is identity-true and the DOM stays parked at the pre-resize offset.

The result: the viewport sits rows above the bottom while every logical flag reports at-bottom, and it's that stale DOM offset that later drags the buffer back into view. Reproducing it needs a prior real scroll to prime the cache, which is why it only showed up intermittently. It's a different path from the one fixed in #11316, which handled a column reflow with a nonzero delta.

## Fix

After the existing public re-pin call, clear xterm's cached viewport position and re-queue the sync. This is the same idiom xterm's own `onBufferActivate` handler uses for an untrustworthy cached position.

Order matters: the public pin call can emit an `onScroll` that would re-prime the very cache being cleared, so the invalidation has to come after it. Both calls stay in place. The public one restores follow-bottom when the buffer is genuinely off-bottom; the invalidation restores the DOM when the buffer was pinned all along.

Deliberately not using an absolute `_core.scrollToBottom(true)` here: it runs before the scrollable element has adopted the post-resize dimensions, so the target clamps a row short, and the synchronous scroll event that follows reports a negative delta, scrolling the terminal off the bottom instead of pinning it.

The invalidation is gated on the renderer having adopted the new row count. A paused (backgrounded) renderer defers its resize to an idle task while its canvas still measures the old row count; forcing the sync there would clamp short and reintroduce the same bug on background panes.

## Known limitation

A pane resized while its renderer is paused still isn't repaired by this. That's unchanged from current `develop` behavior, not a regression, and nothing re-pins it when the pane is revealed again. Fixing that needs a deferred retry mechanism that this PR deliberately doesn't carry.

## Changes

- `src/services/terminal/TerminalResizeController.ts`: the core fix.
- `src/services/terminal/TerminalInstanceService.ts`: extends the E2E-only scroll snapshot.
- `src/services/terminal/__tests__/TerminalResizeController.test.ts`, `src/services/terminal/__tests__/TerminalListenerInstaller.test.ts`: unit tests.
- `e2e/full/terminal/core-terminal-rows-resize-pin.spec.ts`: new Playwright spec.

## Testing

Added a Playwright spec that primes the cache with a real scroll round-trip, applies a rows-only shrink, and asserts logical and visual bottom position in one snapshot. Mutation-tested it: with only the invalidation disabled, it fails with columns unchanged at 211, rows going 52 to 51, `viewportY` equal to `baseY` throughout, max scroll top going 2400 to 2416, but actual scroll top stuck at 2400, stranded exactly one row above bottom. With the fix applied, it passes.

Unit tests cover the call ordering, the scrolled-back guard, the paused-renderer hold-off, the throw path, and the cost of `clearUnseen` that rules out suppressing the re-pin. Full terminal suite: 71 files, 1510 tests, green. Lint ratchet passes.