### PR TITLE
fix(palette): give the anchored tier back the width its rows need

### DIFF
--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -1326,18 +1326,18 @@ function ProjectSwitcherFooter({
 
   return (
     // Container-queried rather than fixed: the same footer serves the anchored
-    // dropdown and the wider command-tier modal, and the passive "Right-click
-    // for more" does not fit the anchored box — so it drops there and the Enter
-    // action and "All agents" (the only affordance with no other entry point)
-    // survive. Tailwind needs each variant written out, so it is a literal.
+    // dropdown and the wider command-tier modal. "Right-click for more" is the
+    // passive rail — it names no key and points at what a right-click already
+    // discovers — so it is the one that drops on the narrower tier, leaving the
+    // Enter action and "All agents" (the only affordance with no other entry
+    // point). Tailwind needs each variant written out, so it is a literal.
     //
-    // There is deliberately no ⌘⌫ Remove rail. It fit the old single 484px
-    // surface, but the anchored footer is 326px: at its widest — ⌘ held, so the
-    // Enter rail reads "⌘↵ New window" — the two rails measure 251px, and a
-    // Remove rail takes that to 343px, which overflows rather than degrading.
-    // A container query cannot drop it only in the ⌘-held state, and ⌘ held is
-    // exactly when it would be worth reading. The chord itself still works; the
-    // context menu is what names it.
+    // There is deliberately no ⌘⌫ Remove rail, and widening the anchored tier
+    // back to 484px (#11736) does not earn it one: the rail was cut for what it
+    // says, not only for the room it took. A footer names what Enter does for
+    // the current selection, and removing a project is destructive — it belongs
+    // where it can be confirmed, which is the row's context menu. The chord
+    // still works; the footer is just not what teaches it.
     <div className="@container/switcher-footer w-full flex items-center justify-between gap-3">
       <span className="shrink-0">
         <kbd className={KBD_CLASS}>{hint.keys}</kbd>

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -1326,18 +1326,17 @@ function ProjectSwitcherFooter({
 
   return (
     // Container-queried rather than fixed: the same footer serves the anchored
-    // dropdown and the wider command-tier modal. "Right-click for more" is the
-    // passive rail — it names no key and points at what a right-click already
-    // discovers — so it is the one that drops on the narrower tier, leaving the
-    // Enter action and "All agents" (the only affordance with no other entry
-    // point). Tailwind needs each variant written out, so it is a literal.
+    // dropdown and the wider command-tier modal. "Right-click for more" names
+    // no key and is the lowest-priority rail, so it is the one that drops on
+    // the narrower tier, leaving the Enter action and "All agents" (the only
+    // affordance with no other entry point). Tailwind needs each variant
+    // written out, so it is a literal.
     //
-    // There is deliberately no ⌘⌫ Remove rail, and widening the anchored tier
-    // back to 484px (#11736) does not earn it one: the rail was cut for what it
-    // says, not only for the room it took. A footer names what Enter does for
-    // the current selection, and removing a project is destructive — it belongs
-    // where it can be confirmed, which is the row's context menu. The chord
-    // still works; the footer is just not what teaches it.
+    // There is no ⌘⌫ Remove rail. It was cut while the anchored tier was 352px
+    // and the rail overflowed; #11736 widened that tier back to 484px, so the
+    // room objection is gone and restoring it is a live option — just not one a
+    // width fix should decide. Remove stays reachable from the row's context
+    // menu and from ⌘⌫ itself, and both open the same confirmation.
     <div className="@container/switcher-footer w-full flex items-center justify-between gap-3">
       <span className="shrink-0">
         <kbd className={KBD_CLASS}>{hint.keys}</kbd>

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -781,12 +781,12 @@ describe("ProjectSwitcherPalette modal mode", () => {
     });
   });
 
-  it("keeps the footer to the rails the anchored box can actually paint", () => {
-    // A ⌘⌫ Remove rail used to sit here and is deliberately gone: it overflows
-    // the 326px anchored footer whenever ⌘ is held, and a container query that
-    // hid it would hide it in every state the dropdown ever renders. Asserted
-    // as an absence because jsdom evaluates no container query — a presence
-    // assertion here would pass on text no user ever sees.
+  it("keeps the footer to the rails the switcher means to name", () => {
+    // A ⌘⌫ Remove rail used to sit here and is deliberately gone: the footer
+    // names what Enter does for the selection, and a destructive action belongs
+    // where it can be confirmed — the row's context menu. Asserted as an
+    // absence because jsdom evaluates no container query — a presence assertion
+    // here would pass on text no user ever sees.
     render(<ProjectSwitcherPalette {...dropdownProps} results={multiProjects} />);
     const footer = screen.getByTestId("palette-footer");
     expect(footer.textContent).toContain("Switch");
@@ -977,9 +977,10 @@ describe("ProjectSwitcherPalette scratch search rows", () => {
 
   it("drops the project-only shortcut hints while a scratch is highlighted", () => {
     // Run on the command tier, the only one that actually paints the
-    // context-menu rail — the anchored dropdown's footer is 326px, so the rail
-    // is container-queried away there, and jsdom evaluates no container query,
-    // which would let this pass on text the user never sees.
+    // context-menu rail — the anchored dropdown's footer stays under the
+    // query's threshold even at the wider tier, so the rail is queried away
+    // there, and jsdom evaluates no container query, which would let this pass
+    // on text the user never sees.
     const commandSearchProps = { ...searchProps, mode: "modal" as const };
     const { rerender } = render(
       <ProjectSwitcherPalette {...commandSearchProps} results={[makeProject({ id: "p1" })]} />

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -781,12 +781,11 @@ describe("ProjectSwitcherPalette modal mode", () => {
     });
   });
 
-  it("keeps the footer to the rails the switcher means to name", () => {
-    // A ⌘⌫ Remove rail used to sit here and is deliberately gone: the footer
-    // names what Enter does for the selection, and a destructive action belongs
-    // where it can be confirmed — the row's context menu. Asserted as an
-    // absence because jsdom evaluates no container query — a presence assertion
-    // here would pass on text no user ever sees.
+  it("keeps the footer to the rails the switcher currently names", () => {
+    // A ⌘⌫ Remove rail used to sit here and is gone: it overflowed the footer
+    // while the anchored tier was 352px, and #11736's widening has not brought
+    // it back. Asserted as an absence because jsdom evaluates no container
+    // query — a presence assertion here would pass on text no user ever sees.
     render(<ProjectSwitcherPalette {...dropdownProps} results={multiProjects} />);
     const footer = screen.getByTestId("palette-footer");
     expect(footer.textContent).toContain("Switch");

--- a/src/components/Worktree/WorktreePalette.tsx
+++ b/src/components/Worktree/WorktreePalette.tsx
@@ -36,8 +36,8 @@ function WorktreeListItem({ worktree, isActive, isSelected, onClick }: WorktreeL
         role="option"
       >
         <div className="flex items-center justify-between gap-2 text-sm">
-          {/* Both sides truncate: a long branch name used to have the width to
-              spare, and on the anchored tier it does not. */}
+          {/* Both sides truncate: branch names have no length worth trusting,
+              so no tier is wide enough to make this unnecessary. */}
           <span className="font-medium text-daintree-text truncate">{worktree.name}</span>
           <div className="flex items-center gap-2 min-w-0 text-xs text-daintree-text/60">
             {worktree.branch && (

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -42,9 +42,16 @@ export { KBD_CLASS };
 
 /**
  * How much box a palette earns. A launcher hanging off a toolbar button and a
- * global command palette are not the same kind of surface, and one width in
- * between served neither: anchored menus sit around 320px, centred command
- * palettes around 600px.
+ * global command palette are not the same kind of surface: the anchored tier
+ * stays visibly narrower because it hangs off a control and reads as that
+ * control's menu, while the command tier is the centred surface the window
+ * defers to.
+ *
+ * Narrower is a step down, not a squeeze. An anchored palette carries the same
+ * rows as its command twin — titles, paths, a status line — so the tier is
+ * sized to that content and not to its chrome. #11736 was the cost of getting
+ * that wrong: sized as a menu, the switcher's dropdown could not hold what it
+ * was still being asked to show.
  *
  * Two tiers, not a free width per palette — palettes open from the same
  * keyboard reflex and often in sequence, so unconstrained per-surface sizing
@@ -58,7 +65,7 @@ export type PaletteSurfaceTier = "anchored" | "command";
  * map at runtime is fine; the scanner only reads the text.
  */
 export const PALETTE_SURFACE_WIDTHS: Record<PaletteSurfaceTier, string> = {
-  anchored: "w-[352px] max-w-[calc(100vw-2rem)]",
+  anchored: "w-[484px] max-w-[calc(100vw-2rem)]",
   command: "w-[608px] max-w-[calc(100vw-2rem)]",
 };
 

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -41,17 +41,18 @@ import {
 export { KBD_CLASS };
 
 /**
- * How much box a palette earns. A launcher hanging off a toolbar button and a
- * global command palette are not the same kind of surface: the anchored tier
- * stays visibly narrower because it hangs off a control and reads as that
- * control's menu, while the command tier is the centred surface the window
- * defers to.
+ * How much box a palette earns. A picker scoped to one question — launch what,
+ * switch where — and a global command palette are not the same kind of surface:
+ * the anchored tier stays visibly narrower, while the command tier is the one
+ * the whole window defers to. Scope, not hosting: most anchored palettes are
+ * centred dialogs like their command siblings, and only the dock launcher and
+ * the project switcher hang off a trigger.
  *
  * Narrower is a step down, not a squeeze. An anchored palette carries the same
  * rows as its command twin — titles, paths, a status line — so the tier is
  * sized to that content and not to its chrome. #11736 was the cost of getting
- * that wrong: sized as a menu, the switcher's dropdown could not hold what it
- * was still being asked to show.
+ * that wrong: sized as if it were a menu, the switcher's dropdown could not
+ * hold what it was still being asked to show.
  *
  * Two tiers, not a free width per palette — palettes open from the same
  * keyboard reflex and often in sequence, so unconstrained per-surface sizing


### PR DESCRIPTION
Resolves #11736

## The fix

Commit `decb03be6` replaced the single `PALETTE_SURFACE_WIDTH` of 484px with a two-tier map, and the project switcher's title-bar dropdown, which renders on the `anchored` tier, fell from 484px to 352px. This restores `PALETTE_SURFACE_WIDTHS.anchored` to `w-[484px] max-w-[calc(100vw-2rem)]`. The `command` tier stays untouched at 608px.

That's the entire functional change. One string.

Widening the shared tier constant, rather than adding a third tier or giving the switcher a one-off `className` override, is what the issue is asking for. The tier map exists so anchored palettes move together instead of each picking their own width. Seven surfaces sit on the anchored tier, and all seven rendered at 484px before the tier split.

## Everything else is prose the widening made false

Four spots carried pixel math or width claims keyed to the old 352px value:

- The `PaletteSurfaceTier` doc comment described anchored as "around 320px".
- `ProjectSwitcherFooter` justified the missing Cmd+Delete Remove rail with "the anchored footer is 326px... a Remove rail takes that to 343px, which overflows".
- Two comments in `ProjectSwitcherPalette.render.test.tsx` referenced that same 326px footer number.
- `WorktreePalette`'s truncation note said the anchored tier lacked width the old surface had.

All four are fixed to describe current behavior.

On the Remove rail specifically: its stated reason for being cut is gone now that 343px fits comfortably in a ~460px footer. I left the rail out rather than restoring it here, but rewrote the comment to say so honestly, cut for room, room is back, restoring it is a live option, but a width fix isn't the place to make that call. Remove stays reachable from the row's right-click context menu and from Cmd+Delete, both opening the same confirmation dialog.

## No behavior changes beyond the width

`@max-[520px]/switcher-footer` still hides "Right-click for more" on the anchored tier (~460px footer) and shows it on command (~584px), same as before. `SECONDARY_DROP_CLASSES` is untouched, neither of its two consumers (`ActionPalette`, `PluginQuickPickDialog`) sits on the anchored tier.

## Testing

432 tests across 12 suites pass, including the three relational tier checks that guard `anchored < command` (`AppPaletteDialog.test.tsx`, `AppPalettePopover.test.tsx`, `SearchablePalette.footer.test.tsx`). 484 < 608 holds, so `e2e/screenshots/palette-review.spec.ts` passes unmodified too.

No new test added. This repo bans tautological assertions, and jsdom doesn't do layout, so nothing at unit level can tell 484px apart from 352px without hardcoding the number. Visual review is the honest guard for a width tuning like this one.

## Known follow-up, not in this PR

`popover.tsx` sets its collision boundary to `calc(100vw - var(--right-obstruction-offset, 0px))`. Radix can shift or flip a fixed-width popover but can't shrink it, so at a narrow window with the Assistant panel open, the two popover-hosted anchored palettes (project switcher, dock launcher) can crowd that boundary. This isn't a regression, v0.30.1 ran the same 484px popover geometry, and fixing the boundary calculation properly is a separate change that touches every consumer of that positioning component, including ones that have nothing to do with this issue. Worth filing on its own.
