### PR TITLE
fix(terminal): stop the pty-host mirror grid diverging silently from the PTY

### DIFF
--- a/electron/services/pty/HeadlessMirrorScheduler.ts
+++ b/electron/services/pty/HeadlessMirrorScheduler.ts
@@ -99,6 +99,9 @@ export class HeadlessMirrorScheduler {
   // the id AFTER the last fully-budget-consuming queue so a hot terminal can't
   // monopolize successive ticks.
   private nextServeId: string | null = null;
+  // Terminal currently inside drainForResize(). While set, enqueue() for that
+  // id must never take the synchronous fast path — see drainForResize().
+  private drainingForResizeId: string | null = null;
 
   /**
    * Queue `data` for the terminal's mirror. `onParsed` fires after the entire
@@ -119,6 +122,7 @@ export class HeadlessMirrorScheduler {
     const slices = sliceFeed(data, onParsed);
     if (
       queue.slices.length === 0 &&
+      id !== this.drainingForResizeId &&
       this.aggregateInFlightChars + data.length <= AGGREGATE_INFLIGHT_CHARS
     ) {
       for (const slice of slices) {
@@ -153,6 +157,62 @@ export class HeadlessMirrorScheduler {
     queue.expedite = true;
     queue.slices.push({ data: "", onParsed: onFlushed });
     this.scheduleTick();
+  }
+
+  /**
+   * Hand every slice still queued for `id` to the mirror, synchronously, then
+   * run `applyResize` with this terminal's queue held closed (#11719).
+   *
+   * Why the resize is passed in rather than done by the caller afterwards: the
+   * two steps are one atomic ordering contract, and holding the queue closed
+   * across BOTH is the whole point. xterm's `Terminal.resize()` calls
+   * `WriteBuffer.flushSync()` before it reflows, so bytes already inside the
+   * mirror's own write buffer parse at the PRE-resize grid — correct, since
+   * that is the grid they were emitted at. Bytes still held HERE would instead
+   * be fed after the reflow and parse at the new grid, which is the buffer
+   * corruption this fixes.
+   *
+   * Why not `flush()`: its callback fires from inside a mirror write callback,
+   * and resizing there re-enters `flushSync` while xterm is mid-`_innerWrite`;
+   * and it drains over `setImmediate` ticks, so post-resize output can queue
+   * behind the sentinel and reach the write buffer before the resize lands —
+   * getting parsed at the old grid, the same corruption mirrored.
+   *
+   * Deliberately ignores both pacing bounds. The per-tick fairness budget and
+   * the aggregate in-flight cap exist to stop mirrors monopolising the event
+   * loop, and neither can be honoured here: no other tick can run between the
+   * drain and the resize without breaking the ordering. The aggregate ledger
+   * goes temporarily over cap and is repaid in full when the resize's
+   * `flushSync` fires the parse callbacks.
+   *
+   * Returns false when a failing write tore the queue down mid-drain, in which
+   * case the mirror is disposing and `applyResize` is skipped.
+   */
+  drainThenResize(id: string, mirror: MirrorWritable, applyResize: () => void): boolean {
+    const queue = this.queues.get(id);
+    // The guard spans the resize as well as the drain: `flushSync` fires parse
+    // callbacks synchronously, and one of those synchronously enqueueing fresh
+    // (post-resize) output would otherwise take the fast path straight into the
+    // write buffer xterm is still draining — parsing new-grid bytes at the old
+    // grid.
+    this.drainingForResizeId = id;
+    try {
+      if (queue) {
+        queue.mirror = mirror;
+        while (queue.slices.length > 0) {
+          const slice = queue.slices.shift()!;
+          this.feedSlice(id, queue, slice);
+          if (queue.cleared) return false;
+        }
+        queue.expedite = false;
+      }
+      applyResize();
+    } finally {
+      this.drainingForResizeId = null;
+    }
+    // Deferred output parked by the guard still needs a tick to be released.
+    if (this.hasPendingSlices()) this.scheduleTick();
+    return true;
   }
 
   /**

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -42,6 +42,7 @@ import { SynchronizedFrameDetector } from "./SynchronizedFrameDetector.js";
 import type { IMarker } from "@xterm/headless";
 import {
   TERMINAL_SESSION_PERSISTENCE_ENABLED,
+  mirrorNeedsResize,
   resizeMirror,
   restoreSessionFromFile,
 } from "./terminalSessionPersistence.js";
@@ -185,6 +186,11 @@ export class TerminalProcess {
   private ptyDataDisposable: { dispose: () => void } | null = null;
   private headlessResponderDisposable: { dispose: () => void } | null = null;
   private synchronizedFrameDetector: SynchronizedFrameDetector | null = null;
+  // Mirror-vs-pty divergence bookkeeping (#11719): the signature of the split
+  // currently being reported (null while the grids agree) so a periodic check
+  // logs once per episode, and a cumulative count for triage.
+  private mirrorDivergenceSignature: string | null = null;
+  private mirrorDivergenceCount = 0;
   private sessionSnapshotter!: SessionSnapshotter;
   private readonly agentOutputTemperature = new AgentActivityTemperature();
   private agentOutputContentSnapshot: VisibleContentSnapshot | undefined;
@@ -676,6 +682,7 @@ export class TerminalProcess {
       feedChunk: (data) => this.feedChunkInThread(data),
       feedPrelude: (data) => this.feedPreludeInThread(data),
       resize: (cols, rows) => this.resizeAnalysisInThread(cols, rows),
+      resyncGeometry: (cols, rows) => this.resyncGeometryInThread(cols, rows),
       handleFocus: () => this.handleFocusInThread(),
       getMonitor: () => this.activityMonitor,
       startMonitor: (opts) => this.startMonitorInThread(opts),
@@ -756,7 +763,53 @@ export class TerminalProcess {
         agentLive: this.isAgentLive,
         agentState: this.terminalInfo.agentState,
       }),
+      onMirrorGeometry: (cols, rows) => this.checkMirrorGeometry(cols, rows),
     };
+  }
+
+  /**
+   * Compare a mirror grid against the PTY's and report a divergence (#11719).
+   *
+   * The mirror is a third grid: it stamps its own geometry onto every snapshot,
+   * so a diverged one is self-consistent — the replay aligns to the claimed
+   * grid, every check passes, and the corruption replays forever. Nothing
+   * anywhere logged the two side by side, which is why this class of bug has
+   * been re-diagnosed from scratch repeatedly.
+   *
+   * Compares against the PTY's LIVE dims, never the last requested ones: a
+   * request that never landed is exactly the case worth catching. Logs once per
+   * episode (signature-deduped, cleared on agreement) rather than once per
+   * check, since this runs on the worker's sample cadence.
+   */
+  private checkMirrorGeometry(mirrorCols: number, mirrorRows: number): void {
+    const terminal = this.terminalInfo;
+    if (terminal.isExited) return;
+    const ptyCols = readPtyDimension(() => terminal.ptyProcess.cols, null);
+    const ptyRows = readPtyDimension(() => terminal.ptyProcess.rows, null);
+    if (ptyCols === null || ptyRows === null) return;
+
+    if (mirrorCols === ptyCols && mirrorRows === ptyRows) {
+      this.mirrorDivergenceSignature = null;
+      return;
+    }
+
+    const signature = `${mirrorCols}x${mirrorRows}:${ptyCols}x${ptyRows}`;
+    if (this.mirrorDivergenceSignature === signature) return;
+    this.mirrorDivergenceSignature = signature;
+    this.mirrorDivergenceCount++;
+    console.warn(
+      `[TerminalProcess] Mirror grid diverged from the pty for ${this.id}: ` +
+        `mirror ${mirrorCols}x${mirrorRows} vs pty ${ptyCols}x${ptyRows} ` +
+        `(divergence #${this.mirrorDivergenceCount}); re-asserting the pty grid`
+    );
+    // Observing the split is also the only reliable trigger to repair it: a
+    // dropped resize is never retried by anything else, and the renderer is
+    // not guaranteed to re-assert a geometry it believes already applied.
+    try {
+      this.analysis.resyncGeometry(ptyCols, ptyRows);
+    } catch (error) {
+      console.error(`Failed to resync mirror geometry for ${this.id}:`, error);
+    }
   }
 
   private startMonitorInThread(opts: MonitorStartOptions): void {
@@ -833,9 +886,17 @@ export class TerminalProcess {
   private resizeAnalysisInThread(cols: number, rows: number): void {
     const terminal = this.terminalInfo;
     if (terminal.headlessTerminal) {
-      // Parked, not applied, while a session replay owns the grid — the replay
-      // reflows to this geometry instead of to the one it opened on (#11552).
-      resizeMirror(terminal.headlessTerminal, cols, rows);
+      const mirror = terminal.headlessTerminal;
+      // Slices the scheduler is still holding were emitted at the OLD grid.
+      // Hand them to the mirror before the reflow so xterm's own pre-resize
+      // flushSync parses them at that grid; feeding them afterwards would lay
+      // old-width output out at the new width (#11719).
+      headlessMirrorScheduler.drainThenResize(this.id, mirror, () => {
+        // Parked, not applied, while a session replay owns the grid — the
+        // replay reflows to this geometry instead of to the one it opened on
+        // (#11552).
+        resizeMirror(mirror, cols, rows);
+      });
       // Reflow rewraps the buffer — invalidate any wake no-change skip.
       terminal.contentEpoch++;
     }
@@ -845,6 +906,30 @@ export class TerminalProcess {
     }
     this.agentOutputTemperature.noteResize(Date.now());
     this.agentOutputContentSnapshot = undefined;
+  }
+
+  /**
+   * Re-assert the mirror's grid WITHOUT the side effects of a real resize
+   * (#11719).
+   *
+   * Driven from `resize()`'s "unchanged" branch, where the PTY is already at
+   * the requested size but the mirror may not be. It must stay side-effect
+   * free: `notifyResize()` opens a 500ms activity-suppression window and resets
+   * four detectors, and geometry gets re-asserted routinely, so firing that
+   * here would repeatedly blind agent detection. No PTY resize happened, so
+   * there are no reflow bytes to suppress either.
+   */
+  private resyncGeometryInThread(cols: number, rows: number): void {
+    const mirror = this.terminalInfo.headlessTerminal;
+    if (!mirror || !mirrorNeedsResize(mirror, cols, rows)) return;
+    console.warn(
+      `[TerminalProcess] Mirror grid diverged for ${this.id}: mirror ${mirror.cols}x${mirror.rows} ` +
+        `vs pty ${cols}x${rows}; re-asserting`
+    );
+    headlessMirrorScheduler.drainThenResize(this.id, mirror, () => {
+      resizeMirror(mirror, cols, rows);
+    });
+    this.terminalInfo.contentEpoch++;
   }
 
   private disposeHeadless(): void {
@@ -1184,6 +1269,17 @@ export class TerminalProcess {
       currentRows = terminal.ptyProcess.rows;
 
       if (currentCols === cols && currentRows === rows) {
+        // The PTY needs no work, but the mirror is a THIRD grid and may have
+        // drifted off this one — and this branch is the only thing a later
+        // re-assertion of the current size reaches, so skipping it outright is
+        // what made mirror divergence permanent (#11719). Re-assert the grid;
+        // the backend no-ops when the mirror is already there, so the common
+        // case stays free of resize side effects.
+        try {
+          this.analysis.resyncGeometry(cols, rows);
+        } catch (error) {
+          console.error(`Failed to resync mirror geometry for ${this.id}:`, error);
+        }
         return {
           requestedCols: cols,
           requestedRows: rows,

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -43,6 +43,7 @@ import type { IMarker } from "@xterm/headless";
 import {
   TERMINAL_SESSION_PERSISTENCE_ENABLED,
   mirrorNeedsResize,
+  mirrorReplayInFlight,
   resizeMirror,
   restoreSessionFromFile,
 } from "./terminalSessionPersistence.js";
@@ -763,7 +764,8 @@ export class TerminalProcess {
         agentLive: this.isAgentLive,
         agentState: this.terminalInfo.agentState,
       }),
-      onMirrorGeometry: (cols, rows) => this.checkMirrorGeometry(cols, rows),
+      onMirrorGeometry: (cols, rows, replayInFlight) =>
+        this.checkMirrorGeometry(cols, rows, replayInFlight),
     };
   }
 
@@ -781,9 +783,19 @@ export class TerminalProcess {
    * episode (signature-deduped, cleared on agreement) rather than once per
    * check, since this runs on the worker's sample cadence.
    */
-  private checkMirrorGeometry(mirrorCols: number, mirrorRows: number): void {
+  private checkMirrorGeometry(
+    mirrorCols: number,
+    mirrorRows: number,
+    replayInFlight: boolean
+  ): void {
     const terminal = this.terminalInfo;
     if (terminal.isExited) return;
+    // A replay deliberately parks the mirror on the snapshot's capture grid
+    // (#11552), so its live geometry is EXPECTED to disagree for the duration.
+    // Reporting that would manufacture a divergence out of healthy behaviour —
+    // and a log that cries wolf is worse than no log, given the whole point is
+    // settling the next report from it.
+    if (replayInFlight) return;
     const ptyCols = readPtyDimension(() => terminal.ptyProcess.cols, null);
     const ptyRows = readPtyDimension(() => terminal.ptyProcess.rows, null);
     if (ptyCols === null || ptyRows === null) return;
@@ -794,17 +806,24 @@ export class TerminalProcess {
     }
 
     const signature = `${mirrorCols}x${mirrorRows}:${ptyCols}x${ptyRows}`;
-    if (this.mirrorDivergenceSignature === signature) return;
-    this.mirrorDivergenceSignature = signature;
-    this.mirrorDivergenceCount++;
-    console.warn(
-      `[TerminalProcess] Mirror grid diverged from the pty for ${this.id}: ` +
-        `mirror ${mirrorCols}x${mirrorRows} vs pty ${ptyCols}x${ptyRows} ` +
-        `(divergence #${this.mirrorDivergenceCount}); re-asserting the pty grid`
-    );
-    // Observing the split is also the only reliable trigger to repair it: a
-    // dropped resize is never retried by anything else, and the renderer is
-    // not guaranteed to re-assert a geometry it believes already applied.
+    if (this.mirrorDivergenceSignature !== signature) {
+      this.mirrorDivergenceSignature = signature;
+      this.mirrorDivergenceCount++;
+      console.warn(
+        `[TerminalProcess] Mirror grid diverged from the pty for ${this.id}: ` +
+          `mirror ${mirrorCols}x${mirrorRows} vs pty ${ptyCols}x${ptyRows} ` +
+          `(divergence #${this.mirrorDivergenceCount}); re-asserting the pty grid`
+      );
+      // The repair reflows the mirror, so a snapshot taken against the pre-
+      // repair buffer is stale. Bump once per episode, not once per sample:
+      // the repair below runs on every sample while the split persists, and
+      // dirtying the epoch each time would defeat the no-change serialize skip
+      // for as long as the divergence lasts.
+      terminal.contentEpoch++;
+    }
+    // Repair on EVERY observation, unlike the log. A repair whose post was
+    // dropped must get another chance — deduping this too would re-seal the
+    // exact divergence it exists to break. The backend no-ops once converged.
     try {
       this.analysis.resyncGeometry(ptyCols, ptyRows);
     } catch (error) {
@@ -886,17 +905,7 @@ export class TerminalProcess {
   private resizeAnalysisInThread(cols: number, rows: number): void {
     const terminal = this.terminalInfo;
     if (terminal.headlessTerminal) {
-      const mirror = terminal.headlessTerminal;
-      // Slices the scheduler is still holding were emitted at the OLD grid.
-      // Hand them to the mirror before the reflow so xterm's own pre-resize
-      // flushSync parses them at that grid; feeding them afterwards would lay
-      // old-width output out at the new width (#11719).
-      headlessMirrorScheduler.drainThenResize(this.id, mirror, () => {
-        // Parked, not applied, while a session replay owns the grid — the
-        // replay reflows to this geometry instead of to the one it opened on
-        // (#11552).
-        resizeMirror(mirror, cols, rows);
-      });
+      this.applyMirrorResize(terminal.headlessTerminal, cols, rows);
       // Reflow rewraps the buffer — invalidate any wake no-change skip.
       terminal.contentEpoch++;
     }
@@ -926,10 +935,33 @@ export class TerminalProcess {
       `[TerminalProcess] Mirror grid diverged for ${this.id}: mirror ${mirror.cols}x${mirror.rows} ` +
         `vs pty ${cols}x${rows}; re-asserting`
     );
+    this.applyMirrorResize(mirror, cols, rows);
+    this.terminalInfo.contentEpoch++;
+  }
+
+  /**
+   * Move the in-thread mirror to `cols`x`rows`, keeping the scheduler's held
+   * output on the correct side of the reflow (#11719).
+   *
+   * A resize that a replay window will only PARK changes no geometry now, so
+   * there is no ordering boundary to put the backlog behind — and draining for
+   * it would push the scheduler's aggregate in-flight ledger over its cap with
+   * no `flushSync` to repay it, stalling every other mirror until the backlog
+   * parsed on its own. Park it directly instead.
+   */
+  private applyMirrorResize(mirror: HeadlessTerminalType, cols: number, rows: number): void {
+    if (mirrorReplayInFlight(mirror)) {
+      resizeMirror(mirror, cols, rows);
+      return;
+    }
+    // Slices the scheduler still holds were emitted at the OLD grid. Handing
+    // them over first lets xterm's own pre-resize flushSync parse them at that
+    // grid; feeding them afterwards lays old-width output out at the new width.
     headlessMirrorScheduler.drainThenResize(this.id, mirror, () => {
+      // Parked, not applied, while a session replay owns the grid — the replay
+      // reflows to this geometry instead of to the one it opened on (#11552).
       resizeMirror(mirror, cols, rows);
     });
-    this.terminalInfo.contentEpoch++;
   }
 
   private disposeHeadless(): void {

--- a/electron/services/pty/__tests__/HeadlessMirrorScheduler.test.ts
+++ b/electron/services/pty/__tests__/HeadlessMirrorScheduler.test.ts
@@ -252,6 +252,110 @@ describe("HeadlessMirrorScheduler", () => {
     expect(scheduler.inFlightChars()).toBe(0);
   });
 
+  describe("drainThenResize (#11719)", () => {
+    it("feeds everything queued to the mirror before the resize runs", async () => {
+      const scheduler = new HeadlessMirrorScheduler();
+      const blocker = createParkedMirror();
+      const mirror = createParkedMirror();
+      const order: string[] = [];
+
+      // Saturate the aggregate cap so t1's feeds are genuinely held back.
+      scheduler.enqueue("blocker", blocker, "x".repeat(AGGREGATE_INFLIGHT_CHARS));
+      scheduler.enqueue("t1", mirror, "old-width-A");
+      scheduler.enqueue("t1", mirror, "old-width-B");
+      await flushTicks();
+      expect(mirror.calls.length).toBe(0);
+
+      scheduler.drainThenResize("t1", mirror, () => order.push("resize"));
+
+      // Every held slice reached the mirror, in order, ahead of the resize —
+      // xterm's own pre-resize flushSync then parses them at the old grid.
+      order.unshift(...mirror.calls.map((c) => c.data));
+      expect(order).toEqual(["old-width-A", "old-width-B", "resize"]);
+      expect(scheduler.queuedChars("t1")).toBe(0);
+    });
+
+    it("drains past the aggregate cap rather than leaving old-grid bytes queued", async () => {
+      const scheduler = new HeadlessMirrorScheduler();
+      const mirror = createParkedMirror();
+
+      // More than the cap can hold in flight at once: pacing must yield to
+      // ordering here, because no tick can run before the caller's resize.
+      const backlog = "z".repeat(AGGREGATE_INFLIGHT_CHARS * 2);
+      scheduler.enqueue("t1", mirror, backlog);
+      await flushTicks();
+      expect(scheduler.queuedChars("t1")).toBeGreaterThan(0);
+
+      scheduler.drainThenResize("t1", mirror, () => {});
+
+      expect(scheduler.queuedChars("t1")).toBe(0);
+      expect(mirror.calls.map((c) => c.data).join("")).toBe(backlog);
+    });
+
+    it("keeps output enqueued during the resize out of the mirror", () => {
+      const scheduler = new HeadlessMirrorScheduler();
+      const mirror = createEagerMirror();
+
+      // A parse callback firing inside the resize enqueues fresh post-resize
+      // output. Taking the synchronous fast path would put new-grid bytes into
+      // the write buffer xterm is still draining at the OLD grid.
+      scheduler.drainThenResize("t1", mirror, () => {
+        scheduler.enqueue("t1", mirror, "post-resize");
+      });
+
+      expect(mirror.written).not.toContain("post-resize");
+      expect(scheduler.queuedChars("t1")).toBe("post-resize".length);
+    });
+
+    it("releases output deferred by the guard on a later tick", async () => {
+      const scheduler = new HeadlessMirrorScheduler();
+      const mirror = createEagerMirror();
+
+      scheduler.drainThenResize("t1", mirror, () => {
+        scheduler.enqueue("t1", mirror, "post-resize");
+      });
+      await flushTicks();
+
+      // Deferred, not dropped — and now parsed at the new grid, which is the
+      // grid it was emitted at.
+      expect(mirror.written).toContain("post-resize");
+      expect(scheduler.queuedChars("t1")).toBe(0);
+    });
+
+    it("skips the resize when a failing write tears the queue down mid-drain", async () => {
+      const scheduler = new HeadlessMirrorScheduler();
+      const blocker = createParkedMirror();
+      const applyResize = vi.fn();
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      const broken = {
+        write() {
+          throw new Error("torn down");
+        },
+      };
+
+      scheduler.enqueue("blocker", blocker, "x".repeat(AGGREGATE_INFLIGHT_CHARS));
+      scheduler.enqueue("t1", broken, "queued");
+      await flushTicks();
+
+      expect(scheduler.drainThenResize("t1", broken, applyResize)).toBe(false);
+      expect(applyResize).not.toHaveBeenCalled();
+      // The torn-down queue released its accounting rather than wedging the cap.
+      expect(scheduler.queuedChars("t1")).toBe(0);
+      consoleError.mockRestore();
+    });
+
+    it("still applies the resize for a terminal the scheduler never saw", () => {
+      // Session restore writes straight to the mirror at construction, so a
+      // terminal can reach a resize with no queue registered at all.
+      const scheduler = new HeadlessMirrorScheduler();
+      const mirror = createEagerMirror();
+      const applyResize = vi.fn();
+
+      expect(scheduler.drainThenResize("never-enqueued", mirror, applyResize)).toBe(true);
+      expect(applyResize).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("recovers accounting when a mirror write throws", () => {
     const scheduler = new HeadlessMirrorScheduler();
     const broken = {

--- a/electron/services/pty/__tests__/HeadlessMirrorScheduler.test.ts
+++ b/electron/services/pty/__tests__/HeadlessMirrorScheduler.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
+import headless, { type Terminal as HeadlessTerminal } from "@xterm/headless";
+import serialize from "@xterm/addon-serialize";
 import { HeadlessMirrorScheduler } from "../HeadlessMirrorScheduler.js";
+
+const { Terminal } = headless;
+const { SerializeAddon } = serialize;
 
 const FEED_SLICE_CHARS = 16 * 1024;
 const AGGREGATE_INFLIGHT_CHARS = 128 * 1024;
@@ -256,22 +261,28 @@ describe("HeadlessMirrorScheduler", () => {
     it("feeds everything queued to the mirror before the resize runs", async () => {
       const scheduler = new HeadlessMirrorScheduler();
       const blocker = createParkedMirror();
-      const mirror = createParkedMirror();
+      // Record writes and the resize into ONE timeline as they happen — a
+      // sequence reconstructed afterwards would pass just as well if the
+      // resize had run first, which is the exact bug under test.
       const order: string[] = [];
+      const mirror = {
+        write(data: string) {
+          order.push(`write:${data}`);
+        },
+      };
 
       // Saturate the aggregate cap so t1's feeds are genuinely held back.
       scheduler.enqueue("blocker", blocker, "x".repeat(AGGREGATE_INFLIGHT_CHARS));
       scheduler.enqueue("t1", mirror, "old-width-A");
       scheduler.enqueue("t1", mirror, "old-width-B");
       await flushTicks();
-      expect(mirror.calls.length).toBe(0);
+      expect(order).toEqual([]);
 
       scheduler.drainThenResize("t1", mirror, () => order.push("resize"));
 
       // Every held slice reached the mirror, in order, ahead of the resize —
       // xterm's own pre-resize flushSync then parses them at the old grid.
-      order.unshift(...mirror.calls.map((c) => c.data));
-      expect(order).toEqual(["old-width-A", "old-width-B", "resize"]);
+      expect(order).toEqual(["write:old-width-A", "write:old-width-B", "resize"]);
       expect(scheduler.queuedChars("t1")).toBe(0);
     });
 
@@ -342,6 +353,49 @@ describe("HeadlessMirrorScheduler", () => {
       // The torn-down queue released its accounting rather than wedging the cap.
       expect(scheduler.queuedChars("t1")).toBe(0);
       consoleError.mockRestore();
+    });
+
+    it("makes queued output parse at the old grid, against a real xterm", async () => {
+      // The contract this whole mechanism exists for, proven on a real parser
+      // rather than a stub: bytes emitted before a resize must lay out at the
+      // width they were emitted at. Mirror stubs can only show message order.
+      const drain = (terminal: HeadlessTerminal): Promise<void> =>
+        new Promise((resolve) => terminal.write("", () => resolve()));
+      const build = () => {
+        const terminal = new Terminal({
+          cols: 40,
+          rows: 10,
+          scrollback: 200,
+          allowProposedApi: true,
+        });
+        const addon = new SerializeAddon();
+        terminal.loadAddon(addon);
+        return { terminal, addon };
+      };
+      // Wider than 40 columns, so where it wraps is entirely a function of the
+      // grid it was parsed at.
+      const content = `${"L".repeat(90)}\r\nsecond line\r\n`;
+
+      const scheduler = new HeadlessMirrorScheduler();
+      const blocker = createParkedMirror();
+      const { terminal: subject, addon: subjectAddon } = build();
+
+      // Saturate the cap so the feed is genuinely still queued at resize time.
+      scheduler.enqueue("blocker", blocker, "x".repeat(AGGREGATE_INFLIGHT_CHARS));
+      scheduler.enqueue("t1", subject, content);
+      await flushTicks();
+      expect(scheduler.queuedChars("t1")).toBeGreaterThan(0);
+
+      scheduler.drainThenResize("t1", subject, () => subject.resize(100, 10));
+      await drain(subject);
+
+      // Reference: the same bytes parsed at the old grid, then reflowed.
+      const { terminal: reference, addon: referenceAddon } = build();
+      await new Promise<void>((resolve) => reference.write(content, () => resolve()));
+      reference.resize(100, 10);
+      await drain(reference);
+
+      expect(subjectAddon.serialize()).toBe(referenceAddon.serialize());
     });
 
     it("still applies the resize for a terminal the scheduler never saw", () => {

--- a/electron/services/pty/__tests__/TerminalProcess.workerAnalysis.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.workerAnalysis.test.ts
@@ -124,13 +124,13 @@ describe("TerminalProcess worker-mode analysis events", () => {
 });
 
 describe("TerminalProcess mirror geometry divergence (#11719)", () => {
-  function memorySample(cols: number, rows: number): WorkerToHostMessage {
+  function memorySample(cols: number, rows: number, replayInFlight = false): WorkerToHostMessage {
     return {
       type: "memory-sample",
       heapUsedBytes: 1,
       externalBytes: 1,
       sessionCount: 1,
-      sessions: [{ terminalId: "t1", bufferLines: 10, cols, rows }],
+      sessions: [{ terminalId: "t1", bufferLines: 10, cols, rows, replayInFlight }],
       sampledAt: 1,
     };
   }
@@ -161,7 +161,7 @@ describe("TerminalProcess mirror geometry divergence (#11719)", () => {
   });
 
   it("logs a divergence once per episode and clears it on agreement", () => {
-    const { terminal, worker } = createWorkerModeTerminal();
+    const { worker } = createWorkerModeTerminal();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const divergenceWarnings = () =>
       warn.mock.calls.filter((call) => String(call[0]).includes("Mirror grid diverged")).length;
@@ -186,11 +186,42 @@ describe("TerminalProcess mirror geometry divergence (#11719)", () => {
     // ...and a fresh split is a fresh episode.
     worker.emit("message", memorySample(120, 40));
     expect(divergenceWarnings()).toBe(2);
-    expect(terminal.getInfo().id).toBe("t1");
     warn.mockRestore();
   });
 
-  it("does not warn for a rows-only split going unnoticed", () => {
+  it("keeps retrying the repair while a split persists, unlike the log", () => {
+    const { worker } = createWorkerModeTerminal();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // Deduping the repair alongside the log would re-seal the divergence: the
+    // first repair's post can be dropped, and nothing else re-drives it.
+    worker.emit("message", memorySample(120, 40));
+    worker.emit("message", memorySample(120, 40));
+    worker.emit("message", memorySample(120, 40));
+
+    expect(
+      warn.mock.calls.filter((c) => String(c[0]).includes("Mirror grid diverged"))
+    ).toHaveLength(1);
+    expect(geometryMessages(worker).length).toBeGreaterThan(1);
+    warn.mockRestore();
+  });
+
+  it("does not report a mirror parked by a session replay", () => {
+    const { worker } = createWorkerModeTerminal();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // A replay deliberately parks the mirror on the snapshot's capture grid
+    // (#11552), so disagreement here is healthy. Crying wolf would make the
+    // log useless for the thing it exists to settle.
+    worker.emit("message", memorySample(40, 12, true));
+
+    expect(
+      warn.mock.calls.filter((c) => String(c[0]).includes("Mirror grid diverged"))
+    ).toHaveLength(0);
+    expect(geometryMessages(worker)).toHaveLength(0);
+  });
+
+  it("reports a rows-only split, which a cols-only check would miss", () => {
     const { worker } = createWorkerModeTerminal();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 

--- a/electron/services/pty/__tests__/TerminalProcess.workerAnalysis.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.workerAnalysis.test.ts
@@ -122,3 +122,84 @@ describe("TerminalProcess worker-mode analysis events", () => {
     expect(agentStateService.handleActivityState).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("TerminalProcess mirror geometry divergence (#11719)", () => {
+  function memorySample(cols: number, rows: number): WorkerToHostMessage {
+    return {
+      type: "memory-sample",
+      heapUsedBytes: 1,
+      externalBytes: 1,
+      sessionCount: 1,
+      sessions: [{ terminalId: "t1", bufferLines: 10, cols, rows }],
+      sampledAt: 1,
+    };
+  }
+
+  function geometryMessages(worker: FakeWorker) {
+    return worker.posted.filter((m) => m.type === "resize" || m.type === "ensure-geometry");
+  }
+
+  it("re-asserts the grid when the PTY is already at the requested size", () => {
+    const { terminal, worker } = createWorkerModeTerminal();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // The mock PTY is 80x24, so this takes the "unchanged" branch — the only
+    // branch a re-assertion of the current size ever reaches.
+    expect(terminal.resize(80, 24).outcome).toBe("unchanged");
+    // Nothing has said the mirror drifted, so no worker traffic is generated.
+    expect(geometryMessages(worker)).toHaveLength(0);
+
+    // The worker reports a mirror on a different grid.
+    worker.emit("message", memorySample(120, 40));
+    expect(geometryMessages(worker)).toHaveLength(1);
+
+    // And a later re-assertion is still able to repair, rather than being
+    // short-circuited by the PTY dims already matching.
+    expect(terminal.resize(80, 24).outcome).toBe("unchanged");
+    expect(geometryMessages(worker).length).toBeGreaterThan(1);
+    warn.mockRestore();
+  });
+
+  it("logs a divergence once per episode and clears it on agreement", () => {
+    const { terminal, worker } = createWorkerModeTerminal();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const divergenceWarnings = () =>
+      warn.mock.calls.filter((call) => String(call[0]).includes("Mirror grid diverged")).length;
+
+    worker.emit("message", memorySample(120, 40));
+    expect(divergenceWarnings()).toBe(1);
+    const logged = String(warn.mock.calls[warn.mock.calls.length - 1]![0]);
+    // Both grids in one line: the whole point is settling the next report from
+    // a user's log rather than from code archaeology.
+    expect(logged).toContain("120x40");
+    expect(logged).toContain("80x24");
+
+    // The check rides the sample cadence, so an unchanged split must not
+    // re-log on every tick.
+    worker.emit("message", memorySample(120, 40));
+    expect(divergenceWarnings()).toBe(1);
+
+    // Converged: the episode closes...
+    worker.emit("message", memorySample(80, 24));
+    expect(divergenceWarnings()).toBe(1);
+
+    // ...and a fresh split is a fresh episode.
+    worker.emit("message", memorySample(120, 40));
+    expect(divergenceWarnings()).toBe(2);
+    expect(terminal.getInfo().id).toBe("t1");
+    warn.mockRestore();
+  });
+
+  it("does not warn for a rows-only split going unnoticed", () => {
+    const { worker } = createWorkerModeTerminal();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // Columns agree; rows do not. Cols-only diagnostics would call this healthy
+    // even though cursor addressing and full-screen TUIs are already corrupt.
+    worker.emit("message", memorySample(80, 40));
+    expect(
+      warn.mock.calls.filter((call) => String(call[0]).includes("Mirror grid diverged")).length
+    ).toBe(1);
+    warn.mockRestore();
+  });
+});

--- a/electron/services/pty/__tests__/analysisWorkerPool.test.ts
+++ b/electron/services/pty/__tests__/analysisWorkerPool.test.ts
@@ -500,7 +500,9 @@ describe("AnalysisWorkerPool", () => {
       heapUsedBytes,
       externalBytes: 5_000_000,
       sessionCount: 1,
-      sessions: [{ terminalId: "t1", bufferLines: 480, cols: 120, rows: 40 }],
+      sessions: [
+        { terminalId: "t1", bufferLines: 480, cols: 120, rows: 40, replayInFlight: false },
+      ],
       sampledAt: 111,
     });
 
@@ -515,7 +517,7 @@ describe("AnalysisWorkerPool", () => {
       expect(accounting[0].heapUsedBytes).toBe(20_000_000);
       expect(accounting[0].externalBytes).toBe(5_000_000);
       expect(accounting[0].sessions).toEqual([
-        { terminalId: "t1", bufferLines: 480, cols: 120, rows: 40 },
+        { terminalId: "t1", bufferLines: 480, cols: 120, rows: 40, replayInFlight: false },
       ]);
       expect(Number.isFinite(accounting[0].ageMs)).toBe(true);
     });
@@ -590,10 +592,15 @@ describe("AnalysisWorkerPool", () => {
 describe("WorkerAnalysisBackend feed accounting", () => {
   function stubBackend() {
     const posted: HostToWorkerMessage[] = [];
+    // A message the pool REFUSED never reached the worker. Recording it in
+    // `posted` alone would make a dropped post indistinguishable from a
+    // delivered one, so anything asserting on delivery reads `delivered`.
+    const delivered: HostToWorkerMessage[] = [];
     const control = { sendSucceeds: true };
     const pool: AnalysisPoolHost = {
       post: (_id, msg) => {
         posted.push(msg);
+        if (control.sendSucceeds) delivered.push(msg);
         return control.sendSucceeds;
       },
       request: () => Promise.resolve(null),
@@ -614,7 +621,7 @@ describe("WorkerAnalysisBackend feed accounting", () => {
     );
     backend.init();
     const dataMessages = () => posted.filter((m) => m.type === "data") as Array<{ data: string }>;
-    return { backend, control, dataMessages, posted };
+    return { backend, control, dataMessages, posted, delivered };
   }
 
   /** Push the backend above its high watermark so the next chunk is held. */
@@ -653,24 +660,78 @@ describe("WorkerAnalysisBackend feed accounting", () => {
       expect(resizeIndex).toBeGreaterThan(heldIndex);
     });
 
-    it("keeps the hold and posts no resize when the flush fails", () => {
-      const { backend, control, posted } = stubBackend();
+    it("restores an undelivered hold instead of dropping it", async () => {
+      const { backend, control, delivered } = stubBackend();
+      holdOutput(backend, "HELD");
+
+      // A serialize flushes the hold — but the post is refused, so the worker
+      // never saw it and the data is still owed.
+      control.sendSucceeds = false;
+      await backend.serialize();
+      expect(delivered.some((m) => m.type === "data" && m.data === "HELD")).toBe(false);
+
+      // Dropping it here would silently lose output; it must still be waiting.
+      control.sendSucceeds = true;
+      await backend.serialize();
+      expect(delivered.some((m) => m.type === "data" && m.data === "HELD")).toBe(true);
+    });
+
+    it("rebuilds at the new grid rather than merging output from two grids", () => {
+      const { backend, control, delivered } = stubBackend();
       const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
       holdOutput(backend, "OLD-WIDTH");
 
+      // The flush across the geometry boundary fails. Keeping the hold would
+      // let post-resize output concatenate onto it — the host coalesces held
+      // output into ONE string, so the merged blob would later parse at a
+      // single grid, which is the corruption in a new disguise.
       control.sendSucceeds = false;
       backend.resize(120, 40);
-      expect(posted.some((m) => m.type === "resize")).toBe(false);
-
-      // The hold was owed, not delivered — dropping it would lose output AND
-      // leave the resize ordered ahead of data the mirror never saw.
       control.sendSucceeds = true;
-      backend.resize(120, 40);
-      const heldIndex = posted.findIndex((m) => m.type === "data" && m.data === "OLD-WIDTH");
-      const resizeIndex = posted.findIndex((m) => m.type === "resize");
-      expect(heldIndex).toBeGreaterThanOrEqual(0);
-      expect(resizeIndex).toBeGreaterThan(heldIndex);
+      backend.feedChunk("NEW-WIDTH", { agentLive: false });
+
+      // Nothing may be delivered that carries both grids' output.
+      const merged = delivered.find(
+        (m) => m.type === "data" && m.data.includes("OLD-WIDTH") && m.data.includes("NEW-WIDTH")
+      );
+      expect(merged).toBeUndefined();
+
+      // And the recovery recreates the session at the grid actually requested,
+      // not the one the dropped resize left behind.
+      backend.resyncGeometry(120, 40);
+      const creates = delivered.filter((m) => m.type === "create") as Array<{
+        cols: number;
+        rows: number;
+      }>;
+      expect(creates.length).toBeGreaterThan(0);
+      expect(creates[creates.length - 1]).toMatchObject({ cols: 120, rows: 40 });
       consoleError.mockRestore();
+    });
+
+    it("recreates the session when the initial create never reached the worker", () => {
+      const posted: HostToWorkerMessage[] = [];
+      const control = { sendSucceeds: false };
+      const pool: AnalysisPoolHost = {
+        post: (_id, msg) => {
+          if (control.sendSucceeds) posted.push(msg);
+          return control.sendSucceeds;
+        },
+        request: () => Promise.resolve(null),
+        unregister: () => {},
+      };
+      const backend = new WorkerAnalysisBackend(
+        { terminalId: "t1", cols: 80, rows: 24, scrollback: 1000, restore: false, spawnedAt: 1 },
+        makeDelegate(),
+        pool
+      );
+      backend.init();
+
+      // The worker has no session for this terminal at all, so an
+      // `ensure-geometry` would be routed nowhere and repair nothing.
+      control.sendSucceeds = true;
+      backend.resyncGeometry(80, 24);
+      expect(posted.filter((m) => m.type === "ensure-geometry")).toHaveLength(0);
+      expect(posted.filter((m) => m.type === "create")).toHaveLength(1);
     });
 
     it("retries a dropped resize on the next re-assert of the same grid", () => {

--- a/electron/services/pty/__tests__/analysisWorkerPool.test.ts
+++ b/electron/services/pty/__tests__/analysisWorkerPool.test.ts
@@ -76,6 +76,7 @@ function makeDelegate(): WorkerAnalysisDelegate {
     onPtyResponse: vi.fn(),
     getProcessState: () => null,
     getAgentContext: () => ({ agentLive: false, agentState: undefined }),
+    onMirrorGeometry: vi.fn(),
   };
 }
 
@@ -499,7 +500,7 @@ describe("AnalysisWorkerPool", () => {
       heapUsedBytes,
       externalBytes: 5_000_000,
       sessionCount: 1,
-      sessions: [{ terminalId: "t1", bufferLines: 480, cols: 120 }],
+      sessions: [{ terminalId: "t1", bufferLines: 480, cols: 120, rows: 40 }],
       sampledAt: 111,
     });
 
@@ -513,7 +514,9 @@ describe("AnalysisWorkerPool", () => {
       expect(accounting[0].alive).toBe(true);
       expect(accounting[0].heapUsedBytes).toBe(20_000_000);
       expect(accounting[0].externalBytes).toBe(5_000_000);
-      expect(accounting[0].sessions).toEqual([{ terminalId: "t1", bufferLines: 480, cols: 120 }]);
+      expect(accounting[0].sessions).toEqual([
+        { terminalId: "t1", bufferLines: 480, cols: 120, rows: 40 },
+      ]);
       expect(Number.isFinite(accounting[0].ageMs)).toBe(true);
     });
 
@@ -611,7 +614,13 @@ describe("WorkerAnalysisBackend feed accounting", () => {
     );
     backend.init();
     const dataMessages = () => posted.filter((m) => m.type === "data") as Array<{ data: string }>;
-    return { backend, control, dataMessages };
+    return { backend, control, dataMessages, posted };
+  }
+
+  /** Push the backend above its high watermark so the next chunk is held. */
+  function holdOutput(backend: WorkerAnalysisBackend, held: string) {
+    backend.feedChunk("A".repeat(200), { agentLive: false });
+    backend.feedChunk(held, { agentLive: false });
   }
 
   it("credits outstanding bytes only when the post was actually sent", () => {
@@ -626,5 +635,76 @@ describe("WorkerAnalysisBackend feed accounting", () => {
     // Outstanding is still 0, so this posts rather than coalescing into a hold.
     backend.feedChunk("Y".repeat(10), { agentLive: false });
     expect(dataMessages().some((m) => m.data.startsWith("Y"))).toBe(true);
+  });
+
+  describe("geometry ordering (#11719)", () => {
+    it("flushes held output ahead of a resize so it parses at the old grid", () => {
+      const { backend, posted } = stubBackend();
+      holdOutput(backend, "OLD-WIDTH");
+
+      backend.resize(120, 40);
+
+      // The hold was emitted at the old grid. If the resize overtakes it the
+      // mirror parses old-width output at the new width — geometry right,
+      // buffer corrupt.
+      const heldIndex = posted.findIndex((m) => m.type === "data" && m.data === "OLD-WIDTH");
+      const resizeIndex = posted.findIndex((m) => m.type === "resize");
+      expect(heldIndex).toBeGreaterThanOrEqual(0);
+      expect(resizeIndex).toBeGreaterThan(heldIndex);
+    });
+
+    it("keeps the hold and posts no resize when the flush fails", () => {
+      const { backend, control, posted } = stubBackend();
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      holdOutput(backend, "OLD-WIDTH");
+
+      control.sendSucceeds = false;
+      backend.resize(120, 40);
+      expect(posted.some((m) => m.type === "resize")).toBe(false);
+
+      // The hold was owed, not delivered — dropping it would lose output AND
+      // leave the resize ordered ahead of data the mirror never saw.
+      control.sendSucceeds = true;
+      backend.resize(120, 40);
+      const heldIndex = posted.findIndex((m) => m.type === "data" && m.data === "OLD-WIDTH");
+      const resizeIndex = posted.findIndex((m) => m.type === "resize");
+      expect(heldIndex).toBeGreaterThanOrEqual(0);
+      expect(resizeIndex).toBeGreaterThan(heldIndex);
+      consoleError.mockRestore();
+    });
+
+    it("retries a dropped resize on the next re-assert of the same grid", () => {
+      const { backend, control, posted } = stubBackend();
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      control.sendSucceeds = false;
+      backend.resize(120, 40);
+      control.sendSucceeds = true;
+
+      // Same grid re-asserted. Without tracking the dropped post this looks
+      // like a no-op and the mirror stays diverged forever.
+      backend.resyncGeometry(120, 40);
+      expect(posted.filter((m) => m.type === "ensure-geometry")).toHaveLength(1);
+
+      // Now that a geometry post has landed, further re-asserts are free.
+      backend.resyncGeometry(120, 40);
+      expect(posted.filter((m) => m.type === "ensure-geometry")).toHaveLength(1);
+      consoleError.mockRestore();
+    });
+
+    it("re-asserts when the worker reports a grid the host did not ask for", () => {
+      const { backend, posted } = stubBackend();
+      backend.resize(120, 40);
+
+      // Believed converged: nothing to do.
+      backend.resyncGeometry(120, 40);
+      expect(posted.some((m) => m.type === "ensure-geometry")).toBe(false);
+
+      // The worker's own sample says otherwise — a rows-only split still
+      // corrupts cursor addressing, so it must count.
+      backend.noteMirrorGeometry(120, 24);
+      backend.resyncGeometry(120, 40);
+      expect(posted.filter((m) => m.type === "ensure-geometry")).toHaveLength(1);
+    });
   });
 });

--- a/electron/services/pty/__tests__/analysisWorkerRuntime.test.ts
+++ b/electron/services/pty/__tests__/analysisWorkerRuntime.test.ts
@@ -332,7 +332,7 @@ describe("AnalysisWorkerRuntime", () => {
       return { cols: session.cols, rows: session.rows };
     };
 
-    it("converges a drifted mirror onto the requested grid", () => {
+    it("converges a drifted mirror onto the requested grid and says so", () => {
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
       const before = mirrorGrid();
 
@@ -340,12 +340,20 @@ describe("AnalysisWorkerRuntime", () => {
 
       expect(mirrorGrid()).toEqual({ cols: 132, rows: 40 });
       expect(mirrorGrid()).not.toEqual(before);
+      // The worker side logs its own side of the split, so a divergence is
+      // traceable even when only worker logs are available.
+      expect(warn.mock.calls.some((c) => String(c[0]).includes("Mirror grid diverged"))).toBe(true);
       warn.mockRestore();
     });
 
-    it("is silent and inert once the mirror already holds that grid", () => {
+    it("touches nothing once the mirror already holds that grid", async () => {
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
       const settled = mirrorGrid();
+      // Content whose wrapping is a function of the grid, so a needless
+      // resize() would be visible as a reflow even at identical dimensions.
+      sendData(`${"W".repeat(200)}\r\n`);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      const before = runtime.collectMemorySample().sessions[0]!.bufferLines;
 
       // The host re-asserts on every "PTY already at this size" call, so the
       // converged case must cost nothing and say nothing.
@@ -357,6 +365,7 @@ describe("AnalysisWorkerRuntime", () => {
       });
 
       expect(mirrorGrid()).toEqual(settled);
+      expect(runtime.collectMemorySample().sessions[0]!.bufferLines).toBe(before);
       expect(warn).not.toHaveBeenCalled();
       warn.mockRestore();
     });
@@ -367,7 +376,9 @@ describe("AnalysisWorkerRuntime", () => {
       // Freshly created 24-row terminal: the buffer holds only the viewport.
       const initial = runtime.collectMemorySample();
       expect(initial.sessionCount).toBe(1);
-      expect(initial.sessions).toEqual([{ terminalId: "t1", bufferLines: 24, cols: 80, rows: 24 }]);
+      expect(initial.sessions).toEqual([
+        { terminalId: "t1", bufferLines: 24, cols: 80, rows: 24, replayInFlight: false },
+      ]);
       expect(initial.heapUsedBytes).toBeGreaterThan(0);
       expect(initial.externalBytes).toBeGreaterThan(0);
 

--- a/electron/services/pty/__tests__/analysisWorkerRuntime.test.ts
+++ b/electron/services/pty/__tests__/analysisWorkerRuntime.test.ts
@@ -326,12 +326,48 @@ describe("AnalysisWorkerRuntime", () => {
     expect(runtime.sessionCount()).toBe(0);
   });
 
+  describe("ensure-geometry (#11719)", () => {
+    const mirrorGrid = () => {
+      const session = runtime.collectMemorySample().sessions[0]!;
+      return { cols: session.cols, rows: session.rows };
+    };
+
+    it("converges a drifted mirror onto the requested grid", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const before = mirrorGrid();
+
+      runtime.handleMessage({ type: "ensure-geometry", terminalId: "t1", cols: 132, rows: 40 });
+
+      expect(mirrorGrid()).toEqual({ cols: 132, rows: 40 });
+      expect(mirrorGrid()).not.toEqual(before);
+      warn.mockRestore();
+    });
+
+    it("is silent and inert once the mirror already holds that grid", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const settled = mirrorGrid();
+
+      // The host re-asserts on every "PTY already at this size" call, so the
+      // converged case must cost nothing and say nothing.
+      runtime.handleMessage({
+        type: "ensure-geometry",
+        terminalId: "t1",
+        cols: settled.cols,
+        rows: settled.rows,
+      });
+
+      expect(mirrorGrid()).toEqual(settled);
+      expect(warn).not.toHaveBeenCalled();
+      warn.mockRestore();
+    });
+  });
+
   describe("memory sampling", () => {
     it("reports isolate memory and real buffer occupancy that grows with output", async () => {
       // Freshly created 24-row terminal: the buffer holds only the viewport.
       const initial = runtime.collectMemorySample();
       expect(initial.sessionCount).toBe(1);
-      expect(initial.sessions).toEqual([{ terminalId: "t1", bufferLines: 24, cols: 80 }]);
+      expect(initial.sessions).toEqual([{ terminalId: "t1", bufferLines: 24, cols: 80, rows: 24 }]);
       expect(initial.heapUsedBytes).toBeGreaterThan(0);
       expect(initial.externalBytes).toBeGreaterThan(0);
 

--- a/electron/services/pty/__tests__/terminalSessionPersistence.test.ts
+++ b/electron/services/pty/__tests__/terminalSessionPersistence.test.ts
@@ -11,6 +11,7 @@ import {
   getSessionPath,
   persistSessionSnapshotAsync,
   persistSessionSnapshotSync,
+  mirrorNeedsResize,
   resizeMirror,
   restoreSessionFromFile,
   deleteSessionFile,
@@ -427,6 +428,31 @@ describe("terminalSessionPersistence", () => {
       source.options.reflowCursorLine = false;
       await drain(source);
       expect(payloadRows(mirror)).toEqual(payloadRows(source));
+    });
+
+    it("reports a stale parked target as needing a resize (#11719)", async () => {
+      const { snapshot } = await captureAt(40, 10, WRAPPED_LINE);
+      persistSessionSnapshotSync("term-parked-target", snapshot);
+
+      const mirror = new Terminal({ cols: 100, rows: 10, scrollback: 200, allowProposedApi: true });
+      expect(restoreSessionFromFile(mirror, "term-parked-target").restored).toBe(true);
+
+      // Parked at the capture grid: the live grid is 40x10, but what the mirror
+      // will actually end up on is the replay TARGET. A geometry check that
+      // only compares the live grid would call this converged and skip the
+      // re-assert, and the replay would then reflow to the stale target.
+      resizeMirror(mirror, 132, 20);
+      expect([mirror.cols, mirror.rows]).toEqual([40, 10]);
+      expect(mirrorNeedsResize(mirror, 132, 20)).toBe(false);
+      expect(mirrorNeedsResize(mirror, 90, 30)).toBe(true);
+      // The live grid matching is not enough while a window is open.
+      expect(mirrorNeedsResize(mirror, 40, 10)).toBe(true);
+
+      await drain(mirror);
+      // Window closed: the live grid is the answer again.
+      expect(mirrorNeedsResize(mirror, 132, 20)).toBe(false);
+      expect(mirrorNeedsResize(mirror, 132, 21)).toBe(true);
+      expect(mirrorNeedsResize(mirror, 133, 20)).toBe(true);
     });
 
     it("applies a resize immediately once no replay is in flight", async () => {

--- a/electron/services/pty/analysis/AnalysisBackend.ts
+++ b/electron/services/pty/analysis/AnalysisBackend.ts
@@ -41,6 +41,19 @@ export interface AnalysisBackend {
   feedPrelude(data: string): void;
   /** Headless resize + monitor resize suppression + temperature reset. */
   resize(cols: number, rows: number): void;
+  /**
+   * Re-assert the mirror's grid without any of `resize`'s side effects
+   * (#11719).
+   *
+   * Called when the PTY is ALREADY at the requested size, so there is no
+   * reflow to suppress and no temperature event to record — only a mirror that
+   * may have drifted and can otherwise never re-converge, because every later
+   * re-assertion short-circuits on the same PTY-dims check. Implementations
+   * must no-op when the mirror is already at this grid: it runs on routine
+   * re-assertions, and firing `notifyResize()` here would repeatedly blind
+   * agent detection for 500ms at a time.
+   */
+  resyncGeometry(cols: number, rows: number): void;
 
   notifyInput(data: string): void;
   notifyFocus(): void;

--- a/electron/services/pty/analysis/AnalysisSession.ts
+++ b/electron/services/pty/analysis/AnalysisSession.ts
@@ -16,6 +16,7 @@ import { Osc94Parser } from "../Osc94Parser.js";
 import { SynchronizedFrameDetector } from "../SynchronizedFrameDetector.js";
 import {
   mirrorNeedsResize,
+  mirrorReplayInFlight,
   resizeMirror,
   restoreSessionFromFile,
 } from "../terminalSessionPersistence.js";
@@ -331,12 +332,18 @@ export class AnalysisSession {
    * viewport rows), not the configured cap. Feeds the worker memory sample so
    * the governor's targeted trim ranks by real usage. Null once freed.
    */
-  bufferStats(): { bufferLines: number; cols: number; rows: number } | null {
+  bufferStats(): {
+    bufferLines: number;
+    cols: number;
+    rows: number;
+    replayInFlight: boolean;
+  } | null {
     if (this.disposed || !this.headlessTerminal) return null;
     return {
       bufferLines: this.headlessTerminal.buffer.active.length,
       cols: this.headlessTerminal.cols,
       rows: this.headlessTerminal.rows,
+      replayInFlight: mirrorReplayInFlight(this.headlessTerminal),
     };
   }
 

--- a/electron/services/pty/analysis/AnalysisSession.ts
+++ b/electron/services/pty/analysis/AnalysisSession.ts
@@ -14,7 +14,11 @@ import { buildActivityMonitorOptions, buildPatternConfig } from "../terminalActi
 import { installHeadlessResponder } from "../headlessResponder.js";
 import { Osc94Parser } from "../Osc94Parser.js";
 import { SynchronizedFrameDetector } from "../SynchronizedFrameDetector.js";
-import { resizeMirror, restoreSessionFromFile } from "../terminalSessionPersistence.js";
+import {
+  mirrorNeedsResize,
+  resizeMirror,
+  restoreSessionFromFile,
+} from "../terminalSessionPersistence.js";
 import {
   measureVisibleContentDelta,
   type VisibleContentSnapshot,
@@ -190,6 +194,28 @@ export class AnalysisSession {
     this.scheduleDigest();
   }
 
+  /**
+   * Repair-only geometry re-assert (#11719). The host cannot see this mirror's
+   * grid, so it re-asserts on every "PTY already at this size" call and relies
+   * on this no-op when nothing drifted — which is why none of `resize`'s
+   * monitor/temperature side effects belong here.
+   */
+  ensureGeometry(cols: number, rows: number): void {
+    if (this.disposed || !this.headlessTerminal) return;
+    if (!mirrorNeedsResize(this.headlessTerminal, cols, rows)) return;
+    console.warn(
+      `[AnalysisSession] Mirror grid diverged for ${this.terminalId}: ` +
+        `mirror ${this.headlessTerminal.cols}x${this.headlessTerminal.rows} vs pty ${cols}x${rows}; re-asserting`
+    );
+    try {
+      resizeMirror(this.headlessTerminal, cols, rows);
+    } catch (error) {
+      console.error(`[AnalysisSession] Failed to resync geometry for ${this.terminalId}:`, error);
+      return;
+    }
+    this.scheduleDigest();
+  }
+
   notifyInput(data: string): void {
     this.monitor?.onInput(data);
   }
@@ -305,11 +331,12 @@ export class AnalysisSession {
    * viewport rows), not the configured cap. Feeds the worker memory sample so
    * the governor's targeted trim ranks by real usage. Null once freed.
    */
-  bufferStats(): { bufferLines: number; cols: number } | null {
+  bufferStats(): { bufferLines: number; cols: number; rows: number } | null {
     if (this.disposed || !this.headlessTerminal) return null;
     return {
       bufferLines: this.headlessTerminal.buffer.active.length,
       cols: this.headlessTerminal.cols,
+      rows: this.headlessTerminal.rows,
     };
   }
 

--- a/electron/services/pty/analysis/AnalysisWorkerPool.ts
+++ b/electron/services/pty/analysis/AnalysisWorkerPool.ts
@@ -380,6 +380,12 @@ export class AnalysisWorkerPool implements AnalysisPoolHost {
       if (this.disposed || slot.worker !== worker || !slot.alive) return;
       const { type: _type, ...sample } = msg;
       slot.memorySample = { ...sample, receivedAt: Date.now() };
+      // Each session carries its mirror's live grid — the host's only view of
+      // the geometry a worker mirror is really parsing at, and so the only way
+      // a silent divergence can ever be noticed (#11719).
+      for (const session of sample.sessions) {
+        this.backends.get(session.terminalId)?.noteMirrorGeometry(session.cols, session.rows);
+      }
       return;
     }
     if (msg.type === "response") {

--- a/electron/services/pty/analysis/AnalysisWorkerPool.ts
+++ b/electron/services/pty/analysis/AnalysisWorkerPool.ts
@@ -384,7 +384,9 @@ export class AnalysisWorkerPool implements AnalysisPoolHost {
       // the geometry a worker mirror is really parsing at, and so the only way
       // a silent divergence can ever be noticed (#11719).
       for (const session of sample.sessions) {
-        this.backends.get(session.terminalId)?.noteMirrorGeometry(session.cols, session.rows);
+        this.backends
+          .get(session.terminalId)
+          ?.noteMirrorGeometry(session.cols, session.rows, session.replayInFlight);
       }
       return;
     }

--- a/electron/services/pty/analysis/AnalysisWorkerRuntime.ts
+++ b/electron/services/pty/analysis/AnalysisWorkerRuntime.ts
@@ -91,6 +91,7 @@ export class AnalysisWorkerRuntime {
           bufferLines: stats.bufferLines,
           cols: stats.cols,
           rows: stats.rows,
+          replayInFlight: stats.replayInFlight,
         });
       }
     }

--- a/electron/services/pty/analysis/AnalysisWorkerRuntime.ts
+++ b/electron/services/pty/analysis/AnalysisWorkerRuntime.ts
@@ -29,6 +29,7 @@ const HEAP_ACTIVITY_MESSAGE_TYPES: ReadonlySet<HostToWorkerMessage["type"]> = ne
   "data",
   "prelude",
   "resize",
+  "ensure-geometry",
   "request",
   "free",
   "set-scrollback",
@@ -85,7 +86,12 @@ export class AnalysisWorkerRuntime {
     for (const [terminalId, session] of this.sessions) {
       const stats = session.bufferStats();
       if (stats) {
-        sessions.push({ terminalId, bufferLines: stats.bufferLines, cols: stats.cols });
+        sessions.push({
+          terminalId,
+          bufferLines: stats.bufferLines,
+          cols: stats.cols,
+          rows: stats.rows,
+        });
       }
     }
     return {
@@ -190,6 +196,9 @@ export class AnalysisWorkerRuntime {
         return;
       case "resize":
         this.sessions.get(msg.terminalId)?.resize(msg.cols, msg.rows);
+        return;
+      case "ensure-geometry":
+        this.sessions.get(msg.terminalId)?.ensureGeometry(msg.cols, msg.rows);
         return;
       case "input":
         this.sessions.get(msg.terminalId)?.notifyInput(msg.data);

--- a/electron/services/pty/analysis/InThreadAnalysisBackend.ts
+++ b/electron/services/pty/analysis/InThreadAnalysisBackend.ts
@@ -20,6 +20,7 @@ export interface InThreadAnalysisHost {
   feedChunk(data: string): void;
   feedPrelude(data: string): void;
   resize(cols: number, rows: number): void;
+  resyncGeometry(cols: number, rows: number): void;
   handleFocus(): void;
   getMonitor(): ActivityMonitor | null;
   startMonitor(opts: MonitorStartOptions): void;
@@ -48,6 +49,10 @@ export class InThreadAnalysisBackend implements AnalysisBackend {
 
   resize(cols: number, rows: number): void {
     this.host.resize(cols, rows);
+  }
+
+  resyncGeometry(cols: number, rows: number): void {
+    this.host.resyncGeometry(cols, rows);
   }
 
   notifyInput(data: string): void {

--- a/electron/services/pty/analysis/WorkerAnalysisBackend.ts
+++ b/electron/services/pty/analysis/WorkerAnalysisBackend.ts
@@ -70,7 +70,7 @@ export interface WorkerAnalysisDelegate {
   getProcessState(): { hasActiveChildren: boolean; cpuUsage: number } | null;
   getAgentContext(): { agentLive: boolean; agentState?: AgentState };
   /** The grid the worker's mirror reported for this terminal (#11719). */
-  onMirrorGeometry(cols: number, rows: number): void;
+  onMirrorGeometry(cols: number, rows: number, replayInFlight: boolean): void;
 }
 
 export interface WorkerBackendSpec {
@@ -122,6 +122,10 @@ export class WorkerAnalysisBackend implements AnalysisBackend {
   // the host cannot account for. Set until a geometry-bearing post lands, so
   // the next re-assert repairs instead of short-circuiting (#11719).
   private geometryPostFailed = false;
+  // The worker may have no session for this terminal at all, because a `create`
+  // post was dropped. Distinct from geometryPostFailed: repairing this needs a
+  // fresh `create`, not an `ensure-geometry` the worker would route nowhere.
+  private sessionCreatePending = false;
   // Last grid the worker reported for this terminal's mirror, from its
   // periodic memory sample. Null until the first sample arrives.
   private observedMirrorGeometry: { cols: number; rows: number } | null = null;
@@ -146,7 +150,10 @@ export class WorkerAnalysisBackend implements AnalysisBackend {
   }
 
   init(): void {
-    this.pool.post(this.spec.terminalId, {
+    // A dropped create leaves NO session in the worker, which no amount of
+    // later `ensure-geometry` can repair — the worker routes those to a session
+    // that does not exist. Remember that so a re-assert rebuilds instead.
+    this.sessionCreatePending = !this.pool.post(this.spec.terminalId, {
       type: "create",
       terminalId: this.spec.terminalId,
       cols: this.spec.cols,
@@ -243,7 +250,17 @@ export class WorkerAnalysisBackend implements AnalysisBackend {
    * the last one made, or a worker-reported grid that disagrees.
    */
   resyncGeometry(cols: number, rows: number): void {
-    if (this.inactive() || !this.geometryMayHaveDrifted(cols, rows)) return;
+    if (this.inactive()) return;
+    if (this.sessionCreatePending) {
+      // There may be no session in the worker to re-assert AT. Rebuild it at
+      // the requested grid instead — `ensure-geometry` would be routed to a
+      // session that does not exist and silently do nothing forever.
+      this.lastCols = cols;
+      this.lastRows = rows;
+      this.rebuildFreshSlot();
+      return;
+    }
+    if (!this.geometryMayHaveDrifted(cols, rows)) return;
     this.postGeometry("ensure-geometry", cols, rows);
   }
 
@@ -267,11 +284,21 @@ export class WorkerAnalysisBackend implements AnalysisBackend {
     // geometry right, buffer content corrupt. Every serialize path already
     // flushes first for the same ordering reason.
     if (!this.flushHeldFeed()) {
-      this.geometryPostFailed = true;
+      // The hold is stuck on the WRONG side of a geometry boundary and cannot
+      // be kept: the host coalesces held output into one string, so the
+      // post-resize output that follows would concatenate onto pre-resize
+      // output and the whole blob would later parse at one grid — the same
+      // corruption in a new disguise. There is no ordering left to preserve,
+      // so drop the analysis buffer and rebuild fresh at the new grid. Same
+      // analysis-only degradation as a feed overflow: persistence stays
+      // suppressed until real output dirties the new buffer, and the renderer
+      // path is untouched.
       console.error(
         `[WorkerAnalysisBackend] Held output could not be flushed before a ${type} for ` +
-          `${this.spec.terminalId}; skipping the geometry post to preserve ordering`
+          `${this.spec.terminalId}; rebuilding the analysis slot at ${cols}x${rows} ` +
+          `rather than merging output from two grids`
       );
+      this.rebuildFreshSlot();
       return;
     }
     this.geometryPostFailed = !this.pool.post(this.spec.terminalId, {
@@ -293,9 +320,13 @@ export class WorkerAnalysisBackend implements AnalysisBackend {
    * — the host's only observation of what a worker mirror is really parsing at
    * (#11719).
    */
-  noteMirrorGeometry(cols: number, rows: number): void {
-    this.observedMirrorGeometry = { cols, rows };
-    this.delegate.onMirrorGeometry(cols, rows);
+  noteMirrorGeometry(cols: number, rows: number, replayInFlight = false): void {
+    // A replay parks the mirror on the capture grid with no host resize behind
+    // it, so that geometry says nothing about whether this mirror owes the PTY
+    // a resize — recording it would make `geometryMayHaveDrifted` chase a grid
+    // the replay is about to reflow away from anyway.
+    this.observedMirrorGeometry = replayInFlight ? null : { cols, rows };
+    this.delegate.onMirrorGeometry(cols, rows, replayInFlight);
   }
 
   notifyInput(data: string): void {
@@ -530,7 +561,7 @@ export class WorkerAnalysisBackend implements AnalysisBackend {
     // replacement; the `create` below carries the geometry instead, and a
     // dropped create leaves it unknown exactly like a dropped resize.
     this.observedMirrorGeometry = null;
-    this.geometryPostFailed = !this.pool.post(this.spec.terminalId, {
+    const created = this.pool.post(this.spec.terminalId, {
       type: "create",
       terminalId: this.spec.terminalId,
       cols: this.lastCols,
@@ -540,6 +571,11 @@ export class WorkerAnalysisBackend implements AnalysisBackend {
       spawnedAt: this.spec.spawnedAt,
       epoch: this.feedEpoch,
     });
+    // The create carries the geometry, so landing it converges the mirror and
+    // dropping it leaves no session at all — the two failure states this slot
+    // can be in, and both are cleared by the same successful post.
+    this.geometryPostFailed = !created;
+    this.sessionCreatePending = !created;
     if (this.monitorSpec) {
       this.postAgentContext();
       // Preserve-state semantics (mirrors the in-thread preserveState path):

--- a/electron/services/pty/analysis/WorkerAnalysisBackend.ts
+++ b/electron/services/pty/analysis/WorkerAnalysisBackend.ts
@@ -69,6 +69,8 @@ export interface WorkerAnalysisDelegate {
   onPtyResponse(data: string): void;
   getProcessState(): { hasActiveChildren: boolean; cpuUsage: number } | null;
   getAgentContext(): { agentLive: boolean; agentState?: AgentState };
+  /** The grid the worker's mirror reported for this terminal (#11719). */
+  onMirrorGeometry(cols: number, rows: number): void;
 }
 
 export interface WorkerBackendSpec {
@@ -116,6 +118,13 @@ export class WorkerAnalysisBackend implements AnalysisBackend {
   // loss, feed overflow); stamped on create/data and echoed in data-ack so a
   // late ack from a superseded generation can't debit the fresh ledger.
   private feedEpoch = 0;
+  // A geometry post that never reached the worker leaves its mirror on a grid
+  // the host cannot account for. Set until a geometry-bearing post lands, so
+  // the next re-assert repairs instead of short-circuiting (#11719).
+  private geometryPostFailed = false;
+  // Last grid the worker reported for this terminal's mirror, from its
+  // periodic memory sample. Null until the first sample arrives.
+  private observedMirrorGeometry: { cols: number; rows: number } | null = null;
 
   constructor(
     private readonly spec: WorkerBackendSpec,
@@ -176,7 +185,7 @@ export class WorkerAnalysisBackend implements AnalysisBackend {
   // Posts a data message stamped with the current epoch, crediting outstanding
   // bytes ONLY when the worker actually received it (a no-op/failed post must
   // not leave phantom outstanding bytes that never ack).
-  private postData(data: string, flags: AnalysisChunkFlags): void {
+  private postData(data: string, flags: AnalysisChunkFlags): boolean {
     const sent = this.pool.post(this.spec.terminalId, {
       type: "data",
       terminalId: this.spec.terminalId,
@@ -187,17 +196,28 @@ export class WorkerAnalysisBackend implements AnalysisBackend {
     if (sent) {
       this.outstandingFeedBytes += data.length;
     }
+    return sent;
   }
 
   // Force-posts any host-side hold, regardless of the low watermark. Called
   // before every serialize request so the per-terminal barrier in the worker
   // runtime orders request-after-data — otherwise a request would overtake the
   // coalesced hold and serialize a buffer missing up to the whole hold.
-  private flushHeldFeed(): void {
-    if (this.heldFeed === null || this.inactive()) return;
+  //
+  // Returns whether the hold actually reached the worker. A failed post leaves
+  // the data owed, so it goes back on the hold rather than being dropped — and
+  // the caller must not proceed with the op it was ordering itself ahead of
+  // (#11719): a resize posted after a failed flush is exactly the inversion the
+  // flush exists to prevent, with the output lost on top.
+  private flushHeldFeed(): boolean {
+    if (this.heldFeed === null || this.inactive()) return true;
     const held = this.heldFeed;
     this.heldFeed = null;
-    this.postData(held.data, held.flags);
+    if (this.postData(held.data, held.flags)) return true;
+    // Nothing can have appended in between — postData is synchronous — so the
+    // hold is restored whole, keeping later chunks behind it in FIFO order.
+    this.heldFeed = held;
+    return false;
   }
 
   feedPrelude(data: string): void {
@@ -211,14 +231,71 @@ export class WorkerAnalysisBackend implements AnalysisBackend {
 
   resize(cols: number, rows: number): void {
     if (this.inactive()) return;
+    this.postGeometry("resize", cols, rows);
+  }
+
+  /**
+   * Repair-only geometry re-assert (#11719). The host cannot read the worker's
+   * mirror grid, so convergence can only be driven by posting — but posting on
+   * every routine re-assertion would force the held feed out and defeat flow
+   * control. Post only when something the host CAN see says the mirror is, or
+   * may be, off: a geometry post that never landed, a request that differs from
+   * the last one made, or a worker-reported grid that disagrees.
+   */
+  resyncGeometry(cols: number, rows: number): void {
+    if (this.inactive() || !this.geometryMayHaveDrifted(cols, rows)) return;
+    this.postGeometry("ensure-geometry", cols, rows);
+  }
+
+  private geometryMayHaveDrifted(cols: number, rows: number): boolean {
+    if (this.geometryPostFailed) return true;
+    if (this.lastCols !== cols || this.lastRows !== rows) return true;
+    // The worker's own periodic sample is the only ground truth available.
+    const observed = this.observedMirrorGeometry;
+    return observed !== null && (observed.cols !== cols || observed.rows !== rows);
+  }
+
+  private postGeometry(type: "resize" | "ensure-geometry", cols: number, rows: number): void {
+    // Intent, not confirmation: a fresh-slot rebuild recreates the session at
+    // these dims, so they must record what was asked for even when the post
+    // below is dropped.
     this.lastCols = cols;
     this.lastRows = rows;
-    this.pool.post(this.spec.terminalId, {
-      type: "resize",
+    // Output coalesced above the high watermark was emitted at the OLD grid.
+    // Posting the resize while it is still held here lets the resize overtake
+    // up to the whole hold, which the mirror then parses at the new width —
+    // geometry right, buffer content corrupt. Every serialize path already
+    // flushes first for the same ordering reason.
+    if (!this.flushHeldFeed()) {
+      this.geometryPostFailed = true;
+      console.error(
+        `[WorkerAnalysisBackend] Held output could not be flushed before a ${type} for ` +
+          `${this.spec.terminalId}; skipping the geometry post to preserve ordering`
+      );
+      return;
+    }
+    this.geometryPostFailed = !this.pool.post(this.spec.terminalId, {
+      type,
       terminalId: this.spec.terminalId,
       cols,
       rows,
     });
+    if (this.geometryPostFailed) {
+      console.error(
+        `[WorkerAnalysisBackend] Mirror ${type} to ${cols}x${rows} was dropped for ` +
+          `${this.spec.terminalId}; its grid is unconfirmed until the next re-assert`
+      );
+    }
+  }
+
+  /**
+   * The mirror grid this terminal's worker reported in its last memory sample
+   * — the host's only observation of what a worker mirror is really parsing at
+   * (#11719).
+   */
+  noteMirrorGeometry(cols: number, rows: number): void {
+    this.observedMirrorGeometry = { cols, rows };
+    this.delegate.onMirrorGeometry(cols, rows);
   }
 
   notifyInput(data: string): void {
@@ -449,7 +526,11 @@ export class WorkerAnalysisBackend implements AnalysisBackend {
     this.viewportLines = [];
     this.cursorLine = null;
     this.persistSuppressed = true;
-    this.pool.post(this.spec.terminalId, {
+    // The old mirror is gone, so its last reported grid says nothing about the
+    // replacement; the `create` below carries the geometry instead, and a
+    // dropped create leaves it unknown exactly like a dropped resize.
+    this.observedMirrorGeometry = null;
+    this.geometryPostFailed = !this.pool.post(this.spec.terminalId, {
       type: "create",
       terminalId: this.spec.terminalId,
       cols: this.lastCols,

--- a/electron/services/pty/analysisWorkerProtocol.ts
+++ b/electron/services/pty/analysisWorkerProtocol.ts
@@ -121,7 +121,18 @@ export interface AnalysisWorkerMemorySample {
    * mirror is really parsing at, so this sample doubles as the divergence
    * signal for #11719 — hence rows, which buffer accounting itself never needs.
    */
-  sessions: Array<{ terminalId: string; bufferLines: number; cols: number; rows: number }>;
+  sessions: Array<{
+    terminalId: string;
+    bufferLines: number;
+    cols: number;
+    rows: number;
+    /**
+     * A session replay owns the grid right now, so `cols`/`rows` are the
+     * capture grid it is parked on rather than a grid it owes the PTY. The
+     * host must not read that expected disagreement as divergence.
+     */
+    replayInFlight: boolean;
+  }>;
   /** Worker-side epoch ms when the sample was taken. */
   sampledAt: number;
 }

--- a/electron/services/pty/analysisWorkerProtocol.ts
+++ b/electron/services/pty/analysisWorkerProtocol.ts
@@ -43,6 +43,18 @@ export type HostToWorkerMessage =
   | { type: "data"; terminalId: string; data: string; flags: AnalysisChunkFlags; epoch: number }
   | { type: "prelude"; terminalId: string; data: string }
   | { type: "resize"; terminalId: string; cols: number; rows: number }
+  | {
+      /**
+       * Repair-only geometry re-assert (#11719). Applies the grid if the
+       * mirror has drifted off it — including a stale replay target — and
+       * otherwise does nothing. Unlike `resize` it fires no monitor resize
+       * suppression or temperature event, because the PTY did not move.
+       */
+      type: "ensure-geometry";
+      terminalId: string;
+      cols: number;
+      rows: number;
+    }
   | { type: "input"; terminalId: string; data: string }
   | { type: "focus"; terminalId: string }
   | { type: "submission"; terminalId: string }
@@ -103,8 +115,13 @@ export interface AnalysisWorkerMemorySample {
    * Actual per-session buffer occupancy (lines really held, not the
    * configured scrollback cap) so the governor's targeted trim can rank by
    * real usage instead of assuming every buffer is full.
+   *
+   * `cols`/`rows` are the mirror's LIVE grid, read off the headless terminal
+   * at sample time. They are the host's only view of the geometry a worker
+   * mirror is really parsing at, so this sample doubles as the divergence
+   * signal for #11719 — hence rows, which buffer accounting itself never needs.
    */
-  sessions: Array<{ terminalId: string; bufferLines: number; cols: number }>;
+  sessions: Array<{ terminalId: string; bufferLines: number; cols: number; rows: number }>;
   /** Worker-side epoch ms when the sample was taken. */
   sampledAt: number;
 }

--- a/electron/services/pty/terminalSessionPersistence.ts
+++ b/electron/services/pty/terminalSessionPersistence.ts
@@ -258,6 +258,19 @@ export function mirrorNeedsResize(
 }
 
 /**
+ * Whether a session replay currently owns this mirror's grid.
+ *
+ * Callers need this to tell a mirror that has DRIFTED off the PTY grid from one
+ * deliberately parked on a capture grid: the parked mirror's live geometry is
+ * expected to disagree, and treating that as divergence produces a false report
+ * out of healthy behaviour. It also marks the resizes that will only record an
+ * intent, so callers can skip work that only pays off for a resize applying now.
+ */
+export function mirrorReplayInFlight(headlessTerminal: HeadlessTerminalType): boolean {
+  return replayWindows.has(headlessTerminal);
+}
+
+/**
  * Park `headlessTerminal` on the grid a snapshot was captured at for the
  * duration of its replay, remembering the grid to return to.
  *

--- a/electron/services/pty/terminalSessionPersistence.ts
+++ b/electron/services/pty/terminalSessionPersistence.ts
@@ -234,6 +234,30 @@ export function resizeMirror(
 }
 
 /**
+ * Whether this mirror still owes a resize to reach `cols`x`rows` (#11719).
+ *
+ * The live grid alone is not the answer. While a replay window is open the
+ * mirror is parked at the capture grid and the resize that matters is the
+ * PARKED TARGET — the geometry the replay will reflow to when it lands. A
+ * mirror whose visible grid happens to match while its parked target is stale
+ * is about to diverge, so it needs the re-assert just as much as one whose
+ * grid is already wrong.
+ *
+ * Lives here rather than at the call sites so `replayWindows` stays private.
+ */
+export function mirrorNeedsResize(
+  headlessTerminal: HeadlessTerminalType,
+  cols: number,
+  rows: number
+): boolean {
+  const window = replayWindows.get(headlessTerminal);
+  if (window) {
+    return window.target.cols !== cols || window.target.rows !== rows;
+  }
+  return headlessTerminal.cols !== cols || headlessTerminal.rows !== rows;
+}
+
+/**
  * Park `headlessTerminal` on the grid a snapshot was captured at for the
  * duration of its replay, remembering the grid to return to.
  *


### PR DESCRIPTION
## Summary

- The pty-host's headless mirror terminal (built on `@xterm/headless`) can parse output at a different geometry than the real PTY, which corrupts its committed buffer.
- Because scrollback snapshots stamp the mirror's own claimed geometry, a diverged mirror is self-consistent: every check passes and the corrupted output replays forever after a view eviction or pty-host restart.
- This fixes the six defects that let that divergence happen and go unnoticed, and adds the observability to catch the next one from a log line instead of a code archaeology session.

Resolves #11719

## The bug

For each session, the pty-host runs a headless mirror terminal that parses all PTY output and produces the scrollback snapshots used after a view eviction or pty-host restart. It's effectively a third grid, alongside the renderer's xterm terminal and the real PTY. If the mirror parses output at a different geometry (columns and rows) than the PTY, its committed buffer becomes corrupt. Snapshots always use the mirror's own geometry, so a corrupted mirror is self-consistent: the renderer aligns the replay to the mirror's claimed geometry, every check passes, and the corrupted output replays indefinitely. None of the previous width-corruption fixes (#11552, #11628, #11638 through #11641) touched the mirror.

## The fix

1. `TerminalProcess.resize()` used to return early with `"unchanged"` whenever the PTY was already at the requested size, so it never reached `this.analysis.resize()`. That meant a mirror that had drifted out of sync once could never re-converge, because every later re-assertion of the same size short-circuited on the same check. That branch now routes through a new side-effect-free method, `resyncGeometry()`, instead of a plain `resize()` call. The distinction matters: the existing `resizeAnalysisInThread` path fires `activityMonitor.notifyResize()`, which opens a 500ms activity-suppression window and resets four detectors, and geometry gets re-asserted routinely, so doing that on every no-op resize would repeatedly blind agent detection.

2. `HeadlessMirrorScheduler` could still be holding queued, unfed slices of output when the mirror was resized, so old-width output got fed into the mirror after the reflow and parsed at the new width. A new `drainThenResize()` hands every queued slice to the mirror first, then applies the resize with the queue held closed. Worth stating explicitly: xterm's `Terminal.resize()` calls `WriteBuffer.flushSync()` before it reflows (verified against the pinned `@xterm/headless` `6.1.0-beta.290`), so anything already inside the write buffer parses at the old grid. The hazard is exclusively bytes held outside xterm. That's also why this can't reuse the existing `flush()`: its callback fires from inside a mirror write callback, and resizing there would re-enter `flushSync` in the middle of `_innerWrite`. The drain deliberately ignores the scheduler's normal pacing bounds, because no other tick can run between the drain and the resize without breaking the ordering.

3. `WorkerAnalysisBackend.resize` used to post its resize message without flushing the held feed first, unlike every serialize path, which all flush. Above the high watermark, up to 32MB of output emitted at the old width could jump behind the resize. It now flushes first. `flushHeldFeed()` also became failure-aware: it used to clear the hold before knowing whether the `postMessage` call had succeeded, which could have silently lost output.

4. A dropped `postMessage` used to be silent, and nothing retried it. Geometry posts now track failure, and the periodic divergence check drives the retry.

5. There was zero observability: nothing logged the mirror's grid or compared it against the PTY's, which is a big part of why this class of bug kept getting re-diagnosed from scratch. The worker's periodic memory sample already carried each mirror's live column count; it now also carries row count and replay state, and the host logs a signature-deduped mirror-vs-PTY line, once per divergence episode, cleared on agreement, with a cumulative count. That log also drives the repair.

## Design notes

- A `postMessage` throw does not synthesize a worker death. It's permanent for that one message (a structured-clone failure), but not necessarily for the worker itself, and treating it as a worker exit risks two live workers for one slot. The periodic divergence check is the retry driver instead.
- When the pre-geometry flush fails, the analysis slot is rebuilt fresh at the new grid rather than keeping the held output. The host coalesces held output into a single string, so keeping it would let post-resize output concatenate onto pre-resize output, and the merged blob would parse at a single grid, the same corruption wearing a different hat. It's the same analysis-only degradation as an existing feed-overflow case: persistence stays suppressed until real output dirties the new buffer, and the renderer path is untouched.
- A mirror parked by a session replay is not reported as diverged. Its live grid is expected to disagree with the PTY for the duration of that replay.

## Testing

1,068 tests pass across the pty suite and every other suite referencing the changed modules; project typecheck, ESLint, and Prettier are clean on all 15 changed files. The new regression tests were mutation-checked: reverting any of the six core fixes individually makes a specific test fail, including a real `@xterm/headless` integration test that compares serialized output against a reference terminal to prove queued output parses at the old grid across a resize.

## Known limitation

The periodic divergence check rides the worker's memory-sample cadence, so it covers the worker path. The in-thread fallback path (used when analysis workers are disabled) only logs when a re-assertion actually repairs the divergence; it has no independent periodic check of its own.
