### PR TITLE
feat(copytree): curated clipboard bundles from an MCP assistant

### DIFF
--- a/electron/schemas/__tests__/copyTreeSelectionValidation.test.ts
+++ b/electron/schemas/__tests__/copyTreeSelectionValidation.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { CopyTreeOptionsSchema } from "../ipc.js";
+
+/**
+ * The IPC half of the selection guard (#11722).
+ *
+ * `filter` and `includePaths` are one selection set, unioned in
+ * `CopyTreeService`. An empty selection cannot be expressed to the CopyTree SDK
+ * — it reads a missing or empty filter as "no filter" and returns the whole
+ * worktree — so an empty list or a blank entry has to be rejected at the
+ * boundary rather than normalized downstream. Getting this wrong turns a
+ * malformed narrow request into a full-repo bundle on the user's clipboard,
+ * which is why it is pinned on both schemas independently: the renderer action
+ * schema guards MCP/palette callers, this one guards everything that reaches
+ * the main process.
+ */
+describe("CopyTreeOptionsSchema selection guards", () => {
+  const parse = (options: unknown) => CopyTreeOptionsSchema.safeParse(options).success;
+
+  it("rejects a selection that would resolve to nothing", () => {
+    for (const options of [
+      { includePaths: [] },
+      { includePaths: [""] },
+      { includePaths: ["src/a.ts", ""] },
+      { filter: [] },
+      { filter: [""] },
+      { filter: "" },
+    ]) {
+      expect(parse(options)).toBe(false);
+    }
+  });
+
+  it("accepts a real selection in either spelling, and both together", () => {
+    expect(parse({ includePaths: ["src/a.ts"] })).toBe(true);
+    expect(parse({ filter: "src/**" })).toBe(true);
+    expect(parse({ filter: ["src/**"] })).toBe(true);
+    expect(parse({ includePaths: ["src/a.ts"], filter: ["tests/**"] })).toBe(true);
+  });
+
+  it("still treats an omitted selection as the whole worktree", () => {
+    // Absent is the one shape that legitimately means "everything" — the guard
+    // above must not have made the field effectively required.
+    expect(parse({})).toBe(true);
+    expect(parse({ format: "xml" })).toBe(true);
+  });
+});

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -473,10 +473,14 @@ export const CopyTreeFormatSchema = z.enum(["xml", "json", "markdown", "tree", "
 export const CopyTreeOptionsSchema = z
   .object({
     format: CopyTreeFormatSchema.optional(),
-    filter: z.union([z.string(), z.array(z.string())]).optional(),
+    // `filter`/`includePaths` are one selection set and are unioned in
+    // CopyTreeService. Blank entries are rejected rather than dropped: an empty
+    // selection reads as "the whole worktree" downstream, so discarding a blank
+    // would widen a malformed narrow request into a full-repo copy.
+    filter: z.union([z.string().min(1), z.array(z.string().min(1))]).optional(),
     exclude: z.union([z.string(), z.array(z.string())]).optional(),
     always: z.array(z.string()).optional(),
-    includePaths: z.array(z.string()).optional(),
+    includePaths: z.array(z.string().min(1)).optional(),
     // Non-empty at both levels: an empty list or a blank entry would resolve to
     // the worktree root, turning a folder copy into a whole-worktree copy that
     // no caller asked for. Absent still means "no scoping".

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -474,13 +474,14 @@ export const CopyTreeOptionsSchema = z
   .object({
     format: CopyTreeFormatSchema.optional(),
     // `filter`/`includePaths` are one selection set and are unioned in
-    // CopyTreeService. Blank entries are rejected rather than dropped: an empty
-    // selection reads as "the whole worktree" downstream, so discarding a blank
-    // would widen a malformed narrow request into a full-repo copy.
-    filter: z.union([z.string().min(1), z.array(z.string().min(1))]).optional(),
+    // CopyTreeService. Non-empty at both levels, like `scopePaths` below: an
+    // empty list or a blank entry leaves the selection empty, which the SDK
+    // reads as "no filter" — i.e. the whole worktree. Rejecting them here keeps
+    // a malformed narrow request from widening into a full-repo copy.
+    filter: z.union([z.string().min(1), z.array(z.string().min(1)).min(1)]).optional(),
     exclude: z.union([z.string(), z.array(z.string())]).optional(),
     always: z.array(z.string()).optional(),
-    includePaths: z.array(z.string().min(1)).optional(),
+    includePaths: z.array(z.string().min(1)).min(1).optional(),
     // Non-empty at both levels: an empty list or a blank entry would resolve to
     // the worktree root, turning a folder copy into a whole-worktree copy that
     // no caller asked for. Absent still means "no scoping".

--- a/electron/services/CopyTreeService.ts
+++ b/electron/services/CopyTreeService.ts
@@ -595,6 +595,32 @@ class CopyTreeService {
     }
   }
 
+  /**
+   * Union `includePaths` and `filter` into the SDK's single `filter`.
+   *
+   * These are two spellings of one selection set. They collapsed with `||`
+   * before, so `includePaths` silently won and a caller that split its selection
+   * across both — literal files in one, globs in the other — lost half of it
+   * with no error and no diagnostic. That split is the natural shape for a
+   * curated bundle assembled by an assistant, which is how the loss surfaced
+   * (#11722).
+   *
+   * Order is `includePaths` first to preserve the previous precedence in the
+   * common single-field case. Duplicates are dropped because a repeated pattern
+   * is counted per match downstream; `undefined` (not `[]`) means "no
+   * selection", since an empty array reads as "select nothing" to the SDK.
+   */
+  private static mergeSelectionPatterns(
+    includePaths: string[] | undefined,
+    filter: string | string[] | undefined
+  ): string[] | undefined {
+    const merged = [
+      ...(includePaths ?? []),
+      ...(filter === undefined ? [] : Array.isArray(filter) ? filter : [filter]),
+    ].filter((pattern) => pattern.length > 0);
+    return merged.length > 0 ? Array.from(new Set(merged)) : undefined;
+  }
+
   private buildSdkOptions(options: CopyTreeOptions, signal: AbortSignal): SdkCopyOptions {
     return {
       signal,
@@ -603,7 +629,7 @@ class CopyTreeService {
       quiet: true,
       format: options.format || "xml",
 
-      filter: options.includePaths || options.filter || undefined,
+      filter: CopyTreeService.mergeSelectionPatterns(options.includePaths, options.filter),
       // Literal paths, not patterns, and orthogonal to `filter`: the walk starts
       // here but the ignore stack is still built from the root down, so a folder
       // copy drops what a whole-project copy would have dropped. Both

--- a/electron/services/CopyTreeService.ts
+++ b/electron/services/CopyTreeService.ts
@@ -616,8 +616,14 @@ class CopyTreeService {
    * a blank pattern here would turn "the caller asked for something that matches
    * nothing" into "copy the entire worktree" — inverting a fail-closed selection
    * into a fail-open one, and putting a whole repo on the clipboard when an
-   * assistant emits a malformed list. Blank entries are rejected by the schemas
-   * instead, where a caller gets told what was wrong.
+   * assistant emits a malformed list.
+   *
+   * Precondition, enforced at both validated boundaries (`CopyTreeOptionsSchema`
+   * in the renderer action definitions and its twin in `electron/schemas/ipc.ts`):
+   * a supplied selection is non-empty and carries no blank entries. Those reject
+   * rather than normalize, so a caller is told what was wrong instead of quietly
+   * receiving everything — an empty array reaching this point would read as "no
+   * filter" one layer down and copy the whole worktree.
    */
   private static mergeSelectionPatterns(
     includePaths: string[] | undefined,

--- a/electron/services/CopyTreeService.ts
+++ b/electron/services/CopyTreeService.ts
@@ -605,20 +605,30 @@ class CopyTreeService {
    * curated bundle assembled by an assistant, which is how the loss surfaced
    * (#11722).
    *
-   * Order is `includePaths` first to preserve the previous precedence in the
-   * common single-field case. Duplicates are dropped because a repeated pattern
-   * is counted per match downstream; `undefined` (not `[]`) means "no
-   * selection", since an empty array reads as "select nothing" to the SDK.
+   * `includePaths` goes first so a single-field call keeps the order it had.
+   * Duplicates are dropped to keep the advertised pattern list tidy — the SDK
+   * stops at the first matching pattern per file, so this changes the selected
+   * set for nobody.
+   *
+   * Only the both-absent case yields `undefined` ("no selection, take the whole
+   * worktree"). A supplied-but-unmatchable selection is passed through as-is,
+   * NOT normalized away: the SDK reads a missing filter as all-files, so dropping
+   * a blank pattern here would turn "the caller asked for something that matches
+   * nothing" into "copy the entire worktree" — inverting a fail-closed selection
+   * into a fail-open one, and putting a whole repo on the clipboard when an
+   * assistant emits a malformed list. Blank entries are rejected by the schemas
+   * instead, where a caller gets told what was wrong.
    */
   private static mergeSelectionPatterns(
     includePaths: string[] | undefined,
     filter: string | string[] | undefined
   ): string[] | undefined {
+    if (includePaths === undefined && filter === undefined) return undefined;
     const merged = [
       ...(includePaths ?? []),
       ...(filter === undefined ? [] : Array.isArray(filter) ? filter : [filter]),
-    ].filter((pattern) => pattern.length > 0);
-    return merged.length > 0 ? Array.from(new Set(merged)) : undefined;
+    ];
+    return Array.from(new Set(merged));
   }
 
   private buildSdkOptions(options: CopyTreeOptions, signal: AbortSignal): SdkCopyOptions {

--- a/electron/services/__tests__/CopyTreeService.sdk-contract.test.ts
+++ b/electron/services/__tests__/CopyTreeService.sdk-contract.test.ts
@@ -493,9 +493,10 @@ describe("CopyTreeService against the installed CopyTree", () => {
         "src/landscape/support/nested/seed.ts",
         "tests/landscape/generator.test.ts",
       ]);
-      // Proves the decoys were walked and then filtered, rather than the walk
-      // never reaching them — without this the assertion above would also pass
-      // on a broken traversal that found nothing.
+      // Exclusion accounting: files were walked and then ruled out by the
+      // pattern, so the count above is a filtered result rather than an empty
+      // traversal. (The exact-list assertion is what proves the selection; this
+      // catches the accounting going silent.)
       expect(result.excluded?.byReason.filterPattern).toBeGreaterThan(0);
     });
 
@@ -554,29 +555,56 @@ describe("CopyTreeService against the installed CopyTree", () => {
     // `.github/workflows/**` or a dotfile config; ordinary sources and tests,
     // which is what the feature is for, are unaffected.
     //
-    // Deliberately `it.fails`: it must not encode the bug as desired behavior,
-    // and it must speak up rather than sit silent once the fix lands. When a
-    // copytree release carrying `{ dot: true }` here is published and this
-    // repo's dependency is raised to it, this test starts FAILING — at which
-    // point drop the `.fails` and keep the assertion as the regression.
-    it.fails("selects a dotfile through a curated glob", async () => {
+    // Pinned as current behavior rather than `it.fails`, which flips ANY
+    // failure to green — a broken fixture write or a renamed option would have
+    // "passed" it forever. The non-dot control is what makes this honest: it
+    // proves the glob and the traversal work, so the dotfile's absence is the
+    // upstream gap and not a typo. When a copytree release with `{ dot: true }`
+    // lands and this repo's dependency is raised to it, the second assertion
+    // starts failing — flip it to `toContain` and delete this comment.
+    it("does not reach a dotfile through a curated glob (upstream copytree gap)", async () => {
       await writeFixture("config/landscape/.defaults.json", '{"DOTFILE_SENTINEL":1}\n');
+      await writeFixture("config/landscape/visible.json", '{"CONTROL_SENTINEL":1}\n');
 
       const result = await copyTreeService.testConfig(tempDir, {
         includePaths: ["config/landscape/**"],
       });
 
-      expect((result.files ?? []).map((file) => file.path)).toContain(
-        "config/landscape/.defaults.json"
-      );
+      expect(result.error).toBeUndefined();
+      const selected = (result.files ?? []).map((file) => file.path);
+      expect(selected).toContain("config/landscape/visible.json");
+      expect(selected).not.toContain("config/landscape/.defaults.json");
     });
 
     it("still selects everything when neither field is given", async () => {
-      // Guards the merge helper's empty case: `[]` would read as "select
-      // nothing" to the SDK, so it must stay `undefined`.
       const result = await copyTreeService.testConfig(tempDir, {});
 
       expect((result.files ?? []).map((file) => file.path)).toContain("src/landscape/preview.ts");
+    });
+
+    // The merge must never widen a selection. An absent filter means "the whole
+    // worktree" to the SDK, so a supplied-but-unmatchable selection that got
+    // normalized away would put the entire repo on the user's clipboard — the
+    // opposite of what the caller asked for, and worst exactly when an
+    // assistant emits a malformed list.
+    it("copies nothing, not everything, when the selection matches nothing", async () => {
+      const result = await copyTreeService.testConfig(tempDir, {
+        includePaths: ["does/not/exist/**"],
+      });
+
+      const selected = (result.files ?? []).map((file) => file.path);
+      expect(selected).toEqual([]);
+      expect(selected).not.toContain("src/landscape/preview.ts");
+    });
+
+    it("treats a blank pattern as unmatchable rather than as no selection", async () => {
+      // The schemas reject a blank entry before this point; if one ever reaches
+      // the service it must still fail closed.
+      const result = await copyTreeService.testConfig(tempDir, { includePaths: [""] });
+
+      expect((result.files ?? []).map((file) => file.path)).not.toContain(
+        "src/landscape/preview.ts"
+      );
     });
   });
 });

--- a/electron/services/__tests__/CopyTreeService.sdk-contract.test.ts
+++ b/electron/services/__tests__/CopyTreeService.sdk-contract.test.ts
@@ -450,4 +450,133 @@ describe("CopyTreeService against the installed CopyTree", () => {
       expect(nodes.map((node) => node.name)).not.toContain("logs");
     });
   });
+
+  // The shape an assistant produces when asked for "everything relevant to X,
+  // including supporting files and tests" (#11722): a handful of exact paths
+  // mixed with globs, scattered across the tree rather than under one subtree.
+  // `scopePaths` cannot express it — it takes literal subtrees and recomputes
+  // budgets over them — so this rides entirely on `includePaths`/`filter`.
+  describe("curated mixed selection", () => {
+    async function writeFixture(relativePath: string, contents: string) {
+      const absolute = path.join(tempDir, relativePath);
+      await fs.mkdir(path.dirname(absolute), { recursive: true });
+      await fs.writeFile(absolute, contents);
+    }
+
+    beforeEach(async () => {
+      await writeFixture("src/landscape/generator.ts", "export const GENERATOR_SENTINEL = 1;\n");
+      await writeFixture("src/landscape/support/math.ts", "export const SUPPORT_SENTINEL = 1;\n");
+      await writeFixture(
+        "src/landscape/support/nested/seed.ts",
+        "export const NESTED_SENTINEL = 1;\n"
+      );
+      await writeFixture("tests/landscape/generator.test.ts", "export const TEST_SENTINEL = 1;\n");
+      // Decoys: same tree, same extensions, deliberately unselected.
+      await writeFixture("src/landscape/preview.ts", "export const PREVIEW_DECOY = 1;\n");
+      await writeFixture("tests/terrain.test.ts", "export const TERRAIN_DECOY = 1;\n");
+      await writeFixture("docs/landscape.md", "# decoy\n");
+    });
+
+    const CURATED = [
+      "src/landscape/generator.ts",
+      "src/landscape/support/**/*.ts",
+      "tests/landscape/*.test.ts",
+    ];
+
+    it("selects exact paths and globs together, and nothing else", async () => {
+      const result = await copyTreeService.testConfig(tempDir, { includePaths: CURATED });
+
+      expect(result.error).toBeUndefined();
+      expect((result.files ?? []).map((file) => file.path).sort()).toEqual([
+        "src/landscape/generator.ts",
+        "src/landscape/support/math.ts",
+        "src/landscape/support/nested/seed.ts",
+        "tests/landscape/generator.test.ts",
+      ]);
+      // Proves the decoys were walked and then filtered, rather than the walk
+      // never reaching them — without this the assertion above would also pass
+      // on a broken traversal that found nothing.
+      expect(result.excluded?.byReason.filterPattern).toBeGreaterThan(0);
+    });
+
+    it("carries the curated files, and only those, into a real generated bundle", async () => {
+      const result = await copyTreeService.generate(tempDir, { includePaths: CURATED });
+
+      expect(result.error).toBeUndefined();
+      expect(result.fileCount).toBe(4);
+      for (const sentinel of [
+        "GENERATOR_SENTINEL",
+        "SUPPORT_SENTINEL",
+        "NESTED_SENTINEL",
+        "TEST_SENTINEL",
+      ]) {
+        expect(result.content).toContain(sentinel);
+      }
+      for (const decoy of ["PREVIEW_DECOY", "TERRAIN_DECOY"]) {
+        expect(result.content).not.toContain(decoy);
+      }
+    });
+
+    // The regression for the `||` collapse: `includePaths` used to win outright,
+    // so a caller that split its selection across both fields silently lost the
+    // `filter` half with no error and no diagnostic (#11722).
+    it("unions includePaths with filter instead of letting one win", async () => {
+      const result = await copyTreeService.testConfig(tempDir, {
+        includePaths: ["src/landscape/generator.ts"],
+        filter: ["tests/landscape/*.test.ts"],
+      });
+
+      expect(result.error).toBeUndefined();
+      expect((result.files ?? []).map((file) => file.path).sort()).toEqual([
+        "src/landscape/generator.ts",
+        "tests/landscape/generator.test.ts",
+      ]);
+    });
+
+    it("accepts a bare string filter alongside includePaths", async () => {
+      const result = await copyTreeService.testConfig(tempDir, {
+        includePaths: ["src/landscape/generator.ts"],
+        filter: "tests/landscape/*.test.ts",
+      });
+
+      expect((result.files ?? []).map((file) => file.path).sort()).toEqual([
+        "src/landscape/generator.ts",
+        "tests/landscape/generator.test.ts",
+      ]);
+    });
+
+    // KNOWN UPSTREAM GAP, not a Daintree one: a curated glob cannot reach a
+    // dotfile. CopyTree 0.17 builds its include matcher as
+    // `micromatch.matcher(this.patterns)` (FileDiscoveryStage.js:485) with no
+    // `dot: true`, while the force-include matcher three lines up
+    // (FileDiscoveryStage.js:472) sets it — so `always` sees dotfiles and
+    // `filter`/`includePaths` do not. That costs a curated bundle things like
+    // `.github/workflows/**` or a dotfile config; ordinary sources and tests,
+    // which is what the feature is for, are unaffected.
+    //
+    // Deliberately `it.fails`: it must not encode the bug as desired behavior,
+    // and it must speak up rather than sit silent once the fix lands. When a
+    // copytree release carrying `{ dot: true }` here is published and this
+    // repo's dependency is raised to it, this test starts FAILING — at which
+    // point drop the `.fails` and keep the assertion as the regression.
+    it.fails("selects a dotfile through a curated glob", async () => {
+      await writeFixture("config/landscape/.defaults.json", '{"DOTFILE_SENTINEL":1}\n');
+
+      const result = await copyTreeService.testConfig(tempDir, {
+        includePaths: ["config/landscape/**"],
+      });
+
+      expect((result.files ?? []).map((file) => file.path)).toContain(
+        "config/landscape/.defaults.json"
+      );
+    });
+
+    it("still selects everything when neither field is given", async () => {
+      // Guards the merge helper's empty case: `[]` would read as "select
+      // nothing" to the SDK, so it must stay `undefined`.
+      const result = await copyTreeService.testConfig(tempDir, {});
+
+      expect((result.files ?? []).map((file) => file.path)).toContain("src/landscape/preview.ts");
+    });
+  });
 });

--- a/electron/services/__tests__/CopyTreeService.sdk-contract.test.ts
+++ b/electron/services/__tests__/CopyTreeService.sdk-contract.test.ts
@@ -598,13 +598,22 @@ describe("CopyTreeService against the installed CopyTree", () => {
     });
 
     it("treats a blank pattern as unmatchable rather than as no selection", async () => {
-      // The schemas reject a blank entry before this point; if one ever reaches
-      // the service it must still fail closed.
+      // Both validated boundaries reject a blank entry before this point; if one
+      // ever reaches the service it must still fail closed rather than widen.
       const result = await copyTreeService.testConfig(tempDir, { includePaths: [""] });
 
       expect((result.files ?? []).map((file) => file.path)).not.toContain(
         "src/landscape/preview.ts"
       );
+    });
+
+    // An empty array cannot express "select nothing" to the SDK — it reads as
+    // "no filter" and copies everything — which is why the schemas reject it
+    // rather than the service trying to render it harmless.
+    it("documents that an empty selection array would widen, hence the schema guard", async () => {
+      const result = await copyTreeService.testConfig(tempDir, { includePaths: [] });
+
+      expect((result.files ?? []).map((file) => file.path)).toContain("src/landscape/preview.ts");
     });
   });
 });

--- a/electron/services/mcp-server/__tests__/tierAuth.test.ts
+++ b/electron/services/mcp-server/__tests__/tierAuth.test.ts
@@ -409,10 +409,18 @@ describe("external tool surface invariants (#10701, #11537)", () => {
     );
   });
 
-  it("keeps the other copyTree tools off the external surface", () => {
-    for (const id of ["copyTree.generate", "copyTree.injectToTerminal", "copyTree.isAvailable"]) {
-      expect(builtInIds.has(id)).toBe(true);
+  it("keeps every other copyTree tool off the external surface", () => {
+    // Derived from the registry rather than listed by hand: a hardcoded list
+    // silently stops covering any copyTree tool added later, which is exactly
+    // when this guard matters.
+    const others = [...BUILT_IN_ACTION_IDS].filter(
+      (id) => id.startsWith("copyTree.") && id !== "copyTree.generateAndCopyFile"
+    );
+
+    expect(others.length).toBeGreaterThan(0);
+    for (const id of others) {
       expect(isTierPermitted("external", id)).toBe(false);
+      expect(shouldExposeTool(makeEntry({ id }), "external")).toBe(false);
     }
   });
 

--- a/electron/services/mcp-server/__tests__/tierAuth.test.ts
+++ b/electron/services/mcp-server/__tests__/tierAuth.test.ts
@@ -397,6 +397,25 @@ describe("external tool surface invariants (#10701, #11537)", () => {
     }
   );
 
+  // The clipboard bundle is the one CopyTree tool an external agent gets: it
+  // can read files for itself, but only Daintree can write the user's system
+  // clipboard. Its siblings stay off the surface, so this pins the membership
+  // rather than the whole namespace (#11722).
+  it("exposes the curated clipboard bundle to the external tier", () => {
+    expect(builtInIds.has("copyTree.generateAndCopyFile")).toBe(true);
+    expect(isTierPermitted("external", "copyTree.generateAndCopyFile")).toBe(true);
+    expect(shouldExposeTool(makeEntry({ id: "copyTree.generateAndCopyFile" }), "external")).toBe(
+      true
+    );
+  });
+
+  it("keeps the other copyTree tools off the external surface", () => {
+    for (const id of ["copyTree.generate", "copyTree.injectToTerminal", "copyTree.isAvailable"]) {
+      expect(builtInIds.has(id)).toBe(true);
+      expect(isTierPermitted("external", id)).toBe(false);
+    }
+  });
+
   it("exposure and dispatch gates agree for a sensitive non-allowlisted action", () => {
     const entry = makeEntry({ id: "system.openExternal", danger: "safe" });
     expect(shouldExposeTool(entry, "external")).toBe(

--- a/shared/config/mcpExternalTierAllowlist.ts
+++ b/shared/config/mcpExternalTierAllowlist.ts
@@ -96,12 +96,18 @@ export const MCP_EXTERNAL_TIER_TOOLS = [
   "worktree.createWithRecipe",
   "worktree.setActive",
 
-  // Passes the selection rule above: an external agent sits in a terminal and
-  // can read files for itself, but it cannot put anything on the user's system
-  // clipboard — only Daintree can. Curating the bundle is the caller's half
-  // (it decides which files matter), delivering it is ours. Without this entry
-  // the tool is reachable only by the in-app assistant via the system tier,
-  // which contradicts the point of the feature: the same request should work
-  // whether Daintree's own assistant or Claude Code/Codex is driving (#11722).
+  // A deliberate product exception rather than a clean pass of the rule above,
+  // so it is worth stating the reasoning plainly. A caller holding
+  // `terminal.sendCommand` could pipe files through `pbcopy` itself, so this is
+  // not a capability it categorically lacks. What it cannot reproduce is the
+  // actual deliverable: one call that applies the project's own CopyTree policy
+  // (ignore rules, budgets, format) and puts a FILE on the clipboard the same
+  // way across macOS, Linux and Windows. The alternative is a brittle
+  // shell-and-pipe reconstruction per platform. Without the entry the feature
+  // only half exists — the in-app assistant reaches it through the system tier
+  // while Claude Code and Codex, the callers #11722 names, cannot.
+  //
+  // Its blast radius is a clipboard overwrite, which `actionRiskBand` already
+  // bands `destructive-local` and the tool advertises via `destructiveHint`.
   "copyTree.generateAndCopyFile",
 ] as const satisfies readonly BuiltInActionId[];

--- a/shared/config/mcpExternalTierAllowlist.ts
+++ b/shared/config/mcpExternalTierAllowlist.ts
@@ -95,4 +95,13 @@ export const MCP_EXTERNAL_TIER_TOOLS = [
   "worktree.getCurrent",
   "worktree.createWithRecipe",
   "worktree.setActive",
+
+  // Passes the selection rule above: an external agent sits in a terminal and
+  // can read files for itself, but it cannot put anything on the user's system
+  // clipboard — only Daintree can. Curating the bundle is the caller's half
+  // (it decides which files matter), delivering it is ours. Without this entry
+  // the tool is reachable only by the in-app assistant via the system tier,
+  // which contradicts the point of the feature: the same request should work
+  // whether Daintree's own assistant or Claude Code/Codex is driving (#11722).
+  "copyTree.generateAndCopyFile",
 ] as const satisfies readonly BuiltInActionId[];

--- a/src/hooks/useWorktreeActions.ts
+++ b/src/hooks/useWorktreeActions.ts
@@ -4,26 +4,16 @@ import { useErrorStore, type ErrorRecord } from "@/store";
 import { useRecipeStore } from "@/store/recipeStore";
 import { logError } from "@/utils/logger";
 import { useNotificationStore } from "@/store/notificationStore";
-import { formatBytes } from "@/lib/formatBytes";
+import { formatCopyResultMessage } from "@/lib/formatCopyResult";
 import { actionService } from "@/services/ActionService";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import type { ActionSource } from "@shared/types/actions";
 import type { CopyTreeBudgetStats, CopyTreeExclusionReason } from "@shared/types/ipc/copyTree";
 
-export function formatCopyResultMessage(payload: {
-  fileCount: number;
-  stats?: { totalSize?: number } | null;
-  format?: string;
-}): string {
-  const fileCount =
-    typeof payload.fileCount === "number" && Number.isFinite(payload.fileCount)
-      ? payload.fileCount
-      : 0;
-  const stats = payload.stats ?? undefined;
-  const sizeStr = stats?.totalSize ? formatBytes(stats.totalSize) : "";
-  const formatStr = payload.format ? ` as ${payload.format.toUpperCase()}` : "";
-  return `Copied ${fileCount} files${sizeStr ? ` (${sizeStr})` : ""}${formatStr} to clipboard`;
-}
+// Moved to a leaf module so the copyTree action definitions can share it
+// without closing an import cycle through `actionService` below (#11722).
+// Re-exported because this was its public home.
+export { formatCopyResultMessage };
 
 /**
  * Reasons that mean "a rule the project already lives by kept this out", as

--- a/src/lib/formatCopyResult.ts
+++ b/src/lib/formatCopyResult.ts
@@ -1,0 +1,25 @@
+import { formatBytes } from "@/lib/formatBytes";
+
+/**
+ * The one-line summary shown after a CopyTree bundle lands on the clipboard.
+ *
+ * Lives here rather than beside its original caller in `useWorktreeActions`
+ * because the copyTree action definitions need it too, and that hook imports
+ * `actionService` — importing it from an action definition would close a cycle
+ * (`ActionService` → definitions → hook → `ActionService`). This module is a
+ * leaf over `formatBytes`, so both sides can depend on it (#11722).
+ */
+export function formatCopyResultMessage(payload: {
+  fileCount: number;
+  stats?: { totalSize?: number } | null;
+  format?: string;
+}): string {
+  const fileCount =
+    typeof payload.fileCount === "number" && Number.isFinite(payload.fileCount)
+      ? payload.fileCount
+      : 0;
+  const stats = payload.stats ?? undefined;
+  const sizeStr = stats?.totalSize ? formatBytes(stats.totalSize) : "";
+  const formatStr = payload.format ? ` as ${payload.format.toUpperCase()}` : "";
+  return `Copied ${fileCount} files${sizeStr ? ` (${sizeStr})` : ""}${formatStr} to clipboard`;
+}

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -952,7 +952,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "copyTree",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Bundle a worktree's context to a file and put it on the system clipboard, replacing whatever the user currently has copied. What lands there is platform-dependent: macOS and Linux copy the file itself, Windows copies its path as text. The bundle is never returned inline — check the budget flags to tell whether it was complete.",
+    "description": "Bundle a worktree's context to a file and put it on the system clipboard, replacing what the user had copied. Selection can mix exact files with globs, so this assembles a curated bundle of scattered related files, their supporting code and tests, rather than the whole worktree. Agent and MCP callers must name the worktree instead of relying on whichever is active. macOS and Linux copy the file, Windows its path. Never returned inline; check the budget flags for completeness.",
     "examples": undefined,
     "id": "copyTree.generateAndCopyFile",
     "keywords": undefined,

--- a/src/services/actions/definitions/__tests__/locationArgs.test.ts
+++ b/src/services/actions/definitions/__tests__/locationArgs.test.ts
@@ -9,6 +9,7 @@ import {
   resolveProjectLocation,
   requireWorktreePath,
   requireWorktreeId,
+  requireExplicitWorktreeForAgentDispatch,
   requireProjectPath,
 } from "../locationArgs";
 import { withPagination, PaginatedResultSchema, decodeIndexCursor } from "../schemas";
@@ -396,5 +397,50 @@ describe("PaginatedResultSchema", () => {
     const schema = PaginatedResultSchema(z.object({ id: z.string() }));
     expect(schema.safeParse({ items: [], hasMore: false, nextCursor: null }).success).toBe(true);
     expect(schema.safeParse({ items: [], hasMore: false }).success).toBe(false);
+  });
+});
+
+describe("requireExplicitWorktreeForAgentDispatch", () => {
+  const agentCtx: ActionContext = { dispatchSource: "agent", activeWorktreeId: "wt-active" };
+  const call =
+    (args: Parameters<typeof requireExplicitWorktreeForAgentDispatch>[1], ctx = agentCtx) =>
+    (): void =>
+      requireExplicitWorktreeForAgentDispatch("copyTree.generateAndCopyFile", args, ctx);
+
+  it("rejects an agent dispatch that names no worktree, even when one is active", () => {
+    // The whole point: an active worktree must NOT satisfy the guard, or a
+    // headless caller silently inherits whatever the user happens to be on.
+    expect(call(undefined)).toThrow(/requires an explicit/);
+    expect(call({})).toThrow(/requires an explicit/);
+  });
+
+  it("names the action and both accepted selectors so the agent can self-correct", () => {
+    expect(call(undefined)).toThrow(
+      "copyTree.generateAndCopyFile requires an explicit `worktreeId` or `worktreePath` when dispatched by an agent or MCP client — pass the `id` or `path` from the worktree-listing capability."
+    );
+  });
+
+  it("accepts either explicit selector", () => {
+    expect(call({ worktreeId: "wt-1" })).not.toThrow();
+    expect(call({ worktreePath: "/repo/feature" })).not.toThrow();
+  });
+
+  it("ignores a blank selector rather than treating it as explicit", () => {
+    // `.min(1)` in the schema rejects these first, but the guard is exported and
+    // must not be the layer that accepts an empty string as a named target.
+    expect(call({ worktreeId: "" })).toThrow(/requires an explicit/);
+    expect(call({ worktreePath: "" })).toThrow(/requires an explicit/);
+  });
+
+  it("leaves every non-agent dispatch on the active-worktree fallback", () => {
+    // Includes the source-less shape used by action unit tests and by any
+    // dispatch that carries no context at all — the guard must fail open there,
+    // which is why it compares to "agent" instead of negating an allowlist.
+    for (const source of ["user", "keybinding", "plugin", undefined] as const) {
+      expect(
+        call(undefined, { dispatchSource: source, activeWorktreeId: "wt-active" })
+      ).not.toThrow();
+    }
+    expect(call(undefined, {})).not.toThrow();
   });
 });

--- a/src/services/actions/definitions/__tests__/locationArgs.test.ts
+++ b/src/services/actions/definitions/__tests__/locationArgs.test.ts
@@ -415,9 +415,16 @@ describe("requireExplicitWorktreeForAgentDispatch", () => {
   });
 
   it("names the action and both accepted selectors so the agent can self-correct", () => {
-    expect(call(undefined)).toThrow(
-      "copyTree.generateAndCopyFile requires an explicit `worktreeId` or `worktreePath` when dispatched by an agent or MCP client — pass the `id` or `path` from the worktree-listing capability."
-    );
+    // The semantic elements an agent needs to recover, not the sentence itself:
+    // pinning the exact wording would force a test edit for a copy tweak.
+    const thrown = call(undefined);
+
+    expect(thrown).toThrow("copyTree.generateAndCopyFile");
+    expect(thrown).toThrow("worktreeId");
+    expect(thrown).toThrow("worktreePath");
+    // Points at where to get one, and says who the rule applies to.
+    expect(thrown).toThrow(/worktree-listing capability/i);
+    expect(thrown).toThrow(/agent or MCP/i);
   });
 
   it("accepts either explicit selector", () => {

--- a/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
@@ -363,19 +363,37 @@ describe("systemActions adversarial", () => {
       );
       expect(copyTreeClientMock.generateAndCopyFile).toHaveBeenCalledWith("wt-1", options);
 
-      // And the schema actually admits that shape — `run()` is called directly
-      // here, so the transform would otherwise never be exercised.
-      const schema = getDef("copyTree.generateAndCopyFile").argsSchema;
-      expect(schema?.safeParse({ worktreePath: "/repo/landscape", options }).success).toBe(true);
+      // And the selection SURVIVES the schema transform — `run()` is called
+      // directly here, so the transform is otherwise never exercised. Asserting
+      // the parsed output rather than `.success`: zod strips unknown keys and
+      // still succeeds, so a dropped field would pass a success-only check
+      // while real dispatch copied the whole worktree.
+      const parsed = getDef("copyTree.generateAndCopyFile").argsSchema?.parse({
+        worktreePath: "/repo/landscape",
+        options,
+      });
+      expect(parsed).toEqual({ worktreePath: "/repo/landscape", options });
     });
 
     it("rejects a blank selection entry instead of widening it to the whole worktree", async () => {
       // An empty selection reads as "everything" downstream, so a blank must be
       // a validation error rather than something quietly dropped.
       const schema = setupActions().getDef("copyTree.generateAndCopyFile").argsSchema;
-      expect(schema?.safeParse({ options: { includePaths: [""] } }).success).toBe(false);
-      expect(schema?.safeParse({ options: { filter: [""] } }).success).toBe(false);
-      expect(schema?.safeParse({ options: { filter: "" } }).success).toBe(false);
+      // A blank entry and an empty list fail the same way: both leave nothing
+      // selected, and nothing selected means everything one layer down.
+      for (const options of [
+        { includePaths: [""] },
+        { includePaths: [] },
+        { includePaths: ["src/a.ts", ""] },
+        { filter: [""] },
+        { filter: [] },
+        { filter: "" },
+      ]) {
+        expect(schema?.safeParse({ options }).success).toBe(false);
+      }
+      // The valid shapes still pass, so the guard above isn't rejecting everything.
+      expect(schema?.safeParse({ options: { includePaths: ["src/a.ts"] } }).success).toBe(true);
+      expect(schema?.safeParse({ options: { filter: "src/**" } }).success).toBe(true);
     });
 
     it("refuses an explicit worktreePath that matches no open worktree", async () => {
@@ -426,19 +444,22 @@ describe("systemActions adversarial", () => {
       );
     });
 
-    it("gives the toast its own rate-limit bucket", async () => {
-      // Falling back to the `type` key would pool this with every other success
-      // toast in the app, so an unrelated burst could replace the one message
-      // that says what is now on the clipboard.
+    it("gives the toast a bucket of its own rather than the shared fallback", async () => {
+      // notify() derives the bucket from `rateLimitKey ?? correlationId ??
+      // context.projectId ?? context.worktreeId ?? type`. With none of those set
+      // it lands on `type` — pooling this with every other success toast in the
+      // app, where an unrelated burst replaces the one message saying what is
+      // now on the clipboard. The invariant is "not the shared bucket", not any
+      // particular string.
       const { run } = setupActions();
       await run(
         "copyTree.generateAndCopyFile",
         { worktreeId: "wt-1" },
         { dispatchSource: "agent" }
       );
-      expect(notifyMock).toHaveBeenCalledWith(
-        expect.objectContaining({ rateLimitKey: "copyTree.generateAndCopyFile" })
-      );
+      const payload = notifyMock.mock.calls[0]?.[0] as { rateLimitKey?: string; type: string };
+      expect(payload.rateLimitKey).toBeTruthy();
+      expect(payload.rateLimitKey).not.toBe(payload.type);
     });
 
     it("describes the copy without a format when none was requested", async () => {

--- a/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
@@ -346,6 +346,54 @@ describe("systemActions adversarial", () => {
       );
     });
 
+    it("forwards the curated selection to the client untouched", async () => {
+      // Without this, swapping the call for `generateAndCopyFile(id, undefined)`
+      // leaves every other test here green while external callers silently lose
+      // their selection and copy the whole worktree.
+      const { getDef, run } = setupActions();
+      const options = {
+        includePaths: ["src/landscape/generator.ts"],
+        filter: ["tests/landscape/*.test.ts"],
+        format: "markdown" as const,
+      };
+      await run(
+        "copyTree.generateAndCopyFile",
+        { worktreeId: "wt-1", options },
+        { dispatchSource: "agent" }
+      );
+      expect(copyTreeClientMock.generateAndCopyFile).toHaveBeenCalledWith("wt-1", options);
+
+      // And the schema actually admits that shape — `run()` is called directly
+      // here, so the transform would otherwise never be exercised.
+      const schema = getDef("copyTree.generateAndCopyFile").argsSchema;
+      expect(schema?.safeParse({ worktreePath: "/repo/landscape", options }).success).toBe(true);
+    });
+
+    it("rejects a blank selection entry instead of widening it to the whole worktree", async () => {
+      // An empty selection reads as "everything" downstream, so a blank must be
+      // a validation error rather than something quietly dropped.
+      const schema = setupActions().getDef("copyTree.generateAndCopyFile").argsSchema;
+      expect(schema?.safeParse({ options: { includePaths: [""] } }).success).toBe(false);
+      expect(schema?.safeParse({ options: { filter: [""] } }).success).toBe(false);
+      expect(schema?.safeParse({ options: { filter: "" } }).success).toBe(false);
+    });
+
+    it("refuses an explicit worktreePath that matches no open worktree", async () => {
+      // Must not fall back to the active worktree: the agent named a target,
+      // and quietly copying a different one is the failure this guards.
+      setWorktreePathIndexAccessor(() => new Map([["wt-known", "/repo/known"]]));
+      const { run } = setupActions();
+      await expect(
+        run(
+          "copyTree.generateAndCopyFile",
+          { worktreePath: "/repo/gone" },
+          { dispatchSource: "agent", activeWorktreeId: "wt-active" }
+        )
+      ).rejects.toThrow(/no open worktree matches that path/i);
+      expect(copyTreeClientMock.generateAndCopyFile).not.toHaveBeenCalled();
+      expect(notifyMock).not.toHaveBeenCalled();
+    });
+
     it("refuses an agent dispatch that names no worktree, before touching the clipboard", async () => {
       const { run } = setupActions();
       await expect(
@@ -373,8 +421,35 @@ describe("systemActions adversarial", () => {
           type: "success",
           title: "Reference file created",
           message: "Copied 3 files (4 KB) as XML to clipboard",
-          context: { eventKind: "completed" },
+          context: { eventKind: "agent" },
         })
+      );
+    });
+
+    it("gives the toast its own rate-limit bucket", async () => {
+      // Falling back to the `type` key would pool this with every other success
+      // toast in the app, so an unrelated burst could replace the one message
+      // that says what is now on the clipboard.
+      const { run } = setupActions();
+      await run(
+        "copyTree.generateAndCopyFile",
+        { worktreeId: "wt-1" },
+        { dispatchSource: "agent" }
+      );
+      expect(notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({ rateLimitKey: "copyTree.generateAndCopyFile" })
+      );
+    });
+
+    it("describes the copy without a format when none was requested", async () => {
+      const { run } = setupActions();
+      await run(
+        "copyTree.generateAndCopyFile",
+        { worktreeId: "wt-1" },
+        { dispatchSource: "agent" }
+      );
+      expect(notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Copied 3 files (4 KB) to clipboard" })
       );
     });
 
@@ -390,10 +465,10 @@ describe("systemActions adversarial", () => {
         { worktreeId: "wt-active" },
         { dispatchSource: "agent", activeWorktreeId: "wt-active" }
       );
-      // `toEqual` on the whole context (not `objectContaining` on it) is what
-      // proves the absence: an added `worktreeId` would fail this.
+      // The nested `context` is a plain object, so it is compared by deep
+      // equality rather than partially: an added `worktreeId` fails this.
       expect(notifyMock).toHaveBeenCalledWith(
-        expect.objectContaining({ context: { eventKind: "completed" } })
+        expect.objectContaining({ context: { eventKind: "agent" } })
       );
     });
 

--- a/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
@@ -437,7 +437,11 @@ describe("systemActions adversarial", () => {
       expect(notifyMock).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "success",
-          title: "Reference file created",
+          // The message is computed from the mocked result (3 files, 4 KB, the
+          // requested format), so it asserts real composition. The title is
+          // pure copy — pinning the wording would force a test edit for a copy
+          // tweak, so only require that the toast carries one.
+          title: expect.stringMatching(/\S/),
           message: "Copied 3 files (4 KB) as XML to clipboard",
           context: { eventKind: "agent" },
         })

--- a/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
@@ -37,6 +37,10 @@ const artifactClientMock = vi.hoisted(() => ({
   applyPatch: vi.fn(),
 }));
 
+const notifyMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/notify", () => ({ notify: notifyMock }));
+
 vi.mock("@/clients", () => ({
   filesClient: filesClientMock,
   copyTreeClient: copyTreeClientMock,
@@ -55,6 +59,10 @@ vi.mock("@/clients", () => ({
 }));
 
 import { registerSystemActions } from "../systemActions";
+import {
+  setWorktreePathIndexAccessor,
+  resetStoreAccessorsForTesting,
+} from "@/store/storeAccessors";
 
 function setupActions(): {
   run: (id: string, args?: unknown, ctx?: Record<string, unknown>) => Promise<unknown>;
@@ -90,6 +98,9 @@ const COPY_TREE_RESULT = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // The worktree path index leaks across files otherwise, so a later suite
+  // would inherit whichever map the last path-resolution test installed.
+  resetStoreAccessorsForTesting();
   for (const fn of Object.values(filesClientMock)) fn.mockResolvedValue(undefined);
   for (const fn of Object.values(copyTreeClientMock)) fn.mockResolvedValue(undefined);
   for (const fn of Object.values(slashCommandsClientMock)) fn.mockResolvedValue(undefined);
@@ -319,6 +330,108 @@ describe("systemActions adversarial", () => {
       await expect(
         run("copyTree.generateAndCopyFile", undefined, { activeWorktreeId: "wt-active" })
       ).rejects.toThrow("Failed to copy file to clipboard: EACCES");
+    });
+
+    it("resolves an explicit worktreePath to the id its IPC takes", async () => {
+      setWorktreePathIndexAccessor(() => new Map([["wt-landscape", "/repo/landscape"]]));
+      const { run } = setupActions();
+      await run(
+        "copyTree.generateAndCopyFile",
+        { worktreePath: "/repo/landscape" },
+        { dispatchSource: "agent", activeWorktreeId: "wt-active" }
+      );
+      expect(copyTreeClientMock.generateAndCopyFile).toHaveBeenCalledWith(
+        "wt-landscape",
+        undefined
+      );
+    });
+
+    it("refuses an agent dispatch that names no worktree, before touching the clipboard", async () => {
+      const { run } = setupActions();
+      await expect(
+        run("copyTree.generateAndCopyFile", undefined, {
+          dispatchSource: "agent",
+          activeWorktreeId: "wt-active",
+        })
+      ).rejects.toThrow(/requires an explicit/);
+      // The guard has to fire before the copy — a rejected call that already
+      // replaced the clipboard is the failure mode this exists to prevent.
+      expect(copyTreeClientMock.generateAndCopyFile).not.toHaveBeenCalled();
+      expect(notifyMock).not.toHaveBeenCalled();
+    });
+
+    it("toasts once on a successful agent dispatch", async () => {
+      const { run } = setupActions();
+      await run(
+        "copyTree.generateAndCopyFile",
+        { worktreeId: "wt-1", options: { format: "xml" } },
+        { dispatchSource: "agent" }
+      );
+      expect(notifyMock).toHaveBeenCalledTimes(1);
+      expect(notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "success",
+          title: "Reference file created",
+          message: "Copied 3 files (4 KB) as XML to clipboard",
+          context: { eventKind: "completed" },
+        })
+      );
+    });
+
+    it("keeps the worktree out of the toast context so notify() cannot suppress it", async () => {
+      // notify() routes a high-priority toast to the inbox instead when
+      // `context.worktreeId` matches the worktree already on screen. An agent
+      // copying the ACTIVE worktree is the common case, so naming it here would
+      // silence exactly the signal this toast exists to deliver. A clipboard
+      // overwrite is invisible regardless of which worktree is displayed.
+      const { run } = setupActions();
+      await run(
+        "copyTree.generateAndCopyFile",
+        { worktreeId: "wt-active" },
+        { dispatchSource: "agent", activeWorktreeId: "wt-active" }
+      );
+      // `toEqual` on the whole context (not `objectContaining` on it) is what
+      // proves the absence: an added `worktreeId` would fail this.
+      expect(notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({ context: { eventKind: "completed" } })
+      );
+    });
+
+    it("stays silent for a user-driven copy and for a source-less dispatch", async () => {
+      const { run } = setupActions();
+      await run("copyTree.generateAndCopyFile", undefined, {
+        dispatchSource: "user",
+        activeWorktreeId: "wt-active",
+      });
+      await run("copyTree.generateAndCopyFile", undefined, { activeWorktreeId: "wt-active" });
+      // The person pressed the button; their clipboard changing is not news.
+      expect(notifyMock).not.toHaveBeenCalled();
+    });
+
+    it("never announces success when the copy failed", async () => {
+      const { run } = setupActions();
+      copyTreeClientMock.generateAndCopyFile.mockResolvedValueOnce({
+        content: "",
+        fileCount: 0,
+        error: "Failed to copy file to clipboard: EACCES",
+      });
+      await expect(
+        run("copyTree.generateAndCopyFile", { worktreeId: "wt-1" }, { dispatchSource: "agent" })
+      ).rejects.toThrow("EACCES");
+      expect(notifyMock).not.toHaveBeenCalled();
+    });
+
+    it("never announces success when no file came back", async () => {
+      const { run } = setupActions();
+      copyTreeClientMock.generateAndCopyFile.mockResolvedValueOnce({
+        content: "",
+        fileCount: 3,
+        // No filePath: the clipboard write had nothing to point at.
+      });
+      await expect(
+        run("copyTree.generateAndCopyFile", { worktreeId: "wt-1" }, { dispatchSource: "agent" })
+      ).rejects.toThrow();
+      expect(notifyMock).not.toHaveBeenCalled();
     });
   });
 

--- a/src/services/actions/definitions/locationArgs.ts
+++ b/src/services/actions/definitions/locationArgs.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { ActionContext } from "@shared/types/actions";
+import type { ActionContext, ActionId } from "@shared/types/actions";
 import { getWorktreePathIndex, getProjectPathIndex } from "@/store/storeAccessors";
 import { paginationShape, foldPagination, type PaginationOptions } from "./schemas";
 
@@ -353,6 +353,45 @@ export function requireWorktreeId(
     throw new Error("Unknown worktree — no open worktree matches that path.");
   }
   throw new Error("No active worktree — supply `worktreeId` or `worktreePath`.");
+}
+
+/**
+ * Fail closed when an agent/MCP caller omits the worktree it means to act on.
+ *
+ * The worktree twin of `requireExplicitTerminalIdForAgentDispatch`, and it
+ * exists for the same reason: {@link resolveWorktreeLocation} falls back to the
+ * active worktree, which is right for a keybinding or a palette pick — the
+ * person can see which worktree is active — and wrong for a headless caller,
+ * which cannot. An agent that curated a file list against one folder must
+ * assert that folder rather than inherit whatever happens to be focused when
+ * the call lands (#11722).
+ *
+ * Deliberately `=== "agent"` rather than `!isForegroundDispatch(source)`: that
+ * helper is an allowlist that fails *open* for an absent source, so reusing it
+ * here would reject every dispatch carrying no context at all — including the
+ * bare `run(args, {})` shape used throughout the action unit tests. `"plugin"`
+ * keeps today's fallback; closing that is a separate capability call.
+ *
+ * Reads the RAW selectors, never the resolved location: `resolveWorktreeLocation`
+ * has already substituted `ctx.activeWorktreeId` by the time it returns, so a
+ * guard placed after it could never tell an explicit target from an inherited
+ * one. Legacy path aliases are not consulted either — no tool that takes one
+ * uses this guard, and folding them in here would duplicate the collapse that
+ * the schema transform already owns.
+ *
+ * Binding only: an explicitly named worktree that doesn't exist still reaches
+ * `requireWorktreeId`'s existing unknown-worktree error, unchanged.
+ */
+export function requireExplicitWorktreeForAgentDispatch(
+  actionId: ActionId,
+  args: WorktreeLocationArgs | undefined,
+  ctx: ActionContext
+): void {
+  if (ctx.dispatchSource === "agent" && !args?.worktreeId && !args?.worktreePath) {
+    throw new Error(
+      `${actionId} requires an explicit \`worktreeId\` or \`worktreePath\` when dispatched by an agent or MCP client — pass the \`id\` or \`path\` from the worktree-listing capability.`
+    );
+  }
 }
 
 /**

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -265,8 +265,12 @@ export const CopyTreeOptionsSchema = z.object({
   // second — the exact shape a curated bundle takes (#11722). They are unioned
   // now, and say so here, since the union is only discoverable from these
   // descriptions on the MCP wire.
+  // Blank entries are rejected, not ignored: a dropped blank would leave the
+  // selection empty, and an absent selection means "the whole worktree" to the
+  // SDK — so silently discarding one turns a malformed narrow request into a
+  // full-repo copy. Same reasoning as `scopePaths` below.
   filter: z
-    .union([z.string(), z.array(z.string())])
+    .union([z.string().min(1), z.array(z.string().min(1))])
     .optional()
     .describe(
       "Selects which files to include, as worktree-relative glob patterns or exact paths. Combined with `includePaths` when both are given; omit both to include the whole worktree."
@@ -274,7 +278,7 @@ export const CopyTreeOptionsSchema = z.object({
   exclude: z.union([z.string(), z.array(z.string())]).optional(),
   always: z.array(z.string()).optional(),
   includePaths: z
-    .array(z.string())
+    .array(z.string().min(1))
     .optional()
     .describe(
       "Selects which files to include, as worktree-relative exact paths or glob patterns. Use this to assemble a curated bundle of scattered files — sources, their supporting code, and their tests — in one call. Combined with `filter` when both are given. Unlike `scopePaths` this does not restrict traversal, so patterns may match anywhere in the worktree."

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -265,12 +265,13 @@ export const CopyTreeOptionsSchema = z.object({
   // second — the exact shape a curated bundle takes (#11722). They are unioned
   // now, and say so here, since the union is only discoverable from these
   // descriptions on the MCP wire.
-  // Blank entries are rejected, not ignored: a dropped blank would leave the
-  // selection empty, and an absent selection means "the whole worktree" to the
-  // SDK — so silently discarding one turns a malformed narrow request into a
-  // full-repo copy. Same reasoning as `scopePaths` below.
+  // Non-empty at both levels, like `scopePaths` below. An empty list and a
+  // blank entry both leave the selection empty, and an empty selection reads as
+  // "no filter" to the SDK — i.e. the whole worktree. Accepting either would
+  // turn a malformed narrow request into a full-repo copy onto the clipboard,
+  // so they are rejected here rather than normalized away downstream.
   filter: z
-    .union([z.string().min(1), z.array(z.string().min(1))])
+    .union([z.string().min(1), z.array(z.string().min(1)).min(1)])
     .optional()
     .describe(
       "Selects which files to include, as worktree-relative glob patterns or exact paths. Combined with `includePaths` when both are given; omit both to include the whole worktree."
@@ -279,6 +280,7 @@ export const CopyTreeOptionsSchema = z.object({
   always: z.array(z.string()).optional(),
   includePaths: z
     .array(z.string().min(1))
+    .min(1)
     .optional()
     .describe(
       "Selects which files to include, as worktree-relative exact paths or glob patterns. Use this to assemble a curated bundle of scattered files — sources, their supporting code, and their tests — in one call. Combined with `filter` when both are given. Unlike `scopePaths` this does not restrict traversal, so patterns may match anywhere in the worktree."

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -259,10 +259,26 @@ export function PaginatedResultSchema<T extends z.ZodTypeAny>(item: T) {
 
 export const CopyTreeOptionsSchema = z.object({
   format: z.enum(["xml", "json", "markdown", "tree", "ndjson", "sarif"]).optional(),
-  filter: z.union([z.string(), z.array(z.string())]).optional(),
+  // `filter` and `includePaths` are two spellings of one selection set, and both
+  // feed the SDK's single `filter`. They used to collapse with `||`, so a caller
+  // that put literal files in one and globs in the other silently lost the
+  // second — the exact shape a curated bundle takes (#11722). They are unioned
+  // now, and say so here, since the union is only discoverable from these
+  // descriptions on the MCP wire.
+  filter: z
+    .union([z.string(), z.array(z.string())])
+    .optional()
+    .describe(
+      "Selects which files to include, as worktree-relative glob patterns or exact paths. Combined with `includePaths` when both are given; omit both to include the whole worktree."
+    ),
   exclude: z.union([z.string(), z.array(z.string())]).optional(),
   always: z.array(z.string()).optional(),
-  includePaths: z.array(z.string()).optional(),
+  includePaths: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Selects which files to include, as worktree-relative exact paths or glob patterns. Use this to assemble a curated bundle of scattered files — sources, their supporting code, and their tests — in one call. Combined with `filter` when both are given. Unlike `scopePaths` this does not restrict traversal, so patterns may match anywhere in the worktree."
+    ),
   // An empty list or blank entry would resolve to the worktree root — a folder
   // copy that silently became a whole-worktree copy. Absent means no scoping.
   scopePaths: z

--- a/src/services/actions/definitions/systemActions.ts
+++ b/src/services/actions/definitions/systemActions.ts
@@ -489,6 +489,13 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
           "Selection, exclusion, formatting, and size-budget settings for the bundle."
         ),
       }).optional(),
+      // `destructiveHint` is otherwise derived from `danger === "confirm"`, so
+      // this would advertise as non-destructive while `actionRiskBand` already
+      // classifies it `destructive-local`. It replaces the clipboard, which has
+      // no inverse — the annotation should say so to a caller deciding whether
+      // to ask first. `danger` stays "safe": the issue wants an assistant-driven
+      // copy to land like a manual one, not behind a confirm dialog.
+      mcpAnnotations: { destructiveHint: true, idempotentHint: false },
       resultSchema: z.object({
         filePath: z.string(),
         fileCount: z.number(),
@@ -526,7 +533,17 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
               stats: result.stats,
               format: args?.options?.format,
             }),
-            context: { eventKind: "completed" },
+            // Its own bucket. The key otherwise falls back to `type`, putting
+            // every "success" toast in the app in one bucket — three unrelated
+            // ones would swallow this into a generic overflow row and lose the
+            // message that says what is on the clipboard.
+            rateLimitKey: "copyTree.generateAndCopyFile",
+            // "agent", not "completed": both route identically (active → high),
+            // but "completed" owns the `completedEnabled` setting, which gates
+            // only main-process completion watches and never a renderer
+            // notify() — so it would offer a "silence completed notifications"
+            // affordance that leaves these copies firing anyway.
+            context: { eventKind: "agent" },
           });
         }
         return {

--- a/src/services/actions/definitions/systemActions.ts
+++ b/src/services/actions/definitions/systemActions.ts
@@ -527,7 +527,10 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
           // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
           notify({
             type: "success",
-            title: "Reference file created",
+            // Matches the title the toolbar's own copy already uses for this
+            // artifact ("context", never "reference file"), paired with the
+            // same formatCopyResultMessage body — see Toolbar.tsx.
+            title: "Context copied",
             message: formatCopyResultMessage({
               fileCount: result.fileCount,
               stats: result.stats,

--- a/src/services/actions/definitions/systemActions.ts
+++ b/src/services/actions/definitions/systemActions.ts
@@ -7,9 +7,12 @@ import {
   withProjectLocation,
   requireWorktreePath,
   requireWorktreeId,
+  requireExplicitWorktreeForAgentDispatch,
   resolveProjectLocation,
 } from "./locationArgs";
 import { z } from "zod";
+import { notify } from "@/lib/notify";
+import { formatCopyResultMessage } from "@/lib/formatCopyResult";
 import {
   artifactClient,
   cliAvailabilityClient,
@@ -466,28 +469,26 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
       id: "copyTree.generateAndCopyFile",
       title: "Generate And Copy Context",
       description:
-        "Bundle a worktree's context to a file and put it on the system clipboard, replacing whatever the user currently has copied. What lands there is platform-dependent: macOS and Linux copy the file itself, Windows copies its path as text. The bundle is never returned inline — check the budget flags to tell whether it was complete.",
+        "Bundle a worktree's context to a file and put it on the system clipboard, replacing what the user had copied. Selection can mix exact files with globs, so this assembles a curated bundle of scattered related files, their supporting code and tests, rather than the whole worktree. Agent and MCP callers must name the worktree instead of relying on whichever is active. macOS and Linux copy the file, Windows its path. Never returned inline; check the budget flags for completeness.",
       category: "copyTree",
       kind: "command",
       danger: "safe",
       scope: "renderer",
       // run() resolves the target from ctx.activeWorktreeId and throws when none
       // is active. Disable-with-reason in the palette rather than letting the
-      // pick produce a "No active worktree" error toast.
+      // pick produce a "No active worktree" error toast. Palette picks dispatch
+      // with source "user", so the agent-only explicit-target guard below never
+      // applies to them and this fallback stays intact.
       palette: {
         mode: "requireContext",
         isReady: (ctx) => Boolean(ctx.activeWorktreeId),
         reason: "Open a worktree to generate its context",
       },
-      argsSchema: z
-        .object({
-          worktreeId: z
-            .string()
-            .optional()
-            .describe("Worktree ID. Defaults to the active worktree."),
-          options: CopyTreeOptionsSchema.optional(),
-        })
-        .optional(),
+      argsSchema: withWorktreeLocation({
+        options: CopyTreeOptionsSchema.optional().describe(
+          "Selection, exclusion, formatting, and size-budget settings for the bundle."
+        ),
+      }).optional(),
       resultSchema: z.object({
         filePath: z.string(),
         fileCount: z.number(),
@@ -496,11 +497,38 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
       }),
       mcpOutputSchema: true,
       run: async (args, ctx: ActionContext) => {
-        const worktreeId = args?.worktreeId ?? ctx.activeWorktreeId;
-        if (!worktreeId) throw new Error("No active worktree");
-        const result = await copyTreeClient.generateAndCopyFile(worktreeId, args?.options);
+        requireExplicitWorktreeForAgentDispatch("copyTree.generateAndCopyFile", args, ctx);
+        const result = await copyTreeClient.generateAndCopyFile(
+          requireWorktreeId(args, ctx),
+          args?.options
+        );
         throwOnCopyTreeFailure(result);
         const { filePath, outputBytes } = requireGeneratedFile(result);
+        // Only an agent/MCP caller gets a toast, and only after the copy has
+        // actually landed. A person who triggered this themselves already knows
+        // their clipboard changed; a headless caller replaced it with nothing on
+        // screen to say so, which is the one case worth interrupting for
+        // (#11722). Ordered after the failure checks so a failed generate or a
+        // failed clipboard write can never announce success.
+        if (ctx.dispatchSource === "agent") {
+          // No `context.worktreeId` here, deliberately: notify() suppresses a
+          // high-priority toast into the inbox when context names the worktree
+          // the user is already looking at, and an agent copying the ACTIVE
+          // worktree is the common case — passing it would silence exactly the
+          // toast this adds. A clipboard overwrite is invisible no matter which
+          // worktree is on screen, so the origin-surface rule doesn't hold here.
+          // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
+          notify({
+            type: "success",
+            title: "Reference file created",
+            message: formatCopyResultMessage({
+              fileCount: result.fileCount,
+              stats: result.stats,
+              format: args?.options?.format,
+            }),
+            context: { eventKind: "completed" },
+          });
+        }
         return {
           filePath,
           fileCount: result.fileCount,

--- a/src/services/actions/definitions/worktreeContextActions.ts
+++ b/src/services/actions/definitions/worktreeContextActions.ts
@@ -310,7 +310,8 @@ export function registerWorktreeContextActions(
           format: z.enum(["xml", "json", "markdown", "tree", "ndjson", "sarif"]).optional(),
           modified: z.boolean().optional(),
           includePaths: z
-            .array(z.string())
+            .array(z.string().min(1))
+            .min(1)
             .optional()
             .describe(
               "Worktree-relative minimatch patterns to scope the context to. Patterns match file paths, so a folder needs a glob: pass 'src/panels/**', not 'src/panels'."


### PR DESCRIPTION
## Summary

- `copyTree.generateAndCopyFile` now raises a toast when the call comes from an agent dispatch source (the in-app assistant or an external MCP client), fired only after the copy actually lands so a failed generate or clipboard write can never announce success.
- Agent-sourced calls must now name an explicit target worktree instead of inheriting the active one, via a new `requireExplicitWorktreeForAgentDispatch` helper.
- Plus three things the issue didn't ask for: a `filter`/`includePaths` union fix, a fail-closed guard on empty selections, and adding the tool to the external MCP tier so Claude Code and Codex can actually reach it.

Resolves #11722

## Changes

**Toast on an agent-driven copy.** Gated on `ctx.dispatchSource === "agent"`, which covers both the in-app assistant and external MCP clients. It deliberately omits `context.worktreeId` from the toast: `notify()` suppresses a high-priority toast into the inbox when the context names the worktree already on screen, and an agent copying the active worktree is the common case, so naming it would have silenced the very toast being added. Uses `eventKind: "agent"` rather than `"completed"`, since `completedEnabled` only gates main-process completion watches and would have offered a silence control that silences nothing. Carries its own `rateLimitKey` so an unrelated burst of success toasts can't swallow it.

**Explicit target for agent callers.** New `requireExplicitWorktreeForAgentDispatch` in `locationArgs.ts`, the worktree twin of the existing `requireExplicitTerminalIdForAgentDispatch`. It reads the raw selectors before resolution (resolution has already substituted the active worktree by the time it returns) and throws only for `dispatchSource === "agent"`. Palette, keybinding, plugin, and source-less callers keep the active-worktree fallback. The action also moves to `withWorktreeLocation`, so it accepts `worktreePath` alongside `worktreeId`, matching its `copyTree.generate` sibling, with no IPC or client signature changes.

**`filter` and `includePaths` are now unioned, not OR'd.** They're two spellings of one selection set and both feed the SDK's single `filter`, but they were collapsing with `||`, so a caller that split its selection across both (literal files in one, globs in the other) silently lost half of it. That split is the natural shape for a curated bundle, which is how it surfaced.

**An empty or blank selection is now rejected instead of widened.** This is the sharp edge. An empty selection reads as "no filter" to CopyTree, meaning the whole worktree, so `includePaths: []` or `[""]` put a full-repo bundle on the clipboard instead of nothing. Both schemas (the action's and the IPC one) now require non-empty at both levels, mirroring the `scopePaths` guard that already did this. Pre-existing behavior, but worth closing now that the tool is reachable externally.

**External MCP tier.** The tool was on the system tier only, so Claude Code and Codex, the callers the issue names, couldn't actually reach it. Added to `MCP_EXTERNAL_TIER_TOOLS` (25/26 against the budget cap). Worth flagging as a product call: a caller holding `terminal.sendCommand` could already pipe a copy through `pbcopy` itself, so this isn't a capability it categorically lacked; what it couldn't reproduce is one call that applies the project's own CopyTree policy and puts a *file* on the clipboard consistently across macOS, Linux, and Windows. Blast radius is a clipboard overwrite, which `actionRiskBand` already bands `destructive-local`, so the tool now advertises `destructiveHint` to match, without escalating `danger` to a confirm gate (the issue explicitly wants this to land like a manual copy).

### Known limitation

A curated glob can't reach a dotfile. CopyTree 0.17 builds its include matcher as `micromatch.matcher(this.patterns)` in `FileDiscoveryStage.js:485` without `dot: true`, while the force-include matcher three lines up sets it, so `always` sees dotfiles and `filter`/`includePaths` don't. That costs things like `.github/workflows/**`; ordinary sources and tests are unaffected. Verified empirically against the installed package and pinned with a control-backed test that will fail once a fixed copytree is published and the dependency is raised. The fix belongs upstream in `gregpriday/copytree`, not here.

### Follow-ups worth their own issues

- `copyTree.injectToTerminal` has the same ambiguity in a sharper form: its explicit `terminalId` names the destination, not the source worktree, so an agent can inject worktree A's bundle into worktree B's live terminal. Left alone here, different action, in-app tiers only, outside this issue's scope.
- The notification kebab offers "Silence agent notifications" for `eventKind: "agent"`, which has no `userOverrideKey`, so the control does nothing. Pre-existing across all eight agent-kind call sites.

## Testing

Targeted suites all green locally: CopyTree service + sdk-contract (runs the real installed package, not a mock), locationArgs, systemActions.adversarial, useWorktreeActions, MCP tierAuth, copyTree IPC handlers, action-definitions quality + manifest snapshot. Plus typecheck, lint ratchet (warnings down 11), prettier, and the IPC/api-surface codegen guards. New coverage includes the curated mixed-list selection against the real SDK, the union fix, the fail-closed empty/blank selection at both schema boundaries, agent-gate behavior across every dispatch source, and toast gating on success and on each failure path.
