### PR TITLE
fix(worktree): stop the new-branch name rewriting itself mid-typing

### DIFF
--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -203,11 +203,6 @@ export function NewWorktreeDialog({
 
   const canAssignIssue = Boolean(currentUser && selectedIssue);
 
-  const onBranchAutoResolved = useCallback(
-    (resolvedName: string) => setBranchInput(resolvedName),
-    [setBranchInput]
-  );
-
   const isExistingMode = branchMode === "existing" && !initialPR;
 
   const {
@@ -218,11 +213,11 @@ export function NewWorktreeDialog({
     branchWasAutoResolved,
     pathWasAutoResolved,
     pathTouchedRef,
+    consumeBranchResolution,
   } = useBranchValidation({
     branchInput,
     rootPath,
     isOpen,
-    onBranchAutoResolved,
     skipAvailabilityCheck: isExistingMode,
     overrideBranchName: isExistingMode ? (selectedExistingBranch ?? "") : undefined,
   });
@@ -554,7 +549,13 @@ export function NewWorktreeDialog({
 
     clearErrors();
 
-    const fullBranchName = isExistingMode ? selectedExistingBranch! : result.fullBranchName!;
+    // Submitting is an acceptance point for a pending auto-increment the user
+    // never blurred into the field, so the placeholder, dispatch, recipe and
+    // toast all name the branch the host will actually create.
+    const resolvedBranchName = isExistingMode ? null : consumeBranchResolution(branchInput);
+    const fullBranchName = isExistingMode
+      ? selectedExistingBranch!
+      : (resolvedBranchName ?? result.fullBranchName!);
 
     const snapBranchMode = branchMode;
     const snapUseExisting = snapBranchMode === "existing";
@@ -837,6 +838,14 @@ export function NewWorktreeDialog({
     [setBranchInput, markBranchInputTouched, markTouched, clearErrors]
   );
 
+  const handleBranchInputBlur = useCallback(
+    (event: React.FocusEvent<HTMLInputElement>) => {
+      const resolved = consumeBranchResolution(event.currentTarget.value);
+      if (resolved) setBranchInput(resolved);
+    },
+    [consumeBranchResolution, setBranchInput]
+  );
+
   const handleWorktreePathChange = useCallback(
     (value: string) => {
       setWorktreePath(value);
@@ -994,6 +1003,7 @@ export function NewWorktreeDialog({
               <NewBranchInput
                 value={branchInput}
                 onChange={handleBranchInputChange}
+                onBlur={handleBranchInputBlur}
                 isCheckingBranch={isCheckingBranch}
                 errorField={errors.errorField}
                 branchWasAutoResolved={branchWasAutoResolved}

--- a/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
+++ b/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
@@ -1290,3 +1290,158 @@ describe("NewWorktreeDialog — in-use base branch selection", () => {
     expect(screen.getByTestId<HTMLInputElement>("branch-name-input").value).toBe("feature/keep-me");
   });
 });
+
+describe("NewWorktreeDialog — deferred branch auto-resolve", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockListBranches.mockResolvedValue(TEST_BRANCHES);
+    mockGetRecentBranches.mockResolvedValue([]);
+    mockGetAvailableBranch.mockImplementation((_root: string, name: string) =>
+      Promise.resolve(name === "feature/terrain" ? "feature/terrain-2" : name)
+    );
+    mockGetDefaultPath.mockImplementation((_root: string, branch: string) =>
+      Promise.resolve(`/test/root-worktrees/${branch}`)
+    );
+    mockDispatch.mockResolvedValue({ ok: true, result: "new-wt-id" });
+    mockGetCurrentUser.mockResolvedValue(null);
+    mockAssignIssue.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  async function typeBranch(value: string) {
+    const branchInput = screen.getByTestId("branch-name-input") as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(branchInput, { target: { value } });
+    });
+    await advanceTimersGradually(500);
+    return branchInput;
+  }
+
+  it("leaves the typed name in place while flagging the conflict", async () => {
+    renderDialog();
+    await advanceTimersGradually(500);
+
+    const branchInput = await typeBranch("feature/terrain");
+
+    expect(branchInput.value).toBe("feature/terrain");
+    expect(screen.getByText(/auto-incremented/i)).toBeDefined();
+  });
+
+  it("does not clobber characters typed past the conflicting prefix", async () => {
+    renderDialog();
+    await advanceTimersGradually(500);
+
+    await typeBranch("feature/terrain");
+    const branchInput = await typeBranch("feature/terrain-shadows");
+
+    expect(branchInput.value).toBe("feature/terrain-shadows");
+    expect(screen.queryByText(/auto-incremented/i)).toBeNull();
+  });
+
+  it("applies the auto-incremented name on blur without re-checking or disabling Create", async () => {
+    renderDialog();
+    await advanceTimersGradually(500);
+
+    const branchInput = await typeBranch("feature/terrain");
+    mockGetAvailableBranch.mockClear();
+    mockGetDefaultPath.mockClear();
+
+    await act(async () => {
+      fireEvent.blur(branchInput);
+    });
+
+    expect(branchInput.value).toBe("feature/terrain-2");
+    // Re-checking a name we already know is free would re-disable Create in the
+    // gap between the blur and the click that caused it, swallowing the click.
+    const createButton = screen.getByTestId("create-worktree-button") as HTMLButtonElement;
+    expect(createButton.disabled).toBe(false);
+
+    await advanceTimersGradually(500);
+    expect(mockGetAvailableBranch).not.toHaveBeenCalled();
+    expect(mockGetDefaultPath).not.toHaveBeenCalled();
+  });
+
+  it("creates the auto-incremented branch when Create follows a blur", async () => {
+    renderDialog();
+    await advanceTimersGradually(500);
+
+    const branchInput = await typeBranch("feature/terrain");
+    await act(async () => {
+      fireEvent.blur(branchInput);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("create-worktree-button"));
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(mockAddPendingCreation).toHaveBeenCalledWith(
+      "/test/root-worktrees/feature/terrain",
+      expect.objectContaining({ branch: "feature/terrain-2" })
+    );
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "worktree.create",
+      expect.objectContaining({
+        options: expect.objectContaining({ newBranch: "feature/terrain-2" }),
+      }),
+      expect.anything()
+    );
+  });
+
+  it("creates the auto-incremented branch when Create fires without a blur", async () => {
+    renderDialog();
+    await advanceTimersGradually(500);
+
+    const branchInput = await typeBranch("feature/terrain");
+    // The field still holds what was typed — Create has to resolve it itself.
+    expect(branchInput.value).toBe("feature/terrain");
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("create-worktree-button"));
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "worktree.create",
+      expect.objectContaining({
+        options: expect.objectContaining({ newBranch: "feature/terrain-2" }),
+      }),
+      expect.anything()
+    );
+  });
+
+  it("creates the typed name when no conflict was detected", async () => {
+    renderDialog();
+    await advanceTimersGradually(500);
+
+    const branchInput = await typeBranch("feature/canyon");
+    await act(async () => {
+      fireEvent.blur(branchInput);
+    });
+    // Blur leaves an unconflicted name untouched.
+    expect(branchInput.value).toBe("feature/canyon");
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("create-worktree-button"));
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "worktree.create",
+      expect.objectContaining({
+        options: expect.objectContaining({ newBranch: "feature/canyon" }),
+      }),
+      expect.anything()
+    );
+  });
+});

--- a/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
+++ b/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
@@ -1336,8 +1336,10 @@ describe("NewWorktreeDialog — deferred branch auto-resolve", () => {
     renderDialog();
     await advanceTimersGradually(500);
 
-    await typeBranch("feature/terrain");
-    const branchInput = await typeBranch("feature/terrain-shadows");
+    const branchInput = await typeBranch("feature/terrain");
+    // Resume typing from whatever the field actually holds. Replacing the value
+    // outright would mask a rewrite, since it overwrites the damage too.
+    await typeBranch(`${branchInput.value}-shadows`);
 
     expect(branchInput.value).toBe("feature/terrain-shadows");
     expect(screen.queryByText(/auto-incremented/i)).toBeNull();
@@ -1348,6 +1350,10 @@ describe("NewWorktreeDialog — deferred branch auto-resolve", () => {
     await advanceTimersGradually(500);
 
     const branchInput = await typeBranch("feature/terrain");
+    const pathInput = screen.getByTestId("worktree-path-input") as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(pathInput, { target: { value: "/custom/path" } });
+    });
     mockGetAvailableBranch.mockClear();
     mockGetDefaultPath.mockClear();
 
@@ -1356,6 +1362,9 @@ describe("NewWorktreeDialog — deferred branch auto-resolve", () => {
     });
 
     expect(branchInput.value).toBe("feature/terrain-2");
+    // Skipping the re-check is what keeps a hand-edited path from being
+    // regenerated out from under the user.
+    expect(pathInput.value).toBe("/custom/path");
     // Re-checking a name we already know is free would re-disable Create in the
     // gap between the blur and the click that caused it, swallowing the click.
     const createButton = screen.getByTestId("create-worktree-button") as HTMLButtonElement;
@@ -1371,9 +1380,14 @@ describe("NewWorktreeDialog — deferred branch auto-resolve", () => {
     await advanceTimersGradually(500);
 
     const branchInput = await typeBranch("feature/terrain");
+    // The rewrite must be the blur's doing, not the debounce's.
+    expect(branchInput.value).toBe("feature/terrain");
+
     await act(async () => {
       fireEvent.blur(branchInput);
     });
+    expect(branchInput.value).toBe("feature/terrain-2");
+
     await act(async () => {
       fireEvent.click(screen.getByTestId("create-worktree-button"));
     });

--- a/src/components/Worktree/hooks/__tests__/useBranchValidation.test.tsx
+++ b/src/components/Worktree/hooks/__tests__/useBranchValidation.test.tsx
@@ -73,6 +73,8 @@ describe("useBranchValidation — deferred branch resolution", () => {
     const { result } = renderValidation("feature/terrain");
     await settle();
 
+    // An offer genuinely exists — the null below is the mismatch talking.
+    expect(result.current.branchWasAutoResolved).toBe(true);
     expect(result.current.consumeBranchResolution("feature/terrain-shadows")).toBeNull();
   });
 
@@ -113,14 +115,18 @@ describe("useBranchValidation — deferred branch resolution", () => {
 
   it("discards a pending resolution as soon as the input changes", async () => {
     mockGetAvailableBranch.mockImplementation((_root: string, name: string) =>
-      Promise.resolve(name === "feature/terrain" ? "feature/terrain-2" : name)
+      Promise.resolve(`${name}-2`)
     );
     const { result, rerender } = renderValidation("feature/terrain");
     await settle();
 
-    rerender({ branchInput: "feature/terrain-shadows" });
-
+    rerender({ branchInput: "feature/canyon" });
     expect(result.current.consumeBranchResolution("feature/terrain")).toBeNull();
+
+    // The new value's own offer still lands, so the null above is invalidation
+    // rather than a consumer that never returns anything.
+    await settle();
+    expect(result.current.consumeBranchResolution("feature/canyon")).toBe("feature/canyon-2");
   });
 
   it("does not re-check a name it just handed over", async () => {
@@ -174,11 +180,13 @@ describe("useBranchValidation — deferred branch resolution", () => {
     });
     await settle();
 
+    // The path still generates, so the hook ran and skipped only the branch check.
+    expect(mockGetDefaultPath).toHaveBeenCalledWith(ROOT, "existing/branch");
     expect(mockGetAvailableBranch).not.toHaveBeenCalled();
     expect(result.current.consumeBranchResolution("feature/terrain")).toBeNull();
   });
 
-  it("drops a cached resolution when the dialog reopens", async () => {
+  it("re-checks on reopen even when the branch and root are unchanged", async () => {
     mockGetAvailableBranch.mockResolvedValue("feature/terrain-2");
     const { result, rerender } = renderHook(
       (props: { isOpen: boolean }) =>
@@ -195,6 +203,14 @@ describe("useBranchValidation — deferred branch resolution", () => {
     rerender({ isOpen: false });
     rerender({ isOpen: true });
 
+    // Reopening clears the path and the cached offer, so it has to ask again —
+    // otherwise the dialog reopens with an empty path it can never refill.
     expect(result.current.consumeBranchResolution("feature/terrain")).toBeNull();
+    mockGetAvailableBranch.mockClear();
+    mockGetDefaultPath.mockClear();
+
+    await settle();
+    expect(mockGetAvailableBranch).toHaveBeenCalledWith(ROOT, "feature/terrain");
+    expect(result.current.worktreePath).toBe("/worktrees/feature/terrain");
   });
 });

--- a/src/components/Worktree/hooks/__tests__/useBranchValidation.test.tsx
+++ b/src/components/Worktree/hooks/__tests__/useBranchValidation.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+const mockGetAvailableBranch = vi.fn();
+const mockGetDefaultPath = vi.fn();
+
+vi.mock("@/clients", () => ({
+  worktreeClient: {
+    getAvailableBranch: (...args: unknown[]) => mockGetAvailableBranch(...args),
+    getDefaultPath: (...args: unknown[]) => mockGetDefaultPath(...args),
+  },
+}));
+
+vi.mock("@/utils/logger", () => ({ logError: vi.fn() }));
+
+import { useBranchValidation } from "../useBranchValidation";
+
+const ROOT = "/test/root";
+
+async function settle() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(400);
+  });
+}
+
+function renderValidation(
+  branchInput: string,
+  extra: { skipAvailabilityCheck?: boolean; overrideBranchName?: string } = {}
+) {
+  return renderHook(
+    (props: { branchInput: string }) =>
+      useBranchValidation({
+        branchInput: props.branchInput,
+        rootPath: ROOT,
+        isOpen: true,
+        ...extra,
+      }),
+    { initialProps: { branchInput } }
+  );
+}
+
+describe("useBranchValidation — deferred branch resolution", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockGetAvailableBranch.mockImplementation((_root: string, name: string) =>
+      Promise.resolve(name)
+    );
+    mockGetDefaultPath.mockImplementation((_root: string, branch: string) =>
+      Promise.resolve(`/worktrees/${branch}`)
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("offers a divergent name once rather than pushing it back into the field", async () => {
+    mockGetAvailableBranch.mockResolvedValue("feature/terrain-2");
+    const { result } = renderValidation("feature/terrain");
+    await settle();
+
+    expect(result.current.branchWasAutoResolved).toBe(true);
+    expect(result.current.consumeBranchResolution("feature/terrain")).toBe("feature/terrain-2");
+    expect(result.current.consumeBranchResolution("feature/terrain")).toBeNull();
+  });
+
+  it("refuses a resolution the field has already moved past", async () => {
+    mockGetAvailableBranch.mockResolvedValue("feature/terrain-2");
+    const { result } = renderValidation("feature/terrain");
+    await settle();
+
+    expect(result.current.consumeBranchResolution("feature/terrain-shadows")).toBeNull();
+  });
+
+  it("matches on the canonical branch name, not the raw input", async () => {
+    mockGetAvailableBranch.mockResolvedValue("feature/terrain-2");
+    const { result } = renderValidation("feat/terrain");
+    await settle();
+
+    expect(mockGetAvailableBranch).toHaveBeenCalledWith(ROOT, "feature/terrain");
+    expect(result.current.consumeBranchResolution("  feat/terrain  ")).toBe("feature/terrain-2");
+  });
+
+  it("has nothing to offer when the typed name is already available", async () => {
+    const { result } = renderValidation("feature/terrain");
+    await settle();
+
+    expect(result.current.branchWasAutoResolved).toBe(false);
+    expect(result.current.consumeBranchResolution("feature/terrain")).toBeNull();
+  });
+
+  it("has nothing to offer when the availability check fails", async () => {
+    mockGetAvailableBranch.mockRejectedValue(new Error("git failed"));
+    const { result } = renderValidation("feature/terrain");
+    await settle();
+
+    expect(result.current.branchWasAutoResolved).toBe(false);
+    expect(result.current.consumeBranchResolution("feature/terrain")).toBeNull();
+  });
+
+  it("keeps a branch resolution when only the path lookup fails", async () => {
+    mockGetAvailableBranch.mockResolvedValue("feature/terrain-2");
+    mockGetDefaultPath.mockRejectedValue(new Error("no path"));
+    const { result } = renderValidation("feature/terrain");
+    await settle();
+
+    expect(result.current.consumeBranchResolution("feature/terrain")).toBe("feature/terrain-2");
+  });
+
+  it("discards a pending resolution as soon as the input changes", async () => {
+    mockGetAvailableBranch.mockImplementation((_root: string, name: string) =>
+      Promise.resolve(name === "feature/terrain" ? "feature/terrain-2" : name)
+    );
+    const { result, rerender } = renderValidation("feature/terrain");
+    await settle();
+
+    rerender({ branchInput: "feature/terrain-shadows" });
+
+    expect(result.current.consumeBranchResolution("feature/terrain")).toBeNull();
+  });
+
+  it("does not re-check a name it just handed over", async () => {
+    mockGetAvailableBranch.mockImplementation((_root: string, name: string) =>
+      Promise.resolve(name === "feature/terrain" ? "feature/terrain-2" : name)
+    );
+    const { result, rerender } = renderValidation("feature/terrain");
+    await settle();
+
+    const settledPath = result.current.worktreePath;
+    act(() => {
+      result.current.consumeBranchResolution("feature/terrain");
+    });
+    mockGetAvailableBranch.mockClear();
+    mockGetDefaultPath.mockClear();
+
+    rerender({ branchInput: "feature/terrain-2" });
+
+    expect(result.current.isCheckingBranch).toBe(false);
+    expect(result.current.isGeneratingPath).toBe(false);
+    expect(result.current.worktreePath).toBe(settledPath);
+    expect(result.current.branchWasAutoResolved).toBe(true);
+
+    await settle();
+    expect(mockGetAvailableBranch).not.toHaveBeenCalled();
+    expect(mockGetDefaultPath).not.toHaveBeenCalled();
+  });
+
+  it("resumes checking for any name other than the accepted one", async () => {
+    mockGetAvailableBranch.mockImplementation((_root: string, name: string) =>
+      Promise.resolve(name === "feature/terrain" ? "feature/terrain-2" : name)
+    );
+    const { result, rerender } = renderValidation("feature/terrain");
+    await settle();
+
+    act(() => {
+      result.current.consumeBranchResolution("feature/terrain");
+    });
+    mockGetAvailableBranch.mockClear();
+
+    rerender({ branchInput: "feature/canyon" });
+    await settle();
+
+    expect(mockGetAvailableBranch).toHaveBeenCalledWith(ROOT, "feature/canyon");
+  });
+
+  it("stays inert while the availability check is skipped", async () => {
+    const { result } = renderValidation("feature/terrain", {
+      skipAvailabilityCheck: true,
+      overrideBranchName: "existing/branch",
+    });
+    await settle();
+
+    expect(mockGetAvailableBranch).not.toHaveBeenCalled();
+    expect(result.current.consumeBranchResolution("feature/terrain")).toBeNull();
+  });
+
+  it("drops a cached resolution when the dialog reopens", async () => {
+    mockGetAvailableBranch.mockResolvedValue("feature/terrain-2");
+    const { result, rerender } = renderHook(
+      (props: { isOpen: boolean }) =>
+        useBranchValidation({
+          branchInput: "feature/terrain",
+          rootPath: ROOT,
+          isOpen: props.isOpen,
+        }),
+      { initialProps: { isOpen: true } }
+    );
+    await settle();
+    expect(result.current.branchWasAutoResolved).toBe(true);
+
+    rerender({ isOpen: false });
+    rerender({ isOpen: true });
+
+    expect(result.current.consumeBranchResolution("feature/terrain")).toBeNull();
+  });
+});

--- a/src/components/Worktree/hooks/useBranchValidation.ts
+++ b/src/components/Worktree/hooks/useBranchValidation.ts
@@ -56,6 +56,10 @@ export function useBranchValidation({
   const effectiveBranchName = overrideBranchName ?? branchInput;
 
   useEffect(() => {
+    // Reopening has to re-check even when the branch and root are unchanged:
+    // the reset above cleared the path, and nothing else would refill it.
+    if (!isOpen) return;
+
     const trimmedInput = effectiveBranchName.trim();
 
     // Any input change invalidates a resolution computed for the previous value.
@@ -199,7 +203,7 @@ export function useBranchValidation({
       abortController.abort();
       setIsGeneratingPath(false);
     };
-  }, [effectiveBranchName, rootPath, skipAvailabilityCheck]);
+  }, [effectiveBranchName, rootPath, skipAvailabilityCheck, isOpen]);
 
   // Applies the offered name only if it still matches what the field holds right
   // now — the argument is read at acceptance time, never captured when the

--- a/src/components/Worktree/hooks/useBranchValidation.ts
+++ b/src/components/Worktree/hooks/useBranchValidation.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { worktreeClient } from "@/clients";
 import { logError } from "@/utils/logger";
 import { validateBranchName } from "@shared/utils/pathPattern";
@@ -12,20 +12,19 @@ export interface UseBranchValidationResult {
   branchWasAutoResolved: boolean;
   pathWasAutoResolved: boolean;
   pathTouchedRef: React.MutableRefObject<boolean>;
+  consumeBranchResolution: (currentInput: string) => string | null;
 }
 
 export function useBranchValidation({
   branchInput,
   rootPath,
   isOpen,
-  onBranchAutoResolved,
   skipAvailabilityCheck = false,
   overrideBranchName,
 }: {
   branchInput: string;
   rootPath: string;
   isOpen: boolean;
-  onBranchAutoResolved: (resolvedName: string) => void;
   skipAvailabilityCheck?: boolean;
   overrideBranchName?: string;
 }): UseBranchValidationResult {
@@ -35,6 +34,10 @@ export function useBranchValidation({
   const [branchWasAutoResolved, setBranchWasAutoResolved] = useState(false);
   const [pathWasAutoResolved, setPathWasAutoResolved] = useState(false);
   const pathTouchedRef = useRef(false);
+  // The debounce only *offers* an auto-incremented name; the caller applies it
+  // on blur/submit so the availability check can't rewrite the field mid-typing.
+  const pendingResolutionRef = useRef<{ requestedName: string; resolvedName: string } | null>(null);
+  const acceptedResolutionRef = useRef<string | null>(null);
 
   // Reset on open
   useEffect(() => {
@@ -45,6 +48,8 @@ export function useBranchValidation({
     setPathWasAutoResolved(false);
     setWorktreePath("");
     pathTouchedRef.current = false;
+    pendingResolutionRef.current = null;
+    acceptedResolutionRef.current = null;
   }, [isOpen]);
 
   // Debounced branch validation + path generation
@@ -52,6 +57,9 @@ export function useBranchValidation({
 
   useEffect(() => {
     const trimmedInput = effectiveBranchName.trim();
+
+    // Any input change invalidates a resolution computed for the previous value.
+    pendingResolutionRef.current = null;
 
     if (!trimmedInput || !rootPath) {
       setBranchWasAutoResolved(false);
@@ -64,6 +72,15 @@ export function useBranchValidation({
     if (!skipAvailabilityCheck) {
       const parsed = parseBranchInput(trimmedInput);
       const fullName = parsed.fullBranchName;
+
+      // A just-accepted name is already known available. Re-checking it would
+      // flip the loading flags back on and disable Create in the window between
+      // the blur and the click that caused it, swallowing the click. Keep the
+      // path and hint from the cycle that produced the resolution.
+      if (acceptedResolutionRef.current === fullName) {
+        acceptedResolutionRef.current = null;
+        return;
+      }
 
       if (parsed.hasPrefix && (!parsed.slug || !parsed.slug.trim())) {
         setBranchWasAutoResolved(false);
@@ -110,13 +127,13 @@ export function useBranchValidation({
             const availableBranch = branchResult.value;
             const branchResolved = availableBranch !== fullName;
             setBranchWasAutoResolved(branchResolved);
-
-            if (branchResolved) {
-              onBranchAutoResolved(availableBranch);
-            }
+            pendingResolutionRef.current = branchResolved
+              ? { requestedName: fullName, resolvedName: availableBranch }
+              : null;
           } else {
             logError("Failed to get available branch", branchResult.reason);
             setBranchWasAutoResolved(false);
+            pendingResolutionRef.current = null;
           }
 
           if (pathResult.status === "fulfilled") {
@@ -182,7 +199,26 @@ export function useBranchValidation({
       abortController.abort();
       setIsGeneratingPath(false);
     };
-  }, [effectiveBranchName, rootPath, onBranchAutoResolved, skipAvailabilityCheck]);
+  }, [effectiveBranchName, rootPath, skipAvailabilityCheck]);
+
+  // Applies the offered name only if it still matches what the field holds right
+  // now — the argument is read at acceptance time, never captured when the
+  // debounce was scheduled, so a superseded suggestion can't land.
+  const consumeBranchResolution = useCallback(
+    (currentInput: string): string | null => {
+      const pending = pendingResolutionRef.current;
+      pendingResolutionRef.current = null;
+
+      if (!pending || skipAvailabilityCheck) return null;
+      if (pending.requestedName !== parseBranchInput(currentInput.trim()).fullBranchName) {
+        return null;
+      }
+
+      acceptedResolutionRef.current = pending.resolvedName;
+      return pending.resolvedName;
+    },
+    [skipAvailabilityCheck]
+  );
 
   return {
     isCheckingBranch,
@@ -192,5 +228,6 @@ export function useBranchValidation({
     branchWasAutoResolved,
     pathWasAutoResolved,
     pathTouchedRef,
+    consumeBranchResolution,
   };
 }

--- a/src/components/Worktree/views/NewBranchInput.tsx
+++ b/src/components/Worktree/views/NewBranchInput.tsx
@@ -9,6 +9,7 @@ import type { PrefixSuggestion } from "../branchPrefixUtils";
 interface NewBranchInputProps {
   value: string;
   onChange: (value: string) => void;
+  onBlur: React.FocusEventHandler<HTMLInputElement>;
   isPending?: boolean;
   isCheckingBranch: boolean;
   errorField?: "base-branch" | "new-branch" | "worktree-path" | null;
@@ -27,6 +28,7 @@ interface NewBranchInputProps {
 export function NewBranchInput({
   value,
   onChange,
+  onBlur,
   isPending,
   isCheckingBranch,
   errorField,
@@ -60,6 +62,7 @@ export function NewBranchInput({
               data-testid="branch-name-input"
               value={value}
               onChange={(e) => onChange(e.target.value)}
+              onBlur={onBlur}
               onKeyDown={onPrefixKeyDown}
               placeholder="feature/add-user-auth"
               className="w-full px-3 pr-10 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/30 font-mono text-sm"


### PR DESCRIPTION
## Summary

- The Create New Worktree dialog's new branch name field rewrote itself while the user was still typing. The 300ms debounced check called `getAvailableBranch` and pushed the auto-incremented result straight back into the live input via `onBranchAutoResolved` -> `setBranchInput`. Typing `feature/terrain-shadows` while `feature/terrain` already existed rewrote the field to `feature/terrain-2` mid-keystroke and clobbered everything typed after that point.
- Fix: the debounce now only offers the resolved name, cached in a ref alongside the exact name it was computed from. `consumeBranchResolution(currentInput)` re-checks that offer against the field's live value at acceptance time, so a superseded suggestion can never land. The dialog applies the offer on blur and on Create.
- Second fix: the validation effect now guards on `isOpen` and lists it as a dependency. Reopening the dialog with an unchanged branch name left the worktree path cleared by the reset effect with nothing to refill it, so Create failed validation on a form the user never touched.

Resolves #11715

## Changes

- Accepting a name short-circuits the next validation cycle. Without that, the blur triggered by clicking Create would restart the check, re-disable the Create button between mousedown and mouseup, and Chromium would silently swallow the click (same failure shape for Tab then Enter).
- Live behavior while typing is unchanged: the availability check, the "Name auto-incremented to avoid conflict with existing branch" hint, and the suggested worktree path update all still run on every keystroke. Only the text overwrite itself is deferred.
- Files touched: `src/components/Worktree/hooks/useBranchValidation.ts`, `src/components/Worktree/NewWorktreeDialog.tsx`, `src/components/Worktree/views/NewBranchInput.tsx`, plus new/updated test files.

## Testing

- Added a new `useBranchValidation` hook test suite covering the offer lifecycle, staleness and invalidation, the one-shot bypass, skip mode, and reopen re-check.
- Added a new `NewWorktreeDialog` describe block covering the typing, blur, and Create paths.
- All 84 targeted tests pass. eslint and prettier are clean on the changed files. No type errors in the Worktree area.
