### PR TITLE
fix(terminal): stop cropping long file paths in the hybrid input

### DIFF
--- a/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
+++ b/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
@@ -1505,6 +1505,50 @@ describe("buildInputBarTheme", () => {
       )
     );
   });
+
+  it("keeps file paths and chip labels fully visible instead of cropping them", () => {
+    const css = readGeneratedCss([buildInputBarTheme(theme)]);
+    for (const selector of [".cm-file-chip", ".cm-chip-label"]) {
+      const decls = parseDeclarations(extractRuleBody(css, selector));
+      expect(clipsText(decls), `${selector} must not crop its text`).toBe(false);
+      expect(
+        canBreakUnbrokenToken(decls),
+        `${selector} must be able to break an unbroken token`
+      ).toBe(true);
+    }
+  });
+
+  it("keeps .cm-file-chip transformable so the entrance animation still applies", () => {
+    const css = readGeneratedCss([buildInputBarTheme(theme)]);
+    const decls = parseDeclarations(extractRuleBody(css, ".cm-file-chip"));
+    // A non-replaced `display: inline` box ignores transform, which would
+    // silently kill the chip-enter translateY.
+    expect(decls["display"]).toBeDefined();
+    expect(decls["display"]).not.toBe("inline");
+  });
+
+  it("floors chip pills at the content line-height rather than pinning a fixed height", () => {
+    const css = readGeneratedCss([buildInputBarTheme(theme)]);
+    const contentLineHeight = parseDeclarations(extractRuleBody(css, ".cm-content"))["line-height"];
+    expect(contentLineHeight).toBeDefined();
+
+    for (const selector of [
+      ".cm-file-drop-chip",
+      ".cm-image-chip",
+      ".cm-diff-chip",
+      ".cm-terminal-chip",
+      ".cm-selection-chip",
+    ]) {
+      const decls = parseDeclarations(extractRuleBody(css, selector));
+      // A fixed height makes a wrapped label spill out of the painted pill.
+      expect(decls["height"], `${selector} must not pin a fixed height`).toBeUndefined();
+      // The floor preserves the single-line size, so it has to track the
+      // editor's line-height instead of drifting from it.
+      expect(decls["min-height"], `${selector} should floor at the content line-height`).toBe(
+        contentLineHeight
+      );
+    }
+  });
 });
 
 const ALL_CHIP_SELECTORS = [
@@ -1587,6 +1631,45 @@ function extractRuleBody(css: string, selector: string): string {
     throw new Error(`selector ${selector} not found in CSS`);
   }
   return match[1];
+}
+
+function parseDeclarations(body: string): Record<string, string> {
+  const decls: Record<string, string> = {};
+  for (const part of body.split(";")) {
+    const idx = part.indexOf(":");
+    if (idx === -1) continue;
+    const prop = part.slice(0, idx).trim().toLowerCase();
+    if (prop)
+      decls[prop] = part
+        .slice(idx + 1)
+        .trim()
+        .toLowerCase();
+  }
+  return decls;
+}
+
+// `pre-wrap`, `pre-line` and `break-spaces` all still wrap — only these two refuse.
+const NON_WRAPPING_WHITE_SPACE = new Set(["nowrap", "pre"]);
+
+// Asserted behaviorally rather than against literal declarations so an
+// equivalent implementation (e.g. `word-break: break-all` in place of
+// `overflow-wrap: anywhere`) keeps passing.
+function clipsText(decls: Record<string, string>): boolean {
+  if (/hidden|clip/.test(`${decls["overflow"] ?? ""} ${decls["overflow-x"] ?? ""}`)) return true;
+  if ((decls["text-overflow"] ?? "clip") !== "clip") return true;
+  if (NON_WRAPPING_WHITE_SPACE.has(decls["white-space"] ?? "normal")) return true;
+  return ["max-width", "width", "max-inline-size", "inline-size"].some((prop) => {
+    const value = decls[prop];
+    return value !== undefined && !["none", "auto", "100%"].includes(value);
+  });
+}
+
+// Breaking a slash-free filename needs both a wrapping white-space and an
+// explicit break opportunity — neither alone is enough.
+function canBreakUnbrokenToken(decls: Record<string, string>): boolean {
+  if (NON_WRAPPING_WHITE_SPACE.has(decls["white-space"] ?? "normal")) return false;
+  const wrap = `${decls["overflow-wrap"] ?? ""} ${decls["word-wrap"] ?? ""}`;
+  return /anywhere|break-word/.test(wrap) || /break-all|break-word/.test(decls["word-break"] ?? "");
 }
 
 function extractAtRuleBody(css: string, atRule: string): string {

--- a/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
+++ b/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
@@ -1510,7 +1510,8 @@ describe("buildInputBarTheme", () => {
     const css = readGeneratedCss([buildInputBarTheme(theme)]);
     for (const selector of [".cm-file-chip", ".cm-chip-label"]) {
       const decls = parseDeclarations(extractRuleBody(css, selector));
-      expect(clipsText(decls), `${selector} must not crop its text`).toBe(false);
+      expect(clipsText(decls), `${selector} must not clip its text`).toBe(false);
+      expect(capsInlineSize(decls), `${selector} must not cap its inline size`).toBe(false);
       expect(
         canBreakUnbrokenToken(decls),
         `${selector} must be able to break an unbroken token`
@@ -1518,13 +1519,14 @@ describe("buildInputBarTheme", () => {
     }
   });
 
-  it("keeps .cm-file-chip transformable so the entrance animation still applies", () => {
+  it("preserves whitespace runs so paths differing only by spacing stay distinct", () => {
     const css = readGeneratedCss([buildInputBarTheme(theme)]);
-    const decls = parseDeclarations(extractRuleBody(css, ".cm-file-chip"));
-    // A non-replaced `display: inline` box ignores transform, which would
-    // silently kill the chip-enter translateY.
-    expect(decls["display"]).toBeDefined();
-    expect(decls["display"]).not.toBe("inline");
+    for (const selector of [".cm-file-chip", ".cm-chip-label"]) {
+      const decls = parseDeclarations(extractRuleBody(css, selector));
+      // Quoted @tokens can carry runs of spaces; collapsing them renders two
+      // different files identically, which is the bug the crop already caused.
+      expect(preservesWhitespace(decls), `${selector} must not collapse whitespace`).toBe(true);
+    }
   });
 
   it("floors chip pills at the content line-height rather than pinning a fixed height", () => {
@@ -1540,8 +1542,11 @@ describe("buildInputBarTheme", () => {
       ".cm-selection-chip",
     ]) {
       const decls = parseDeclarations(extractRuleBody(css, selector));
-      // A fixed height makes a wrapped label spill out of the painted pill.
-      expect(decls["height"], `${selector} must not pin a fixed height`).toBeUndefined();
+      // Any pinned block size makes a wrapped label spill out of the painted
+      // pill, whichever property expresses it.
+      for (const prop of ["height", "block-size", "max-height", "max-block-size"]) {
+        expect(decls[prop], `${selector} must not pin its block size via ${prop}`).toBeUndefined();
+      }
       // The floor preserves the single-line size, so it has to track the
       // editor's line-height instead of drifting from it.
       expect(decls["min-height"], `${selector} should floor at the content line-height`).toBe(
@@ -1643,33 +1648,75 @@ function parseDeclarations(body: string): Record<string, string> {
       decls[prop] = part
         .slice(idx + 1)
         .trim()
-        .toLowerCase();
+        .toLowerCase()
+        .replace(/\s*!important$/, "");
   }
   return decls;
 }
 
-// `pre-wrap`, `pre-line` and `break-spaces` all still wrap — only these two refuse.
+// `pre-wrap`, `pre-line` and `break-spaces` all still wrap — only these refuse.
 const NON_WRAPPING_WHITE_SPACE = new Set(["nowrap", "pre"]);
 
-// Asserted behaviorally rather than against literal declarations so an
-// equivalent implementation (e.g. `word-break: break-all` in place of
-// `overflow-wrap: anywhere`) keeps passing.
+// `white-space` may be a legacy single keyword or the modern
+// `<collapse> <text-wrap>` shorthand, and `text-wrap`/`text-wrap-mode` can
+// suppress wrapping alone — so tokenize instead of comparing whole values.
+function refusesToWrap(decls: Record<string, string>): boolean {
+  const whiteSpace = decls["white-space"];
+  if (whiteSpace?.split(/\s+/).some((t) => NON_WRAPPING_WHITE_SPACE.has(t))) return true;
+  return decls["text-wrap"] === "nowrap" || decls["text-wrap-mode"] === "nowrap";
+}
+
+// Collapsing values would render `@"a  b.ts"` and `@"a b.ts"` identically — the
+// same indistinguishable-paths failure the cropping caused.
+const WHITESPACE_PRESERVING = new Set(["pre", "pre-wrap", "break-spaces", "preserve"]);
+
+function preservesWhitespace(decls: Record<string, string>): boolean {
+  return !!decls["white-space"]?.split(/\s+/).some((t) => WHITESPACE_PRESERVING.has(t));
+}
+
+// Clipping proper — declarations that hide characters outright.
 function clipsText(decls: Record<string, string>): boolean {
   if (/hidden|clip/.test(`${decls["overflow"] ?? ""} ${decls["overflow-x"] ?? ""}`)) return true;
   if ((decls["text-overflow"] ?? "clip") !== "clip") return true;
-  if (NON_WRAPPING_WHITE_SPACE.has(decls["white-space"] ?? "normal")) return true;
+  return refusesToWrap(decls);
+}
+
+// Content- or container-derived sizes let a chip use the width it is given; a
+// fixed length or sub-full percentage caps it regardless of available space.
+const UNCAPPED_INLINE_SIZES = new Set([
+  "none",
+  "auto",
+  "100%",
+  "fit-content",
+  "min-content",
+  "max-content",
+  "stretch",
+  "-webkit-fill-available",
+]);
+
+function capsInlineSize(decls: Record<string, string>): boolean {
   return ["max-width", "width", "max-inline-size", "inline-size"].some((prop) => {
     const value = decls[prop];
-    return value !== undefined && !["none", "auto", "100%"].includes(value);
+    return value !== undefined && !UNCAPPED_INLINE_SIZES.has(value);
   });
 }
+
+// Only these zero the min-content contribution, which is what lets a chip
+// shrink inside a narrow pane. `overflow-wrap: break-word` deliberately does
+// NOT qualify: it breaks glyphs but still reports the unbroken token's width as
+// min-content, so the chip would keep forcing the pane wider. Exact matches
+// rather than substring tests, so `var(--break-word-policy)` can't slip past.
+const MIN_CONTENT_ZEROING_BREAKS: ReadonlyArray<readonly [string, string]> = [
+  ["overflow-wrap", "anywhere"],
+  ["word-break", "break-all"],
+  ["word-break", "break-word"],
+];
 
 // Breaking a slash-free filename needs both a wrapping white-space and an
 // explicit break opportunity — neither alone is enough.
 function canBreakUnbrokenToken(decls: Record<string, string>): boolean {
-  if (NON_WRAPPING_WHITE_SPACE.has(decls["white-space"] ?? "normal")) return false;
-  const wrap = `${decls["overflow-wrap"] ?? ""} ${decls["word-wrap"] ?? ""}`;
-  return /anywhere|break-word/.test(wrap) || /break-all|break-word/.test(decls["word-break"] ?? "");
+  if (refusesToWrap(decls)) return false;
+  return MIN_CONTENT_ZEROING_BREAKS.some(([prop, value]) => decls[prop] === value);
 }
 
 function extractAtRuleBody(css: string, atRule: string): string {

--- a/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
+++ b/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
@@ -1663,7 +1663,10 @@ const NON_WRAPPING_WHITE_SPACE = new Set(["nowrap", "pre"]);
 function refusesToWrap(decls: Record<string, string>): boolean {
   const whiteSpace = decls["white-space"];
   if (whiteSpace?.split(/\s+/).some((t) => NON_WRAPPING_WHITE_SPACE.has(t))) return true;
-  return decls["text-wrap"] === "nowrap" || decls["text-wrap-mode"] === "nowrap";
+  // `text-wrap` is itself a shorthand (`<mode> <style>`, e.g. `nowrap pretty`).
+  return [decls["text-wrap"], decls["text-wrap-mode"]].some(
+    (v) => v?.split(/\s+/).includes("nowrap") ?? false
+  );
 }
 
 // Collapsing values would render `@"a  b.ts"` and `@"a b.ts"` identically — the
@@ -1683,22 +1686,29 @@ function clipsText(decls: Record<string, string>): boolean {
 
 // Content- or container-derived sizes let a chip use the width it is given; a
 // fixed length or sub-full percentage caps it regardless of available space.
-const UNCAPPED_INLINE_SIZES = new Set([
-  "none",
+const UNCAPPED_SIZES = new Set([
   "auto",
   "100%",
   "fit-content",
-  "min-content",
-  "max-content",
   "stretch",
   "-webkit-fill-available",
 ]);
 
+// A max-* cap only constrains when it can resolve below the content's width, so
+// `none` and `max-content` leave the chip free where a definite `width` would not.
+const UNCAPPED_MAX_SIZES = new Set([...UNCAPPED_SIZES, "none", "max-content"]);
+
 function capsInlineSize(decls: Record<string, string>): boolean {
-  return ["max-width", "width", "max-inline-size", "inline-size"].some((prop) => {
+  const capped = (prop: string, uncapped: Set<string>) => {
     const value = decls[prop];
-    return value !== undefined && !UNCAPPED_INLINE_SIZES.has(value);
-  });
+    return value !== undefined && !uncapped.has(value);
+  };
+  return (
+    capped("width", UNCAPPED_SIZES) ||
+    capped("inline-size", UNCAPPED_SIZES) ||
+    capped("max-width", UNCAPPED_MAX_SIZES) ||
+    capped("max-inline-size", UNCAPPED_MAX_SIZES)
+  );
 }
 
 // Only these zero the min-content contribution, which is what lets a chip

--- a/src/components/Terminal/inputEditorExtensions/base.ts
+++ b/src/components/Terminal/inputEditorExtensions/base.ts
@@ -17,7 +17,10 @@ const INLINE_CHIP_BASE = {
   // minHeight, not height: a wrapped label has to grow the pill rather than
   // spill out of its painted background. Single-line chips still land on 20px.
   minHeight: "20px",
-  verticalAlign: "bottom",
+  // top, not bottom: a wrapped pill is taller than the line box, and adjacent
+  // text should sit on its first row rather than its last. Identical for
+  // single-line chips, whose height already equals the line box.
+  verticalAlign: "top",
   whiteSpace: "nowrap",
   gap: "4px",
   padding: "0 5px",
@@ -98,15 +101,17 @@ export function buildInputBarTheme(theme: ITheme): Extension {
         textDecoration: "underline dotted 1px",
         textUnderlineOffset: "2px",
         // The full path stays visible and wraps: truncating hid the tail, so two
-        // out-of-tree files could render identically. `anywhere` (not
-        // `break-word`) also zeroes min-content, so the chip shrinks in narrow
-        // panes instead of blowing them out.
-        whiteSpace: "normal",
+        // out-of-tree files could render identically. `break-spaces` (not
+        // `normal`) because quoted tokens can carry runs of spaces that
+        // `normal` would collapse — the same indistinguishable-paths bug by
+        // another route. `anywhere` (not `break-word`) zeroes min-content, so
+        // the chip shrinks in narrow panes instead of blowing them out.
+        whiteSpace: "break-spaces",
         overflowWrap: "anywhere",
-        verticalAlign: "bottom",
+        verticalAlign: "top",
       },
       ".cm-chip-label": {
-        whiteSpace: "normal",
+        whiteSpace: "break-spaces",
         overflowWrap: "anywhere",
         minWidth: "0",
       },

--- a/src/components/Terminal/inputEditorExtensions/base.ts
+++ b/src/components/Terminal/inputEditorExtensions/base.ts
@@ -14,7 +14,9 @@ export const TERMINAL_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width=
 const INLINE_CHIP_BASE = {
   display: "inline-flex",
   alignItems: "center",
-  height: "20px",
+  // minHeight, not height: a wrapped label has to grow the pill rather than
+  // spill out of its painted background. Single-line chips still land on 20px.
+  minHeight: "20px",
   verticalAlign: "bottom",
   whiteSpace: "nowrap",
   gap: "4px",
@@ -95,19 +97,18 @@ export function buildInputBarTheme(theme: ITheme): Extension {
         color: c.chipColor,
         textDecoration: "underline dotted 1px",
         textUnderlineOffset: "2px",
-        // Long paths ellipsize instead of blowing out narrow panes; the hover
-        // tooltip still shows the full path.
-        maxWidth: "280px",
-        overflow: "hidden",
-        textOverflow: "ellipsis",
-        whiteSpace: "nowrap",
+        // The full path stays visible and wraps: truncating hid the tail, so two
+        // out-of-tree files could render identically. `anywhere` (not
+        // `break-word`) also zeroes min-content, so the chip shrinks in narrow
+        // panes instead of blowing them out.
+        whiteSpace: "normal",
+        overflowWrap: "anywhere",
         verticalAlign: "bottom",
       },
       ".cm-chip-label": {
-        maxWidth: "180px",
-        overflow: "hidden",
-        textOverflow: "ellipsis",
-        whiteSpace: "nowrap",
+        whiteSpace: "normal",
+        overflowWrap: "anywhere",
+        minWidth: "0",
       },
       ".cm-tooltip": {
         background: "transparent",


### PR DESCRIPTION
Summary: File-reference chips in the hybrid input cropped long paths with a CSS max-width plus ellipsis, so the tail of the path was only reachable by hovering. Two files outside the project tree — say ~/Downloads/a/very/long/x.ts and ~/Downloads/b/very/long/y.ts — rendered identically once truncated. The chips now show the full path and wrap like ordinary editor text (EditorView.lineWrapping was already on).

What changed:
- `.cm-file-chip`: dropped the 280px cap, `overflow: hidden` and `text-overflow: ellipsis`. Now `white-space: break-spaces` + `overflow-wrap: anywhere`.
- `.cm-chip-label` (drop/image chip filenames): dropped the 180px cap and the same clipping trio, same wrapping treatment, plus `min-width: 0` for the flex case.
- `INLINE_CHIP_BASE`: `height: 20px` became `min-height: 20px`. The shared pill had a hard-pinned height, so a wrapped label would have spilled out of its painted background instead of growing it. Single-line chips are unaffected — the pill's content box is already exactly the 20px line-height with no vertical padding.
- `vertical-align` on chip boxes moved from `bottom` to `top`, so adjacent text sits on a wrapped chip's first row rather than its last. Provably a no-op for single-line chips, whose height already equals the line box.

Two details worth calling out:
- `overflow-wrap: anywhere` rather than `break-word`: only `anywhere` zeroes the flex item's min-content contribution, which is what lets the chip shrink inside a narrow pane instead of forcing it wider. `break-word` breaks glyphs but still reports the unbroken token's full width.
- `white-space: break-spaces` rather than `normal`: `normal` collapses runs of spaces, and quoted @tokens can legitimately carry them, so `@"a  b.ts"` and `@"a b.ts"` would have rendered identically — the same indistinguishable-paths bug, reintroduced by another route. `break-spaces` is also what CodeMirror itself lists as wrapping-safe.

Testing: three new tests in the buildInputBarTheme suite assert behavioral invariants over the generated stylesheet rather than literal declarations, so an equivalent implementation (e.g. `word-break: break-all` in place of `overflow-wrap: anywhere`) still passes: no chip rule clips its text or caps its inline size, both can break an unbroken token, both preserve whitespace runs, and no pill pins a block size. All three fail against the pre-fix CSS. 229 tests pass across the hybrid-input suites.

Follow-ups (deliberately out of scope here, worth separate issues):
- The autocomplete menu still truncates directories in JS at 59 chars and uses Tailwind `truncate`, so duplicate basenames with long shared prefixes remain ambiguous there. Different component, needs a full-path field — not a CSS fix.
- A Playwright geometry test is the only way to truly prove wrapping (jsdom does no layout). It needs a full app build to verify locally, so it is left for a follow-up rather than shipped unverified into a release-gating bucket.
- Filenames containing tabs or newlines can still render ambiguously. Pre-existing, not a regression from this change, and the fix is character escaping in the widget.

Resolves #11725