### PR TITLE
fix(terminal): build restored panes on their persisted grid, not 80x24

### DIFF
--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -16,6 +16,7 @@ import type { AgentState, AgentId, WaitingReason } from "./agent.js";
 import type { TerminalSpawnSource, AddPanelFocusPolicy } from "./panel.js";
 import type { BuiltInAgentId } from "../config/agentIds.js";
 import type { ActionContext } from "./actions.js";
+import type { TerminalGeometry } from "./terminal.js";
 
 /** Fields shared by all panel creation requests */
 export interface AddPanelOptionsBase {
@@ -174,6 +175,23 @@ export interface AddPanelOptionsBase {
    * launch path captures its own snapshot via `help.provisionSession` instead.
    */
   actionContext?: ActionContext;
+  /**
+   * Grid this PTY panel is known to already be on, supplied by hydration from
+   * the persisted `terminalSizes` entry. Used as the xterm CONSTRUCTOR size so a
+   * restored pane is born on its real grid.
+   *
+   * A restored pane in a non-selected worktree is prewarmed but never attached,
+   * so nothing ever fits it, yet it stays content-live and parses whatever the
+   * surviving PTY streams. Born at xterm's 80×24 default it commits every
+   * cursor-addressed repaint from a ~200-column agent into an 80-column grid,
+   * and the damage is real cell data that no later fit or Redraw can undo
+   * (#11718). Renderer-side only: the PTY it reconnects to is already on this
+   * grid, so nothing on this path may resize it.
+   *
+   * Transient — hydration-only, never persisted, and never a reason to move a
+   * surviving PTY. A real fit supersedes it normally once the pane attaches.
+   */
+  initialTerminalGeometry?: TerminalGeometry;
 }
 
 /**

--- a/src/services/terminal/TerminalRestoreController.ts
+++ b/src/services/terminal/TerminalRestoreController.ts
@@ -67,40 +67,42 @@ export class TerminalRestoreController {
    * `TerminalResizeController.resizeTerminal`), so it always holds the newest
    * intended geometry (#11552).
    */
-  private beginRestoreWindow(managed: ManagedTerminal, captureGeometry?: TerminalGeometry): number {
+  private beginRestoreWindow(managed: ManagedTerminal): number {
     if (!managed.isSerializedRestoreInProgress) {
-      managed.pendingRestoreGeometry = this.intendedGeometry(managed, captureGeometry);
+      managed.pendingRestoreGeometry = this.intendedGeometry(managed);
     }
     managed.isSerializedRestoreInProgress = true;
     return ++managed.restoreWindowToken;
   }
 
   /**
-   * The grid this pane belongs on, as best known when a restore window opens.
+   * The grid this pane must end up on, or `undefined` when nothing here knows.
    *
-   * `terminal.cols/rows` is only evidence of the pane's real grid once xterm has
+   * `terminal.cols/rows` is evidence of the pane's real grid only once xterm has
    * been opened against a measured host. A pane that has never been opened is
-   * still on whatever it was CONSTRUCTED at, which for anything the persisted
-   * size didn't reach is xterm's 80×24 default — and seeding that made
-   * `endRestoreWindow` snap a correctly-aligned replay back onto it, then leave
-   * the still-live pane parsing a ~200-column agent into 80 columns until the
-   * user finally selected its worktree (#11718).
+   * still on whatever it was CONSTRUCTED at — xterm's 80×24 default for anything
+   * the persisted size didn't reach — and seeding that made `endRestoreWindow`
+   * snap a correctly-aligned replay back onto it, leaving a still-live pane
+   * parsing a ~200-column agent into 80 columns until the user finally selected
+   * its worktree (#11718).
    *
-   * For that parked case prefer, in order: the attach target (the persisted
-   * grid, which is where the surviving PTY already is), then the snapshot's
-   * capture grid (at least where the mirror and PTY were last agreed). Both are
-   * strictly better evidence than a constructor default. Only the SEED changes:
-   * a resize landing mid-window still overwrites this via `resizeTerminal`, so a
-   * parked resize continues to win, exactly as before.
+   * So a parked pane seeds from its attach target: the persisted grid, which is
+   * where the surviving PTY already is. With no valid target we return nothing
+   * rather than guess, which makes `endRestoreWindow` skip its corrective resize
+   * and leave the pane on the capture grid `alignToCaptureGeometry` just put it
+   * on — the grid the mirror and PTY were last agreed on, and the best evidence
+   * left. Deliberately expressed as an absent target rather than as the capture
+   * geometry: `fetchAndRestore` opens its window BEFORE the snapshot exists, so
+   * a seed computed here could never have seen it, and the nested restore cannot
+   * reseed an open window.
+   *
+   * Only the SEED changes. A resize landing mid-window still overwrites this via
+   * `resizeTerminal`, so a parked resize continues to win, exactly as before.
    */
-  private intendedGeometry(
-    managed: ManagedTerminal,
-    captureGeometry: TerminalGeometry | undefined
-  ): TerminalGeometry {
+  private intendedGeometry(managed: ManagedTerminal): TerminalGeometry | undefined {
     if (!managed.isOpened) {
       const target = { cols: managed.targetCols, rows: managed.targetRows };
-      if (isValidTerminalGeometry(target)) return target;
-      if (isValidTerminalGeometry(captureGeometry)) return captureGeometry;
+      return isValidTerminalGeometry(target) ? target : undefined;
     }
     return { cols: managed.terminal.cols, rows: managed.terminal.rows };
   }
@@ -143,6 +145,10 @@ export class TerminalRestoreController {
    * that parked resize on every geometry-less replay, leaving xterm on the old
    * grid while the PTY had already been told the new one. It is a no-op when
    * the grid already matches, which is the common case.
+   *
+   * An ABSENT target is meaningful, not a bug: a never-opened pane with no
+   * attach target has no grid worth returning to, so the capture grid the replay
+   * just landed on stands (#11718).
    *
    * `reflowCursorLine` is off by default in xterm, which leaves the wrapped
    * group containing the cursor untouched by a resize — reflowing to a narrower
@@ -217,7 +223,7 @@ export class TerminalRestoreController {
       }
 
       const restoreGeneration = ++managed.restoreGeneration;
-      restoreWindow = this.beginRestoreWindow(managed, captureGeometry);
+      restoreWindow = this.beginRestoreWindow(managed);
       managed.lastScrollbackRestoreError = undefined;
 
       const scrollBackOffset = managed.isUserScrolledBack
@@ -281,7 +287,7 @@ export class TerminalRestoreController {
     }
 
     const restoreGeneration = ++managed.restoreGeneration;
-    const restoreWindow = this.beginRestoreWindow(managed, captureGeometry);
+    const restoreWindow = this.beginRestoreWindow(managed);
     managed.lastScrollbackRestoreError = undefined;
 
     const task = async (): Promise<boolean> => {

--- a/src/services/terminal/TerminalRestoreController.ts
+++ b/src/services/terminal/TerminalRestoreController.ts
@@ -67,15 +67,42 @@ export class TerminalRestoreController {
    * `TerminalResizeController.resizeTerminal`), so it always holds the newest
    * intended geometry (#11552).
    */
-  private beginRestoreWindow(managed: ManagedTerminal): number {
+  private beginRestoreWindow(managed: ManagedTerminal, captureGeometry?: TerminalGeometry): number {
     if (!managed.isSerializedRestoreInProgress) {
-      managed.pendingRestoreGeometry = {
-        cols: managed.terminal.cols,
-        rows: managed.terminal.rows,
-      };
+      managed.pendingRestoreGeometry = this.intendedGeometry(managed, captureGeometry);
     }
     managed.isSerializedRestoreInProgress = true;
     return ++managed.restoreWindowToken;
+  }
+
+  /**
+   * The grid this pane belongs on, as best known when a restore window opens.
+   *
+   * `terminal.cols/rows` is only evidence of the pane's real grid once xterm has
+   * been opened against a measured host. A pane that has never been opened is
+   * still on whatever it was CONSTRUCTED at, which for anything the persisted
+   * size didn't reach is xterm's 80×24 default — and seeding that made
+   * `endRestoreWindow` snap a correctly-aligned replay back onto it, then leave
+   * the still-live pane parsing a ~200-column agent into 80 columns until the
+   * user finally selected its worktree (#11718).
+   *
+   * For that parked case prefer, in order: the attach target (the persisted
+   * grid, which is where the surviving PTY already is), then the snapshot's
+   * capture grid (at least where the mirror and PTY were last agreed). Both are
+   * strictly better evidence than a constructor default. Only the SEED changes:
+   * a resize landing mid-window still overwrites this via `resizeTerminal`, so a
+   * parked resize continues to win, exactly as before.
+   */
+  private intendedGeometry(
+    managed: ManagedTerminal,
+    captureGeometry: TerminalGeometry | undefined
+  ): TerminalGeometry {
+    if (!managed.isOpened) {
+      const target = { cols: managed.targetCols, rows: managed.targetRows };
+      if (isValidTerminalGeometry(target)) return target;
+      if (isValidTerminalGeometry(captureGeometry)) return captureGeometry;
+    }
+    return { cols: managed.terminal.cols, rows: managed.terminal.rows };
   }
 
   /**
@@ -190,7 +217,7 @@ export class TerminalRestoreController {
       }
 
       const restoreGeneration = ++managed.restoreGeneration;
-      restoreWindow = this.beginRestoreWindow(managed);
+      restoreWindow = this.beginRestoreWindow(managed, captureGeometry);
       managed.lastScrollbackRestoreError = undefined;
 
       const scrollBackOffset = managed.isUserScrolledBack
@@ -254,7 +281,7 @@ export class TerminalRestoreController {
     }
 
     const restoreGeneration = ++managed.restoreGeneration;
-    const restoreWindow = this.beginRestoreWindow(managed);
+    const restoreWindow = this.beginRestoreWindow(managed, captureGeometry);
     managed.lastScrollbackRestoreError = undefined;
 
     const task = async (): Promise<boolean> => {

--- a/src/services/terminal/__tests__/TerminalRestoreController.replay.test.ts
+++ b/src/services/terminal/__tests__/TerminalRestoreController.replay.test.ts
@@ -10,6 +10,7 @@ import { SerializeAddon } from "@xterm/addon-serialize";
 import { TerminalRestoreController } from "../TerminalRestoreController";
 import type { ManagedTerminal } from "../types";
 import type { SerializedTerminalSnapshot } from "@shared/types/terminal";
+import { terminalClient } from "@/clients";
 
 vi.mock("@/clients", () => ({
   terminalClient: { getSerializedState: vi.fn() },
@@ -264,6 +265,83 @@ describe("TerminalRestoreController replay fidelity (real xterm)", () => {
 
       const live = makeTerminal(80, 24);
       const { controller } = makeController(live, { isOpened: false });
+
+      controller.restoreFromSerialized("t1", snapshot.data, snapshot);
+      await flush(live);
+      await Promise.resolve();
+
+      expect(live.cols).toBe(CAPTURE_COLS);
+      expect(live.rows).toBe(PARKED_ROWS);
+    });
+
+    it("keeps that fallback through fetchAndRestore, the path hydration uses", async () => {
+      // fetchAndRestore opens its window BEFORE the snapshot exists, and the
+      // nested restore cannot reseed an open window — so a seed computed from
+      // capture geometry would never survive this entry point. Expressing "no
+      // target" as an absent seed is what makes the two paths agree.
+      const { snapshot } = await capture(CAPTURE_COLS, WRAPPED_LINE, PARKED_ROWS);
+      vi.mocked(terminalClient.getSerializedState).mockResolvedValue(snapshot);
+
+      const live = makeTerminal(80, 24);
+      const { controller } = makeController(live, { isOpened: false });
+
+      await controller.fetchAndRestore("t1");
+      await flush(live);
+      await Promise.resolve();
+
+      expect(live.cols).toBe(CAPTURE_COLS);
+      expect(live.rows).toBe(PARKED_ROWS);
+    });
+
+    it("prefers the parked target over the capture grid through fetchAndRestore", async () => {
+      const { snapshot } = await capture(CAPTURE_COLS, WRAPPED_LINE, PARKED_ROWS);
+      vi.mocked(terminalClient.getSerializedState).mockResolvedValue(snapshot);
+
+      const live = makeTerminal(80, 24);
+      const { controller } = makeController(live, {
+        isOpened: false,
+        targetCols: PARKED_COLS,
+        targetRows: PARKED_ROWS,
+      });
+
+      await controller.fetchAndRestore("t1");
+      await flush(live);
+      await Promise.resolve();
+
+      expect(live.cols).toBe(PARKED_COLS);
+    });
+
+    it("applies the parked target on the incremental path too", async () => {
+      // Large snapshots take the incremental route, which opens its own window.
+      const bulk = `${WRAPPED_LINE}\r\n`.repeat(40) + WRAPPED_LINE;
+      const { snapshot } = await capture(CAPTURE_COLS, bulk, PARKED_ROWS);
+
+      const live = makeTerminal(80, 24);
+      const { controller } = makeController(live, {
+        isOpened: false,
+        targetCols: PARKED_COLS,
+        targetRows: PARKED_ROWS,
+      });
+
+      await controller.restoreFromSerializedIncremental("t1", snapshot.data, snapshot);
+      await flush(live);
+      await Promise.resolve();
+
+      expect(live.cols).toBe(PARKED_COLS);
+      expect(live.rows).toBe(PARKED_ROWS);
+    });
+
+    it("ignores a parked target that is not a grid a terminal could have had", async () => {
+      // Corrupt or legacy persisted state must not become the pane's grid; the
+      // capture grid stands instead.
+      const { snapshot } = await capture(CAPTURE_COLS, WRAPPED_LINE, PARKED_ROWS);
+
+      const live = makeTerminal(80, 24);
+      const { controller } = makeController(live, {
+        isOpened: false,
+        targetCols: 100_000,
+        targetRows: PARKED_ROWS,
+      });
 
       controller.restoreFromSerialized("t1", snapshot.data, snapshot);
       await flush(live);

--- a/src/services/terminal/__tests__/TerminalRestoreController.replay.test.ts
+++ b/src/services/terminal/__tests__/TerminalRestoreController.replay.test.ts
@@ -45,16 +45,17 @@ describe("TerminalRestoreController replay fidelity (real xterm)", () => {
   const writeAndFlush = (terminal: Terminal, data: string): Promise<void> =>
     new Promise<void>((resolve) => terminal.write(data, () => resolve()));
 
-  function makeTerminal(cols: number, rows = 10): Terminal {
+  function makeTerminal(cols: number, rows: number = 10): Terminal {
     return new Terminal({ cols, rows, scrollback: 200, allowProposedApi: true });
   }
 
   /** Capture a snapshot the way the pty-host mirror does. */
   async function capture(
     cols: number,
-    content: string
+    content: string,
+    rows?: number
   ): Promise<{ snapshot: SerializedTerminalSnapshot; source: Terminal }> {
-    const source = makeTerminal(cols);
+    const source = makeTerminal(cols, rows);
     const addon = new SerializeAddon();
     source.loadAddon(addon);
     await writeAndFlush(source, content);
@@ -85,7 +86,10 @@ describe("TerminalRestoreController replay fidelity (real xterm)", () => {
   const cursorOf = (terminal: Terminal) =>
     `${terminal.buffer.active.cursorX},${terminal.buffer.active.cursorY}`;
 
-  function makeController(terminal: Terminal): {
+  function makeController(
+    terminal: Terminal,
+    overrides: Partial<ManagedTerminal> = {}
+  ): {
     controller: TerminalRestoreController;
     managed: ManagedTerminal;
   } {
@@ -97,6 +101,11 @@ describe("TerminalRestoreController replay fidelity (real xterm)", () => {
       isSerializedRestoreInProgress: false,
       deferredOutput: [],
       isUserScrolledBack: false,
+      // Opened: these panes were attached and measured, so `terminal.cols/rows`
+      // genuinely describes their grid. Parked panes are the exception and say
+      // so explicitly (#11718).
+      isOpened: true,
+      ...overrides,
     } as unknown as ManagedTerminal;
     const controller = new TerminalRestoreController({
       getInstance: (id) => (id === "t1" ? managed : undefined),
@@ -184,5 +193,123 @@ describe("TerminalRestoreController replay fidelity (real xterm)", () => {
 
     expect(live.cols).toBe(100);
     expect(readBuffer(live).length).toBeGreaterThan(0);
+  });
+
+  /**
+   * A parked pane must end a restore on the grid it is really on (#11718).
+   *
+   * A pane restored into a non-selected worktree is prewarmed but never
+   * attached, so nothing fits it — yet it stays content-live and keeps parsing
+   * whatever its surviving PTY streams. `terminal.cols/rows` for such a pane is
+   * xterm's constructor default, not evidence of anything, and seeding the
+   * restore window from it left the pane back at 80×24 after a correctly
+   * aligned replay. Every subsequent agent repaint then wrapped into the wrong
+   * rows, and because that is committed cell data no later fit or Redraw undoes
+   * it — it only clears once new output scrolls it away.
+   */
+  describe("parked pane geometry", () => {
+    const PARKED_COLS = 120;
+    const PARKED_ROWS = 30;
+    const CAPTURE_COLS = 90;
+
+    // Longer than the 80-column default and shorter than the pane's real grid,
+    // so it occupies one row on the real grid and wraps onto a second at the
+    // default. Erase-line then only clears the first of those two rows, which
+    // is how one repainting status line becomes fragments down the pane.
+    const STATUS_LINE = "* Cooking".padEnd(95, ".");
+
+    /** Cursor-addressed repaints, the way an agent CLI emits them. */
+    async function streamStatusRepaints(terminal: Terminal): Promise<void> {
+      for (let frame = 0; frame < 4; frame++) {
+        await writeAndFlush(terminal, `\x1b[1;1H\x1b[2K${STATUS_LINE} ${frame}`);
+      }
+    }
+
+    it("parses live output at the pane's real grid, not the constructor default", async () => {
+      const { snapshot, source } = await capture(CAPTURE_COLS, WRAPPED_LINE, PARKED_ROWS);
+
+      // Ground truth: the same session on the real grid throughout — what the
+      // user would have seen had the view never been evicted.
+      const truth = await reflowed(source, PARKED_COLS);
+      await streamStatusRepaints(truth);
+
+      // The pane as hydration builds it: prewarmed at xterm's default, never
+      // attached, carrying the persisted grid only as an attach target.
+      const live = makeTerminal(80, 24);
+      const { controller } = makeController(live, {
+        isOpened: false,
+        targetCols: PARKED_COLS,
+        targetRows: PARKED_ROWS,
+      });
+
+      controller.restoreFromSerialized("t1", snapshot.data, snapshot);
+      await flush(live);
+      // endRestoreWindow hops out of the write callback via queueMicrotask, so
+      // the geometry is only settled one tick after the replay drains.
+      await Promise.resolve();
+
+      // Live PTY output arrives long before the user selects this worktree.
+      await streamStatusRepaints(live);
+
+      expect(live.cols).toBe(PARKED_COLS);
+      expect(readBuffer(live)).toEqual(readBuffer(truth));
+      expect(cursorOf(live)).toBe(cursorOf(truth));
+    });
+
+    it("falls back to the snapshot's capture grid when the pane has no target", async () => {
+      // No persisted size reached this pane, so the grid the mirror and PTY were
+      // last agreed on is the best evidence left — still better than a default
+      // the pane was never on.
+      const { snapshot } = await capture(CAPTURE_COLS, WRAPPED_LINE, PARKED_ROWS);
+
+      const live = makeTerminal(80, 24);
+      const { controller } = makeController(live, { isOpened: false });
+
+      controller.restoreFromSerialized("t1", snapshot.data, snapshot);
+      await flush(live);
+      await Promise.resolve();
+
+      expect(live.cols).toBe(CAPTURE_COLS);
+    });
+
+    it("keeps a resize that lands mid-replay ahead of the parked target", async () => {
+      // The window seed is the only thing that changed: a real resize arriving
+      // during the replay still parks into pendingRestoreGeometry and still
+      // wins, exactly as before (#11552).
+      const { snapshot } = await capture(CAPTURE_COLS, WRAPPED_LINE, PARKED_ROWS);
+
+      const live = makeTerminal(80, 24);
+      const { controller, managed } = makeController(live, {
+        isOpened: false,
+        targetCols: PARKED_COLS,
+        targetRows: PARKED_ROWS,
+      });
+
+      controller.restoreFromSerialized("t1", snapshot.data, snapshot);
+      managed.pendingRestoreGeometry = { cols: 64, rows: 20 };
+      await flush(live);
+      await Promise.resolve();
+
+      expect(live.cols).toBe(64);
+      expect(live.rows).toBe(20);
+    });
+
+    it("leaves an opened pane's live grid authoritative", async () => {
+      // An attached pane WAS measured, so its own grid outranks a stale target.
+      const { snapshot } = await capture(CAPTURE_COLS, WRAPPED_LINE, PARKED_ROWS);
+
+      const live = makeTerminal(100);
+      const { controller } = makeController(live, {
+        isOpened: true,
+        targetCols: PARKED_COLS,
+        targetRows: PARKED_ROWS,
+      });
+
+      controller.restoreFromSerialized("t1", snapshot.data, snapshot);
+      await flush(live);
+      await Promise.resolve();
+
+      expect(live.cols).toBe(100);
+    });
   });
 });

--- a/src/services/terminal/__tests__/TerminalRestoreController.test.ts
+++ b/src/services/terminal/__tests__/TerminalRestoreController.test.ts
@@ -119,6 +119,10 @@ describe("TerminalRestoreController", () => {
       isSerializedRestoreInProgress: false,
       deferredOutput: [],
       isUserScrolledBack: false,
+      // These model an attached pane: `mockTerminal.cols` is a measured grid, so
+      // the restore window may seed from it. A never-opened pane is still on its
+      // constructor default and seeds from its target instead (#11718).
+      isOpened: true,
       ...overrides,
     } as unknown as ManagedTerminal;
   }

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -263,6 +263,12 @@ export interface ManagedTerminal {
    * overwritten by any resize that lands mid-replay
    * (`TerminalResizeController.resizeTerminal` parks instead of applying), and
    * drained by the restore that normalizes back. Undefined outside a restore.
+   *
+   * "The real grid" is `terminal.cols/rows` only for an OPENED pane. A pane that
+   * has never been opened was never measured, so it still sits at whatever it
+   * was constructed at; `TerminalRestoreController.intendedGeometry` seeds those
+   * from the attach target or the snapshot's capture grid instead, so a restore
+   * cannot strand a live background pane on a constructor default (#11718).
    */
   pendingRestoreGeometry?: TerminalGeometry;
   /**

--- a/src/store/slices/panelRegistry/__tests__/addPanelSpawnDims.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/addPanelSpawnDims.test.ts
@@ -243,7 +243,12 @@ describe("construction geometry for restored panes (#11718)", () => {
     vi.mocked(terminalInstanceService.prewarmTerminal).mockReset();
   });
 
-  /** The cols/rows the xterm constructor was actually handed for `id`. */
+  /**
+   * The options `id` was prewarmed with — spread straight into `new Terminal()`
+   * by `createManagedTerminal`, so cols/rows here are the constructor grid.
+   * (`prewarmTerminal` is mocked at this layer; the real constructor behaviour
+   * is covered against a live xterm in TerminalRestoreController.replay.test.ts.)
+   */
   async function prewarmDims(id: string): Promise<{ cols?: number; rows?: number } | undefined> {
     const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
     const call = vi
@@ -335,10 +340,35 @@ describe("construction geometry for restored panes (#11718)", () => {
     });
     await drainMicrotasks();
 
+    // All-or-nothing across every consumer — a partial application would leak
+    // the valid half into one of them.
     expect(await prewarmDims("restored-3")).not.toMatchObject({ rows: 51 });
     const spawnArgs = terminalClient.spawn.mock.calls.find(
       (call) => (call[0] as { id?: string }).id === "restored-3"
     )?.[0] as { cols: number; rows: number };
     expect(spawnArgs.rows).not.toBe(51);
+    const panel = usePanelStore.getState().panelsById["restored-3"] as PtyPanelData;
+    expect(panel.rows).not.toBe(51);
+  });
+
+  it("rejects a grid beyond the shared maximum, not just a zero one", async () => {
+    // Reachable from legacy or corrupted persisted state, and structurally
+    // different from the zero case: every field is a positive integer.
+    const { addPanel } = usePanelStore.getState();
+    await addPanel({
+      kind: "terminal",
+      launchAgentId: "claude",
+      command: "claude",
+      requestedId: "restored-4",
+      cwd: "/",
+      bypassLimits: true,
+      initialTerminalGeometry: { cols: 100_000, rows: 51 },
+    });
+    await drainMicrotasks();
+
+    expect(await prewarmDims("restored-4")).not.toMatchObject({ cols: 100_000 });
+    const panel = usePanelStore.getState().panelsById["restored-4"] as PtyPanelData;
+    expect(panel.cols).toBe(80);
+    expect(panel.rows).toBe(24);
   });
 });

--- a/src/store/slices/panelRegistry/__tests__/addPanelSpawnDims.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/addPanelSpawnDims.test.ts
@@ -213,3 +213,132 @@ describe("spawn-time PTY geometry (#10863)", () => {
     expect(spawnArgs.rows).toBe(panel.rows);
   });
 });
+
+/**
+ * Construction-time geometry for restored panes (#11718).
+ *
+ * A pane restored into a non-selected worktree is prewarmed and never attached,
+ * so nothing ever fits it — but it stays content-live and parses everything its
+ * surviving PTY streams. Born at 80×24 it commits a ~200-column agent's
+ * cursor-addressed repaints into an 80-column grid, and no later fit or Redraw
+ * can undo committed cells. Hydration hands the persisted grid in so the pane
+ * never exists at the default.
+ */
+describe("construction geometry for restored panes (#11718)", () => {
+  beforeEach(async () => {
+    const { reset } = usePanelStore.getState();
+    await reset();
+
+    const { terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn>; resize: ReturnType<typeof vi.fn> };
+    };
+    terminalClient.spawn.mockReset();
+    terminalClient.spawn.mockImplementation(async ({ id }: { id?: string }) => id ?? "spawn-id");
+    terminalClient.resize.mockReset();
+
+    const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
+    vi.mocked(terminalInstanceService.get).mockReset();
+    vi.mocked(terminalInstanceService.get).mockReturnValue(null as never);
+    vi.mocked(terminalInstanceService.sendPtyResize).mockReset();
+    vi.mocked(terminalInstanceService.prewarmTerminal).mockReset();
+  });
+
+  /** The cols/rows the xterm constructor was actually handed for `id`. */
+  async function prewarmDims(id: string): Promise<{ cols?: number; rows?: number } | undefined> {
+    const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
+    const call = vi
+      .mocked(terminalInstanceService.prewarmTerminal)
+      .mock.calls.find((c) => c[0] === id);
+    return call?.[2] as { cols?: number; rows?: number } | undefined;
+  }
+
+  it("builds a reconnected pane's xterm at the persisted grid and never touches its PTY", async () => {
+    const { terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn>; resize: ReturnType<typeof vi.fn> };
+    };
+    const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
+
+    const { addPanel } = usePanelStore.getState();
+    await addPanel({
+      kind: "terminal",
+      launchAgentId: "claude",
+      command: "claude",
+      existingId: "restored-1",
+      cwd: "/",
+      bypassLimits: true,
+      initialTerminalGeometry: { cols: 203, rows: 51 },
+    });
+    await drainMicrotasks();
+
+    // The constructor, not a later resize: the exposure window this closes runs
+    // from construction, and a parked xterm has no attach to consume a target.
+    expect(await prewarmDims("restored-1")).toMatchObject({ cols: 203, rows: 51 });
+    // Panel record agrees, so every other consumer of the pane's grid does too.
+    const panel = usePanelStore.getState().panelsById["restored-1"] as PtyPanelData;
+    expect(panel.cols).toBe(203);
+    expect(panel.rows).toBe(51);
+    // Renderer-only. The reconnected PTY is already on this grid, and the
+    // estimate this path would otherwise send is a fixed guess, not a fit.
+    expect(terminalInstanceService.sendPtyResize).not.toHaveBeenCalled();
+    expect(terminalClient.resize).not.toHaveBeenCalled();
+    expect(terminalClient.spawn).not.toHaveBeenCalled();
+  });
+
+  it("boots a respawned pane's PTY on the same grid it built the xterm at", async () => {
+    const { terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn> };
+    };
+
+    const { addPanel } = usePanelStore.getState();
+    await addPanel({
+      kind: "terminal",
+      launchAgentId: "claude",
+      command: "claude",
+      requestedId: "restored-2",
+      cwd: "/",
+      bypassLimits: true,
+      initialTerminalGeometry: { cols: 203, rows: 51 },
+    });
+    await drainMicrotasks();
+
+    // A respawn creates a NEW PTY, so seeding the renderer alone would just
+    // invert the bug — the agent would paint for 80 columns into a 203-column
+    // grid. The pair is the invariant, not either value alone.
+    const spawnArgs = terminalClient.spawn.mock.calls.find(
+      (call) => (call[0] as { id?: string }).id === "restored-2"
+    )?.[0] as { cols: number; rows: number };
+    expect(spawnArgs).toBeDefined();
+    expect(await prewarmDims("restored-2")).toMatchObject({
+      cols: spawnArgs.cols,
+      rows: spawnArgs.rows,
+    });
+    expect(spawnArgs.cols).toBe(203);
+    expect(spawnArgs.rows).toBe(51);
+  });
+
+  it("ignores a geometry that is not a grid a terminal could have had", async () => {
+    const { terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn> };
+    };
+
+    const { addPanel } = usePanelStore.getState();
+    await addPanel({
+      kind: "terminal",
+      launchAgentId: "claude",
+      command: "claude",
+      requestedId: "restored-3",
+      cwd: "/",
+      bypassLimits: true,
+      // Half-valid: partially defaulting it would boot the pane on a grid the
+      // PTY is not on, which is the failure being fixed.
+      initialTerminalGeometry: { cols: 0, rows: 51 } as never,
+    });
+    await drainMicrotasks();
+
+    expect(await prewarmDims("restored-3")).not.toMatchObject({ rows: 51 });
+    const spawnArgs = terminalClient.spawn.mock.calls.find(
+      (call) => (call[0] as { id?: string }).id === "restored-3"
+    )?.[0] as { cols: number; rows: number };
+    expect(spawnArgs.rows).not.toBe(51);
+  });
+});

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -722,8 +722,8 @@ export const createAddPanelActions = (
       originalPresetId: options.originalPresetId ?? options.agentPresetId,
       agentLaunchFlags: options.agentLaunchFlags,
       env: computeEnvProvenance(options.env),
-      initialCols: 80,
-      initialRows: 24,
+      initialCols: constructionDims?.cols ?? 80,
+      initialRows: constructionDims?.rows ?? 24,
       spawnedBy: options.spawnedBy,
       resumedFromSessionId: options.agentSessionId,
     });

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -39,6 +39,7 @@ import { agentLifecycleLedger } from "@/services/terminal/lifecycleLedger";
 import { computeEnvProvenance } from "@shared/utils/agentLifecycleLedger";
 import { getViewWorkspaceId } from "@/store/viewWorkspaceId";
 import { countPanelsTowardLimit } from "./panelCount";
+import { isValidTerminalGeometry } from "@shared/types/terminal";
 
 // Lazy accessor to break circular dependency: addPanel -> projectStore -> panelPersistence -> addPanel.
 // Resolved on first call (after app init), then cached.
@@ -460,6 +461,19 @@ export const createAddPanelActions = (
         ? estimateOverlayGridDims(getTerminalAppearanceSnapshot().fontSize)
         : null;
 
+    // The grid this pane is BORN on. Hydration supplies the persisted size for
+    // a restored pane so it never exists at 80×24 — a restore into a
+    // non-selected worktree is prewarmed and never fitted, so the default would
+    // stand for as long as the user stays away while the surviving PTY streams
+    // into it (#11718). Overlay keeps precedence: its estimate is the grid its
+    // XtermAdapter is about to fit to, and the two never co-occur (an overlay
+    // is never a restore). Re-validated here because `addPanel` is also reached
+    // from plugins and MCP.
+    const restoredDims = isValidTerminalGeometry(options.initialTerminalGeometry)
+      ? options.initialTerminalGeometry
+      : null;
+    const constructionDims = overlayDims ?? restoredDims;
+
     // Single active-grid launches mount their visible xterm immediately
     // (TerminalPane skips the spawnStatus gate), overlapping xterm.open()
     // and the first fit with the env fetch + spawn IPC below. Decided at
@@ -484,8 +498,8 @@ export const createAddPanelActions = (
       ...(options.titleMode && { titleMode: options.titleMode }),
       worktreeId: options.worktreeId,
       cwd: options.cwd ?? "",
-      cols: overlayDims?.cols ?? 80,
-      rows: overlayDims?.rows ?? 24,
+      cols: constructionDims?.cols ?? 80,
+      rows: constructionDims?.rows ?? 24,
       agentState,
       waitingReason,
       lastStateChange,
@@ -790,9 +804,10 @@ export const createAddPanelActions = (
       // Overlay panes are BORN at their estimated grid (xterm constructor
       // cols/rows) so pre-attach CLI output wraps near the final width — a
       // prewarmed-but-unattached xterm otherwise sits at the 80×24 default
-      // until the help panel's XtermAdapter mounts (#10863).
-      const prewarmOptions = overlayDims
-        ? { ...terminalOptions, cols: overlayDims.cols, rows: overlayDims.rows }
+      // until the help panel's XtermAdapter mounts (#10863). Restored panes get
+      // their persisted grid the same way, for the same reason (#11718).
+      const prewarmOptions = constructionDims
+        ? { ...terminalOptions, cols: constructionDims.cols, rows: constructionDims.rows }
         : terminalOptions;
 
       // Prewarm ALL terminal types to ensure the managed instance and data
@@ -839,8 +854,12 @@ export const createAddPanelActions = (
         // spawn path just fixed (#10863), and for a settled-strategy agent
         // this call arms a 500ms timer that can land AFTER the spawn. When the
         // estimate is unavailable (non-finite inputs), skip entirely and let
-        // the spawn-time dims own overlay geometry.
-        if (!isDockOrInactive && (location !== "overlay" || overlayDims)) {
+        // the spawn-time dims own overlay geometry. A restored pane skips it
+        // too: its PTY is already on the persisted grid we just constructed at,
+        // and this estimate is a fixed DOCK_TERM-derived guess, not a
+        // measurement — sending it would move a healthy PTY off that grid
+        // (#11718).
+        if (!isDockOrInactive && !restoredDims && (location !== "overlay" || overlayDims)) {
           const { cols, rows } =
             overlayDims ?? calculateTerminalDimensions(widthPx, heightPx, fontSize);
           terminalInstanceService.sendPtyResize(id, cols, rows);
@@ -926,8 +945,8 @@ export const createAddPanelActions = (
           // pty-host (no terminal yet), and booting at 80×24 anyway left the
           // CLI painting a width the renderer wasn't wrapping at (#10863).
           const attachedDims = getAttachedGridDims(id);
-          const spawnCols = attachedDims?.cols ?? overlayDims?.cols ?? 80;
-          const spawnRows = attachedDims?.rows ?? overlayDims?.rows ?? 24;
+          const spawnCols = attachedDims?.cols ?? constructionDims?.cols ?? 80;
+          const spawnRows = attachedDims?.rows ?? constructionDims?.rows ?? 24;
           await terminalClient.spawn({
             id,
             projectId: capturedWorkspaceId,

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -410,6 +410,73 @@ describe("restorePanelsPhase — saved panels", () => {
     await restorePanelsPhase([panel("t1")], ctx);
     expect(setTargetSizeMock).not.toHaveBeenCalled();
   });
+
+  /**
+   * The saved size must reach xterm's CONSTRUCTOR, not just the attach target
+   * (#11718). `setTargetSize` is consumed at first attach, and a pane restored
+   * into a non-selected worktree never attaches — it sits prewarmed at 80×24
+   * parsing everything its surviving PTY streams. The size is keyed by the
+   * persisted id, so it is resolvable before `addPanel`, which is the only point
+   * early enough to close the window completely.
+   */
+  const geometryPassedToAddPanel = (
+    addPanel: Mock,
+    id: string
+  ): { cols: number; rows: number } | undefined =>
+    (
+      addPanel.mock.calls.find(
+        (call) => (call[0] as { existingId?: string; requestedId?: string }).existingId === id
+      )?.[0] as { initialTerminalGeometry?: { cols: number; rows: number } }
+    )?.initialTerminalGeometry;
+
+  it("hands the saved grid to addPanel when reconnecting a matched backend terminal", async () => {
+    const ctx = makeContext({ terminalSizes: { t1: { cols: 203, rows: 51 } } });
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+    await restorePanelsPhase([panel("t1")], ctx);
+    expect(geometryPassedToAddPanel(ctx.addPanel, "t1")).toEqual({ cols: 203, rows: 51 });
+  });
+
+  it("hands the saved grid to addPanel on the reconnect-fallback path", async () => {
+    const ctx = makeContext({ terminalSizes: { t1: { cols: 203, rows: 51 } } });
+    reconnectWithTimeoutMock.mockResolvedValue({
+      status: "found",
+      terminal: { id: "t1", cwd: "/cwd" },
+    });
+    await restorePanelsPhase([panel("t1")], ctx);
+    expect(geometryPassedToAddPanel(ctx.addPanel, "t1")).toEqual({ cols: 203, rows: 51 });
+  });
+
+  it("hands the saved grid to addPanel when respawning a dead PTY", async () => {
+    const ctx = makeContext({ terminalSizes: { t1: { cols: 203, rows: 51 } } });
+    reconnectWithTimeoutMock.mockResolvedValue({ status: "not_found" });
+    await restorePanelsPhase([panel("t1")], ctx);
+    const respawnArgs = ctx.addPanel.mock.calls[0]?.[0] as {
+      initialTerminalGeometry?: { cols: number; rows: number };
+    };
+    expect(respawnArgs.initialTerminalGeometry).toEqual({ cols: 203, rows: 51 });
+  });
+
+  it("omits an invalid saved grid rather than partially defaulting it", async () => {
+    const ctx = makeContext({ terminalSizes: { t1: { cols: 0, rows: 51 } } });
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+    await restorePanelsPhase([panel("t1")], ctx);
+    expect(geometryPassedToAddPanel(ctx.addPanel, "t1")).toBeUndefined();
+  });
+
+  it("resolves the grid before addPanel, not after it returns", async () => {
+    // The ordering IS the fix: an xterm prewarmed inside addPanel has already
+    // begun parsing live PTY output by the time addPanel resolves.
+    const ctx = makeContext({ terminalSizes: { t1: { cols: 203, rows: 51 } } });
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+    let sawTargetSizeBeforeAddPanel = false;
+    ctx.addPanel.mockImplementation(async (args: { existingId?: string }) => {
+      if (setTargetSizeMock.mock.calls.length > 0) sawTargetSizeBeforeAddPanel = true;
+      return args.existingId ?? "";
+    });
+    await restorePanelsPhase([panel("t1")], ctx);
+    expect(sawTargetSizeBeforeAddPanel).toBe(false);
+    expect(geometryPassedToAddPanel(ctx.addPanel, "t1")).toEqual({ cols: 203, rows: 51 });
+  });
 });
 
 describe("restorePanelsPhase — worktree re-home validation (#11387)", () => {

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -465,17 +465,21 @@ describe("restorePanelsPhase — saved panels", () => {
 
   it("resolves the grid before addPanel, not after it returns", async () => {
     // The ordering IS the fix: an xterm prewarmed inside addPanel has already
-    // begun parsing live PTY output by the time addPanel resolves.
+    // begun parsing live PTY output by the time addPanel resolves. Read
+    // synchronously inside the mock — vitest records the args object by
+    // reference, so inspecting it afterwards cannot distinguish a value that was
+    // present on entry from one assigned after addPanel returned.
     const ctx = makeContext({ terminalSizes: { t1: { cols: 203, rows: 51 } } });
     ctx.backendTerminalMap.set("t1", backend("t1"));
-    let sawTargetSizeBeforeAddPanel = false;
-    ctx.addPanel.mockImplementation(async (args: { existingId?: string }) => {
-      if (setTargetSizeMock.mock.calls.length > 0) sawTargetSizeBeforeAddPanel = true;
-      return args.existingId ?? "";
-    });
+    let geometryOnEntry: unknown = "addPanel was never called";
+    ctx.addPanel.mockImplementation(
+      async (args: { existingId?: string; initialTerminalGeometry?: unknown }) => {
+        geometryOnEntry = args.initialTerminalGeometry;
+        return args.existingId ?? "";
+      }
+    );
     await restorePanelsPhase([panel("t1")], ctx);
-    expect(sawTargetSizeBeforeAddPanel).toBe(false);
-    expect(geometryPassedToAddPanel(ctx.addPanel, "t1")).toEqual({ cols: 203, rows: 51 });
+    expect(geometryOnEntry).toEqual({ cols: 203, rows: 51 });
   });
 });
 
@@ -712,6 +716,21 @@ describe("restorePanelsPhase — orphan reconnection", () => {
     const { restoreTasks } = await restorePanelsPhase([], ctx);
     expect(ctx.addPanel).not.toHaveBeenCalled();
     expect(restoreTasks).toEqual([]);
+  });
+
+  it("hands an orphan's saved grid to addPanel, keyed by its backend id (#11718)", async () => {
+    // Orphans go through the same prewarm-then-target ordering as saved panels
+    // and can be attributed to a worktree that is not the selected one, so they
+    // are squarely in this bug's blast radius.
+    const ctx = makeContext({
+      activeWorktreeId: "wA",
+      terminalSizes: { o1: { cols: 203, rows: 51 } },
+    });
+    ctx.backendTerminalMap.set("o1", backend("o1"));
+    await restorePanelsPhase([], ctx);
+    expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({
+      initialTerminalGeometry: { cols: 203, rows: 51 },
+    });
   });
 });
 

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -38,8 +38,33 @@ import {
   getCurrentLaunchCliDetail,
   resolveAgentLaunchBaseCommand,
 } from "@/utils/agentLaunchCommand";
+import { isValidTerminalGeometry } from "@shared/types/terminal";
+import type { TerminalGeometry } from "@shared/types/terminal";
 
 type AddPanelFn = HydrationOptions["addPanel"];
+
+/**
+ * The persisted grid for a saved pane, keyed by the id it was persisted under —
+ * resolvable BEFORE `addPanel`, which is the whole point.
+ *
+ * `setTargetSize` after the fact only parks the size for the next attach, and a
+ * pane restored into a non-selected worktree never attaches: it sits prewarmed
+ * at xterm's 80×24 default parsing everything its surviving PTY streams
+ * (#11718). Feeding this into the xterm constructor instead closes the window
+ * entirely — there is no moment at which the pane exists on the wrong grid.
+ *
+ * Rejects anything not a plausible grid rather than partially defaulting: a
+ * half-valid entry would boot the pane on a geometry the PTY is not on, which
+ * is the failure being fixed.
+ */
+function resolvePersistedGeometry(
+  terminalSizes: Record<string, { cols: number; rows: number }> | undefined,
+  terminalId: string
+): TerminalGeometry | undefined {
+  if (!terminalSizes || typeof terminalSizes !== "object") return undefined;
+  const saved = terminalSizes[terminalId];
+  return isValidTerminalGeometry(saved) ? saved : undefined;
+}
 type RestoreTerminalOrderFn = NonNullable<HydrationOptions["restoreTerminalOrder"]>;
 
 /**
@@ -623,6 +648,10 @@ export async function restorePanelsPhase(
             // onto the moved worktree's new root so persisted state and a later
             // respawn don't reference the vanished path (#11388).
             rebaseMovedArgsCwd(args, movedRootsById.get(saved.id));
+            // Born on the persisted grid, not 80×24 — the reconnected PTY is
+            // already there and a hidden-worktree pane never gets fitted
+            // (#11718).
+            args.initialTerminalGeometry = resolvePersistedGeometry(terminalSizes, saved.id);
             const location = args.location as "grid" | "dock";
 
             logHydrationInfo(`[HYDRATION] Adding terminal from backend:`, {
@@ -709,6 +738,10 @@ export async function restorePanelsPhase(
                 // Rebase the reconnected PTY's live (old-path) cwd onto the
                 // moved worktree's new root, like the matched-backend path.
                 rebaseMovedArgsCwd(reconnectArgs, movedRootsById.get(saved.id));
+                reconnectArgs.initialTerminalGeometry = resolvePersistedGeometry(
+                  terminalSizes,
+                  saved.id
+                );
                 const restoredTerminalId = await addPanel(reconnectArgs);
                 restoredIdsByIndex.set(capturedIndex, restoredTerminalId);
 
@@ -771,6 +804,14 @@ export async function restorePanelsPhase(
                 // worktreeId, or names a deleted one — which also keeps the
                 // respawn's cwd pointing at a directory that still exists.
                 respawnArgs.worktreeId = await resolveRestoredWorktreeId(respawnArgs.worktreeId);
+
+                // A respawn boots a NEW PTY, so this also pairs the spawn: the
+                // renderer and the PTY start on one grid instead of the pane
+                // being seeded wide while the agent paints for 80 columns.
+                respawnArgs.initialTerminalGeometry = resolvePersistedGeometry(
+                  terminalSizes,
+                  saved.id
+                );
 
                 logHydrationInfo(
                   `Respawning PTY panel: ${saved.id} (${respawnArgs.launchAgentId ? "agent" : "terminal"})`
@@ -1004,6 +1045,9 @@ export async function restorePanelsPhase(
           orphanArgs.worktreeId = effectiveActiveWorktreeId;
           orphanArgs.worktreeIdSource = "inferred";
         }
+        // Same prewarm-before-target ordering as the saved-panel paths, and an
+        // orphan can land in a worktree that is not the selected one.
+        orphanArgs.initialTerminalGeometry = resolvePersistedGeometry(terminalSizes, terminal.id);
         const restoredTerminalId = await addPanel(orphanArgs);
 
         if (terminal.activityTier) {


### PR DESCRIPTION
## The bug

A pane restored into a worktree that isn't the selected one is prewarmed but never attached, so nothing ever fits it, yet it stays deliberately content-live and parses everything its surviving PTY streams. Born at xterm's 80×24 constructor default, it committed a ~200-column agent's cursor-addressed repaints into an 80-column grid. That's committed cell data, which is why Redraw never fixed it and the pane only healed once new output scrolled the damage away. Full project-view eviction under memory pressure is what made this routine rather than rare: the memory drop in the report is the eviction.

Two links in the chain, both closed here:

1. The persisted grid existed, but `setTargetSize` only writes `targetCols`/`targetRows`, which are consumed in `ensureOpened`, reachable only from `attach()`, which a background pane never reaches.
2. `beginRestoreWindow` seeded `pendingRestoreGeometry` from `managed.terminal.cols/rows` at that moment, so `endRestoreWindow` snapped a correctly-aligned replay straight back to the constructor default.

## The fix

Renderer grid only: the PTY is already on the right grid, so nothing on this path resizes it.

- Thread the persisted grid into the xterm **constructor** via a new `initialTerminalGeometry` option (hydration → `addPanel` → `prewarmTerminal` → `new Terminal`), generalizing the overlay path from #10863. The size is keyed by the persisted id, so it was always resolvable *before* `addPanel`, the only point early enough to close the whole exposure window.
- Applied in all four PTY restore branches: matched backend, reconnect fallback, respawn, and orphan reconnect.
- Pair a **respawn's** PTY spawn dims to the same grid: a respawn boots a new PTY, so seeding only the renderer would just invert the bug. Skip the estimated `sendPtyResize` for a reconnect: that estimate is a fixed `DOCK_TERM`-derived guess, not a fit, and its PTY is already correct.
- Seed the restore window from the pane's *intended* grid. `terminal.cols/rows` is evidence only once xterm has been opened against a measured host; a parked pane seeds from its attach target instead, and with no valid target seeds nothing at all, so `endRestoreWindow` skips its corrective resize and the pane keeps the capture grid the replay just put it on. Only the seed changes, so a resize landing mid-replay still parks and still wins (#11552).
- Stamp the lifecycle ledger with the real construction grid instead of a hard-coded 80×24, so the audit trail stops reporting the exact false geometry this fix exists to diagnose.

## Why "no target" is an absent seed rather than the capture geometry

`fetchAndRestore` opens its restore window *before* the snapshot exists, and a nested restore cannot reseed an open window. Since that's the entry point hydration actually uses (`scrollbackRestoreScheduler`), a seed computed from capture geometry would have been dead code on the real path. Expressing it as an absent target is what makes every entry point agree.

## Tests

Real `@xterm/headless` under `@vitest-environment node`, compared against a reflowed twin rather than hardcoded values, following the #11552 pattern. The headline test streams cursor-addressed status-line repaints into a parked pane before any attach and asserts its buffer and cursor match a twin that was on the real grid all along. Six of the new parked-pane tests fail without the fix; the rest guard behavior that must not change (mid-replay resize precedence, opened-pane authority, all-or-nothing validation). Also covers both `fetchAndRestore` orderings, the incremental path, the orphan branch, and over-maximum grids.

Verified locally: 982 tests across 55 affected files, tsc, scoped prettier/eslint, and the lint ratchet.

## Follow-ups (not in this PR)

- **Defect 2 from the issue**: pty-host mirror divergence (`TerminalProcess.resize` early-return, `AnalysisWorkerPool.post()` swallowing throws, `WorkerAnalysisBackend.resize` missing `flushHeldFeed()`, no mirror-grid logging). Out of scope by request; needs its own issue.
- **`terminalSizes` is never written.** `projectClient.setTerminalSizes` has no production caller, and main only preserves `existingState?.terminalSizes`, so persisted grids are never refreshed; entries are legacy-only or absent. This fix degrades correctly either way (no entry → the pane lands on the capture grid instead of 80×24; a stale entry → it lands on the stale grid where `develop` lands on 80×24), but the persistence gap is worth its own issue.

Resolves #11718
