### PR TITLE
fix(protocols): read app:// assets via fs.readFile, not fs.open

### DIFF
--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -3181,6 +3181,9 @@ describe("createAppProtocolHandler — ASAR-safe buffered read", () => {
     const response = await handler(makeRequest());
 
     expect(response.status).toBe(404);
+    // A retry through fs.open here would look like a harmless fallback and put
+    // the asar extraction right back (#11726) — there is no second attempt.
+    expect(fs.open).not.toHaveBeenCalled();
   });
 
   it("returns 404 when the read rejects with EISDIR (directory that slipped past isFile)", async () => {
@@ -3203,6 +3206,7 @@ describe("createAppProtocolHandler — ASAR-safe buffered read", () => {
     const response = await handler(makeRequest());
 
     expect(response.status).toBe(500);
+    expect(fs.open).not.toHaveBeenCalled();
   });
 
   describe("404 diagnostics (#11635)", () => {
@@ -3277,18 +3281,20 @@ describe("createAppProtocolHandler — ASAR-safe buffered read", () => {
 
     it("reports a body-read failure as its own stage, apart from stat and not-a-file", async () => {
       const fs = await import("fs/promises");
+      // Carries a code and nothing else: errors reach us wrapped or synthesized
+      // often enough that the report has to omit the syscall fields it wasn't
+      // given rather than log them as undefined.
       vi.mocked(fs.readFile).mockRejectedValue(
-        Object.assign(new Error("nope"), { code: "EISDIR", syscall: "read" })
+        Object.assign(new Error("nope"), { code: "EISDIR" })
       );
 
       const handler = await captureHandler();
       await handler(makeRequest());
 
-      expect(await notFoundLog()).toMatchObject({
-        stage: "read",
-        code: "EISDIR",
-        syscall: "read",
-      });
+      const logged = await notFoundLog();
+      expect(logged).toMatchObject({ stage: "read", code: "EISDIR" });
+      expect(logged).not.toHaveProperty("path");
+      expect(logged).not.toHaveProperty("syscall");
     });
 
     it("logs the resolver rejection with its reason and never touches disk", async () => {

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -92,6 +92,7 @@ const fsPromisesMocks = vi.hoisted(() => ({
   realpath: vi.fn(),
   stat: vi.fn(),
   open: vi.fn(),
+  readFile: vi.fn(),
   constants: { O_RDONLY: 0, O_NOFOLLOW: 0x100, O_NONBLOCK: 0x4 },
 }));
 
@@ -3019,7 +3020,7 @@ describe("createPluginProtocolHandler", () => {
   });
 });
 
-describe("createAppProtocolHandler — direct disk read", () => {
+describe("createAppProtocolHandler — ASAR-safe buffered read", () => {
   type ProtocolHandler = (request: GlobalRequest) => Promise<Response>;
 
   async function captureHandler(): Promise<ProtocolHandler> {
@@ -3038,14 +3039,6 @@ describe("createAppProtocolHandler — direct disk read", () => {
     return new Request(`app://daintree${pathname}`, init) as GlobalRequest;
   }
 
-  function makeFileHandle(content: string | Buffer = "bytes") {
-    const buffer = typeof content === "string" ? Buffer.from(content) : content;
-    return {
-      readFile: vi.fn().mockResolvedValue(buffer),
-      close: vi.fn().mockResolvedValue(undefined),
-    };
-  }
-
   beforeEach(async () => {
     vi.clearAllMocks();
     const fs = await import("fs/promises");
@@ -3053,9 +3046,7 @@ describe("createAppProtocolHandler — direct disk read", () => {
       mtime: new Date(0),
       isFile: () => true,
     } as Awaited<ReturnType<typeof fs.stat>>);
-    vi.mocked(fs.open).mockResolvedValue(
-      makeFileHandle() as unknown as Awaited<ReturnType<typeof fs.open>>
-    );
+    vi.mocked(fs.readFile).mockResolvedValue(Buffer.from("bytes"));
     const appProtocol = await import("../../utils/appProtocol.js");
     vi.mocked(appProtocol.resolveAppUrlToDistPath).mockReturnValue({
       filePath: "/tmp/dist/assets/index-abc123.js",
@@ -3067,7 +3058,7 @@ describe("createAppProtocolHandler — direct disk read", () => {
     vi.mocked(appProtocol.isNotModified).mockReturnValue(false);
   });
 
-  it("serves the file straight off disk with fs.open(O_RDONLY) and never touches net.fetch", async () => {
+  it("serves the file with fs.readFile and never calls fs.open or net.fetch", async () => {
     const { net } = await import("electron");
     const fs = await import("fs/promises");
 
@@ -3078,12 +3069,15 @@ describe("createAppProtocolHandler — direct disk read", () => {
     expect(await response.text()).toBe("bytes");
     // The whole point of #9768: read directly, no Chromium network-stack hop.
     expect(vi.mocked(net.fetch)).not.toHaveBeenCalled();
-    expect(fs.open).toHaveBeenCalledTimes(1);
-    const openArgs = vi.mocked(fs.open).mock.calls[0];
-    expect(openArgs[0]).toBe("/tmp/dist/assets/index-abc123.js");
-    // No O_NOFOLLOW — app:// uses lexical containment with no realpath, so there
-    // is no TOCTOU window for the flag to close.
-    expect(openArgs[1]).toBe(fs.constants.O_RDONLY);
+    expect(fs.readFile).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(fs.readFile).mock.calls[0][0]).toBe("/tmp/dist/assets/index-abc123.js");
+    // #11726: dist/ lives inside the asar, and fs.open on an archived path makes
+    // Electron extract it to a memoized temp file. Once that file is reaped the
+    // entry goes stale and every open throws ENOENT for the life of the process,
+    // so index.html — and with it every project switch — fails until restart.
+    // fs.readFile reads off the archive's backing fd and never extracts. Swapping
+    // back to open would silently reintroduce the bug, so guard it here.
+    expect(fs.open).not.toHaveBeenCalled();
   });
 
   it("builds the 200 response headers from the validator stats (Last-Modified / Cache-Control)", async () => {
@@ -3121,10 +3115,10 @@ describe("createAppProtocolHandler — direct disk read", () => {
     );
 
     expect(response.status).toBe(404);
-    expect(fs.open).not.toHaveBeenCalled();
+    expect(fs.readFile).not.toHaveBeenCalled();
   });
 
-  it("short-circuits to 304 without opening the file when the validator matches", async () => {
+  it("short-circuits to 304 without reading the file when the validator matches", async () => {
     const fs = await import("fs/promises");
     const appProtocol = await import("../../utils/appProtocol.js");
     vi.mocked(appProtocol.isNotModified).mockReturnValue(true);
@@ -3137,7 +3131,7 @@ describe("createAppProtocolHandler — direct disk read", () => {
     );
 
     expect(response.status).toBe(304);
-    expect(fs.open).not.toHaveBeenCalled();
+    expect(fs.readFile).not.toHaveBeenCalled();
   });
 
   it("returns 405 for non-GET/HEAD methods without resolving a path", async () => {
@@ -3163,7 +3157,7 @@ describe("createAppProtocolHandler — direct disk read", () => {
 
     expect(response.status).toBe(404);
     expect(fs.stat).not.toHaveBeenCalled();
-    expect(fs.open).not.toHaveBeenCalled();
+    expect(fs.readFile).not.toHaveBeenCalled();
   });
 
   it("returns 404 when stat fails (missing file)", async () => {
@@ -3174,12 +3168,14 @@ describe("createAppProtocolHandler — direct disk read", () => {
     const response = await handler(makeRequest());
 
     expect(response.status).toBe(404);
-    expect(fs.open).not.toHaveBeenCalled();
+    expect(fs.readFile).not.toHaveBeenCalled();
   });
 
-  it("returns 404 when fs.open rejects with ENOENT", async () => {
+  it("returns 404 when the read rejects with ENOENT after stat succeeded", async () => {
     const fs = await import("fs/promises");
-    vi.mocked(fs.open).mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+    vi.mocked(fs.readFile).mockRejectedValue(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+    );
 
     const handler = await captureHandler();
     const response = await handler(makeRequest());
@@ -3187,9 +3183,11 @@ describe("createAppProtocolHandler — direct disk read", () => {
     expect(response.status).toBe(404);
   });
 
-  it("returns 404 when fs.open rejects with EISDIR (directory URL on Windows)", async () => {
+  it("returns 404 when the read rejects with EISDIR (directory that slipped past isFile)", async () => {
     const fs = await import("fs/promises");
-    vi.mocked(fs.open).mockRejectedValue(Object.assign(new Error("EISDIR"), { code: "EISDIR" }));
+    vi.mocked(fs.readFile).mockRejectedValue(
+      Object.assign(new Error("EISDIR"), { code: "EISDIR" })
+    );
 
     const handler = await captureHandler();
     const response = await handler(makeRequest());
@@ -3197,72 +3195,14 @@ describe("createAppProtocolHandler — direct disk read", () => {
     expect(response.status).toBe(404);
   });
 
-  it("returns 404 when readFile rejects with EISDIR (directory open succeeds on macOS/Linux)", async () => {
+  it("returns 500 when the read fails with an error that isn't a missing file", async () => {
     const fs = await import("fs/promises");
-    const handle = {
-      readFile: vi.fn().mockRejectedValue(Object.assign(new Error("EISDIR"), { code: "EISDIR" })),
-      close: vi.fn().mockResolvedValue(undefined),
-    };
-    vi.mocked(fs.open).mockResolvedValue(handle as unknown as Awaited<ReturnType<typeof fs.open>>);
-
-    const handler = await captureHandler();
-    const response = await handler(makeRequest());
-
-    expect(response.status).toBe(404);
-    expect(handle.close).toHaveBeenCalledTimes(1);
-  });
-
-  it("returns 500 and closes the handle when readFile fails unexpectedly", async () => {
-    const fs = await import("fs/promises");
-    const handle = {
-      readFile: vi.fn().mockRejectedValue(Object.assign(new Error("EIO"), { code: "EIO" })),
-      close: vi.fn().mockResolvedValue(undefined),
-    };
-    vi.mocked(fs.open).mockResolvedValue(handle as unknown as Awaited<ReturnType<typeof fs.open>>);
+    vi.mocked(fs.readFile).mockRejectedValue(Object.assign(new Error("EIO"), { code: "EIO" }));
 
     const handler = await captureHandler();
     const response = await handler(makeRequest());
 
     expect(response.status).toBe(500);
-    expect(handle.close).toHaveBeenCalledTimes(1);
-  });
-
-  it("returns 500 when fs.open rejects with an unexpected error", async () => {
-    const fs = await import("fs/promises");
-    vi.mocked(fs.open).mockRejectedValue(Object.assign(new Error("EACCES"), { code: "EACCES" }));
-
-    const handler = await captureHandler();
-    const response = await handler(makeRequest());
-
-    expect(response.status).toBe(500);
-  });
-
-  it("closes the file handle on the success path", async () => {
-    const fs = await import("fs/promises");
-    const handle = makeFileHandle("bytes");
-    vi.mocked(fs.open).mockResolvedValue(handle as unknown as Awaited<ReturnType<typeof fs.open>>);
-
-    const handler = await captureHandler();
-    const response = await handler(makeRequest());
-
-    expect(response.status).toBe(200);
-    expect(handle.close).toHaveBeenCalledTimes(1);
-  });
-
-  it("returns 200 when close() rejects after a successful read (close errors are swallowed)", async () => {
-    const fs = await import("fs/promises");
-    const handle = {
-      readFile: vi.fn().mockResolvedValue(Buffer.from("ok")),
-      close: vi.fn().mockRejectedValue(new Error("EBADF")),
-    };
-    vi.mocked(fs.open).mockResolvedValue(handle as unknown as Awaited<ReturnType<typeof fs.open>>);
-
-    const handler = await captureHandler();
-    const response = await handler(makeRequest());
-
-    expect(response.status).toBe(200);
-    expect(await response.text()).toBe("ok");
-    expect(handle.close).toHaveBeenCalledTimes(1);
   });
 
   describe("404 diagnostics (#11635)", () => {
@@ -3288,7 +3228,12 @@ describe("createAppProtocolHandler — direct disk read", () => {
     it("distinguishes the stat failure from the other 404 branches", async () => {
       const fs = await import("fs/promises");
       vi.mocked(fs.stat).mockRejectedValue(
-        Object.assign(new Error("nope"), { code: "ENOENT", errno: -2 })
+        Object.assign(new Error("nope"), {
+          code: "ENOENT",
+          errno: -2,
+          path: "/tmp/dist/assets/vanished.js",
+          syscall: "stat",
+        })
       );
 
       const handler = await captureHandler();
@@ -3302,6 +3247,11 @@ describe("createAppProtocolHandler — direct disk read", () => {
         filePath: "/tmp/dist/assets/index-abc123.js",
         code: "ENOENT",
         errno: -2,
+        // Carried through from the failing syscall alongside filePath, so a
+        // report can tell the path we asked for apart from the one the
+        // filesystem layer actually reported (#11726).
+        path: "/tmp/dist/assets/vanished.js",
+        syscall: "stat",
       });
     });
 
@@ -3319,24 +3269,26 @@ describe("createAppProtocolHandler — direct disk read", () => {
       expect(logged).toMatchObject({ stage: "not-a-file" });
       // Nothing threw, so there is no errno to invent.
       expect(logged).not.toHaveProperty("code");
+      // Same for the syscall fields: this branch has no caught error to read
+      // them off, and a report that carried them anyway would be fiction.
+      expect(logged).not.toHaveProperty("path");
+      expect(logged).not.toHaveProperty("syscall");
     });
 
-    it("separates an open failure from a read failure", async () => {
+    it("reports a body-read failure as its own stage, apart from stat and not-a-file", async () => {
       const fs = await import("fs/promises");
-      vi.mocked(fs.open).mockRejectedValue(Object.assign(new Error("nope"), { code: "EISDIR" }));
+      vi.mocked(fs.readFile).mockRejectedValue(
+        Object.assign(new Error("nope"), { code: "EISDIR", syscall: "read" })
+      );
 
       const handler = await captureHandler();
       await handler(makeRequest());
-      expect(await notFoundLog()).toMatchObject({ stage: "open", code: "EISDIR" });
 
-      vi.mocked(await import("../../utils/logger.js")).logWarn.mockClear();
-      vi.mocked(fs.open).mockResolvedValue({
-        readFile: vi.fn().mockRejectedValue(Object.assign(new Error("nope"), { code: "EISDIR" })),
-        close: vi.fn().mockResolvedValue(undefined),
-      } as unknown as Awaited<ReturnType<typeof fs.open>>);
-
-      await handler(makeRequest());
-      expect(await notFoundLog()).toMatchObject({ stage: "read", code: "EISDIR" });
+      expect(await notFoundLog()).toMatchObject({
+        stage: "read",
+        code: "EISDIR",
+        syscall: "read",
+      });
     });
 
     it("logs the resolver rejection with its reason and never touches disk", async () => {

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -58,7 +58,7 @@ let cachedGetPluginDir: GetPluginDir | null = null;
  * preload (#11635), and the stage is the only thing that tells the otherwise
  * identical branches apart in a production log.
  */
-type AppNotFoundStage = "resolve" | "stat" | "not-a-file" | "open" | "read";
+type AppNotFoundStage = "resolve" | "stat" | "not-a-file" | "read";
 
 function appNotFound(
   stage: AppNotFoundStage,
@@ -74,6 +74,12 @@ function appNotFound(
     ...(typeof cause === "string" ? { reason: cause } : {}),
     ...(errno?.code ? { code: errno.code } : {}),
     ...(errno?.errno !== undefined ? { errno: errno.errno } : {}),
+    // The path the failing syscall itself reported, kept alongside the
+    // handler-resolved filePath: when the two disagree the report names the
+    // layer that rewrote it, which is the only way to tell a damaged dist tree
+    // apart from a packaging indirection failing underneath us (#11726).
+    ...(errno?.path !== undefined ? { path: errno.path } : {}),
+    ...(errno?.syscall !== undefined ? { syscall: errno.syscall } : {}),
   });
   return new Response("Not Found", {
     status: 404,
@@ -128,37 +134,34 @@ function createAppProtocolHandler(distPath: string) {
     // Read the bytes directly off disk instead of round-tripping through
     // net.fetch(). Custom-scheme responses never enter Chromium's HTTP disk
     // cache, so the fetch path added a Chromium network-stack hop plus a second
-    // in-memory copy on every asset load for no caching benefit. No O_NOFOLLOW:
-    // unlike daintree-file:// / plugin://, resolveAppUrlToDistPath does lexical
-    // (path.resolve + startsWith) containment with no realpath, so there is no
-    // realpath/open TOCTOU window for the flag to close — adding it would imply
-    // a defense that isn't set up here. dist assets are application-owned.
-    let fileHandle: Awaited<ReturnType<typeof fs.open>>;
+    // in-memory copy on every asset load for no caching benefit.
+    //
+    // This must stay fs.readFile, never fs.open: dist/ ships inside the asar
+    // (it is deliberately not in asarUnpack), and Electron backs fs.open on an
+    // archived path with Archive::CopyFileOut — an extraction to a temp file
+    // memoized in external_files_ for callers that need a real fd. If that temp
+    // file is reaped out from under a long-running app, the memoized entry goes
+    // stale and every later open throws ENOENT while stat keeps succeeding off
+    // the archive header, so index.html stops loading until restart and every
+    // project switch fails (#11726). fs.readFile is patched separately to read
+    // straight off the archive's own backing fd and never extracts.
+    //
+    // No O_NOFOLLOW to reach for either: unlike daintree-file:// / plugin://,
+    // resolveAppUrlToDistPath does lexical (path.resolve + startsWith)
+    // containment with no realpath, so there is no realpath/open TOCTOU window
+    // for the flag to close — adding it would imply a defense that isn't set up
+    // here. dist assets are application-owned.
     try {
-      fileHandle = await fs.open(filePath, fs.constants.O_RDONLY);
-    } catch (err) {
-      const errCode = (err as NodeJS.ErrnoException).code;
-      if (errCode === "ENOENT" || errCode === "EISDIR") {
-        return appNotFound("open", request.url, filePath, err);
-      }
-      console.error("[MAIN] Error serving file:", filePath, err);
-      return new Response("Internal Server Error", {
-        status: 500,
-        headers: buildHeaders("text/plain"),
-      });
-    }
-
-    try {
-      const buffer = await fileHandle.readFile();
+      const buffer = await fs.readFile(filePath);
       return new Response(buffer, {
         status: 200,
         headers: buildHeaders(getMimeType(filePath), { stats, filePath }),
       });
     } catch (err) {
-      // fs.open on a directory succeeds on macOS/Linux; the EISDIR only surfaces
-      // here at readFile. Map it to 404 like the open path so a directory URL
-      // never returns a 500.
-      if ((err as NodeJS.ErrnoException).code === "EISDIR") {
+      // A directory that slipped past the isFile() guard surfaces as EISDIR;
+      // map it and a vanished file to 404 so neither returns a 500.
+      const errCode = (err as NodeJS.ErrnoException).code;
+      if (errCode === "ENOENT" || errCode === "EISDIR") {
         return appNotFound("read", request.url, filePath, err);
       }
       console.error("[MAIN] Error serving file:", filePath, err);
@@ -166,9 +169,6 @@ function createAppProtocolHandler(distPath: string) {
         status: 500,
         headers: buildHeaders("text/plain"),
       });
-    } finally {
-      // Swallow close errors so they don't mask a preceding readFile failure.
-      await fileHandle.close().catch(() => {});
     }
   };
 }


### PR DESCRIPTION
## Summary
- `createAppProtocolHandler` serves every `app://daintree/...` asset, including `dist/index.html`, from inside the ASAR. It read files with `fs.open(filePath, O_RDONLY)`, then `fileHandle.readFile()`, then `close()`. Electron backs `fs.open` on an ASAR path with an extraction to an OS temp file, memoized in `external_files_`. That path exists for callers needing a real fd (native `dlopen`, `child_process.spawn`), not for ordinary reads.
- When the temp file gets reaped out from under a long-running app (suspected macOS ~3-day `/var/folders` reaping, trigger unproven), the memoized entry goes stale: `fs.stat` keeps succeeding off the archive header while `fs.open` throws `ENOENT` for the rest of the process lifetime. `index.html` stops loading, so every project switch fails until restart.
- `dist/` is deliberately not in `asarUnpack`, which is why `app://` alone hits this. `plugin://` assets are unpacked and `daintree-file://` serves real filesystem paths.

Resolves #11726

## Changes
- Read with a single `fs.readFile(filePath)` instead of open/read/close. Electron patches `fs.readFile` separately to read straight off the archive's own backing fd at the header-recorded offset, so it never extracts.
- Collapse the two catch blocks into one: `ENOENT` and `EISDIR` both map to 404, everything else to 500. This slightly widens behavior (the old read-stage catch used to send `ENOENT` to 500; it now inherits the old open-stage behavior).
- Drop the now-unreachable `"open"` member from `AppNotFoundStage`. Four stages remain, representing handler phases rather than syscalls.
- `appNotFound` now logs the failing syscall's own `path` and `syscall` alongside the resolved `filePath`, so a future report can tell a genuinely damaged `dist` tree from a packaging indirection failing underneath it.

## Testing
- `npx vitest run` over the test twin plus all 12 suites referencing the module: 281 tests across 13 files, all passing, including `ProjectViewManager.switchFailure.test.ts`, which covers the #11635/#11644 safeguard this fix sits behind.
- `eslint` and `prettier --check` clean on both changed files.
- Reviewed by two parallel adversarial automated passes (correctness; tests/edge cases). The correctness pass returned no findings: it verified the `ENOENT` to 404 widening is inert against the safeguard (`ProjectViewFactory.ts:208` probes the committed document for an application-owned `#root`, so recovery is status-independent), confirmed Buffer/BodyInit parity under Node 24.18's fetch, and confirmed there's no fd leak (path-based `readFile` routes both fulfilment and rejection through `handleFdClose`; ASAR reads use the archive-owned fd). That pass surfaced two hardening gaps, both fixed in a follow-up commit.

## Note
The packaged-ASAR trigger isn't reproducible in a dev-mode run or in E2E testing, so the regression contract is encoded structurally instead: the handler must call `fs.readFile` and must never call `fs.open`, asserted on the success path and on both read-failure paths, so an innocent-looking fallback-to-open refactor can't reintroduce the extraction.

Related to #11635 and its fix #11644.
