### PR TITLE
feat(copytree): accept an optional name on the copy-tree MCP tools

### DIFF
--- a/electron/ipc/__tests__/copyTreePreloadPayload.test.ts
+++ b/electron/ipc/__tests__/copyTreePreloadPayload.test.ts
@@ -45,14 +45,24 @@ describe("copyTree preload bindings forward every argument they accept", () => {
       .map((part) => part.replace(/\/\/.*$/gm, "").trim())
       .filter(Boolean);
 
-  it("places each declared parameter into the invoke payload", async () => {
-    const source = await readFile(PRELOAD_CTS, "utf8");
-
-    // Bounded to the copyTree namespace so an unrelated binding elsewhere in
-    // this 1500-line file can never satisfy or fail these assertions.
+  /**
+   * The copyTree namespace only, so an unrelated binding elsewhere in this
+   * 1500-line file can neither satisfy nor fail these assertions.
+   *
+   * Both delimiters are asserted. Without the closing check a missed sentinel
+   * yields `indexOf` = -1, and `slice(start, -1)` would quietly widen the scan
+   * to the rest of the file instead of failing.
+   */
+  const copyTreeBlock = (source: string): string => {
     const start = source.indexOf("    copyTree: {");
-    expect(start, "copyTree namespace not found in preload.cts").toBeGreaterThan(-1);
-    const block = source.slice(start, source.indexOf("\n    },", start));
+    expect(start, "copyTree namespace opening not found in preload.cts").toBeGreaterThan(-1);
+    const end = source.indexOf("\n    },", start);
+    expect(end, "copyTree namespace closing not found in preload.cts").toBeGreaterThan(start);
+    return source.slice(start, end);
+  };
+
+  it("places each declared parameter into the invoke payload", async () => {
+    const block = copyTreeBlock(await readFile(PRELOAD_CTS, "utf8"));
 
     const bindings = [...block.matchAll(BINDING)].map((match) => ({
       method: match[1]!,
@@ -76,9 +86,7 @@ describe("copyTree preload bindings forward every argument they accept", () => {
   });
 
   it("accepts the run name on all three run-recording bindings", async () => {
-    const source = await readFile(PRELOAD_CTS, "utf8");
-    const start = source.indexOf("    copyTree: {");
-    const block = source.slice(start, source.indexOf("\n    },", start));
+    const block = copyTreeBlock(await readFile(PRELOAD_CTS, "utf8"));
 
     // The check above proves whatever is declared gets forwarded; this proves
     // the run name is declared at all. Without it, deleting the parameter and

--- a/electron/ipc/__tests__/copyTreePreloadPayload.test.ts
+++ b/electron/ipc/__tests__/copyTreePreloadPayload.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const PRELOAD_CTS = path.resolve(__dirname, "..", "..", "preload.cts");
+
+/**
+ * The copyTree preload bindings are a silent-drop seam.
+ *
+ * They translate positional renderer arguments into the IPC payload object, and
+ * nothing else in the suite crosses them: the client tests replace
+ * `window.electron.copyTree` with mocks, and the handler tests invoke the main
+ * handlers directly, so a parameter that is declared but never placed into the
+ * payload is invisible to both. Typecheck does not help either — every one of
+ * these parameters is optional, so dropping one from the object literal is
+ * legal TypeScript that silently sends `undefined` forever.
+ *
+ * This channel has no `defineIpcNamespace` codegen backing it (there is no
+ * `copyTree.preload.ts`), so a source contract is the only place the invariant
+ * can live. It is deliberately general rather than a list of expected keys:
+ * "every parameter this binding accepts is forwarded" holds for any future
+ * argument too, and pinning today's key names would just restate the source.
+ *
+ * Read as text rather than imported because `preload.cts` is CommonJS built for
+ * the Electron sandbox and pulls in `electron` at module scope.
+ */
+describe("copyTree preload bindings forward every argument they accept", () => {
+  /** `method: (params) => _unwrappingInvoke(CHANNEL, { payload })` */
+  const BINDING =
+    /(\w+):\s*\(([^)]*)\)\s*=>\s*_unwrappingInvoke\(\s*(CHANNELS\.\w+),\s*\{([^}]*)\}/g;
+
+  const paramNames = (params: string): string[] =>
+    params
+      .split(",")
+      .map((part) => part.split(":")[0]!.trim().replace(/\?$/, ""))
+      .filter(Boolean);
+
+  const payloadKeys = (payload: string): string[] =>
+    payload
+      .split(",")
+      .map((part) => part.replace(/\/\/.*$/gm, "").trim())
+      .filter(Boolean);
+
+  it("places each declared parameter into the invoke payload", async () => {
+    const source = await readFile(PRELOAD_CTS, "utf8");
+
+    // Bounded to the copyTree namespace so an unrelated binding elsewhere in
+    // this 1500-line file can never satisfy or fail these assertions.
+    const start = source.indexOf("    copyTree: {");
+    expect(start, "copyTree namespace not found in preload.cts").toBeGreaterThan(-1);
+    const block = source.slice(start, source.indexOf("\n    },", start));
+
+    const bindings = [...block.matchAll(BINDING)].map((match) => ({
+      method: match[1]!,
+      channel: match[3]!,
+      params: paramNames(match[2]!),
+      payload: payloadKeys(match[4]!),
+    }));
+
+    // Guards the scanner itself: a rename or a reformat that stopped matching
+    // would otherwise report a vacuous pass over zero bindings.
+    expect(bindings.map((binding) => binding.method)).toEqual(
+      expect.arrayContaining(["generate", "generateAndCopyFile", "injectToTerminal"])
+    );
+
+    for (const { method, channel, params, payload } of bindings) {
+      expect(
+        params.filter((param) => !payload.includes(param)),
+        `${method} (${channel}) accepts these arguments but never forwards them`
+      ).toEqual([]);
+    }
+  });
+
+  it("accepts the run name on all three run-recording bindings", async () => {
+    const source = await readFile(PRELOAD_CTS, "utf8");
+    const start = source.indexOf("    copyTree: {");
+    const block = source.slice(start, source.indexOf("\n    },", start));
+
+    // The check above proves whatever is declared gets forwarded; this proves
+    // the run name is declared at all. Without it, deleting the parameter and
+    // its payload key together would keep the pair consistent and pass (#11734).
+    const named = [...block.matchAll(BINDING)]
+      .filter((match) => paramNames(match[2]!).includes("name"))
+      .map((match) => match[1]!);
+
+    expect(named.sort()).toEqual(["generate", "generateAndCopyFile", "injectToTerminal"]);
+  });
+});

--- a/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
@@ -1286,6 +1286,52 @@ describe("copy-tree run history recording", () => {
     expect(lastRecordedRun()[1]).toMatchObject({ source: "mcp", worktreeId: "wt-1" });
   });
 
+  /**
+   * The caller-supplied label reaching history (#11734).
+   *
+   * Every channel is covered rather than one representative: each validates
+   * through its own payload schema, and an ordinary zod object *strips* an
+   * undeclared key instead of rejecting it. A channel that was missed would
+   * therefore keep passing every other assertion in this file while silently
+   * dropping the name — the exact failure this table exists to catch.
+   */
+  describe.each([
+    { channel: CHANNELS.COPYTREE_GENERATE, extra: {} as Record<string, unknown> },
+    { channel: CHANNELS.COPYTREE_GENERATE_AND_COPY_FILE, extra: {} as Record<string, unknown> },
+    { channel: CHANNELS.COPYTREE_INJECT, extra: { terminalId: "t-1" } },
+  ])("$channel run name", ({ channel, extra }) => {
+    it("forwards a supplied name to the history append", async () => {
+      makeService();
+      const handler = getInvokeHandler(channel);
+
+      await handler(mockSender, { worktreeId: "wt-1", name: "Authentication stuff", ...extra });
+
+      expect(lastRecordedRun()[1].name).toBe("Authentication stuff");
+    });
+
+    it("forwards the raw value, leaving normalization to the history layer", async () => {
+      makeService();
+      const handler = getInvokeHandler(channel);
+
+      // Untrimmed on purpose: `applyCopyTreeRun` owns blank-as-absent and
+      // truncation, so trimming here too would give the same input two
+      // normalizations that can drift apart.
+      await handler(mockSender, { worktreeId: "wt-1", name: "  spaced  ", ...extra });
+
+      expect(lastRecordedRun()[1].name).toBe("  spaced  ");
+    });
+
+    it("records the run with no name when none was supplied", async () => {
+      makeService();
+      const handler = getInvokeHandler(channel);
+
+      await handler(mockSender, { worktreeId: "wt-1", ...extra });
+
+      expect(copyTreeHistoryMock.recordCopyTreeRun).toHaveBeenCalledTimes(1);
+      expect(lastRecordedRun()[1].name).toBeUndefined();
+    });
+  });
+
   it("stores the caller's runtime options, not the settings-merged ones", async () => {
     projectStoreMock.getProjectSettings.mockResolvedValue({
       excludedPaths: ["vendor"],

--- a/electron/ipc/handlers/copyTree.ts
+++ b/electron/ipc/handlers/copyTree.ts
@@ -260,11 +260,20 @@ export function resolveCopyTreeProjectId(
  */
 async function recordCompletedCopyTreeRun(
   projectId: string | null,
-  validated: { worktreeId: string; options?: CopyTreeOptions; source?: CopyTreeRunSource },
+  validated: {
+    worktreeId: string;
+    options?: CopyTreeOptions;
+    name?: string;
+    source?: CopyTreeRunSource;
+  },
   result: CopyTreeResult
 ): Promise<void> {
   try {
     await recordCopyTreeRun(projectId, {
+      // Forwarded raw, including blank and untrimmed values: `applyCopyTreeRun`
+      // is the authoritative normalization seam (blank-as-absent, trim,
+      // truncate), and normalizing twice would let the two drift.
+      name: validated.name,
       options: validated.options ?? {},
       source: validated.source ?? "unknown",
       worktreeId: validated.worktreeId,

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1417,24 +1417,28 @@ function buildElectronApi(): ElectronAPI {
         worktreeId: string,
         options?: CopyTreeOptions,
         includeContent?: boolean,
-        source?: CopyTreeRunSource
+        source?: CopyTreeRunSource,
+        name?: string
       ) =>
         _unwrappingInvoke(CHANNELS.COPYTREE_GENERATE, {
           worktreeId,
           options,
           includeContent,
           source,
+          name,
         }),
 
       generateAndCopyFile: (
         worktreeId: string,
         options?: CopyTreeOptions,
-        source?: CopyTreeRunSource
+        source?: CopyTreeRunSource,
+        name?: string
       ) =>
         _unwrappingInvoke(CHANNELS.COPYTREE_GENERATE_AND_COPY_FILE, {
           worktreeId,
           options,
           source,
+          name,
         }),
 
       injectToTerminal: (
@@ -1442,7 +1446,8 @@ function buildElectronApi(): ElectronAPI {
         worktreeId: string,
         options?: CopyTreeOptions,
         injectionId?: string,
-        source?: CopyTreeRunSource
+        source?: CopyTreeRunSource,
+        name?: string
       ) =>
         _unwrappingInvoke(CHANNELS.COPYTREE_INJECT, {
           terminalId,
@@ -1450,6 +1455,7 @@ function buildElectronApi(): ElectronAPI {
           options,
           injectionId,
           source,
+          name,
         }),
 
       isAvailable: () => _unwrappingInvoke(CHANNELS.COPYTREE_AVAILABLE),

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -506,6 +506,16 @@ export const CopyTreeOptionsSchema = z
  */
 export const CopyTreeRunSourceSchema = z.enum(COPY_TREE_RUN_SOURCES);
 
+/**
+ * Caller-supplied display label for a run (#11734).
+ *
+ * Unconstrained beyond being a string, deliberately. Blank is valid input and
+ * resolves as absent, and `resolveCopyTreeRunName` is the single trim/truncate
+ * seam for every consumer — a `.max()` here would reject an oversized cosmetic
+ * label by failing the whole (expensive) generation instead of shortening it.
+ */
+const CopyTreeRunNameSchema = z.string().optional();
+
 export const CopyTreeGeneratePayloadSchema = z.object({
   worktreeId: z.string().min(1),
   options: CopyTreeOptionsSchema,
@@ -514,12 +524,14 @@ export const CopyTreeGeneratePayloadSchema = z.object({
   // CopyTreeOptionsSchema: the destination is chosen by the main process, so a
   // tool call can never turn into an arbitrary file write.
   includeContent: z.boolean().optional(),
+  name: CopyTreeRunNameSchema,
   source: CopyTreeRunSourceSchema.optional(),
 });
 
 export const CopyTreeGenerateAndCopyFilePayloadSchema = z.object({
   worktreeId: z.string().min(1),
   options: CopyTreeOptionsSchema,
+  name: CopyTreeRunNameSchema,
   source: CopyTreeRunSourceSchema.optional(),
 });
 
@@ -528,6 +540,7 @@ export const CopyTreeInjectPayloadSchema = z.object({
   worktreeId: z.string().min(1),
   options: CopyTreeOptionsSchema,
   injectionId: z.string().min(1).optional(),
+  name: CopyTreeRunNameSchema,
   source: CopyTreeRunSourceSchema.optional(),
 });
 

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -378,19 +378,22 @@ export interface ElectronAPI extends GeneratedElectronAPI {
       worktreeId: string,
       options?: CopyTreeOptions,
       includeContent?: boolean,
-      source?: CopyTreeRunSource
+      source?: CopyTreeRunSource,
+      name?: string
     ): Promise<CopyTreeResult>;
     generateAndCopyFile(
       worktreeId: string,
       options?: CopyTreeOptions,
-      source?: CopyTreeRunSource
+      source?: CopyTreeRunSource,
+      name?: string
     ): Promise<CopyTreeResult>;
     injectToTerminal(
       terminalId: string,
       worktreeId: string,
       options?: CopyTreeOptions,
       injectionId?: string,
-      source?: CopyTreeRunSource
+      source?: CopyTreeRunSource,
+      name?: string
     ): Promise<CopyTreeResult>;
     isAvailable(): Promise<boolean>;
     cancel(injectionId?: string): Promise<void>;

--- a/shared/types/ipc/copyTree.ts
+++ b/shared/types/ipc/copyTree.ts
@@ -72,6 +72,18 @@ export interface CopyTreeGeneratePayload {
    */
   includeContent?: boolean;
   /**
+   * Caller-supplied display label for the run, shown in the project's
+   * copy-tree history and in the completion notification (#11734).
+   *
+   * Deliberately a payload field rather than a `CopyTreeOptions` one, for the
+   * same reason as `source`: it names the run for a human, it does not select
+   * or format anything, so it must stay out of the dedupe key — two runs that
+   * build the identical bundle are one history entry whatever they were
+   * called. Blank counts as absent, and an absent name falls back to a label
+   * derived from the options.
+   */
+  name?: string;
+  /**
    * Which surface asked for the run, recorded in the project's copy-tree
    * history (#11732).
    *
@@ -86,6 +98,8 @@ export interface CopyTreeGeneratePayload {
 export interface CopyTreeGenerateAndCopyFilePayload {
   worktreeId: string;
   options?: CopyTreeOptions;
+  /** See {@link CopyTreeGeneratePayload.name}. */
+  name?: string;
   /** See {@link CopyTreeGeneratePayload.source}. */
   source?: CopyTreeRunSource;
 }
@@ -97,6 +111,8 @@ export interface CopyTreeInjectPayload {
   options?: CopyTreeOptions;
   /** Unique identifier for this injection operation (for per-operation cancellation) */
   injectionId?: string;
+  /** See {@link CopyTreeGeneratePayload.name}. */
+  name?: string;
   /** See {@link CopyTreeGeneratePayload.source}. */
   source?: CopyTreeRunSource;
 }

--- a/shared/utils/__tests__/copyTreeHistory.test.ts
+++ b/shared/utils/__tests__/copyTreeHistory.test.ts
@@ -228,6 +228,29 @@ describe("resolveCopyTreeRunName", () => {
     const name = resolveCopyTreeRunName("y".repeat(500), {});
     expect(name.length).toBeLessThanOrEqual(COPY_TREE_HISTORY_NAME_MAX_LENGTH);
   });
+
+  // The derived branch already pins both boundaries above. The supplied branch
+  // needs its own: the two only share `truncateName` by construction, so a
+  // change to either could regress this one while the derived tests stay green
+  // — and this is the branch every named MCP run takes (#11734).
+  it("leaves a supplied name of exactly the limit untouched", () => {
+    const exact = "y".repeat(COPY_TREE_HISTORY_NAME_MAX_LENGTH);
+    const name = resolveCopyTreeRunName(exact, {});
+    expect(name).toBe(exact);
+    expect(name).not.toContain("…");
+  });
+
+  it("never splits a surrogate pair when bounding a supplied name", () => {
+    // Slide the emoji across the boundary so one offset lands mid-pair; a plain
+    // `slice` persists a lone surrogate, which renders as a replacement glyph
+    // and stops comparing equal to the same name resolved elsewhere.
+    for (let pad = 0; pad < 6; pad++) {
+      const supplied = `${"y".repeat(COPY_TREE_HISTORY_NAME_MAX_LENGTH - 4 + pad)}${"🌳".repeat(6)}`;
+      const name = resolveCopyTreeRunName(supplied, {});
+      expect(name.length).toBeLessThanOrEqual(COPY_TREE_HISTORY_NAME_MAX_LENGTH);
+      expect(name).toBe([...name].join(""));
+    }
+  });
 });
 
 describe("sortCopyTreeHistory", () => {

--- a/shared/utils/__tests__/copyTreeHistory.test.ts
+++ b/shared/utils/__tests__/copyTreeHistory.test.ts
@@ -244,11 +244,18 @@ describe("resolveCopyTreeRunName", () => {
     // Slide the emoji across the boundary so one offset lands mid-pair; a plain
     // `slice` persists a lone surrogate, which renders as a replacement glyph
     // and stops comparing equal to the same name resolved elsewhere.
+    //
+    // Checked by code point rather than by round-tripping the string: spreading
+    // yields a lone surrogate as its own element, so `[...name].join("")` equals
+    // `name` for EVERY input and would assert nothing.
     for (let pad = 0; pad < 6; pad++) {
       const supplied = `${"y".repeat(COPY_TREE_HISTORY_NAME_MAX_LENGTH - 4 + pad)}${"🌳".repeat(6)}`;
       const name = resolveCopyTreeRunName(supplied, {});
       expect(name.length).toBeLessThanOrEqual(COPY_TREE_HISTORY_NAME_MAX_LENGTH);
-      expect(name).toBe([...name].join(""));
+      for (const char of name) {
+        const code = char.codePointAt(0) as number;
+        expect(code >= 0xd800 && code <= 0xdfff).toBe(false);
+      }
     }
   });
 });

--- a/src/clients/__tests__/copyTreeClient.test.ts
+++ b/src/clients/__tests__/copyTreeClient.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const typedGlobal = globalThis as unknown as Record<string, unknown>;
+
+let copyTreeClient: typeof import("../copyTreeClient").copyTreeClient;
+
+let generateMock: ReturnType<typeof vi.fn>;
+let generateAndCopyFileMock: ReturnType<typeof vi.fn>;
+let injectToTerminalMock: ReturnType<typeof vi.fn>;
+
+const RESULT = { success: true, fileCount: 12 };
+
+/**
+ * The client is a thin positional wrapper over the preload bindings, and that
+ * thinness is exactly what needs guarding: `source` and `name` are both
+ * trailing optionals of history metadata, so dropping one or transposing the
+ * two is a silent mislabelling rather than a type error — every argument from
+ * `options` onward is optional, and `name` and `source` are both strings to
+ * TypeScript at the call site (#11734).
+ */
+describe("copyTreeClient", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+
+    generateMock = vi.fn().mockResolvedValue(RESULT);
+    generateAndCopyFileMock = vi.fn().mockResolvedValue(RESULT);
+    injectToTerminalMock = vi.fn().mockResolvedValue(RESULT);
+
+    typedGlobal.window = {
+      electron: {
+        copyTree: {
+          generate: generateMock,
+          generateAndCopyFile: generateAndCopyFileMock,
+          injectToTerminal: injectToTerminalMock,
+        },
+      },
+    };
+
+    const mod = await import("../copyTreeClient");
+    copyTreeClient = mod.copyTreeClient;
+  });
+
+  afterEach(() => {
+    delete typedGlobal.window;
+  });
+
+  describe("generate", () => {
+    it("forwards the run name after the source", async () => {
+      await expect(
+        copyTreeClient.generate("wt-1", { modified: true }, true, "mcp", "Auth flow context")
+      ).resolves.toEqual(RESULT);
+
+      expect(generateMock).toHaveBeenCalledWith(
+        "wt-1",
+        { modified: true },
+        true,
+        "mcp",
+        "Auth flow context"
+      );
+    });
+
+    it("passes the name through undefined when the caller omits it", async () => {
+      await copyTreeClient.generate("wt-1", undefined, undefined, "toolbar");
+
+      expect(generateMock).toHaveBeenCalledWith("wt-1", undefined, undefined, "toolbar", undefined);
+    });
+  });
+
+  describe("generateAndCopyFile", () => {
+    it("forwards the run name after the source", async () => {
+      await expect(
+        copyTreeClient.generateAndCopyFile("wt-1", { modified: true }, "mcp", "Auth flow context")
+      ).resolves.toEqual(RESULT);
+
+      expect(generateAndCopyFileMock).toHaveBeenCalledWith(
+        "wt-1",
+        { modified: true },
+        "mcp",
+        "Auth flow context"
+      );
+    });
+
+    it("passes the name through undefined when the caller omits it", async () => {
+      await copyTreeClient.generateAndCopyFile("wt-1", undefined, "toolbar");
+
+      expect(generateAndCopyFileMock).toHaveBeenCalledWith("wt-1", undefined, "toolbar", undefined);
+    });
+  });
+
+  describe("injectToTerminal", () => {
+    it("forwards the run name after the source", async () => {
+      await expect(
+        copyTreeClient.injectToTerminal(
+          "t-1",
+          "wt-1",
+          { modified: true },
+          "inj-1",
+          "mcp",
+          "Auth flow context"
+        )
+      ).resolves.toEqual(RESULT);
+
+      expect(injectToTerminalMock).toHaveBeenCalledWith(
+        "t-1",
+        "wt-1",
+        { modified: true },
+        "inj-1",
+        "mcp",
+        "Auth flow context"
+      );
+    });
+
+    it("passes the name through undefined when the caller omits it", async () => {
+      await copyTreeClient.injectToTerminal("t-1", "wt-1", undefined, undefined, "terminal");
+
+      expect(injectToTerminalMock).toHaveBeenCalledWith(
+        "t-1",
+        "wt-1",
+        undefined,
+        undefined,
+        "terminal",
+        undefined
+      );
+    });
+  });
+});

--- a/src/clients/__tests__/copyTreeClient.test.ts
+++ b/src/clients/__tests__/copyTreeClient.test.ts
@@ -1,7 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const typedGlobal = globalThis as unknown as Record<string, unknown>;
-
 let copyTreeClient: typeof import("../copyTreeClient").copyTreeClient;
 
 let generateMock: ReturnType<typeof vi.fn>;
@@ -26,7 +24,10 @@ describe("copyTreeClient", () => {
     generateAndCopyFileMock = vi.fn().mockResolvedValue(RESULT);
     injectToTerminalMock = vi.fn().mockResolvedValue(RESULT);
 
-    typedGlobal.window = {
+    // `vi.stubGlobal` rather than assigning onto a cast `globalThis`: the client
+    // reads `window.electron` at call time, so a stub installed here is enough,
+    // and it unwinds through `unstubAllGlobals` instead of a `delete`.
+    vi.stubGlobal("window", {
       electron: {
         copyTree: {
           generate: generateMock,
@@ -34,14 +35,14 @@ describe("copyTreeClient", () => {
           injectToTerminal: injectToTerminalMock,
         },
       },
-    };
+    });
 
     const mod = await import("../copyTreeClient");
     copyTreeClient = mod.copyTreeClient;
   });
 
   afterEach(() => {
-    delete typedGlobal.window;
+    vi.unstubAllGlobals();
   });
 
   describe("generate", () => {

--- a/src/clients/copyTreeClient.ts
+++ b/src/clients/copyTreeClient.ts
@@ -13,23 +13,30 @@ import type {
  * history can record it (#11732). It is optional on purpose — it has no effect
  * on the generated bundle, and a caller that omits it is recorded as `unknown`
  * rather than mislabelled.
+ *
+ * `name` is the run's display label (#11734) and is history metadata for the
+ * same reason: it names the run for a human without changing what gets built,
+ * which is why it sits here rather than in `CopyTreeOptions`. Both trail every
+ * generation argument, so existing callers keep their current arity.
  */
 export const copyTreeClient = {
   generate: (
     worktreeId: string,
     options?: CopyTreeOptions,
     includeContent?: boolean,
-    source?: CopyTreeRunSource
+    source?: CopyTreeRunSource,
+    name?: string
   ): Promise<CopyTreeResult> => {
-    return window.electron.copyTree.generate(worktreeId, options, includeContent, source);
+    return window.electron.copyTree.generate(worktreeId, options, includeContent, source, name);
   },
 
   generateAndCopyFile: (
     worktreeId: string,
     options?: CopyTreeOptions,
-    source?: CopyTreeRunSource
+    source?: CopyTreeRunSource,
+    name?: string
   ): Promise<CopyTreeResult> => {
-    return window.electron.copyTree.generateAndCopyFile(worktreeId, options, source);
+    return window.electron.copyTree.generateAndCopyFile(worktreeId, options, source, name);
   },
 
   injectToTerminal: (
@@ -37,14 +44,16 @@ export const copyTreeClient = {
     worktreeId: string,
     options?: CopyTreeOptions,
     injectionId?: string,
-    source?: CopyTreeRunSource
+    source?: CopyTreeRunSource,
+    name?: string
   ): Promise<CopyTreeResult> => {
     return window.electron.copyTree.injectToTerminal(
       terminalId,
       worktreeId,
       options,
       injectionId,
-      source
+      source,
+      name
     );
   },
 

--- a/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
@@ -799,36 +799,49 @@ describe("systemActions adversarial", () => {
    * passing every other assertion here while silently discarding the name.
    */
   describe("copyTree run name", () => {
+    const RAW_NAME = "  Auth flow context  ";
+
+    // The FULL expected client tuple, not just the trailing slot. Asserting only
+    // the last argument would still pass if `source` were dropped and the name
+    // slid into its place — losing attribution silently. Both are strings, so
+    // nothing upstream of this catches that swap.
     const CASES = [
       {
         id: "copyTree.generate",
         mock: copyTreeClientMock.generate,
         args: {} as Record<string, unknown>,
         base: "Context generated",
+        call: ["wt-active", undefined, undefined, "unknown", RAW_NAME],
       },
       {
         id: "copyTree.generateAndCopyFile",
         mock: copyTreeClientMock.generateAndCopyFile,
         args: {} as Record<string, unknown>,
         base: "Context copied",
+        call: ["wt-active", undefined, "unknown", RAW_NAME],
       },
       {
         id: "copyTree.injectToTerminal",
         mock: copyTreeClientMock.injectToTerminal,
         args: { terminalId: "t-1" },
         base: "Context injected",
+        call: ["t-1", "wt-active", undefined, undefined, "unknown", RAW_NAME],
       },
     ];
 
     const titleOf = (): string =>
       (notifyMock.mock.calls[0]?.[0] as { title: string } | undefined)?.title ?? "";
 
-    it.each(CASES)("$id advertises name as an optional string with guidance", ({ id }) => {
+    /**
+     * The `name` property as an MCP client actually receives it.
+     *
+     * Goes through the real conversion, matching ActionService.computeSchemas:
+     * a `.describe()` attached to the wrong link in a zod chain is dropped by
+     * toJSONSchema without error, so reading `.description` off the zod object
+     * would assert text that is never sent.
+     */
+    const emitName = (id: string): { type?: string; description?: string } => {
       const schema = setupActions().getDef(id).argsSchema;
-      // Through the real conversion, matching ActionService.computeSchemas: a
-      // `.describe()` attached to the wrong link in the chain is dropped by
-      // toJSONSchema without error, so reading `.description` off the zod
-      // object would assert text the MCP client is never sent.
       const emitted = z.toJSONSchema(schema!, {
         io: "input",
         unrepresentable: "any",
@@ -839,13 +852,27 @@ describe("systemActions adversarial", () => {
         properties?: Record<string, { type?: string; description?: string }>;
         required?: string[];
       };
-
-      expect(emitted.properties?.name?.type).toBe("string");
       expect(emitted.required ?? []).not.toContain("name");
-      // The two facts a caller needs to use the field well; without them the
-      // field advertises as an unexplained free-text string.
-      expect(emitted.properties?.name?.description).toContain("copy-tree history");
-      expect(emitted.properties?.name?.description).toContain("2 to 4 words");
+      return emitted.properties?.name ?? {};
+    };
+
+    it.each(CASES)("$id advertises name as an optional described string", ({ id }) => {
+      const emitted = emitName(id);
+      expect(emitted.type).toBe("string");
+      // Only that SOME text survived the conversion. Asserting the wording
+      // would copy a literal out of the source and break on a harmless reword;
+      // the failure worth catching is the silent one, where the text is dropped
+      // in transit and the field ships as an unexplained free-text string.
+      expect(emitted.description).toBeTruthy();
+    });
+
+    it("advertises one identical name description across all three tools", () => {
+      // The real invariant behind the wording: all three read from a single
+      // field constant, so a tool that drifted to its own reworded copy — the
+      // way three hand-written descriptions inevitably do — fails here without
+      // pinning what the text actually says.
+      const descriptions = CASES.map(({ id }) => emitName(id).description);
+      expect(new Set(descriptions).size).toBe(1);
     });
 
     it.each(CASES)("$id survives the schema transform rather than being stripped", ({ id }) => {
@@ -862,25 +889,23 @@ describe("systemActions adversarial", () => {
       expect(parsed.name).toBe("Auth flow");
     });
 
-    it.each(CASES)("$id forwards the raw name to the client", async ({ id, mock, args }) => {
-      const { run } = setupActions();
-      // Untrimmed: the client and IPC layers forward verbatim so that
-      // resolveCopyTreeRunName stays the single normalization seam.
-      await run(id, { ...args, name: "  Auth flow context  " }, { activeWorktreeId: "wt-active" });
+    it.each(CASES)(
+      "$id forwards the raw name in the slot after the source",
+      async ({ id, mock, args, call }) => {
+        const { run } = setupActions();
+        // Untrimmed: the client and IPC layers forward verbatim so that
+        // resolveCopyTreeRunName stays the single normalization seam.
+        await run(id, { ...args, name: RAW_NAME }, { activeWorktreeId: "wt-active" });
 
-      const call = mock.mock.calls[0] as unknown[];
-      expect(call[call.length - 1]).toBe("  Auth flow context  ");
-    });
+        expect(mock.mock.calls[0]).toEqual(call);
+      }
+    );
 
     it.each(CASES)(
       "$id labels its completion with the supplied name",
       async ({ id, args, base }) => {
         const { run } = setupActions();
-        await run(
-          id,
-          { ...args, name: "  Auth flow context  " },
-          { activeWorktreeId: "wt-active" }
-        );
+        await run(id, { ...args, name: RAW_NAME }, { activeWorktreeId: "wt-active" });
 
         // Trimmed for display even though it is forwarded raw — the label the
         // user reads must match the one the history stores.
@@ -928,10 +953,10 @@ describe("systemActions adversarial", () => {
           { activeWorktreeId: "wt-active" }
         );
 
-        // deriveCopyTreeRunName would return "auth" here. Surfacing it would
-        // restate, cryptically, the selection the body already summarizes.
+        // deriveCopyTreeRunName returns "auth" for this selection — a bare
+        // basename, which is exactly the kind of fallback that reads as a
+        // riddle in a headline. The exact match below already excludes it.
         expect(titleOf()).toBe(base);
-        expect(titleOf()).not.toContain("auth");
       }
     );
   });

--- a/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { COPY_TREE_UNMATCHED_SELECTORS } from "@shared/types/ipc/copyTree";
+import { COPY_TREE_HISTORY_NAME_MAX_LENGTH } from "@shared/types/ipc/copyTreeHistory";
 import type { ActionCallbacks, ActionRegistry, AnyActionDefinition } from "../../actionTypes";
 
 const filesClientMock = vi.hoisted(() => ({
@@ -200,7 +201,8 @@ describe("systemActions adversarial", () => {
         "wt-active",
         undefined,
         undefined,
-        "unknown"
+        "unknown",
+        undefined
       );
     });
 
@@ -212,7 +214,8 @@ describe("systemActions adversarial", () => {
         "wt-active",
         options,
         undefined,
-        "unknown"
+        "unknown",
+        undefined
       );
     });
 
@@ -223,7 +226,8 @@ describe("systemActions adversarial", () => {
         "wt-active",
         undefined,
         true,
-        "unknown"
+        "unknown",
+        undefined
       );
     });
 
@@ -400,7 +404,8 @@ describe("systemActions adversarial", () => {
       expect(copyTreeClientMock.generateAndCopyFile).toHaveBeenCalledWith(
         "wt-active",
         undefined,
-        "unknown"
+        "unknown",
+        undefined
       );
     });
 
@@ -443,7 +448,8 @@ describe("systemActions adversarial", () => {
       expect(copyTreeClientMock.generateAndCopyFile).toHaveBeenCalledWith(
         "wt-landscape",
         undefined,
-        "mcp"
+        "mcp",
+        undefined
       );
     });
 
@@ -462,7 +468,12 @@ describe("systemActions adversarial", () => {
         { worktreeId: "wt-1", options },
         { dispatchSource: "agent" }
       );
-      expect(copyTreeClientMock.generateAndCopyFile).toHaveBeenCalledWith("wt-1", options, "mcp");
+      expect(copyTreeClientMock.generateAndCopyFile).toHaveBeenCalledWith(
+        "wt-1",
+        options,
+        "mcp",
+        undefined
+      );
 
       // And the selection SURVIVES the schema transform — `run()` is called
       // directly here, so the transform is otherwise never exercised. Asserting
@@ -661,7 +672,8 @@ describe("systemActions adversarial", () => {
         "wt-active",
         undefined,
         undefined,
-        "unknown"
+        "unknown",
+        undefined
       );
     });
 
@@ -677,7 +689,8 @@ describe("systemActions adversarial", () => {
         "wt-explicit",
         undefined,
         undefined,
-        "unknown"
+        "unknown",
+        undefined
       );
     });
 
@@ -775,6 +788,152 @@ describe("systemActions adversarial", () => {
         );
       }
     });
+  });
+
+  /**
+   * The optional run name an MCP caller can attach (#11734).
+   *
+   * Table-driven over all three tools because the field is declared three times
+   * against two different schema builders, and a plain zod object *strips* an
+   * undeclared key rather than rejecting it — a tool that was missed would keep
+   * passing every other assertion here while silently discarding the name.
+   */
+  describe("copyTree run name", () => {
+    const CASES = [
+      {
+        id: "copyTree.generate",
+        mock: copyTreeClientMock.generate,
+        args: {} as Record<string, unknown>,
+        base: "Context generated",
+      },
+      {
+        id: "copyTree.generateAndCopyFile",
+        mock: copyTreeClientMock.generateAndCopyFile,
+        args: {} as Record<string, unknown>,
+        base: "Context copied",
+      },
+      {
+        id: "copyTree.injectToTerminal",
+        mock: copyTreeClientMock.injectToTerminal,
+        args: { terminalId: "t-1" },
+        base: "Context injected",
+      },
+    ];
+
+    const titleOf = (): string =>
+      (notifyMock.mock.calls[0]?.[0] as { title: string } | undefined)?.title ?? "";
+
+    it.each(CASES)("$id advertises name as an optional string with guidance", ({ id }) => {
+      const schema = setupActions().getDef(id).argsSchema;
+      // Through the real conversion, matching ActionService.computeSchemas: a
+      // `.describe()` attached to the wrong link in the chain is dropped by
+      // toJSONSchema without error, so reading `.description` off the zod
+      // object would assert text the MCP client is never sent.
+      const emitted = z.toJSONSchema(schema!, {
+        io: "input",
+        unrepresentable: "any",
+        reused: "inline",
+        cycles: "ref",
+        target: "draft-2020-12",
+      }) as {
+        properties?: Record<string, { type?: string; description?: string }>;
+        required?: string[];
+      };
+
+      expect(emitted.properties?.name?.type).toBe("string");
+      expect(emitted.required ?? []).not.toContain("name");
+      // The two facts a caller needs to use the field well; without them the
+      // field advertises as an unexplained free-text string.
+      expect(emitted.properties?.name?.description).toContain("copy-tree history");
+      expect(emitted.properties?.name?.description).toContain("2 to 4 words");
+    });
+
+    it.each(CASES)("$id survives the schema transform rather than being stripped", ({ id }) => {
+      const schema = setupActions().getDef(id).argsSchema;
+      // Asserting the parsed OUTPUT, not `.success`: zod strips unknown keys and
+      // still reports success, so a success-only check passes on a dropped field.
+      const parsed = schema!.parse({
+        worktreeId: "wt-1",
+        terminalId: "t-1",
+        name: "Auth flow",
+      }) as {
+        name?: string;
+      };
+      expect(parsed.name).toBe("Auth flow");
+    });
+
+    it.each(CASES)("$id forwards the raw name to the client", async ({ id, mock, args }) => {
+      const { run } = setupActions();
+      // Untrimmed: the client and IPC layers forward verbatim so that
+      // resolveCopyTreeRunName stays the single normalization seam.
+      await run(id, { ...args, name: "  Auth flow context  " }, { activeWorktreeId: "wt-active" });
+
+      const call = mock.mock.calls[0] as unknown[];
+      expect(call[call.length - 1]).toBe("  Auth flow context  ");
+    });
+
+    it.each(CASES)(
+      "$id labels its completion with the supplied name",
+      async ({ id, args, base }) => {
+        const { run } = setupActions();
+        await run(
+          id,
+          { ...args, name: "  Auth flow context  " },
+          { activeWorktreeId: "wt-active" }
+        );
+
+        // Trimmed for display even though it is forwarded raw — the label the
+        // user reads must match the one the history stores.
+        expect(titleOf()).toBe(`${base} — Auth flow context`);
+      }
+    );
+
+    it.each(CASES)("$id truncates a long name to the stored length", async ({ id, args, base }) => {
+      const { run } = setupActions();
+      await run(id, { ...args, name: "y".repeat(500) }, { activeWorktreeId: "wt-active" });
+
+      const label = titleOf().slice(base.length + 3);
+      expect(label.length).toBe(COPY_TREE_HISTORY_NAME_MAX_LENGTH);
+      expect(label.endsWith("…")).toBe(true);
+    });
+
+    it.each(CASES)(
+      "$id leaves its title untouched when no name is supplied",
+      async ({ id, args, base }) => {
+        const { run } = setupActions();
+        await run(id, args, { activeWorktreeId: "wt-active" });
+
+        // The derived fallback is deliberately NOT shown: it exists so every
+        // history row has a label, and appending it here would read as noise on
+        // an unnarrowed run ("Context copied — Full context"). This is also what
+        // keeps every pre-existing caller's title byte-identical.
+        expect(titleOf()).toBe(base);
+      }
+    );
+
+    it.each(CASES)("$id treats a blank name as no name at all", async ({ id, args, base }) => {
+      const { run } = setupActions();
+      await run(id, { ...args, name: "   " }, { activeWorktreeId: "wt-active" });
+
+      expect(titleOf()).toBe(base);
+    });
+
+    it.each(CASES)(
+      "$id never derives a label from the options it was given",
+      async ({ id, args, base }) => {
+        const { run } = setupActions();
+        await run(
+          id,
+          { ...args, options: { scopePaths: ["src/auth"] } },
+          { activeWorktreeId: "wt-active" }
+        );
+
+        // deriveCopyTreeRunName would return "auth" here. Surfacing it would
+        // restate, cryptically, the selection the body already summarizes.
+        expect(titleOf()).toBe(base);
+        expect(titleOf()).not.toContain("auth");
+      }
+    );
   });
 
   // #11731. An empty bundle used to arrive as `noFilesMatched: true` and nothing

--- a/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
@@ -829,8 +829,21 @@ describe("systemActions adversarial", () => {
       },
     ];
 
-    const titleOf = (): string =>
-      (notifyMock.mock.calls[0]?.[0] as { title: string } | undefined)?.title ?? "";
+    // Parsed rather than asserted, matching schemaDescriptions.test.ts: a cast
+    // would declare the shape true, while a parse makes a conversion that
+    // stopped returning it fail here instead of yielding `undefined` silently.
+    const EmittedName = z.object({
+      properties: z
+        .object({
+          name: z.object({ type: z.string().optional(), description: z.string().optional() }),
+        })
+        .optional(),
+      required: z.array(z.string()).optional(),
+    });
+
+    const NotifyPayload = z.object({ title: z.string() });
+
+    const titleOf = (): string => NotifyPayload.parse(notifyMock.mock.calls[0]?.[0]).title;
 
     /**
      * The `name` property as an MCP client actually receives it.
@@ -842,18 +855,19 @@ describe("systemActions adversarial", () => {
      */
     const emitName = (id: string): { type?: string; description?: string } => {
       const schema = setupActions().getDef(id).argsSchema;
-      const emitted = z.toJSONSchema(schema!, {
-        io: "input",
-        unrepresentable: "any",
-        reused: "inline",
-        cycles: "ref",
-        target: "draft-2020-12",
-      }) as {
-        properties?: Record<string, { type?: string; description?: string }>;
-        required?: string[];
-      };
+      const emitted = EmittedName.parse(
+        z.toJSONSchema(schema!, {
+          io: "input",
+          unrepresentable: "any",
+          reused: "inline",
+          cycles: "ref",
+          target: "draft-2020-12",
+        })
+      );
       expect(emitted.required ?? []).not.toContain("name");
-      return emitted.properties?.name ?? {};
+      // `properties.name` is required by the schema above, so a tool that never
+      // advertised the field fails in the parse rather than here.
+      return emitted.properties!.name;
     };
 
     it.each(CASES)("$id advertises name as an optional described string", ({ id }) => {
@@ -879,13 +893,9 @@ describe("systemActions adversarial", () => {
       const schema = setupActions().getDef(id).argsSchema;
       // Asserting the parsed OUTPUT, not `.success`: zod strips unknown keys and
       // still reports success, so a success-only check passes on a dropped field.
-      const parsed = schema!.parse({
-        worktreeId: "wt-1",
-        terminalId: "t-1",
-        name: "Auth flow",
-      }) as {
-        name?: string;
-      };
+      const parsed = z
+        .object({ name: z.string().optional() })
+        .parse(schema!.parse({ worktreeId: "wt-1", terminalId: "t-1", name: "Auth flow" }));
       expect(parsed.name).toBe("Auth flow");
     });
 

--- a/src/services/actions/definitions/systemActions.ts
+++ b/src/services/actions/definitions/systemActions.ts
@@ -144,17 +144,21 @@ const copyTreeRunNameField = z
   .string()
   .optional()
   .describe(
-    "Short human-readable label for this copy tree, shown in the user's copy-tree history and in the completion notification. Use 2 to 4 words describing what the context is for, for example 'auth flow context'. Omit it and a label is derived from the selection instead."
+    "Short human-readable label for this copy tree, shown in the user's copy-tree history and in the completion notification. Use 2 to 4 words describing what the context is for, for example 'auth flow context'. Omit it and the history entry falls back to a label derived from the selection, while the notification stays unlabelled."
   );
 
 /**
  * The completion title for a copy-tree run, labelled when the caller named it.
  *
  * Only a *supplied* name is appended, never the derived fallback. The fallback
- * exists so every history row has a label; a notification already has one in
- * `base`, so appending a derived label would read as noise on an unnarrowed run
- * ("Context copied — Full context") or restate, cryptically, the same selection
- * the body already summarizes. That also keeps every existing caller's title
+ * exists so every history row stays navigable, and it is a heuristic — a path
+ * basename, a raw pattern, or "Full context" — which reads as noise in a
+ * headline that already says what happened ("Context copied — Full context")
+ * and as a riddle when it is a bare basename. It can also disagree with the
+ * stored row outright: a deduped unnamed run keeps whatever explicit name is
+ * already on the entry, so a freshly derived label would name the run something
+ * the history does not. An explicit name is caller intent and worth promoting;
+ * the fallback is not. This also keeps every existing caller's title
  * byte-identical — nothing but an explicitly named run changes.
  *
  * Resolved through the helper the main process persists with, so the label the

--- a/src/services/actions/definitions/systemActions.ts
+++ b/src/services/actions/definitions/systemActions.ts
@@ -144,7 +144,7 @@ const copyTreeRunNameField = z
   .string()
   .optional()
   .describe(
-    "Short human-readable label for this copy tree, shown in the user's copy-tree history and in the completion notification. Use 2 to 4 words describing what the context is for, for example 'auth flow context'. Omit it and the history entry falls back to a label derived from the selection, while the notification stays unlabelled."
+    "Short human-readable label for this copy tree, shown in the user's copy-tree history and in the completion notification. Use 2 to 4 words describing what the context is for, for example 'auth flow context'. Omit it and the notification stays unlabelled, while the history entry keeps the label it already has or, if this selection is new, one derived from it."
   );
 
 /**

--- a/src/services/actions/definitions/systemActions.ts
+++ b/src/services/actions/definitions/systemActions.ts
@@ -14,6 +14,7 @@ import { z } from "zod";
 import { notify } from "@/lib/notify";
 import { formatCopyResultMessage } from "@/lib/formatCopyResult";
 import { resolveCopyTreeRunSource } from "@/lib/copyTreeRunSource";
+import { resolveCopyTreeRunName } from "@shared/utils/copyTreeHistory";
 import {
   artifactClient,
   cliAvailabilityClient,
@@ -128,6 +129,43 @@ function requireGeneratedFile(result: CopyTreeResult): { filePath: string; outpu
     throw new Error("Failed to generate context");
   }
   return { filePath: result.filePath, outputBytes: result.outputBytes };
+}
+
+/**
+ * The optional display label an MCP caller can attach to a run (#11734).
+ *
+ * One definition for all three copy-tree tools: the field means the same thing
+ * on each, and the text below is what an agent actually reads when deciding
+ * whether to pass it, so a per-tool reword would be three chances to drift.
+ * `.describe()` sits last in the chain because anything after it is what
+ * `toJSONSchema` emits — attached earlier the text is silently dropped.
+ */
+const copyTreeRunNameField = z
+  .string()
+  .optional()
+  .describe(
+    "Short human-readable label for this copy tree, shown in the user's copy-tree history and in the completion notification. Use 2 to 4 words describing what the context is for, for example 'auth flow context'. Omit it and a label is derived from the selection instead."
+  );
+
+/**
+ * The completion title for a copy-tree run, labelled when the caller named it.
+ *
+ * Only a *supplied* name is appended, never the derived fallback. The fallback
+ * exists so every history row has a label; a notification already has one in
+ * `base`, so appending a derived label would read as noise on an unnarrowed run
+ * ("Context copied — Full context") or restate, cryptically, the same selection
+ * the body already summarizes. That also keeps every existing caller's title
+ * byte-identical — nothing but an explicitly named run changes.
+ *
+ * Resolved through the helper the main process persists with, so the label the
+ * user sees is the one stored in history, trimmed and truncated alike. Options
+ * are not passed: the derive branch is unreachable for a non-blank name, and
+ * feeding them in would imply the fallback can surface here, which is the one
+ * thing this must not do.
+ */
+function copyTreeRunTitle(base: string, suppliedName: string | undefined): string {
+  const trimmed = suppliedName?.trim();
+  return trimmed ? `${base} — ${resolveCopyTreeRunName(trimmed, undefined)}` : base;
 }
 
 export function registerSystemActions(actions: ActionRegistry, _callbacks: ActionCallbacks): void {
@@ -435,6 +473,7 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
       mcpAnnotations: { readOnlyHint: false, idempotentHint: false },
       argsSchema: withWorktreeLocation({
         options: CopyTreeOptionsSchema.optional(),
+        name: copyTreeRunNameField,
         includeContent: z
           .boolean()
           .optional()
@@ -451,7 +490,8 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
           requireWorktreeId(args, ctx),
           args?.options,
           args?.includeContent,
-          resolveCopyTreeRunSource(ctx.dispatchSource, ctx.copyTreeRunSource)
+          resolveCopyTreeRunSource(ctx.dispatchSource, ctx.copyTreeRunSource),
+          args?.name
         );
         throwOnCopyTreeFailure(result);
         const { filePath, outputBytes } = requireGeneratedFile(result);
@@ -480,7 +520,7 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
         // unprotected-success-toast rule, so a disable here would be dead.
         notify({
           type: "success",
-          title: "Context generated",
+          title: copyTreeRunTitle("Context generated", args?.name),
           message: formatCopyResultMessage(
             {
               fileCount: result.fileCount,
@@ -540,6 +580,7 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
         options: CopyTreeOptionsSchema.optional().describe(
           "Selection, exclusion, formatting, and size-budget settings for the bundle."
         ),
+        name: copyTreeRunNameField,
       }).optional(),
       // `destructiveHint` is otherwise derived from `danger === "confirm"`, so
       // this would advertise as non-destructive while `actionRiskBand` already
@@ -560,7 +601,8 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
         const result = await copyTreeClient.generateAndCopyFile(
           requireWorktreeId(args, ctx),
           args?.options,
-          resolveCopyTreeRunSource(ctx.dispatchSource, ctx.copyTreeRunSource)
+          resolveCopyTreeRunSource(ctx.dispatchSource, ctx.copyTreeRunSource),
+          args?.name
         );
         throwOnCopyTreeFailure(result);
         const { filePath, outputBytes } = requireGeneratedFile(result);
@@ -584,7 +626,7 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
           // Matches the title every other copy-tree completion uses for this
           // artifact ("context", never "reference file"), paired with the same
           // formatCopyResultMessage body — see worktreeContextActions.ts.
-          title: "Context copied",
+          title: copyTreeRunTitle("Context copied", args?.name),
           message: formatCopyResultMessage({
             fileCount: result.fileCount,
             stats: result.stats,
@@ -627,6 +669,7 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
         terminalId: z.string(),
         worktreeId: z.string().optional().describe("Worktree ID. Defaults to the active worktree."),
         options: CopyTreeOptionsSchema.optional(),
+        name: copyTreeRunNameField,
       }),
       // No path: this bundle is streamed into the PTY and never written to disk.
       resultSchema: z.object({
@@ -634,7 +677,7 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
         stats: CopyTreeStatsSchema,
       }),
       mcpOutputSchema: true,
-      run: async ({ terminalId, worktreeId, options }, ctx: ActionContext) => {
+      run: async ({ terminalId, worktreeId, options, name }, ctx: ActionContext) => {
         const resolvedWorktreeId = worktreeId ?? ctx.activeWorktreeId;
         if (!resolvedWorktreeId) throw new Error("No active worktree");
         const result = await copyTreeClient.injectToTerminal(
@@ -642,7 +685,8 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
           resolvedWorktreeId,
           options,
           undefined,
-          resolveCopyTreeRunSource(ctx.dispatchSource, ctx.copyTreeRunSource)
+          resolveCopyTreeRunSource(ctx.dispatchSource, ctx.copyTreeRunSource),
+          name
         );
         throwOnCopyTreeFailure(result);
         // "injected … into terminal", not "copied": the bundle streams into a
@@ -654,7 +698,7 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
         // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
         notify({
           type: "success",
-          title: "Context injected",
+          title: copyTreeRunTitle("Context injected", name),
           message: formatCopyResultMessage(
             {
               fileCount: result.fileCount,


### PR DESCRIPTION
## Summary

- Adds an optional `name` parameter to all three copy-tree MCP action tools (`copyTree.generate`, `copyTree.generateAndCopyFile`, `copyTree.injectToTerminal`), so an agent-initiated copy tree run shows up in the project's copy-tree history and completion notification under a human-readable label like "auth flow context" instead of an auto-derived one.
- The downstream machinery already existed from #11732: `CopyTreeHistoryAppendInput.name` was declared and `applyCopyTreeRun` already consumed it. The gap was entirely upstream, so this threads the value through six hops between the action schema and the history append, mirroring how `source` was threaded in #11732.

Resolves #11734

## Changes

1. `electron/schemas/ipc.ts`: the three copyTree action zod payload schemas
2. `shared/types/ipc/copyTree.ts`: hand-typed payload interfaces
3. `electron/ipc/handlers/copyTree.ts`: `recordCompletedCopyTreeRun`, the single construction site of `CopyTreeHistoryAppendInput`
4. `electron/preload.cts` + `shared/types/ipc/api.ts`: both hand-maintained, no codegen, changed in lockstep
5. `src/clients/copyTreeClient.ts`
6. `src/services/actions/definitions/systemActions.ts`: the three `argsSchemas` and run bodies

### Design notes

- `name` stays outside `CopyTreeOptions` so it never enters the history dedupe hash. Two runs that produce an identical bundle stay a single history entry regardless of what they were called.
- `name` is appended after `source` positionally at every hop. Inserting it before would silently reinterpret existing `source` arguments as a name.
- The value is forwarded raw, untrimmed, and possibly blank, so `resolveCopyTreeRunName` stays the single trim and truncate seam. A blank name is treated as absent and preserves a stored label rather than wiping it.
- The completion notification is labelled only when the caller actually supplied a name. The derived fallback exists to keep history rows navigable, and appending it to the notification would read as noise ("Context copied, Full context") or disagree with the stored row on a deduped run. Every pre-existing caller's notification title stays byte-identical.
- The toolbar and human name-entry UI is a separate issue (#11733) and out of scope here.

## Testing

- New `electron/ipc/__tests__/copyTreePreloadPayload.test.ts` closes the one hop no existing suite crossed (the client tests mock `window.electron`, the handler tests invoke handlers directly, and the optional param means typecheck permits a dropped payload key). It asserts a general invariant: every declared copyTree preload argument reaches the invoke payload.
- New `src/clients/__tests__/copyTreeClient.test.ts` pins the positional contract with distinct source and name sentinel values.
- `copyTree.handlers.test.ts` gains a table over all three channels proving `name` reaches `recordCopyTreeRun`, is forwarded raw, and that omitting it records no name.
- `systemActions.adversarial.test.ts` gains a table over all three tools covering the emitted JSON Schema, schema-transform survival, full client call tuples, notification labelling, truncation, and the blank, absent, and derived cases.
- `shared/utils/__tests__/copyTreeHistory.test.ts` gains exact-limit and surrogate-boundary coverage for the supplied-name branch.
- Both new guard tests were mutation-tested: each fails with a precise message when its regression is introduced.

Locally, 465 tests pass across every module this branch touches. Changed files are prettier-clean with zero new eslint warnings, verified per-file against `origin/develop`. No local end-to-end run: it needs a full build, and since this only adds a supplied-name path and leaves the no-name path byte-identical, `e2e/full/terminal/core-context-injection.spec.ts` can't be affected by it.
