### PR TITLE
fix(worktree): keep the New Worktree dialog open when picking an in-use base branch

### DIFF
--- a/e2e/full/worktree/new-worktree-dialog.spec.ts
+++ b/e2e/full/worktree/new-worktree-dialog.spec.ts
@@ -164,4 +164,34 @@ test.describe.serial("Full: New Worktree Dialog", () => {
     await expect(listbox).toHaveCount(0, { timeout: T_SHORT });
     await expect(trigger).toContainText(/Clone current layout/i, { timeout: T_MEDIUM });
   });
+
+  test("selecting an in-use base branch keeps the dialog open and the form intact", async () => {
+    const { window } = ctx;
+    await openDialog(window);
+
+    // Dirty the form first: #11714 discarded typed input by closing the dialog,
+    // so a surviving value is the observable proof the diversion is gone.
+    const branchInput = window.locator(SEL.worktree.branchNameInput);
+    await branchInput.fill("e2e-keeps-form-state");
+
+    const trigger = window.locator(SEL.worktree.baseBranchTrigger);
+    await expect(trigger).toBeVisible({ timeout: T_MEDIUM });
+    await trigger.click();
+
+    // The popover portals to <body>, so query the listbox from the page root.
+    const listbox = window.locator(SEL.worktree.baseBranchListbox);
+    await expect(listbox).toBeVisible({ timeout: T_MEDIUM });
+
+    // withFeatureBranch checks feature/test-branch out into a linked worktree,
+    // so its row is the one carrying the "in use" badge.
+    const inUseOption = listbox.getByRole("option", { name: /feature\/test-branch/ });
+    await expect(inUseOption).toContainText("in use", { timeout: T_MEDIUM });
+    await inUseOption.click();
+
+    // #6289: gate on the portaled listbox unmounting before asserting on the trigger.
+    await expect(listbox).toHaveCount(0, { timeout: T_SHORT });
+    await expect(window.locator(SEL.worktree.newDialog)).toBeVisible();
+    await expect(trigger).toContainText("feature/test-branch", { timeout: T_MEDIUM });
+    await expect(branchInput).toHaveValue("e2e-keeps-form-state");
+  });
 });

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -129,6 +129,8 @@ export const SEL = {
     environmentGroup: '[role="radiogroup"][aria-label="Worktree environment mode"]',
     recipeTrigger: "#recipe-selector-trigger",
     recipeListbox: "#recipe-selector",
+    baseBranchTrigger: "#base-branch",
+    baseBranchListbox: "#branch-list",
     validationError: "#validation-error",
     overviewCell: "[data-worktree-overview-cell]",
     overviewCellFor: (id: string) => `[data-worktree-overview-cell="${id}"]`,

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -977,7 +977,6 @@ export function NewWorktreeDialog({
                 branchListRef={branchListRef}
                 errorField={errors.errorField}
                 branchOptionsLength={branchOptions.length}
-                onClose={onClose}
               />
             )}
 

--- a/src/components/Worktree/__tests__/BaseBranchCombobox.test.tsx
+++ b/src/components/Worktree/__tests__/BaseBranchCombobox.test.tsx
@@ -65,7 +65,7 @@ function optionRow(
 }
 
 describe("BaseBranchCombobox in-use rows", () => {
-  it("routes a click on an in-use branch to onSelect, like the Enter key does", () => {
+  it("routes a click on an in-use branch to onSelect instead of diverting it", () => {
     const onSelect = vi.fn();
     const inUseRow = optionRow("main", { id: "main-wt", name: "main-worktree" });
     const freeRow = optionRow("develop", null);

--- a/src/components/Worktree/__tests__/BaseBranchCombobox.test.tsx
+++ b/src/components/Worktree/__tests__/BaseBranchCombobox.test.tsx
@@ -2,10 +2,11 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, afterEach, beforeAll, vi } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { createRef } from "react";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { BaseBranchCombobox } from "../views/BaseBranchCombobox";
+import type { BranchPickerRow, BranchWorktreeRef } from "../branchPickerUtils";
 
 class ResizeObserverStub {
   observe() {}
@@ -37,12 +38,56 @@ function renderCombobox(overrides: Partial<Parameters<typeof BaseBranchCombobox>
         branchInputRef={createRef<HTMLInputElement>()}
         branchListRef={createRef<HTMLDivElement>()}
         branchOptionsLength={0}
-        onClose={() => {}}
         {...overrides}
       />
     </TooltipProvider>
   );
 }
+
+function optionRow(
+  name: string,
+  inUseWorktree: BranchWorktreeRef | null
+): BranchPickerRow & { kind: "option" } {
+  return {
+    kind: "option",
+    name,
+    isCurrent: false,
+    isRemote: false,
+    remoteName: null,
+    labelText: name,
+    searchText: name,
+    score: 0,
+    matchRanges: [],
+    isRecent: false,
+    recentRank: 0,
+    inUseWorktree,
+  };
+}
+
+describe("BaseBranchCombobox in-use rows", () => {
+  it("routes a click on an in-use branch to onSelect, like the Enter key does", () => {
+    const onSelect = vi.fn();
+    const inUseRow = optionRow("main", { id: "main-wt", name: "main-worktree" });
+    const freeRow = optionRow("develop", null);
+    renderCombobox({
+      branchRows: [inUseRow, freeRow],
+      selectableRows: [inUseRow, freeRow],
+      onSelect,
+    });
+
+    fireEvent.click(screen.getAllByRole("option")[0]!);
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0]![0]).toBe(inUseRow);
+  });
+
+  it("labels the in-use badge with the owning worktree name, not the branch name", () => {
+    const inUseRow = optionRow("main", { id: "main-wt", name: "main-worktree" });
+    renderCombobox({ branchRows: [inUseRow], selectableRows: [inUseRow] });
+
+    expect(screen.getByTitle("In use by worktree: main-worktree")).toBeTruthy();
+  });
+});
 
 describe("BaseBranchCombobox empty states", () => {
   it("renders zero-data EmptyState when no branches and no query", () => {

--- a/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
+++ b/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
@@ -3,6 +3,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup, act, fireEvent } from "@testing-library/react";
+import { useState } from "react";
 import type { BranchInfo } from "@/types/electron";
 
 vi.stubGlobal(
@@ -1172,5 +1173,100 @@ describe("NewWorktreeDialog — recipe scope visibility (#11510)", () => {
     await advanceTimersGradually(500);
 
     expect(recipePickerCalls.last?.defaultRecipeId).toBe("global-work");
+  });
+});
+
+describe("NewWorktreeDialog — in-use base branch selection", () => {
+  // `main` is in use by `main-wt` via mockWorktreeDataMap. Make `develop` the
+  // current branch so it wins deriveDefaultBaseBranch — otherwise `main` is
+  // already the default and clicking it would change nothing observable.
+  const BRANCHES_WITH_DEVELOP_CURRENT: BranchInfo[] = TEST_BRANCHES.map((b) => ({
+    ...b,
+    current: b.name === "develop",
+  }));
+
+  function baseBranchLabel(): string {
+    return document.getElementById("base-branch")?.textContent ?? "";
+  }
+
+  function inUseBaseBranchOption(): HTMLElement {
+    const list = document.getElementById("branch-list");
+    if (!list) throw new Error("base-branch listbox not rendered");
+    const row = Array.from(list.querySelectorAll('[role="option"]')).find((el) =>
+      el.querySelector('[title^="In use by worktree:"]')
+    );
+    if (!row) throw new Error("no in-use branch row rendered in the base-branch listbox");
+    return row as HTMLElement;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockListBranches.mockResolvedValue(BRANCHES_WITH_DEVELOP_CURRENT);
+    mockGetRecentBranches.mockResolvedValue([]);
+    mockGetAvailableBranch.mockImplementation((_root: string, name: string) =>
+      Promise.resolve(name)
+    );
+    mockGetDefaultPath.mockImplementation((_root: string, branch: string) =>
+      Promise.resolve(`/test/root-worktrees/${branch}`)
+    );
+    mockDispatch.mockResolvedValue({ ok: true, result: "new-wt-id" });
+    mockGetCurrentUser.mockResolvedValue(null);
+    mockAssignIssue.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("selects an in-use branch as the base without closing the dialog or switching worktrees", async () => {
+    const onClose = vi.fn();
+    renderDialog({ onClose });
+    await advanceTimersGradually(500);
+
+    expect(baseBranchLabel()).toContain("develop");
+
+    const row = inUseBaseBranchOption();
+    expect(row.textContent).toContain("main");
+
+    await act(async () => {
+      fireEvent.click(row);
+    });
+
+    expect(baseBranchLabel()).toContain("main");
+    expect(onClose).not.toHaveBeenCalled();
+    expect(mockDispatch.mock.calls.map((c) => c[0])).not.toContain("worktree.setActive");
+  });
+
+  it("preserves a typed branch name across an in-use base-branch selection", async () => {
+    // renderDialog() pins isOpen={true}, so it can never unmount and any
+    // "still mounted"/"input survived" assertion against it passes even with the
+    // bug present. Drive `isOpen` from onClose so the close actually unmounts.
+    function ControlledDialog() {
+      const [open, setOpen] = useState(true);
+      return open ? (
+        <NewWorktreeDialog isOpen onClose={() => setOpen(false)} rootPath="/test/root" />
+      ) : null;
+    }
+
+    render(<ControlledDialog />);
+    await advanceTimersGradually(500);
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId("branch-name-input"), {
+        target: { value: "feature/keep-me" },
+      });
+    });
+    await advanceTimersGradually(1000);
+
+    await act(async () => {
+      fireEvent.click(inUseBaseBranchOption());
+    });
+
+    expect(screen.queryByTestId("new-worktree-dialog")).not.toBeNull();
+    expect((screen.getByTestId("branch-name-input") as HTMLInputElement).value).toBe(
+      "feature/keep-me"
+    );
   });
 });

--- a/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
+++ b/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
@@ -1185,17 +1185,20 @@ describe("NewWorktreeDialog — in-use base branch selection", () => {
     current: b.name === "develop",
   }));
 
+  const IN_USE_BRANCH = "main";
+
   function baseBranchLabel(): string {
     return document.getElementById("base-branch")?.textContent ?? "";
   }
 
-  function inUseBaseBranchOption(): HTMLElement {
+  /** Match on the row's label span so `main` never resolves to `origin/main`. */
+  function baseBranchOption(label: string): HTMLElement {
     const list = document.getElementById("branch-list");
     if (!list) throw new Error("base-branch listbox not rendered");
-    const row = Array.from(list.querySelectorAll('[role="option"]')).find((el) =>
-      el.querySelector('[title^="In use by worktree:"]')
+    const row = Array.from(list.querySelectorAll('[role="option"]')).find(
+      (el) => el.querySelector("span")?.textContent === label
     );
-    if (!row) throw new Error("no in-use branch row rendered in the base-branch listbox");
+    if (!row) throw new Error(`no base-branch row labelled "${label}"`);
     return row as HTMLElement;
   }
 
@@ -1225,16 +1228,35 @@ describe("NewWorktreeDialog — in-use base branch selection", () => {
     renderDialog({ onClose });
     await advanceTimersGradually(500);
 
-    expect(baseBranchLabel()).toContain("develop");
+    expect(baseBranchLabel()).toBe("develop (current)");
 
-    const row = inUseBaseBranchOption();
-    expect(row.textContent).toContain("main");
+    const row = baseBranchOption(IN_USE_BRANCH);
+    expect(row.querySelector('[title^="In use by worktree:"]')).not.toBeNull();
 
     await act(async () => {
       fireEvent.click(row);
     });
 
-    expect(baseBranchLabel()).toContain("main");
+    // Exact, not substring: `toContain("main")` would also accept `origin/main`.
+    expect(baseBranchLabel()).toBe(IN_USE_BRANCH);
+    expect(baseBranchOption(IN_USE_BRANCH).getAttribute("aria-selected")).toBe("true");
+    expect(onClose).not.toHaveBeenCalled();
+    expect(mockDispatch.mock.calls.map((c) => c[0])).not.toContain("worktree.setActive");
+  });
+
+  it("reaches the same selection with Enter as with a click", async () => {
+    const onClose = vi.fn();
+    renderDialog({ onClose });
+    await advanceTimersGradually(500);
+
+    // selectedIndex starts at 0, so Enter targets whichever row leads the list.
+    expect(baseBranchOption(IN_USE_BRANCH).getAttribute("data-option-index")).toBe("0");
+
+    await act(async () => {
+      fireEvent.keyDown(screen.getByLabelText("Search base branches"), { key: "Enter" });
+    });
+
+    expect(baseBranchLabel()).toBe(IN_USE_BRANCH);
     expect(onClose).not.toHaveBeenCalled();
     expect(mockDispatch.mock.calls.map((c) => c[0])).not.toContain("worktree.setActive");
   });
@@ -1261,7 +1283,7 @@ describe("NewWorktreeDialog — in-use base branch selection", () => {
     await advanceTimersGradually(1000);
 
     await act(async () => {
-      fireEvent.click(inUseBaseBranchOption());
+      fireEvent.click(baseBranchOption(IN_USE_BRANCH));
     });
 
     expect(screen.queryByTestId("new-worktree-dialog")).not.toBeNull();

--- a/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
+++ b/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
@@ -1195,11 +1195,11 @@ describe("NewWorktreeDialog — in-use base branch selection", () => {
   function baseBranchOption(label: string): HTMLElement {
     const list = document.getElementById("branch-list");
     if (!list) throw new Error("base-branch listbox not rendered");
-    const row = Array.from(list.querySelectorAll('[role="option"]')).find(
+    const row = Array.from(list.querySelectorAll<HTMLElement>('[role="option"]')).find(
       (el) => el.querySelector("span")?.textContent === label
     );
     if (!row) throw new Error(`no base-branch row labelled "${label}"`);
-    return row as HTMLElement;
+    return row;
   }
 
   beforeEach(() => {
@@ -1287,8 +1287,6 @@ describe("NewWorktreeDialog — in-use base branch selection", () => {
     });
 
     expect(screen.queryByTestId("new-worktree-dialog")).not.toBeNull();
-    expect((screen.getByTestId("branch-name-input") as HTMLInputElement).value).toBe(
-      "feature/keep-me"
-    );
+    expect(screen.getByTestId<HTMLInputElement>("branch-name-input").value).toBe("feature/keep-me");
   });
 });

--- a/src/components/Worktree/views/BaseBranchCombobox.tsx
+++ b/src/components/Worktree/views/BaseBranchCombobox.tsx
@@ -5,7 +5,6 @@ import { EmptyState } from "@/components/ui/EmptyState";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Check, ChevronsUpDown, Info, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { actionService } from "@/services/ActionService";
 import { HighlightBranchText } from "./HighlightBranchText";
 import type { BranchPickerRow } from "../branchPickerUtils";
 
@@ -26,7 +25,6 @@ interface BaseBranchComboboxProps {
   errorField?: "base-branch" | "new-branch" | "worktree-path" | null;
   branchOptionsLength: number;
   disabled?: boolean;
-  onClose: () => void;
 }
 
 export function BaseBranchCombobox({
@@ -46,7 +44,6 @@ export function BaseBranchCombobox({
   errorField,
   branchOptionsLength,
   disabled,
-  onClose,
 }: BaseBranchComboboxProps) {
   return (
     <div className="space-y-2">
@@ -163,17 +160,7 @@ export function BaseBranchCombobox({
                       data-option-index={idx}
                       role="option"
                       aria-selected={row.name === baseBranch}
-                      onClick={() => {
-                        if (row.inUseWorktree) {
-                          actionService.dispatch("worktree.setActive", {
-                            worktreeId: row.inUseWorktree.id,
-                          });
-                          onOpenChange(false);
-                          onClose();
-                          return;
-                        }
-                        onSelect(row);
-                      }}
+                      onClick={() => onSelect(row)}
                       className={cn(
                         "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
                         row.name === baseBranch && "bg-daintree-border",


### PR DESCRIPTION
## Summary

- Clicking a branch row tagged "in use" in the New Worktree dialog's Base Branch dropdown was closing the whole dialog and discarding any typed form input, instead of just selecting that branch as the base.
- Root cause: the row's click handler dispatched `worktree.setActive` and then called the dialog's own `onClose`, the same callback used by Cancel, Escape, and the backdrop. Pressing Enter on the identical row already did the right thing.
- Fix converges click onto the same path Enter was already taking, and removes the dead code that fell out of it.

Resolves #11714

## Problem

In the New Worktree dialog's Base Branch dropdown, clicking a branch row tagged "in use" dispatched `worktree.setActive` and then called the dialog's own `onClose()`, the same callback as Cancel, Escape, and the backdrop. So the whole dialog closed and any typed form input was discarded. Pressing Enter on the identical row behaved correctly: it just selected the branch and left the dialog open.

## Root cause

Not a copy-paste slip. The diversion traces back to `cc64ed416`, "feat(branch-picker): add fuzzy search, MRU sorting, and worktree indicators", whose message reads "Add worktree-in-use indicators with 'in use' badge and click-to-switch." Click-to-switch was a deliberate feature, just applied in the wrong context. It fits a worktree switcher, not a base-branch selector.

`git worktree add -b <new> <path> <base>` works fine when `<base>` is checked out elsewhere. Git only forbids two worktrees sharing the same branch as HEAD, so "in use" is purely informational here.

## Fix

The option row's handler is now just `onClick={() => onSelect(row)}`, converging click onto the path Enter already used. The "in use" badge is unchanged. This also cleared out the resulting dead code: the `actionService` import, and the `onClose` prop from `BaseBranchComboboxProps` plus its call site in `NewWorktreeDialog`.

## Why existing-branch mode is untouched

`ExistingBranchPicker` has no `inUseWorktree` concept. In-use branches are excluded further up, in `NewWorktreeDialog`'s `existingBranchCandidates`. That asymmetry is correct: existing-branch mode genuinely can't reuse a checked-out branch, base-branch mode can.

## Testing

Added 3 new unit regressions plus an E2E case. All three unit regressions were mutation-verified: they fail against the reverted, buggy source and pass against the fix.

The dialog test uses a small `ControlledDialog` harness, since the suite's shared `renderDialog()` pins `isOpen={true}` and can never unmount, which would have made a "dialog survived" assertion vacuous. Also added an Enter-path test so click/Enter parity is explicitly covered.

Local results: 72 unit tests pass across the 3 affected files; `e2e/full/worktree/new-worktree-dialog.spec.ts` had 6 passed.

## Follow-up (not in this PR)

The retained "in use" badge uses the `text-status-warning` orange treatment. Now that it carries no click behavior, that treatment arguably over-signals unavailability for a branch that's actually a perfectly valid base. Leaving it alone deliberately: the issue asks for the tag to stay as informational UI, and re-styling it is a design call worth a separate look.
