### PR TITLE
fix(copytree): teach the MCP schema the folder-needs-a-glob rule

### DIFF
--- a/electron/services/CopyTreeService.ts
+++ b/electron/services/CopyTreeService.ts
@@ -15,6 +15,7 @@ import type {
   CopyTreeBudgetStats,
   CopyTreeExclusionReason,
   CopyTreeExclusionSummary,
+  CopyTreeUnmatchedSelector,
   FileTreeNode,
 } from "../../shared/types/ipc/copyTree.js";
 import { fileTreeService } from "./FileTreeService.js";
@@ -182,11 +183,16 @@ class CopyTreeService {
         progressThrottleMs: 100,
       };
 
+      // Captured from the request rather than from `sdkOptions`, which has
+      // already unioned the two spellings into one `filter`.
+      const suppliedSelector = CopyTreeService.suppliedPatternSelector(options);
+
       if (outputPath) {
         return await this.streamToFile(
           copytree.copyStream,
           rootPath,
           sdkOptions,
+          suppliedSelector,
           outputPath,
           controller
         );
@@ -202,7 +208,7 @@ class CopyTreeService {
         stats: {
           totalSize: result.stats.totalSize,
           duration: result.stats.duration,
-          ...this.mapBudgetStats(result.stats),
+          ...this.mapBudgetStats(result.stats, suppliedSelector),
         },
       };
     } catch (error: unknown) {
@@ -233,6 +239,7 @@ class CopyTreeService {
     copyStream: (typeof import("copytree"))["copyStream"],
     rootPath: string,
     sdkOptions: SdkCopyOptions,
+    suppliedSelector: CopyTreeUnmatchedSelector | undefined,
     outputPath: string,
     controller: AbortController
   ): Promise<CopyTreeResult> {
@@ -316,7 +323,7 @@ class CopyTreeService {
         stats: {
           totalSize: finished.stats.totalSize,
           duration: finished.stats.duration,
-          ...this.mapBudgetStats(finished.stats),
+          ...this.mapBudgetStats(finished.stats, suppliedSelector),
         },
       };
     } catch (error) {
@@ -386,7 +393,7 @@ class CopyTreeService {
         includedFiles: included.length,
         includedSize: included.reduce((total, entry) => total + entry.size, 0),
         files: included,
-        ...this.mapBudgetStats(result.stats),
+        ...this.mapBudgetStats(result.stats, CopyTreeService.suppliedPatternSelector(options)),
       };
     } catch (error: unknown) {
       return {
@@ -637,6 +644,47 @@ class CopyTreeService {
     return Array.from(new Set(merged));
   }
 
+  /**
+   * Name the pattern selectors this request supplied, the way it spelled them.
+   *
+   * Read before `mergeSelectionPatterns` collapses the two into one SDK
+   * `filter`, because afterwards they are indistinguishable — and a caller who
+   * only ever sent `includePaths` should not be told its `filter` missed. When
+   * both carry patterns neither can be singled out, so the pair is reported.
+   */
+  private static suppliedPatternSelector(
+    options: CopyTreeOptions
+  ): CopyTreeUnmatchedSelector | undefined {
+    const hasIncludePaths = (options.includePaths?.length ?? 0) > 0;
+    const filter = options.filter;
+    const hasFilter = Array.isArray(filter) ? filter.length > 0 : (filter?.length ?? 0) > 0;
+
+    if (hasIncludePaths && hasFilter) return "filterAndIncludePaths";
+    if (hasIncludePaths) return "includePaths";
+    if (hasFilter) return "filter";
+    return undefined;
+  }
+
+  /**
+   * Blame the supplied patterns for an empty run, but only when they earned it.
+   *
+   * `filterPattern` counts files the walker produced and the include patterns
+   * then rejected. The walker prunes by scope, gitignore and config excludes as
+   * it goes and tests include patterns first among its per-file checks, so a
+   * non-zero count is proof that real files reached the patterns and none
+   * survived — never that the subtree was empty to begin with. Gated on
+   * `noFilesMatched` as well because that same count is ordinary on a
+   * SUCCESSFUL narrow selection: every file outside the selection is booked
+   * there, and reporting it then would flag healthy runs.
+   */
+  private static deriveUnmatchedSelector(
+    stats: CopyResult["stats"],
+    supplied: CopyTreeUnmatchedSelector | undefined
+  ): CopyTreeUnmatchedSelector | undefined {
+    if (supplied === undefined || stats.noFilesMatched !== true) return undefined;
+    return (stats.excluded?.byReason?.filterPattern ?? 0) > 0 ? supplied : undefined;
+  }
+
   private buildSdkOptions(options: CopyTreeOptions, signal: AbortSignal): SdkCopyOptions {
     return {
       signal,
@@ -681,11 +729,15 @@ class CopyTreeService {
     };
   }
 
-  private mapBudgetStats(stats: CopyResult["stats"]): CopyTreeBudgetStats {
+  private mapBudgetStats(
+    stats: CopyResult["stats"],
+    suppliedSelector: CopyTreeUnmatchedSelector | undefined
+  ): CopyTreeBudgetStats {
     return {
       estimatedOutputChars: stats.estimatedOutputChars,
       estimatedTokens: stats.estimatedTokens,
       noFilesMatched: stats.noFilesMatched,
+      unmatchedSelector: CopyTreeService.deriveUnmatchedSelector(stats, suppliedSelector),
       excluded: this.mapExclusions(stats.excluded),
       truncated: stats.truncated,
       truncatedCount: stats.truncatedCount,

--- a/electron/services/CopyTreeService.ts
+++ b/electron/services/CopyTreeService.ts
@@ -655,9 +655,16 @@ class CopyTreeService {
   private static suppliedPatternSelector(
     options: CopyTreeOptions
   ): CopyTreeUnmatchedSelector | undefined {
-    const hasIncludePaths = (options.includePaths?.length ?? 0) > 0;
+    // Deliberately mirrors what `mergeSelectionPatterns` above counts as a
+    // contribution, down to the scalar case: it wraps a non-undefined string
+    // into a one-entry list, so `filter: ""` becomes the unmatchable pattern
+    // `[""]` and is very much supplied — while `filter: []` contributes nothing
+    // and leaves the SDK unfiltered. Both boundaries reject those inputs, but
+    // the direct-service path does not, and disagreeing with the merge is how
+    // the caller whose selection emptied the run gets told nothing.
     const filter = options.filter;
-    const hasFilter = Array.isArray(filter) ? filter.length > 0 : (filter?.length ?? 0) > 0;
+    const hasIncludePaths = (options.includePaths?.length ?? 0) > 0;
+    const hasFilter = Array.isArray(filter) ? filter.length > 0 : filter !== undefined;
 
     if (hasIncludePaths && hasFilter) return "filterAndIncludePaths";
     if (hasIncludePaths) return "includePaths";
@@ -666,23 +673,62 @@ class CopyTreeService {
   }
 
   /**
+   * Exclusion reasons that can only be booked BEFORE the include patterns run.
+   *
+   * The walker prunes by ignore file, config exclude and scope as it descends,
+   * so everything here happened to files that never reached the pattern check.
+   * Anything NOT on this list — a later stage, or a reason a future SDK adds —
+   * removed a file that had already passed the patterns, which is the whole
+   * point of the distinction below. Unknown reasons falling outside it is the
+   * safe direction: the hint goes quiet rather than blaming the wrong field.
+   */
+  private static readonly PRE_PATTERN_EXCLUSIONS: ReadonlySet<string> = new Set<string>([
+    "gitignore",
+    "copytreeignore",
+    "globalGitignore",
+    "gitInfoExclude",
+    "configExclude",
+    "scopeFilter",
+    "testExclude",
+    "unreadable",
+  ] satisfies CopyTreeExclusionReason[]);
+
+  /**
    * Blame the supplied patterns for an empty run, but only when they earned it.
    *
-   * `filterPattern` counts files the walker produced and the include patterns
-   * then rejected. The walker prunes by scope, gitignore and config excludes as
-   * it goes and tests include patterns first among its per-file checks, so a
-   * non-zero count is proof that real files reached the patterns and none
-   * survived — never that the subtree was empty to begin with. Gated on
-   * `noFilesMatched` as well because that same count is ordinary on a
-   * SUCCESSFUL narrow selection: every file outside the selection is booked
-   * there, and reporting it then would flag healthy runs.
+   * `filterPattern` counts files that reached the include-pattern check and
+   * failed it, so a non-zero count is necessary — but it is nowhere near
+   * sufficient. `noFilesMatched` is `files.length === 0` measured after the
+   * WHOLE pipeline, and the git filter, the file-count and total-size budgets,
+   * `exclude`, the size gate and the character limit all run after the pattern
+   * check. So a run holding one decoy file that failed the patterns and one
+   * real match that a later stage then dropped satisfies both conditions while
+   * the patterns did their job perfectly — and telling that caller to rewrite
+   * its `includePaths` sends it to fix the one part of the request that worked,
+   * which is the same failure #11731 is about, pointed the other way.
+   *
+   * A file removed after the patterns is therefore proof they matched something
+   * and disqualifies the hint. `truncated` is a second, cheap read on the same
+   * question for a budget that drops a file without booking a reason.
    */
   private static deriveUnmatchedSelector(
     stats: CopyResult["stats"],
     supplied: CopyTreeUnmatchedSelector | undefined
   ): CopyTreeUnmatchedSelector | undefined {
     if (supplied === undefined || stats.noFilesMatched !== true) return undefined;
-    return (stats.excluded?.byReason?.filterPattern ?? 0) > 0 ? supplied : undefined;
+
+    const byReason: Record<string, number> = stats.excluded?.byReason ?? {};
+    if ((byReason.filterPattern ?? 0) <= 0) return undefined;
+    if (stats.truncated === true) return undefined;
+
+    const survivedThePatterns = Object.entries(byReason).some(
+      ([reason, count]) =>
+        count > 0 &&
+        reason !== "filterPattern" &&
+        !CopyTreeService.PRE_PATTERN_EXCLUSIONS.has(reason)
+    );
+
+    return survivedThePatterns ? undefined : supplied;
   }
 
   private buildSdkOptions(options: CopyTreeOptions, signal: AbortSignal): SdkCopyOptions {

--- a/electron/services/CopyTreeService.ts
+++ b/electron/services/CopyTreeService.ts
@@ -681,6 +681,17 @@ class CopyTreeService {
    * removed a file that had already passed the patterns, which is the whole
    * point of the distinction below. Unknown reasons falling outside it is the
    * safe direction: the hint goes quiet rather than blaming the wrong field.
+   *
+   * `optionExclude` is here despite reading like a post-pattern stage, and the
+   * distinction is load-bearing rather than academic. `exclude` is installed as
+   * an ignore LAYER on the walker (`kind: 'option-exclude'`), so it prunes
+   * before the patterns are ever consulted; the later re-application in
+   * ProfileFilterStage only exists to outrank ignore negations and has nothing
+   * left to remove. Treating it as post-pattern would silence the hint on
+   * ordinary runs, because the IPC handler folds a project's `excludedPaths`
+   * and `alwaysExclude` into `exclude` whenever the caller omits it — so the
+   * one diagnostic #11731 asked for would go missing on precisely the
+   * configured real-world repositories that need it.
    */
   private static readonly PRE_PATTERN_EXCLUSIONS: ReadonlySet<string> = new Set<string>([
     "gitignore",
@@ -688,10 +699,14 @@ class CopyTreeService {
     "globalGitignore",
     "gitInfoExclude",
     "configExclude",
+    "optionExclude",
     "scopeFilter",
     "testExclude",
     "unreadable",
-  ] satisfies CopyTreeExclusionReason[]);
+    // Walker-emitted, and the one post-loop emitter books it for forced entries
+    // that bypass the patterns entirely — so it never implies a pattern match.
+    "symlinkEscape",
+  ] satisfies (CopyTreeExclusionReason | "symlinkEscape")[]);
 
   /**
    * Blame the supplied patterns for an empty run, but only when they earned it.
@@ -709,7 +724,10 @@ class CopyTreeService {
    *
    * A file removed after the patterns is therefore proof they matched something
    * and disqualifies the hint. `truncated` is a second, cheap read on the same
-   * question for a budget that drops a file without booking a reason.
+   * question for a budget that drops a file without booking a reason. What was
+   * pruned on the way IN says nothing either way, which is what the allowlist
+   * above is for — suppressing on those would leave the hint firing only on
+   * repositories with no ignore rules and no configured excludes.
    */
   private static deriveUnmatchedSelector(
     stats: CopyResult["stats"],

--- a/electron/services/__tests__/CopyTreeService.sdk-contract.test.ts
+++ b/electron/services/__tests__/CopyTreeService.sdk-contract.test.ts
@@ -234,6 +234,10 @@ describe("CopyTreeService against the installed CopyTree", () => {
       // The renderer's "why is this empty" toast reads byReason, so a pruned
       // folder has to be accounted for rather than vanishing silently.
       expect(result.excluded?.total).toBeGreaterThan(0);
+      // No pattern was supplied and none could have run — the walk was already
+      // empty. Naming a selector here would send a caller to fix the one part
+      // of its request that was correct (#11731).
+      expect(result.unmatchedSelector).toBeUndefined();
     });
 
     it("reports a scoped path that doesn't exist as a sanitized error", async () => {
@@ -498,6 +502,40 @@ describe("CopyTreeService against the installed CopyTree", () => {
       // traversal. (The exact-list assertion is what proves the selection; this
       // catches the accounting going silent.)
       expect(result.excluded?.byReason.filterPattern).toBeGreaterThan(0);
+      // ...and that same count is why blame is gated on `noFilesMatched` too:
+      // this run succeeded, so nothing is to blame for it (#11731).
+      expect(result.unmatchedSelector).toBeUndefined();
+    });
+
+    // The failure #11731 traced, reproduced against the real SDK: every path a
+    // caller sent named a directory that exists, and the run came back empty
+    // with no error and nothing to correct.
+    it("blames the patterns when a bare directory selects nothing", async () => {
+      const result = await copyTreeService.testConfig(tempDir, {
+        includePaths: ["src/landscape"],
+      });
+
+      // The directory is real — the same fixture the curated selection above
+      // pulls four files out of — so "no such path" is not the explanation.
+      expect(result.error).toBeUndefined();
+      expect(result.includedFiles).toBe(0);
+      expect(result.noFilesMatched).toBe(true);
+      // Files reached the pattern check and every one was rejected there, which
+      // is what makes the patterns rather than the traversal the culprit.
+      expect(result.excluded?.byReason.filterPattern).toBeGreaterThan(0);
+      expect(result.unmatchedSelector).toBe("includePaths");
+    });
+
+    it("blames neither selector when the glob form of the same folder works", async () => {
+      // The remedy the description now prescribes has to actually be the
+      // remedy, or the hint sends callers somewhere that fails the same way.
+      const result = await copyTreeService.testConfig(tempDir, {
+        includePaths: ["src/landscape/**"],
+      });
+
+      expect(result.includedFiles).toBeGreaterThan(0);
+      expect(result.noFilesMatched).toBeFalsy();
+      expect(result.unmatchedSelector).toBeUndefined();
     });
 
     it("carries the curated files, and only those, into a real generated bundle", async () => {

--- a/electron/services/__tests__/CopyTreeService.sdk-contract.test.ts
+++ b/electron/services/__tests__/CopyTreeService.sdk-contract.test.ts
@@ -567,16 +567,31 @@ describe("CopyTreeService against the installed CopyTree", () => {
         expect(result.unmatchedSelector).toBeUndefined();
       });
 
-      it("stays quiet when `exclude` removed what the patterns selected", async () => {
-        const result = await copyTreeService.testConfig(tempDir, {
-          includePaths: ["src/landscape/**"],
-          exclude: ["src/landscape/**"],
-        });
+      // The git filter is the other post-pattern stage that can empty a run
+      // this way, but reaching it needs a real repository with a real diff.
+      // Its mapping is covered by the mocked `gitFilter` row in
+      // CopyTreeService.test.ts; the size gate above is what proves the
+      // post-pattern rule against the real pipeline, so a git fixture here
+      // would add process spawning without adding a distinct guarantee.
+    });
 
-        expect(result.noFilesMatched).toBe(true);
-        expect(result.excluded?.byReason.filterPattern).toBeGreaterThan(0);
-        expect(result.unmatchedSelector).toBeUndefined();
+    it("still blames a bare directory on a repo that has configured excludes", async () => {
+      // `exclude` is installed as an ignore LAYER on the walker, so it prunes
+      // before the patterns are consulted and proves nothing about them. It is
+      // also not optional in practice: the IPC handler folds a project's
+      // `excludedPaths` and `alwaysExclude` into `exclude` whenever the caller
+      // omits it, so treating its accounting as post-pattern would silence the
+      // #11731 diagnostic on exactly the configured repositories that need it.
+      const result = await copyTreeService.testConfig(tempDir, {
+        includePaths: ["src/landscape"],
+        exclude: ["docs/**"],
       });
+
+      expect(result.noFilesMatched).toBe(true);
+      // The precondition: the exclude really did book entries, so this is not
+      // passing because the layer never fired.
+      expect(result.excluded?.byReason.optionExclude).toBeGreaterThan(0);
+      expect(result.unmatchedSelector).toBe("includePaths");
     });
 
     it("carries the curated files, and only those, into a real generated bundle", async () => {

--- a/electron/services/__tests__/CopyTreeService.sdk-contract.test.ts
+++ b/electron/services/__tests__/CopyTreeService.sdk-contract.test.ts
@@ -533,9 +533,50 @@ describe("CopyTreeService against the installed CopyTree", () => {
         includePaths: ["src/landscape/**"],
       });
 
-      expect(result.includedFiles).toBeGreaterThan(0);
+      // The deepest fixture file specifically: a `/**` that regressed to direct
+      // children only would still leave `includedFiles` non-zero, so a count
+      // check alone would not notice the folder remedy half-working.
+      expect(result.files?.map((file) => file.path)).toContain(
+        "src/landscape/support/nested/seed.ts"
+      );
       expect(result.noFilesMatched).toBeFalsy();
       expect(result.unmatchedSelector).toBeUndefined();
+    });
+
+    // `noFilesMatched` is `files.length === 0` measured once the whole pipeline
+    // has run, and the size gate, the git filter and the budgets all run after
+    // the pattern check. So "some file failed the patterns" and "the run came
+    // back empty" can both be true while the patterns matched perfectly — the
+    // decoys supply the first, a later stage removes the real match. Blaming
+    // the patterns there would send a caller to rewrite the one field that
+    // worked, which is #11731 pointed the other way.
+    describe("a later stage, not the patterns, emptying the run", () => {
+      it("stays quiet when the size gate dropped the only match", async () => {
+        // The pattern selects exactly one real file; the gate then rejects it,
+        // while the unselected decoys have already been booked as filterPattern.
+        const result = await copyTreeService.testConfig(tempDir, {
+          includePaths: ["src/landscape/generator.ts"],
+          maxFileSize: 1,
+        });
+
+        expect(result.noFilesMatched).toBe(true);
+        // The precondition that makes this test meaningful: without it the run
+        // could be empty for some third reason and pass vacuously.
+        expect(result.excluded?.byReason.filterPattern).toBeGreaterThan(0);
+        expect(result.excluded?.byReason.sizeGate).toBeGreaterThan(0);
+        expect(result.unmatchedSelector).toBeUndefined();
+      });
+
+      it("stays quiet when `exclude` removed what the patterns selected", async () => {
+        const result = await copyTreeService.testConfig(tempDir, {
+          includePaths: ["src/landscape/**"],
+          exclude: ["src/landscape/**"],
+        });
+
+        expect(result.noFilesMatched).toBe(true);
+        expect(result.excluded?.byReason.filterPattern).toBeGreaterThan(0);
+        expect(result.unmatchedSelector).toBeUndefined();
+      });
     });
 
     it("carries the curated files, and only those, into a real generated bundle", async () => {

--- a/electron/services/__tests__/CopyTreeService.stream.test.ts
+++ b/electron/services/__tests__/CopyTreeService.stream.test.ts
@@ -40,7 +40,10 @@ type StreamOptions = {
  * Stand in for the SDK generator: yield the given chunks, then report
  * completion exactly as `copyStream` does — only on a run that finished.
  */
-function streamYielding(chunks: string[], options: { complete?: boolean } = {}) {
+function streamYielding(
+  chunks: string[],
+  options: { complete?: boolean; stats?: typeof STATS } = {}
+) {
   return (_rootPath: string, streamOptions: StreamOptions) =>
     (async function* () {
       for (const chunk of chunks) {
@@ -50,7 +53,7 @@ function streamYielding(chunks: string[], options: { complete?: boolean } = {}) 
         streamOptions.onComplete?.({
           outputFormatVersion: "copytree-xml@1",
           manifest: [],
-          stats: STATS,
+          stats: options.stats ?? STATS,
         });
       }
     })();
@@ -113,6 +116,50 @@ describe("CopyTreeService streaming to a file", () => {
       duration: STATS.duration,
       estimatedTokens: STATS.estimatedTokens,
     });
+  });
+
+  // This is the branch production actually takes: the IPC handler passes an
+  // output path, so `copyTree.generate` and `copyTree.generateAndCopyFile` both
+  // land here rather than in the buffered `copy()` path. A selector captured in
+  // `generate()` and not threaded this far would leave two of the three
+  // advertised MCP actions without the hint (#11731).
+  it("attributes an empty streamed bundle to the selector that emptied it", async () => {
+    copyStreamMock.mockImplementation(
+      streamYielding(["<files/>"], {
+        stats: {
+          ...STATS,
+          totalFiles: 0,
+          noFilesMatched: true,
+          excluded: { total: 4, byReason: { filterPattern: 4 } },
+        },
+      })
+    );
+
+    const result = await copyTreeService.generate(
+      tempDir,
+      { includePaths: ["src/panels"], filter: "docs" },
+      undefined,
+      "op-1",
+      outputPath
+    );
+
+    // Both spellings were supplied and neither can be singled out once they are
+    // unioned, so the pair is what the caller gets.
+    expect(result.stats?.unmatchedSelector).toBe("filterAndIncludePaths");
+  });
+
+  it("leaves a streamed bundle that found files unattributed", async () => {
+    copyStreamMock.mockImplementation(streamYielding(["<files/>"]));
+
+    const result = await copyTreeService.generate(
+      tempDir,
+      { includePaths: ["src/**"] },
+      undefined,
+      "op-1",
+      outputPath
+    );
+
+    expect(result.stats?.unmatchedSelector).toBeUndefined();
   });
 
   it("publishes atomically, leaving no partial behind", async () => {

--- a/electron/services/__tests__/CopyTreeService.test.ts
+++ b/electron/services/__tests__/CopyTreeService.test.ts
@@ -544,6 +544,12 @@ describe("CopyTreeService", () => {
         { supplied: { includePaths: ["src/panels"] }, expected: "includePaths" },
         { supplied: { filter: "src/panels" }, expected: "filter" },
         { supplied: { filter: ["src/panels"] }, expected: "filter" },
+        // A scalar filter is wrapped into a one-entry list by
+        // `mergeSelectionPatterns`, so even a blank one is a real, unmatchable
+        // pattern the SDK enforces. Counting it as absent here would leave the
+        // caller whose selection emptied the run with nothing to correct — the
+        // very thing this field exists to prevent.
+        { supplied: { filter: "" }, expected: "filter" },
         {
           supplied: { includePaths: ["src/panels"], filter: "docs" },
           expected: "filterAndIncludePaths",
@@ -601,7 +607,7 @@ describe("CopyTreeService", () => {
       // failed the patterns and a real match that a later stage then dropped
       // satisfy both halves of the old gate while the patterns did their job.
       // Each reason here belongs to a stage that runs after the pattern check.
-      it.each(["sizeGate", "gitFilter", "optionExclude", "charBudget", "duplicate"])(
+      it.each(["sizeGate", "gitFilter", "charBudget", "duplicate", "fileCountBudget"])(
         "stays quiet when %s removed a file that had already passed the patterns",
         async (reason) => {
           mockEmptyRun({ filterPattern: 4, [reason]: 1 });
@@ -626,7 +632,21 @@ describe("CopyTreeService", () => {
         expect(result.unmatchedSelector).toBeUndefined();
       });
 
-      it.each(["gitignore", "configExclude", "scopeFilter", "testExclude", "unreadable"])(
+      it.each([
+        "gitignore",
+        "copytreeignore",
+        "globalGitignore",
+        "gitInfoExclude",
+        "configExclude",
+        // `exclude` is a walker ignore layer, not a later stage — and the IPC
+        // handler injects a project's excludedPaths/alwaysExclude into it, so
+        // suppressing here would silence the hint on configured repositories.
+        "optionExclude",
+        "scopeFilter",
+        "testExclude",
+        "unreadable",
+        "symlinkEscape",
+      ])(
         "still blames the patterns when the only company is %s, pruned on the way in",
         async (reason) => {
           // These are booked by the walker before a file ever reaches the

--- a/electron/services/__tests__/CopyTreeService.test.ts
+++ b/electron/services/__tests__/CopyTreeService.test.ts
@@ -597,6 +597,76 @@ describe("CopyTreeService", () => {
         expect(result.unmatchedSelector).toBeUndefined();
       });
 
+      // `noFilesMatched` is measured after the WHOLE pipeline, so a decoy that
+      // failed the patterns and a real match that a later stage then dropped
+      // satisfy both halves of the old gate while the patterns did their job.
+      // Each reason here belongs to a stage that runs after the pattern check.
+      it.each(["sizeGate", "gitFilter", "optionExclude", "charBudget", "duplicate"])(
+        "stays quiet when %s removed a file that had already passed the patterns",
+        async (reason) => {
+          mockEmptyRun({ filterPattern: 4, [reason]: 1 });
+
+          const result = await copyTreeService.testConfig(tempDir, {
+            includePaths: ["src/panels/**"],
+          });
+
+          expect(result.noFilesMatched).toBe(true);
+          expect(result.unmatchedSelector).toBeUndefined();
+        }
+      );
+
+      it("stays quiet on a reason it has never heard of", async () => {
+        // A future SDK stage books an exclusion under a new key. Unknown has to
+        // mean "ran after the patterns" — going silent costs a caller one
+        // diagnostic, blaming the wrong field costs it the retry loop.
+        mockEmptyRun({ filterPattern: 4, someFutureStage: 1 });
+
+        const result = await copyTreeService.testConfig(tempDir, { includePaths: ["src/**"] });
+
+        expect(result.unmatchedSelector).toBeUndefined();
+      });
+
+      it.each(["gitignore", "configExclude", "scopeFilter", "testExclude", "unreadable"])(
+        "still blames the patterns when the only company is %s, pruned on the way in",
+        async (reason) => {
+          // These are booked by the walker before a file ever reaches the
+          // pattern check, so they say nothing about whether the patterns
+          // matched. Suppressing on them would silence the hint on any real
+          // repository, where a .gitignore is a given.
+          mockEmptyRun({ filterPattern: 4, [reason]: 12 });
+
+          const result = await copyTreeService.testConfig(tempDir, {
+            includePaths: ["src/panels"],
+          });
+
+          expect(result.unmatchedSelector).toBe("includePaths");
+        }
+      );
+
+      it("stays quiet when a budget truncated the run without booking a reason", async () => {
+        copyMock.mockResolvedValue({
+          output: "",
+          outputFormatVersion: null,
+          manifest: [],
+          stats: {
+            totalFiles: 0,
+            totalSize: 0,
+            duration: 1,
+            estimatedOutputChars: 0,
+            estimatedTokens: 0,
+            noFilesMatched: true,
+            excluded: { total: 4, byReason: { filterPattern: 4 } },
+            truncated: true,
+            truncatedCount: 1,
+            truncatedBy: "charLimit",
+          },
+        });
+
+        const result = await copyTreeService.testConfig(tempDir, { includePaths: ["a.ts"] });
+
+        expect(result.unmatchedSelector).toBeUndefined();
+      });
+
       it("stays quiet when no selector was supplied at all", async () => {
         // A whole-worktree copy of an empty directory has nothing to blame.
         mockEmptyRun({ filterPattern: 3 });

--- a/electron/services/__tests__/CopyTreeService.test.ts
+++ b/electron/services/__tests__/CopyTreeService.test.ts
@@ -509,6 +509,113 @@ describe("CopyTreeService", () => {
       expect(result.excluded).toEqual({ total: 2, byReason: { sizeGate: 1, gitignore: 1 } });
     });
 
+    // #11731: `noFilesMatched: true` alone left a caller that had passed a bare
+    // directory to `includePaths` with nothing to correct, so it guessed at the
+    // option shape for 13 rounds. The blame is derived rather than reported by
+    // the SDK: `filterPattern` counts files the walker produced and the include
+    // patterns then rejected, so a non-zero count on an empty run proves the
+    // patterns emptied it. The real-SDK direction of that claim is pinned in
+    // CopyTreeService.sdk-contract.test.ts; these rows pin the mapping.
+    describe("blaming a selector for an empty run", () => {
+      function mockEmptyRun(byReason: Record<string, number>) {
+        copyMock.mockResolvedValue({
+          output: "",
+          outputFormatVersion: null,
+          manifest: [],
+          stats: {
+            totalFiles: 0,
+            totalSize: 0,
+            duration: 1,
+            estimatedOutputChars: 0,
+            estimatedTokens: 0,
+            noFilesMatched: true,
+            excluded: {
+              total: Object.values(byReason).reduce((sum, count) => sum + count, 0),
+              byReason,
+            },
+          },
+        });
+      }
+
+      // Named the way the CALLER spelled it. Both spellings collapse into one
+      // SDK `filter` before it runs, so telling a caller that only ever sent
+      // `includePaths` that its `filter` missed would name a field it never set.
+      it.each([
+        { supplied: { includePaths: ["src/panels"] }, expected: "includePaths" },
+        { supplied: { filter: "src/panels" }, expected: "filter" },
+        { supplied: { filter: ["src/panels"] }, expected: "filter" },
+        {
+          supplied: { includePaths: ["src/panels"], filter: "docs" },
+          expected: "filterAndIncludePaths",
+        },
+      ])("names $expected when that is what was supplied", async ({ supplied, expected }) => {
+        mockEmptyRun({ filterPattern: 4 });
+
+        const result = await copyTreeService.testConfig(tempDir, supplied);
+
+        expect(result.noFilesMatched).toBe(true);
+        expect(result.unmatchedSelector).toBe(expected);
+      });
+
+      it("stays quiet when the patterns never got the chance to reject anything", async () => {
+        // Zero `filterPattern` means nothing survived the walk to reach the
+        // pattern check — an empty scope, an empty repo, a `modified` run with
+        // no changes. Blaming the patterns there would send a caller to rewrite
+        // the one part of its request that was fine.
+        mockEmptyRun({ scopeFilter: 2 });
+
+        const result = await copyTreeService.testConfig(tempDir, {
+          includePaths: ["src/**"],
+          scopePaths: ["empty"],
+        });
+
+        expect(result.noFilesMatched).toBe(true);
+        expect(result.unmatchedSelector).toBeUndefined();
+      });
+
+      it("stays quiet on a successful narrow selection, where the count is normal", async () => {
+        // Every file outside a narrow selection is booked as `filterPattern`, so
+        // the count alone flags healthy runs. `noFilesMatched` is the other half
+        // of the gate for exactly this row.
+        copyMock.mockResolvedValue({
+          output: "",
+          outputFormatVersion: null,
+          manifest: [{ path: "a.ts", size: 10, outcome: "included" }],
+          stats: {
+            totalFiles: 1,
+            totalSize: 10,
+            duration: 1,
+            estimatedOutputChars: 0,
+            estimatedTokens: 0,
+            noFilesMatched: false,
+            excluded: { total: 9, byReason: { filterPattern: 9 } },
+          },
+        });
+
+        const result = await copyTreeService.testConfig(tempDir, { includePaths: ["a.ts"] });
+
+        expect(result.unmatchedSelector).toBeUndefined();
+      });
+
+      it("stays quiet when no selector was supplied at all", async () => {
+        // A whole-worktree copy of an empty directory has nothing to blame.
+        mockEmptyRun({ filterPattern: 3 });
+
+        const result = await copyTreeService.testConfig(tempDir);
+
+        expect(result.noFilesMatched).toBe(true);
+        expect(result.unmatchedSelector).toBeUndefined();
+      });
+
+      it("reaches the generated bundle, not just the dry run", async () => {
+        mockEmptyRun({ filterPattern: 4 });
+
+        const result = await copyTreeService.generate(tempDir, { includePaths: ["src/panels"] });
+
+        expect(result.stats?.unmatchedSelector).toBe("includePaths");
+      });
+    });
+
     it("surfaces which budget truncated the run", async () => {
       copyMock.mockResolvedValue({
         output: "",

--- a/shared/types/ipc/copyTree.ts
+++ b/shared/types/ipc/copyTree.ts
@@ -10,7 +10,12 @@ export interface CopyTreeOptions {
   exclude?: string | string[];
   always?: string[];
 
-  /** Explicit file/folder paths to include (used by file picker modal) */
+  /**
+   * Worktree-relative file paths or glob patterns to include (used by the file
+   * picker modal). Unioned into the SDK's single `filter`, which matches against
+   * FILE paths — so a bare directory name matches nothing. A folder needs a glob
+   * (`src/panels/**`), or belongs in `scopePaths` below.
+   */
   includePaths?: string[];
 
   /**
@@ -164,6 +169,26 @@ export interface CopyTreeExclusionSummary {
 /** Which budget dropped files first */
 export type CopyTreeTruncatedBy = "maxFileCount" | "maxTotalSize" | "charLimit";
 
+/**
+ * Which pattern selector a caller supplied, named the way the caller spelled it.
+ *
+ * `filter` and `includePaths` are unioned into the SDK's single `filter` before
+ * it runs, so once a run is over the two can no longer be told apart from its
+ * stats — which is why supplying both reports the pair rather than guessing.
+ *
+ * A tuple rather than a bare union: `CopyTreeStatsSchema` builds its `z.enum`
+ * from this, so the wire enum and this type cannot drift. Dispatch parses
+ * results against that schema (#11539), and a member here that the enum lacked
+ * would fail the parse and take the whole result down with it.
+ */
+export const COPY_TREE_UNMATCHED_SELECTORS = [
+  "filter",
+  "includePaths",
+  "filterAndIncludePaths",
+] as const;
+
+export type CopyTreeUnmatchedSelector = (typeof COPY_TREE_UNMATCHED_SELECTORS)[number];
+
 /** Budget and estimate reporting shared by real runs and dry runs */
 export interface CopyTreeBudgetStats {
   /**
@@ -175,6 +200,21 @@ export interface CopyTreeBudgetStats {
   estimatedTokens?: number;
   /** True when nothing matched — a valid outcome, not an error */
   noFilesMatched?: boolean;
+  /**
+   * Which supplied pattern selector emptied the run, when one did.
+   *
+   * `noFilesMatched` alone says nothing about WHICH selector missed, so a caller
+   * that passed a bare directory to `includePaths` learns only that it got
+   * nothing and is left guessing at the option shape (#11731). Set only when the
+   * run came back empty AND files reached the pattern check and were rejected
+   * there — `excluded.byReason.filterPattern > 0`. The walker applies scope,
+   * gitignore and config excludes while walking and tests include patterns
+   * first among the per-file checks, so that count can only be non-zero if real
+   * files survived those layers and the patterns then ruled every one of them
+   * out. An empty scope, an empty repo or a `modified` filter with no changes
+   * therefore leaves this unset rather than blaming the patterns.
+   */
+  unmatchedSelector?: CopyTreeUnmatchedSelector;
   /** What didn't make it, and why */
   excluded?: CopyTreeExclusionSummary;
   /** Whether a budget dropped files */

--- a/shared/types/ipc/copyTree.ts
+++ b/shared/types/ipc/copyTree.ts
@@ -205,14 +205,16 @@ export interface CopyTreeBudgetStats {
    *
    * `noFilesMatched` alone says nothing about WHICH selector missed, so a caller
    * that passed a bare directory to `includePaths` learns only that it got
-   * nothing and is left guessing at the option shape (#11731). Set only when the
-   * run came back empty AND files reached the pattern check and were rejected
-   * there — `excluded.byReason.filterPattern > 0`. The walker applies scope,
-   * gitignore and config excludes while walking and tests include patterns
-   * first among the per-file checks, so that count can only be non-zero if real
-   * files survived those layers and the patterns then ruled every one of them
-   * out. An empty scope, an empty repo or a `modified` filter with no changes
-   * therefore leaves this unset rather than blaming the patterns.
+   * nothing and is left guessing at the option shape (#11731).
+   *
+   * Set only when the run came back empty, files reached the pattern check and
+   * were rejected there, and NOTHING was removed after the patterns ran. That
+   * last condition is what keeps the hint honest: `noFilesMatched` is measured
+   * once the whole pipeline is done, and the git filter, the budgets, `exclude`
+   * and the size gate all run later — so a single file removed by one of those
+   * is proof the patterns matched it, and the patterns are not what emptied the
+   * run. An empty scope, an empty repo, a `modified` filter with no changes and
+   * a budget that dropped the last file therefore all leave this unset.
    */
   unmatchedSelector?: CopyTreeUnmatchedSelector;
   /** What didn't make it, and why */

--- a/shared/types/ipc/copyTree.ts
+++ b/shared/types/ipc/copyTree.ts
@@ -210,11 +210,15 @@ export interface CopyTreeBudgetStats {
    * Set only when the run came back empty, files reached the pattern check and
    * were rejected there, and NOTHING was removed after the patterns ran. That
    * last condition is what keeps the hint honest: `noFilesMatched` is measured
-   * once the whole pipeline is done, and the git filter, the budgets, `exclude`
-   * and the size gate all run later — so a single file removed by one of those
-   * is proof the patterns matched it, and the patterns are not what emptied the
-   * run. An empty scope, an empty repo, a `modified` filter with no changes and
-   * a budget that dropped the last file therefore all leave this unset.
+   * once the whole pipeline is done, and the git filter, the budgets and the
+   * size gate all run later — so a single file removed by one of those is proof
+   * the patterns matched it, and the patterns are not what emptied the run. An
+   * empty scope, an empty repo, a `modified` filter with no changes and a
+   * budget that dropped the last file therefore all leave this unset.
+   *
+   * Ignore rules, configured excludes and scope prune while the walker
+   * descends, before the patterns are consulted, so they neither set nor
+   * suppress this.
    */
   unmatchedSelector?: CopyTreeUnmatchedSelector;
   /** What didn't make it, and why */

--- a/src/services/actions/definitions/__tests__/schemaDescriptions.test.ts
+++ b/src/services/actions/definitions/__tests__/schemaDescriptions.test.ts
@@ -129,11 +129,19 @@ describe("argument descriptions carry the semantics prose no longer states", () 
       const description = emit(CopyTreeOptionsSchema).properties?.[field]?.description ?? "";
 
       expect(description).toMatch(/patterns match file paths/i);
+
       // Both halves of the contrast, not just the rule: "a folder needs a glob"
       // is advice a caller cannot act on without seeing the two forms side by
       // side, which is exactly what the working `worktree.copyTree` text shows.
-      expect(description).toContain("src/panels/**");
-      expect(description).toMatch(/not 'src\/panels'/);
+      // Captured rather than compared against copied literals, so the example
+      // path can change freely but the two forms still have to be the SAME
+      // folder — text that globbed one path and warned off another would read
+      // as guidance and teach nothing.
+      const contrast = description.match(/pass '([^']+)', not '([^']+)'/);
+      expect(contrast).not.toBeNull();
+      const [, recommended, rejected] = contrast ?? [];
+      expect(recommended).toBe(`${rejected}/**`);
+
       // The redirect matters as much as the warning — the caller's real intent
       // was a folder, and `scopePaths` is the field that takes one.
       expect(description).toMatch(/scopePaths/);

--- a/src/services/actions/definitions/__tests__/schemaDescriptions.test.ts
+++ b/src/services/actions/definitions/__tests__/schemaDescriptions.test.ts
@@ -117,6 +117,52 @@ describe("argument descriptions carry the semantics prose no longer states", () 
     expect(scope).toMatch(/empty list is rejected|rejected rather than/i);
   });
 
+  // #11731: a caller sent `includePaths: ["src/worldgen", ...]`, every directory
+  // existed, and the call returned zero files with no error — then burned 13
+  // rounds guessing. Both spellings of the selection feed the SDK's single
+  // `filter`, which matches against FILE paths, so a bare directory matches
+  // nothing. The wire description is the only place that rule can be learned,
+  // and a caller reads the description of whichever field it reached for.
+  it.each(["includePaths", "filter"])(
+    "warns on %s that a folder needs a glob, and where a folder belongs instead",
+    (field) => {
+      const description = emit(CopyTreeOptionsSchema).properties?.[field]?.description ?? "";
+
+      expect(description).toMatch(/patterns match file paths/i);
+      // Both halves of the contrast, not just the rule: "a folder needs a glob"
+      // is advice a caller cannot act on without seeing the two forms side by
+      // side, which is exactly what the working `worktree.copyTree` text shows.
+      expect(description).toContain("src/panels/**");
+      expect(description).toMatch(/not 'src\/panels'/);
+      // The redirect matters as much as the warning — the caller's real intent
+      // was a folder, and `scopePaths` is the field that takes one.
+      expect(description).toMatch(/scopePaths/);
+    }
+  );
+
+  it("keeps the union and traversal guidance the folder rule was added beside", () => {
+    const includePaths = emit(CopyTreeOptionsSchema).properties?.includePaths?.description ?? "";
+
+    // Regression guard on the reword itself. None of this is recoverable from
+    // anywhere else on the wire: #11722's union with `filter` is invisible from
+    // the types, and the traversal contrast is what stops a caller reaching for
+    // `scopePaths` when it genuinely wants patterns matched worktree-wide.
+    expect(includePaths).toMatch(/curated bundle/i);
+    expect(includePaths).toMatch(/combined with `filter`/i);
+    expect(includePaths).toMatch(/does not restrict traversal/i);
+  });
+
+  it("says a scope path is literal, so the folder rule does not carry over to it", () => {
+    const scope = emit(CopyTreeOptionsSchema).properties?.scopePaths?.description ?? "";
+
+    // The inverse trap, and the one the fix above could create: a caller that
+    // has just learned "a folder needs a glob" carries '/**' over to the field
+    // that walks literal paths, where it matches nothing either.
+    expect(scope).toMatch(/not glob patterns/i);
+    expect(scope).toMatch(/literal file or directory paths/i);
+    expect(scope).toMatch(/prefer this over[^.]*folder/i);
+  });
+
   it("keeps the terminal-id contract on the hand-written wait schema", () => {
     // A hand-written JSON Schema rather than a zod conversion, so none of the
     // propagation above applies to it. Note this constant is NOT what the

--- a/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
@@ -615,4 +615,87 @@ describe("systemActions adversarial", () => {
       ).rejects.toThrow("Terminal closed during injection");
     });
   });
+
+  // #11731. An empty bundle used to arrive as `noFilesMatched: true` and nothing
+  // else, so a caller that had passed a bare directory could not tell which of
+  // its fields to correct. All three actions project the same stats, and all
+  // three are the MCP surface a caller hits, so a hint on one of them is a hint
+  // two thirds of callers never see.
+  describe("empty-result attribution across the copyTree actions", () => {
+    const EMPTY_RUN = {
+      content: "",
+      fileCount: 0,
+      filePath: "/tmp/daintree-context/repo-main-x.xml",
+      outputBytes: 460,
+      stats: {
+        totalSize: 0,
+        duration: 1800,
+        noFilesMatched: true,
+        unmatchedSelector: "includePaths" as const,
+        // Present on the IPC result, and deliberately NOT forwarded: the
+        // per-reason breakdown is the bulk #11528 took off this surface, and
+        // `unmatchedSelector` exists so a caller never needs it.
+        excluded: { total: 42, byReason: { filterPattern: 42 } },
+      },
+    };
+
+    const CASES = [
+      { id: "copyTree.generate", mock: copyTreeClientMock.generate, args: undefined },
+      {
+        id: "copyTree.generateAndCopyFile",
+        mock: copyTreeClientMock.generateAndCopyFile,
+        args: { worktreeId: "wt-active" },
+      },
+      {
+        id: "copyTree.injectToTerminal",
+        mock: copyTreeClientMock.injectToTerminal,
+        args: { terminalId: "t-1" },
+      },
+    ];
+
+    it.each(CASES)(
+      "$id names the selector that missed and drops the breakdown",
+      async ({ id, mock, args }) => {
+        const { run, getDef } = setupActions();
+        mock.mockResolvedValueOnce({ ...EMPTY_RUN });
+
+        const result = (await run(id, args, { activeWorktreeId: "wt-active" })) as {
+          stats?: Record<string, unknown>;
+        };
+
+        expect(result.stats).toMatchObject({
+          noFilesMatched: true,
+          unmatchedSelector: "includePaths",
+        });
+        expect(result.stats).not.toHaveProperty("excluded");
+
+        // Parsed through the action's own resultSchema, not just inspected:
+        // dispatch parses results (#11539), so a field the projection returns but
+        // the schema never declared is a field the caller is never sent — and an
+        // enum out of step with the shared tuple would fail the call outright.
+        const resultSchema = getDef(id).resultSchema;
+        expect(resultSchema).toBeDefined();
+        expect(resultSchema?.parse(result)).toMatchObject({
+          stats: { unmatchedSelector: "includePaths" },
+        });
+      }
+    );
+
+    it("omits the hint entirely when nothing was to blame", async () => {
+      const { run } = setupActions();
+      copyTreeClientMock.generate.mockResolvedValueOnce({
+        ...EMPTY_RUN,
+        stats: { totalSize: 0, duration: 1800, noFilesMatched: true },
+      });
+
+      const result = (await run("copyTree.generate", undefined, {
+        activeWorktreeId: "wt-active",
+      })) as { stats?: Record<string, unknown> };
+
+      // Absent rather than null: an empty scope or an empty worktree has no
+      // selector at fault, and a present-but-empty field reads as one.
+      expect(result.stats).not.toHaveProperty("unmatchedSelector");
+      expect(result.stats).toMatchObject({ noFilesMatched: true });
+    });
+  });
 });

--- a/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { COPY_TREE_UNMATCHED_SELECTORS } from "@shared/types/ipc/copyTree";
 import type { ActionCallbacks, ActionRegistry, AnyActionDefinition } from "../../actionTypes";
 
 const filesClientMock = vi.hoisted(() => ({
@@ -696,6 +698,58 @@ describe("systemActions adversarial", () => {
       // selector at fault, and a present-but-empty field reads as one.
       expect(result.stats).not.toHaveProperty("unmatchedSelector");
       expect(result.stats).toMatchObject({ noFilesMatched: true });
+    });
+
+    it.each(COPY_TREE_UNMATCHED_SELECTORS)(
+      "carries %s through dispatch's result parse",
+      async (selector) => {
+        // Every member, not just the one the service happens to emit most often:
+        // dispatch parses results against `resultSchema` (#11539), so a schema
+        // narrower than the shared tuple turns a correct diagnostic into a
+        // RESULT_VALIDATION_ERROR that destroys the whole call.
+        const { run, getDef } = setupActions();
+        copyTreeClientMock.generate.mockResolvedValueOnce({
+          ...EMPTY_RUN,
+          stats: { ...EMPTY_RUN.stats, unmatchedSelector: selector },
+        });
+
+        const result = await run("copyTree.generate", undefined, { activeWorktreeId: "wt-active" });
+
+        expect(getDef("copyTree.generate").resultSchema?.parse(result)).toMatchObject({
+          stats: { unmatchedSelector: selector },
+        });
+      }
+    );
+
+    it.each(CASES)("$id advertises the hint on the wire, not just in its return", ({ id }) => {
+      // The projection returning a field and the MCP client being TOLD about it
+      // are different surfaces: `computeSchemas` converts `resultSchema` in
+      // output mode, and a description attached to the wrong link in a zod
+      // chain is dropped there silently. Same conversion, same options.
+      const { getDef } = setupActions();
+      const def = getDef(id);
+      expect(def.mcpOutputSchema).toBe(true);
+
+      const emitted = z.toJSONSchema(def.resultSchema as z.ZodType, {
+        io: "output",
+        unrepresentable: "any",
+        reused: "inline",
+        cycles: "ref",
+        target: "draft-2020-12",
+      }) as {
+        properties?: {
+          stats?: {
+            properties?: { unmatchedSelector?: { enum?: string[]; description?: string } };
+          };
+        };
+      };
+
+      const advertised = emitted.properties?.stats?.properties?.unmatchedSelector;
+      // Derived from the shared tuple rather than a copied literal: a member
+      // added there and left out of the wire enum fails here.
+      expect(advertised?.enum).toEqual([...COPY_TREE_UNMATCHED_SELECTORS]);
+      // The value alone is not actionable — the remedy is the point.
+      expect(advertised?.description ?? "").toMatch(/scopePaths/);
     });
   });
 });

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -274,7 +274,7 @@ export const CopyTreeOptionsSchema = z.object({
     .union([z.string().min(1), z.array(z.string().min(1)).min(1)])
     .optional()
     .describe(
-      "Selects which files to include, as worktree-relative glob patterns or exact paths. Combined with `includePaths` when both are given; omit both to include the whole worktree."
+      "Selects which files to include, as worktree-relative exact file paths or glob patterns. Patterns match file paths, so a folder needs a glob: pass 'src/panels/**', not 'src/panels'; prefer `scopePaths` when selecting a folder. Combined with `includePaths` when both are given; omit both to include the whole worktree."
     ),
   exclude: z.union([z.string(), z.array(z.string())]).optional(),
   always: z.array(z.string()).optional(),
@@ -283,7 +283,7 @@ export const CopyTreeOptionsSchema = z.object({
     .min(1)
     .optional()
     .describe(
-      "Selects which files to include, as worktree-relative exact paths or glob patterns. Use this to assemble a curated bundle of scattered files — sources, their supporting code, and their tests — in one call. Combined with `filter` when both are given. Unlike `scopePaths` this does not restrict traversal, so patterns may match anywhere in the worktree."
+      "Selects which files to include, as worktree-relative exact file paths or glob patterns. Patterns match file paths, so a folder needs a glob: pass 'src/panels/**', not 'src/panels'; prefer `scopePaths` when selecting a folder. Use this to assemble a curated bundle of scattered files — sources, their supporting code, and their tests — in one call. Combined with `filter` when both are given. Unlike `scopePaths` this does not restrict traversal, so patterns may match anywhere in the worktree."
     ),
   // An empty list or blank entry would resolve to the worktree root — a folder
   // copy that silently became a whole-worktree copy. Absent means no scoping.
@@ -292,7 +292,7 @@ export const CopyTreeOptionsSchema = z.object({
     .min(1)
     .optional()
     .describe(
-      "Restricts the copy to these subtrees, relative to the worktree root. Omit to include the whole worktree; supplying an empty list is rejected rather than treated as no scoping, since that would silently copy everything."
+      "Restricts the copy to these subtrees, as worktree-relative literal file or directory paths to walk — not glob patterns, so pass 'src/panels', not 'src/panels/**'. Prefer this over `filter` or `includePaths` when selecting a folder. Omit to include the whole worktree; supplying an empty list is rejected rather than treated as no scoping, since that would silently copy everything."
     ),
   modified: z.boolean().optional(),
   changed: z.string().optional(),

--- a/src/services/actions/definitions/systemActions.ts
+++ b/src/services/actions/definitions/systemActions.ts
@@ -24,6 +24,7 @@ import {
 } from "@/clients";
 import { cancelContextInjection } from "@/hooks/useContextInjection";
 import type { CopyTreeResult } from "@shared/types";
+import { COPY_TREE_UNMATCHED_SELECTORS } from "@shared/types/ipc/copyTree";
 
 /**
  * The generation numbers every CopyTree action reports.
@@ -42,6 +43,16 @@ const CopyTreeStatsSchema = z
     duration: z.number(),
     estimatedTokens: z.number().optional().describe("Rough token count, accurate to about ±20%"),
     noFilesMatched: z.boolean().optional().describe("Nothing matched — a valid outcome, not error"),
+    // Still a scalar, so it stays on the right side of #11528's line: it names
+    // the field to fix rather than shipping the per-reason breakdown a caller
+    // would have to interpret. Without it `noFilesMatched` says only that the
+    // bundle is empty, and the caller guesses at the option shape (#11731).
+    unmatchedSelector: z
+      .enum(COPY_TREE_UNMATCHED_SELECTORS)
+      .optional()
+      .describe(
+        "Which supplied selector matched no files. For a folder, add '/**' to the pattern or use scopePaths instead."
+      ),
     truncated: z.boolean().optional().describe("A budget dropped or cut short some files"),
     truncatedCount: z.number().optional(),
     truncatedBy: z
@@ -80,6 +91,7 @@ function projectCopyTreeStats(stats: NonNullable<CopyTreeResult["stats"]>) {
     duration: stats.duration,
     ...(stats.estimatedTokens !== undefined && { estimatedTokens: stats.estimatedTokens }),
     ...(stats.noFilesMatched !== undefined && { noFilesMatched: stats.noFilesMatched }),
+    ...(stats.unmatchedSelector !== undefined && { unmatchedSelector: stats.unmatchedSelector }),
     ...(stats.truncated !== undefined && { truncated: stats.truncated }),
     ...(stats.truncatedCount !== undefined && { truncatedCount: stats.truncatedCount }),
     ...(stats.truncatedBy !== undefined && { truncatedBy: stats.truncatedBy }),


### PR DESCRIPTION
## Summary

- `CopyTreeOptionsSchema` backs three MCP-exposed actions (`copyTree.generate`, `copyTree.generateAndCopyFile`, `copyTree.injectToTerminal`), and its `includePaths` description never said patterns are matched against file paths, so a bare directory name matched nothing. `worktree.copyTree`'s own action schema has documented this correctly all along, MCP callers just never see it.
- Updated the descriptions on `includePaths`, `filter`, and `scopePaths` to state the rule and point callers at the fix, and added a derived `unmatchedSelector` stat so an empty bundle names which field to fix instead of just reporting empty.

Resolves #11731

## What was happening

In a real support session (`ses_76f64e17`), a caller sent seven real paths, three of them directories. It got back `fileCount: 0` with no error in 1.8 seconds, then spent 13 more rounds guessing at the option shape and never produced a bundle. `CopyTreeService.mergeSelectionPatterns` unions `includePaths` into the SDK's single `filter`, which matches patterns against file paths, so a bare directory never matches anything, and nothing in the description said so.

## Changes

**1. Fix the descriptions.** `includePaths` and `filter` both now carry the rule and the redirect: patterns match file paths, so a folder needs a glob, pass `src/panels/**` not `src/panels`, and prefer `scopePaths` when selecting a folder. Both fields needed the update because they union into one SDK filter and a caller only reads whichever one it happened to use. `scopePaths` now says explicitly that it takes literal paths, not globs, since teaching people to append `/**` everywhere would otherwise open the same trap in reverse.

**2. Add `unmatchedSelector` to the result stats.** A new scalar (`"filter" | "includePaths" | "filterAndIncludePaths"`) that names which field to fix when a bundle comes back empty. It's derived from existing data, not newly tracked, so no SDK change was needed. It stays a single scalar deliberately: #11528 already pulled the per-reason exclusion breakdown off this result surface, and it's not coming back.

## The subtle part

The obvious way to derive the hint is wrong, and the first pass at this fix got it wrong. `noFilesMatched` is `files.length === 0` measured after the whole pipeline runs, but the git filter, the size budgets, the size gate, and the character limit all run after the include-pattern check. So a decoy file can pass the patterns while the real match gets removed by one of those later stages, leaving an empty result even though the patterns worked correctly. Blaming the patterns there would send the caller to fix the one field that was already right, recreating this same bug pointed the other way. The hint is suppressed whenever anything was removed by a stage that runs after the pattern check, and any exclusion reason the code doesn't recognize is conservatively treated as post-pattern, so a future SDK stage makes the hint go quiet instead of lying.

The same logic runs in reverse on the way in: ignore rules, the scope option, and configured excludes all prune files during the walk, and none of that says anything about whether the patterns matched. `optionExclude` needed particular care here. An `exclude` option is installed as a walker ignore layer, and the IPC handler folds a project's `excludedPaths` and `alwaysExclude` into that same layer whenever the caller omits one. Treating that as post-pattern pruning would have silenced the diagnostic on exactly the configured repositories that need it most.

## Testing

410 tests across 16 files pass locally, plus both typechecks (renderer/shared and electron) and lint/format on the changed files. New coverage:

- Description propagation through the real `z.toJSONSchema` conversion, including a check that the glob example and the bare-directory example name the same folder.
- Real-SDK cases against copytree `0.17.0`: the bare-directory miss, the glob fix reaching a deeply nested file, size-gate suppression of the hint, and a bare directory against a repo with configured excludes.
- The streamed output-path branch, which is what production actually uses for two of the three affected actions.
- Every enum value tested through dispatch's result parsing.
- The emitted output JSON Schema, proving all three actions actually advertise the new field.

## Out of scope

`electron/schemas/ipc.ts`'s internal duplicate of the options schema never reaches MCP callers, so it's untouched. The action-manifest snapshot doesn't need regeneration either, its projection already excludes `inputSchema`/`outputSchema`.

Companion issues in other repos cover the calling side and aren't part of this PR: daintreehq/assistant-backend#19, daintreehq/assistant-backend#20, daintreehq/assistant#311, daintreehq/assistant#312.