### PR TITLE
feat(copytree): record copy-tree runs in a per-project history

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -942,6 +942,10 @@ export const CHANNELS = {
   RUN_HISTORY_APPEND: "run-history:append",
   RUN_HISTORY_CLEAR: "run-history:clear",
 
+  // Copy-tree run history (#11732). Read-only: the main process records a run
+  // where it completes, so there is no append channel to forge entries through.
+  COPY_TREE_HISTORY_GET_RECORDS: "copy-tree-history:get-records",
+
   // Plugin channels
   PLUGIN_LIST: "plugin:list",
   PLUGIN_INSTALL: "plugin:install",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -58,6 +58,7 @@ import { registerForgeSettingsHandlers } from "./handlers/forgeSettings.js";
 import { registerForgeAuditHandlers } from "./handlers/forgeAudit.js";
 import { initForgeHealthRelay, disposeForgeHealthRelay } from "../services/forgeHealthRelay.js";
 import { registerRunHistoryHandlers } from "./handlers/runHistory.js";
+import { registerCopyTreeHistoryHandlers } from "./handlers/copyTreeHistory.js";
 import { registerFleetHandlers } from "./handlers/fleet.js";
 import { registerVoiceInputHandlers } from "./handlers/voiceInput.js";
 import { registerMcpServerHandlers } from "./handlers/mcpServer.js";
@@ -187,6 +188,7 @@ export function registerIpcHandlers(deps: HandlerDependencies): () => void {
     });
     register(() => registerForgeAuditHandlers());
     register(() => registerRunHistoryHandlers());
+    register(() => registerCopyTreeHistoryHandlers(deps));
     register(() => registerFleetHandlers());
     register(() => registerVoiceInputHandlers(deps));
     register(() => registerMcpServerHandlers());

--- a/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
@@ -69,6 +69,7 @@ vi.mock("../../../window/windowRef.js", () => ({
   setMainWindow: vi.fn(),
 }));
 
+import type { CopyTreeHistoryAppendInput } from "../../../../shared/types/ipc/copyTreeHistory.js";
 import { CHANNELS } from "../../channels.js";
 import { _resetRateLimitQueuesForTest } from "../../utils.js";
 import { contextDir, _resetReservedPathsForTests } from "../../../services/copyTreeOutputFile.js";
@@ -1223,9 +1224,11 @@ describe("copy-tree run history recording", () => {
     return generateContext;
   }
 
-  function lastRecordedRun() {
+  function lastRecordedRun(): [string | null, CopyTreeHistoryAppendInput] {
     const calls = copyTreeHistoryMock.recordCopyTreeRun.mock.calls;
-    return calls[calls.length - 1] as [string | null, Record<string, unknown>];
+    const last = calls[calls.length - 1];
+    if (!last) throw new Error("recordCopyTreeRun was never called");
+    return last;
   }
 
   beforeEach(async () => {

--- a/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
@@ -46,6 +46,12 @@ vi.mock("../../../services/ProjectStore.js", () => ({
   projectStore: projectStoreMock,
 }));
 
+const copyTreeHistoryMock = vi.hoisted(() => ({
+  recordCopyTreeRun: vi.fn<() => Promise<void>>(async () => {}),
+}));
+
+vi.mock("../../../services/copyTreeHistoryService.js", () => copyTreeHistoryMock);
+
 vi.mock("../../../window/windowRef.js", () => ({
   getProjectViewManager: windowRefMock.getProjectViewManager,
   setProjectViewManager: vi.fn(),
@@ -1158,5 +1164,212 @@ describe("nextChunkBoundary", () => {
       }
     }
     expect(i).toBe(content.length);
+  });
+});
+
+describe("copy-tree run history recording", () => {
+  const PROJECT_ID = "p".repeat(64);
+  let tmpRoot: string;
+
+  /**
+   * Register the handlers against a workspace host that reports a completed
+   * run. `overrides` shapes what the host returns so a test can drive the
+   * failure paths.
+   */
+  function makeService(overrides: Record<string, unknown> = {}, hasTerminal = true) {
+    const generateContext = vi.fn(
+      async (_root: string, _options: unknown, _onProgress: unknown, outputPath?: string) => {
+        const body = "<files/>";
+        if (outputPath) {
+          await nodeFs.writeFile(outputPath, body, { encoding: "utf8", mode: 0o600 });
+        }
+        return {
+          content: body,
+          fileCount: 12,
+          ...(outputPath
+            ? { filePath: outputPath, outputBytes: Buffer.byteLength(body, "utf8") }
+            : {}),
+          stats: { totalSize: 345, duration: 67 },
+          ...overrides,
+        };
+      }
+    );
+
+    browserWindowMock.fromWebContents.mockReturnValue({ id: 7, isDestroyed: () => false });
+    ipcMainMock.handle.mockClear();
+    registerCopyTreeHandlers({
+      mainWindow: {
+        isDestroyed: () => false,
+        webContents: { isDestroyed: () => false, send: vi.fn() },
+      },
+      ptyClient: { hasTerminal: vi.fn(() => hasTerminal), write: vi.fn() },
+      worktreeService: {
+        getAllStatesAsync: vi.fn(async () => [
+          { id: "wt-1", path: "/repos/daintree", branch: "main" },
+        ]),
+        generateContext,
+        testConfig: vi.fn(),
+        getContextFileTree: vi.fn(),
+      },
+    } as never);
+    return generateContext;
+  }
+
+  function lastRecordedRun() {
+    const calls = copyTreeHistoryMock.recordCopyTreeRun.mock.calls;
+    return calls[calls.length - 1] as [string | null, Record<string, unknown>];
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    _resetRateLimitQueuesForTest();
+    _resetReservedPathsForTests();
+    copyTreeHistoryMock.recordCopyTreeRun.mockReset().mockResolvedValue(undefined);
+    tmpRoot = await nodeFs.mkdtemp(nodePath.join(nodeOs.tmpdir(), "daintree-history-"));
+    vi.stubEnv("TMPDIR", tmpRoot);
+    vi.stubEnv("TEMP", tmpRoot);
+    vi.stubEnv("TMP", tmpRoot);
+    projectStoreMock.getCurrentProjectId.mockReturnValue(PROJECT_ID);
+    projectStoreMock.getProjectById.mockReturnValue(null);
+    projectStoreMock.getProjectSettings.mockReset();
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await nodeFs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("records a generate run once, against the resolved project", async () => {
+    makeService();
+    const handler = getInvokeHandler(CHANNELS.COPYTREE_GENERATE);
+
+    await handler(mockSender, { worktreeId: "wt-1", source: "toolbar" });
+
+    expect(copyTreeHistoryMock.recordCopyTreeRun).toHaveBeenCalledTimes(1);
+    const [projectId, input] = lastRecordedRun();
+    expect(projectId).toBe(PROJECT_ID);
+    expect(input).toMatchObject({
+      source: "toolbar",
+      worktreeId: "wt-1",
+      stats: { fileCount: 12, totalSize: 345, duration: 67 },
+    });
+  });
+
+  it("records a clipboard run once", async () => {
+    makeService();
+    const handler = getInvokeHandler(CHANNELS.COPYTREE_GENERATE_AND_COPY_FILE);
+
+    await handler(mockSender, { worktreeId: "wt-1", source: "worktree-card" });
+
+    expect(copyTreeHistoryMock.recordCopyTreeRun).toHaveBeenCalledTimes(1);
+    expect(lastRecordedRun()[1]).toMatchObject({ source: "worktree-card" });
+  });
+
+  it("records an injection run — same intent, different delivery", async () => {
+    makeService();
+    const handler = getInvokeHandler(CHANNELS.COPYTREE_INJECT);
+
+    await handler(mockSender, { terminalId: "t-1", worktreeId: "wt-1", source: "mcp" });
+
+    expect(copyTreeHistoryMock.recordCopyTreeRun).toHaveBeenCalledTimes(1);
+    expect(lastRecordedRun()[1]).toMatchObject({ source: "mcp", worktreeId: "wt-1" });
+  });
+
+  it("stores the caller's runtime options, not the settings-merged ones", async () => {
+    projectStoreMock.getProjectSettings.mockResolvedValue({
+      excludedPaths: ["vendor"],
+      copyTreeSettings: { maxContextSize: 4242, alwaysInclude: ["*.md"] },
+    });
+    projectStoreMock.getProjectById.mockReturnValue({ id: PROJECT_ID, status: "open" });
+    windowRefMock.getProjectViewManager.mockReturnValue({
+      getProjectIdForWebContents: () => PROJECT_ID,
+    });
+    const generateContext = makeService();
+    const handler = getInvokeHandler(CHANNELS.COPYTREE_GENERATE);
+
+    await handler(mockSender, {
+      worktreeId: "wt-1",
+      options: { modified: true },
+      source: "toolbar",
+    });
+
+    // The host really did receive the merged options...
+    const mergedOptions = generateContext.mock.calls[0][1] as Record<string, unknown>;
+    expect(mergedOptions.maxTotalSize).toBe(4242);
+    // ...while the record keeps only what the caller asked for, so a re-run
+    // picks up whatever the project settings say at that later time.
+    expect(lastRecordedRun()[1].options).toEqual({ modified: true });
+  });
+
+  it("records an absent source as unknown rather than guessing a surface", async () => {
+    makeService();
+    const handler = getInvokeHandler(CHANNELS.COPYTREE_GENERATE);
+
+    await handler(mockSender, { worktreeId: "wt-1" });
+
+    expect(lastRecordedRun()[1]).toMatchObject({ source: "unknown", options: {} });
+  });
+
+  it("records the file count even when the host reported no stats", async () => {
+    makeService({ stats: undefined });
+    const handler = getInvokeHandler(CHANNELS.COPYTREE_GENERATE);
+
+    await handler(mockSender, { worktreeId: "wt-1" });
+
+    expect(lastRecordedRun()[1].stats).toEqual({
+      fileCount: 12,
+      totalSize: undefined,
+      duration: undefined,
+    });
+  });
+
+  it("does not record a failed generation", async () => {
+    makeService({ error: "Failed to generate context" });
+    const handler = getInvokeHandler(CHANNELS.COPYTREE_GENERATE);
+
+    await handler(mockSender, { worktreeId: "wt-1" });
+
+    expect(copyTreeHistoryMock.recordCopyTreeRun).not.toHaveBeenCalled();
+  });
+
+  it("does not record a run whose worktree could not be found", async () => {
+    makeService();
+    const handler = getInvokeHandler(CHANNELS.COPYTREE_GENERATE);
+
+    await handler(mockSender, { worktreeId: "wt-missing" });
+
+    expect(copyTreeHistoryMock.recordCopyTreeRun).not.toHaveBeenCalled();
+  });
+
+  it("does not record an injection into a terminal that no longer exists", async () => {
+    makeService({}, false);
+    const handler = getInvokeHandler(CHANNELS.COPYTREE_INJECT);
+
+    await handler(mockSender, { terminalId: "t-gone", worktreeId: "wt-1" });
+
+    expect(copyTreeHistoryMock.recordCopyTreeRun).not.toHaveBeenCalled();
+  });
+
+  it("does not record a rejected payload", async () => {
+    makeService();
+    const handler = getInvokeHandler(CHANNELS.COPYTREE_GENERATE);
+
+    await handler(mockSender, { worktreeId: "wt-1", source: "not-a-surface" });
+
+    expect(copyTreeHistoryMock.recordCopyTreeRun).not.toHaveBeenCalled();
+  });
+
+  it("still returns the copy result when recording rejects", async () => {
+    // recordCopyTreeRun swallows its own failures, but the handler must not
+    // depend on that: a rejection here must not turn a delivered copy into an
+    // error the user sees.
+    copyTreeHistoryMock.recordCopyTreeRun.mockRejectedValue(new Error("disk on fire"));
+    makeService();
+    const handler = getInvokeHandler(CHANNELS.COPYTREE_GENERATE);
+
+    const result = (await handler(mockSender, { worktreeId: "wt-1" })) as Record<string, unknown>;
+
+    expect(result.error).toBeUndefined();
+    expect(result.fileCount).toBe(12);
   });
 });

--- a/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
@@ -46,8 +46,16 @@ vi.mock("../../../services/ProjectStore.js", () => ({
   projectStore: projectStoreMock,
 }));
 
+// Typed to the production signature so a parameter change fails at compile time
+// rather than silently leaving the assertions below asserting the wrong shape.
 const copyTreeHistoryMock = vi.hoisted(() => ({
-  recordCopyTreeRun: vi.fn<() => Promise<void>>(async () => {}),
+  recordCopyTreeRun:
+    vi.fn<
+      (
+        projectId: string | null,
+        input: import("../../../../shared/types/ipc/copyTreeHistory.js").CopyTreeHistoryAppendInput
+      ) => Promise<void>
+    >(),
 }));
 
 vi.mock("../../../services/copyTreeHistoryService.js", () => copyTreeHistoryMock);
@@ -1168,7 +1176,7 @@ describe("nextChunkBoundary", () => {
 });
 
 describe("copy-tree run history recording", () => {
-  const PROJECT_ID = "p".repeat(64);
+  const PROJECT_ID = "a1b2c3d4".repeat(8);
   let tmpRoot: string;
 
   /**

--- a/electron/ipc/handlers/__tests__/copyTreeHistory.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/copyTreeHistory.handlers.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
+const projectStoreMock = vi.hoisted(() => ({
+  getCurrentProjectId: vi.fn<() => string | null>(() => null),
+  getProjectById: vi.fn<(projectId: string) => { id: string; status: string } | null>(() => null),
+  getCopyTreeHistory: vi.fn<(projectId: string) => Promise<unknown[]>>(),
+}));
+
+const browserWindowMock = vi.hoisted(() => ({
+  fromWebContents: vi.fn<() => { id: number; isDestroyed: () => boolean } | null>(() => null),
+  getAllWindows: vi.fn(() => []),
+}));
+
+const windowRefMock = vi.hoisted(() => ({
+  getProjectViewManager: vi.fn<
+    () => { getProjectIdForWebContents: (id: number) => string | null } | null
+  >(() => null),
+}));
+
+vi.mock("electron", () => ({
+  ipcMain: ipcMainMock,
+  clipboard: { writeBuffer: vi.fn(), writeText: vi.fn() },
+  BrowserWindow: browserWindowMock,
+}));
+
+vi.mock("../../../services/ProjectStore.js", () => ({ projectStore: projectStoreMock }));
+
+vi.mock("../../../window/windowRef.js", () => ({
+  getProjectViewManager: windowRefMock.getProjectViewManager,
+  setProjectViewManager: vi.fn(),
+  getWindowRegistry: vi.fn(() => null),
+  setWindowRegistry: vi.fn(),
+  getMainWindow: vi.fn(() => null),
+  setMainWindow: vi.fn(),
+}));
+
+import { CHANNELS } from "../../channels.js";
+import { registerCopyTreeHistoryHandlers } from "../copyTreeHistory.js";
+
+const PROJECT_A = "a".repeat(64);
+const PROJECT_B = "b".repeat(64);
+
+function getHandler(): (...args: unknown[]) => Promise<unknown> {
+  const call = (ipcMainMock.handle as Mock).mock.calls.find(
+    ([channel]) => channel === CHANNELS.COPY_TREE_HISTORY_GET_RECORDS
+  );
+  if (!call) throw new Error("copy-tree-history:get-records was never registered");
+  return call[1] as (...args: unknown[]) => Promise<unknown>;
+}
+
+/**
+ * Register against a sender view bound to `viewProjectId`, mirroring how
+ * production supplies the ProjectViewManager through handler dependencies.
+ */
+function registerBoundTo(viewProjectId: string | null) {
+  ipcMainMock.handle.mockClear();
+  registerCopyTreeHistoryHandlers({
+    projectViewManager: { getProjectIdForWebContents: () => viewProjectId },
+  } as never);
+}
+
+/** Unwrap the `{ ok: true, data }` envelope the IPC security layer adds. */
+async function invoke(sender = { id: 1 }): Promise<unknown> {
+  const result = (await getHandler()({ sender })) as { ok?: boolean; data?: unknown };
+  return result?.ok ? result.data : result;
+}
+
+describe("copyTreeHistory handlers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    projectStoreMock.getCurrentProjectId.mockReturnValue(null);
+    projectStoreMock.getProjectById.mockReturnValue(null);
+    projectStoreMock.getCopyTreeHistory.mockReset().mockResolvedValue([]);
+    browserWindowMock.fromWebContents.mockReturnValue(null);
+    windowRefMock.getProjectViewManager.mockReturnValue(null);
+    registerBoundTo(PROJECT_A);
+  });
+
+  it("exposes only a read — there is no channel to forge entries through", () => {
+    const channels = (ipcMainMock.handle as Mock).mock.calls.map(([channel]) => channel as string);
+    expect(channels).toEqual([CHANNELS.COPY_TREE_HISTORY_GET_RECORDS]);
+  });
+
+  it("serves the history of the project bound to the sender's view", async () => {
+    registerBoundTo(PROJECT_A);
+    projectStoreMock.getProjectById.mockReturnValue({ id: PROJECT_A, status: "open" });
+    projectStoreMock.getCopyTreeHistory.mockResolvedValue([{ id: "r1" }]);
+
+    await expect(invoke()).resolves.toEqual([{ id: "r1" }]);
+    expect(projectStoreMock.getCopyTreeHistory).toHaveBeenCalledWith(PROJECT_A);
+  });
+
+  it("never serves another project's history to a bound view", async () => {
+    // The reader resolves from the sender's own binding, so a different project
+    // being current globally cannot redirect the read.
+    registerBoundTo(PROJECT_A);
+    projectStoreMock.getProjectById.mockImplementation((id) =>
+      id === PROJECT_A ? { id: PROJECT_A, status: "open" } : { id: PROJECT_B, status: "open" }
+    );
+    projectStoreMock.getCurrentProjectId.mockReturnValue(PROJECT_B);
+
+    await invoke();
+
+    expect(projectStoreMock.getCopyTreeHistory).toHaveBeenCalledWith(PROJECT_A);
+    expect(projectStoreMock.getCopyTreeHistory).not.toHaveBeenCalledWith(PROJECT_B);
+  });
+
+  it("returns an empty history for a view bound to no project", async () => {
+    // Must NOT fall back to the globally-current project — an unbound view
+    // inheriting the global pointer is the #6015 bug class.
+    registerBoundTo(null);
+    projectStoreMock.getCurrentProjectId.mockReturnValue(PROJECT_B);
+
+    await expect(invoke()).resolves.toEqual([]);
+    expect(projectStoreMock.getCopyTreeHistory).not.toHaveBeenCalled();
+  });
+
+  it("reports an unreadable history as empty instead of failing the call", async () => {
+    // A file whose quarantine could not be renamed stays unreadable. The writer
+    // still refuses to overwrite it; the reader just has nothing to show.
+    registerBoundTo(PROJECT_A);
+    projectStoreMock.getProjectById.mockReturnValue({ id: PROJECT_A, status: "open" });
+    projectStoreMock.getCopyTreeHistory.mockRejectedValue(new Error("EPERM"));
+
+    await expect(invoke()).resolves.toEqual([]);
+  });
+});

--- a/electron/ipc/handlers/copyTree.ts
+++ b/electron/ipc/handlers/copyTree.ts
@@ -25,6 +25,7 @@ import type {
   FileTreeNode,
   CopyTreeOptions,
 } from "../../types/index.js";
+import type { CopyTreeRunSource } from "../../../shared/types/ipc/copyTreeHistory.js";
 
 type CopyTreeFormat = NonNullable<CopyTreeOptions["format"]>;
 
@@ -105,6 +106,7 @@ import type {
   ProjectSettings,
 } from "../../types/index.js";
 import { projectStore } from "../../services/ProjectStore.js";
+import { recordCopyTreeRun } from "../../services/copyTreeHistoryService.js";
 import { contextInjectionTracker } from "../../services/ContextInjectionTracker.js";
 import {
   fitContentToResultBudget,
@@ -228,12 +230,53 @@ export function mergeCopyTreeOptions(
  * can be evicted while a later await is in flight, and a binding that vanishes
  * mid-request would silently drop the project's exclusions from the context.
  */
-function resolveCopyTreeProjectId(ctx: IpcContext, deps: HandlerDependencies): string | null {
+export function resolveCopyTreeProjectId(
+  ctx: IpcContext,
+  deps: HandlerDependencies
+): string | null {
   const scopedProject = resolveScopedProjectForIpcContext(ctx, deps);
   if (scopedProject === null) {
     return projectStore.getCurrentProjectId();
   }
   return scopedProject.project?.id ?? null;
+}
+
+/**
+ * Record a completed run in the project's copy-tree history (#11732).
+ *
+ * Takes the *validated* payload rather than the merged options: merging folds
+ * in live project settings, and a record that froze those in would replay a
+ * stale configuration the next time it is re-run.
+ *
+ * `projectId` must be the value captured synchronously before the handler's
+ * first await — re-resolving here would read whatever project the sender's view
+ * has since been repointed at.
+ *
+ * Awaited by its callers so the write and its snapshot push stay ordered behind
+ * the per-project queue, and swallowing here rather than only inside the service
+ * so that ordering can never cost the caller its result: by this point the
+ * bundle has already been delivered, and no bookkeeping failure may turn a
+ * completed copy into an error the user sees.
+ */
+async function recordCompletedCopyTreeRun(
+  projectId: string | null,
+  validated: { worktreeId: string; options?: CopyTreeOptions; source?: CopyTreeRunSource },
+  result: CopyTreeResult
+): Promise<void> {
+  try {
+    await recordCopyTreeRun(projectId, {
+      options: validated.options ?? {},
+      source: validated.source ?? "unknown",
+      worktreeId: validated.worktreeId,
+      stats: {
+        fileCount: result.fileCount,
+        totalSize: result.stats?.totalSize,
+        duration: result.stats?.duration,
+      },
+    });
+  } catch (error) {
+    console.warn("[CopyTree] Failed to record run in the project history:", error);
+  }
 }
 
 /** Load the CopyTree-relevant settings for a project resolved by `resolveCopyTreeProjectId`. */
@@ -371,7 +414,13 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
     const mergedOptions = mergeCopyTreeOptions(projectSettings, validated.options);
 
     const result = await generateToFile(worktree, mergedOptions, onProgress);
-    if (result.error || !result.filePath || !validated.includeContent) {
+    if (result.error) {
+      return result;
+    }
+
+    await recordCompletedCopyTreeRun(settingsProjectId, validated, result);
+
+    if (!result.filePath || !validated.includeContent) {
       return result;
     }
 
@@ -495,6 +544,11 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       }
 
       console.log(`[${traceId}] Copied context file to clipboard: ${filePath}`);
+
+      // Only the clean path records: the catch below still returns a usable
+      // file path, but the copy the user asked for did not happen, so it does
+      // not belong in a history whose entries are meant to be re-run.
+      await recordCompletedCopyTreeRun(settingsProjectId, validated, result);
 
       return {
         content: "",
@@ -660,6 +714,12 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       }
 
       console.log(`[${traceId}] CopyTree inject completed successfully`);
+
+      // Injection is the same intent as a copy with a different delivery, so it
+      // earns a history entry too — and dedupes against the clipboard run that
+      // used the same options.
+      await recordCompletedCopyTreeRun(settingsProjectId, validated, result);
+
       // The renderer reads only fileCount/stats; drop the (possibly multi-MB)
       // content so the contextBridge doesn't clone a second copy into the heap.
       return {

--- a/electron/ipc/handlers/copyTree.ts
+++ b/electron/ipc/handlers/copyTree.ts
@@ -515,6 +515,12 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       return result;
     }
 
+    // Recorded on generation, not on the clipboard write below. The bundle now
+    // exists and its path rides back even when the clipboard step throws, so a
+    // run the user would most want to retry is exactly the one that must not be
+    // missing from the history.
+    await recordCompletedCopyTreeRun(settingsProjectId, validated, result);
+
     const filePath = result.filePath;
 
     try {
@@ -544,11 +550,6 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       }
 
       console.log(`[${traceId}] Copied context file to clipboard: ${filePath}`);
-
-      // Only the clean path records: the catch below still returns a usable
-      // file path, but the copy the user asked for did not happen, so it does
-      // not belong in a history whose entries are meant to be re-run.
-      await recordCompletedCopyTreeRun(settingsProjectId, validated, result);
 
       return {
         content: "",

--- a/electron/ipc/handlers/copyTreeHistory.preload.ts
+++ b/electron/ipc/handlers/copyTreeHistory.preload.ts
@@ -1,0 +1,26 @@
+import type { IpcInvokeMap } from "../../types/index.js";
+
+export const COPY_TREE_HISTORY_METHOD_CHANNELS = {
+  getRecords: "copy-tree-history:get-records",
+} as const satisfies Record<string, keyof IpcInvokeMap>;
+
+type Methods = typeof COPY_TREE_HISTORY_METHOD_CHANNELS;
+
+export type CopyTreeHistoryPreloadBindings = {
+  [M in keyof Methods]: (
+    ...args: IpcInvokeMap[Methods[M]]["args"]
+  ) => Promise<IpcInvokeMap[Methods[M]]["result"]>;
+};
+
+type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
+
+export function buildCopyTreeHistoryPreloadBindings(
+  invoke: Invoker
+): CopyTreeHistoryPreloadBindings {
+  const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const method of Object.keys(COPY_TREE_HISTORY_METHOD_CHANNELS) as Array<keyof Methods>) {
+    const channel = COPY_TREE_HISTORY_METHOD_CHANNELS[method];
+    out[method as string] = (...args) => invoke(channel, ...args);
+  }
+  return out as unknown as CopyTreeHistoryPreloadBindings;
+}

--- a/electron/ipc/handlers/copyTreeHistory.ts
+++ b/electron/ipc/handlers/copyTreeHistory.ts
@@ -1,0 +1,49 @@
+import { projectStore } from "../../services/ProjectStore.js";
+import { defineIpcNamespace, op } from "../define.js";
+import type { HandlerDependencies } from "../types.js";
+import type { CopyTreeHistoryRecord } from "../../../shared/types/ipc/copyTreeHistory.js";
+import { resolveCopyTreeProjectId } from "./copyTree.js";
+import { COPY_TREE_HISTORY_METHOD_CHANNELS } from "./copyTreeHistory.preload.js";
+
+/**
+ * Read side of the per-project copy-tree run history (#11732).
+ *
+ * Read-only by design: the main process is the single writer, and it records a
+ * run at the point the run actually completes rather than trusting a renderer
+ * to report one. There is deliberately no `append` op here — a writable channel
+ * would let any window forge entries for the project it happens to be bound to.
+ *
+ * Scoping reuses the *same* resolver the generate handlers write through, so a
+ * view can never read a history it would not have written to.
+ */
+export function buildCopyTreeHistoryNamespace(deps: HandlerDependencies) {
+  return defineIpcNamespace({
+    name: "copyTreeHistory",
+    ops: {
+      getRecords: op(
+        COPY_TREE_HISTORY_METHOD_CHANNELS.getRecords,
+        async (ctx): Promise<CopyTreeHistoryRecord[]> => {
+          const projectId = resolveCopyTreeProjectId(ctx, deps);
+          if (!projectId) return [];
+          try {
+            return await projectStore.getCopyTreeHistory(projectId);
+          } catch (error) {
+            // A quarantine that could not be renamed leaves the file unreadable.
+            // An empty list is the honest answer for a reader; the write path
+            // still refuses to overwrite it.
+            console.warn(
+              `[CopyTreeHistory] Failed to read history for project ${projectId}:`,
+              error
+            );
+            return [];
+          }
+        },
+        { withContext: true }
+      ),
+    },
+  });
+}
+
+export function registerCopyTreeHistoryHandlers(deps: HandlerDependencies): () => void {
+  return buildCopyTreeHistoryNamespace(deps).register();
+}

--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -82,6 +82,7 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
   "forge:remote-changed": "external",
   "plugin:bg-update-available": "external",
   "run-history:update": "external",
+  "copy-tree-history:update": "external",
   "plugin:deep-link": "external",
   "plugin:archive-install-intent": "external",
   "terminal:exit": "external",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -49,6 +49,7 @@ import { buildScratchPreloadBindings } from "./ipc/handlers/scratch/preload.js";
 import { buildMcpServerPreloadBindings } from "./ipc/handlers/mcpServer.preload.js";
 import { buildForgeAuditPreloadBindings } from "./ipc/handlers/forgeAudit.preload.js";
 import { buildRunHistoryPreloadBindings } from "./ipc/handlers/runHistory.preload.js";
+import { buildCopyTreeHistoryPreloadBindings } from "./ipc/handlers/copyTreeHistory.preload.js";
 import { buildGeminiPreloadBindings } from "./ipc/handlers/gemini.preload.js";
 import { buildMilestonesPreloadBindings } from "./ipc/handlers/milestones.preload.js";
 import { buildOnboardingPreloadBindings } from "./ipc/handlers/onboarding.preload.js";
@@ -92,6 +93,7 @@ import type {
   TerminalSpawnOptions,
   CopyTreeOptions,
   CopyTreeProgress,
+  CopyTreeRunSource,
   CopyTreeTestConfigOptions,
   AppState,
   LogEntry,
@@ -1411,23 +1413,43 @@ function buildElectronApi(): ElectronAPI {
 
     // CopyTree API
     copyTree: {
-      generate: (worktreeId: string, options?: CopyTreeOptions, includeContent?: boolean) =>
-        _unwrappingInvoke(CHANNELS.COPYTREE_GENERATE, { worktreeId, options, includeContent }),
+      generate: (
+        worktreeId: string,
+        options?: CopyTreeOptions,
+        includeContent?: boolean,
+        source?: CopyTreeRunSource
+      ) =>
+        _unwrappingInvoke(CHANNELS.COPYTREE_GENERATE, {
+          worktreeId,
+          options,
+          includeContent,
+          source,
+        }),
 
-      generateAndCopyFile: (worktreeId: string, options?: CopyTreeOptions) =>
-        _unwrappingInvoke(CHANNELS.COPYTREE_GENERATE_AND_COPY_FILE, { worktreeId, options }),
+      generateAndCopyFile: (
+        worktreeId: string,
+        options?: CopyTreeOptions,
+        source?: CopyTreeRunSource
+      ) =>
+        _unwrappingInvoke(CHANNELS.COPYTREE_GENERATE_AND_COPY_FILE, {
+          worktreeId,
+          options,
+          source,
+        }),
 
       injectToTerminal: (
         terminalId: string,
         worktreeId: string,
         options?: CopyTreeOptions,
-        injectionId?: string
+        injectionId?: string,
+        source?: CopyTreeRunSource
       ) =>
         _unwrappingInvoke(CHANNELS.COPYTREE_INJECT, {
           terminalId,
           worktreeId,
           options,
           injectionId,
+          source,
         }),
 
       isAvailable: () => _unwrappingInvoke(CHANNELS.COPYTREE_AVAILABLE),
@@ -2863,6 +2885,7 @@ function buildElectronApi(): ElectronAPI {
     forgeAudit: buildForgeAuditPreloadBindings(_unwrappingInvoke),
 
     runHistory: buildRunHistoryPreloadBindings(_unwrappingInvoke),
+    copyTreeHistory: buildCopyTreeHistoryPreloadBindings(_unwrappingInvoke),
 
     // Voice Input API
     voiceInput: {

--- a/electron/schemas/copyTreeHistory.ts
+++ b/electron/schemas/copyTreeHistory.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+import { CopyTreeOptionsSchema, CopyTreeRunSourceSchema } from "./ipc.js";
+
+export const CopyTreeRunStatsSchema = z.object({
+  fileCount: z.number().int().nonnegative(),
+  totalSize: z.number().nonnegative().optional(),
+  duration: z.number().nonnegative().optional(),
+});
+
+/**
+ * Validates a persisted record on the way back in. `options` reuses the same
+ * schema the IPC boundary applies, so a record can never rehydrate into
+ * something the generate handlers would have rejected.
+ */
+export const CopyTreeHistoryRecordSchema = z.object({
+  id: z.string().min(1),
+  dedupeKey: z.string().min(1),
+  name: z.string().min(1),
+  options: CopyTreeOptionsSchema.unwrap(),
+  source: CopyTreeRunSourceSchema,
+  worktreeId: z.string().min(1),
+  stats: CopyTreeRunStatsSchema,
+  createdAt: z.number().int().nonnegative(),
+  lastUsedAt: z.number().int().nonnegative(),
+  runCount: z.number().int().positive(),
+});
+
+export const CopyTreeHistoryFileSchema = z.object({
+  _schemaVersion: z.number().int().nonnegative(),
+  records: z.array(CopyTreeHistoryRecordSchema),
+});

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { BUILT_IN_PANEL_KINDS, panelKindHasPty } from "../../shared/config/panelKindRegistry.js";
 import { BUILT_IN_AGENT_IDS } from "../../shared/config/agentIds.js";
 import { MAX_TERMINAL_GRID_DIMENSION } from "../../shared/types/terminal.js";
+import { COPY_TREE_RUN_SOURCES } from "../../shared/types/ipc/copyTreeHistory.js";
 import {
   ASSISTANT_HOST_PROTOCOL_VERSION,
   type AssistantHostEvent,
@@ -497,6 +498,14 @@ export const CopyTreeOptionsSchema = z
   })
   .optional();
 
+/**
+ * Which surface asked for a copy-tree run (#11732). Left `.optional()` rather
+ * than given a `.default()` so the schema keeps describing omission honestly —
+ * the main handler is what maps an absent source to `unknown`, and it is the
+ * only writer of the history.
+ */
+export const CopyTreeRunSourceSchema = z.enum(COPY_TREE_RUN_SOURCES);
+
 export const CopyTreeGeneratePayloadSchema = z.object({
   worktreeId: z.string().min(1),
   options: CopyTreeOptionsSchema,
@@ -505,11 +514,13 @@ export const CopyTreeGeneratePayloadSchema = z.object({
   // CopyTreeOptionsSchema: the destination is chosen by the main process, so a
   // tool call can never turn into an arbitrary file write.
   includeContent: z.boolean().optional(),
+  source: CopyTreeRunSourceSchema.optional(),
 });
 
 export const CopyTreeGenerateAndCopyFilePayloadSchema = z.object({
   worktreeId: z.string().min(1),
   options: CopyTreeOptionsSchema,
+  source: CopyTreeRunSourceSchema.optional(),
 });
 
 export const CopyTreeInjectPayloadSchema = z.object({
@@ -517,6 +528,7 @@ export const CopyTreeInjectPayloadSchema = z.object({
   worktreeId: z.string().min(1),
   options: CopyTreeOptionsSchema,
   injectionId: z.string().min(1).optional(),
+  source: CopyTreeRunSourceSchema.optional(),
 });
 
 export const CopyTreeCancelPayloadSchema = z.object({

--- a/electron/services/ProjectFileStore.ts
+++ b/electron/services/ProjectFileStore.ts
@@ -3,8 +3,14 @@ import type { TerminalRecipe } from "../types/index.js";
 import fs from "fs/promises";
 import { existsSync } from "fs";
 import { resilientRename, resilientAtomicWriteFile } from "../utils/fs.js";
-import { getProjectStateDir, recipesFilePath } from "./projectStorePaths.js";
+import {
+  getProjectStateDir,
+  recipesFilePath,
+  copyTreeHistoryFilePath,
+} from "./projectStorePaths.js";
 import { TerminalRecipeSchema, filterValidTerminalEntries } from "../schemas/ipc.js";
+import { decodeCopyTreeHistoryFile, encodeCopyTreeHistoryFile } from "./copyTreeHistoryCodec.js";
+import type { CopyTreeHistoryRecord } from "../../shared/types/ipc/copyTreeHistory.js";
 
 export const RECIPES_SCHEMA_VERSION = 1;
 
@@ -16,6 +22,10 @@ export class ProjectFileStore {
   // read the same on-disk snapshot and the last write silently clobbers the
   // other. Mirrors ProjectStateManager.enqueueProjectStateUpdate.
   private readonly recipesWriteQueues = new Map<string, Promise<void>>();
+
+  // Same reasoning, separate chain: a copy-tree run must not wait behind a
+  // recipe import, and the two files never appear in one another's updaters.
+  private readonly copyTreeHistoryWriteQueues = new Map<string, Promise<void>>();
 
   // --- Recipes ---
 
@@ -255,5 +265,106 @@ export class ProjectFileStore {
       const recipes = await this.getRecipes(projectId);
       return recipes.filter((r) => r.id !== recipeId);
     });
+  }
+
+  // --- Copy-tree run history (#11732) ---
+
+  /**
+   * Read the project's copy-tree history, newest-first.
+   *
+   * A missing file is an empty history. A damaged or newer-than-us file is
+   * quarantined by rename and reported empty — but if the rename itself fails
+   * this **throws** rather than returning `[]`. Returning empty there would let
+   * the next append write a fresh file straight over data we failed to preserve,
+   * which is the one outcome quarantining exists to prevent.
+   */
+  async getCopyTreeHistory(projectId: string): Promise<CopyTreeHistoryRecord[]> {
+    const filePath = copyTreeHistoryFilePath(this.projectsConfigDir, projectId);
+    if (!filePath) {
+      return [];
+    }
+
+    let content: string;
+    try {
+      content = await fs.readFile(filePath, "utf-8");
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+        return [];
+      }
+      throw error;
+    }
+
+    const decoded = decodeCopyTreeHistoryFile(content);
+    if (decoded.ok) {
+      return decoded.records;
+    }
+
+    const quarantinePath =
+      decoded.reason === "future-version"
+        ? `${filePath}.future-v${decoded.onDiskVersion}`
+        : `${filePath}.corrupted.${Date.now()}`;
+    const target = existsSync(quarantinePath) ? `${quarantinePath}.${Date.now()}` : quarantinePath;
+
+    await resilientRename(filePath, target);
+    console.warn(
+      `[ProjectFileStore] copy-tree history for ${projectId} was unreadable (${decoded.reason}); quarantined to ${target}`
+    );
+    return [];
+  }
+
+  /**
+   * Serialize copy-tree history read-modify-write cycles per project, so two
+   * runs completing in the same tick cannot both read the pre-write snapshot and
+   * have the later write silently drop the earlier one's dedupe bump.
+   *
+   * Same three load-bearing details as {@link enqueueRecipesUpdate}, and the
+   * same rule for updaters: read through the unqueued {@link getCopyTreeHistory}
+   * and never re-enter this queue for the same project.
+   */
+  enqueueCopyTreeHistoryUpdate(
+    projectId: string,
+    updater: () => CopyTreeHistoryRecord[] | null | Promise<CopyTreeHistoryRecord[] | null>
+  ): Promise<void> {
+    const current = this.copyTreeHistoryWriteQueues.get(projectId) ?? Promise.resolve();
+    const next = current
+      .catch(() => {})
+      .then(async () => {
+        const updated = await updater();
+        if (updated !== null) {
+          await this.saveCopyTreeHistoryInner(projectId, updated);
+        }
+      });
+    this.copyTreeHistoryWriteQueues.set(projectId, next);
+    const cleanup = () => {
+      if (this.copyTreeHistoryWriteQueues.get(projectId) === next) {
+        this.copyTreeHistoryWriteQueues.delete(projectId);
+      }
+    };
+    next.then(cleanup, cleanup);
+    return next;
+  }
+
+  private async saveCopyTreeHistoryInner(
+    projectId: string,
+    records: CopyTreeHistoryRecord[]
+  ): Promise<void> {
+    const stateDir = getProjectStateDir(this.projectsConfigDir, projectId);
+    const filePath = copyTreeHistoryFilePath(this.projectsConfigDir, projectId);
+    if (!stateDir || !filePath) {
+      throw new Error(`Invalid project ID: ${projectId}`);
+    }
+
+    const jsonString = encodeCopyTreeHistoryFile(records);
+
+    try {
+      await resilientAtomicWriteFile(filePath, jsonString, "utf-8");
+    } catch (error) {
+      const isEnoent = error instanceof Error && "code" in error && error.code === "ENOENT";
+      if (!isEnoent) {
+        throw error;
+      }
+      await fs.mkdir(stateDir, { recursive: true });
+      await resilientAtomicWriteFile(filePath, jsonString, "utf-8");
+    }
   }
 }

--- a/electron/services/ProjectFileStore.ts
+++ b/electron/services/ProjectFileStore.ts
@@ -10,7 +10,12 @@ import {
 } from "./projectStorePaths.js";
 import { TerminalRecipeSchema, filterValidTerminalEntries } from "../schemas/ipc.js";
 import { decodeCopyTreeHistoryFile, encodeCopyTreeHistoryFile } from "./copyTreeHistoryCodec.js";
-import type { CopyTreeHistoryRecord } from "../../shared/types/ipc/copyTreeHistory.js";
+import { applyCopyTreeRun } from "./copyTreeHistoryLog.js";
+import { randomUUID } from "crypto";
+import type {
+  CopyTreeHistoryAppendInput,
+  CopyTreeHistoryRecord,
+} from "../../shared/types/ipc/copyTreeHistory.js";
 
 export const RECIPES_SCHEMA_VERSION = 1;
 
@@ -272,13 +277,57 @@ export class ProjectFileStore {
   /**
    * Read the project's copy-tree history, newest-first.
    *
-   * A missing file is an empty history. A damaged or newer-than-us file is
-   * quarantined by rename and reported empty — but if the rename itself fails
-   * this **throws** rather than returning `[]`. Returning empty there would let
-   * the next append write a fresh file straight over data we failed to preserve,
-   * which is the one outcome quarantining exists to prevent.
+   * Takes a turn in the write queue even though it mutates nothing itself:
+   * {@link readCopyTreeHistory} quarantines an unreadable file, so two
+   * unserialized readers — or a reader racing the append's own read — can both
+   * decide to rename it, and whichever loses gets `ENOENT` and fails. Queuing
+   * makes the quarantine happen exactly once, and also means a caller reads
+   * committed state rather than a snapshot a pending append is about to replace.
    */
   async getCopyTreeHistory(projectId: string): Promise<CopyTreeHistoryRecord[]> {
+    let records: CopyTreeHistoryRecord[] = [];
+    await this.enqueueCopyTreeHistoryUpdate(projectId, async () => {
+      records = await this.readCopyTreeHistory(projectId);
+      return null;
+    });
+    return records;
+  }
+
+  /**
+   * Fold a completed run into the project's history and return the committed
+   * snapshot.
+   *
+   * Lives here rather than in ProjectStore so the read, the dedupe fold and the
+   * write all happen inside one queued turn using the unqueued read — a caller
+   * composing this from the outside would have to reach for
+   * {@link getCopyTreeHistory}, which takes its own turn and would deadlock
+   * behind the turn awaiting it.
+   */
+  async appendCopyTreeRun(
+    projectId: string,
+    input: CopyTreeHistoryAppendInput
+  ): Promise<CopyTreeHistoryRecord[]> {
+    let snapshot: CopyTreeHistoryRecord[] = [];
+    await this.enqueueCopyTreeHistoryUpdate(projectId, async () => {
+      const current = await this.readCopyTreeHistory(projectId);
+      snapshot = applyCopyTreeRun(current, input, { id: randomUUID(), now: Date.now() });
+      return snapshot;
+    });
+    return snapshot;
+  }
+
+  /**
+   * Unqueued read. A missing file is an empty history. A damaged or
+   * newer-than-us file is quarantined by rename and reported empty — but if the
+   * rename itself fails this **throws** rather than returning `[]`. Returning
+   * empty there would let the next append write a fresh file straight over data
+   * we failed to preserve, which is the one outcome quarantining exists to
+   * prevent.
+   *
+   * Private because calling it outside the queue reintroduces the double-
+   * quarantine race described on {@link getCopyTreeHistory}.
+   */
+  private async readCopyTreeHistory(projectId: string): Promise<CopyTreeHistoryRecord[]> {
     const filePath = copyTreeHistoryFilePath(this.projectsConfigDir, projectId);
     if (!filePath) {
       return [];

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -38,6 +38,12 @@ import { ProjectSettingsManager } from "./ProjectSettingsManager.js";
 import { ProjectStateManager, type ProjectStateReadResult } from "./ProjectStateManager.js";
 import { invalidatePrefetchCache } from "./prefetchHydrateCache.js";
 import { ProjectFileStore } from "./ProjectFileStore.js";
+import { applyCopyTreeRun } from "./copyTreeHistoryLog.js";
+import type {
+  CopyTreeHistoryAppendInput,
+  CopyTreeHistoryRecord,
+} from "../../shared/types/ipc/copyTreeHistory.js";
+import { randomUUID } from "crypto";
 import { GlobalFileStore } from "./GlobalFileStore.js";
 import { ProjectIdentityFiles } from "./ProjectIdentityFiles.js";
 import {
@@ -1540,6 +1546,30 @@ export class ProjectStore {
 
   getEffectiveNotificationSettings(): NotificationSettings {
     return this.settingsManager.getEffectiveNotificationSettings(this.getCurrentProjectId());
+  }
+
+  // --- Copy-tree run history (#11732) ---
+
+  async getCopyTreeHistory(projectId: string): Promise<CopyTreeHistoryRecord[]> {
+    return this.fileStore.getCopyTreeHistory(projectId);
+  }
+
+  /**
+   * Fold a completed run into the project's history and return the committed
+   * snapshot. The read, the dedupe fold and the write all happen inside one
+   * queued turn, so concurrent runs for the same project cannot lose a bump.
+   */
+  async appendCopyTreeRun(
+    projectId: string,
+    input: CopyTreeHistoryAppendInput
+  ): Promise<CopyTreeHistoryRecord[]> {
+    let snapshot: CopyTreeHistoryRecord[] = [];
+    await this.fileStore.enqueueCopyTreeHistoryUpdate(projectId, async () => {
+      const current = await this.fileStore.getCopyTreeHistory(projectId);
+      snapshot = applyCopyTreeRun(current, input, { id: randomUUID(), now: Date.now() });
+      return snapshot;
+    });
+    return snapshot;
   }
 
   // --- Recipes ---

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -38,12 +38,10 @@ import { ProjectSettingsManager } from "./ProjectSettingsManager.js";
 import { ProjectStateManager, type ProjectStateReadResult } from "./ProjectStateManager.js";
 import { invalidatePrefetchCache } from "./prefetchHydrateCache.js";
 import { ProjectFileStore } from "./ProjectFileStore.js";
-import { applyCopyTreeRun } from "./copyTreeHistoryLog.js";
 import type {
   CopyTreeHistoryAppendInput,
   CopyTreeHistoryRecord,
 } from "../../shared/types/ipc/copyTreeHistory.js";
-import { randomUUID } from "crypto";
 import { GlobalFileStore } from "./GlobalFileStore.js";
 import { ProjectIdentityFiles } from "./ProjectIdentityFiles.js";
 import {
@@ -1554,22 +1552,11 @@ export class ProjectStore {
     return this.fileStore.getCopyTreeHistory(projectId);
   }
 
-  /**
-   * Fold a completed run into the project's history and return the committed
-   * snapshot. The read, the dedupe fold and the write all happen inside one
-   * queued turn, so concurrent runs for the same project cannot lose a bump.
-   */
   async appendCopyTreeRun(
     projectId: string,
     input: CopyTreeHistoryAppendInput
   ): Promise<CopyTreeHistoryRecord[]> {
-    let snapshot: CopyTreeHistoryRecord[] = [];
-    await this.fileStore.enqueueCopyTreeHistoryUpdate(projectId, async () => {
-      const current = await this.fileStore.getCopyTreeHistory(projectId);
-      snapshot = applyCopyTreeRun(current, input, { id: randomUUID(), now: Date.now() });
-      return snapshot;
-    });
-    return snapshot;
+    return this.fileStore.appendCopyTreeRun(projectId, input);
   }
 
   // --- Recipes ---

--- a/electron/services/__tests__/ProjectFileStore.copyTreeHistory.test.ts
+++ b/electron/services/__tests__/ProjectFileStore.copyTreeHistory.test.ts
@@ -1,0 +1,296 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import path from "path";
+
+const fsMock = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  mkdir: vi.fn(),
+}));
+
+const fsSyncMock = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+}));
+
+const utilsMock = vi.hoisted(() => ({
+  resilientRename: vi.fn(),
+  resilientAtomicWriteFile: vi.fn(),
+}));
+
+vi.mock("fs/promises", () => ({ default: fsMock, ...fsMock }));
+vi.mock("fs", () => ({ ...fsSyncMock }));
+vi.mock("../../utils/fs.js", () => utilsMock);
+
+import { ProjectFileStore } from "../ProjectFileStore.js";
+import { applyCopyTreeRun } from "../copyTreeHistoryLog.js";
+import { encodeCopyTreeHistoryFile } from "../copyTreeHistoryCodec.js";
+import { COPY_TREE_HISTORY_SCHEMA_VERSION } from "../../../shared/types/ipc/copyTreeHistory.js";
+import type {
+  CopyTreeHistoryAppendInput,
+  CopyTreeHistoryRecord,
+} from "../../../shared/types/ipc/copyTreeHistory.js";
+import type { CopyTreeOptions } from "../../../shared/types/ipc/copyTree.js";
+
+const VALID_ID = "a".repeat(64);
+const OTHER_ID = "b".repeat(64);
+const CONFIG_DIR = path.normalize("/tmp/daintree-projects");
+
+function historyFilePath(projectId: string): string {
+  return path.join(CONFIG_DIR, projectId, "copy-tree-history.json");
+}
+
+/**
+ * Model copy-tree-history.json on disk keyed by file path, with a per-write
+ * delay that widens the read→write window. An implementation without the
+ * per-project queue loses one of two concurrent appends here, so these tests
+ * fail loudly if the queue is ever removed.
+ */
+function installDiskModel(writeDelayMs = 0): Map<string, string> {
+  const disk = new Map<string, string>();
+  fsMock.readFile.mockImplementation(async (filePath: string) => {
+    const content = disk.get(filePath);
+    if (content === undefined) {
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    }
+    return content;
+  });
+  utilsMock.resilientAtomicWriteFile.mockImplementation(async (filePath: string, data: string) => {
+    if (writeDelayMs > 0) await new Promise((resolve) => setTimeout(resolve, writeDelayMs));
+    disk.set(filePath, data);
+  });
+  return disk;
+}
+
+/** Mirrors ProjectStore.appendCopyTreeRun: read, fold and write in one turn. */
+function append(
+  store: ProjectFileStore,
+  projectId: string,
+  id: string,
+  now: number,
+  overrides: Partial<CopyTreeHistoryAppendInput> = {}
+): Promise<void> {
+  return store.enqueueCopyTreeHistoryUpdate(projectId, async () => {
+    const current = await store.getCopyTreeHistory(projectId);
+    return applyCopyTreeRun(
+      current,
+      {
+        options: {},
+        source: "toolbar",
+        worktreeId: "wt-1",
+        stats: { fileCount: 1 },
+        ...overrides,
+      },
+      { id, now }
+    );
+  });
+}
+
+function readDisk(disk: Map<string, string>, projectId: string): CopyTreeHistoryRecord[] {
+  const raw = disk.get(historyFilePath(projectId));
+  expect(raw).toBeDefined();
+  return (JSON.parse(raw as string) as { records: CopyTreeHistoryRecord[] }).records;
+}
+
+describe("ProjectFileStore copy-tree history", () => {
+  let store: ProjectFileStore;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    store = new ProjectFileStore(CONFIG_DIR);
+    fsMock.mkdir.mockResolvedValue(undefined);
+    utilsMock.resilientRename.mockResolvedValue(undefined);
+    fsSyncMock.existsSync.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("treats a project with no history file as an empty history", async () => {
+    installDiskModel();
+    await expect(store.getCopyTreeHistory(VALID_ID)).resolves.toEqual([]);
+  });
+
+  it("returns an empty history for an id that cannot own a state directory", async () => {
+    installDiskModel();
+    await expect(store.getCopyTreeHistory("../../../etc/passwd")).resolves.toEqual([]);
+    expect(fsMock.readFile).not.toHaveBeenCalled();
+  });
+
+  it("propagates a read failure that is not a missing file", async () => {
+    fsMock.readFile.mockRejectedValue(Object.assign(new Error("EACCES"), { code: "EACCES" }));
+    await expect(store.getCopyTreeHistory(VALID_ID)).rejects.toThrow("EACCES");
+  });
+
+  it("serializes two concurrent appends of different options so neither is lost", async () => {
+    const disk = installDiskModel(5);
+
+    await Promise.all([
+      append(store, VALID_ID, "id-1", 1_000, { options: { modified: true } }),
+      append(store, VALID_ID, "id-2", 2_000, { options: { changed: "develop" } }),
+    ]);
+
+    const records = readDisk(disk, VALID_ID);
+    expect(records).toHaveLength(2);
+    expect(records.map((r) => r.id).sort()).toEqual(["id-1", "id-2"]);
+  });
+
+  it("collapses two concurrent appends of identical options into one bumped entry", async () => {
+    const disk = installDiskModel(5);
+
+    await Promise.all([
+      append(store, VALID_ID, "id-1", 1_000),
+      append(store, VALID_ID, "id-2", 2_000),
+    ]);
+
+    const records = readDisk(disk, VALID_ID);
+    expect(records).toHaveLength(1);
+    // Without serialization the second write would overwrite a snapshot read
+    // before the first landed, leaving runCount at 1.
+    expect(records[0].runCount).toBe(2);
+  });
+
+  it("keeps different projects independent", async () => {
+    const disk = installDiskModel(5);
+
+    await Promise.all([
+      append(store, VALID_ID, "id-1", 1_000),
+      append(store, OTHER_ID, "id-2", 1_000),
+    ]);
+
+    expect(readDisk(disk, VALID_ID).map((r) => r.id)).toEqual(["id-1"]);
+    expect(readDisk(disk, OTHER_ID).map((r) => r.id)).toEqual(["id-2"]);
+  });
+
+  it("does not let a failed update poison the next one in the chain", async () => {
+    const disk = installDiskModel(5);
+
+    const failing = store.enqueueCopyTreeHistoryUpdate(VALID_ID, () => {
+      throw new Error("updater blew up");
+    });
+    const following = append(store, VALID_ID, "id-2", 2_000);
+
+    await expect(failing).rejects.toThrow("updater blew up");
+    await expect(following).resolves.toBeUndefined();
+    expect(readDisk(disk, VALID_ID).map((r) => r.id)).toEqual(["id-2"]);
+  });
+
+  it("skips the write when the updater returns null", async () => {
+    installDiskModel();
+    await store.enqueueCopyTreeHistoryUpdate(VALID_ID, () => null);
+    expect(utilsMock.resilientAtomicWriteFile).not.toHaveBeenCalled();
+  });
+
+  it("creates the state directory when the first write finds it missing", async () => {
+    const disk = new Map<string, string>();
+    fsMock.readFile.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+    let firstAttempt = true;
+    utilsMock.resilientAtomicWriteFile.mockImplementation(
+      async (filePath: string, data: string) => {
+        if (firstAttempt) {
+          firstAttempt = false;
+          throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+        }
+        disk.set(filePath, data);
+      }
+    );
+
+    await append(store, VALID_ID, "id-1", 1_000);
+
+    expect(fsMock.mkdir).toHaveBeenCalledWith(path.join(CONFIG_DIR, VALID_ID), { recursive: true });
+    expect(readDisk(disk, VALID_ID).map((r) => r.id)).toEqual(["id-1"]);
+  });
+
+  it("quarantines a damaged file by renaming it, never by deleting it", async () => {
+    installDiskModel();
+    fsMock.readFile.mockResolvedValue("{ not json");
+
+    await expect(store.getCopyTreeHistory(VALID_ID)).resolves.toEqual([]);
+
+    expect(utilsMock.resilientRename).toHaveBeenCalledTimes(1);
+    const [from, to] = utilsMock.resilientRename.mock.calls[0] as [string, string];
+    expect(from).toBe(historyFilePath(VALID_ID));
+    expect(to.startsWith(`${historyFilePath(VALID_ID)}.corrupted.`)).toBe(true);
+  });
+
+  it("quarantines a newer app's file under a name that records its version", async () => {
+    installDiskModel();
+    fsMock.readFile.mockResolvedValue(
+      JSON.stringify({ _schemaVersion: COPY_TREE_HISTORY_SCHEMA_VERSION + 5, records: [] })
+    );
+
+    await expect(store.getCopyTreeHistory(VALID_ID)).resolves.toEqual([]);
+
+    const [, to] = utilsMock.resilientRename.mock.calls[0] as [string, string];
+    expect(to).toBe(`${historyFilePath(VALID_ID)}.future-v${COPY_TREE_HISTORY_SCHEMA_VERSION + 5}`);
+  });
+
+  it("does not clobber an existing quarantine file of the same name", async () => {
+    installDiskModel();
+    fsMock.readFile.mockResolvedValue(
+      JSON.stringify({ _schemaVersion: COPY_TREE_HISTORY_SCHEMA_VERSION + 1, records: [] })
+    );
+    fsSyncMock.existsSync.mockReturnValue(true);
+
+    await store.getCopyTreeHistory(VALID_ID);
+
+    const [, to] = utilsMock.resilientRename.mock.calls[0] as [string, string];
+    expect(to).toMatch(new RegExp(`\\.future-v${COPY_TREE_HISTORY_SCHEMA_VERSION + 1}\\.\\d+$`));
+  });
+
+  it("refuses to write over a damaged file whose quarantine failed", async () => {
+    // The dangerous case: if the rename fails and the read still reports an
+    // empty history, the next append writes a fresh file straight over data
+    // that was never preserved.
+    installDiskModel();
+    fsMock.readFile.mockResolvedValue("{ not json");
+    utilsMock.resilientRename.mockRejectedValue(new Error("EPERM"));
+
+    await expect(append(store, VALID_ID, "id-1", 1_000)).rejects.toThrow("EPERM");
+    expect(utilsMock.resilientAtomicWriteFile).not.toHaveBeenCalled();
+  });
+
+  it("reads back what a previous append wrote", async () => {
+    installDiskModel();
+
+    await append(store, VALID_ID, "id-1", 1_000, { options: { modified: true } });
+    const records = await store.getCopyTreeHistory(VALID_ID);
+
+    expect(records).toHaveLength(1);
+    expect(records[0].name).toBe("Modified files");
+    expect((records[0].options as CopyTreeOptions).modified).toBe(true);
+  });
+
+  it("starts fresh after a damaged file is quarantined", async () => {
+    const disk = installDiskModel();
+    disk.set(historyFilePath(VALID_ID), "{ not json");
+
+    await append(store, VALID_ID, "id-1", 1_000);
+
+    expect(utilsMock.resilientRename).toHaveBeenCalledTimes(1);
+    expect(readDisk(disk, VALID_ID).map((r) => r.id)).toEqual(["id-1"]);
+  });
+
+  it("writes the versioned envelope, not a bare array", async () => {
+    const disk = installDiskModel();
+    await append(store, VALID_ID, "id-1", 1_000);
+
+    const parsed = JSON.parse(disk.get(historyFilePath(VALID_ID)) as string) as {
+      _schemaVersion: number;
+      records: unknown[];
+    };
+    expect(parsed._schemaVersion).toBe(COPY_TREE_HISTORY_SCHEMA_VERSION);
+    expect(Array.isArray(parsed.records)).toBe(true);
+  });
+
+  it("round-trips a history written by the encoder", async () => {
+    const disk = installDiskModel();
+    const records = applyCopyTreeRun(
+      [],
+      { options: { filter: "src/**" }, source: "mcp", worktreeId: "wt-9", stats: { fileCount: 2 } },
+      { id: "seeded", now: 5_000 }
+    );
+    disk.set(historyFilePath(VALID_ID), encodeCopyTreeHistoryFile(records));
+
+    await expect(store.getCopyTreeHistory(VALID_ID)).resolves.toEqual(records);
+    expect(utilsMock.resilientRename).not.toHaveBeenCalled();
+  });
+});

--- a/electron/services/__tests__/ProjectFileStore.copyTreeHistory.test.ts
+++ b/electron/services/__tests__/ProjectFileStore.copyTreeHistory.test.ts
@@ -59,27 +59,23 @@ function installDiskModel(writeDelayMs = 0): Map<string, string> {
   return disk;
 }
 
-/** Mirrors ProjectStore.appendCopyTreeRun: read, fold and write in one turn. */
+/**
+ * Drive the REAL production coordinator. Ids and timestamps are minted inside
+ * it, so the assertions below key off content rather than a supplied id — a
+ * test-owned reimplementation of the fold would stay green if the production
+ * one stopped queueing its read.
+ */
 function append(
   store: ProjectFileStore,
   projectId: string,
-  id: string,
-  now: number,
   overrides: Partial<CopyTreeHistoryAppendInput> = {}
-): Promise<void> {
-  return store.enqueueCopyTreeHistoryUpdate(projectId, async () => {
-    const current = await store.getCopyTreeHistory(projectId);
-    return applyCopyTreeRun(
-      current,
-      {
-        options: {},
-        source: "toolbar",
-        worktreeId: "wt-1",
-        stats: { fileCount: 1 },
-        ...overrides,
-      },
-      { id, now }
-    );
+): Promise<CopyTreeHistoryRecord[]> {
+  return store.appendCopyTreeRun(projectId, {
+    options: {},
+    source: "toolbar",
+    worktreeId: "wt-1",
+    stats: { fileCount: 1 },
+    ...overrides,
   });
 }
 
@@ -124,22 +120,19 @@ describe("ProjectFileStore copy-tree history", () => {
     const disk = installDiskModel(5);
 
     await Promise.all([
-      append(store, VALID_ID, "id-1", 1_000, { options: { modified: true } }),
-      append(store, VALID_ID, "id-2", 2_000, { options: { changed: "develop" } }),
+      append(store, VALID_ID, { options: { modified: true } }),
+      append(store, VALID_ID, { options: { changed: "develop" } }),
     ]);
 
     const records = readDisk(disk, VALID_ID);
     expect(records).toHaveLength(2);
-    expect(records.map((r) => r.id).sort()).toEqual(["id-1", "id-2"]);
+    expect(records.map((r) => r.name).sort()).toEqual(["Changed since develop", "Modified files"]);
   });
 
   it("collapses two concurrent appends of identical options into one bumped entry", async () => {
     const disk = installDiskModel(5);
 
-    await Promise.all([
-      append(store, VALID_ID, "id-1", 1_000),
-      append(store, VALID_ID, "id-2", 2_000),
-    ]);
+    await Promise.all([append(store, VALID_ID), append(store, VALID_ID)]);
 
     const records = readDisk(disk, VALID_ID);
     expect(records).toHaveLength(1);
@@ -152,12 +145,31 @@ describe("ProjectFileStore copy-tree history", () => {
     const disk = installDiskModel(5);
 
     await Promise.all([
-      append(store, VALID_ID, "id-1", 1_000),
-      append(store, OTHER_ID, "id-2", 1_000),
+      append(store, VALID_ID, { worktreeId: "wt-a" }),
+      append(store, OTHER_ID, { worktreeId: "wt-b" }),
     ]);
 
-    expect(readDisk(disk, VALID_ID).map((r) => r.id)).toEqual(["id-1"]);
-    expect(readDisk(disk, OTHER_ID).map((r) => r.id)).toEqual(["id-2"]);
+    expect(readDisk(disk, VALID_ID).map((r) => r.worktreeId)).toEqual(["wt-a"]);
+    expect(readDisk(disk, OTHER_ID).map((r) => r.worktreeId)).toEqual(["wt-b"]);
+  });
+
+  it("does not make one project wait behind another project's in-flight write", async () => {
+    // A single global queue would satisfy the isolation test above. This one
+    // fails unless the queues are genuinely keyed per project.
+    installDiskModel();
+    let releaseA: () => void = () => {};
+    const blocked = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+    utilsMock.resilientAtomicWriteFile.mockImplementation(async (filePath: string) => {
+      if (filePath === historyFilePath(VALID_ID)) await blocked;
+    });
+
+    const slow = append(store, VALID_ID);
+    await expect(append(store, OTHER_ID)).resolves.toHaveLength(1);
+
+    releaseA();
+    await slow;
   });
 
   it("does not let a failed update poison the next one in the chain", async () => {
@@ -166,11 +178,11 @@ describe("ProjectFileStore copy-tree history", () => {
     const failing = store.enqueueCopyTreeHistoryUpdate(VALID_ID, () => {
       throw new Error("updater blew up");
     });
-    const following = append(store, VALID_ID, "id-2", 2_000);
+    const following = append(store, VALID_ID, { worktreeId: "wt-after" });
 
     await expect(failing).rejects.toThrow("updater blew up");
-    await expect(following).resolves.toBeUndefined();
-    expect(readDisk(disk, VALID_ID).map((r) => r.id)).toEqual(["id-2"]);
+    await expect(following).resolves.toHaveLength(1);
+    expect(readDisk(disk, VALID_ID).map((r) => r.worktreeId)).toEqual(["wt-after"]);
   });
 
   it("skips the write when the updater returns null", async () => {
@@ -193,22 +205,55 @@ describe("ProjectFileStore copy-tree history", () => {
       }
     );
 
-    await append(store, VALID_ID, "id-1", 1_000);
+    await append(store, VALID_ID);
 
     expect(fsMock.mkdir).toHaveBeenCalledWith(path.join(CONFIG_DIR, VALID_ID), { recursive: true });
-    expect(readDisk(disk, VALID_ID).map((r) => r.id)).toEqual(["id-1"]);
+    expect(readDisk(disk, VALID_ID)).toHaveLength(1);
   });
 
   it("quarantines a damaged file by renaming it, never by deleting it", async () => {
-    installDiskModel();
-    fsMock.readFile.mockResolvedValue("{ not json");
+    const disk = installDiskModel();
+    const damaged = "{ not json";
+    disk.set(historyFilePath(VALID_ID), damaged);
+    // Model the rename so the assertion is about where the BYTES ended up, not
+    // merely that a rename was requested.
+    utilsMock.resilientRename.mockImplementation(async (from: string, to: string) => {
+      const content = disk.get(from);
+      if (content === undefined) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      disk.delete(from);
+      disk.set(to, content);
+    });
 
     await expect(store.getCopyTreeHistory(VALID_ID)).resolves.toEqual([]);
 
-    expect(utilsMock.resilientRename).toHaveBeenCalledTimes(1);
     const [from, to] = utilsMock.resilientRename.mock.calls[0] as [string, string];
     expect(from).toBe(historyFilePath(VALID_ID));
     expect(to.startsWith(`${historyFilePath(VALID_ID)}.corrupted.`)).toBe(true);
+    expect(disk.get(to)).toBe(damaged);
+    expect(disk.has(historyFilePath(VALID_ID))).toBe(false);
+  });
+
+  it("quarantines an unreadable file exactly once when a read and an append race it", async () => {
+    // Both see the damage; whichever renames second would hit ENOENT and fail,
+    // losing a completed run. Serializing the quarantine-capable read is what
+    // makes only one of them attempt it.
+    const disk = installDiskModel();
+    disk.set(historyFilePath(VALID_ID), "{ not json");
+    utilsMock.resilientRename.mockImplementation(async (from: string, to: string) => {
+      const content = disk.get(from);
+      if (content === undefined) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      disk.delete(from);
+      disk.set(to, content);
+    });
+
+    const [, appended] = await Promise.all([
+      store.getCopyTreeHistory(VALID_ID),
+      append(store, VALID_ID, { worktreeId: "wt-raced" }),
+    ]);
+
+    expect(utilsMock.resilientRename).toHaveBeenCalledTimes(1);
+    expect(appended).toHaveLength(1);
+    expect(readDisk(disk, VALID_ID).map((r) => r.worktreeId)).toEqual(["wt-raced"]);
   });
 
   it("quarantines a newer app's file under a name that records its version", async () => {
@@ -244,14 +289,14 @@ describe("ProjectFileStore copy-tree history", () => {
     fsMock.readFile.mockResolvedValue("{ not json");
     utilsMock.resilientRename.mockRejectedValue(new Error("EPERM"));
 
-    await expect(append(store, VALID_ID, "id-1", 1_000)).rejects.toThrow("EPERM");
+    await expect(append(store, VALID_ID)).rejects.toThrow("EPERM");
     expect(utilsMock.resilientAtomicWriteFile).not.toHaveBeenCalled();
   });
 
   it("reads back what a previous append wrote", async () => {
     installDiskModel();
 
-    await append(store, VALID_ID, "id-1", 1_000, { options: { modified: true } });
+    await append(store, VALID_ID, { options: { modified: true } });
     const records = await store.getCopyTreeHistory(VALID_ID);
 
     expect(records).toHaveLength(1);
@@ -263,15 +308,15 @@ describe("ProjectFileStore copy-tree history", () => {
     const disk = installDiskModel();
     disk.set(historyFilePath(VALID_ID), "{ not json");
 
-    await append(store, VALID_ID, "id-1", 1_000);
+    await append(store, VALID_ID);
 
     expect(utilsMock.resilientRename).toHaveBeenCalledTimes(1);
-    expect(readDisk(disk, VALID_ID).map((r) => r.id)).toEqual(["id-1"]);
+    expect(readDisk(disk, VALID_ID)).toHaveLength(1);
   });
 
   it("writes the versioned envelope, not a bare array", async () => {
     const disk = installDiskModel();
-    await append(store, VALID_ID, "id-1", 1_000);
+    await append(store, VALID_ID);
 
     const parsed = JSON.parse(disk.get(historyFilePath(VALID_ID)) as string) as {
       _schemaVersion: number;

--- a/electron/services/__tests__/copyTreeHistoryCodec.test.ts
+++ b/electron/services/__tests__/copyTreeHistoryCodec.test.ts
@@ -153,6 +153,14 @@ describe("decodeCopyTreeHistoryFile", () => {
     expect(decodeCopyTreeHistoryFile(raw)).toEqual({ ok: false, reason: "corrupt" });
   });
 
+  it("never writes more records than it will read back", () => {
+    const records = Array.from({ length: COPY_TREE_HISTORY_MAX_RECORDS + 5 }, (_, i) =>
+      record({ id: `id-${i}`, dedupeKey: `key-${i}` })
+    );
+    const parsed = JSON.parse(encodeCopyTreeHistoryFile(records)) as { records: unknown[] };
+    expect(parsed.records).toHaveLength(COPY_TREE_HISTORY_MAX_RECORDS);
+  });
+
   it("bounds how many records a hand-edited file can push through", () => {
     const records = Array.from({ length: COPY_TREE_HISTORY_MAX_RECORDS + 25 }, (_, i) =>
       record({ id: `id-${i}`, dedupeKey: `key-${i}`, lastUsedAt: 10_000 - i })

--- a/electron/services/__tests__/copyTreeHistoryCodec.test.ts
+++ b/electron/services/__tests__/copyTreeHistoryCodec.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { decodeCopyTreeHistoryFile, encodeCopyTreeHistoryFile } from "../copyTreeHistoryCodec.js";
+import { COPY_TREE_HISTORY_SCHEMA_VERSION } from "../../../shared/types/ipc/copyTreeHistory.js";
+import type { CopyTreeHistoryRecord } from "../../../shared/types/ipc/copyTreeHistory.js";
+
+function record(overrides: Partial<CopyTreeHistoryRecord> = {}): CopyTreeHistoryRecord {
+  return {
+    id: "id-1",
+    dedupeKey: "key-1",
+    name: "Full context",
+    options: { format: "xml" },
+    source: "toolbar",
+    worktreeId: "wt-1",
+    stats: { fileCount: 4, totalSize: 40, duration: 12 },
+    createdAt: 1_000,
+    lastUsedAt: 2_000,
+    runCount: 2,
+    ...overrides,
+  };
+}
+
+describe("encode/decode round trip", () => {
+  it("returns exactly what was written", () => {
+    const records = [record(), record({ id: "id-2", dedupeKey: "key-2", stats: { fileCount: 0 } })];
+    const decoded = decodeCopyTreeHistoryFile(encodeCopyTreeHistoryFile(records));
+    expect(decoded).toEqual({ ok: true, records });
+  });
+
+  it("stamps the current schema version on write", () => {
+    const parsed = JSON.parse(encodeCopyTreeHistoryFile([])) as { _schemaVersion: number };
+    expect(parsed._schemaVersion).toBe(COPY_TREE_HISTORY_SCHEMA_VERSION);
+  });
+
+  it("cannot be tricked into writing a caller-supplied schema version", () => {
+    const forged = [record({ _schemaVersion: 999 } as unknown as Partial<CopyTreeHistoryRecord>)];
+    const parsed = JSON.parse(encodeCopyTreeHistoryFile(forged)) as { _schemaVersion: number };
+    expect(parsed._schemaVersion).toBe(COPY_TREE_HISTORY_SCHEMA_VERSION);
+  });
+
+  it("survives a round trip through an empty history", () => {
+    expect(decodeCopyTreeHistoryFile(encodeCopyTreeHistoryFile([]))).toEqual({
+      ok: true,
+      records: [],
+    });
+  });
+});
+
+describe("decodeCopyTreeHistoryFile", () => {
+  it("never throws, whatever it is handed", () => {
+    const inputs = [
+      "",
+      "   ",
+      "not json",
+      "null",
+      "[]",
+      "42",
+      '"a string"',
+      "{}",
+      '{"records":[]}',
+      '{"_schemaVersion":"one","records":[]}',
+      '{"_schemaVersion":-1,"records":[]}',
+      '{"_schemaVersion":1.5,"records":[]}',
+      '{"_schemaVersion":1,"records":{}}',
+      '{"_schemaVersion":1}',
+    ];
+    for (const raw of inputs) {
+      expect(() => decodeCopyTreeHistoryFile(raw)).not.toThrow();
+      expect(decodeCopyTreeHistoryFile(raw).ok).toBe(false);
+    }
+  });
+
+  it("reports unparseable content as damage", () => {
+    expect(decodeCopyTreeHistoryFile("{ oh no")).toEqual({ ok: false, reason: "corrupt" });
+  });
+
+  it("reports a bare array as damage rather than accepting a legacy shape", () => {
+    // There is no legacy format for this file — an array root means something
+    // else wrote it, and quarantining beats silently adopting it.
+    expect(decodeCopyTreeHistoryFile(JSON.stringify([record()]))).toEqual({
+      ok: false,
+      reason: "corrupt",
+    });
+  });
+
+  it("distinguishes a newer app's file from a damaged one, and says how new", () => {
+    const raw = JSON.stringify({
+      _schemaVersion: COPY_TREE_HISTORY_SCHEMA_VERSION + 3,
+      records: [],
+    });
+    expect(decodeCopyTreeHistoryFile(raw)).toEqual({
+      ok: false,
+      reason: "future-version",
+      onDiskVersion: COPY_TREE_HISTORY_SCHEMA_VERSION + 3,
+    });
+  });
+
+  it("classifies a newer version before its shape, so a new field is not misread as damage", () => {
+    const raw = JSON.stringify({
+      _schemaVersion: COPY_TREE_HISTORY_SCHEMA_VERSION + 1,
+      records: [{ totallyDifferent: true }],
+    });
+    const decoded = decodeCopyTreeHistoryFile(raw);
+    expect(decoded).toMatchObject({ ok: false, reason: "future-version" });
+  });
+
+  it("rejects the whole file when a record is malformed", () => {
+    const raw = JSON.stringify({
+      _schemaVersion: COPY_TREE_HISTORY_SCHEMA_VERSION,
+      records: [record(), { id: "id-2" }],
+    });
+    expect(decodeCopyTreeHistoryFile(raw)).toEqual({ ok: false, reason: "corrupt" });
+  });
+
+  it("rejects a record whose run count is not a positive integer", () => {
+    for (const runCount of [0, -1, 1.5]) {
+      const raw = JSON.stringify({
+        _schemaVersion: COPY_TREE_HISTORY_SCHEMA_VERSION,
+        records: [record({ runCount })],
+      });
+      expect(decodeCopyTreeHistoryFile(raw)).toEqual({ ok: false, reason: "corrupt" });
+    }
+  });
+
+  it("rejects a record whose source is not a known surface", () => {
+    const raw = JSON.stringify({
+      _schemaVersion: COPY_TREE_HISTORY_SCHEMA_VERSION,
+      records: [record({ source: "telepathy" as never })],
+    });
+    expect(decodeCopyTreeHistoryFile(raw)).toEqual({ ok: false, reason: "corrupt" });
+  });
+
+  it("rejects options the generate handlers would themselves have refused", () => {
+    // An empty scopePaths would resolve to the worktree root, widening a folder
+    // copy into a full one — the IPC schema blocks it, so rehydration must too.
+    const raw = JSON.stringify({
+      _schemaVersion: COPY_TREE_HISTORY_SCHEMA_VERSION,
+      records: [record({ options: { scopePaths: [] } })],
+    });
+    expect(decodeCopyTreeHistoryFile(raw)).toEqual({ ok: false, reason: "corrupt" });
+  });
+
+  it("accepts a record whose stats carry only a file count", () => {
+    const raw = JSON.stringify({
+      _schemaVersion: COPY_TREE_HISTORY_SCHEMA_VERSION,
+      records: [record({ stats: { fileCount: 7 } })],
+    });
+    const decoded = decodeCopyTreeHistoryFile(raw);
+    expect(decoded.ok).toBe(true);
+    expect(decoded.ok && decoded.records[0].stats).toEqual({ fileCount: 7 });
+  });
+
+  it("drops an unknown top-level key a newer same-version build added", () => {
+    const raw = JSON.stringify({
+      _schemaVersion: COPY_TREE_HISTORY_SCHEMA_VERSION,
+      records: [record()],
+      somethingElse: 1,
+    });
+    expect(decodeCopyTreeHistoryFile(raw).ok).toBe(true);
+  });
+});

--- a/electron/services/__tests__/copyTreeHistoryCodec.test.ts
+++ b/electron/services/__tests__/copyTreeHistoryCodec.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { decodeCopyTreeHistoryFile, encodeCopyTreeHistoryFile } from "../copyTreeHistoryCodec.js";
-import { COPY_TREE_HISTORY_SCHEMA_VERSION } from "../../../shared/types/ipc/copyTreeHistory.js";
+import {
+  COPY_TREE_HISTORY_MAX_RECORDS,
+  COPY_TREE_HISTORY_SCHEMA_VERSION,
+} from "../../../shared/types/ipc/copyTreeHistory.js";
 import type { CopyTreeHistoryRecord } from "../../../shared/types/ipc/copyTreeHistory.js";
 
 function record(overrides: Partial<CopyTreeHistoryRecord> = {}): CopyTreeHistoryRecord {
@@ -28,12 +31,6 @@ describe("encode/decode round trip", () => {
 
   it("stamps the current schema version on write", () => {
     const parsed = JSON.parse(encodeCopyTreeHistoryFile([])) as { _schemaVersion: number };
-    expect(parsed._schemaVersion).toBe(COPY_TREE_HISTORY_SCHEMA_VERSION);
-  });
-
-  it("cannot be tricked into writing a caller-supplied schema version", () => {
-    const forged = [record({ _schemaVersion: 999 } as unknown as Partial<CopyTreeHistoryRecord>)];
-    const parsed = JSON.parse(encodeCopyTreeHistoryFile(forged)) as { _schemaVersion: number };
     expect(parsed._schemaVersion).toBe(COPY_TREE_HISTORY_SCHEMA_VERSION);
   });
 
@@ -147,6 +144,26 @@ describe("decodeCopyTreeHistoryFile", () => {
     const decoded = decodeCopyTreeHistoryFile(raw);
     expect(decoded.ok).toBe(true);
     expect(decoded.ok && decoded.records[0].stats).toEqual({ fileCount: 7 });
+  });
+
+  it("rejects a version below the current one, which nothing ever wrote", () => {
+    // No v0 exists, so an older number means another writer produced the file —
+    // reading it through today's schema would misinterpret a stranger's shape.
+    const raw = JSON.stringify({ _schemaVersion: 0, records: [] });
+    expect(decodeCopyTreeHistoryFile(raw)).toEqual({ ok: false, reason: "corrupt" });
+  });
+
+  it("bounds how many records a hand-edited file can push through", () => {
+    const records = Array.from({ length: COPY_TREE_HISTORY_MAX_RECORDS + 25 }, (_, i) =>
+      record({ id: `id-${i}`, dedupeKey: `key-${i}`, lastUsedAt: 10_000 - i })
+    );
+    const decoded = decodeCopyTreeHistoryFile(
+      JSON.stringify({ _schemaVersion: COPY_TREE_HISTORY_SCHEMA_VERSION, records })
+    );
+    expect(decoded.ok).toBe(true);
+    expect(decoded.ok && decoded.records).toHaveLength(COPY_TREE_HISTORY_MAX_RECORDS);
+    // Newest-first on disk, so the head is what survives.
+    expect(decoded.ok && decoded.records[0].id).toBe("id-0");
   });
 
   it("drops an unknown top-level key a newer same-version build added", () => {

--- a/electron/services/__tests__/copyTreeHistoryLog.test.ts
+++ b/electron/services/__tests__/copyTreeHistoryLog.test.ts
@@ -197,6 +197,34 @@ describe("applyCopyTreeRun", () => {
     expect(keptRefs).not.toContain("ref-1");
   });
 
+  it("lets one explicit name replace another", () => {
+    let records = applyCopyTreeRun([], input({ name: "First name" }), { id: "id-1", now: 1 });
+    records = applyCopyTreeRun(records, input({ name: "Second name" }), { id: "id-2", now: 2 });
+    expect(records).toHaveLength(1);
+    expect(records[0].name).toBe("Second name");
+    expect(records[0].id).toBe("id-1");
+  });
+
+  it("does not evict the run that just happened when the clock has moved backwards", () => {
+    let records: CopyTreeHistoryRecord[] = [];
+    for (let i = 0; i < COPY_TREE_HISTORY_MAX_RECORDS; i++) {
+      records = applyCopyTreeRun(records, input({ options: { changed: `ref-${i}` } }), {
+        id: `id-${i}`,
+        now: 1_000_000 + i,
+      });
+    }
+
+    // A clock correction lands this run before everything already stored.
+    records = applyCopyTreeRun(records, input({ options: { changed: "after-rollback" } }), {
+      id: "id-rollback",
+      now: 1,
+    });
+
+    expect(records.map((r) => (r.options as CopyTreeOptions).changed)).toContain("after-rollback");
+    expect(records[0].id).toBe("id-rollback");
+    expect(records).toHaveLength(COPY_TREE_HISTORY_MAX_RECORDS);
+  });
+
   it("stores the caller's options verbatim", () => {
     const options = { scopePaths: ["src/z", "src/a"], format: "markdown" as const };
     const [record] = applyCopyTreeRun([], input({ options }), { id: "id-1", now: 1 });
@@ -210,9 +238,9 @@ describe("applyCopyTreeRun", () => {
     expect(first).toEqual(snapshot);
   });
 
-  it("ignores a stale entry order on disk when deciding what to evict", () => {
-    // A hand-edited or partially-written file can arrive out of order; eviction
-    // must still drop the least recently used entry, not the last in the array.
+  it("reorders a history that arrived out of order on disk", () => {
+    // A hand-edited file can be out of order; the fold must re-establish
+    // newest-first so the tail really is the eviction candidate.
     const stale: CopyTreeHistoryRecord[] = [
       {
         id: "old",

--- a/electron/services/__tests__/copyTreeHistoryLog.test.ts
+++ b/electron/services/__tests__/copyTreeHistoryLog.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+import { applyCopyTreeRun, copyTreeOptionsDedupeKey } from "../copyTreeHistoryLog.js";
+import { COPY_TREE_HISTORY_MAX_RECORDS } from "../../../shared/types/ipc/copyTreeHistory.js";
+import type {
+  CopyTreeHistoryAppendInput,
+  CopyTreeHistoryRecord,
+} from "../../../shared/types/ipc/copyTreeHistory.js";
+import type { CopyTreeOptions } from "../../../shared/types/ipc/copyTree.js";
+
+function input(overrides: Partial<CopyTreeHistoryAppendInput> = {}): CopyTreeHistoryAppendInput {
+  return {
+    options: {},
+    source: "toolbar",
+    worktreeId: "wt-1",
+    stats: { fileCount: 3, totalSize: 100, duration: 5 },
+    ...overrides,
+  };
+}
+
+describe("copyTreeOptionsDedupeKey", () => {
+  it("agrees across the spellings of one option set", () => {
+    expect(copyTreeOptionsDedupeKey({ filter: "src/**", exclude: ["b", "a"] })).toBe(
+      copyTreeOptionsDedupeKey({ exclude: ["a", "b"], filter: ["src/**"] })
+    );
+  });
+
+  it("treats absent and empty options as the same run", () => {
+    expect(copyTreeOptionsDedupeKey(undefined)).toBe(copyTreeOptionsDedupeKey({}));
+  });
+
+  it("separates option sets that select different files", () => {
+    expect(copyTreeOptionsDedupeKey({ modified: true })).not.toBe(copyTreeOptionsDedupeKey({}));
+    expect(copyTreeOptionsDedupeKey({ scopePaths: ["src"] })).not.toBe(
+      copyTreeOptionsDedupeKey({ scopePaths: ["lib"] })
+    );
+  });
+});
+
+describe("applyCopyTreeRun", () => {
+  it("records a first run with a run count of one and matching timestamps", () => {
+    const [record] = applyCopyTreeRun([], input(), { id: "id-1", now: 1_000 });
+    expect(record.runCount).toBe(1);
+    expect(record.createdAt).toBe(1_000);
+    expect(record.lastUsedAt).toBe(1_000);
+    expect(record.dedupeKey).toBe(copyTreeOptionsDedupeKey({}));
+  });
+
+  it("collapses repeat runs of the same option set into one bumped entry", () => {
+    let records = applyCopyTreeRun([], input(), { id: "id-1", now: 1_000 });
+    records = applyCopyTreeRun(records, input(), { id: "id-2", now: 2_000 });
+    records = applyCopyTreeRun(records, input(), { id: "id-3", now: 3_000 });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].runCount).toBe(3);
+    expect(records[0].id).toBe("id-1");
+    expect(records[0].createdAt).toBe(1_000);
+    expect(records[0].lastUsedAt).toBe(3_000);
+  });
+
+  it("dedupes runs whose options differ only in array order or string-vs-array form", () => {
+    let records = applyCopyTreeRun([], input({ options: { filter: "a" } }), {
+      id: "id-1",
+      now: 1_000,
+    });
+    records = applyCopyTreeRun(records, input({ options: { filter: ["a"] } }), {
+      id: "id-2",
+      now: 2_000,
+    });
+    expect(records).toHaveLength(1);
+    expect(records[0].runCount).toBe(2);
+  });
+
+  it("keeps runs with genuinely different options apart", () => {
+    let records = applyCopyTreeRun([], input({ options: { modified: true } }), {
+      id: "id-1",
+      now: 1_000,
+    });
+    records = applyCopyTreeRun(records, input({ options: {} }), { id: "id-2", now: 2_000 });
+    expect(records).toHaveLength(2);
+  });
+
+  it("dedupes across delivery surfaces and worktrees, adopting the newest", () => {
+    let records = applyCopyTreeRun([], input({ source: "toolbar", worktreeId: "wt-1" }), {
+      id: "id-1",
+      now: 1_000,
+    });
+    records = applyCopyTreeRun(records, input({ source: "mcp", worktreeId: "wt-2" }), {
+      id: "id-2",
+      now: 2_000,
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].source).toBe("mcp");
+    expect(records[0].worktreeId).toBe("wt-2");
+  });
+
+  it("replaces stats with the newest run's rather than keeping the first", () => {
+    let records = applyCopyTreeRun(
+      [],
+      input({ stats: { fileCount: 1, totalSize: 10, duration: 2 } }),
+      {
+        id: "id-1",
+        now: 1_000,
+      }
+    );
+    records = applyCopyTreeRun(
+      records,
+      input({ stats: { fileCount: 9, totalSize: 90, duration: 20 } }),
+      { id: "id-2", now: 2_000 }
+    );
+    expect(records[0].stats).toEqual({ fileCount: 9, totalSize: 90, duration: 20 });
+  });
+
+  it("derives a name when none is supplied", () => {
+    const [record] = applyCopyTreeRun([], input({ options: { modified: true } }), {
+      id: "id-1",
+      now: 1,
+    });
+    expect(record.name).toBe("Modified files");
+  });
+
+  it("lets a supplied name replace the stored one without forking the entry", () => {
+    let records = applyCopyTreeRun([], input(), { id: "id-1", now: 1_000 });
+    const derivedName = records[0].name;
+    records = applyCopyTreeRun(records, input({ name: "Release context" }), {
+      id: "id-2",
+      now: 2_000,
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].name).toBe("Release context");
+    expect(records[0].name).not.toBe(derivedName);
+    expect(records[0].id).toBe("id-1");
+  });
+
+  it("does not let a later unnamed run reset a supplied name", () => {
+    let records = applyCopyTreeRun([], input({ name: "Release context" }), { id: "id-1", now: 1 });
+    records = applyCopyTreeRun(records, input(), { id: "id-2", now: 2 });
+    records = applyCopyTreeRun(records, input({ name: "   " }), { id: "id-3", now: 3 });
+    expect(records[0].name).toBe("Release context");
+  });
+
+  it("orders the most recently used run first", () => {
+    let records = applyCopyTreeRun([], input({ options: { modified: true } }), {
+      id: "id-1",
+      now: 1_000,
+    });
+    records = applyCopyTreeRun(records, input({ options: {} }), { id: "id-2", now: 2_000 });
+    expect(records[0].id).toBe("id-2");
+
+    records = applyCopyTreeRun(records, input({ options: { modified: true } }), {
+      id: "id-3",
+      now: 3_000,
+    });
+    expect(records[0].id).toBe("id-1");
+  });
+
+  it("keeps a re-run entry ahead of the one it overtook when both land in the same tick", () => {
+    let records = applyCopyTreeRun([], input({ options: { modified: true } }), {
+      id: "id-1",
+      now: 7,
+    });
+    records = applyCopyTreeRun(records, input({ options: {} }), { id: "id-2", now: 7 });
+    records = applyCopyTreeRun(records, input({ options: { modified: true } }), {
+      id: "id-3",
+      now: 7,
+    });
+    expect(records[0].id).toBe("id-1");
+  });
+
+  it("evicts the least recently used entry once the cap is reached", () => {
+    let records: CopyTreeHistoryRecord[] = [];
+    for (let i = 0; i < COPY_TREE_HISTORY_MAX_RECORDS; i++) {
+      records = applyCopyTreeRun(records, input({ options: { changed: `ref-${i}` } }), {
+        id: `id-${i}`,
+        now: 1_000 + i,
+      });
+    }
+    expect(records).toHaveLength(COPY_TREE_HISTORY_MAX_RECORDS);
+
+    // Re-run the oldest-by-insertion entry so it is no longer the least recent.
+    records = applyCopyTreeRun(records, input({ options: { changed: "ref-0" } }), {
+      id: "ignored",
+      now: 9_000,
+    });
+    records = applyCopyTreeRun(records, input({ options: { changed: "brand-new" } }), {
+      id: "id-new",
+      now: 9_001,
+    });
+
+    expect(records).toHaveLength(COPY_TREE_HISTORY_MAX_RECORDS);
+    const keptRefs = records.map((r) => (r.options as CopyTreeOptions).changed);
+    expect(keptRefs).toContain("brand-new");
+    // Survives on recency, despite being the first ever inserted.
+    expect(keptRefs).toContain("ref-0");
+    // The genuinely least-recently-used entry is the one that went.
+    expect(keptRefs).not.toContain("ref-1");
+  });
+
+  it("stores the caller's options verbatim", () => {
+    const options = { scopePaths: ["src/z", "src/a"], format: "markdown" as const };
+    const [record] = applyCopyTreeRun([], input({ options }), { id: "id-1", now: 1 });
+    expect(record.options).toEqual(options);
+  });
+
+  it("does not mutate the records it was given", () => {
+    const first = applyCopyTreeRun([], input(), { id: "id-1", now: 1_000 });
+    const snapshot = structuredClone(first);
+    applyCopyTreeRun(first, input(), { id: "id-2", now: 2_000 });
+    expect(first).toEqual(snapshot);
+  });
+
+  it("ignores a stale entry order on disk when deciding what to evict", () => {
+    // A hand-edited or partially-written file can arrive out of order; eviction
+    // must still drop the least recently used entry, not the last in the array.
+    const stale: CopyTreeHistoryRecord[] = [
+      {
+        id: "old",
+        dedupeKey: copyTreeOptionsDedupeKey({ changed: "old" }),
+        name: "old",
+        options: { changed: "old" },
+        source: "toolbar",
+        worktreeId: "wt",
+        stats: { fileCount: 1 },
+        createdAt: 1,
+        lastUsedAt: 1,
+        runCount: 1,
+      },
+      {
+        id: "recent",
+        dedupeKey: copyTreeOptionsDedupeKey({ changed: "recent" }),
+        name: "recent",
+        options: { changed: "recent" },
+        source: "toolbar",
+        worktreeId: "wt",
+        stats: { fileCount: 1 },
+        createdAt: 1,
+        lastUsedAt: 9_999,
+        runCount: 1,
+      },
+    ];
+    const records = applyCopyTreeRun(stale, input({ options: { changed: "newest" } }), {
+      id: "newest",
+      now: 10_000,
+    });
+    expect(records.map((r) => r.id)).toEqual(["newest", "recent", "old"]);
+  });
+});

--- a/electron/services/__tests__/copyTreeHistoryService.test.ts
+++ b/electron/services/__tests__/copyTreeHistoryService.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const projectStoreMock = vi.hoisted(() => ({
+  appendCopyTreeRun: vi.fn<(projectId: string, input: unknown) => Promise<unknown[]>>(),
+}));
+
+const registryMock = vi.hoisted(() => ({
+  getWebContentsForProject: vi.fn<(projectId: string) => unknown[]>(() => []),
+}));
+
+vi.mock("../ProjectStore.js", () => ({ projectStore: projectStoreMock }));
+vi.mock("../../window/webContentsRegistry.js", () => registryMock);
+
+import { CHANNELS } from "../../ipc/channels.js";
+import { recordCopyTreeRun } from "../copyTreeHistoryService.js";
+import type { CopyTreeHistoryAppendInput } from "../../../shared/types/ipc/copyTreeHistory.js";
+
+const PROJECT_A = "a".repeat(64);
+const PROJECT_B = "b".repeat(64);
+
+const INPUT: CopyTreeHistoryAppendInput = {
+  options: { modified: true },
+  source: "toolbar",
+  worktreeId: "wt-1",
+  stats: { fileCount: 3 },
+};
+
+function view() {
+  return { send: vi.fn() };
+}
+
+describe("recordCopyTreeRun", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    projectStoreMock.appendCopyTreeRun.mockResolvedValue([{ id: "r1" }]);
+    registryMock.getWebContentsForProject.mockReturnValue([]);
+  });
+
+  it("appends against the project it was given", async () => {
+    await recordCopyTreeRun(PROJECT_A, INPUT);
+    expect(projectStoreMock.appendCopyTreeRun).toHaveBeenCalledWith(PROJECT_A, INPUT);
+  });
+
+  it("does nothing at all without a project", async () => {
+    await recordCopyTreeRun(null, INPUT);
+    expect(projectStoreMock.appendCopyTreeRun).not.toHaveBeenCalled();
+    expect(registryMock.getWebContentsForProject).not.toHaveBeenCalled();
+  });
+
+  it("pushes the committed snapshot to every view bound to that project", async () => {
+    const first = view();
+    const second = view();
+    registryMock.getWebContentsForProject.mockReturnValue([first, second]);
+    projectStoreMock.appendCopyTreeRun.mockResolvedValue([{ id: "r1" }, { id: "r2" }]);
+
+    await recordCopyTreeRun(PROJECT_A, INPUT);
+
+    for (const wc of [first, second]) {
+      expect(wc.send).toHaveBeenCalledWith(CHANNELS.EVENTS_PUSH, {
+        name: "copy-tree-history:update",
+        payload: { projectId: PROJECT_A, records: [{ id: "r1" }, { id: "r2" }] },
+      });
+    }
+  });
+
+  it("only ever asks for the owning project's views", async () => {
+    // The leak this guards against: a global broadcast would hand project A's
+    // paths and options to a window showing project B (#11125's failure mode).
+    const viewA = view();
+    registryMock.getWebContentsForProject.mockImplementation((projectId) =>
+      projectId === PROJECT_A ? [viewA] : []
+    );
+
+    await recordCopyTreeRun(PROJECT_A, INPUT);
+
+    expect(registryMock.getWebContentsForProject).toHaveBeenCalledTimes(1);
+    expect(registryMock.getWebContentsForProject).toHaveBeenCalledWith(PROJECT_A);
+    expect(registryMock.getWebContentsForProject).not.toHaveBeenCalledWith(PROJECT_B);
+    expect(viewA.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends nothing when no view is bound to the project", async () => {
+    registryMock.getWebContentsForProject.mockReturnValue([]);
+    await expect(recordCopyTreeRun(PROJECT_A, INPUT)).resolves.toBeUndefined();
+  });
+
+  it("does not let one dead view stop the others from receiving the snapshot", async () => {
+    const dead = {
+      send: vi.fn(() => {
+        throw new Error("destroyed");
+      }),
+    };
+    const alive = view();
+    registryMock.getWebContentsForProject.mockReturnValue([dead, alive]);
+
+    await expect(recordCopyTreeRun(PROJECT_A, INPUT)).resolves.toBeUndefined();
+    expect(alive.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows an append failure — the copy already happened", async () => {
+    projectStoreMock.appendCopyTreeRun.mockRejectedValue(new Error("quarantine failed"));
+    const bound = view();
+    registryMock.getWebContentsForProject.mockReturnValue([bound]);
+
+    await expect(recordCopyTreeRun(PROJECT_A, INPUT)).resolves.toBeUndefined();
+    // Nothing committed, so nothing is pushed.
+    expect(bound.send).not.toHaveBeenCalled();
+  });
+});

--- a/electron/services/copyTreeHistoryCodec.ts
+++ b/electron/services/copyTreeHistoryCodec.ts
@@ -1,0 +1,60 @@
+import { CopyTreeHistoryFileSchema } from "../schemas/copyTreeHistory.js";
+import {
+  COPY_TREE_HISTORY_SCHEMA_VERSION,
+  type CopyTreeHistoryRecord,
+} from "../../shared/types/ipc/copyTreeHistory.js";
+
+/**
+ * Why a copy-tree history file could not be read. `future-version` is separated
+ * from `corrupt` because the two quarantine under different names and mean
+ * different things to a user: one is damage, the other is a downgrade.
+ */
+export type CopyTreeHistoryDecodeResult =
+  | { ok: true; records: CopyTreeHistoryRecord[] }
+  | { ok: false; reason: "corrupt" }
+  | { ok: false; reason: "future-version"; onDiskVersion: number };
+
+/**
+ * Total: never throws, for any input at all. Callers branch on the result
+ * instead of wrapping this in a try, so there is no path where a parse failure
+ * silently degrades to "empty history" and the next write destroys the file.
+ */
+export function decodeCopyTreeHistoryFile(raw: string): CopyTreeHistoryDecodeResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { ok: false, reason: "corrupt" };
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { ok: false, reason: "corrupt" };
+  }
+
+  // Version is classified before shape: a file from a newer app may legitimately
+  // fail today's schema, and reporting that as damage would quarantine it under
+  // the wrong name and lose why it was unreadable.
+  const rawVersion = (parsed as Record<string, unknown>)._schemaVersion;
+  if (typeof rawVersion !== "number" || !Number.isInteger(rawVersion) || rawVersion < 0) {
+    return { ok: false, reason: "corrupt" };
+  }
+  if (rawVersion > COPY_TREE_HISTORY_SCHEMA_VERSION) {
+    return { ok: false, reason: "future-version", onDiskVersion: rawVersion };
+  }
+
+  const result = CopyTreeHistoryFileSchema.safeParse(parsed);
+  if (!result.success) {
+    return { ok: false, reason: "corrupt" };
+  }
+
+  return { ok: true, records: result.data.records };
+}
+
+/**
+ * Builds the envelope field by field rather than spreading an input object, so
+ * a forged `_schemaVersion` riding along on a record set is structurally
+ * incapable of reaching disk.
+ */
+export function encodeCopyTreeHistoryFile(records: CopyTreeHistoryRecord[]): string {
+  return JSON.stringify({ _schemaVersion: COPY_TREE_HISTORY_SCHEMA_VERSION, records }, null, 2);
+}

--- a/electron/services/copyTreeHistoryCodec.ts
+++ b/electron/services/copyTreeHistoryCodec.ts
@@ -64,7 +64,18 @@ export function decodeCopyTreeHistoryFile(raw: string): CopyTreeHistoryDecodeRes
  * Builds the envelope field by field rather than spreading an input object, so
  * a forged `_schemaVersion` riding along on a record set is structurally
  * incapable of reaching disk.
+ *
+ * Applies the same cap the decoder does. Without it a caller could persist more
+ * than the cap and have the surplus vanish on the next read, making the decoder
+ * the first place records disappear rather than the writer.
  */
 export function encodeCopyTreeHistoryFile(records: CopyTreeHistoryRecord[]): string {
-  return JSON.stringify({ _schemaVersion: COPY_TREE_HISTORY_SCHEMA_VERSION, records }, null, 2);
+  return JSON.stringify(
+    {
+      _schemaVersion: COPY_TREE_HISTORY_SCHEMA_VERSION,
+      records: records.slice(0, COPY_TREE_HISTORY_MAX_RECORDS),
+    },
+    null,
+    2
+  );
 }

--- a/electron/services/copyTreeHistoryCodec.ts
+++ b/electron/services/copyTreeHistoryCodec.ts
@@ -1,5 +1,6 @@
 import { CopyTreeHistoryFileSchema } from "../schemas/copyTreeHistory.js";
 import {
+  COPY_TREE_HISTORY_MAX_RECORDS,
   COPY_TREE_HISTORY_SCHEMA_VERSION,
   type CopyTreeHistoryRecord,
 } from "../../shared/types/ipc/copyTreeHistory.js";
@@ -41,13 +42,22 @@ export function decodeCopyTreeHistoryFile(raw: string): CopyTreeHistoryDecodeRes
   if (rawVersion > COPY_TREE_HISTORY_SCHEMA_VERSION) {
     return { ok: false, reason: "future-version", onDiskVersion: rawVersion };
   }
+  // Nothing ever wrote a version below the current one, so an older number is
+  // not a file to migrate — it is a file something else produced. Accepting it
+  // would read a stranger's shape through today's schema.
+  if (rawVersion < COPY_TREE_HISTORY_SCHEMA_VERSION) {
+    return { ok: false, reason: "corrupt" };
+  }
 
   const result = CopyTreeHistoryFileSchema.safeParse(parsed);
   if (!result.success) {
     return { ok: false, reason: "corrupt" };
   }
 
-  return { ok: true, records: result.data.records };
+  // The writer never emits more than the cap, but a hand-edited file can hold
+  // any number and every record is cloned across IPC on each push. Records are
+  // newest-first, so the head is the set worth keeping.
+  return { ok: true, records: result.data.records.slice(0, COPY_TREE_HISTORY_MAX_RECORDS) };
 }
 
 /**

--- a/electron/services/copyTreeHistoryLog.ts
+++ b/electron/services/copyTreeHistoryLog.ts
@@ -49,6 +49,13 @@ export function applyCopyTreeRun(
   const existing = records.find((record) => record.dedupeKey === dedupeKey);
   const suppliedName = input.name?.trim();
 
+  // Never stamp a run as older than something already on disk. `Date.now()` can
+  // move backwards across a clock correction or a DST-adjacent system change,
+  // and a stored future timestamp has the same effect — either would sort the
+  // run that just happened below all 20 existing records and evict it on the
+  // spot, which is the exact opposite of what recency is for.
+  const now = Math.max(stamp.now, ...records.map((record) => record.lastUsedAt), 0);
+
   const updated: CopyTreeHistoryRecord = existing
     ? {
         ...existing,
@@ -57,7 +64,7 @@ export function applyCopyTreeRun(
         source: input.source,
         worktreeId: input.worktreeId,
         stats: input.stats,
-        lastUsedAt: stamp.now,
+        lastUsedAt: now,
         runCount: existing.runCount + 1,
       }
     : {
@@ -68,8 +75,8 @@ export function applyCopyTreeRun(
         source: input.source,
         worktreeId: input.worktreeId,
         stats: input.stats,
-        createdAt: stamp.now,
-        lastUsedAt: stamp.now,
+        createdAt: now,
+        lastUsedAt: now,
         runCount: 1,
       };
 

--- a/electron/services/copyTreeHistoryLog.ts
+++ b/electron/services/copyTreeHistoryLog.ts
@@ -75,7 +75,11 @@ export function applyCopyTreeRun(
         source: input.source,
         worktreeId: input.worktreeId,
         stats: input.stats,
-        createdAt: now,
+        // The clamp exists to order this run against the others, so only
+        // `lastUsedAt` takes it. `createdAt` answers "when did this entry first
+        // appear", and inheriting a stray future timestamp from an unrelated
+        // record would make that answer permanently wrong.
+        createdAt: Math.max(stamp.now, 0),
         lastUsedAt: now,
         runCount: 1,
       };

--- a/electron/services/copyTreeHistoryLog.ts
+++ b/electron/services/copyTreeHistoryLog.ts
@@ -1,0 +1,81 @@
+import { stableArgsSha256 } from "../utils/pluginMcpHash.js";
+import {
+  canonicalizeCopyTreeOptions,
+  resolveCopyTreeRunName,
+  sortCopyTreeHistory,
+} from "../../shared/utils/copyTreeHistory.js";
+import {
+  COPY_TREE_HISTORY_MAX_RECORDS,
+  type CopyTreeHistoryAppendInput,
+  type CopyTreeHistoryRecord,
+} from "../../shared/types/ipc/copyTreeHistory.js";
+import type { CopyTreeOptions } from "../../shared/types/ipc/copyTree.js";
+
+/**
+ * Dedupe key for a run: SHA-256 over the canonicalized runtime options and
+ * nothing else.
+ *
+ * Name, source, worktree, stats, delivery mode and timestamps all stay out —
+ * the issue's requirement is that identical *options* collapse into one entry,
+ * and that renaming an entry can never fork it.
+ */
+export function copyTreeOptionsDedupeKey(options?: CopyTreeOptions): string {
+  return stableArgsSha256(canonicalizeCopyTreeOptions(options));
+}
+
+/**
+ * Fold a completed run into the project's history.
+ *
+ * Pure: takes the current newest-first list and returns a new one, never
+ * mutating its input or the records inside it.
+ *
+ * On a dedupe hit the entry is bumped rather than duplicated — `runCount` rises,
+ * `lastUsedAt` moves to now, and the mutable facts (options, source, worktree,
+ * stats) adopt the newest run so a frequently-reused entry never shows stale
+ * size or duration. `id` and `createdAt` survive, so the entry keeps its
+ * identity for anything holding a reference to it.
+ *
+ * Name resolution is asymmetric on purpose: an explicit name overwrites (that
+ * is what a rename looks like from here), while an absent one preserves
+ * whatever is stored. Without that, the next unnamed run would quietly reset a
+ * user-supplied name back to the derived label.
+ */
+export function applyCopyTreeRun(
+  records: CopyTreeHistoryRecord[],
+  input: CopyTreeHistoryAppendInput,
+  stamp: { id: string; now: number }
+): CopyTreeHistoryRecord[] {
+  const dedupeKey = copyTreeOptionsDedupeKey(input.options);
+  const existing = records.find((record) => record.dedupeKey === dedupeKey);
+  const suppliedName = input.name?.trim();
+
+  const updated: CopyTreeHistoryRecord = existing
+    ? {
+        ...existing,
+        name: suppliedName ? resolveCopyTreeRunName(suppliedName, input.options) : existing.name,
+        options: input.options,
+        source: input.source,
+        worktreeId: input.worktreeId,
+        stats: input.stats,
+        lastUsedAt: stamp.now,
+        runCount: existing.runCount + 1,
+      }
+    : {
+        id: stamp.id,
+        dedupeKey,
+        name: resolveCopyTreeRunName(input.name, input.options),
+        options: input.options,
+        source: input.source,
+        worktreeId: input.worktreeId,
+        stats: input.stats,
+        createdAt: stamp.now,
+        lastUsedAt: stamp.now,
+        runCount: 1,
+      };
+
+  const rest = records.filter((record) => record.dedupeKey !== dedupeKey);
+  // Front-load the touched record before sorting so it also wins ties — a
+  // second run inside the same millisecond must not fall behind the entry it
+  // just overtook. `sortCopyTreeHistory` is stable, so the position holds.
+  return sortCopyTreeHistory([updated, ...rest]).slice(0, COPY_TREE_HISTORY_MAX_RECORDS);
+}

--- a/electron/services/copyTreeHistoryService.ts
+++ b/electron/services/copyTreeHistoryService.ts
@@ -1,0 +1,53 @@
+// eager-import-allow: reaches the project file store only from copy-tree IPC handlers, never at boot
+import { CHANNELS } from "../ipc/channels.js";
+import { getWebContentsForProject } from "../window/webContentsRegistry.js";
+import { projectStore } from "./ProjectStore.js";
+import type {
+  CopyTreeHistoryAppendInput,
+  CopyTreeHistoryRecord,
+} from "../../shared/types/ipc/copyTreeHistory.js";
+
+/**
+ * Push a copy-tree history snapshot to the views that own the project.
+ *
+ * Deliberately not `broadcastToProjectRenderers`: that helper falls back to a
+ * global broadcast when no project views are registered, which for per-project
+ * data would hand one project's history to whatever window happened to be open
+ * — the failure mode #11125 already hit CopyTree with. No exact binding means
+ * nothing to push.
+ */
+function pushCopyTreeHistory(projectId: string, records: CopyTreeHistoryRecord[]): void {
+  for (const wc of getWebContentsForProject(projectId)) {
+    try {
+      wc.send(CHANNELS.EVENTS_PUSH, {
+        name: "copy-tree-history:update",
+        payload: { projectId, records },
+      });
+    } catch {
+      // Silently ignore send failures during window initialization/disposal.
+    }
+  }
+}
+
+/**
+ * Record a completed copy-tree run and push the new snapshot.
+ *
+ * Never throws and never rejects: recording is bookkeeping alongside a run that
+ * has already delivered its bundle, so a corrupt history file, a failed
+ * quarantine or a dead renderer must not turn a successful copy into a failed
+ * one. Callers `await` it so the write and its push stay ordered behind the
+ * per-project queue, and get back `undefined` either way.
+ */
+export async function recordCopyTreeRun(
+  projectId: string | null,
+  input: CopyTreeHistoryAppendInput
+): Promise<void> {
+  if (!projectId) return;
+
+  try {
+    const records = await projectStore.appendCopyTreeRun(projectId, input);
+    pushCopyTreeHistory(projectId, records);
+  } catch (error) {
+    console.warn(`[CopyTreeHistory] Failed to record run for project ${projectId}:`, error);
+  }
+}

--- a/electron/services/projectQuarantineCleanup.ts
+++ b/electron/services/projectQuarantineCleanup.ts
@@ -12,6 +12,8 @@ const QUARANTINE_PREFIXES = [
   "settings.json.corrupted.",
   "recipes.json.corrupted.",
   "recipes.json.future-v",
+  "copy-tree-history.json.corrupted.",
+  "copy-tree-history.json.future-v",
 ];
 
 const GLOBAL_RECIPES_QUARANTINE_PREFIXES = ["recipes.json.corrupted."];

--- a/electron/services/projectStorePaths.ts
+++ b/electron/services/projectStorePaths.ts
@@ -6,6 +6,7 @@ export const UTF8_BOM = "\uFEFF";
 
 const SETTINGS_FILENAME = "settings.json";
 const RECIPES_FILENAME = "recipes.json";
+const COPY_TREE_HISTORY_FILENAME = "copy-tree-history.json";
 
 const STATE_FILENAME = "state.json";
 
@@ -104,4 +105,13 @@ export function recipesFilePath(projectsConfigDir: string, projectId: string): s
   const stateDir = getProjectStateDir(projectsConfigDir, projectId);
   if (!stateDir) return null;
   return path.join(stateDir, RECIPES_FILENAME);
+}
+
+export function copyTreeHistoryFilePath(
+  projectsConfigDir: string,
+  projectId: string
+): string | null {
+  const stateDir = getProjectStateDir(projectsConfigDir, projectId);
+  if (!stateDir) return null;
+  return path.join(stateDir, COPY_TREE_HISTORY_FILENAME);
 }

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -1,6 +1,7 @@
 import type { BuiltInKeyAction } from "./keymap.js";
 import type { BuiltInRuntimeActionId } from "../config/actionIds.js";
 import type { z } from "zod";
+import type { CopyTreeRunSource } from "./ipc/copyTreeHistory.js";
 
 export type ActionSource = "user" | "keybinding" | "menu" | "agent" | "context-menu" | "plugin";
 
@@ -129,6 +130,18 @@ export interface ActionContext {
    * use it to grant capabilities one source otherwise lacks.
    */
   dispatchSource?: ActionSource;
+  /**
+   * Which UI surface triggered a copy-tree run, for the project's copy-tree
+   * history (#11732). Set by `ActionService.dispatch` from the matching
+   * {@link ActionDispatchOptions} field.
+   *
+   * Deliberately here and not in any action's `argsSchema`: it exists because
+   * `dispatchSource` cannot separate the worktree card from the file browser
+   * (both `"context-menu"`), and putting it in args would publish it on the MCP
+   * tool surface where an agent could label its own runs as a user's click.
+   * Purely descriptive — it grants nothing and gates nothing.
+   */
+  copyTreeRunSource?: CopyTreeRunSource;
 }
 
 export type InferActionArgs<S extends z.ZodTypeAny | undefined> = [S] extends [z.ZodTypeAny]
@@ -406,6 +419,8 @@ export interface ActionDispatchOptions {
    * Used by agent dispatch to bind context at dispatch time and prevent confused-deputy attacks.
    */
   contextOverride?: ActionContext;
+  /** See {@link ActionContext.copyTreeRunSource}. */
+  copyTreeRunSource?: CopyTreeRunSource;
 }
 
 export interface ActionDispatchPayload {

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -424,6 +424,21 @@ export {
   RUN_HISTORY_MAX_TARGETS,
 } from "./ipc/runHistory.js";
 
+// Copy-tree run history - per-project record of copy-tree runs (#11732)
+export type {
+  CopyTreeHistoryRecord,
+  CopyTreeHistoryAppendInput,
+  CopyTreeHistoryFile,
+  CopyTreeRunSource,
+  CopyTreeRunStats,
+} from "./ipc/copyTreeHistory.js";
+export {
+  COPY_TREE_HISTORY_SCHEMA_VERSION,
+  COPY_TREE_HISTORY_MAX_RECORDS,
+  COPY_TREE_HISTORY_NAME_MAX_LENGTH,
+  COPY_TREE_RUN_SOURCES,
+} from "./ipc/copyTreeHistory.js";
+
 // Event types - event context for correlation
 export type { EventContext } from "./events.js";
 

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -102,6 +102,7 @@ import type {
   FileTreeNode,
   CopyTreeProgress,
 } from "./copyTree.js";
+import type { CopyTreeRunSource } from "./copyTreeHistory.js";
 import type {
   SystemWakePayload,
   SystemOpenInEditorPayload,
@@ -376,14 +377,20 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     generate(
       worktreeId: string,
       options?: CopyTreeOptions,
-      includeContent?: boolean
+      includeContent?: boolean,
+      source?: CopyTreeRunSource
     ): Promise<CopyTreeResult>;
-    generateAndCopyFile(worktreeId: string, options?: CopyTreeOptions): Promise<CopyTreeResult>;
+    generateAndCopyFile(
+      worktreeId: string,
+      options?: CopyTreeOptions,
+      source?: CopyTreeRunSource
+    ): Promise<CopyTreeResult>;
     injectToTerminal(
       terminalId: string,
       worktreeId: string,
       options?: CopyTreeOptions,
-      injectionId?: string
+      injectionId?: string,
+      source?: CopyTreeRunSource
     ): Promise<CopyTreeResult>;
     isAvailable(): Promise<boolean>;
     cancel(injectionId?: string): Promise<void>;

--- a/shared/types/ipc/copyTree.ts
+++ b/shared/types/ipc/copyTree.ts
@@ -1,3 +1,5 @@
+import type { CopyTreeRunSource } from "./copyTreeHistory.js";
+
 /** CopyTree generation options */
 export interface CopyTreeOptions {
   /** Output format */
@@ -64,11 +66,23 @@ export interface CopyTreeGeneratePayload {
    * context-generation setting.
    */
   includeContent?: boolean;
+  /**
+   * Which surface asked for the run, recorded in the project's copy-tree
+   * history (#11732).
+   *
+   * Optional, and never part of the dedupe key: it describes the caller, not
+   * the context to build, so omitting it changes nothing about the bundle. A
+   * caller that doesn't identify itself is recorded as `unknown` rather than
+   * being attributed to a surface it didn't come from.
+   */
+  source?: CopyTreeRunSource;
 }
 
 export interface CopyTreeGenerateAndCopyFilePayload {
   worktreeId: string;
   options?: CopyTreeOptions;
+  /** See {@link CopyTreeGeneratePayload.source}. */
+  source?: CopyTreeRunSource;
 }
 
 /** Payload for injecting CopyTree context to terminal */
@@ -78,6 +92,8 @@ export interface CopyTreeInjectPayload {
   options?: CopyTreeOptions;
   /** Unique identifier for this injection operation (for per-operation cancellation) */
   injectionId?: string;
+  /** See {@link CopyTreeGeneratePayload.source}. */
+  source?: CopyTreeRunSource;
 }
 
 /** Payload for cancelling a specific injection operation */

--- a/shared/types/ipc/copyTreeHistory.ts
+++ b/shared/types/ipc/copyTreeHistory.ts
@@ -1,0 +1,111 @@
+/**
+ * Per-project record of copy-tree runs (#11732).
+ *
+ * Every delivery mode — clipboard file, bare generate, terminal injection —
+ * funnels through the three main-process handlers in
+ * `electron/ipc/handlers/copyTree.ts`, so recording there captures the toolbar,
+ * both context menus, the file browser and MCP in one place.
+ *
+ * Unlike the process-global run-history ring (#9949), this history is scoped to
+ * a single project: it lives in `userData/projects/<projectId>/copy-tree-history.json`
+ * alongside `settings.json` / `recipes.json`, and its snapshot push goes only to
+ * views bound to that project.
+ *
+ * Records store the caller's runtime options *before* `mergeCopyTreeOptions`
+ * folds in project settings. Re-running dispatches those options through the
+ * normal path so live settings and excludes still apply; storing the merged
+ * result would freeze settings drift into the record.
+ */
+
+import type { CopyTreeOptions } from "./copyTree.js";
+
+export const COPY_TREE_HISTORY_SCHEMA_VERSION = 1;
+
+/**
+ * Cap per project. The UI surfaces about five, so this leaves room for the
+ * long tail without letting the file grow unbounded.
+ */
+export const COPY_TREE_HISTORY_MAX_RECORDS = 20;
+
+/** Cap on the persisted display name, whether supplied or derived. */
+export const COPY_TREE_HISTORY_NAME_MAX_LENGTH = 120;
+
+/**
+ * Which surface asked for the run. Recorded because the same options mean
+ * different things from a file-browser folder menu and an agent tool call.
+ *
+ * `terminal` and `workflow` cover the two in-app injection paths that are
+ * neither a user-facing copy button nor an agent call. `unknown` is the honest
+ * answer for a caller that did not identify itself — never a stand-in for one
+ * of the named surfaces.
+ */
+export const COPY_TREE_RUN_SOURCES = [
+  "toolbar",
+  "shortcut",
+  "worktree-card",
+  "file-browser",
+  "mcp",
+  "terminal",
+  "workflow",
+  "unknown",
+] as const;
+
+export type CopyTreeRunSource = (typeof COPY_TREE_RUN_SOURCES)[number];
+
+/**
+ * The subset of `CopyTreeResult` worth keeping. `fileCount` is always present
+ * on a completed run; `totalSize` and `duration` ride on the result's optional
+ * `stats`, so they are optional here too — a run that reported no stats is
+ * recorded with what it did report rather than dropped or padded with zeros.
+ */
+export interface CopyTreeRunStats {
+  fileCount: number;
+  totalSize?: number;
+  duration?: number;
+}
+
+export interface CopyTreeHistoryRecord {
+  id: string;
+  /**
+   * SHA-256 over the canonicalized options alone. The name deliberately sits
+   * outside it, so renaming an entry later cannot fork the history.
+   */
+  dedupeKey: string;
+  /** Caller-supplied when given, otherwise derived from the options. */
+  name: string;
+  /** Exactly what the caller passed, pre-merge. */
+  options: CopyTreeOptions;
+  /** Surface of the most recent run. */
+  source: CopyTreeRunSource;
+  /** Worktree of the most recent run. */
+  worktreeId: string;
+  /** Stats of the most recent run. */
+  stats: CopyTreeRunStats;
+  /** Epoch ms of the first run with these options. */
+  createdAt: number;
+  /** Epoch ms of the most recent run. Drives LRU eviction. */
+  lastUsedAt: number;
+  /** How many runs have collapsed into this entry. */
+  runCount: number;
+}
+
+/**
+ * What a completed run contributes. The main process is authoritative for
+ * `id`, `dedupeKey`, `createdAt`, `lastUsedAt` and `runCount` — it stamps them
+ * so nothing upstream can forge history ordering.
+ */
+export interface CopyTreeHistoryAppendInput {
+  /** Optional; blank is treated as absent. Wired by #11734. */
+  name?: string;
+  options: CopyTreeOptions;
+  source: CopyTreeRunSource;
+  worktreeId: string;
+  stats: CopyTreeRunStats;
+}
+
+/** On-disk shape. `_schemaVersion` is stamped by the encoder, never accepted. */
+export interface CopyTreeHistoryFile {
+  _schemaVersion: number;
+  /** Newest-first. */
+  records: CopyTreeHistoryRecord[];
+}

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -85,6 +85,11 @@ export interface GeneratedElectronAPI {
       ...args: IpcInvokeMap["connectivity:get-state"]["args"]
     ): Promise<IpcInvokeMap["connectivity:get-state"]["result"]>;
   };
+  copyTreeHistory: {
+    getRecords(
+      ...args: IpcInvokeMap["copy-tree-history:get-records"]["args"]
+    ): Promise<IpcInvokeMap["copy-tree-history:get-records"]["result"]>;
+  };
   devPreview: {
     ensure(
       ...args: IpcInvokeMap["dev-preview:ensure"]["args"]

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -166,6 +166,10 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: import("./connectivity.js").ServiceConnectivitySnapshot;
   };
+  "copy-tree-history:get-records": {
+    args: [];
+    result: import("./copyTreeHistory.js").CopyTreeHistoryRecord[];
+  };
   "demo:annotate": {
     args: [payload: import("./demo.js").DemoAnnotatePayload];
     result: import("./demo.js").DemoAnnotateResult;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1938,6 +1938,15 @@ export interface IpcEventMap {
   // run is recorded or the log is cleared.
   "run-history:update": import("./runHistory.js").RunHistoryRecord[];
 
+  // Copy-tree run history changed (main → renderer, #11732). Sent only to views
+  // bound to `projectId`, never broadcast: unlike the run-history ring this is
+  // per-project data, so the id rides along and the renderer mirror ignores a
+  // snapshot for anything but its own project.
+  "copy-tree-history:update": {
+    projectId: string;
+    records: import("./copyTreeHistory.js").CopyTreeHistoryRecord[];
+  };
+
   // `daintree://` deep-link intent (main → renderer, #9559). Delivered to the
   // primary window once it has painted; the renderer opens the Plugin Manager
   // (URL pre-filled for install, or scrolled to the plugin for open). Routing
@@ -2067,6 +2076,8 @@ export type IpcEventBusMap = Pick<
   | "plugin:bg-update-available"
   // Run history changed (global broadcast)
   | "run-history:update"
+  // Copy-tree run history changed (project-scoped send)
+  | "copy-tree-history:update"
   // Plugin deep-link intent (targeted at the primary window)
   | "plugin:deep-link"
   // Double-clicked `.dntr` archive awaiting confirmation (targeted at the primary window)

--- a/shared/utils/__tests__/copyTreeHistory.test.ts
+++ b/shared/utils/__tests__/copyTreeHistory.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../copyTreeHistory.js";
 import { COPY_TREE_HISTORY_NAME_MAX_LENGTH } from "../../types/ipc/copyTreeHistory.js";
 import type { CopyTreeHistoryRecord } from "../../types/ipc/copyTreeHistory.js";
+import type { CopyTreeOptions } from "../../types/ipc/copyTree.js";
 
 describe("canonicalizeCopyTreeOptions", () => {
   it("collapses a string pattern and its one-element array form to the same shape", () => {
@@ -96,8 +97,18 @@ describe("canonicalizeCopyTreeOptions", () => {
     expect(options.scopePaths).toEqual(["z", "a"]);
   });
 
-  it("returns an empty object for absent options", () => {
-    expect(canonicalizeCopyTreeOptions(undefined)).toEqual({});
+  it("treats absent options the same as empty ones", () => {
+    expect(canonicalizeCopyTreeOptions(undefined)).toEqual(canonicalizeCopyTreeOptions({}));
+  });
+
+  it("keeps the folded selection in its own namespace", () => {
+    // A future real `CopyTreeOptions.selection` field must not land in the same
+    // slot as today's folded filter/includePaths, or the two would collide.
+    const folded = canonicalizeCopyTreeOptions({ filter: ["a"] });
+    const strayField = canonicalizeCopyTreeOptions({
+      selection: ["a"],
+    } as unknown as CopyTreeOptions);
+    expect(folded).not.toEqual(strayField);
   });
 });
 

--- a/shared/utils/__tests__/copyTreeHistory.test.ts
+++ b/shared/utils/__tests__/copyTreeHistory.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import {
+  canonicalizeCopyTreeOptions,
+  deriveCopyTreeRunName,
+  resolveCopyTreeRunName,
+  sortCopyTreeHistory,
+} from "../copyTreeHistory.js";
+import { COPY_TREE_HISTORY_NAME_MAX_LENGTH } from "../../types/ipc/copyTreeHistory.js";
+import type { CopyTreeHistoryRecord } from "../../types/ipc/copyTreeHistory.js";
+
+describe("canonicalizeCopyTreeOptions", () => {
+  it("collapses a string pattern and its one-element array form to the same shape", () => {
+    expect(canonicalizeCopyTreeOptions({ filter: "src/**" })).toEqual(
+      canonicalizeCopyTreeOptions({ filter: ["src/**"] })
+    );
+    expect(canonicalizeCopyTreeOptions({ exclude: "dist" })).toEqual(
+      canonicalizeCopyTreeOptions({ exclude: ["dist"] })
+    );
+  });
+
+  it("makes the unordered array fields order-insensitive", () => {
+    const forwards = canonicalizeCopyTreeOptions({
+      filter: ["b", "a"],
+      exclude: ["z", "y"],
+      always: ["q", "p"],
+      includePaths: ["n", "m"],
+      scopePaths: ["d", "c"],
+    });
+    const backwards = canonicalizeCopyTreeOptions({
+      filter: ["a", "b"],
+      exclude: ["y", "z"],
+      always: ["p", "q"],
+      includePaths: ["m", "n"],
+      scopePaths: ["c", "d"],
+    });
+    expect(forwards).toEqual(backwards);
+  });
+
+  it("drops duplicates within an unordered field", () => {
+    expect(canonicalizeCopyTreeOptions({ scopePaths: ["src", "src", "lib"] })).toEqual(
+      canonicalizeCopyTreeOptions({ scopePaths: ["lib", "src"] })
+    );
+  });
+
+  it("keeps an absent field distinct from an explicitly empty one", () => {
+    // `undefined` lets project settings back-fill at merge time; `[]` blocks
+    // that back-fill, so the two are different runs.
+    expect(canonicalizeCopyTreeOptions({})).not.toEqual(
+      canonicalizeCopyTreeOptions({ exclude: [] })
+    );
+  });
+
+  it("omits undefined-valued keys so they cannot split an otherwise identical run", () => {
+    expect(canonicalizeCopyTreeOptions({ modified: undefined, filter: "a" })).toEqual(
+      canonicalizeCopyTreeOptions({ filter: "a" })
+    );
+  });
+
+  it("preserves scalar differences that change what gets copied", () => {
+    const base = canonicalizeCopyTreeOptions({ format: "xml", modified: true, charLimit: 10 });
+    expect(base).not.toEqual(
+      canonicalizeCopyTreeOptions({ format: "json", modified: true, charLimit: 10 })
+    );
+    expect(base).not.toEqual(
+      canonicalizeCopyTreeOptions({ format: "xml", modified: false, charLimit: 10 })
+    );
+    expect(base).not.toEqual(
+      canonicalizeCopyTreeOptions({ format: "xml", modified: true, charLimit: 11 })
+    );
+  });
+
+  it("does not treat filter and includePaths as interchangeable", () => {
+    // They union into one selection set downstream, but only `filter` suppresses
+    // the project-setting filter — so the two runtime shapes are not the same run.
+    expect(canonicalizeCopyTreeOptions({ filter: ["src/**"] })).not.toEqual(
+      canonicalizeCopyTreeOptions({ includePaths: ["src/**"] })
+    );
+  });
+
+  it("does not mutate the caller's options", () => {
+    const options = { scopePaths: ["z", "a"] };
+    canonicalizeCopyTreeOptions(options);
+    expect(options.scopePaths).toEqual(["z", "a"]);
+  });
+
+  it("returns an empty object for absent options", () => {
+    expect(canonicalizeCopyTreeOptions(undefined)).toEqual({});
+  });
+});
+
+describe("deriveCopyTreeRunName", () => {
+  it("names an unnarrowed run for the whole context", () => {
+    expect(deriveCopyTreeRunName(undefined)).toBe("Full context");
+    expect(deriveCopyTreeRunName({})).toBe("Full context");
+    expect(deriveCopyTreeRunName({ format: "json" })).toBe("Full context");
+  });
+
+  it("names a scoped run after the folder, not its path", () => {
+    expect(deriveCopyTreeRunName({ scopePaths: ["src/panels/file-browser"] })).toBe("file-browser");
+  });
+
+  it("handles Windows separators in a scoped path", () => {
+    expect(deriveCopyTreeRunName({ scopePaths: ["src\\panels\\terminal"] })).toBe("terminal");
+  });
+
+  it("counts the remainder when several paths are scoped", () => {
+    expect(deriveCopyTreeRunName({ scopePaths: ["src/a", "src/b", "src/c"] })).toBe("a +2 more");
+  });
+
+  it("labels multiple paths identically regardless of the order they arrived in", () => {
+    expect(deriveCopyTreeRunName({ scopePaths: ["src/b", "src/a"] })).toBe(
+      deriveCopyTreeRunName({ scopePaths: ["src/a", "src/b"] })
+    );
+  });
+
+  it("shows the filter string when only a pattern narrows the run", () => {
+    expect(deriveCopyTreeRunName({ filter: "**/*.ts" })).toBe("**/*.ts");
+  });
+
+  it("names a git-filtered run for what it selects", () => {
+    expect(deriveCopyTreeRunName({ modified: true })).toBe("Modified files");
+    expect(deriveCopyTreeRunName({ changed: "develop" })).toBe("Changed since develop");
+  });
+
+  it("ignores modified:false, which narrows nothing", () => {
+    expect(deriveCopyTreeRunName({ modified: false })).toBe("Full context");
+  });
+
+  it("prefers the concrete selection over the git filter when both are present", () => {
+    expect(deriveCopyTreeRunName({ scopePaths: ["src/lib"], modified: true })).toBe("lib");
+    expect(deriveCopyTreeRunName({ filter: "**/*.ts", modified: true })).toBe("**/*.ts");
+  });
+
+  it("falls through a scope path that has no basename", () => {
+    expect(deriveCopyTreeRunName({ scopePaths: ["/"], modified: true })).toBe("Modified files");
+  });
+
+  it("bounds the derived name", () => {
+    const name = deriveCopyTreeRunName({ filter: "x".repeat(500) });
+    expect(name.length).toBeLessThanOrEqual(COPY_TREE_HISTORY_NAME_MAX_LENGTH);
+  });
+});
+
+describe("resolveCopyTreeRunName", () => {
+  it("prefers a supplied name over the derived one", () => {
+    expect(resolveCopyTreeRunName("Release notes context", { modified: true })).toBe(
+      "Release notes context"
+    );
+  });
+
+  it("treats a blank supplied name as absent", () => {
+    expect(resolveCopyTreeRunName("   ", { modified: true })).toBe("Modified files");
+    expect(resolveCopyTreeRunName("", undefined)).toBe("Full context");
+  });
+
+  it("trims a supplied name", () => {
+    expect(resolveCopyTreeRunName("  spaced  ", {})).toBe("spaced");
+  });
+
+  it("bounds a supplied name", () => {
+    const name = resolveCopyTreeRunName("y".repeat(500), {});
+    expect(name.length).toBeLessThanOrEqual(COPY_TREE_HISTORY_NAME_MAX_LENGTH);
+  });
+});
+
+describe("sortCopyTreeHistory", () => {
+  const record = (id: string, lastUsedAt: number): CopyTreeHistoryRecord => ({
+    id,
+    dedupeKey: id,
+    name: id,
+    options: {},
+    source: "toolbar",
+    worktreeId: "wt",
+    stats: { fileCount: 1 },
+    createdAt: 0,
+    lastUsedAt,
+    runCount: 1,
+  });
+
+  it("orders newest-first", () => {
+    const sorted = sortCopyTreeHistory([record("a", 1), record("b", 3), record("c", 2)]);
+    expect(sorted.map((r) => r.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("keeps the incoming order of records that tie", () => {
+    const sorted = sortCopyTreeHistory([record("a", 5), record("b", 5), record("c", 5)]);
+    expect(sorted.map((r) => r.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("does not mutate the input", () => {
+    const input = [record("a", 1), record("b", 2)];
+    sortCopyTreeHistory(input);
+    expect(input.map((r) => r.id)).toEqual(["a", "b"]);
+  });
+});

--- a/shared/utils/__tests__/copyTreeHistory.test.ts
+++ b/shared/utils/__tests__/copyTreeHistory.test.ts
@@ -34,6 +34,8 @@ describe("canonicalizeCopyTreeOptions", () => {
       scopePaths: ["c", "d"],
     });
     expect(forwards).toEqual(backwards);
+    // ...and the ordering really was the only difference.
+    expect(forwards).not.toEqual(canonicalizeCopyTreeOptions({ scopePaths: ["c", "d"] }));
   });
 
   it("drops duplicates within an unordered field", () => {
@@ -69,11 +71,22 @@ describe("canonicalizeCopyTreeOptions", () => {
     );
   });
 
-  it("does not treat filter and includePaths as interchangeable", () => {
-    // They union into one selection set downstream, but only `filter` suppresses
-    // the project-setting filter — so the two runtime shapes are not the same run.
-    expect(canonicalizeCopyTreeOptions({ filter: ["src/**"] })).not.toEqual(
+  it("treats filter and includePaths as one selection set", () => {
+    // CopyTreeService.mergeSelectionPatterns unions them into the SDK's single
+    // `filter`, and mergeCopyTreeOptions back-fills neither from project
+    // settings — so the two spellings request the identical run and must not
+    // occupy two history rows.
+    expect(canonicalizeCopyTreeOptions({ filter: ["src/**"] })).toEqual(
       canonicalizeCopyTreeOptions({ includePaths: ["src/**"] })
+    );
+    expect(canonicalizeCopyTreeOptions({ filter: "a", includePaths: ["b"] })).toEqual(
+      canonicalizeCopyTreeOptions({ filter: ["b", "a"] })
+    );
+  });
+
+  it("still separates a selection from no selection at all", () => {
+    expect(canonicalizeCopyTreeOptions({ filter: ["src/**"] })).not.toEqual(
+      canonicalizeCopyTreeOptions({})
     );
   });
 
@@ -135,9 +148,52 @@ describe("deriveCopyTreeRunName", () => {
     expect(deriveCopyTreeRunName({ scopePaths: ["/"], modified: true })).toBe("Modified files");
   });
 
-  it("bounds the derived name", () => {
-    const name = deriveCopyTreeRunName({ filter: "x".repeat(500) });
+  it("bounds the derived name and keeps its prefix", () => {
+    const name = deriveCopyTreeRunName({ filter: `${"x".repeat(500)}yz` });
     expect(name.length).toBeLessThanOrEqual(COPY_TREE_HISTORY_NAME_MAX_LENGTH);
+    expect(name.startsWith("xxx")).toBe(true);
+    expect(name.endsWith("…")).toBe(true);
+  });
+
+  it("leaves a name exactly at the limit untouched", () => {
+    const exact = "x".repeat(COPY_TREE_HISTORY_NAME_MAX_LENGTH);
+    expect(deriveCopyTreeRunName({ filter: exact })).toBe(exact);
+    expect(deriveCopyTreeRunName({ filter: `${exact}y` })).not.toBe(`${exact}y`);
+  });
+
+  it("never truncates through a surrogate pair", () => {
+    // A lone high surrogate renders as a replacement glyph and breaks equality
+    // against the same name derived elsewhere.
+    for (let pad = 0; pad < 6; pad++) {
+      const name = deriveCopyTreeRunName({
+        filter: `${"x".repeat(COPY_TREE_HISTORY_NAME_MAX_LENGTH - 4 + pad)}${"🌳".repeat(6)}`,
+      });
+      expect(name.length).toBeLessThanOrEqual(COPY_TREE_HISTORY_NAME_MAX_LENGTH);
+      for (const char of name) {
+        const code = char.codePointAt(0) as number;
+        expect(code >= 0xd800 && code <= 0xdfff).toBe(false);
+      }
+    }
+  });
+
+  it("names a picker selection after the chosen file", () => {
+    expect(deriveCopyTreeRunName({ includePaths: ["src/lib/utils.ts"] })).toBe("utils.ts");
+    expect(deriveCopyTreeRunName({ includePaths: ["src/a.ts", "src/b.ts"] })).toBe("a.ts +1 more");
+  });
+
+  it("prefers a scoped folder over a picker selection", () => {
+    expect(deriveCopyTreeRunName({ scopePaths: ["src/panels"], includePaths: ["a.ts"] })).toBe(
+      "panels"
+    );
+  });
+
+  it("falls through a whitespace-only filter rather than labelling a run with blanks", () => {
+    expect(deriveCopyTreeRunName({ filter: "   ", modified: true })).toBe("Modified files");
+    expect(deriveCopyTreeRunName({ filter: ["  ", "\t"] })).toBe("Full context");
+  });
+
+  it("trims a filter used as the label", () => {
+    expect(deriveCopyTreeRunName({ filter: "  **/*.ts  " })).toBe("**/*.ts");
   });
 });
 

--- a/shared/utils/copyTreeHistory.ts
+++ b/shared/utils/copyTreeHistory.ts
@@ -110,9 +110,14 @@ function labelList(values: string[], render: (value: string) => string): string 
     .sort()
     .map(render)
     .filter((label) => label.length > 0);
-  if (rendered.length === 0) return null;
 
-  return rendered.length > 1 ? `${rendered[0]} +${rendered.length - 1} more` : rendered[0];
+  // Destructured rather than indexed: under `noUncheckedIndexedAccess` a
+  // `rendered[0]` read stays `string | undefined` however the length was
+  // checked, and this function promises `string | null`.
+  const [first, ...rest] = rendered;
+  if (first === undefined) return null;
+
+  return rest.length > 0 ? `${first} +${rest.length} more` : first;
 }
 
 /**

--- a/shared/utils/copyTreeHistory.ts
+++ b/shared/utils/copyTreeHistory.ts
@@ -23,13 +23,22 @@ import type { CopyTreeOptions } from "../types/ipc/copyTree.js";
  * future option whose order *is* significant then keeps its order by default
  * instead of being silently canonicalized into a different run.
  */
-const UNORDERED_ARRAY_FIELDS = new Set<keyof CopyTreeOptions>([
-  "filter",
-  "exclude",
-  "always",
-  "includePaths",
-  "scopePaths",
-]);
+const UNORDERED_ARRAY_FIELDS = new Set<keyof CopyTreeOptions>(["exclude", "always", "scopePaths"]);
+
+/**
+ * `filter` and `includePaths` are two spellings of one thing. `CopyTreeService`
+ * unions them into the SDK's single `filter` set, and `mergeCopyTreeOptions`
+ * back-fills neither from project settings, so the two carry no independent
+ * meaning by the time a run happens. Hashing them separately would file the
+ * same run under two history entries.
+ */
+const SELECTION_FIELDS = ["filter", "includePaths"] as const;
+
+function toArray(value: unknown): string[] | null {
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) return value as string[];
+  return null;
+}
 
 /**
  * Normalize runtime options into the object that gets hashed for the dedupe
@@ -37,8 +46,9 @@ const UNORDERED_ARRAY_FIELDS = new Set<keyof CopyTreeOptions>([
  * merge time), while an explicit empty array is preserved — it blocks that
  * back-fill and so means something different from omission.
  *
- * Only the shape is normalized here; key ordering is handled downstream by the
- * stable hash.
+ * The result is a hash input, not a usable options object: the selection fields
+ * are folded into one synthetic key. Only the shape is normalized here; key
+ * ordering is handled downstream by the stable hash.
  */
 export function canonicalizeCopyTreeOptions(options?: CopyTreeOptions): Record<string, unknown> {
   const out: Record<string, unknown> = {};
@@ -46,14 +56,15 @@ export function canonicalizeCopyTreeOptions(options?: CopyTreeOptions): Record<s
 
   for (const [key, value] of Object.entries(options)) {
     if (value === undefined) continue;
+    if ((SELECTION_FIELDS as readonly string[]).includes(key)) continue;
 
     if (!UNORDERED_ARRAY_FIELDS.has(key as keyof CopyTreeOptions)) {
       out[key] = value;
       continue;
     }
 
-    const list = typeof value === "string" ? [value] : value;
-    if (!Array.isArray(list)) {
+    const list = toArray(value);
+    if (!list) {
       // Shape the schema should have rejected. Keep it verbatim rather than
       // coercing, so two genuinely different malformed inputs stay distinct.
       out[key] = value;
@@ -61,6 +72,19 @@ export function canonicalizeCopyTreeOptions(options?: CopyTreeOptions): Record<s
     }
 
     out[key] = [...new Set(list)].sort();
+  }
+
+  const selection: string[] = [];
+  let hasSelection = false;
+  for (const field of SELECTION_FIELDS) {
+    const value = options[field];
+    if (value === undefined) continue;
+    hasSelection = true;
+    const list = toArray(value);
+    if (list) selection.push(...list);
+  }
+  if (hasSelection) {
+    out.selection = [...new Set(selection)].sort();
   }
 
   return out;
@@ -76,18 +100,33 @@ function toList(value: string | string[] | undefined): string[] {
  * stable across two runs that dedupe together) plus a count of the rest.
  */
 function labelList(values: string[], render: (value: string) => string): string | null {
-  const sorted = [...new Set(values)].sort();
-  const first = sorted.find((value) => render(value).length > 0);
-  if (first === undefined) return null;
+  // Deduplicate on the source value, not the rendered one: two folders that
+  // share a basename (`src/a`, `lib/a`) are two selections, and collapsing them
+  // would under-report the count rather than merely being ambiguous.
+  const rendered = [...new Set(values)]
+    .sort()
+    .map(render)
+    .filter((label) => label.length > 0);
+  if (rendered.length === 0) return null;
 
-  const label = render(first);
-  return sorted.length > 1 ? `${label} +${sorted.length - 1} more` : label;
+  return rendered.length > 1 ? `${rendered[0]} +${rendered.length - 1} more` : rendered[0];
 }
 
+/**
+ * Bound the stored name without cutting through a character. A plain `slice`
+ * splits a surrogate pair — an emoji straddling the limit would persist as a
+ * lone surrogate, which renders as a replacement glyph and breaks equality
+ * against the same name derived elsewhere.
+ */
 function truncateName(name: string): string {
-  return name.length > COPY_TREE_HISTORY_NAME_MAX_LENGTH
-    ? `${name.slice(0, COPY_TREE_HISTORY_NAME_MAX_LENGTH - 1).trimEnd()}…`
-    : name;
+  if (name.length <= COPY_TREE_HISTORY_NAME_MAX_LENGTH) return name;
+
+  let out = "";
+  for (const char of name) {
+    if (out.length + char.length > COPY_TREE_HISTORY_NAME_MAX_LENGTH - 1) break;
+    out += char;
+  }
+  return `${out.trimEnd()}…`;
 }
 
 /**

--- a/shared/utils/copyTreeHistory.ts
+++ b/shared/utils/copyTreeHistory.ts
@@ -52,7 +52,7 @@ function toArray(value: unknown): string[] | null {
  */
 export function canonicalizeCopyTreeOptions(options?: CopyTreeOptions): Record<string, unknown> {
   const out: Record<string, unknown> = {};
-  if (!options) return out;
+  if (!options) return { options: out };
 
   for (const [key, value] of Object.entries(options)) {
     if (value === undefined) continue;
@@ -83,11 +83,14 @@ export function canonicalizeCopyTreeOptions(options?: CopyTreeOptions): Record<s
     const list = toArray(value);
     if (list) selection.push(...list);
   }
-  if (hasSelection) {
-    out.selection = [...new Set(selection)].sort();
-  }
 
-  return out;
+  // Two namespaces rather than a synthetic key alongside the real ones: a
+  // future `CopyTreeOptions.selection` field would otherwise canonicalize into
+  // the same slot as today's folded `filter`/`includePaths` and either collide
+  // with it or be overwritten by it.
+  return hasSelection
+    ? { options: out, selection: [...new Set(selection)].sort() }
+    : { options: out };
 }
 
 function toList(value: string | string[] | undefined): string[] {

--- a/shared/utils/copyTreeHistory.ts
+++ b/shared/utils/copyTreeHistory.ts
@@ -1,0 +1,131 @@
+/**
+ * Pure helpers behind the per-project copy-tree run history (#11732).
+ *
+ * Both live in `shared/` because the fallback label is needed by the main
+ * process when it records a run, by the toolbar dropdown that renders it
+ * (#11733), and by the MCP naming surface (#11734) — one derivation, three
+ * consumers, no drift.
+ */
+
+import { basename } from "./path.js";
+import {
+  COPY_TREE_HISTORY_NAME_MAX_LENGTH,
+  type CopyTreeHistoryRecord,
+} from "../types/ipc/copyTreeHistory.js";
+import type { CopyTreeOptions } from "../types/ipc/copyTree.js";
+
+/**
+ * Option fields whose array order carries no meaning: every one is an
+ * any-match pattern or path set, so `["a","b"]` and `["b","a"]` select the same
+ * files and must dedupe to one history entry.
+ *
+ * Deliberately an allowlist rather than a recursive sort of every array — a
+ * future option whose order *is* significant then keeps its order by default
+ * instead of being silently canonicalized into a different run.
+ */
+const UNORDERED_ARRAY_FIELDS = new Set<keyof CopyTreeOptions>([
+  "filter",
+  "exclude",
+  "always",
+  "includePaths",
+  "scopePaths",
+]);
+
+/**
+ * Normalize runtime options into the object that gets hashed for the dedupe
+ * key. Absent fields are dropped (they let project settings back-fill at
+ * merge time), while an explicit empty array is preserved — it blocks that
+ * back-fill and so means something different from omission.
+ *
+ * Only the shape is normalized here; key ordering is handled downstream by the
+ * stable hash.
+ */
+export function canonicalizeCopyTreeOptions(options?: CopyTreeOptions): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (!options) return out;
+
+  for (const [key, value] of Object.entries(options)) {
+    if (value === undefined) continue;
+
+    if (!UNORDERED_ARRAY_FIELDS.has(key as keyof CopyTreeOptions)) {
+      out[key] = value;
+      continue;
+    }
+
+    const list = typeof value === "string" ? [value] : value;
+    if (!Array.isArray(list)) {
+      // Shape the schema should have rejected. Keep it verbatim rather than
+      // coercing, so two genuinely different malformed inputs stay distinct.
+      out[key] = value;
+      continue;
+    }
+
+    out[key] = [...new Set(list)].sort();
+  }
+
+  return out;
+}
+
+function toList(value: string | string[] | undefined): string[] {
+  if (value === undefined) return [];
+  return typeof value === "string" ? [value] : value;
+}
+
+/**
+ * Label a set of values by its first entry (in canonical order, so the label is
+ * stable across two runs that dedupe together) plus a count of the rest.
+ */
+function labelList(values: string[], render: (value: string) => string): string | null {
+  const sorted = [...new Set(values)].sort();
+  const first = sorted.find((value) => render(value).length > 0);
+  if (first === undefined) return null;
+
+  const label = render(first);
+  return sorted.length > 1 ? `${label} +${sorted.length - 1} more` : label;
+}
+
+function truncateName(name: string): string {
+  return name.length > COPY_TREE_HISTORY_NAME_MAX_LENGTH
+    ? `${name.slice(0, COPY_TREE_HISTORY_NAME_MAX_LENGTH - 1).trimEnd()}…`
+    : name;
+}
+
+/**
+ * Fallback display name for a run, derived from its options.
+ *
+ * Ordered from the most concrete narrowing the caller chose to the least: an
+ * explicit path selection beats a pattern, which beats a git-derived filter,
+ * and a run that narrowed nothing is the full context.
+ */
+export function deriveCopyTreeRunName(options?: CopyTreeOptions): string {
+  const scoped = labelList(toList(options?.scopePaths), (value) => basename(value));
+  if (scoped) return truncateName(scoped);
+
+  const included = labelList(toList(options?.includePaths), (value) => basename(value));
+  if (included) return truncateName(included);
+
+  const filtered = labelList(toList(options?.filter), (value) => value.trim());
+  if (filtered) return truncateName(filtered);
+
+  if (options?.modified) return "Modified files";
+  if (options?.changed) return truncateName(`Changed since ${options.changed}`);
+
+  return "Full context";
+}
+
+/**
+ * Resolve the name to persist. A blank supplied name counts as absent so a
+ * caller passing `""` gets the derived label rather than an unlabelled entry.
+ */
+export function resolveCopyTreeRunName(
+  suppliedName: string | undefined,
+  options: CopyTreeOptions | undefined
+): string {
+  const trimmed = suppliedName?.trim();
+  return trimmed ? truncateName(trimmed) : deriveCopyTreeRunName(options);
+}
+
+/** Newest-first, as persisted. Exported for consumers that re-sort a snapshot. */
+export function sortCopyTreeHistory(records: CopyTreeHistoryRecord[]): CopyTreeHistoryRecord[] {
+  return [...records].sort((a, b) => b.lastUsedAt - a.lastUsedAt);
+}

--- a/src/clients/copyTreeClient.ts
+++ b/src/clients/copyTreeClient.ts
@@ -2,31 +2,50 @@ import type {
   CopyTreeOptions,
   CopyTreeResult,
   CopyTreeProgress,
+  CopyTreeRunSource,
   CopyTreeTestConfigOptions,
   CopyTreeTestConfigResult,
   FileTreeNode,
 } from "@shared/types";
 
+/**
+ * `source` names the surface that asked for the run so the project's copy-tree
+ * history can record it (#11732). It is optional on purpose — it has no effect
+ * on the generated bundle, and a caller that omits it is recorded as `unknown`
+ * rather than mislabelled.
+ */
 export const copyTreeClient = {
   generate: (
     worktreeId: string,
     options?: CopyTreeOptions,
-    includeContent?: boolean
+    includeContent?: boolean,
+    source?: CopyTreeRunSource
   ): Promise<CopyTreeResult> => {
-    return window.electron.copyTree.generate(worktreeId, options, includeContent);
+    return window.electron.copyTree.generate(worktreeId, options, includeContent, source);
   },
 
-  generateAndCopyFile: (worktreeId: string, options?: CopyTreeOptions): Promise<CopyTreeResult> => {
-    return window.electron.copyTree.generateAndCopyFile(worktreeId, options);
+  generateAndCopyFile: (
+    worktreeId: string,
+    options?: CopyTreeOptions,
+    source?: CopyTreeRunSource
+  ): Promise<CopyTreeResult> => {
+    return window.electron.copyTree.generateAndCopyFile(worktreeId, options, source);
   },
 
   injectToTerminal: (
     terminalId: string,
     worktreeId: string,
     options?: CopyTreeOptions,
-    injectionId?: string
+    injectionId?: string,
+    source?: CopyTreeRunSource
   ): Promise<CopyTreeResult> => {
-    return window.electron.copyTree.injectToTerminal(terminalId, worktreeId, options, injectionId);
+    return window.electron.copyTree.injectToTerminal(
+      terminalId,
+      worktreeId,
+      options,
+      injectionId,
+      source
+    );
   },
 
   isAvailable: (): Promise<boolean> => {

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -820,7 +820,7 @@ export function Toolbar({
 
     setIsCopyingTree(true);
 
-    return handleCopyTree(activeWorktree)
+    return handleCopyTree(activeWorktree, "toolbar")
       .then((resultMessage) => {
         if (!resultMessage) return;
         setTreeCopied(true);
@@ -850,7 +850,7 @@ export function Toolbar({
   const handleCopyTreeOverflow = useCallback(() => {
     if (isCopyingTree || !activeWorktree) return;
     setIsCopyingTree(true);
-    return handleCopyTree(activeWorktree)
+    return handleCopyTree(activeWorktree, "toolbar")
       .then((resultMessage) => {
         if (!resultMessage) return;
         // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok

--- a/src/components/Sidebar/SidebarWorktreeRow.tsx
+++ b/src/components/Sidebar/SidebarWorktreeRow.tsx
@@ -60,7 +60,7 @@ function SidebarWorktreeRow({
 
   const onSelect = useCallback(() => selectWorktree(worktreeId), [selectWorktree, worktreeId]);
   const onCopyTree = useCallback(
-    () => worktree && worktreeActions.handleCopyTree(worktree),
+    () => worktree && worktreeActions.handleCopyTree(worktree, "worktree-card"),
     [worktree, worktreeActions]
   );
   const onOpenEditor = useCallback(

--- a/src/components/Sidebar/StaticWorktreeRow.tsx
+++ b/src/components/Sidebar/StaticWorktreeRow.tsx
@@ -54,7 +54,7 @@ function StaticWorktreeRow({
 
   const onSelect = useCallback(() => selectWorktree(worktreeId), [selectWorktree, worktreeId]);
   const onCopyTree = useCallback(
-    () => worktree && worktreeActions.handleCopyTree(worktree),
+    () => worktree && worktreeActions.handleCopyTree(worktree, "worktree-card"),
     [worktree, worktreeActions]
   );
   const onOpenEditor = useCallback(

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -485,11 +485,11 @@ export function WorktreeCard({
   };
 
   const handleCopyContextFull = () => {
-    void copyContextWithFeedback(worktree.id, "context-menu");
+    void copyContextWithFeedback(worktree.id, "context-menu", undefined, "worktree-card");
   };
 
   const handleCopyContextModified = () => {
-    void copyContextWithFeedback(worktree.id, "context-menu", { modified: true });
+    void copyContextWithFeedback(worktree.id, "context-menu", { modified: true }, "worktree-card");
   };
 
   const { copy: copyWorktreePath } = useCopyWithFeedback();

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useEffectEvent, useRef, useMemo, useStat
 import { X, FilterX, AlertTriangle, Trash2, GitBranch } from "lucide-react";
 import { Layers, Plug } from "@/components/icons";
 import { cn } from "@/lib/utils";
+import type { CopyTreeRunSource } from "@shared/types";
 import { useShallow } from "zustand/react/shallow";
 import { WorktreeCard } from "./WorktreeCard";
 import { WorktreeFilterPopover } from "./WorktreeFilterPopover";
@@ -48,7 +49,10 @@ interface OverviewWorktreeCardProps {
   totalWorktreeCount: number;
   variant?: "sidebar" | "grid";
   onSelectWorktree: (worktreeId: string) => void;
-  onCopyTree: (worktree: WorktreeSnapshot) => Promise<string | undefined> | void;
+  onCopyTree: (
+    worktree: WorktreeSnapshot,
+    copyTreeRunSource?: CopyTreeRunSource
+  ) => Promise<string | undefined> | void;
   onOpenEditor: (worktree: WorktreeSnapshot) => void;
   onSaveLayout?: (worktree: WorktreeSnapshot) => void;
   onLaunchAgent?: (worktreeId: string, agentId: string) => void;
@@ -97,7 +101,7 @@ function OverviewWorktreeCard({
   }, [onSelectWorktree, onClose, worktreeId]);
 
   const handleCopyTree = useCallback(
-    () => worktree && onCopyTree(worktree),
+    () => worktree && onCopyTree(worktree, "worktree-card"),
     [worktree, onCopyTree]
   );
   const handleOpenEditor = useCallback(
@@ -188,7 +192,10 @@ export interface WorktreeOverviewModalProps {
   activeWorktreeId: string | null;
   focusedWorktreeId: string | null;
   onSelectWorktree: (worktreeId: string) => void;
-  onCopyTree: (worktree: WorktreeSnapshot) => Promise<string | undefined> | void;
+  onCopyTree: (
+    worktree: WorktreeSnapshot,
+    copyTreeRunSource?: CopyTreeRunSource
+  ) => Promise<string | undefined> | void;
   onOpenEditor: (worktree: WorktreeSnapshot) => void;
   onSaveLayout?: (worktree: WorktreeSnapshot) => void;
   onLaunchAgent?: (worktreeId: string, agentId: string) => void;

--- a/src/hooks/useContextInjection.ts
+++ b/src/hooks/useContextInjection.ts
@@ -382,7 +382,8 @@ export function useContextInjection(targetTerminalId?: string): UseContextInject
           activeTerminal,
           worktreeId,
           options,
-          injectionUuid
+          injectionUuid,
+          "terminal"
         );
 
         if (result.error) {

--- a/src/hooks/useWorktreeActions.ts
+++ b/src/hooks/useWorktreeActions.ts
@@ -8,6 +8,7 @@ import { formatCopyResultMessage } from "@/lib/formatCopyResult";
 import { actionService } from "@/services/ActionService";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import type { ActionSource } from "@shared/types/actions";
+import type { CopyTreeRunSource } from "@shared/types";
 import type { CopyTreeBudgetStats, CopyTreeExclusionReason } from "@shared/types/ipc/copyTree";
 
 // Moved to a leaf module so the copyTree action definitions can share it
@@ -60,7 +61,10 @@ export function describeEmptyFolderCopy(stats?: CopyTreeBudgetStats | null): str
 export async function copyContextWithFeedback(
   worktreeId: string,
   source: ActionSource,
-  options?: { modified?: boolean; includePaths?: string[]; scopePaths?: string[] }
+  options?: { modified?: boolean; includePaths?: string[]; scopePaths?: string[] },
+  // Which surface this is. `source` can't answer it — the worktree card and the
+  // file browser both dispatch as "context-menu" — so callers that know say so.
+  copyTreeRunSource?: CopyTreeRunSource
 ): Promise<void> {
   // Direct store call: this is a spinner-then-update pattern that depends on
   // an unconditional toast id. notify() returns "" when notifications are
@@ -89,7 +93,7 @@ export async function copyContextWithFeedback(
         includePaths: options?.includePaths,
         scopePaths: options?.scopePaths,
       },
-      { source }
+      { source, copyTreeRunSource }
     );
 
     if (!result.ok) {
@@ -168,7 +172,10 @@ export interface UseWorktreeActionsOptions {
 }
 
 export interface WorktreeActions {
-  handleCopyTree: (worktree: WorktreeSnapshot) => Promise<string | undefined>;
+  handleCopyTree: (
+    worktree: WorktreeSnapshot,
+    copyTreeRunSource?: CopyTreeRunSource
+  ) => Promise<string | undefined>;
   handleOpenEditor: (worktree: WorktreeSnapshot) => void;
   handleOpenIssue: (worktree: WorktreeSnapshot) => void;
   handleOpenPR: (worktree: WorktreeSnapshot) => void;
@@ -182,12 +189,15 @@ export function useWorktreeActions({
   const addError = useErrorStore((state) => state.addError);
 
   const handleCopyTree = useCallback(
-    async (worktree: WorktreeSnapshot): Promise<string | undefined> => {
+    async (
+      worktree: WorktreeSnapshot,
+      copyTreeRunSource?: CopyTreeRunSource
+    ): Promise<string | undefined> => {
       try {
         const result = await actionService.dispatch(
           "worktree.copyTree",
           { worktreeId: worktree.id },
-          { source: "user" }
+          { source: "user", copyTreeRunSource }
         );
         if (!result.ok) {
           throw new Error(result.error.message);

--- a/src/lib/__tests__/copyTreeRunSource.test.ts
+++ b/src/lib/__tests__/copyTreeRunSource.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { resolveCopyTreeRunSource } from "../copyTreeRunSource";
+import type { ActionSource } from "@shared/types/actions";
+
+describe("resolveCopyTreeRunSource", () => {
+  it("lets a caller that knows its surface override the dispatch source", () => {
+    // The case that motivates the parameter: both of these dispatch as
+    // "context-menu", so only the explicit value tells them apart.
+    expect(resolveCopyTreeRunSource("context-menu", "worktree-card")).toBe("worktree-card");
+    expect(resolveCopyTreeRunSource("context-menu", "file-browser")).toBe("file-browser");
+  });
+
+  it("honours an explicit surface even when the dispatch source is inferable", () => {
+    expect(resolveCopyTreeRunSource("keybinding", "toolbar")).toBe("toolbar");
+    expect(resolveCopyTreeRunSource("agent", "toolbar")).toBe("toolbar");
+  });
+
+  it("infers a keyboard shortcut", () => {
+    expect(resolveCopyTreeRunSource("keybinding")).toBe("shortcut");
+  });
+
+  it("infers an agent dispatch as MCP", () => {
+    expect(resolveCopyTreeRunSource("agent")).toBe("mcp");
+  });
+
+  it("refuses to guess for sources that do not identify a surface", () => {
+    const ambiguous: ActionSource[] = ["user", "menu", "context-menu", "plugin"];
+    for (const source of ambiguous) {
+      expect(resolveCopyTreeRunSource(source)).toBe("unknown");
+    }
+  });
+
+  it("falls back to unknown when there is no dispatch source at all", () => {
+    expect(resolveCopyTreeRunSource(undefined)).toBe("unknown");
+  });
+});

--- a/src/lib/copyTreeRunSource.ts
+++ b/src/lib/copyTreeRunSource.ts
@@ -1,0 +1,26 @@
+import type { ActionSource } from "@shared/types";
+import type { CopyTreeRunSource } from "@shared/types";
+
+/**
+ * Map an action dispatch onto the surface recorded in the copy-tree history
+ * (#11732).
+ *
+ * `ActionSource` cannot answer this alone: the worktree card and the file
+ * browser both dispatch as `"context-menu"`, and every agent path — external
+ * MCP client or the in-app assistant, which drives the IDE through the same
+ * manifest — dispatches as `"agent"`. So a caller that knows which surface it
+ * is passes `explicit` and wins; only the unambiguous cases are inferred.
+ *
+ * Anything else resolves to `"unknown"` rather than being attributed to the
+ * most likely surface — a wrong label in the history is worse than no label,
+ * because the history is what a user re-runs from.
+ */
+export function resolveCopyTreeRunSource(
+  dispatchSource: ActionSource | undefined,
+  explicit?: CopyTreeRunSource
+): CopyTreeRunSource {
+  if (explicit) return explicit;
+  if (dispatchSource === "keybinding") return "shortcut";
+  if (dispatchSource === "agent") return "mcp";
+  return "unknown";
+}

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -848,9 +848,12 @@ export function FileBrowserPane({
       if (!sourceWorktreeId) return;
       // Literal path, not a pattern: scoping keeps the worktree's ignore rules
       // in play, so the folder yields what a whole-worktree copy would have.
-      void copyContextWithFeedback(sourceWorktreeId, "context-menu", {
-        scopePaths: [path],
-      });
+      void copyContextWithFeedback(
+        sourceWorktreeId,
+        "context-menu",
+        { scopePaths: [path] },
+        "file-browser"
+      );
     },
     [sourceWorktreeId]
   );

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -1279,7 +1279,10 @@ describe("folder context menu", () => {
     expect(copyContextWithFeedbackMock).toHaveBeenCalledWith(
       "wt-1",
       "context-menu",
-      expect.anything()
+      expect.anything(),
+      // The dispatch source cannot tell this apart from a worktree-card copy,
+      // so the pane names its own surface for the run history (#11732).
+      "file-browser"
     );
   });
 });

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -545,7 +545,15 @@ export class ActionService {
       // context provider) a run-scoped context carrying the dispatch source
       // so source-aware definitions (plugin synthetic actions) can avoid
       // double-confirming an agent dispatch the MCP bridge already gated.
-      const runContext: ActionContext = { ...context, dispatchSource: source };
+      const runContext: ActionContext = {
+        ...context,
+        dispatchSource: source,
+        // Stamped from the dispatch options for the same reason as
+        // `dispatchSource`: it is the caller's own claim about which surface it
+        // is, and a definition must not be able to read a stale one left on a
+        // shared context object.
+        copyTreeRunSource: options?.copyTreeRunSource,
+      };
       const result = await definition.run(validatedArgs, runContext);
       // Enforce the action's own result contract. Zod objects strip unknown
       // keys, so this is what makes the published projection the delivered one

--- a/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
@@ -1125,7 +1125,8 @@ describe("worktree action hardening", () => {
 
     expect(mocks.copyTreeClient.generateAndCopyFile).toHaveBeenCalledWith(
       "wt-1",
-      expect.objectContaining({ modified: true })
+      expect.objectContaining({ modified: true }),
+      "unknown"
     );
   });
 
@@ -1168,10 +1169,13 @@ describe("worktree action hardening", () => {
 
     const result = await copyTree.run({ format: "json" }, { focusedWorktreeId: "wt-2" } as never);
 
-    expect(mocks.copyTreeClient.generateAndCopyFile).toHaveBeenCalledWith("wt-2", {
-      format: "json",
-      modified: undefined,
-    });
+    expect(mocks.copyTreeClient.generateAndCopyFile).toHaveBeenCalledWith(
+      "wt-2",
+      { format: "json", modified: undefined },
+      // No dispatch source on this bare context, and the surface is not
+      // inferable from one — recorded as unknown rather than guessed (#11732).
+      "unknown"
+    );
     expect(result).toEqual({
       worktreeId: "wt-2",
       fileCount: 4,

--- a/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
@@ -194,20 +194,35 @@ describe("systemActions adversarial", () => {
     it("falls back to ctx.activeWorktreeId when worktreeId is omitted", async () => {
       const { run } = setupActions();
       await run("copyTree.generate", undefined, { activeWorktreeId: "wt-active" });
-      expect(copyTreeClientMock.generate).toHaveBeenCalledWith("wt-active", undefined, undefined);
+      expect(copyTreeClientMock.generate).toHaveBeenCalledWith(
+        "wt-active",
+        undefined,
+        undefined,
+        "unknown"
+      );
     });
 
     it("forwards options when provided", async () => {
       const { run } = setupActions();
       const options = { format: "xml" as const };
       await run("copyTree.generate", { options }, { activeWorktreeId: "wt-active" });
-      expect(copyTreeClientMock.generate).toHaveBeenCalledWith("wt-active", options, undefined);
+      expect(copyTreeClientMock.generate).toHaveBeenCalledWith(
+        "wt-active",
+        options,
+        undefined,
+        "unknown"
+      );
     });
 
     it("forwards the content opt-in so the head is only read when asked for", async () => {
       const { run } = setupActions();
       await run("copyTree.generate", { includeContent: true }, { activeWorktreeId: "wt-active" });
-      expect(copyTreeClientMock.generate).toHaveBeenCalledWith("wt-active", undefined, true);
+      expect(copyTreeClientMock.generate).toHaveBeenCalledWith(
+        "wt-active",
+        undefined,
+        true,
+        "unknown"
+      );
     });
 
     it("throws when worktreeId is omitted and no active worktree", async () => {
@@ -302,7 +317,11 @@ describe("systemActions adversarial", () => {
     it("falls back to ctx.activeWorktreeId when worktreeId is omitted", async () => {
       const { run } = setupActions();
       await run("copyTree.generateAndCopyFile", undefined, { activeWorktreeId: "wt-active" });
-      expect(copyTreeClientMock.generateAndCopyFile).toHaveBeenCalledWith("wt-active", undefined);
+      expect(copyTreeClientMock.generateAndCopyFile).toHaveBeenCalledWith(
+        "wt-active",
+        undefined,
+        "unknown"
+      );
     });
 
     it("returns the file handle without the bundle", async () => {
@@ -340,9 +359,11 @@ describe("systemActions adversarial", () => {
         { worktreePath: "/repo/landscape" },
         { dispatchSource: "agent", activeWorktreeId: "wt-active" }
       );
+      // An agent dispatch is recorded as an MCP-sourced run (#11732).
       expect(copyTreeClientMock.generateAndCopyFile).toHaveBeenCalledWith(
         "wt-landscape",
-        undefined
+        undefined,
+        "mcp"
       );
     });
 
@@ -361,7 +382,7 @@ describe("systemActions adversarial", () => {
         { worktreeId: "wt-1", options },
         { dispatchSource: "agent" }
       );
-      expect(copyTreeClientMock.generateAndCopyFile).toHaveBeenCalledWith("wt-1", options);
+      expect(copyTreeClientMock.generateAndCopyFile).toHaveBeenCalledWith("wt-1", options, "mcp");
 
       // And the selection SURVIVES the schema transform — `run()` is called
       // directly here, so the transform is otherwise never exercised. Asserting
@@ -546,7 +567,9 @@ describe("systemActions adversarial", () => {
       expect(copyTreeClientMock.injectToTerminal).toHaveBeenCalledWith(
         "t-1",
         "wt-active",
-        undefined
+        undefined,
+        undefined,
+        "unknown"
       );
     });
 
@@ -560,7 +583,9 @@ describe("systemActions adversarial", () => {
       expect(copyTreeClientMock.injectToTerminal).toHaveBeenCalledWith(
         "t-1",
         "wt-explicit",
-        undefined
+        undefined,
+        undefined,
+        "unknown"
       );
     });
 

--- a/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
@@ -655,7 +655,15 @@ describe("workflow.startWorkOnIssue", () => {
       "claude",
       expect.objectContaining({ worktreeId: "wt-new", cwd: "/repo/feature/issue-6609-add-tools" })
     );
-    expect(copyTreeClientMock.injectToTerminal).toHaveBeenCalledWith("term-1", "wt-new");
+    expect(copyTreeClientMock.injectToTerminal).toHaveBeenCalledWith(
+      "term-1",
+      "wt-new",
+      undefined,
+      undefined,
+      // Workflow creation is its own surface in the run history (#11732) — not
+      // a toolbar copy and not an agent tool call.
+      "workflow"
+    );
     expect(result.terminalId).toBe("term-1");
     expect(result.contextInjected).toBe(true);
     expect(result.recipeLaunched).toBe(false);

--- a/src/services/actions/definitions/systemActions.ts
+++ b/src/services/actions/definitions/systemActions.ts
@@ -13,6 +13,7 @@ import {
 import { z } from "zod";
 import { notify } from "@/lib/notify";
 import { formatCopyResultMessage } from "@/lib/formatCopyResult";
+import { resolveCopyTreeRunSource } from "@/lib/copyTreeRunSource";
 import {
   artifactClient,
   cliAvailabilityClient,
@@ -437,7 +438,8 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
         const result = await copyTreeClient.generate(
           requireWorktreeId(args, ctx),
           args?.options,
-          args?.includeContent
+          args?.includeContent,
+          resolveCopyTreeRunSource(ctx.dispatchSource, ctx.copyTreeRunSource)
         );
         throwOnCopyTreeFailure(result);
         const { filePath, outputBytes } = requireGeneratedFile(result);
@@ -507,7 +509,8 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
         requireExplicitWorktreeForAgentDispatch("copyTree.generateAndCopyFile", args, ctx);
         const result = await copyTreeClient.generateAndCopyFile(
           requireWorktreeId(args, ctx),
-          args?.options
+          args?.options,
+          resolveCopyTreeRunSource(ctx.dispatchSource, ctx.copyTreeRunSource)
         );
         throwOnCopyTreeFailure(result);
         const { filePath, outputBytes } = requireGeneratedFile(result);
@@ -587,7 +590,9 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
         const result = await copyTreeClient.injectToTerminal(
           terminalId,
           resolvedWorktreeId,
-          options
+          options,
+          undefined,
+          resolveCopyTreeRunSource(ctx.dispatchSource, ctx.copyTreeRunSource)
         );
         throwOnCopyTreeFailure(result);
         return {

--- a/src/services/actions/definitions/workflowCreationActions.ts
+++ b/src/services/actions/definitions/workflowCreationActions.ts
@@ -620,7 +620,13 @@ export function registerWorkflowCreationActions(
             // the same check useContextInjection makes. Without it every
             // resolved call reported success, which now matters: the flag is
             // published as structuredContent rather than buried in text.
-            const injection = await copyTreeClient.injectToTerminal(terminalId, worktreeId);
+            const injection = await copyTreeClient.injectToTerminal(
+              terminalId,
+              worktreeId,
+              undefined,
+              undefined,
+              "workflow"
+            );
             contextInjected = !injection?.error;
           } catch {
             // Best-effort — agent is launched; user can re-inject manually.

--- a/src/services/actions/definitions/worktreeContextActions.ts
+++ b/src/services/actions/definitions/worktreeContextActions.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import type { ActionContext } from "@shared/types/actions";
 import type { BuiltInRuntimeActionId } from "@shared/config/actionIds";
 import { copyTreeClient, systemClient } from "@/clients";
+import { resolveCopyTreeRunSource } from "@/lib/copyTreeRunSource";
 import { actionService } from "@/services/ActionService";
 import { getCurrentViewStore, getCurrentViewStoreOrNull } from "@/store/createWorktreeStore";
 import { useForgeProviderHealthStore } from "@/store/forgeProviderHealthStore";
@@ -336,12 +337,16 @@ export function registerWorktreeContextActions(
 
         const format = explicitFormat ?? DEFAULT_COPYTREE_FORMAT;
 
-        const result = await copyTreeClient.generateAndCopyFile(targetWorktreeId, {
-          format,
-          modified,
-          ...(includePaths && includePaths.length > 0 ? { includePaths } : {}),
-          ...(scopePaths && scopePaths.length > 0 ? { scopePaths } : {}),
-        });
+        const result = await copyTreeClient.generateAndCopyFile(
+          targetWorktreeId,
+          {
+            format,
+            modified,
+            ...(includePaths && includePaths.length > 0 ? { includePaths } : {}),
+            ...(scopePaths && scopePaths.length > 0 ? { scopePaths } : {}),
+          },
+          resolveCopyTreeRunSource(ctx.dispatchSource, ctx.copyTreeRunSource)
+        );
 
         if (result.error) {
           if (modified && result.error.includes("No valid files")) {
@@ -377,8 +382,14 @@ export function registerWorktreeContextActions(
           modified: z.boolean().optional(),
         })
         .optional(),
-      run: async (args) => {
-        const result = await actionService.dispatch("worktree.copyTree", args, { source: "user" });
+      run: async (args, ctx: ActionContext) => {
+        // The re-dispatch resets `source` to "user", which would otherwise
+        // erase that an agent called the alias — forward the resolved surface
+        // explicitly so the history records the real caller.
+        const result = await actionService.dispatch("worktree.copyTree", args, {
+          source: "user",
+          copyTreeRunSource: resolveCopyTreeRunSource(ctx.dispatchSource, ctx.copyTreeRunSource),
+        });
         if (!result.ok) {
           throw new Error(result.error.message);
         }

--- a/src/store/__tests__/copyTreeHistoryStore.test.ts
+++ b/src/store/__tests__/copyTreeHistoryStore.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CopyTreeHistoryRecord } from "@shared/types";
+
+function makeRecord(id: string): CopyTreeHistoryRecord {
+  return {
+    id,
+    dedupeKey: `key-${id}`,
+    name: id,
+    options: {},
+    source: "toolbar",
+    worktreeId: "wt-1",
+    stats: { fileCount: 1 },
+    createdAt: 0,
+    lastUsedAt: 0,
+    runCount: 1,
+  };
+}
+
+type Push = { projectId: string; records: CopyTreeHistoryRecord[] };
+
+let eventCallback: ((payload: Push) => void) | null = null;
+const getRecords = vi.fn<() => Promise<CopyTreeHistoryRecord[]>>();
+const eventsOn = vi.fn((_name: string, cb: (payload: Push) => void) => {
+  eventCallback = cb;
+  return () => {
+    eventCallback = null;
+  };
+});
+const logError = vi.fn();
+
+vi.mock("@/utils/logger", () => ({ logError: (...args: unknown[]) => logError(...args) }));
+
+(globalThis as { window?: unknown }).window = {
+  electron: {
+    copyTreeHistory: { getRecords },
+    events: { on: eventsOn },
+  },
+};
+
+// Imported after the window stub so the module's top-level references resolve.
+const { useCopyTreeHistoryStore, _resetCopyTreeHistoryStoreForTest } =
+  await import("../copyTreeHistoryStore.js");
+
+describe("copyTreeHistoryStore", () => {
+  beforeEach(() => {
+    getRecords.mockReset().mockResolvedValue([]);
+    eventsOn.mockClear();
+    logError.mockClear();
+    eventCallback = null;
+    _resetCopyTreeHistoryStoreForTest();
+  });
+
+  afterEach(() => {
+    _resetCopyTreeHistoryStoreForTest();
+  });
+
+  it("pulls a snapshot on init and clears the loading flag", async () => {
+    getRecords.mockResolvedValue([makeRecord("a")]);
+    useCopyTreeHistoryStore.getState().init();
+
+    await vi.waitFor(() => {
+      expect(useCopyTreeHistoryStore.getState().loading).toBe(false);
+    });
+    expect(useCopyTreeHistoryStore.getState().records.map((r) => r.id)).toEqual(["a"]);
+  });
+
+  it("is idempotent — repeated init subscribes only once", () => {
+    useCopyTreeHistoryStore.getState().init();
+    useCopyTreeHistoryStore.getState().init();
+    expect(eventsOn).toHaveBeenCalledTimes(1);
+    expect(getRecords).toHaveBeenCalledTimes(1);
+  });
+
+  it("subscribes before pulling, so a push during init is not missed", () => {
+    let subscribedBeforePull = false;
+    getRecords.mockImplementation(() => {
+      subscribedBeforePull = eventCallback !== null;
+      return Promise.resolve([]);
+    });
+
+    useCopyTreeHistoryStore.getState().init();
+    expect(subscribedBeforePull).toBe(true);
+  });
+
+  it("applies a pushed snapshot", async () => {
+    useCopyTreeHistoryStore.getState().init();
+    await vi.waitFor(() => expect(eventCallback).not.toBeNull());
+
+    eventCallback?.({ projectId: "p1", records: [makeRecord("pushed")] });
+
+    expect(useCopyTreeHistoryStore.getState().records.map((r) => r.id)).toEqual(["pushed"]);
+    expect(useCopyTreeHistoryStore.getState().loading).toBe(false);
+  });
+
+  it("does not let a slow pull overwrite a fresher push", async () => {
+    let resolvePull: (records: CopyTreeHistoryRecord[]) => void = () => {};
+    getRecords.mockReturnValue(
+      new Promise<CopyTreeHistoryRecord[]>((resolve) => {
+        resolvePull = resolve;
+      })
+    );
+
+    useCopyTreeHistoryStore.getState().init();
+    eventCallback?.({ projectId: "p1", records: [makeRecord("fresh")] });
+
+    resolvePull([makeRecord("stale")]);
+    await vi.waitFor(() => {
+      expect(useCopyTreeHistoryStore.getState().loading).toBe(false);
+    });
+
+    expect(useCopyTreeHistoryStore.getState().records.map((r) => r.id)).toEqual(["fresh"]);
+  });
+
+  it("clears loading and logs when the pull fails", async () => {
+    getRecords.mockRejectedValue(new Error("nope"));
+    useCopyTreeHistoryStore.getState().init();
+
+    await vi.waitFor(() => {
+      expect(useCopyTreeHistoryStore.getState().loading).toBe(false);
+    });
+    expect(useCopyTreeHistoryStore.getState().records).toEqual([]);
+    expect(logError).toHaveBeenCalled();
+  });
+
+  it("unsubscribes on reset so a later push cannot reach a stale store", () => {
+    useCopyTreeHistoryStore.getState().init();
+    _resetCopyTreeHistoryStoreForTest();
+    expect(eventCallback).toBeNull();
+    expect(useCopyTreeHistoryStore.getState().loading).toBe(true);
+    expect(useCopyTreeHistoryStore.getState().records).toEqual([]);
+  });
+});

--- a/src/store/copyTreeHistoryStore.ts
+++ b/src/store/copyTreeHistoryStore.ts
@@ -1,0 +1,61 @@
+import { create } from "zustand";
+import { logError } from "@/utils/logger";
+import type { CopyTreeHistoryRecord } from "@shared/types";
+
+/**
+ * Renderer mirror of the current project's copy-tree run history (#11732). The
+ * source of truth is the Main-process per-project file; this store is NOT
+ * persisted — it pulls a snapshot on first mount and stays current via the
+ * `copy-tree-history:update` push.
+ *
+ * Project scoping is enforced entirely in Main: unlike the process-global
+ * run-history ring, this snapshot is *sent* only to the views bound to its
+ * project rather than broadcast and filtered here, so a view can never be
+ * handed another project's history to discard. The `projectId` on the payload
+ * is what makes the event self-describing (event inspector, #11733's dropdown),
+ * not a filter this store depends on for correctness.
+ */
+interface CopyTreeHistoryState {
+  records: CopyTreeHistoryRecord[];
+  loading: boolean;
+  /** Idempotent: pulls the current snapshot and subscribes to live updates. */
+  init: () => void;
+}
+
+let initialized = false;
+let unsubscribe: (() => void) | null = null;
+// True once a push has populated the store. The pull-on-mount resolves
+// asynchronously and can land AFTER a fresher push — when that happens the
+// stale snapshot must not overwrite it.
+let receivedPush = false;
+
+export const useCopyTreeHistoryStore = create<CopyTreeHistoryState>((set) => ({
+  records: [],
+  loading: true,
+  init: () => {
+    if (initialized) return;
+    initialized = true;
+
+    unsubscribe = window.electron.events.on("copy-tree-history:update", ({ records }) => {
+      receivedPush = true;
+      set({ records, loading: false });
+    });
+
+    window.electron.copyTreeHistory
+      .getRecords()
+      .then((records) => set(receivedPush ? { loading: false } : { records, loading: false }))
+      .catch((err) => {
+        logError("Failed to load copy-tree history", err);
+        set({ loading: false });
+      });
+  },
+}));
+
+/** Test-only: reset the module-level init guard between cases. */
+export function _resetCopyTreeHistoryStoreForTest(): void {
+  unsubscribe?.();
+  unsubscribe = null;
+  initialized = false;
+  receivedPush = false;
+  useCopyTreeHistoryStore.setState({ records: [], loading: true });
+}


### PR DESCRIPTION
## Summary

- Adds the storage foundation for copy-tree run history: every copy-tree run (clipboard copy, bare generate, terminal injection) is now recorded per project so a recent run can be re-run exactly.
- This is the foundation for two follow-up issues: a recents dropdown in the toolbar (#11733) and named MCP copy trees (#11734). Neither UI piece is in this PR, just the storage, concurrency, dedupe, and IPC plumbing.

Resolves #11732

## Design decisions

**Storage.** Each project gets a `copy-tree-history.json` file under `userData/projects/<id>/`, following the existing `ProjectFileStore` pattern: schema-versioned envelope, atomic write, quarantine-by-rename on corruption. This is deliberately not the run-history ring from #9949, that store is process-global with no project column, so it's the wrong storage engine despite an issue comment suggesting it.

**Concurrency.** Every read-modify-write goes through a per-project keyed-tail queue. Without it, two runs completing in the same tick would both read the pre-write snapshot and one would silently lose the other's dedupe bump. Reads take a queue turn too, because reading quarantines a damaged file: an unqueued reader racing an append could both try to rename it, and the loser gets `ENOENT` and drops a completed run.

**Dedupe.** SHA-256 over the canonicalized runtime options only. `filter` and `includePaths` fold into one selection set, because `CopyTreeService.mergeSelectionPatterns` unions them into the SDK's single filter and neither is back-filled from project settings, so hashing them apart would file one run under two entries. The name lives outside the hash key so renaming an entry can't fork the history.

**Options are stored pre-merge**, so a later re-run picks up whatever project settings say at that later time, rather than replaying a frozen configuration.

**Cap and eviction.** 20 entries per project, evicted by least-recently-used rather than insertion order, since a "Full context" entry re-run daily shouldn't fall off just because it was first. Timestamps are clamped to the newest stored one so a backwards clock can't evict the run that just happened.

**Source attribution.** A new optional field threaded through the three IPC payloads and their UI call sites. `ActionContext.dispatchSource` doesn't work for this: the worktree card and file browser both dispatch as `context-menu`, and MCP and the in-app assistant both dispatch as `agent`. The field rides on `ActionContext` rather than any action's `argsSchema`, specifically so an agent can't label its own runs as a user's click.

**Push scoping.** History snapshots go only to views bound to the owning project via `getWebContentsForProject`, never `broadcastToProjectRenderers`, which falls back to a global broadcast when no project views are registered. That's the same leak shape as #11125.

## Not covered

- `scopePaths` aren't path-normalized, so `src/a` and `src/a/` file as two separate entries. Normalizing literal paths changes what reaches generation, so that belongs with the picker work.
- The history reader returns an empty list both when there's no history and when the history file is unreadable. A discriminated state for that is the toolbar dropdown's concern (#11733).

## Testing

994 tests across 31 files pass locally, including 7 new suites: the pure canonicalize/naming helpers, the dedupe/LRU reducer, the codec, per-project store concurrency and quarantine behavior, the project-scoped push service, the read IPC namespace, and the source resolver.

Typecheck is clean across renderer, electron, and preload. All six IPC and API guard scripts pass, and the lint ratchet passes.
