### PR TITLE
feat(copytree): turn the toolbar button into a recents dropdown

### DIFF
--- a/e2e/full/terminal/core-context-injection.spec.ts
+++ b/e2e/full/terminal/core-context-injection.spec.ts
@@ -4,13 +4,12 @@ import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
 import { createFixtureRepo } from "../../helpers/fixtures";
 import { openAndOnboardProject } from "../../helpers/project";
 import {
-  clickToolbarButton,
+  copyFullContextFromToolbar,
   getGridPanelCount,
   getGridPanelIds,
   getPanelById,
   openTerminal,
 } from "../../helpers/panels";
-import { SEL } from "../../helpers/selectors";
 import { waitForTerminalTextIgnoringLineBreaks } from "../../helpers/terminal";
 import { T_MEDIUM, T_LONG } from "../../helpers/timeouts";
 
@@ -58,7 +57,9 @@ test.describe.serial("Core: Context Injection", () => {
     // Clear clipboard before testing to avoid false positives
     await app.evaluate(({ clipboard }) => clipboard.writeText(""));
 
-    await clickToolbarButton(window, SEL.toolbar.copyContext, T_MEDIUM);
+    // The toolbar button opens a recents panel now (#11733); the copy itself is
+    // its first row. The helper handles the routes that still copy on the spot.
+    await copyFullContextFromToolbar(window, T_MEDIUM);
 
     // The Copy Context button writes a *file reference* to the clipboard (the
     // generated context lives in a temp file), not the raw text — so readText()

--- a/e2e/full/terminal/core-terminal-panels.spec.ts
+++ b/e2e/full/terminal/core-terminal-panels.spec.ts
@@ -8,7 +8,7 @@ import {
   getFirstGridPanel,
   getGridPanelCount,
   getDockPanelCount,
-  clickToolbarButton,
+  copyFullContextFromToolbar,
   expectToolbarButtonReachable,
   openTerminal,
 } from "../../helpers/panels";
@@ -383,7 +383,10 @@ test.describe.serial("Core: Terminal & Panels", () => {
     test("Copy Context button transitions through states", async () => {
       const { window } = ctx;
 
-      await clickToolbarButton(window, SEL.toolbar.copyContext, T_MEDIUM);
+      // The trigger opens a recents panel rather than copying (#11733); the
+      // helper follows through to the panel's "Copy full context" row so the
+      // serial clipboard assertion below still has a copy to observe.
+      await copyFullContextFromToolbar(window, T_MEDIUM);
       await expectToolbarButtonReachable(window, SEL.toolbar.copyContext, T_LONG);
     });
 

--- a/e2e/full/terminal/core-terminal-panels.spec.ts
+++ b/e2e/full/terminal/core-terminal-panels.spec.ts
@@ -381,7 +381,12 @@ test.describe.serial("Core: Terminal & Panels", () => {
     });
 
     test("Copy Context button transitions through states", async () => {
-      const { window } = ctx;
+      const { app, window } = ctx;
+
+      // Clear first: the next test in this serial block asserts the clipboard
+      // is non-empty, which would pass on leftover content from an earlier
+      // test even if this copy did nothing.
+      await app.evaluate(({ clipboard }) => clipboard.writeText(""));
 
       // The trigger opens a recents panel rather than copying (#11733); the
       // helper follows through to the panel's "Copy full context" row so the

--- a/e2e/full/terminal/core-terminal-panels.spec.ts
+++ b/e2e/full/terminal/core-terminal-panels.spec.ts
@@ -385,8 +385,16 @@ test.describe.serial("Core: Terminal & Panels", () => {
 
       // Clear first: the next test in this serial block asserts the clipboard
       // is non-empty, which would pass on leftover content from an earlier
-      // test even if this copy did nothing.
-      await app.evaluate(({ clipboard }) => clipboard.writeText(""));
+      // test even if this copy did nothing. `clear()` rather than
+      // `writeText("")` — writing empty text still installs a text format, so
+      // the format-count assertion would stay satisfied by the reset itself.
+      await app.evaluate(({ clipboard }) => clipboard.clear());
+      await expect
+        .poll(async () => app.evaluate(({ clipboard }) => clipboard.availableFormats().length), {
+          timeout: T_SHORT,
+          message: "Clipboard should start empty so the copy below is what the next test sees",
+        })
+        .toBe(0);
 
       // The trigger opens a recents panel rather than copying (#11733); the
       // helper follows through to the panel's "Copy full context" row so the

--- a/e2e/helpers/panels.ts
+++ b/e2e/helpers/panels.ts
@@ -391,6 +391,29 @@ export async function clickToolbarButton(
 }
 
 /**
+ * Copy the active worktree's full context from the toolbar (#11733).
+ *
+ * The visible copy-tree button no longer copies — it opens a recents dropdown
+ * whose first row does. Every other route it can take still copies on the spot:
+ * the overflow row and the `Cmd+Shift+C` fallback both bypass the panel by
+ * design, and which route `clickToolbarButton` picks depends on the CI viewport
+ * width. So the panel row is clicked only if a panel actually opened.
+ */
+export async function copyFullContextFromToolbar(page: Page, timeout = 5000): Promise<void> {
+  await clickToolbarButton(page, SEL.toolbar.copyContext, timeout);
+
+  const fullCopyRow = page.getByRole("button", { name: "Copy full context", exact: true });
+  if (
+    await fullCopyRow
+      .first()
+      .isVisible({ timeout: 1000 })
+      .catch(() => false)
+  ) {
+    await fullCopyRow.first().click({ timeout });
+  }
+}
+
+/**
  * Assert that a toolbar command can be reached either as a visible button or
  * through the overflow menu. Use this for toolbar responsiveness checks where
  * direct button visibility depends on CI viewport width.

--- a/e2e/helpers/panels.ts
+++ b/e2e/helpers/panels.ts
@@ -354,6 +354,14 @@ async function hasToolbarOverflowItem(
 }
 
 /**
+ * Which route a toolbar command was actually invoked through. Callers whose
+ * expectations differ per route (a button that opens a panel when visible but
+ * runs immediately from the overflow menu) need this to stay deterministic —
+ * which route applies depends on the CI viewport width.
+ */
+export type ToolbarClickRoute = "visible" | "overflow" | "tray" | "shortcut";
+
+/**
  * Click a toolbar button, handling the case where it may be hidden
  * in the overflow menu on small displays (e.g., Windows CI).
  * Checks direct visibility first, then falls back to the overflow menu.
@@ -362,7 +370,7 @@ export async function clickToolbarButton(
   page: Page,
   selector: string,
   timeout = 5000
-): Promise<void> {
+): Promise<ToolbarClickRoute> {
   await dismissBlockingPalette(page);
 
   const toolbar = page.getByRole("toolbar", { name: "Main toolbar" });
@@ -370,21 +378,21 @@ export async function clickToolbarButton(
 
   for (const candidate of getToolbarButtonLocators(toolbar, selector, label)) {
     if (await clickFirstVisible(candidate, 3000, 1000)) {
-      return;
+      return "visible";
     }
   }
 
   if (label && (await clickToolbarOverflowItem(page, toolbar, label, timeout))) {
-    return;
+    return "overflow";
   }
 
   if (label && (await clickPanelTrayItem(page, toolbar, label, timeout))) {
-    return;
+    return "tray";
   }
 
   if (label && toolbarShortcuts[label]) {
     await page.keyboard.press(toolbarShortcuts[label]);
-    return;
+    return "shortcut";
   }
 
   throw new Error(`Toolbar button ${label ?? selector} was not visible or present`);
@@ -394,23 +402,23 @@ export async function clickToolbarButton(
  * Copy the active worktree's full context from the toolbar (#11733).
  *
  * The visible copy-tree button no longer copies — it opens a recents dropdown
- * whose first row does. Every other route it can take still copies on the spot:
- * the overflow row and the `Cmd+Shift+C` fallback both bypass the panel by
- * design, and which route `clickToolbarButton` picks depends on the CI viewport
- * width. So the panel row is clicked only if a panel actually opened.
+ * whose first row does. Every other route still copies on the spot: the overflow
+ * row and the `Cmd+Shift+C` fallback both bypass the panel by design.
+ *
+ * Branching on the returned route rather than probing for the panel is what
+ * makes this deterministic. `locator.isVisible()` does not wait — its `timeout`
+ * option is a no-op — so a probe would race a cold lazy chunk and silently
+ * return having copied nothing, leaving the caller's clipboard assertion to pass
+ * on whatever was there before.
  */
 export async function copyFullContextFromToolbar(page: Page, timeout = 5000): Promise<void> {
-  await clickToolbarButton(page, SEL.toolbar.copyContext, timeout);
+  const route = await clickToolbarButton(page, SEL.toolbar.copyContext, timeout);
+  if (route !== "visible") return;
 
-  const fullCopyRow = page.getByRole("button", { name: "Copy full context", exact: true });
-  if (
-    await fullCopyRow
-      .first()
-      .isVisible({ timeout: 1000 })
-      .catch(() => false)
-  ) {
-    await fullCopyRow.first().click({ timeout });
-  }
+  const panel = page.getByRole("dialog", { name: "Copy context" });
+  const fullCopyRow = panel.getByRole("button", { name: "Copy full context", exact: true });
+  await fullCopyRow.waitFor({ state: "visible", timeout });
+  await fullCopyRow.click({ timeout });
 }
 
 /**

--- a/src/components/CopyTree/CopyTreeRecentsPanel.tsx
+++ b/src/components/CopyTree/CopyTreeRecentsPanel.tsx
@@ -1,0 +1,155 @@
+import { useEffect } from "react";
+import { Folders, History } from "@/components/icons";
+import { cn } from "@/lib/utils";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { ScrollShadow } from "@/components/ui/ScrollShadow";
+import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
+import { useDohertyGate } from "@/hooks/useDeferredLoading";
+import { useCopyTreeHistoryStore } from "@/store/copyTreeHistoryStore";
+import { formatBytes } from "@/lib/formatBytes";
+import { formatRelativeTime } from "@/lib/formatRelativeTime";
+import type { CopyTreeHistoryRecord } from "@shared/types";
+
+/**
+ * How many recent runs the panel shows. Main keeps twenty per project so the
+ * long tail survives a burst of one-off copies; the panel is a shortcut list,
+ * not a browser, so it takes the newest handful.
+ */
+const RECENTS_LIMIT = 5;
+
+/** Row count while hydrating — a plausible list, not the cap. */
+const SKELETON_ROWS = 3;
+
+/**
+ * The compact second line on a recent: how big the run was and when it last
+ * ran. Deliberately not `formatCopyResultMessage` — that composes a completion
+ * sentence ("Copied 12 files (3.4 KB) as XML to clipboard") for the toast that
+ * announces a copy just happened, which is the wrong tense and far too long for
+ * a list row describing a copy the user might repeat.
+ *
+ * `totalSize` rides on the run result's optional stats, so a run that reported
+ * no size is shown without one rather than padded with a zero.
+ */
+export function formatRecentMeta(record: CopyTreeHistoryRecord, now?: number): string {
+  const { fileCount, totalSize } = record.stats;
+  const parts = [fileCount === 1 ? "1 file" : `${fileCount} files`];
+  if (totalSize) parts.push(formatBytes(totalSize));
+  parts.push(formatRelativeTime(record.lastUsedAt, now));
+  return parts.join(" · ");
+}
+
+// Rows carry no accent: hierarchy here comes from typography and placement, and
+// the panel is one focus region where the focus ring is the only anchor that
+// earns emphasis. The keyboard highlight rides the same neutral surface as
+// hover rather than a second colour, and the app's default focus outline is
+// left in place rather than replaced.
+const rowClass = cn(
+  "w-full flex items-center gap-2.5 px-3 py-2 text-left",
+  "text-daintree-text hover:bg-overlay-raised focus-visible:bg-overlay-raised",
+  "transition-colors"
+);
+
+interface CopyTreeRecentsPanelProps {
+  /** The old one-click behavior, now one click deeper. */
+  onCopyFullContext: () => void;
+  /** Re-run a stored option set against the active worktree. */
+  onRunRecent: (record: CopyTreeHistoryRecord) => void;
+}
+
+/**
+ * The copy-tree toolbar dropdown (#11733).
+ *
+ * Six output formats, filters, scoped copies and MCP-named copy trees had all
+ * collapsed behind one button that silently generated the full tree. This panel
+ * keeps that copy one click away and puts the project's recent runs beside it.
+ *
+ * Lazy-loaded and mounted only once the dropdown has opened, so the history
+ * mirror's IPC pull is paid on first use rather than at app start.
+ */
+export function CopyTreeRecentsPanel({
+  onCopyFullContext,
+  onRunRecent,
+}: CopyTreeRecentsPanelProps) {
+  const records = useCopyTreeHistoryStore((s) => s.records);
+  const loading = useCopyTreeHistoryStore((s) => s.loading);
+  const init = useCopyTreeHistoryStore((s) => s.init);
+
+  // Idempotent at the store: later opens re-run this and return immediately.
+  // The subscription deliberately outlives the panel — an MCP or context-menu
+  // copy taken while the dropdown is closed still lands before the next open.
+  useEffect(() => {
+    init();
+  }, [init]);
+
+  // Records arrive newest-first and project-scoped from Main, so this is the
+  // whole selection step.
+  const recents = records.slice(0, RECENTS_LIMIT);
+
+  // Header and primary row paint immediately; only the recents section waits.
+  // The bones are `immediate` because this gate has already proven the wait
+  // exceeded the Doherty threshold — the class-level delay would gate it twice.
+  const showSkeleton = useDohertyGate(loading);
+
+  return (
+    <div className="w-[360px] max-h-[420px] flex flex-col">
+      <div className="flex items-center pl-3 pr-2 py-2 border-b border-divider">
+        <span className="text-xs font-medium text-daintree-text/80">Copy context</span>
+      </div>
+
+      <button type="button" onClick={onCopyFullContext} className={rowClass}>
+        <Folders className="w-4 h-4 shrink-0 text-daintree-text/70" aria-hidden="true" />
+        <span className="min-w-0 flex-1 truncate text-sm font-medium">Copy full context</span>
+      </button>
+
+      <div className="flex items-center px-3 pt-2 pb-1 border-t border-divider">
+        <span className="text-xs font-medium text-daintree-text/80">Recent</span>
+      </div>
+
+      <ScrollShadow className="flex-1 min-h-0">
+        {/* One stable child: the shadow hook observes firstElementChild, so it
+            must outlive the skeleton/empty-state/list swaps below. */}
+        <div className="pb-1">
+          {loading ? (
+            showSkeleton ? (
+              <Skeleton label="Loading recent copies" className="flex flex-col gap-2 px-3 py-2">
+                {Array.from({ length: SKELETON_ROWS }, (_, i) => (
+                  <div key={i} className="flex flex-col gap-1.5">
+                    <SkeletonBone immediate heightPx={12} className="w-1/2" />
+                    <SkeletonBone immediate heightPx={10} className="w-2/3" />
+                  </div>
+                ))}
+              </Skeleton>
+            ) : null
+          ) : recents.length === 0 ? (
+            <EmptyState
+              variant="zero-data"
+              scale="popover"
+              title="Copy a context to start your recents"
+              icon={<History />}
+              className="py-6"
+            />
+          ) : (
+            <ul className="flex flex-col">
+              {recents.map((record) => (
+                <li key={record.id}>
+                  <button
+                    type="button"
+                    onClick={() => onRunRecent(record)}
+                    className={cn(rowClass, "items-start")}
+                  >
+                    <span className="min-w-0 flex-1 flex flex-col gap-0.5">
+                      <span className="truncate text-sm">{record.name}</span>
+                      <span className="truncate text-[11px] text-daintree-text/50">
+                        {formatRecentMeta(record)}
+                      </span>
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </ScrollShadow>
+    </div>
+  );
+}

--- a/src/components/CopyTree/CopyTreeRecentsPanel.tsx
+++ b/src/components/CopyTree/CopyTreeRecentsPanel.tsx
@@ -1,9 +1,9 @@
-import { useEffect } from "react";
+import { useEffect, useId, useRef } from "react";
 import { Folders, History } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { ScrollShadow } from "@/components/ui/ScrollShadow";
-import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
+import { Skeleton, SkeletonBone, SkeletonHint } from "@/components/ui/Skeleton";
 import { useDohertyGate } from "@/hooks/useDeferredLoading";
 import { useCopyTreeHistoryStore } from "@/store/copyTreeHistoryStore";
 import { formatBytes } from "@/lib/formatBytes";
@@ -73,6 +73,17 @@ export function CopyTreeRecentsPanel({
   const records = useCopyTreeHistoryStore((s) => s.records);
   const loading = useCopyTreeHistoryStore((s) => s.loading);
   const init = useCopyTreeHistoryStore((s) => s.init);
+  const headingId = useId();
+  const primaryRowRef = useRef<HTMLButtonElement>(null);
+
+  // The trigger advertises `aria-haspopup="dialog"`, and this panel is where
+  // the button's own action now lives — so focus has to come in with it. The
+  // dropdown portals to the end of <body>, so a keyboard user who left focus on
+  // the trigger would otherwise have to tab through the whole app to reach
+  // these rows. The body unmounts on close, so this runs once per open.
+  useEffect(() => {
+    primaryRowRef.current?.focus();
+  }, []);
 
   // Idempotent at the store: later opens re-run this and return immediately.
   // The subscription deliberately outlives the panel — an MCP or context-menu
@@ -91,12 +102,19 @@ export function CopyTreeRecentsPanel({
   const showSkeleton = useDohertyGate(loading);
 
   return (
-    <div className="w-[360px] max-h-[420px] flex flex-col">
+    <div
+      data-copy-tree-panel=""
+      role="dialog"
+      aria-labelledby={headingId}
+      className="w-[360px] max-h-[420px] flex flex-col"
+    >
       <div className="flex items-center pl-3 pr-2 py-2 border-b border-divider">
-        <span className="text-xs font-medium text-daintree-text/80">Copy context</span>
+        <span id={headingId} className="text-xs font-medium text-daintree-text/80">
+          Copy context
+        </span>
       </div>
 
-      <button type="button" onClick={onCopyFullContext} className={rowClass}>
+      <button ref={primaryRowRef} type="button" onClick={onCopyFullContext} className={rowClass}>
         <Folders className="w-4 h-4 shrink-0 text-daintree-text/70" aria-hidden="true" />
         <span className="min-w-0 flex-1 truncate text-sm font-medium">Copy full context</span>
       </button>
@@ -111,14 +129,21 @@ export function CopyTreeRecentsPanel({
         <div className="pb-1">
           {loading ? (
             showSkeleton ? (
-              <Skeleton label="Loading recent copies" className="flex flex-col gap-2 px-3 py-2">
-                {Array.from({ length: SKELETON_ROWS }, (_, i) => (
-                  <div key={i} className="flex flex-col gap-1.5">
-                    <SkeletonBone immediate heightPx={12} className="w-1/2" />
-                    <SkeletonBone immediate heightPx={10} className="w-2/3" />
-                  </div>
-                ))}
-              </Skeleton>
+              <>
+                <Skeleton label="Loading recent copies" className="flex flex-col gap-2 px-3 py-2">
+                  {Array.from({ length: SKELETON_ROWS }, (_, i) => (
+                    <div key={i} className="flex flex-col gap-1.5">
+                      <SkeletonBone immediate heightPx={12} className="w-1/2" />
+                      <SkeletonBone immediate heightPx={10} className="w-2/3" />
+                    </div>
+                  ))}
+                </Skeleton>
+                {/* Sibling, never nested: the Skeleton wrapper's aria-busy
+                    silences mutations inside its subtree. A local history read
+                    should never take this long, so if it does the user needs to
+                    be told rather than left watching a pulse. */}
+                <SkeletonHint className="px-3 pb-2" />
+              </>
             ) : null
           ) : recents.length === 0 ? (
             <EmptyState

--- a/src/components/CopyTree/__tests__/CopyTreeRecentsPanel.test.tsx
+++ b/src/components/CopyTree/__tests__/CopyTreeRecentsPanel.test.tsx
@@ -31,6 +31,11 @@ import {
   _resetCopyTreeHistoryStoreForTest,
 } from "@/store/copyTreeHistoryStore";
 
+// Hoisted so the mock factory can reference the spy directly rather than
+// through a closure that only resolves at mount time — a later edit to
+// `init: initSpy` would otherwise become a TDZ collection failure.
+const { initSpy } = vi.hoisted(() => ({ initSpy: vi.fn() }));
+
 vi.mock("@/store/copyTreeHistoryStore", async () => {
   const { create } = await import("zustand");
   const store = create<{
@@ -40,15 +45,13 @@ vi.mock("@/store/copyTreeHistoryStore", async () => {
   }>(() => ({
     records: [],
     loading: true,
-    init: () => initSpy(),
+    init: initSpy,
   }));
   return {
     useCopyTreeHistoryStore: store,
     _resetCopyTreeHistoryStoreForTest: () => store.setState({ records: [], loading: true }),
   };
 });
-
-const initSpy = vi.fn();
 
 function makeRecord(overrides: Partial<CopyTreeHistoryRecord> = {}): CopyTreeHistoryRecord {
   const id = overrides.id ?? "r1";
@@ -122,6 +125,8 @@ describe("CopyTreeRecentsPanel", () => {
   it("never falls back to a spinner while hydrating", () => {
     // The panel's shape is predictable, so the loading rule is skeleton-or-
     // nothing; a spinner here is the specific thing the issue ruled out.
+    // `.animate-spin` is what the shared Spinner actually renders — it carries
+    // no test id, so that is the only marker that would catch a regression.
     vi.useFakeTimers();
     const { container, unmount } = render(
       <CopyTreeRecentsPanel onCopyFullContext={noop} onRunRecent={noop} />
@@ -129,9 +134,84 @@ describe("CopyTreeRecentsPanel", () => {
     act(() => {
       vi.advanceTimersByTime(500);
     });
-    expect(container.querySelector('[data-testid="spinner"]')).toBeNull();
     expect(container.querySelector(".animate-spin")).toBeNull();
     unmount();
+  });
+
+  it("tears the skeleton down once history resolves and does not bring it back", () => {
+    // The gate's timer is still pending when loading flips. Without the outer
+    // `loading` branch owning the swap, a late-firing gate would remount a
+    // skeleton over an already-populated list.
+    vi.useFakeTimers();
+    const { unmount } = render(
+      <CopyTreeRecentsPanel onCopyFullContext={noop} onRunRecent={noop} />
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(screen.queryByRole("status")).not.toBeNull();
+
+    act(() => {
+      useCopyTreeHistoryStore.setState({ records: [makeRecord()], loading: false });
+    });
+    expect(screen.queryByRole("status")).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(screen.queryByRole("status")).toBeNull();
+
+    unmount();
+  });
+
+  it("shows no skeleton at all when history resolves inside the gate", () => {
+    vi.useFakeTimers();
+    const { unmount } = render(
+      <CopyTreeRecentsPanel onCopyFullContext={noop} onRunRecent={noop} />
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+      useCopyTreeHistoryStore.setState({ records: [makeRecord()], loading: false });
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.queryByRole("status")).toBeNull();
+    unmount();
+  });
+
+  it("is a named dialog that takes focus so the rows are keyboard-reachable", () => {
+    // The trigger declares aria-haspopup="dialog" and the panel now owns the
+    // button's former action. Portaled to the end of <body>, an unfocused panel
+    // would leave a keyboard user tabbing through the whole app to reach it.
+    seed([makeRecord()]);
+    render(<CopyTreeRecentsPanel onCopyFullContext={noop} onRunRecent={noop} />);
+
+    const dialog = screen.getByRole("dialog");
+    const labelId = dialog.getAttribute("aria-labelledby");
+    expect(labelId).toBeTruthy();
+    // The name has to resolve to real text inside the panel — a dangling id
+    // leaves the dialog anonymous to a screen reader. Asserted by resolution
+    // rather than against a duplicated literal.
+    expect(document.getElementById(labelId!)?.textContent?.trim()).toBeTruthy();
+
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: "Copy full context" }));
+  });
+
+  it("activates a row from the keyboard", () => {
+    seed([makeRecord({ name: "authentication stuff" })]);
+    const onRunRecent = vi.fn();
+    render(<CopyTreeRecentsPanel onCopyFullContext={noop} onRunRecent={onRunRecent} />);
+
+    const row = screen.getByRole("button", { name: /authentication stuff/ });
+    row.focus();
+    fireEvent.keyDown(row, { key: "Enter" });
+    fireEvent.click(row);
+
+    expect(onRunRecent).toHaveBeenCalledTimes(1);
   });
 
   it("names the next action when the project has no history yet", () => {

--- a/src/components/CopyTree/__tests__/CopyTreeRecentsPanel.test.tsx
+++ b/src/components/CopyTree/__tests__/CopyTreeRecentsPanel.test.tsx
@@ -1,0 +1,228 @@
+// @vitest-environment jsdom
+/**
+ * CopyTreeRecentsPanel — the copy-tree toolbar dropdown body (#11733).
+ *
+ * The panel is what turned a silent one-click full copy into a two-stage
+ * interaction, so what matters here is that the primary action stays reachable
+ * at all times, that the recents list faithfully reflects the project history
+ * it is a shortcut into, and that a hydrating history never flashes chrome the
+ * Doherty gate exists to suppress.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+
+// jsdom ships no ResizeObserver; ScrollShadow's shadow hook constructs one.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = ResizeObserverStub as typeof ResizeObserver;
+  }
+});
+
+import type { CopyTreeHistoryRecord } from "@shared/types";
+import { CopyTreeRecentsPanel, formatRecentMeta } from "../CopyTreeRecentsPanel";
+import {
+  useCopyTreeHistoryStore,
+  _resetCopyTreeHistoryStoreForTest,
+} from "@/store/copyTreeHistoryStore";
+
+vi.mock("@/store/copyTreeHistoryStore", async () => {
+  const { create } = await import("zustand");
+  const store = create<{
+    records: CopyTreeHistoryRecord[];
+    loading: boolean;
+    init: () => void;
+  }>(() => ({
+    records: [],
+    loading: true,
+    init: () => initSpy(),
+  }));
+  return {
+    useCopyTreeHistoryStore: store,
+    _resetCopyTreeHistoryStoreForTest: () => store.setState({ records: [], loading: true }),
+  };
+});
+
+const initSpy = vi.fn();
+
+function makeRecord(overrides: Partial<CopyTreeHistoryRecord> = {}): CopyTreeHistoryRecord {
+  const id = overrides.id ?? "r1";
+  return {
+    id,
+    dedupeKey: `key-${id}`,
+    name: `Run ${id}`,
+    options: {},
+    source: "toolbar",
+    worktreeId: "wt-1",
+    stats: { fileCount: 3, totalSize: 2048 },
+    createdAt: 0,
+    lastUsedAt: 1_000,
+    runCount: 1,
+    ...overrides,
+  };
+}
+
+function seed(records: CopyTreeHistoryRecord[]) {
+  act(() => {
+    useCopyTreeHistoryStore.setState({ records, loading: false });
+  });
+}
+
+const noop = () => {};
+
+describe("CopyTreeRecentsPanel", () => {
+  beforeEach(() => {
+    initSpy.mockClear();
+    _resetCopyTreeHistoryStoreForTest();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("initializes the history mirror on mount", () => {
+    // The store has no other consumer in the app, so if the panel stops calling
+    // init() the recents list is permanently empty rather than merely stale.
+    seed([]);
+    render(<CopyTreeRecentsPanel onCopyFullContext={noop} onRunRecent={noop} />);
+    expect(initSpy).toHaveBeenCalled();
+  });
+
+  it("offers the full copy while history is still hydrating", () => {
+    // The primary row is the old one-click behavior. Gating it behind the
+    // history pull would make the panel slower than the button it replaced.
+    render(<CopyTreeRecentsPanel onCopyFullContext={noop} onRunRecent={noop} />);
+    expect(screen.getByRole("button", { name: "Copy full context" })).toBeTruthy();
+  });
+
+  it("shows no loading chrome before the Doherty threshold, then skeleton rows", () => {
+    vi.useFakeTimers();
+    const { unmount } = render(
+      <CopyTreeRecentsPanel onCopyFullContext={noop} onRunRecent={noop} />
+    );
+
+    // A fast hydration must resolve without ever having painted a placeholder.
+    expect(screen.queryByRole("status")).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(screen.getByRole("status")).toBeTruthy();
+
+    // Unmount before restoring real timers so the gate's pending timeout cannot
+    // fire against a torn-down tree.
+    unmount();
+  });
+
+  it("never falls back to a spinner while hydrating", () => {
+    // The panel's shape is predictable, so the loading rule is skeleton-or-
+    // nothing; a spinner here is the specific thing the issue ruled out.
+    vi.useFakeTimers();
+    const { container, unmount } = render(
+      <CopyTreeRecentsPanel onCopyFullContext={noop} onRunRecent={noop} />
+    );
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(container.querySelector('[data-testid="spinner"]')).toBeNull();
+    expect(container.querySelector(".animate-spin")).toBeNull();
+    unmount();
+  });
+
+  it("names the next action when the project has no history yet", () => {
+    seed([]);
+    render(<CopyTreeRecentsPanel onCopyFullContext={noop} onRunRecent={noop} />);
+    // Empty-state convention: point at what to do, not at what is missing.
+    const emptyText = screen.getByText(/copy a context/i).textContent ?? "";
+    expect(emptyText.toLowerCase()).not.toContain("no recent");
+  });
+
+  it("surfaces only the five newest runs, in the order Main sent them", () => {
+    // Main already sorts newest-first and caps the durable list; re-sorting here
+    // would fight that, so the contract is "take the first five, unchanged".
+    const records = Array.from({ length: 8 }, (_, i) => makeRecord({ id: `r${i}` }));
+    seed(records);
+    render(<CopyTreeRecentsPanel onCopyFullContext={noop} onRunRecent={noop} />);
+
+    const rendered = screen
+      .getAllByRole("button")
+      .map((b) => b.textContent ?? "")
+      .filter((t) => t.startsWith("Run "));
+
+    expect(rendered).toHaveLength(5);
+    expect(rendered[0]).toContain("Run r0");
+    expect(rendered[4]).toContain("Run r4");
+    expect(screen.queryByText("Run r5")).toBeNull();
+  });
+
+  it("hands the clicked record back untouched so its stored options replay intact", () => {
+    // The whole point of the recents list: whatever was captured — including
+    // fields the flat `worktree.copyTree` schema would strip — comes back out.
+    const record = makeRecord({
+      id: "curated",
+      name: "authentication stuff",
+      options: { filter: ["src/auth/**"], format: "markdown", sort: "size", withLineNumbers: true },
+    });
+    seed([record]);
+    const onRunRecent = vi.fn();
+    render(<CopyTreeRecentsPanel onCopyFullContext={noop} onRunRecent={onRunRecent} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /authentication stuff/ }));
+
+    expect(onRunRecent).toHaveBeenCalledWith(record);
+    expect(onRunRecent.mock.calls[0]![0].options).toBe(record.options);
+  });
+
+  it("routes the primary row to the full-copy callback", () => {
+    seed([makeRecord()]);
+    const onCopyFullContext = vi.fn();
+    const onRunRecent = vi.fn();
+    render(
+      <CopyTreeRecentsPanel onCopyFullContext={onCopyFullContext} onRunRecent={onRunRecent} />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy full context" }));
+
+    expect(onCopyFullContext).toHaveBeenCalledTimes(1);
+    expect(onRunRecent).not.toHaveBeenCalled();
+  });
+});
+
+describe("formatRecentMeta", () => {
+  it("drops the size segment when the run recorded none", () => {
+    // `totalSize` rides on the result's optional stats, so a run that reported
+    // none must read as unknown rather than as zero bytes.
+    const withSize = formatRecentMeta(
+      makeRecord({ stats: { fileCount: 3, totalSize: 2048 } }),
+      1_000
+    );
+    const withoutSize = formatRecentMeta(makeRecord({ stats: { fileCount: 3 } }), 1_000);
+
+    expect(withSize.split(" · ")).toHaveLength(3);
+    expect(withoutSize.split(" · ")).toHaveLength(2);
+    expect(withoutSize).not.toMatch(/\d+\s?(B|KB|MB)/);
+  });
+
+  it("agrees with the byte formatter the rest of the app uses", async () => {
+    const { formatBytes } = await import("@/lib/formatBytes");
+    const meta = formatRecentMeta(makeRecord({ stats: { fileCount: 2, totalSize: 5000 } }), 1_000);
+    expect(meta).toContain(formatBytes(5000));
+  });
+
+  it("singularizes a one-file run", () => {
+    const one = formatRecentMeta(makeRecord({ stats: { fileCount: 1 } }), 1_000);
+    const many = formatRecentMeta(makeRecord({ stats: { fileCount: 2 } }), 1_000);
+    expect(one.startsWith("1 file ")).toBe(true);
+    expect(many.startsWith("2 files")).toBe(true);
+  });
+
+  it("reports the last run time relative to now", () => {
+    const meta = formatRecentMeta(makeRecord({ lastUsedAt: 0 }), 3 * 60 * 60 * 1000);
+    expect(meta).toContain("hours ago");
+  });
+});

--- a/src/components/CopyTree/__tests__/CopyTreeRecentsPanel.test.tsx
+++ b/src/components/CopyTree/__tests__/CopyTreeRecentsPanel.test.tsx
@@ -201,17 +201,26 @@ describe("CopyTreeRecentsPanel", () => {
     expect(document.activeElement).toBe(screen.getByRole("button", { name: "Copy full context" }));
   });
 
-  it("activates a row from the keyboard", () => {
+  it("builds every row as a real button so Enter and Space work natively", () => {
+    // Asserting the element type rather than firing Enter: jsdom does not
+    // synthesize a click from Enter, so a keydown test would prove nothing
+    // about activation. Native button semantics are the thing this component
+    // actually controls — a regression to a clickable div would fail here,
+    // and it is what makes the panel operable without a roving-tabindex system.
     seed([makeRecord({ name: "authentication stuff" })]);
-    const onRunRecent = vi.fn();
-    render(<CopyTreeRecentsPanel onCopyFullContext={noop} onRunRecent={onRunRecent} />);
+    render(<CopyTreeRecentsPanel onCopyFullContext={noop} onRunRecent={noop} />);
 
-    const row = screen.getByRole("button", { name: /authentication stuff/ });
-    row.focus();
-    fireEvent.keyDown(row, { key: "Enter" });
-    fireEvent.click(row);
-
-    expect(onRunRecent).toHaveBeenCalledTimes(1);
+    const rows = [
+      screen.getByRole("button", { name: "Copy full context" }),
+      screen.getByRole("button", { name: /authentication stuff/ }),
+    ];
+    for (const row of rows) {
+      expect(row.tagName).toBe("BUTTON");
+      // Without an explicit type, a button inside a form defaults to submit.
+      expect(row.getAttribute("type")).toBe("button");
+      expect(row.hasAttribute("disabled")).toBe(false);
+      expect(row.getAttribute("tabindex")).toBeNull();
+    }
   });
 
   it("names the next action when the project has no history yet", () => {

--- a/src/components/CopyTree/__tests__/copyTreeFocus.test.tsx
+++ b/src/components/CopyTree/__tests__/copyTreeFocus.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+/**
+ * Close-time focus restoration for the copy-tree dropdown (#11733).
+ *
+ * The trigger's own action moved inside the panel, so the panel takes focus on
+ * open — which makes handing it back on close the toolbar's problem. The trap is
+ * the exit transition: `FixedDropdown` keeps its body mounted while the panel
+ * animates out, so for that whole window the focused row is still in the
+ * document and "has anything else claimed focus?" cannot be answered by looking
+ * for `<body>`. These tests render the real dropdown so that window is real.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import { useRef, useState } from "react";
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = ResizeObserverStub as typeof ResizeObserver;
+  }
+});
+
+vi.mock("@/store/uiStore", () => ({
+  useUIStore: (selector: (state: { overlayStack: string[] }) => unknown) =>
+    selector({ overlayStack: [] }),
+}));
+
+vi.mock("@/store/copyTreeHistoryStore", async () => {
+  const { create } = await import("zustand");
+  const store = create(() => ({ records: [], loading: false, init: () => {} }));
+  return { useCopyTreeHistoryStore: store };
+});
+
+import { FixedDropdown } from "@/components/ui/fixed-dropdown";
+import { useGlobalEscapeDispatcher } from "@/hooks/useGlobalEscapeDispatcher";
+import { _resetForTests } from "@/lib/escapeStack";
+import { CopyTreeRecentsPanel } from "../CopyTreeRecentsPanel";
+import { restoreCopyTreeTriggerFocus } from "../copyTreeFocus";
+
+let frames: FrameRequestCallback[] = [];
+
+function flushFrames() {
+  act(() => {
+    const queued = frames;
+    frames = [];
+    for (const cb of queued) cb(0);
+  });
+}
+
+function Harness() {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  useGlobalEscapeDispatcher();
+
+  // The toolbar's `closeCopyTreePanel`, and the only part of it worth mirroring:
+  // drop the open state, then let the helper decide about focus.
+  const close = () => {
+    setOpen(false);
+    restoreCopyTreeTriggerFocus(triggerRef.current);
+  };
+
+  return (
+    <>
+      <button ref={triggerRef} type="button" onClick={() => setOpen(true)}>
+        Copy context
+      </button>
+      <input data-testid="outside" />
+      <FixedDropdown
+        open={open}
+        onOpenChange={(next) => {
+          if (!next) close();
+        }}
+        anchorRef={triggerRef}
+      >
+        <CopyTreeRecentsPanel onCopyFullContext={close} onRunRecent={close} />
+      </FixedDropdown>
+    </>
+  );
+}
+
+function openPanel() {
+  const trigger = screen.getByRole("button", { name: "Copy context" });
+  fireEvent.click(trigger);
+  flushFrames();
+  return trigger;
+}
+
+describe("copy-tree dropdown focus restoration", () => {
+  beforeEach(() => {
+    _resetForTests();
+    frames = [];
+    vi.useFakeTimers();
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => frames.push(cb));
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+    render(<Harness />);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("hands focus back to the trigger while the panel is still animating out", () => {
+    const trigger = openPanel();
+    const primaryRow = screen.getByRole("button", { name: "Copy full context" });
+    expect(document.activeElement).toBe(primaryRow);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    flushFrames();
+
+    // The panel is still mounted here — the exact window in which a check for
+    // `<body>` alone finds the focused row instead and restores nothing.
+    expect(screen.queryByRole("dialog")).not.toBeNull();
+    expect(document.activeElement).toBe(trigger);
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("hands focus back to the trigger when a row is chosen", () => {
+    const trigger = openPanel();
+    fireEvent.click(screen.getByRole("button", { name: "Copy full context" }));
+    flushFrames();
+
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("leaves focus wherever an outside click put it", () => {
+    openPanel();
+    const outside = screen.getByTestId("outside");
+
+    // The dismiss path runs off `mousedown`, ahead of the browser's own focus
+    // transfer — so the panel still holds focus at the moment it closes.
+    fireEvent.mouseDown(outside);
+    act(() => {
+      outside.focus();
+    });
+    flushFrames();
+
+    expect(document.activeElement).toBe(outside);
+  });
+});

--- a/src/components/CopyTree/copyTreeFocus.ts
+++ b/src/components/CopyTree/copyTreeFocus.ts
@@ -1,0 +1,41 @@
+/**
+ * Focus hand-off for the copy-tree toolbar dropdown (#11733). Kept out of
+ * `Toolbar.tsx` so the close-time restoration can be exercised against a real
+ * DOM — the toolbar itself is too large to mount in jsdom.
+ */
+
+// The panel portals out of the toolbar, so "is focus still inside it?" can't be
+// answered by a DOM ancestor check from the trigger. The marker attribute is
+// the panel component's half of that contract.
+const COPY_TREE_PANEL_SELECTOR = "[data-copy-tree-panel]";
+
+export function isInsideCopyTreePanel(node: Element | null): boolean {
+  return node instanceof HTMLElement && node.closest(COPY_TREE_PANEL_SELECTOR) !== null;
+}
+
+/**
+ * Hand focus back to the trigger when closing the panel would otherwise strand
+ * it — but never fight a destination the user chose.
+ *
+ * Both reads matter. The first happens at close time, and can only rule the
+ * restore OUT: the dismiss path runs off `mousedown`, which fires before the
+ * browser's default focus transfer, so focus still sitting in the panel here
+ * says nothing about where it is headed.
+ *
+ * The second runs a frame later, once focus has settled, and counts the exiting
+ * panel as "nowhere". Closing does not unmount the body: `FixedDropdown` plays
+ * an exit transition first, so a frame later the focused row is still in the
+ * document, and it is the unmount at the end of that window — not this frame —
+ * that would otherwise drop the user on `<body>`.
+ */
+export function restoreCopyTreeTriggerFocus(trigger: HTMLElement | null): void {
+  const active = document.activeElement;
+  if (!isInsideCopyTreePanel(active) && active !== null && active !== document.body) return;
+
+  requestAnimationFrame(() => {
+    const settled = document.activeElement;
+    if (settled === null || settled === document.body || isInsideCopyTreePanel(settled)) {
+      trigger?.focus();
+    }
+  });
+}

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -849,14 +849,26 @@ export function Toolbar({
   // Close and hand focus back to the trigger — but only when focus would
   // otherwise be lost. An outside click has already moved focus somewhere the
   // user chose, and yanking it back to the toolbar would fight that.
+  //
+  // The decision is deferred a frame because it cannot be made yet: the
+  // dismiss path runs off `mousedown`, which fires BEFORE the browser's default
+  // focus transfer, so reading `activeElement` here would still show the panel
+  // row on an outside click and restore the trigger over the user's choice.
+  // After the frame, focus has settled — landing on `body` is the honest signal
+  // that nothing else claimed it.
   const closeCopyTreePanel = useCallback(() => {
     const active = document.activeElement;
     const focusWasInPanel =
-      active instanceof HTMLElement && active.closest(COPY_TREE_PANEL_SELECTOR);
+      active instanceof HTMLElement && active.closest(COPY_TREE_PANEL_SELECTOR) !== null;
     setCopyTreeOpen(false);
-    if (focusWasInPanel || active === null || active === document.body) {
-      copyTreeButtonRef.current?.focus();
-    }
+    if (!focusWasInPanel && active !== null && active !== document.body) return;
+
+    requestAnimationFrame(() => {
+      const settled = document.activeElement;
+      if (settled === null || settled === document.body) {
+        copyTreeButtonRef.current?.focus();
+      }
+    });
   }, []);
 
   // The visible button opens the panel; it no longer copies. Every immediate
@@ -1626,7 +1638,16 @@ export function Toolbar({
     // absolute` eviction styles never reach it — an open panel would strand on
     // screen and then re-anchor to the hidden button's rect on the next resize.
     if (overflowSet.has("copy-tree")) {
+      const active = document.activeElement;
+      const focusWasInPanel =
+        active instanceof HTMLElement && active.closest(COPY_TREE_PANEL_SELECTOR) !== null;
       setCopyTreeOpen(false);
+      // The anchor is on its way to being hidden, so it can't take focus back.
+      // The overflow trigger is where the command now lives, which makes it the
+      // honest destination — otherwise a keyboard user is dropped onto <body>.
+      if (focusWasInPanel) {
+        document.querySelector<HTMLElement>("[data-toolbar-overflow-trigger]")?.focus();
+      }
     }
   }, [leftOverflow, rightOverflow]);
 

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -123,6 +123,10 @@ import { ToolbarPortalButton } from "./ToolbarPortalButton";
 import { ToolbarAssistantButton } from "./ToolbarAssistantButton";
 import { useOverflowBadgeSeverity, type OverflowBadgeSeverity } from "./useOverflowBadgeSeverity";
 import { FixedDropdown } from "@/components/ui/fixed-dropdown";
+import {
+  isInsideCopyTreePanel,
+  restoreCopyTreeTriggerFocus,
+} from "@/components/CopyTree/copyTreeFocus";
 import type { CopyTreeHistoryRecord } from "@shared/types";
 
 import {
@@ -137,11 +141,6 @@ function preloadCopyTreeRecentsPanel() {
 const LazyCopyTreeRecentsPanel = lazy(() =>
   preloadCopyTreeRecentsPanel().then((m) => ({ default: m.CopyTreeRecentsPanel }))
 );
-
-// The panel portals out of the toolbar, so "is focus still inside it?" can't be
-// answered by a DOM ancestor check from here. The marker attribute is the panel
-// component's half of that contract.
-const COPY_TREE_PANEL_SELECTOR = "[data-copy-tree-panel]";
 
 type OverflowMenuMeta = { label: string; icon: React.ComponentType<{ className?: string }> };
 
@@ -846,29 +845,13 @@ export function Toolbar({
     void preloadCopyTreeRecentsPanel();
   }, []);
 
-  // Close and hand focus back to the trigger — but only when focus would
-  // otherwise be lost. An outside click has already moved focus somewhere the
-  // user chose, and yanking it back to the toolbar would fight that.
-  //
-  // The decision is deferred a frame because it cannot be made yet: the
-  // dismiss path runs off `mousedown`, which fires BEFORE the browser's default
-  // focus transfer, so reading `activeElement` here would still show the panel
-  // row on an outside click and restore the trigger over the user's choice.
-  // After the frame, focus has settled — landing on `body` is the honest signal
-  // that nothing else claimed it.
+  // Close and hand focus back to the trigger, but only when closing would
+  // otherwise strand it — an outside click has already moved focus somewhere the
+  // user chose, and yanking it back to the toolbar would fight that. The
+  // deferred-frame reasoning lives with the helper.
   const closeCopyTreePanel = useCallback(() => {
-    const active = document.activeElement;
-    const focusWasInPanel =
-      active instanceof HTMLElement && active.closest(COPY_TREE_PANEL_SELECTOR) !== null;
     setCopyTreeOpen(false);
-    if (!focusWasInPanel && active !== null && active !== document.body) return;
-
-    requestAnimationFrame(() => {
-      const settled = document.activeElement;
-      if (settled === null || settled === document.body) {
-        copyTreeButtonRef.current?.focus();
-      }
-    });
+    restoreCopyTreeTriggerFocus(copyTreeButtonRef.current);
   }, []);
 
   // The visible button opens the panel; it no longer copies. Every immediate
@@ -1638,15 +1621,21 @@ export function Toolbar({
     // absolute` eviction styles never reach it — an open panel would strand on
     // screen and then re-anchor to the hidden button's rect on the next resize.
     if (overflowSet.has("copy-tree")) {
-      const active = document.activeElement;
-      const focusWasInPanel =
-        active instanceof HTMLElement && active.closest(COPY_TREE_PANEL_SELECTOR) !== null;
+      const focusWasInPanel = isInsideCopyTreePanel(document.activeElement);
       setCopyTreeOpen(false);
       // The anchor is on its way to being hidden, so it can't take focus back.
       // The overflow trigger is where the command now lives, which makes it the
       // honest destination — otherwise a keyboard user is dropped onto <body>.
+      // It has to be the trigger on the side that swallowed the button: the
+      // other one renders display:none and untabbable when its own side has no
+      // overflow, so focusing it would be the silent no-op this prevents.
       if (focusWasInPanel) {
-        document.querySelector<HTMLElement>("[data-toolbar-overflow-trigger]")?.focus();
+        const side = rightOverflow.includes("copy-tree") ? "right" : "left";
+        toolbarRef.current
+          ?.querySelector<HTMLElement>(
+            `[data-toolbar-overflow-trigger][data-toolbar-overflow-side="${side}"][data-visible="true"]`
+          )
+          ?.focus();
       }
     }
   }, [leftOverflow, rightOverflow]);

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -138,6 +138,11 @@ const LazyCopyTreeRecentsPanel = lazy(() =>
   preloadCopyTreeRecentsPanel().then((m) => ({ default: m.CopyTreeRecentsPanel }))
 );
 
+// The panel portals out of the toolbar, so "is focus still inside it?" can't be
+// answered by a DOM ancestor check from here. The marker attribute is the panel
+// component's half of that contract.
+const COPY_TREE_PANEL_SELECTOR = "[data-copy-tree-panel]";
+
 type OverflowMenuMeta = { label: string; icon: React.ComponentType<{ className?: string }> };
 
 const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text relative";
@@ -841,29 +846,47 @@ export function Toolbar({
     void preloadCopyTreeRecentsPanel();
   }, []);
 
+  // Close and hand focus back to the trigger — but only when focus would
+  // otherwise be lost. An outside click has already moved focus somewhere the
+  // user chose, and yanking it back to the toolbar would fight that.
+  const closeCopyTreePanel = useCallback(() => {
+    const active = document.activeElement;
+    const focusWasInPanel =
+      active instanceof HTMLElement && active.closest(COPY_TREE_PANEL_SELECTOR);
+    setCopyTreeOpen(false);
+    if (focusWasInPanel || active === null || active === document.body) {
+      copyTreeButtonRef.current?.focus();
+    }
+  }, []);
+
   // The visible button opens the panel; it no longer copies. Every immediate
   // route is deliberately left alone: `Cmd+Shift+C` dispatches
   // `worktree.copyTree` without passing through here at all, and the overflow
   // item calls `handleCopyTreeClick` directly — a nested panel inside the
   // overflow menu isn't worth it (#11733).
+  //
+  // The in-flight check matches what the button already announces: it renders
+  // `aria-disabled` while copying, and the shared Button doesn't suppress
+  // clicks on that alone, so without this the "disabled" trigger still opens a
+  // panel whose rows would all decline to run.
   const handleCopyTreeToggle = useCallback(() => {
-    if (!activeWorktree) return;
+    if (isCopyingTree || !activeWorktree) return;
     setCopyTreeOpen((open) => !open);
-  }, [activeWorktree]);
+  }, [isCopyingTree, activeWorktree]);
 
   // The panel's primary row: the old one-click behavior, now one click deeper.
   const handleCopyTreeFullContext = useCallback(() => {
-    setCopyTreeOpen(false);
+    closeCopyTreePanel();
     void handleCopyTreeClick();
-  }, [handleCopyTreeClick]);
+  }, [closeCopyTreePanel, handleCopyTreeClick]);
 
-  // A recents row. Replayed against the ACTIVE worktree, not `record.worktreeId`
-  // — the history dedupe key covers options alone, so a record's worktree is
-  // whichever one ran it last rather than a stable target, and it may name a
-  // worktree that has since been removed.
+  // A recents row. Replayed against the ACTIVE worktree, never the worktree
+  // stored on the record — the history dedupe key covers options alone, so a
+  // record's worktree is whichever one ran it last rather than a stable target,
+  // and it may name a worktree that has since been removed.
   const handleCopyTreeRunRecent = useCallback(
     (record: CopyTreeHistoryRecord) => {
-      setCopyTreeOpen(false);
+      closeCopyTreePanel();
       if (isCopyingTree || !activeWorktree) return;
 
       setIsCopyingTree(true);
@@ -871,7 +894,7 @@ export function Toolbar({
         setIsCopyingTree(false);
       });
     },
-    [isCopyingTree, activeWorktree, handleCopyTreeWithOptions]
+    [closeCopyTreePanel, isCopyingTree, activeWorktree, handleCopyTreeWithOptions]
   );
 
   // The anchor stops being interactive without a worktree, and the panel's rows
@@ -1259,7 +1282,9 @@ export function Toolbar({
             </ContextMenu>
             <FixedDropdown
               open={copyTreeOpen}
-              onOpenChange={setCopyTreeOpen}
+              onOpenChange={(open) => {
+                if (!open) closeCopyTreePanel();
+              }}
               anchorRef={copyTreeButtonRef}
               className="p-0"
             >
@@ -1368,6 +1393,7 @@ export function Toolbar({
       handleCopyTreeToggle,
       handleCopyTreeFullContext,
       handleCopyTreeRunRecent,
+      closeCopyTreePanel,
       copyTreeOpen,
       copyTreePanelMounted,
       isCopyingTree,
@@ -1595,6 +1621,12 @@ export function Toolbar({
     }
     if (overflowSet.has("notification-center")) {
       useUIStore.getState().closeNotificationCenter();
+    }
+    // The panel is portaled to document.body, so the wrapper's `invisible
+    // absolute` eviction styles never reach it — an open panel would strand on
+    // screen and then re-anchor to the hidden button's rect on the next resize.
+    if (overflowSet.has("copy-tree")) {
+      setCopyTreeOpen(false);
     }
   }, [leftOverflow, rightOverflow]);
 

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -1,5 +1,6 @@
 import {
   Suspense,
+  lazy,
   useRef,
   useState,
   useEffect,
@@ -121,12 +122,21 @@ import { ToolbarProblemsButton } from "./ToolbarProblemsButton";
 import { ToolbarPortalButton } from "./ToolbarPortalButton";
 import { ToolbarAssistantButton } from "./ToolbarAssistantButton";
 import { useOverflowBadgeSeverity, type OverflowBadgeSeverity } from "./useOverflowBadgeSeverity";
+import { FixedDropdown } from "@/components/ui/fixed-dropdown";
+import type { CopyTreeHistoryRecord } from "@shared/types";
 
 import {
   LAUNCHABLE_AGENT_IDS,
   isBuiltInAgentId,
   type BuiltInAgentId,
 } from "@shared/config/agentIds";
+
+function preloadCopyTreeRecentsPanel() {
+  return import("@/components/CopyTree/CopyTreeRecentsPanel");
+}
+const LazyCopyTreeRecentsPanel = lazy(() =>
+  preloadCopyTreeRecentsPanel().then((m) => ({ default: m.CopyTreeRecentsPanel }))
+);
 
 type OverflowMenuMeta = { label: string; icon: React.ComponentType<{ className?: string }> };
 
@@ -641,6 +651,12 @@ export function Toolbar({
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [isCopyingTree, setIsCopyingTree] = useState(false);
   const showCopyingSpinner = useDohertyGate(isCopyingTree);
+  // Local to the toolbar — the panel has no palette entry or action of its own,
+  // so nothing outside this component needs to open it (#11733).
+  const [copyTreeOpen, setCopyTreeOpen] = useState(false);
+  const copyTreeButtonRef = useRef<HTMLButtonElement>(null);
+  // Latch after first open so reopening never re-suspends.
+  const copyTreePanelMounted = useKeepMounted(copyTreeOpen);
 
   const hasActiveVoiceRecording = useVoiceRecordingStore(
     (state) =>
@@ -664,7 +680,7 @@ export function Toolbar({
   const prevFocusedToolbarItemRef = useRef<HTMLElement | null>(null);
   const forgeStatsRef = useRef<ForgeStatsHandle>(null);
 
-  const { handleCopyTree } = useWorktreeActions();
+  const { handleCopyTree, handleCopyTreeWithOptions } = useWorktreeActions();
   const sidebarShortcut = useKeybindingDisplay("nav.toggleSidebar");
   const copyTreeShortcut = useKeybindingDisplay("worktree.copyTree");
   const devServerShortcut = useKeybindingDisplay("devServer.start");
@@ -817,6 +833,53 @@ export function Toolbar({
       setIsCopyingTree(false);
     });
   }, [isCopyingTree, activeWorktree, handleCopyTree]);
+
+  // Warm the panel chunk before the first click — React 19 `lazy` still shows
+  // the fallback for one frame on a cold chunk, and this dropdown's whole point
+  // is that the copy is one click deeper than it used to be.
+  useEffect(() => {
+    void preloadCopyTreeRecentsPanel();
+  }, []);
+
+  // The visible button opens the panel; it no longer copies. Every immediate
+  // route is deliberately left alone: `Cmd+Shift+C` dispatches
+  // `worktree.copyTree` without passing through here at all, and the overflow
+  // item calls `handleCopyTreeClick` directly — a nested panel inside the
+  // overflow menu isn't worth it (#11733).
+  const handleCopyTreeToggle = useCallback(() => {
+    if (!activeWorktree) return;
+    setCopyTreeOpen((open) => !open);
+  }, [activeWorktree]);
+
+  // The panel's primary row: the old one-click behavior, now one click deeper.
+  const handleCopyTreeFullContext = useCallback(() => {
+    setCopyTreeOpen(false);
+    void handleCopyTreeClick();
+  }, [handleCopyTreeClick]);
+
+  // A recents row. Replayed against the ACTIVE worktree, not `record.worktreeId`
+  // — the history dedupe key covers options alone, so a record's worktree is
+  // whichever one ran it last rather than a stable target, and it may name a
+  // worktree that has since been removed.
+  const handleCopyTreeRunRecent = useCallback(
+    (record: CopyTreeHistoryRecord) => {
+      setCopyTreeOpen(false);
+      if (isCopyingTree || !activeWorktree) return;
+
+      setIsCopyingTree(true);
+      void handleCopyTreeWithOptions(activeWorktree, record.options, "toolbar").finally(() => {
+        setIsCopyingTree(false);
+      });
+    },
+    [isCopyingTree, activeWorktree, handleCopyTreeWithOptions]
+  );
+
+  // The anchor stops being interactive without a worktree, and the panel's rows
+  // all need one to run — leaving it open would strand a dead menu over the
+  // toolbar.
+  useEffect(() => {
+    if (!activeWorktree && copyTreeOpen) setCopyTreeOpen(false);
+  }, [activeWorktree, copyTreeOpen]);
 
   const getToolbarItems = useCallback(
     () =>
@@ -1155,41 +1218,61 @@ export function Toolbar({
       },
       "copy-tree": {
         render: () => (
-          <ContextMenu>
-            <ContextMenuTrigger asChild>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    data-toolbar-item=""
-                    onClick={handleCopyTreeClick}
-                    aria-disabled={isCopyingTree || !activeWorktree || undefined}
-                    className={cn(
-                      "toolbar-icon-button relative",
-                      "text-daintree-text",
-                      isCopyingTree && "cursor-wait opacity-70",
-                      "aria-disabled:opacity-50 aria-disabled:cursor-not-allowed"
-                    )}
-                    aria-label={isCopyingTree ? "Copying…" : "Copy context"}
-                    aria-keyshortcuts={copyTreeAriaShortcut}
-                  >
-                    {showCopyingSpinner ? <Spinner /> : <Folders />}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" className="font-medium">
-                  {isCopyingTree
-                    ? "Copying…"
-                    : !activeWorktree
-                      ? "Open a worktree first"
-                      : createTooltipContent("Copy context", copyTreeShortcut)}
-                </TooltipContent>
-              </Tooltip>
-            </ContextMenuTrigger>
-            <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
-              <ToolbarContextMenuItems buttonId="copy-tree" side="right" />
-            </ContextMenuContent>
-          </ContextMenu>
+          <div className="relative">
+            <ContextMenu>
+              <ContextMenuTrigger asChild>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      ref={copyTreeButtonRef}
+                      variant="ghost"
+                      size="icon"
+                      data-toolbar-item=""
+                      onClick={handleCopyTreeToggle}
+                      aria-disabled={isCopyingTree || !activeWorktree || undefined}
+                      className={cn(
+                        "toolbar-icon-button relative",
+                        "text-daintree-text",
+                        isCopyingTree && "cursor-wait opacity-70",
+                        "aria-disabled:opacity-50 aria-disabled:cursor-not-allowed"
+                      )}
+                      aria-label={isCopyingTree ? "Copying…" : "Copy context"}
+                      aria-keyshortcuts={copyTreeAriaShortcut}
+                      aria-haspopup="dialog"
+                      aria-expanded={copyTreeOpen}
+                    >
+                      {showCopyingSpinner ? <Spinner /> : <Folders />}
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="font-medium">
+                    {isCopyingTree
+                      ? "Copying…"
+                      : !activeWorktree
+                        ? "Open a worktree first"
+                        : createTooltipContent("Copy context", copyTreeShortcut)}
+                  </TooltipContent>
+                </Tooltip>
+              </ContextMenuTrigger>
+              <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
+                <ToolbarContextMenuItems buttonId="copy-tree" side="right" />
+              </ContextMenuContent>
+            </ContextMenu>
+            <FixedDropdown
+              open={copyTreeOpen}
+              onOpenChange={setCopyTreeOpen}
+              anchorRef={copyTreeButtonRef}
+              className="p-0"
+            >
+              {copyTreePanelMounted && (
+                <Suspense fallback={null}>
+                  <LazyCopyTreeRecentsPanel
+                    onCopyFullContext={handleCopyTreeFullContext}
+                    onRunRecent={handleCopyTreeRunRecent}
+                  />
+                </Suspense>
+              )}
+            </FixedDropdown>
+          </div>
         ),
         isAvailable: true,
       },
@@ -1282,7 +1365,11 @@ export function Toolbar({
       copyTreeShortcut,
       copyTreeAriaShortcut,
       currentProject,
-      handleCopyTreeClick,
+      handleCopyTreeToggle,
+      handleCopyTreeFullContext,
+      handleCopyTreeRunRecent,
+      copyTreeOpen,
+      copyTreePanelMounted,
       isCopyingTree,
       showCopyingSpinner,
       activeWorktree,

--- a/src/components/Layout/__tests__/Toolbar.overflow.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.overflow.test.ts
@@ -152,18 +152,30 @@ describe("Toolbar overflow menu state preservation — issue #9821", () => {
   });
 
   describe("copy-tree feedback from overflow — #9821, superseded by #11735", () => {
-    it("shares one handler between the visible button and the overflow item", () => {
+    it("keeps the overflow item on the immediate-copy handler the panel also calls", () => {
       // #9821 gave overflow its own handler because the visible button's only
-      // feedback was an inline check the overflow menu couldn't show. Now that
-      // completion is a toast from the `worktree.copyTree` action, both routes
-      // are identical — a second handler could only drift from the first.
+      // feedback was an inline check the overflow menu couldn't show. Once
+      // completion became a toast from the `worktree.copyTree` action, both
+      // routes collapsed onto one handler — and #11733 kept it that way rather
+      // than nesting a panel inside the overflow menu. So the overflow row and
+      // the panel's own "Copy full context" row must reach the SAME handler;
+      // a second one could only drift from the first.
       expect(source).toMatch(/"copy-tree":\s*\(\)\s*=>\s*\{\s*void handleCopyTreeClick\(\)/);
       expect(source).not.toContain("handleCopyTreeOverflow");
-      // The visible button half of the same invariant: without this, deleting
-      // the overflow handler could pass while the button itself lost its wiring.
+      expect(source).toMatch(
+        /const handleCopyTreeFullContext = useCallback\(\(\) => \{[\s\S]*?void handleCopyTreeClick\(\)/
+      );
+    });
+
+    it("routes the visible button to the panel, not to the immediate copy (#11733)", () => {
+      // The half of the split that is easy to regress: re-pointing the trigger
+      // back at `handleCopyTreeClick` would restore one-click copying and
+      // silently strand the panel. Asserted on the block rather than the file
+      // because the immediate handler still legitimately appears elsewhere.
       const copyTreeBlock = source.match(/"copy-tree":\s*\{[\s\S]*?isAvailable/);
       expect(copyTreeBlock).not.toBeNull();
-      expect(copyTreeBlock![0]).toContain("onClick={handleCopyTreeClick}");
+      expect(copyTreeBlock![0]).toContain("onClick={handleCopyTreeToggle}");
+      expect(copyTreeBlock![0]).not.toContain("onClick={handleCopyTreeClick}");
     });
 
     it("no longer raises its own copy-tree toast in the toolbar", () => {

--- a/src/components/Layout/__tests__/Toolbar.overflow.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.overflow.test.ts
@@ -169,13 +169,12 @@ describe("Toolbar overflow menu state preservation — issue #9821", () => {
 
     it("routes the visible button to the panel, not to the immediate copy (#11733)", () => {
       // The half of the split that is easy to regress: re-pointing the trigger
-      // back at `handleCopyTreeClick` would restore one-click copying and
+      // back at the immediate handler would restore one-click copying and
       // silently strand the panel. Asserted on the block rather than the file
       // because the immediate handler still legitimately appears elsewhere.
       const copyTreeBlock = source.match(/"copy-tree":\s*\{[\s\S]*?isAvailable/);
       expect(copyTreeBlock).not.toBeNull();
       expect(copyTreeBlock![0]).toContain("onClick={handleCopyTreeToggle}");
-      expect(copyTreeBlock![0]).not.toContain("onClick={handleCopyTreeClick}");
     });
 
     it("no longer raises its own copy-tree toast in the toolbar", () => {

--- a/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
@@ -272,6 +272,51 @@ describe("Toolbar shortcut tooltips — issue #3443", () => {
     });
   });
 
+  describe("copy-tree recents dropdown — issue #11733", () => {
+    it("advertises the trigger as a dialog disclosure", () => {
+      const copyTreeBlock = source.match(/"copy-tree":\s*\{[\s\S]*?isAvailable/);
+      expect(copyTreeBlock).not.toBeNull();
+      // The button no longer performs its action on click, so it has to say so:
+      // without both halves a screen-reader user gets no signal that anything
+      // opened, and no way to tell open from closed.
+      expect(copyTreeBlock![0]).toContain('aria-haspopup="dialog"');
+      expect(copyTreeBlock![0]).toContain("aria-expanded={copyTreeOpen}");
+      expect(copyTreeBlock![0]).toContain("<FixedDropdown");
+      expect(copyTreeBlock![0]).toContain("anchorRef={copyTreeButtonRef}");
+    });
+
+    it("leaves FixedDropdown's keepMounted unset so the body unmounts on close", () => {
+      // #8005/#6787: Activity-hidden bodies keep portaled Radix content mounted
+      // (stranding it at 0,0) and retain transient state across reveals. This
+      // panel has no state worth preserving, so it opts out entirely rather
+      // than working around either failure mode. The `useKeepMounted` latch
+      // below is a different thing — it only stops `Suspense` re-suspending.
+      const copyTreeBlock = source.match(/"copy-tree":\s*\{[\s\S]*?isAvailable/);
+      expect(copyTreeBlock).not.toBeNull();
+      expect(copyTreeBlock![0]).not.toMatch(/keepMounted/);
+      expect(source).toContain("const copyTreePanelMounted = useKeepMounted(copyTreeOpen);");
+    });
+
+    it("warms the panel chunk before the first click", () => {
+      // React 19 `lazy` still shows the fallback for a frame on a cold chunk,
+      // and the copy is already one click deeper than it used to be.
+      expect(source).toContain("void preloadCopyTreeRecentsPanel();");
+      expect(source).toMatch(/lazy\(\(\) =>\s*preloadCopyTreeRecentsPanel\(\)/);
+    });
+
+    it("replays a recent against the active worktree, never the record's own", () => {
+      // The history dedupe key covers options alone, so `record.worktreeId` is
+      // whichever worktree ran it last — provenance, not a stable target, and
+      // possibly one that no longer exists.
+      const handler = source.match(
+        /const handleCopyTreeRunRecent = useCallback\([\s\S]*?\n {2}\);/
+      );
+      expect(handler).not.toBeNull();
+      expect(handler![0]).toContain("handleCopyTreeWithOptions(activeWorktree, record.options");
+      expect(handler![0]).not.toContain("record.worktreeId");
+    });
+  });
+
   describe("sidebar toggle drops always-on armed highlight — issue #8357", () => {
     it("marks the sidebar toggle button with data-sidebar-toggle", () => {
       const sidebarBlock = source.match(/"sidebar-toggle":\s*\{[\s\S]*?isAvailable/);

--- a/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
@@ -311,13 +311,24 @@ describe("Toolbar shortcut tooltips — issue #3443", () => {
       const ariaDisabled = copyTreeBlock![0].match(/aria-disabled=\{([^}]+)\}/);
       expect(ariaDisabled).not.toBeNull();
 
-      const toggle = source.match(/const handleCopyTreeToggle = useCallback\([\s\S]*?\n {2}\);/);
-      expect(toggle).not.toBeNull();
-      // Every condition the button announces as disabling must also gate the
-      // toggle. `undefined` is the JSX spelling of "not disabled", not a term.
-      for (const term of ariaDisabled![1]!.split("||").map((t) => t.trim())) {
-        if (term === "undefined") continue;
-        expect(toggle![0]).toContain(term.replace(/^!/, ""));
+      // `undefined` is the JSX spelling of "not disabled", not a condition.
+      const disablingTerms = ariaDisabled![1]!
+        .split("||")
+        .map((t) => t.trim().replace(/^!/, ""))
+        .filter((t) => t !== "undefined" && t !== "");
+      // Guard against a vacuous pass: an expression that yielded no terms would
+      // make the loop below assert nothing at all.
+      expect(disablingTerms.length).toBeGreaterThan(0);
+
+      // Read the early-return condition specifically, not the whole callback —
+      // its dependency array names the same identifiers, so a body-wide
+      // substring check would still pass with the guard deleted.
+      const earlyReturn = source.match(
+        /const handleCopyTreeToggle = useCallback\(\(\) => \{\s*if \(([^)]+)\) return;/
+      );
+      expect(earlyReturn).not.toBeNull();
+      for (const term of disablingTerms) {
+        expect(earlyReturn![1]).toContain(term);
       }
     });
   });

--- a/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
@@ -273,47 +273,52 @@ describe("Toolbar shortcut tooltips — issue #3443", () => {
   });
 
   describe("copy-tree recents dropdown — issue #11733", () => {
-    it("advertises the trigger as a dialog disclosure", () => {
-      const copyTreeBlock = source.match(/"copy-tree":\s*\{[\s\S]*?isAvailable/);
-      expect(copyTreeBlock).not.toBeNull();
-      // The button no longer performs its action on click, so it has to say so:
-      // without both halves a screen-reader user gets no signal that anything
-      // opened, and no way to tell open from closed.
-      expect(copyTreeBlock![0]).toContain('aria-haspopup="dialog"');
-      expect(copyTreeBlock![0]).toContain("aria-expanded={copyTreeOpen}");
-      expect(copyTreeBlock![0]).toContain("<FixedDropdown");
-      expect(copyTreeBlock![0]).toContain("anchorRef={copyTreeButtonRef}");
-    });
+    // Only invariants that can't be reached from a render live here; the
+    // panel's own dialog role, focus handling and row behavior are covered
+    // behaviorally in CopyTreeRecentsPanel.test.tsx. Toolbar.tsx is too large
+    // to mount in jsdom, which is the reason this file reads source at all.
 
-    it("leaves FixedDropdown's keepMounted unset so the body unmounts on close", () => {
-      // #8005/#6787: Activity-hidden bodies keep portaled Radix content mounted
-      // (stranding it at 0,0) and retain transient state across reveals. This
-      // panel has no state worth preserving, so it opts out entirely rather
-      // than working around either failure mode. The `useKeepMounted` latch
-      // below is a different thing — it only stops `Suspense` re-suspending.
-      const copyTreeBlock = source.match(/"copy-tree":\s*\{[\s\S]*?isAvailable/);
-      expect(copyTreeBlock).not.toBeNull();
-      expect(copyTreeBlock![0]).not.toMatch(/keepMounted/);
-      expect(source).toContain("const copyTreePanelMounted = useKeepMounted(copyTreeOpen);");
-    });
-
-    it("warms the panel chunk before the first click", () => {
-      // React 19 `lazy` still shows the fallback for a frame on a cold chunk,
-      // and the copy is already one click deeper than it used to be.
-      expect(source).toContain("void preloadCopyTreeRecentsPanel();");
-      expect(source).toMatch(/lazy\(\(\) =>\s*preloadCopyTreeRecentsPanel\(\)/);
-    });
-
-    it("replays a recent against the active worktree, never the record's own", () => {
+    it("never replays a recent against the worktree stored on the record", () => {
       // The history dedupe key covers options alone, so `record.worktreeId` is
       // whichever worktree ran it last — provenance, not a stable target, and
-      // possibly one that no longer exists.
-      const handler = source.match(
-        /const handleCopyTreeRunRecent = useCallback\([\s\S]*?\n {2}\);/
+      // possibly one that no longer exists. File-wide rather than block-scoped:
+      // the field must not be read anywhere in the toolbar, however the handler
+      // is later refactored or extracted.
+      expect(source).toContain("handleCopyTreeWithOptions(activeWorktree, record.options");
+      expect(source).not.toContain("record.worktreeId");
+    });
+
+    it("closes the panel wherever a sibling dropdown is closed on overflow eviction", () => {
+      // Relational, and the reason it matters: the panel is portaled to
+      // document.body, so the wrapper's `invisible absolute` eviction styles
+      // never reach it. Whatever set of ids that effect closes, copy-tree
+      // belongs in it — asserted against its neighbours rather than as a
+      // standalone literal, so deleting the effect fails here too.
+      const evictionEffect = source.match(
+        /Close open dropdowns when their buttons move into overflow[\s\S]*?\}, \[leftOverflow, rightOverflow\]\);/
       );
-      expect(handler).not.toBeNull();
-      expect(handler![0]).toContain("handleCopyTreeWithOptions(activeWorktree, record.options");
-      expect(handler![0]).not.toContain("record.worktreeId");
+      expect(evictionEffect).not.toBeNull();
+      expect(evictionEffect![0]).toContain('overflowSet.has("notification-center")');
+      expect(evictionEffect![0]).toContain('overflowSet.has("copy-tree")');
+    });
+
+    it("gates opening the panel on the same condition the trigger reports as disabled", () => {
+      // The shared Button doesn't suppress clicks on aria-disabled alone, so a
+      // trigger that announces "disabled" while copying must also refuse to
+      // open — otherwise the panel appears and every row silently declines.
+      const copyTreeBlock = source.match(/"copy-tree":\s*\{[\s\S]*?isAvailable/);
+      expect(copyTreeBlock).not.toBeNull();
+      const ariaDisabled = copyTreeBlock![0].match(/aria-disabled=\{([^}]+)\}/);
+      expect(ariaDisabled).not.toBeNull();
+
+      const toggle = source.match(/const handleCopyTreeToggle = useCallback\([\s\S]*?\n {2}\);/);
+      expect(toggle).not.toBeNull();
+      // Every condition the button announces as disabling must also gate the
+      // toggle. `undefined` is the JSX spelling of "not disabled", not a term.
+      for (const term of ariaDisabled![1]!.split("||").map((t) => t.trim())) {
+        if (term === "undefined") continue;
+        expect(toggle![0]).toContain(term.replace(/^!/, ""));
+      }
     });
   });
 

--- a/src/hooks/__tests__/useWorktreeActions.test.tsx
+++ b/src/hooks/__tests__/useWorktreeActions.test.tsx
@@ -92,6 +92,93 @@ describe("useWorktreeActions", () => {
     expect(updateNotificationMock).not.toHaveBeenCalled();
   });
 
+  describe("handleCopyTreeWithOptions — replaying a recent (#11733)", () => {
+    // Every field `CopyTreeOptions` carries. The point of the fixture is that
+    // it is wider than `worktree.copyTree`'s flat args schema, which accepts
+    // only worktreeId/format/modified/includePaths/scopePaths and — because Zod
+    // object parsing strips rather than rejects unknown keys — would drop the
+    // rest without erroring.
+    const storedOptions = {
+      format: "markdown" as const,
+      filter: ["src/auth/**"],
+      exclude: ["**/*.snap"],
+      always: ["README.md"],
+      includePaths: ["src/index.ts"],
+      scopePaths: ["src"],
+      modified: true,
+      changed: "HEAD~3",
+      maxFileSize: 1024,
+      maxTotalSize: 4096,
+      maxFileCount: 50,
+      withLineNumbers: true,
+      charLimit: 10_000,
+      sort: "size" as const,
+    };
+
+    it("routes through the action that accepts the whole options object", async () => {
+      dispatchMock.mockResolvedValueOnce({ ok: true, result: {} });
+
+      const { result } = renderHook(() => useWorktreeActions());
+      await result.current.handleCopyTreeWithOptions(worktree, storedOptions, "toolbar");
+
+      const [actionId, args] = dispatchMock.mock.calls[0]!;
+      expect(actionId).toBe("copyTree.generateAndCopyFile");
+      // Nested, not spread: flattening would put the options through the wrong
+      // schema and silently lose most of them.
+      expect(args.options).toEqual(storedOptions);
+      expect(Object.keys(args)).toEqual(["worktreeId", "options"]);
+    });
+
+    it("targets the supplied worktree rather than anything carried on the record", async () => {
+      dispatchMock.mockResolvedValueOnce({ ok: true, result: {} });
+
+      const { result } = renderHook(() => useWorktreeActions());
+      await result.current.handleCopyTreeWithOptions(worktree, storedOptions);
+
+      expect(dispatchMock.mock.calls[0]![1].worktreeId).toBe(worktree.id);
+    });
+
+    it("forwards the run source so history attributes the replay to the toolbar", async () => {
+      dispatchMock.mockResolvedValueOnce({ ok: true, result: {} });
+
+      const { result } = renderHook(() => useWorktreeActions());
+      await result.current.handleCopyTreeWithOptions(worktree, storedOptions, "toolbar");
+
+      expect(dispatchMock.mock.calls[0]![2]).toEqual({
+        source: "user",
+        copyTreeRunSource: "toolbar",
+      });
+    });
+
+    it("reports a failed replay the same way a failed full copy is reported", async () => {
+      // Shared failure path: a user cannot tell the two routes apart, so the
+      // error surface must not either. Same classification branch as the
+      // full-copy case above.
+      dispatchMock.mockResolvedValueOnce({
+        ok: false,
+        error: { message: "permission denied" },
+      });
+
+      const { result } = renderHook(() => useWorktreeActions());
+      await expect(
+        result.current.handleCopyTreeWithOptions(worktree, storedOptions)
+      ).resolves.toBeUndefined();
+
+      expect(addErrorMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "filesystem", context: { worktreeId: "wt-1" } })
+      );
+    });
+
+    it("settles after a thrown dispatch so the caller's spinner can clear", async () => {
+      dispatchMock.mockRejectedValueOnce(new Error("boom"));
+
+      const { result } = renderHook(() => useWorktreeActions());
+      await expect(
+        result.current.handleCopyTreeWithOptions(worktree, storedOptions)
+      ).resolves.toBeUndefined();
+    });
+  });
+
   it("records a failed copy in the error store without rejecting", async () => {
     dispatchMock.mockResolvedValueOnce({
       ok: false,

--- a/src/hooks/__tests__/useWorktreeActions.test.tsx
+++ b/src/hooks/__tests__/useWorktreeActions.test.tsx
@@ -124,9 +124,13 @@ describe("useWorktreeActions", () => {
       const [actionId, args] = dispatchMock.mock.calls[0]!;
       expect(actionId).toBe("copyTree.generateAndCopyFile");
       // Nested, not spread: flattening would put the options through the wrong
-      // schema and silently lose most of them.
+      // schema and silently lose most of them. The representative flattened
+      // fields are the ones `worktree.copyTree` would have accepted, so their
+      // presence at the top level is exactly what a regression looks like.
       expect(args.options).toEqual(storedOptions);
-      expect(Object.keys(args)).toEqual(["worktreeId", "options"]);
+      expect(args.format).toBeUndefined();
+      expect(args.modified).toBeUndefined();
+      expect(args.scopePaths).toBeUndefined();
     });
 
     it("targets the supplied worktree rather than anything carried on the record", async () => {
@@ -150,32 +154,49 @@ describe("useWorktreeActions", () => {
       });
     });
 
-    it("reports a failed replay the same way a failed full copy is reported", async () => {
-      // Shared failure path: a user cannot tell the two routes apart, so the
-      // error surface must not either. Same classification branch as the
-      // full-copy case above.
-      dispatchMock.mockResolvedValueOnce({
-        ok: false,
-        error: { message: "permission denied" },
+    it("classifies and phrases a failed replay exactly like a failed full copy", async () => {
+      // A user cannot tell the two routes apart, so the error surface must not
+      // either. Compared side by side rather than restated, so a change to one
+      // path's classification without the other fails here. `source` is the one
+      // field that legitimately differs — the Problems panel shows it verbatim,
+      // and the replay only ever comes from the toolbar.
+      const failure = { ok: false, error: { message: "permission denied" } };
+
+      const { result } = renderHook(() => useWorktreeActions());
+
+      dispatchMock.mockResolvedValueOnce(failure);
+      await result.current.handleCopyTree(worktree);
+      const fullCopyError = addErrorMock.mock.calls.at(-1)![0];
+
+      dispatchMock.mockResolvedValueOnce(failure);
+      await result.current.handleCopyTreeWithOptions(worktree, storedOptions);
+      const replayError = addErrorMock.mock.calls.at(-1)![0];
+
+      // `correlationId` is a fresh UUID per report and `details` is a stack
+      // trace naming the calling function, so neither can match across paths.
+      // What must match is the classification and the words the user reads.
+      const comparable = ({
+        correlationId: _id,
+        source: _source,
+        details: _details,
+        ...rest
+      }: typeof replayError) => rest;
+      expect(comparable(replayError)).toEqual(comparable(fullCopyError));
+      expect(replayError.source).not.toBe(fullCopyError.source);
+    });
+
+    it("settles after a synchronous throw so the caller's spinner can clear", async () => {
+      // Not mockRejectedValue: a throw *before* a promise is returned is the
+      // case that would escape a `.finally()` on the returned value.
+      dispatchMock.mockImplementationOnce(() => {
+        throw new Error("boom");
       });
 
       const { result } = renderHook(() => useWorktreeActions());
       await expect(
         result.current.handleCopyTreeWithOptions(worktree, storedOptions)
       ).resolves.toBeUndefined();
-
-      expect(addErrorMock).toHaveBeenCalledWith(
-        expect.objectContaining({ type: "filesystem", context: { worktreeId: "wt-1" } })
-      );
-    });
-
-    it("settles after a thrown dispatch so the caller's spinner can clear", async () => {
-      dispatchMock.mockRejectedValueOnce(new Error("boom"));
-
-      const { result } = renderHook(() => useWorktreeActions());
-      await expect(
-        result.current.handleCopyTreeWithOptions(worktree, storedOptions)
-      ).resolves.toBeUndefined();
+      expect(addErrorMock).toHaveBeenCalled();
     });
   });
 

--- a/src/hooks/useWorktreeActions.ts
+++ b/src/hooks/useWorktreeActions.ts
@@ -170,7 +170,7 @@ export function useWorktreeActions({
   // same way a full copy does — the user cannot tell the two routes apart, so
   // neither should the error surface.
   const reportCopyFailure = useCallback(
-    (worktreeId: string, e: unknown): void => {
+    (worktreeId: string, e: unknown, source = "WorktreeCard"): void => {
       const message = formatErrorMessage(e, "Failed to copy context to clipboard");
       const details = e instanceof Error ? e.stack : undefined;
 
@@ -189,7 +189,7 @@ export function useWorktreeActions({
         type: errorType,
         message: `Copy context failed: ${message}`,
         details,
-        source: "WorktreeCard",
+        source,
         context: {
           worktreeId,
         },
@@ -226,6 +226,11 @@ export function useWorktreeActions({
   /**
    * Re-run a stored option set — the toolbar's recents rows (#11733).
    *
+   * Reported against the toolbar rather than the worktree card, which is the
+   * only surface that reaches this path — the Problems panel shows that source
+   * verbatim, so inheriting the full-copy helper's label would point at a
+   * component the user never touched.
+   *
    * Routed through `copyTree.generateAndCopyFile`, NOT `worktree.copyTree`:
    * that action's args schema is flat and narrow (`format`, `modified`,
    * `includePaths`, `scopePaths`), and Zod object parsing strips unknown keys
@@ -260,7 +265,7 @@ export function useWorktreeActions({
           throw new Error(result.error.message);
         }
       } catch (e) {
-        reportCopyFailure(worktree.id, e);
+        reportCopyFailure(worktree.id, e, "Toolbar");
       }
     },
     [reportCopyFailure]

--- a/src/hooks/useWorktreeActions.ts
+++ b/src/hooks/useWorktreeActions.ts
@@ -9,7 +9,7 @@ import { actionService } from "@/services/ActionService";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import type { ActionSource } from "@shared/types/actions";
 import type { CopyTreeRunSource } from "@shared/types";
-import type { CopyTreeBudgetStats } from "@shared/types/ipc/copyTree";
+import type { CopyTreeBudgetStats, CopyTreeOptions } from "@shared/types/ipc/copyTree";
 
 // Both live in a leaf module: `formatCopyResultMessage` because the copyTree
 // action definitions need it and importing it from here would close a cycle
@@ -148,6 +148,11 @@ export interface WorktreeActions {
     worktree: WorktreeSnapshot,
     copyTreeRunSource?: CopyTreeRunSource
   ) => Promise<void>;
+  handleCopyTreeWithOptions: (
+    worktree: WorktreeSnapshot,
+    options: CopyTreeOptions,
+    copyTreeRunSource?: CopyTreeRunSource
+  ) => Promise<void>;
   handleOpenEditor: (worktree: WorktreeSnapshot) => void;
   handleOpenIssue: (worktree: WorktreeSnapshot) => void;
   handleOpenPR: (worktree: WorktreeSnapshot) => void;
@@ -159,6 +164,43 @@ export function useWorktreeActions({
   onOpenRecipeEditor,
 }: UseWorktreeActionsOptions = {}): WorktreeActions {
   const addError = useErrorStore((state) => state.addError);
+
+  // Shared failure path for both copy routes below. Classifying and recording
+  // here rather than at each call site keeps a replayed recent reporting the
+  // same way a full copy does — the user cannot tell the two routes apart, so
+  // neither should the error surface.
+  const reportCopyFailure = useCallback(
+    (worktreeId: string, e: unknown): void => {
+      const message = formatErrorMessage(e, "Failed to copy context to clipboard");
+      const details = e instanceof Error ? e.stack : undefined;
+
+      let errorType: ErrorRecord["type"] = "process";
+      if (message.includes("not available") || message.includes("not installed")) {
+        errorType = "config";
+      } else if (
+        message.includes("permission") ||
+        message.includes("EACCES") ||
+        message.includes("denied")
+      ) {
+        errorType = "filesystem";
+      }
+
+      addError({
+        type: errorType,
+        message: `Copy context failed: ${message}`,
+        details,
+        source: "WorktreeCard",
+        context: {
+          worktreeId,
+        },
+        retryability: "auto",
+        correlationId: crypto.randomUUID(),
+      });
+
+      logError("Failed to copy context", undefined, { message });
+    },
+    [addError]
+  );
 
   // Resolves once the copy has settled; the completion toast belongs to the
   // `worktree.copyTree` action so the keybinding and palette routes — which
@@ -175,36 +217,53 @@ export function useWorktreeActions({
           throw new Error(result.error.message);
         }
       } catch (e) {
-        const message = formatErrorMessage(e, "Failed to copy context to clipboard");
-        const details = e instanceof Error ? e.stack : undefined;
-
-        let errorType: ErrorRecord["type"] = "process";
-        if (message.includes("not available") || message.includes("not installed")) {
-          errorType = "config";
-        } else if (
-          message.includes("permission") ||
-          message.includes("EACCES") ||
-          message.includes("denied")
-        ) {
-          errorType = "filesystem";
-        }
-
-        addError({
-          type: errorType,
-          message: `Copy context failed: ${message}`,
-          details,
-          source: "WorktreeCard",
-          context: {
-            worktreeId: worktree.id,
-          },
-          retryability: "auto",
-          correlationId: crypto.randomUUID(),
-        });
-
-        logError("Failed to copy context", undefined, { message });
+        reportCopyFailure(worktree.id, e);
       }
     },
-    [addError]
+    [reportCopyFailure]
+  );
+
+  /**
+   * Re-run a stored option set — the toolbar's recents rows (#11733).
+   *
+   * Routed through `copyTree.generateAndCopyFile`, NOT `worktree.copyTree`:
+   * that action's args schema is flat and narrow (`format`, `modified`,
+   * `includePaths`, `scopePaths`), and Zod object parsing strips unknown keys
+   * without erroring — so a record carrying `filter`, `exclude`, `always`,
+   * `changed`, the size budgets, `withLineNumbers`, `charLimit` or `sort` would
+   * replay as a quietly different copy. `generateAndCopyFile` takes the whole
+   * nested options object and validates every field.
+   *
+   * `options` is passed through verbatim. An empty selection array reads as "no
+   * filter" — i.e. the whole worktree — to the SDK, so the schema rejects those
+   * at the validated boundary; normalizing them here would reintroduce exactly
+   * the fail-open this repo already fixed once.
+   *
+   * The target is the worktree the caller hands over — the active one — rather
+   * than `record.worktreeId`. The dedupe key covers options alone, so a record's
+   * `worktreeId` adopts whichever worktree ran it last: it is provenance, not a
+   * stable original target, and may name a worktree that no longer exists.
+   */
+  const handleCopyTreeWithOptions = useCallback(
+    async (
+      worktree: WorktreeSnapshot,
+      options: CopyTreeOptions,
+      copyTreeRunSource?: CopyTreeRunSource
+    ): Promise<void> => {
+      try {
+        const result = await actionService.dispatch(
+          "copyTree.generateAndCopyFile",
+          { worktreeId: worktree.id, options },
+          { source: "user", copyTreeRunSource }
+        );
+        if (!result.ok) {
+          throw new Error(result.error.message);
+        }
+      } catch (e) {
+        reportCopyFailure(worktree.id, e);
+      }
+    },
+    [reportCopyFailure]
   );
 
   const handleOpenEditor = useCallback((worktree: WorktreeSnapshot) => {
@@ -266,6 +325,7 @@ export function useWorktreeActions({
   return useMemo(
     () => ({
       handleCopyTree,
+      handleCopyTreeWithOptions,
       handleOpenEditor,
       handleOpenIssue,
       handleOpenPR,
@@ -274,6 +334,7 @@ export function useWorktreeActions({
     }),
     [
       handleCopyTree,
+      handleCopyTreeWithOptions,
       handleOpenEditor,
       handleOpenIssue,
       handleOpenPR,


### PR DESCRIPTION
## Summary

- The toolbar copy-tree button no longer copies the full context tree immediately on click. It now opens a `FixedDropdown` panel anchored to the button, about 360px wide, modelled on the notification centre dropdown.
- The panel leads with a primary "Copy full context" row (the old one-click behaviour), then a divider, then the five most recent copy-tree runs from the per-project history added in #11732, each showing name, file count, size, and relative time, and each re-runnable in one click.
- `Cmd+Shift+C` and the toolbar-overflow row are unchanged: both still do the immediate full copy with no panel in the way.

Resolves #11733

## Changes

- `src/components/CopyTree/CopyTreeRecentsPanel.tsx` (new): lazy-loaded dropdown body with the primary row and recents list.
- `src/components/Layout/Toolbar.tsx`: wires the trigger to the panel, splits the click handler, adds the `FixedDropdown`, closes it on worktree eviction.
- `src/hooks/useWorktreeActions.ts`: new `handleCopyTreeWithOptions` plus a shared failure reporter used by both the immediate copy and recents replay.
- Test and e2e updates across `Toolbar`, `useWorktreeActions`, `e2e/helpers/panels.ts`, and the two affected terminal e2e specs.

### Implementation notes

**Recents replay dispatches `copyTree.generateAndCopyFile`, not `worktree.copyTree`.** The `worktree.copyTree` args schema is flat and narrow, and Zod silently strips unknown keys. Replaying a stored history record through it would quietly drop 10 of the 14 `CopyTreeOptions` fields (`filter`, `exclude`, `always`, `changed`, the three size budgets, `withLineNumbers`, `charLimit`, `sort`). Both paths converge on the same client method and IPC channel, so history recording itself is unchanged.

**A recent always replays against the active worktree, never `record.worktreeId`.** The history dedupe key only covers the options, so a record's stored worktree ID is just whichever worktree last ran it: provenance, not a stable target. It can also name a worktree that no longer exists.

**The trigger stays inline in `Toolbar.tsx`** rather than getting extracted into its own component, so the existing source-contract tests from #8179 and #11735 (spinner ternary, no check-icon, uncontrolled tooltip, memo deps) keep applying to it without modification.

**`FixedDropdown`'s `keepMounted` is deliberately left unset.** Activity-hidden bodies strand portaled Radix content and retain transient state (see #8005, #6787). A separate `useKeepMounted` latch handles the narrower problem of Suspense re-suspending on reopen.

**The panel is a named `role="dialog"`** that takes focus on open and hands it back to the trigger on close, since the button's own action now lives inside the panel rather than firing on click.

## Testing

- 599 tests across 19 files pass locally: all `Toolbar` suites, both `useWorktreeActions` suites, `worktreeContextActions.copyTree`, `copyTreeHistoryStore`, `FileBrowserPane`, and the `accentGuard` and `colorSystem` contracts.
- `tsc --noEmit` clean.
- `eslint` and `prettier` clean on all 10 changed files.
- E2E specs were updated but not run locally (needs a full app build; PR CI doesn't run e2e).
