### PR TITLE
fix(plugins): resolve a plugin dir before publishing its panel contribution

### DIFF
--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -347,17 +347,40 @@ describe("registerPluginHandlers", () => {
   it("PLUGIN_ACTIVATE_FOR_VIEW resolves on success and throws the cause on failure (#10618)", async () => {
     const handler = getHandler("plugin:activate-for-view");
 
-    // Success: the handler resolves void (#6020 — IPC handlers return void on
-    // success rather than an { ok } envelope) so the renderer proceeds to import.
+    // Success: the handler resolves undefined (#6020 — IPC handlers return void
+    // on success rather than an { ok } envelope) so the renderer proceeds to
+    // import. A plain activation must NOT ask for a recovery generation (#11728)
+    // — that would mint a second module namespace on every first mount.
     mockActivatePluginForView.mockResolvedValueOnce({ ok: true });
     await expect(handler({}, "acme.demo.viewer")).resolves.toBeUndefined();
-    expect(mockActivatePluginForView).toHaveBeenCalledWith("acme.demo.viewer");
+    expect(mockActivatePluginForView).toHaveBeenCalledWith("acme.demo.viewer", false);
 
     // Failure: the handler throws so the IPC call rejects and the renderer's
     // PluginViewHost surfaces the real activation cause. The thrown message
     // carries the underlying error text.
     mockActivatePluginForView.mockResolvedValueOnce({ ok: false, error: "activate-boom" });
     await expect(handler({}, "acme.demo.viewer")).rejects.toThrow(/activate-boom/);
+  });
+
+  it("PLUGIN_ACTIVATE_FOR_VIEW forwards a recovery request and returns the minted path (#11728)", async () => {
+    const handler = getHandler("plugin:activate-for-view");
+
+    // The renderer's retry-after-import-failure path. Only main may build the
+    // replacement URL, so the handler's job is to forward the request and hand
+    // back whatever the service minted — unchanged.
+    mockActivatePluginForView.mockResolvedValueOnce({
+      ok: true,
+      recoveryComponentPath: "plugin://acme.demo/__dtv-9/dist/view.js",
+    });
+    await expect(handler({}, "acme.demo.viewer", true)).resolves.toBe(
+      "plugin://acme.demo/__dtv-9/dist/view.js"
+    );
+    expect(mockActivatePluginForView).toHaveBeenCalledWith("acme.demo.viewer", true);
+
+    // A recovery request the service declines (PTY panel, view-less kind) still
+    // resolves — the renderer falls back to the path it already has.
+    mockActivatePluginForView.mockResolvedValueOnce({ ok: true });
+    await expect(handler({}, "acme.demo.viewer", true)).resolves.toBeUndefined();
   });
 
   it("PLUGIN_INSTALL_FROM_FILE returns cancelled when the picker is dismissed", async () => {

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -353,7 +353,12 @@ describe("registerPluginHandlers", () => {
     // — that would mint a second module namespace on every first mount.
     mockActivatePluginForView.mockResolvedValueOnce({ ok: true });
     await expect(handler({}, "acme.demo.viewer")).resolves.toBeUndefined();
-    expect(mockActivatePluginForView).toHaveBeenCalledWith("acme.demo.viewer", false);
+    // The behavioral half — the kind is forwarded and recovery is NOT requested.
+    // Asserted as "falsy" rather than literal `false` so normalizing to
+    // `undefined` stays green: what matters is that a first mount can't burn a
+    // second module namespace, not which falsy value expresses that.
+    expect(mockActivatePluginForView.mock.calls[0]![0]).toBe("acme.demo.viewer");
+    expect(mockActivatePluginForView.mock.calls[0]![1]).toBeFalsy();
 
     // Failure: the handler throws so the IPC call rejects and the renderer's
     // PluginViewHost surfaces the real activation cause. The thrown message
@@ -381,6 +386,13 @@ describe("registerPluginHandlers", () => {
     // resolves — the renderer falls back to the path it already has.
     mockActivatePluginForView.mockResolvedValueOnce({ ok: true });
     await expect(handler({}, "acme.demo.viewer", true)).resolves.toBeUndefined();
+
+    // Only a real `true` requests recovery. A truthy non-boolean arriving over
+    // IPC must not mint a namespace, so the flag is compared by identity rather
+    // than coerced.
+    mockActivatePluginForView.mockResolvedValueOnce({ ok: true });
+    await handler({}, "acme.demo.viewer", "yes");
+    expect(mockActivatePluginForView.mock.calls.at(-1)![1]).toBe(false);
   });
 
   it("PLUGIN_INSTALL_FROM_FILE returns cancelled when the picker is dismissed", async () => {

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -197,7 +197,14 @@ async function handleInstall(
 ): Promise<PluginInstallResult> {
   const invalid = await validateDntrArchivePath(archivePath);
   if (invalid) return invalid;
-  return (await getPluginService()).installPlugin(archivePath, opts);
+  const service = await getPluginService();
+  // Same init gate as `handleInstallFromPath` (#11280): `initialize()` assumes no
+  // install overlaps it — its sweep deletes staging dirs and the blocklist is
+  // still unset. It also keeps the #11728 addressability invariant intact, since
+  // an install that beat the deferred task here would publish panel kinds while
+  // the `plugin://` resolver was still the 404-everything placeholder.
+  await service.waitForInit();
+  return service.installPlugin(archivePath, opts);
 }
 
 // Job ids are renderer-minted UUIDs used only as a correlation key. Bound the
@@ -507,7 +514,10 @@ export async function handleInstallFromUrl(
       return failed("fetch_failed", "Couldn't download the plugin from that URL.");
     }
 
-    return (await getPluginService()).installPlugin(tempPath, {
+    const service = await getPluginService();
+    // See `handleInstall` — the same init gate, for the same two reasons.
+    await service.waitForInit();
+    return service.installPlugin(tempPath, {
       source: "url",
       originalUrl: trimmed,
       ...(jobId === undefined ? {} : { jobId }),

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -666,13 +666,23 @@ async function handlePanelKindsGet(): Promise<PanelKindConfig[]> {
  * {@link AppError} (#6020 — IPC handlers throw instead of returning an `{ ok }`
  * envelope) so the IPC call rejects and `PluginViewHost` surfaces the real
  * activation cause through its ErrorBoundary BEFORE importing the module (#10618),
- * instead of failing later with a generic import timeout. Resolves (void) once
- * the owning plugin is already activated, or when the kind id is unknown.
+ * instead of failing later with a generic import timeout. Resolves once the
+ * owning plugin is already activated, or when the kind id is unknown.
+ *
+ * `requestRecoveryPath` asks main to mint a replacement `plugin://` URL on a
+ * fresh view generation, for the case where the renderer's previous import of
+ * this view already failed (#11728) — that specifier is permanently poisoned in
+ * the module map, so recovery needs a URL V8 has never seen. Returns the
+ * main-built path, or `undefined` when none applies (no recovery requested,
+ * unknown kind, PTY panel, or no matching view contribution).
  */
-async function handleActivateForView(panelKindId: string): Promise<void> {
+async function handleActivateForView(
+  panelKindId: string,
+  requestRecoveryPath?: boolean
+): Promise<string | undefined> {
   const result: PluginActivationResult = await (
     await getPluginService()
-  ).activatePluginForView(panelKindId);
+  ).activatePluginForView(panelKindId, requestRecoveryPath === true);
   if (!result.ok) {
     throw new AppError({
       code: "PLUGIN_ACTIVATION_FAILED",
@@ -680,6 +690,7 @@ async function handleActivateForView(panelKindId: string): Promise<void> {
       userMessage: result.error,
     });
   }
+  return result.recoveryComponentPath;
 }
 
 /**

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -682,9 +682,12 @@ if (!gotTheLock) {
       // `createWindow()` so `registerProtocolsForSession` wires per-session
       // handlers; the deferred `plugin-service` task later calls
       // `setPluginDirResolver()` to point it at the real `getPluginDir` and
-      // drains queued `.dntr` paths via `activateOpenFileInstaller`. plugin://
-      // requests only arrive after the renderer mounts and plugins activate —
-      // well after first paint — so the placeholder window is never observed.
+      // drains queued `.dntr` paths via `activateOpenFileInstaller`. The
+      // placeholder is unobservable because a renderer can only learn a
+      // `plugin://` module URL from a panel-kind contribution, and those are
+      // published by PluginService — which installs the live resolver as its
+      // first act, before any plugin loads (#11728). Keep that ordering: a 404
+      // served here is permanent for that specifier in the renderer's module map.
       registerPluginProtocol(() => undefined);
       // Wire the `daintree://` deep-link path (#9559): take over live macOS
       // `open-url` events and drain any cold-launch URL (queued `open-url` on

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -1205,6 +1205,11 @@ export class PluginService {
       dir: pluginDir,
       loadedAt: Date.now(),
       isBuiltin: opts.isBuiltin,
+      // One generation per load, shared by every view this plugin contributes,
+      // so a reload swaps the whole plugin's view modules together (#11301).
+      // Held on the plugin rather than a local so `activatePluginForView` can
+      // mint a sibling recovery generation later (#11728).
+      viewGeneration: allocatePluginViewGeneration(),
     };
 
     if (manifest.main) {
@@ -1224,10 +1229,12 @@ export class PluginService {
     // `devMode` to the provenance record so `listPlugins()` surfaces the "DEV"
     // badge (#9290). A dev plugin needs a `main` entry to run in the worker.
     //
-    // Synchronous `existsSync` on purpose: an `await` here would split the
-    // synchronous critical section between the duplicate-name check above and
-    // the `this.plugins.set` below, letting two concurrent loads of the same
-    // name both slip past dedup.
+    // Synchronous `existsSync` on purpose: it keeps this step from adding
+    // another suspension point between the duplicate-name check above and the
+    // `this.plugins.set` below. That stretch is NOT a critical section though —
+    // `await registerPluginSkills(...)` further down already splits it, so two
+    // concurrent loads of the same name can still both pass dedup. Tracked
+    // separately; closing it needs an explicit name reservation at the check.
     if (!opts.isBuiltin) {
       const isDev = existsSync(path.join(pluginDir, DEV_MARKER_FILENAME));
       if (isDev && plugin.resolvedMain) {
@@ -1245,71 +1252,6 @@ export class PluginService {
           );
         }
       }
-    }
-
-    // Index views by bare id so the panels loop can attach `componentPath` in
-    // a single registerPanelKind pass (#9229). View ids are pre-namespace; the
-    // runtime panel id is `${manifest.name}.${panel.id}`.
-    // One generation per load, shared by every view this plugin contributes, so
-    // a reload swaps the whole plugin's view modules together (#11301). Reading
-    // it here rather than per-panel also keeps a plugin's chunks in one virtual
-    // namespace, which is what lets relative imports inherit the generation.
-    const viewGeneration = allocatePluginViewGeneration();
-    const viewsByBareId = new Map<string, ViewContribution>();
-    const unmatchedViewIds = new Set<string>();
-    for (const view of manifest.contributes.views) {
-      // `location` is narrowed to `"panel"` and `componentPath` safety is
-      // enforced by `ViewContributionSchema` at manifest parse — an unsupported
-      // location or unsafe path fails validation before we reach this loop.
-      if (viewsByBareId.has(view.id)) {
-        // Two entries with the same bare id — last would silently overwrite
-        // earlier. Surface the authoring mistake; keep the first to make the
-        // outcome deterministic.
-        console.warn(
-          `[PluginService] Plugin "${manifest.name}": views has duplicate entries for id "${view.id}"; keeping the first occurrence`
-        );
-        continue;
-      }
-      viewsByBareId.set(view.id, view);
-      unmatchedViewIds.add(view.id);
-    }
-
-    for (const panel of manifest.contributes.panels) {
-      const panelId = `${manifest.name}.${panel.id}`;
-      const view = viewsByBareId.get(panel.id);
-      if (view) unmatchedViewIds.delete(panel.id);
-      registerPanelKind({
-        id: panelId,
-        name: panel.name,
-        iconId: panel.iconId,
-        color: panel.color,
-        hasPty: panel.hasPty,
-        canRestart: panel.canRestart,
-        canConvert: panel.canConvert,
-        showInPalette: panel.showInPalette,
-        // Dockable by default; only forward an explicit opt-out (or opt-in) so
-        // absence stays `undefined` and `panelKindIsDockable` applies the
-        // default. #11332.
-        ...(panel.dockable !== undefined ? { dockable: panel.dockable } : {}),
-        extensionId: manifest.name,
-        ...(view && !panel.hasPty
-          ? { componentPath: buildPluginViewUrl(manifest.name, view.componentPath, viewGeneration) }
-          : {}),
-      });
-      if (view && panel.hasPty) {
-        // A PTY panel with a matching view is contradictory — the view module
-        // would never render because TerminalPane owns the surface. Surface the
-        // collision rather than silently dropping the view.
-        console.warn(
-          `[PluginService] Plugin "${manifest.name}": views entry "${view.id}" matches a panel with hasPty=true; the view will be ignored because PTY panels are rendered by TerminalPane`
-        );
-      }
-    }
-
-    for (const orphanId of unmatchedViewIds) {
-      console.warn(
-        `[PluginService] Plugin "${manifest.name}": views entry "${orphanId}" has no matching contributes.panels entry and will be ignored`
-      );
     }
 
     for (const btn of manifest.contributes.toolbarButtons) {
@@ -1403,6 +1345,86 @@ export class PluginService {
     // inside the plugin's own init, and registerHandler/registerPluginAction
     // throw "Unknown plugin" even for a correctly loaded plugin.
     this.plugins.set(manifest.name, plugin);
+
+    // Panel kinds are published only AFTER the map commit above, with no await
+    // in between (#11728). `registerPanelKind` is what makes a panel
+    // addressable — it carries the `plugin://` `componentPath` and schedules the
+    // `plugin:panel-kinds-changed` broadcast — while `getPluginDir` (the
+    // protocol handler's resolver) reads `this.plugins`. Publishing first, as
+    // this block used to, handed the renderer a URL that the protocol could not
+    // yet resolve; any plugin with an await before the commit (a `skills`
+    // contribution alone was enough) 404'd its own view module, and a rejected
+    // dynamic import is permanent for that specifier. The map commit is now the
+    // single addressability gate, so this ordering is the invariant, not an
+    // incidental arrangement.
+    //
+    // Index views by bare id so the panels loop can attach `componentPath` in
+    // a single registerPanelKind pass (#9229). View ids are pre-namespace; the
+    // runtime panel id is `${manifest.name}.${panel.id}`. The generation lives
+    // on `plugin` (allocated at construction) so every view shares one virtual
+    // namespace, which is what lets relative imports inherit it (#11301).
+    const viewsByBareId = new Map<string, ViewContribution>();
+    const unmatchedViewIds = new Set<string>();
+    for (const view of manifest.contributes.views) {
+      // `location` is narrowed to `"panel"` and `componentPath` safety is
+      // enforced by `ViewContributionSchema` at manifest parse — an unsupported
+      // location or unsafe path fails validation before we reach this loop.
+      if (viewsByBareId.has(view.id)) {
+        // Two entries with the same bare id — last would silently overwrite
+        // earlier. Surface the authoring mistake; keep the first to make the
+        // outcome deterministic.
+        console.warn(
+          `[PluginService] Plugin "${manifest.name}": views has duplicate entries for id "${view.id}"; keeping the first occurrence`
+        );
+        continue;
+      }
+      viewsByBareId.set(view.id, view);
+      unmatchedViewIds.add(view.id);
+    }
+
+    for (const panel of manifest.contributes.panels) {
+      const panelId = `${manifest.name}.${panel.id}`;
+      const view = viewsByBareId.get(panel.id);
+      if (view) unmatchedViewIds.delete(panel.id);
+      registerPanelKind({
+        id: panelId,
+        name: panel.name,
+        iconId: panel.iconId,
+        color: panel.color,
+        hasPty: panel.hasPty,
+        canRestart: panel.canRestart,
+        canConvert: panel.canConvert,
+        showInPalette: panel.showInPalette,
+        // Dockable by default; only forward an explicit opt-out (or opt-in) so
+        // absence stays `undefined` and `panelKindIsDockable` applies the
+        // default. #11332.
+        ...(panel.dockable !== undefined ? { dockable: panel.dockable } : {}),
+        extensionId: manifest.name,
+        ...(view && !panel.hasPty
+          ? {
+              componentPath: buildPluginViewUrl(
+                manifest.name,
+                view.componentPath,
+                plugin.viewGeneration
+              ),
+            }
+          : {}),
+      });
+      if (view && panel.hasPty) {
+        // A PTY panel with a matching view is contradictory — the view module
+        // would never render because TerminalPane owns the surface. Surface the
+        // collision rather than silently dropping the view.
+        console.warn(
+          `[PluginService] Plugin "${manifest.name}": views entry "${view.id}" matches a panel with hasPty=true; the view will be ignored because PTY panels are rendered by TerminalPane`
+        );
+      }
+    }
+
+    for (const orphanId of unmatchedViewIds) {
+      console.warn(
+        `[PluginService] Plugin "${manifest.name}": views entry "${orphanId}" has no matching contributes.panels entry and will be ignored`
+      );
+    }
 
     // Plugins without a `main` entry contribute no executable code — the
     // provenance record reflects a clean load immediately. Plugins with a
@@ -2004,8 +2026,21 @@ export class PluginService {
    * `{ ok: true }` here and falls through to the renderer's generic import
    * error. Built-ins are app-bundled trusted code where this is rare; surfacing
    * it would need a separate in-memory built-in load-error map.
+   *
+   * `requestRecoveryPath` is the renderer's "my import of this view's module
+   * failed, give me a URL V8 hasn't seen" request (#11728). A rejected dynamic
+   * import is permanent for its specifier, so re-importing the published path
+   * can never recover; only a fresh generation segment can. The replacement URL
+   * is always built HERE from the loaded manifest — the renderer never supplies
+   * a path, and never appends its own cache-buster (which would grow the module
+   * map without bound). The generation is minted at most once per plugin load
+   * and shared by every view the plugin contributes, so a plugin occupies two
+   * namespaces at worst no matter how many times the user retries.
    */
-  async activatePluginForView(panelKindId: string): Promise<PluginActivationResult> {
+  async activatePluginForView(
+    panelKindId: string,
+    requestRecoveryPath = false
+  ): Promise<PluginActivationResult> {
     if (typeof panelKindId !== "string" || panelKindId.length === 0) return { ok: true };
     for (const [pluginId, plugin] of this.plugins) {
       for (const panel of plugin.manifest.contributes.panels) {
@@ -2015,7 +2050,25 @@ export class PluginService {
           if (loadError) {
             return { ok: false, error: loadError.message, stack: loadError.stack };
           }
-          return { ok: true };
+          if (!requestRecoveryPath) return { ok: true };
+          // Re-read through the map: `activatePlugin` awaited above, so an
+          // unload/disable in that window must not mint a generation onto a
+          // detached plugin object the protocol will no longer resolve.
+          const live = this.plugins.get(pluginId);
+          if (!live || live !== plugin) return { ok: true };
+          const view = panel.hasPty
+            ? undefined
+            : live.manifest.contributes.views.find((v) => v.id === panel.id);
+          if (!view) return { ok: true };
+          live.recoveryViewGeneration ??= allocatePluginViewGeneration();
+          return {
+            ok: true,
+            recoveryComponentPath: buildPluginViewUrl(
+              pluginId,
+              view.componentPath,
+              live.recoveryViewGeneration
+            ),
+          };
         }
       }
     }

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -132,6 +132,7 @@ import type { PluginIpcContext } from "../../../shared/types/plugin.js";
 import {
   clearPanelKindRegistry,
   getPanelKindConfig,
+  onPanelKindRegistered,
 } from "../../../shared/config/panelKindRegistry.js";
 import {
   clearToolbarButtonRegistry,
@@ -296,6 +297,76 @@ describe("PluginService integration — panel contributions", () => {
       showInPalette: true,
       extensionId: "acme.panel-plugin",
     });
+  });
+
+  it("makes the plugin dir plugin://-resolvable before publishing an addressable panel (#11728)", async () => {
+    // The invariant: at the instant a panel kind carrying a `componentPath` is
+    // published, `getPluginDir` — the resolver the `plugin://` protocol handler
+    // calls — must already answer for that plugin. Publishing first handed the
+    // renderer a URL the protocol could not resolve; it 404'd, and a rejected
+    // dynamic import is permanent for that specifier, so the panel stayed broken
+    // until a full window reload.
+    //
+    // A `skills` contribution is what made this reliably reproducible: its
+    // `await` sat between the old publication point and the plugins-map commit
+    // that `getPluginDir` reads. The fixture declares one so the await is real.
+    const dir = await writePlugin("acme.gated-view", {
+      name: "acme.gated-view",
+      version: "1.0.0",
+      contributes: {
+        panels: [{ id: "viewer", name: "Viewer", iconId: "eye", color: "#0af" }],
+        views: [{ id: "viewer", location: "panel", componentPath: "./dist/view.js" }],
+        skills: [{ id: "s", name: "S", path: "./skills/s.md", triggers: ["s"] }],
+      },
+    });
+    await fs.mkdir(path.join(dir, "skills"), { recursive: true });
+    await fs.writeFile(
+      path.join(dir, "skills", "s.md"),
+      "---\ndescription: d\n---\n\nbody\n",
+      "utf8"
+    );
+
+    // A second plugin so the scan's `Promise.allSettled` fan-out is real: the
+    // skills-bearing plugin above suspends mid-load while this one runs to
+    // completion, which is exactly the interleaving that made the bug show up on
+    // real installs rather than as a rare flake.
+    const plainDir = await writePlugin("acme.plain-view", {
+      name: "acme.plain-view",
+      version: "1.0.0",
+      contributes: {
+        panels: [{ id: "viewer", name: "Viewer", iconId: "eye", color: "#fa0" }],
+        views: [{ id: "viewer", location: "panel", componentPath: "./dist/view.js" }],
+      },
+    });
+
+    const service = new PluginService(tmpDir, "0.0.0");
+
+    // Recorded synchronously inside the registration callback — the same turn the
+    // broadcast is scheduled on, which is what the renderer ultimately reads.
+    // Asserting after initialize() would prove nothing: by then everything is in
+    // the map regardless of the order it got there.
+    const observed: Array<{ id: string; resolvedDir: string | undefined }> = [];
+    const unsubscribe = onPanelKindRegistered((config) => {
+      if (!config.componentPath || !config.extensionId) return;
+      observed.push({ id: config.id, resolvedDir: service.getPluginDir(config.extensionId) });
+    });
+
+    try {
+      await service.initialize();
+    } finally {
+      unsubscribe();
+    }
+
+    // Every addressable panel, not just the first: one plugin getting the order
+    // right while a concurrently-loading sibling does not is the actual failure.
+    expect(observed.map((o) => o.id).sort()).toEqual([
+      "acme.gated-view.viewer",
+      "acme.plain-view.viewer",
+    ]);
+    // Before the fix these were `undefined` — the panel was published while the
+    // plugin was still absent from the map `getPluginDir` reads.
+    expect(observed.find((o) => o.id === "acme.gated-view.viewer")!.resolvedDir).toBe(dir);
+    expect(observed.find((o) => o.id === "acme.plain-view.viewer")!.resolvedDir).toBe(plainDir);
   });
 
   it("registers multiple panels from one plugin with full config per panel", async () => {

--- a/electron/services/__tests__/PluginService.provenanceAndActivation.test.ts
+++ b/electron/services/__tests__/PluginService.provenanceAndActivation.test.ts
@@ -772,6 +772,59 @@ describe("Deferred activation — activatePlugin", () => {
     }
   });
 
+  it("commits the plugin to the map before publishing an addressable panel (#11728)", async () => {
+    // The core invariant, asserted in a suite the PR gate actually runs — the
+    // real-registry version of this lives in PluginService.integration.test.ts,
+    // which the default vitest config excludes.
+    //
+    // `registerPanelKind` IS the publication point: it carries the `plugin://`
+    // componentPath and schedules the broadcast. Observing `getPluginDir` from
+    // inside the mock therefore samples the exact instant the renderer becomes
+    // able to request that module. Checking after `initialize()` would prove
+    // nothing — by then everything is in the map regardless of ordering.
+    //
+    // The fixture contributes a skill because its `await` is what used to sit
+    // between publication and the map commit.
+    const pluginDir = path.join(tmpDir, "view-order");
+    await fs.mkdir(path.join(pluginDir, "skills"), { recursive: true });
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "acme.view-order",
+        version: "1.0.0",
+        contributes: {
+          panels: [{ id: "viewer", name: "Viewer", iconId: "eye", color: "#123" }],
+          views: [{ id: "viewer", componentPath: "view.mjs", location: "panel" }],
+          skills: [{ id: "s", name: "S", path: "./skills/s.md", triggers: ["s"] }],
+        },
+      })
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "skills", "s.md"),
+      "---\ndescription: d\n---\n\nbody\n",
+      "utf8"
+    );
+
+    const service = new PluginService(tmpDir);
+    const observed: Array<{ id: string; resolvedDir: string | undefined }> = [];
+    vi.mocked(registerPanelKind).mockImplementation((config) => {
+      if (!config.componentPath || !config.extensionId) return;
+      observed.push({ id: config.id, resolvedDir: service.getPluginDir(config.extensionId) });
+    });
+
+    try {
+      await service.initialize();
+    } finally {
+      vi.mocked(registerPanelKind).mockReset();
+    }
+
+    expect(observed).toHaveLength(1);
+    expect(observed[0]!.id).toBe("acme.view-order.viewer");
+    // Before the fix this was `undefined`: the panel was published while the
+    // plugin was still absent from the map `getPluginDir` reads.
+    expect(observed[0]!.resolvedDir).toBe(pluginDir);
+  });
+
   it("activatePluginForView mints one shared recovery view generation per load (#11728)", async () => {
     const pluginDir = path.join(tmpDir, "view-recover");
     await fs.mkdir(pluginDir);
@@ -819,10 +872,17 @@ describe("Deferred activation — activatePlugin", () => {
     const second = await service.activatePluginForView("acme.view-recover.two", true);
     const third = await service.activatePluginForView("acme.view-recover.one", true);
 
-    const genOf = (url: string): number | null =>
-      stripPluginViewGeneration(new URL(url).pathname.slice(1))?.generation ?? null;
-    const fileOf = (url: string): string =>
-      stripPluginViewGeneration(new URL(url).pathname.slice(1))?.path ?? "";
+    // Parse rather than string-match, so the assertions below are about URL
+    // structure (host, file, generation) instead of a formatting literal.
+    const parse = (url: string): { host: string; file: string; generation: number | null } => {
+      const parsed = new URL(url);
+      const stripped = stripPluginViewGeneration(parsed.pathname.slice(1));
+      return {
+        host: parsed.hostname,
+        file: stripped?.path ?? "",
+        generation: stripped?.generation ?? null,
+      };
+    };
 
     const recoveredOne = (first as { recoveryComponentPath?: string }).recoveryComponentPath;
     const recoveredTwo = (second as { recoveryComponentPath?: string }).recoveryComponentPath;
@@ -830,15 +890,32 @@ describe("Deferred activation — activatePlugin", () => {
     expect(recoveredOne).toBeDefined();
     expect(recoveredTwo).toBeDefined();
 
-    // A URL V8 has never seen — that is the entire point, since the module map
-    // keys the failure by specifier and never evicts it.
-    expect(genOf(recoveredOne!)).not.toBe(genOf(primaryOne!));
-    // ...but the same file behind it: only the virtual namespace changed.
-    expect(fileOf(recoveredOne!)).toBe(fileOf(primaryOne!));
+    const one = parse(recoveredOne!);
+    const two = parse(recoveredTwo!);
+    const primary = parse(primaryOne!);
+    const primaryB = parse(primaryTwo!);
+
+    // Both really carry a generation. Without this, a recovery URL that dropped
+    // the segment entirely would satisfy the "differs from primary" check below
+    // on `null`, and the test would bless a URL that recovers nothing.
+    expect(typeof one.generation).toBe("number");
+    expect(typeof two.generation).toBe("number");
+
+    // A URL V8 has never seen — the entire point, since the module map keys the
+    // failure by specifier and never evicts it.
+    expect(one.generation).not.toBe(primary.generation);
+    // ...addressing the same plugin and the same file behind it: only the
+    // virtual namespace changed. Without the host/file checks, returning another
+    // plugin's URL — or panel `one`'s module for panel `two` — would pass.
+    expect(one.host).toBe(primary.host);
+    expect(one.file).toBe(primary.file);
+    expect(two.host).toBe(primaryB.host);
+    expect(two.file).toBe(primaryB.file);
+    expect(one.file).not.toBe(two.file);
 
     // One generation for the whole plugin, so a reload still swaps every view
     // together and relative imports keep resolving within one namespace.
-    expect(genOf(recoveredTwo!)).toBe(genOf(recoveredOne!));
+    expect(two.generation).toBe(one.generation);
     // Bounded: retrying again reuses it instead of minting a third namespace.
     expect(recoveredAgain).toBe(recoveredOne);
 

--- a/electron/services/__tests__/PluginService.provenanceAndActivation.test.ts
+++ b/electron/services/__tests__/PluginService.provenanceAndActivation.test.ts
@@ -215,6 +215,8 @@ vi.mock("../plugin/PluginDevWorkerMainBridge.js", () => ({
 import { PluginService } from "../PluginService.js";
 import { getPluginManifestSchema } from "../../schemas/plugin.js";
 import { type PluginIpcContext } from "../../../shared/types/plugin.js";
+import { registerPanelKind } from "../../../shared/config/panelKindRegistry.js";
+import { stripPluginViewGeneration } from "../../../shared/utils/pluginViewUrl.js";
 
 function makeCtx(pluginId: string, overrides: Partial<PluginIpcContext> = {}): PluginIpcContext {
   return {
@@ -768,6 +770,82 @@ describe("Deferred activation — activatePlugin", () => {
     } finally {
       delete (globalThis as Record<string, unknown>).__viewOwnerActivated;
     }
+  });
+
+  it("activatePluginForView mints one shared recovery view generation per load (#11728)", async () => {
+    const pluginDir = path.join(tmpDir, "view-recover");
+    await fs.mkdir(pluginDir);
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "acme.view-recover",
+        version: "1.0.0",
+        contributes: {
+          panels: [
+            { id: "one", name: "One", iconId: "eye", color: "#111" },
+            { id: "two", name: "Two", iconId: "pen", color: "#222" },
+            { id: "term", name: "Term", iconId: "terminal", color: "#333", hasPty: true },
+          ],
+          views: [
+            { id: "one", componentPath: "one.mjs", location: "panel" },
+            { id: "two", componentPath: "two.mjs", location: "panel" },
+          ],
+        },
+      })
+    );
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    // The paths actually handed to the renderer at load, read back off the
+    // registry call rather than reconstructed — reconstructing them here would
+    // just restate the implementation.
+    const published = new Map<string, string>();
+    for (const [config] of vi.mocked(registerPanelKind).mock.calls) {
+      if (config.componentPath) published.set(config.id, config.componentPath);
+    }
+    const primaryOne = published.get("acme.view-recover.one");
+    const primaryTwo = published.get("acme.view-recover.two");
+    expect(primaryOne).toBeDefined();
+    expect(primaryTwo).toBeDefined();
+
+    // No recovery requested → nothing minted. A first mount must not burn a
+    // second module namespace.
+    await expect(service.activatePluginForView("acme.view-recover.one")).resolves.toEqual({
+      ok: true,
+    });
+
+    const first = await service.activatePluginForView("acme.view-recover.one", true);
+    const second = await service.activatePluginForView("acme.view-recover.two", true);
+    const third = await service.activatePluginForView("acme.view-recover.one", true);
+
+    const genOf = (url: string): number | null =>
+      stripPluginViewGeneration(new URL(url).pathname.slice(1))?.generation ?? null;
+    const fileOf = (url: string): string =>
+      stripPluginViewGeneration(new URL(url).pathname.slice(1))?.path ?? "";
+
+    const recoveredOne = (first as { recoveryComponentPath?: string }).recoveryComponentPath;
+    const recoveredTwo = (second as { recoveryComponentPath?: string }).recoveryComponentPath;
+    const recoveredAgain = (third as { recoveryComponentPath?: string }).recoveryComponentPath;
+    expect(recoveredOne).toBeDefined();
+    expect(recoveredTwo).toBeDefined();
+
+    // A URL V8 has never seen — that is the entire point, since the module map
+    // keys the failure by specifier and never evicts it.
+    expect(genOf(recoveredOne!)).not.toBe(genOf(primaryOne!));
+    // ...but the same file behind it: only the virtual namespace changed.
+    expect(fileOf(recoveredOne!)).toBe(fileOf(primaryOne!));
+
+    // One generation for the whole plugin, so a reload still swaps every view
+    // together and relative imports keep resolving within one namespace.
+    expect(genOf(recoveredTwo!)).toBe(genOf(recoveredOne!));
+    // Bounded: retrying again reuses it instead of minting a third namespace.
+    expect(recoveredAgain).toBe(recoveredOne);
+
+    // A PTY panel is rendered by TerminalPane, so there is no module to recover.
+    await expect(service.activatePluginForView("acme.view-recover.term", true)).resolves.toEqual({
+      ok: true,
+    });
   });
 
   it("activatePluginForView is a no-op for an unknown or empty panel kind id (#10523)", async () => {

--- a/electron/services/plugin/PluginServiceTypes.ts
+++ b/electron/services/plugin/PluginServiceTypes.ts
@@ -22,6 +22,20 @@ export interface LoadedPlugin {
    * in-process `import()` loader.
    */
   devMode?: boolean;
+  /**
+   * Virtual `__dtv-N` namespace segment minted once per load and shared by every
+   * view this plugin contributes (#11301), so a reload swaps the whole plugin's
+   * view modules together and relative imports inherit the generation.
+   */
+  viewGeneration: number;
+  /**
+   * Second generation, minted lazily the first time a renderer reports an
+   * import-stage failure for one of this plugin's views (#11728). A rejected
+   * dynamic import is permanent for its specifier, so recovery needs a URL V8
+   * has never seen. Allocated at most once per load and shared by every view,
+   * which bounds a plugin to two namespaces however many times the user retries.
+   */
+  recoveryViewGeneration?: number;
 }
 
 export type WorkspaceWorktreeEvent = "worktree-update" | "worktree-activated" | "worktree-removed";

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -1336,8 +1336,14 @@ export function registerPluginProtocol(getPluginDir: GetPluginDir): void {
  * import settles (#10322). `registerPluginProtocol` runs before `createWindow`
  * with a placeholder resolver that returns `undefined` (every request 404s),
  * keeping the heavy ~2900-line PluginService module off the first-paint path.
- * Once the deferred `plugin-service` task initializes the singleton, it calls
- * this to point the already-registered handler at the real `getPluginDir`. The
+ *
+ * Ordering is load-bearing (#11728): the deferred `plugin-service` task must
+ * call this immediately after importing the singleton and BEFORE `initialize()`
+ * — not after it. `getPluginDir` is a plain map lookup, safe to install at any
+ * time, whereas waiting for `initialize()` leaves the placeholder live across
+ * the whole scan, during which the first plugin already publishes an addressable
+ * `plugin://` componentPath. A 404 served in that window is permanent for that
+ * specifier in the renderer's module map. The
  * handler delegates through `resolvePluginDir`, which reads `cachedGetPluginDir`
  * live, so the swap reaches every handler already registered (default session
  * plus any per-session handlers wired during `createWindow`).

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -756,9 +756,13 @@ describe("initGlobalServices task ordering", () => {
 
     const pending = Promise.resolve(run!());
     try {
-      // Yield past the deferred `import()` so the task reaches its first real
-      // await, without letting initialize() complete.
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      // Poll until the task has actually entered initialize(), rather than
+      // assuming one macrotask outruns the deferred `import()` — that holds only
+      // when a previous test already warmed the module, so this test would be
+      // order-dependent (and pool-dependent) if run alone.
+      for (let i = 0; i < 200 && pluginInitialize.mock.calls.length === 0; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
 
       // The scan is demonstrably still in flight...
       expect(pluginInitialize).toHaveBeenCalledTimes(1);

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -711,7 +711,7 @@ describe("initGlobalServices task ordering", () => {
     expect(registeredTaskNames).toContain("plugin-service");
   });
 
-  it("plugin-service task swaps in the live plugin:// resolver after initialize() (#10322)", async () => {
+  it("plugin-service task swaps in the live plugin:// resolver (#10322)", async () => {
     const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
     await initGlobalServices(fakeRegistry);
 
@@ -728,6 +728,53 @@ describe("initGlobalServices task ordering", () => {
     const resolver = setPluginDirResolver.mock.calls[0]![0] as (id: string) => string | undefined;
     expect(resolver("acme.tool")).toBe("/plugins/acme.tool");
     expect(pluginGetPluginDir).toHaveBeenCalledWith("acme.tool");
+  });
+
+  it("plugin-service task installs the plugin:// resolver BEFORE initialize() runs (#11728)", async () => {
+    // Ordering invariant, not an incidental arrangement. `initialize()` sweeps
+    // temp dirs, fetches the blocklist over the network, then awaits three
+    // sequential `loadFromDir` passes — while the FIRST plugin it loads already
+    // broadcasts an addressable `plugin://` componentPath. Wiring the resolver
+    // afterwards left the 404-everything placeholder live for that whole span,
+    // and a rejected dynamic import is permanent for its specifier (the module
+    // map has no eviction), so a restored plugin panel could never recover.
+    // The gate is built eagerly, not inside the mock implementation, so the
+    // `finally` below can always release it — an assertion that fires before
+    // initialize() is even reached would otherwise leave the task parked on a
+    // promise nothing can resolve, turning a clear failure into a timeout.
+    let releaseInit!: () => void;
+    const initGate = new Promise<void>((resolve) => {
+      releaseInit = resolve;
+    });
+    pluginInitialize.mockImplementationOnce(() => initGate);
+
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    const run = registeredTaskRuns.get("plugin-service");
+    expect(run).toBeDefined();
+
+    const pending = Promise.resolve(run!());
+    try {
+      // Yield past the deferred `import()` so the task reaches its first real
+      // await, without letting initialize() complete.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // The scan is demonstrably still in flight...
+      expect(pluginInitialize).toHaveBeenCalledTimes(1);
+      // ...and the resolver is already live. Before the fix this was 0.
+      expect(setPluginDirResolver).toHaveBeenCalledTimes(1);
+      // Proof the task really is parked inside initialize() rather than done:
+      // the post-initialize steps have not run yet.
+      expect(activateOpenFileInstaller).not.toHaveBeenCalled();
+    } finally {
+      releaseInit();
+      await pending;
+    }
+
+    expect(setPluginDirResolver.mock.invocationCallOrder[0]!).toBeLessThan(
+      pluginInitialize.mock.invocationCallOrder[0]!
+    );
   });
 
   it("plugin-service task drains queued open-file archives after initialize() (#10322)", async () => {

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -885,27 +885,28 @@ export async function initGlobalServices(
   // and return empty lists from internal Maps until initialize() populates them.
   // Plugin contributions broadcast on registration, so late init is renderer-safe.
   //
-  // Timing note (#10322): `initialize()` registers panel-kind contributions
-  // mid-chain, so the `plugin:panel-kinds-changed` broadcast can reach the
-  // renderer a microtask before `setPluginDirResolver()` below swaps the
-  // `plugin://` handler off its placeholder. A plugin panel restored from
-  // persisted state could therefore 404 its first asset fetch. That window is
-  // self-healing: `PluginViewHost`'s `ErrorBoundary` offers a "Try again" that
-  // re-imports once the live resolver is in place.
   registerDeferredTask({
     name: "plugin-service",
     run: async () => {
       const { pluginService } = await import("../services/PluginService.js");
+      // Point the already-registered `plugin://` handler at the live resolver
+      // BEFORE `initialize()` runs, not after (#11728). `getPluginDir` is a
+      // plain lookup in a map that exists from construction, so it is safe to
+      // call at any point — it simply returns `undefined` until a plugin
+      // registers. Wiring it after `initialize()` left the placeholder resolver
+      // live for the whole scan: `initialize()` sweeps temp dirs, fetches the
+      // blocklist over the network, then awaits three sequential `loadFromDir`
+      // passes (builtin, user, sideload), while the FIRST plugin's
+      // `registerPanelKind` already broadcast an addressable `componentPath`.
+      // Every `plugin://` module request in that window 404'd, and a rejected
+      // dynamic import is permanent for that specifier — the module map has no
+      // eviction, so "Try again" re-imported the same poisoned URL forever.
+      setPluginDirResolver((pluginId) => pluginService.getPluginDir(pluginId));
       try {
         await pluginService.initialize();
       } catch (err) {
         console.error("[MAIN] PluginService initialization failed:", err);
       }
-      // Point the already-registered `plugin://` handler at the live resolver
-      // (#10322). main.ts registers the handler before first paint with a
-      // placeholder that 404s; now that the singleton is initialized, swap in
-      // the real `getPluginDir` so plugin asset requests resolve.
-      setPluginDirResolver((pluginId) => pluginService.getPluginDir(pluginId));
       // macOS: drain any `.dntr` paths queued during cold launch (Finder
       // double-click / "Open With") and take over live open-file events now
       // that PluginService can install an approved archive. Each path is queued

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1009,8 +1009,8 @@ export interface GeneratedIpcInvokeMap {
     result: void;
   };
   "plugin:activate-for-view": {
-    args: [panelKindId: string];
-    result: void;
+    args: [panelKindId: string, requestRecoveryPath?: boolean | undefined];
+    result: string | undefined;
   };
   "plugin:agents-get": {
     args: [];

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -955,7 +955,20 @@ export interface PluginLoadError {
  * renderer throws renderer-side from `{ ok: false }` so the real activation
  * cause reaches the view's ErrorBoundary instead of a generic import timeout.
  */
-export type PluginActivationResult = { ok: true } | { ok: false; error: string; stack?: string };
+export type PluginActivationResult =
+  | {
+      ok: true;
+      /**
+       * A main-minted `plugin://` URL on a fresh view generation, returned only
+       * when the caller asked to recover from an import-stage failure (#11728).
+       * The renderer imports this instead of the poisoned specifier — a rejected
+       * dynamic import is permanent for its URL, so only a specifier V8 has
+       * never seen re-evaluates. Absent for PTY/view-less kinds and whenever no
+       * recovery was requested.
+       */
+      recoveryComponentPath?: string;
+    }
+  | { ok: false; error: string; stack?: string };
 
 /**
  * Wire envelope for every push over the `plugin:{pluginId}:{channel}` transport

--- a/src/components/Plugin/PluginViewContent.tsx
+++ b/src/components/Plugin/PluginViewContent.tsx
@@ -75,6 +75,27 @@ export interface PluginViewContentProps {
 const PLUGIN_VIEW_IMPORT_TIMEOUT_MS = 10_000;
 
 /**
+ * Errors raised by the `plugin://` module fetch itself (or by the timeout that
+ * fires while one is in flight), as opposed to an activation rejection or a
+ * throw from the view's own render. Only these are worth recovering with a fresh
+ * view generation: the module map keys failures by specifier and never evicts
+ * them, so re-importing the same URL after a fetch failure is guaranteed to fail
+ * again. A module that loaded but exported the wrong shape, or a view that threw
+ * while rendering, would fail identically on a new specifier — those keep the
+ * plain remount. Tracked in a WeakSet rather than a flag on the error so the
+ * error object the boundary logs and displays stays untouched.
+ */
+const importStageFailures = new WeakSet<object>();
+
+function markImportStageFailure(err: unknown): void {
+  if (typeof err === "object" && err !== null) importStageFailures.add(err);
+}
+
+function isImportStageFailure(err: unknown): boolean {
+  return typeof err === "object" && err !== null && importStageFailures.has(err);
+}
+
+/**
  * Carries the host's close callback down to the factory-scoped fallback without
  * putting it in the fallback's component identity. Default is an empty object so
  * a content instance mounted without a host (tests, a future embedder) simply
@@ -122,14 +143,18 @@ function isPluginViewModule(mod: unknown): mod is { default: ComponentType<Panel
  *     fresh state-held ref produces a new `lazy()` call so `import()` is
  *     re-evaluated rather than returning the cached failed promise.
  *
- * `componentPath` is imported verbatim. It already carries a per-load
- * generation segment minted by `buildPluginViewUrl` in main, which is what makes
- * an upgraded plugin's view actually load: V8 caches ESM module records by URL
- * and Chromium has no way to evict an entry (Vite #14438 / Chromium #350426234,
+ * `componentPath` is imported as given. It already carries a per-load generation
+ * segment minted by `buildPluginViewUrl` in main, which is what makes an
+ * upgraded plugin's view actually load: V8 caches ESM module records by URL and
+ * Chromium has no way to evict an entry (Vite #14438 / Chromium #350426234,
  * still unresolved), so only a specifier V8 has never seen re-evaluates. Never
  * add a cache-buster HERE — a per-render or per-retry parameter would grow the
- * module map without bound, which is exactly what the generation segment avoids
- * by changing only when main reloads the plugin.
+ * module map without bound. The one exception is deliberate and still
+ * main-minted: after an import-stage failure the retry asks main for a
+ * replacement URL on a second generation (#11728), because the failed entry is
+ * keyed by specifier and re-importing it can only fail again. Main allocates
+ * that generation at most once per plugin load and shares it across the plugin's
+ * views, so the bound is two namespaces per load rather than one per retry.
  */
 export function makePluginViewContent(
   config: PluginViewContentConfig
@@ -153,12 +178,12 @@ export function makePluginViewContent(
     );
 
     // Re-pull here rather than at mount, because at mount the plugin may not be
-    // listable yet: `loadPlugin` registers the panel kind (which is what mounts
-    // this content) before awaiting skill loading and entering the plugins map,
-    // and `daintree-plugin dev` never fires provenance at all. Reaching this
-    // component means the view rendered and threw, so its plugin is certainly
-    // loaded by now and this pull can see it. The pane fails closed meanwhile
-    // and upgrades in place when the snapshot lands.
+    // listable yet: `daintree-plugin dev` never fires provenance at all. (Panel
+    // kinds are now published after the plugins-map commit, so a kind that
+    // mounted this content does at least have a loaded plugin behind it —
+    // #11728.) Reaching this component means the view rendered and threw, so
+    // this pull can see it. The pane fails closed meanwhile and upgrades in
+    // place when the snapshot lands.
     const refreshPluginRuntime = usePluginRuntimeStore((s) => s.refresh);
     useEffect(() => refreshPluginRuntime(), [refreshPluginRuntime]);
 
@@ -179,7 +204,17 @@ export function makePluginViewContent(
     );
   }
 
-  const createLazyView = (): LazyExoticComponent<ComponentType<PanelViewProps>> =>
+  // Replacement specifier for `componentPath` once main has minted one, cached at
+  // factory scope so it outlives both the `lazy()` wrapper and the component
+  // instance (#11728). A remount that fell back to the poisoned original would
+  // undo the recovery, and `usePluginPanelKinds` caches this factory per
+  // (kindId, componentPath) — so every panel of this kind shares the one
+  // recovery generation, which is exactly the granularity main mints it at.
+  let recoveryComponentPath: string | undefined;
+
+  const createLazyView = (
+    requestRecoveryPath = false
+  ): LazyExoticComponent<ComponentType<PanelViewProps>> =>
     lazy<ComponentType<PanelViewProps>>(async () => {
       // Race the `plugin://` import against a timeout. A wedged protocol load
       // (handler hang, never-resolving fetch) would otherwise sit behind
@@ -205,18 +240,42 @@ export function makePluginViewContent(
           // failed (e.g. a manifest collision or an activate() throw) instead of
           // the generic import timeout the module load would otherwise produce
           // once its handlers never bound.
-          await window.electron?.plugin?.activateForView?.(kindId);
-          return import(/* @vite-ignore */ componentPath);
+          //
+          // On a retry after an import-stage failure this also asks main for a
+          // replacement URL on a fresh view generation (#11728). The previous
+          // specifier is permanently poisoned — the module map never evicts a
+          // failed entry — so recovery needs a URL V8 has never seen. Main
+          // builds it from the loaded manifest and mints the generation once per
+          // plugin load, which caps the module map at two namespaces per plugin
+          // however many times the user retries. The first attempt keeps the
+          // single-argument call so it stays a pure activation request.
+          const recovered = requestRecoveryPath
+            ? await window.electron?.plugin?.activateForView?.(kindId, true)
+            : await window.electron?.plugin?.activateForView?.(kindId);
+          if (typeof recovered === "string" && recovered.length > 0) {
+            recoveryComponentPath = recovered;
+          }
+          try {
+            return await import(/* @vite-ignore */ recoveryComponentPath ?? componentPath);
+          } catch (err) {
+            markImportStageFailure(err);
+            throw err;
+          }
         })().finally(() => {
           if (timeoutId !== undefined) clearTimeout(timeoutId);
         }),
         new Promise<never>((_, reject) => {
           timeoutId = setTimeout(() => {
-            reject(
-              new Error(
-                `Plugin "${pluginId}" view module at ${componentPath} timed out after ${PLUGIN_VIEW_IMPORT_TIMEOUT_MS}ms`
-              )
+            // Counts as an import-stage failure: the losing `import()` keeps
+            // running after this rejects (dynamic import has no cancellation),
+            // so if it eventually fails it poisons this specifier behind our
+            // back. Retrying on a fresh generation sidesteps that entirely,
+            // which is why the timeout is safe to leave uncancelled (#11728).
+            const timeoutError = new Error(
+              `Plugin "${pluginId}" view module at ${recoveryComponentPath ?? componentPath} timed out after ${PLUGIN_VIEW_IMPORT_TIMEOUT_MS}ms`
             );
+            markImportStageFailure(timeoutError);
+            reject(timeoutError);
           }, PLUGIN_VIEW_IMPORT_TIMEOUT_MS);
         }),
       ]);
@@ -317,9 +376,19 @@ export function makePluginViewContent(
 
     const closeContextValue = useMemo(() => ({ onRequestClose }), [onRequestClose]);
 
-    const handleRenderError = useCallback(() => {
-      reportViewRenderFailed(panelId, { kindId, pluginId });
-    }, [panelId]);
+    // Whether the error the boundary is currently showing came from the module
+    // fetch, which is what decides if "Try again" needs a fresh specifier from
+    // main or just a remount. A ref because only the reset handler reads it, and
+    // re-rendering on it would be pointless churn.
+    const lastErrorWasImportStage = useRef(false);
+
+    const handleRenderError = useCallback(
+      (error: Error) => {
+        lastErrorWasImportStage.current = isImportStageFailure(error);
+        reportViewRenderFailed(panelId, { kindId, pluginId });
+      },
+      [panelId]
+    );
 
     const handleReset = (): void => {
       // Abort the outgoing view's signal before swapping in a fresh controller —
@@ -330,7 +399,11 @@ export function makePluginViewContent(
       // Fresh controller for the retry so the new lazy import sees an unaborted
       // signal; the mirror effect propagates it to controllerRef for teardown.
       setController(new AbortController());
-      setLazyView(() => createLazyView());
+      // Ask main for a fresh view generation only when the module fetch is what
+      // failed (#11728) — a new `lazy()` wrapper alone cannot recover that,
+      // because the poisoned entry belongs to the specifier, not the wrapper.
+      // Activation failures and render throws still just remount.
+      setLazyView(() => createLazyView(lastErrorWasImportStage.current));
       setRetryCount((c) => c + 1);
       // The retry is under way, so the panel is no longer failed — it is loading.
       // Clearing here (rather than waiting for the next commit) keeps a worker

--- a/src/components/Plugin/PluginViewContent.tsx
+++ b/src/components/Plugin/PluginViewContent.tsx
@@ -85,14 +85,30 @@ const PLUGIN_VIEW_IMPORT_TIMEOUT_MS = 10_000;
  * plain remount. Tracked in a WeakSet rather than a flag on the error so the
  * error object the boundary logs and displays stays untouched.
  */
-const importStageFailures = new WeakSet<object>();
+const importStageFailures = new WeakSet<WeakKey>();
 
-function markImportStageFailure(err: unknown): void {
-  if (typeof err === "object" && err !== null) importStageFailures.add(err);
+function isWeakKey(value: unknown): value is WeakKey {
+  return (typeof value === "object" && value !== null) || typeof value === "function";
+}
+
+/**
+ * Mark a module-fetch failure and return the value to throw. A module is free to
+ * `throw "boom"` (or `null`) during evaluation, and `import()` rejects with that
+ * exact value — which cannot key a WeakSet. Those rejections are wrapped in a
+ * real Error carrying the original as `cause`, so the classification survives
+ * and the boundary gets something it can actually render. Object and function
+ * rejections are marked in place, leaving the error identity untouched.
+ */
+function markImportStageFailure(err: unknown): unknown {
+  const marked = isWeakKey(err)
+    ? err
+    : new Error(`Plugin view module failed to load: ${String(err)}`, { cause: err });
+  importStageFailures.add(marked);
+  return marked;
 }
 
 function isImportStageFailure(err: unknown): boolean {
-  return typeof err === "object" && err !== null && importStageFailures.has(err);
+  return isWeakKey(err) && importStageFailures.has(err);
 }
 
 /**
@@ -258,8 +274,7 @@ export function makePluginViewContent(
           try {
             return await import(/* @vite-ignore */ recoveryComponentPath ?? componentPath);
           } catch (err) {
-            markImportStageFailure(err);
-            throw err;
+            throw markImportStageFailure(err);
           }
         })().finally(() => {
           if (timeoutId !== undefined) clearTimeout(timeoutId);
@@ -271,11 +286,21 @@ export function makePluginViewContent(
             // so if it eventually fails it poisons this specifier behind our
             // back. Retrying on a fresh generation sidesteps that entirely,
             // which is why the timeout is safe to leave uncancelled (#11728).
-            const timeoutError = new Error(
-              `Plugin "${pluginId}" view module at ${recoveryComponentPath ?? componentPath} timed out after ${PLUGIN_VIEW_IMPORT_TIMEOUT_MS}ms`
+            //
+            // Deliberately conservative: a timeout can also mean activation
+            // stalled, in which case the specifier was never touched and the
+            // extra generation is unnecessary. Harmless — main mints at most one
+            // per plugin load either way. Not unit-tested, because driving the
+            // real timer needs fake timers around a live `lazy` factory, which
+            // leaves an unhandled rejection from the uncancelled loser; the
+            // marking is a superset that can only over-recover, never fail.
+            reject(
+              markImportStageFailure(
+                new Error(
+                  `Plugin "${pluginId}" view module at ${recoveryComponentPath ?? componentPath} timed out after ${PLUGIN_VIEW_IMPORT_TIMEOUT_MS}ms`
+                )
+              )
             );
-            markImportStageFailure(timeoutError);
-            reject(timeoutError);
           }, PLUGIN_VIEW_IMPORT_TIMEOUT_MS);
         }),
       ]);

--- a/src/components/Plugin/__tests__/PluginViewContent.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewContent.test.tsx
@@ -32,6 +32,7 @@ interface CapturedFallbackProps {
 interface CapturedBoundaryProps {
   children: React.ReactNode;
   onReset?: () => void;
+  onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
   resetKeys?: Array<string | number>;
   componentName?: string;
   fallback?: React.ComponentType<CapturedFallbackProps>;
@@ -56,7 +57,12 @@ vi.mock("@/components/ErrorBoundary", async () => {
     static getDerivedStateFromError(): { hasError: true } {
       return { hasError: true };
     }
-    componentDidCatch(): void {}
+    // Forwards to `onError` like the real boundary does — the content classifies
+    // the error there to decide whether "Try again" needs a fresh module
+    // specifier, so a stub that swallowed it would hide that branch (#11728).
+    componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+      this.props.onError?.(error, errorInfo);
+    }
     componentDidUpdate(prev: { resetKeys?: Array<string | number> }): void {
       const next = this.props.resetKeys?.[0];
       if (this.state.hasError && next !== this.state.lastKey) {
@@ -401,6 +407,89 @@ describe("makePluginViewContent", () => {
       expect(String(cause)).not.toMatch(/is not a function/);
       // The content still mounted its (stubbed) view rather than crashing.
       expect(screen.getByTestId("plugin-view")).toBeTruthy();
+    } finally {
+      vi.doUnmock("react");
+    }
+  });
+
+  it("retries an import failure on a main-minted specifier, and a render failure in place (#11728)", async () => {
+    // The bug: a rejected dynamic import is permanent for its specifier — the
+    // module map never evicts a failed entry — so the old "Try again", which
+    // minted a fresh `lazy()` around the SAME url, could never recover. Recovery
+    // has to come from main as a new view generation. But it must be requested
+    // only for import failures: a view that threw while rendering, or an
+    // activation that failed, would fail identically on a new specifier, and
+    // minting one per retry would grow the module map without bound.
+    //
+    // The replacement is a `data:` module so the second attempt genuinely
+    // resolves. That is the assertion: `plugin://acme/dashboard.js` cannot load
+    // here, so a resolved module proves the factory imported the path main
+    // returned rather than the original.
+    const recoveryPath = "data:text/javascript,export default () => null";
+    const activateForView = vi.fn((_kindId: string, recover?: boolean) =>
+      Promise.resolve(recover === true ? recoveryPath : undefined)
+    );
+    Object.defineProperty(window, "electron", {
+      configurable: true,
+      writable: true,
+      value: { plugin: { onPanelKindsChanged: onPanelKindsChangedMock, activateForView } },
+    });
+
+    // React can run the `useState` initializer more than once on a concurrent
+    // mount, so the newest factory is the live one — indexing from 0 would drive
+    // a discarded generation.
+    const factories: Array<() => Promise<unknown>> = [];
+    vi.doMock("react", async () => {
+      const actual = await vi.importActual<typeof import("react")>("react");
+      return {
+        ...actual,
+        lazy: (factory: () => Promise<unknown>) => {
+          factories.push(factory);
+          return function StubView() {
+            return <div data-testid="plugin-view" />;
+          };
+        },
+      };
+    });
+
+    try {
+      const { makePluginViewContent } = await import("../PluginViewContent");
+      const Content = makePluginViewContent(makeContentConfig());
+
+      render(<Content panelId="panel-recover" />);
+      await waitFor(() => expect(factories).not.toHaveLength(0));
+
+      // First attempt: plain activation (no recovery flag), then an import that
+      // cannot resolve in this environment — exactly the shape of the bug.
+      const importError = await factories.at(-1)!().then(
+        () => null,
+        (err: unknown) => err
+      );
+      expect(importError).toBeInstanceOf(Error);
+      expect(activateForView.mock.calls.at(-1)).toEqual(["acme.dashboard"]);
+
+      // Hand the boundary the real rejection, then click through its "Try again".
+      const countBeforeRetry = factories.length;
+      act(() => boundaryProps.last!.onError!(importError as Error, { componentStack: "" }));
+      act(() => boundaryProps.last!.onReset!());
+      await waitFor(() => expect(factories.length).toBeGreaterThan(countBeforeRetry));
+
+      // The retry asks main for a replacement specifier...
+      const recovered = await factories.at(-1)!();
+      expect(activateForView.mock.calls.at(-1)).toEqual(["acme.dashboard", true]);
+      // ...and actually imports it: this only resolves via the returned url.
+      expect(recovered).toHaveProperty("default");
+
+      // Now the other half of the classification. A view that throws during
+      // render is not a poisoned specifier, so its retry must stay on the path
+      // it has rather than burning a second namespace.
+      const countBeforeRenderRetry = factories.length;
+      act(() => boundaryProps.last!.onError!(new Error("view exploded"), { componentStack: "" }));
+      act(() => boundaryProps.last!.onReset!());
+      await waitFor(() => expect(factories.length).toBeGreaterThan(countBeforeRenderRetry));
+
+      await factories.at(-1)!();
+      expect(activateForView.mock.calls.at(-1)).toEqual(["acme.dashboard"]);
     } finally {
       vi.doUnmock("react");
     }

--- a/src/components/Plugin/__tests__/PluginViewContent.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewContent.test.tsx
@@ -495,6 +495,69 @@ describe("makePluginViewContent", () => {
     }
   });
 
+  it("classifies a module that rejects with a non-object value as import-stage (#11728)", async () => {
+    // A plugin module is free to `throw "boom"` at evaluation, and `import()`
+    // rejects with that exact primitive — which cannot key the WeakSet the
+    // classification uses. That failure still poisons the specifier, so it must
+    // still earn a fresh generation; the primitive is wrapped in a real Error
+    // (preserving the original as `cause`) rather than silently misclassified.
+    const recoveryPath = "data:text/javascript,export default () => null";
+    const activateForView = vi.fn((_kindId: string, recover?: boolean) =>
+      Promise.resolve(recover === true ? recoveryPath : undefined)
+    );
+    Object.defineProperty(window, "electron", {
+      configurable: true,
+      writable: true,
+      value: { plugin: { onPanelKindsChanged: onPanelKindsChangedMock, activateForView } },
+    });
+
+    const factories: Array<() => Promise<unknown>> = [];
+    vi.doMock("react", async () => {
+      const actual = await vi.importActual<typeof import("react")>("react");
+      return {
+        ...actual,
+        lazy: (factory: () => Promise<unknown>) => {
+          factories.push(factory);
+          return function StubView() {
+            return <div data-testid="plugin-view" />;
+          };
+        },
+      };
+    });
+
+    try {
+      const { makePluginViewContent } = await import("../PluginViewContent");
+      // A real module that throws a bare string on evaluation.
+      const Content = makePluginViewContent(
+        makeContentConfig({ componentPath: 'data:text/javascript,throw "boom"' })
+      );
+
+      render(<Content panelId="panel-primitive" />);
+      await waitFor(() => expect(factories).not.toHaveLength(0));
+
+      const thrown = await factories.at(-1)!().then(
+        () => null,
+        (err: unknown) => err
+      );
+      // Wrapped, not passed through raw — a bare string would also render badly
+      // in the diagnostics fallback.
+      expect(thrown).toBeInstanceOf(Error);
+      expect((thrown as Error).cause).toBe("boom");
+
+      const countBeforeRetry = factories.length;
+      act(() => boundaryProps.last!.onError!(thrown as Error, { componentStack: "" }));
+      act(() => boundaryProps.last!.onReset!());
+      await waitFor(() => expect(factories.length).toBeGreaterThan(countBeforeRetry));
+
+      // The classification survived the wrap, so recovery is requested.
+      const recovered = await factories.at(-1)!();
+      expect(activateForView.mock.calls.at(-1)).toEqual(["acme.dashboard", true]);
+      expect(recovered).toHaveProperty("default");
+    } finally {
+      vi.doUnmock("react");
+    }
+  });
+
   it("aborts the outgoing signal on retry and the post-retry signal on kind removal", async () => {
     // Regression guard for the renderer-first teardown contract (#9501/#10512).
     // Two failure modes, both invisible to a "doesn't throw" assertion: (1) a


### PR DESCRIPTION
## Summary

**The bug.** A plugin panel restored from persisted workspace state could permanently fail to load. Its first `plugin://<id>/__dtv-N/dist/view.js` import 404'd, and a rejected dynamic import is forever sticky for that specifier — the HTML module map has no eviction — so "Try again", which re-imported the same URL, could never recover it. Only Force Reload Window did.

**Two ordering races made the URL addressable before the protocol could resolve it.**

1. Global. `globalServicesInit` installed the live `plugin://` resolver only after `await pluginService.initialize()`. That call sweeps temp dirs, fetches the blocklist over the network, then runs three sequential `loadFromDir` passes (builtin, user, sideload), each loading its plugins concurrently. The first plugin's `registerPanelKind` broadcast lands early in that span, so the 404-everything placeholder was live for all of it. This is much wider than the "microtask" the old comment claimed, which is why it reproduced on real installs rather than as a rare flake. The resolver is now wired immediately after the dynamic import, before `initialize()` — `getPluginDir` is a plain map lookup, safe to install at any time.

2. Per-plugin. `loadPlugin` published panel kinds *before* `this.plugins.set(...)`, which is the very map `getPluginDir` reads, with `await registerPluginSkills(...)` in between. Any plugin contributing skills published a componentPath its own directory couldn't yet resolve. Panel publication now happens after the map commit with no intervening await, making that commit the single addressability gate.

**Defence in depth.** "Try again" now recovers. On an import-stage failure the retry asks main for a replacement URL on a fresh view generation, since the poisoned entry is keyed by specifier. Main mints that generation at most once per plugin load and shares it across the plugin's views, so a plugin costs two module namespaces at worst however many times you retry — this respects the #11301 rule that only main may mint a generation and the renderer must never add a cache-buster. Render-stage and activation failures still just remount; they'd fail identically on a new specifier.

**Also fixed in review:** `handleInstall` and `handleInstallFromUrl` called `installPlugin` without awaiting `waitForInit()`, unlike `handleInstallFromPath`, which documents exactly why that gate exists. An install that beat the deferred plugin-service task could publish panel kinds against the placeholder resolver, reopening the same window through the install path — and it overlapped `initialize()`'s staging sweep with the blocklist still unset.

Resolves #11728

## Changes

- Wire the live `plugin://` resolver immediately after the dynamic import, before `pluginService.initialize()` runs
- Commit a loaded plugin to `this.plugins` before publishing its panel-kind contribution, removing the intervening `await`
- Gate `handleInstall` and `handleInstallFromUrl` on `waitForInit()`, matching `handleInstallFromPath`
- Classify non-object import failures and mint a fresh view generation on import-stage retry so "Try again" can recover a poisoned specifier
- Add regression tests that observe `getPluginDir` from inside the `registerPanelKind` callback and assert the resolver is installed while `initialize()` is still pending

## Testing

The ordering invariants are covered by tests verified to fail before the fix: the publication-order test observes `getPluginDir` from inside the `registerPanelKind` callback (the exact publication instant) and saw `undefined`; the startup test asserts the resolver is installed while `initialize()` is still pending and saw zero calls. Both real-registry and mocked-registry versions exist — note `vitest.config.ts` excludes `**/*.integration.test.*`, so the invariant also lives in a suite the PR gate actually runs.

Local: 930 plugin-service tests, 385 window/IPC/protocol, 230 renderer, 60 integration, plus typecheck, prettier and eslint on all 14 changed files. React-compiler ratchet baseline unchanged.

**Two things I deliberately didn't do**, both considered and rejected:
- A protocol-level readiness gate that parks `plugin://` requests until the resolver is live. `componentPath` exists only in the runtime panel-kind registry, never in the persisted `PanelInstance`, so with the ordering fixed there's no reachable window for it to guard — and it would turn a synchronous resolver into an async one, adding a never-settles mode to a handler Electron awaits with no timeout.
- An e2e restart spec. It doesn't run in PR CI, needs a full build to validate, gates releases, and with a small fixture would pass on the buggy code too. Deterministic invariant tests that provably fail pre-fix are stronger coverage here.