### PR TITLE
Redesign the copy context dropdown and replace its completion toast with a tooltip

### DIFF
--- a/src/components/CopyTree/CopyTreeRecentsPanel.tsx
+++ b/src/components/CopyTree/CopyTreeRecentsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { Folders, History } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { EmptyState } from "@/components/ui/EmptyState";
@@ -49,6 +49,16 @@ const rowClass = cn(
   "transition-colors"
 );
 
+// The primary action is the panel's header: a framed button in its own padded
+// band rather than the first row of the list, so it reads as "the button, with
+// its history underneath" instead of one more entry. Neutral raised surface —
+// the focus ring it takes on open is the region's one emphasis signal.
+const primaryButtonClass = cn(
+  "w-full flex items-center gap-2.5 rounded-[var(--radius-md)] px-3 py-2 text-left",
+  "border border-divider bg-overlay-subtle text-daintree-text hover:bg-overlay-raised",
+  "transition-colors"
+);
+
 interface CopyTreeRecentsPanelProps {
   /** The old one-click behavior, now one click deeper. */
   onCopyFullContext: () => void;
@@ -73,7 +83,6 @@ export function CopyTreeRecentsPanel({
   const records = useCopyTreeHistoryStore((s) => s.records);
   const loading = useCopyTreeHistoryStore((s) => s.loading);
   const init = useCopyTreeHistoryStore((s) => s.init);
-  const headingId = useId();
   const primaryRowRef = useRef<HTMLButtonElement>(null);
 
   // The trigger advertises `aria-haspopup="dialog"`, and this panel is where
@@ -96,7 +105,7 @@ export function CopyTreeRecentsPanel({
   // whole selection step.
   const recents = records.slice(0, RECENTS_LIMIT);
 
-  // Header and primary row paint immediately; only the recents section waits.
+  // The primary button paints immediately; only the recents section waits.
   // The bones are `immediate` because this gate has already proven the wait
   // exceeded the Doherty threshold — the class-level delay would gate it twice.
   const showSkeleton = useDohertyGate(loading);
@@ -105,28 +114,28 @@ export function CopyTreeRecentsPanel({
     <div
       data-copy-tree-panel=""
       role="dialog"
-      aria-labelledby={headingId}
-      className="w-[360px] max-h-[420px] flex flex-col"
+      aria-label="Copy context"
+      className="w-[320px] max-h-[420px] flex flex-col"
     >
-      <div className="flex items-center pl-3 pr-2 py-2 border-b border-divider">
-        <span id={headingId} className="text-xs font-medium text-daintree-text/80">
-          Copy context
-        </span>
-      </div>
-
-      <button ref={primaryRowRef} type="button" onClick={onCopyFullContext} className={rowClass}>
-        <Folders className="w-4 h-4 shrink-0 text-daintree-text/70" aria-hidden="true" />
-        <span className="min-w-0 flex-1 truncate text-sm font-medium">Copy full context</span>
-      </button>
-
-      <div className="flex items-center px-3 pt-2 pb-1 border-t border-divider">
-        <span className="text-xs font-medium text-daintree-text/80">Recent</span>
+      {/* No headings: the framed primary button IS the header, and everything
+          under the divider is self-evidently the run history — each row names
+          its run and ends in a relative timestamp. */}
+      <div className="p-1.5 border-b border-divider">
+        <button
+          ref={primaryRowRef}
+          type="button"
+          onClick={onCopyFullContext}
+          className={primaryButtonClass}
+        >
+          <Folders className="w-4 h-4 shrink-0 text-daintree-text/70" aria-hidden="true" />
+          <span className="min-w-0 flex-1 truncate text-sm font-medium">Copy full context</span>
+        </button>
       </div>
 
       <ScrollShadow className="flex-1 min-h-0">
         {/* One stable child: the shadow hook observes firstElementChild, so it
             must outlive the skeleton/empty-state/list swaps below. */}
-        <div className="pb-1">
+        <div className="py-1">
           {loading ? (
             showSkeleton ? (
               <>

--- a/src/components/CopyTree/__tests__/CopyTreeRecentsPanel.test.tsx
+++ b/src/components/CopyTree/__tests__/CopyTreeRecentsPanel.test.tsx
@@ -187,16 +187,13 @@ describe("CopyTreeRecentsPanel", () => {
     // The trigger declares aria-haspopup="dialog" and the panel now owns the
     // button's former action. Portaled to the end of <body>, an unfocused panel
     // would leave a keyboard user tabbing through the whole app to reach it.
+    // The panel has no visible heading — the primary button is its header — so
+    // the dialog's name must come from an aria-label instead. Resolved through
+    // the accessibility tree rather than read off the attribute.
     seed([makeRecord()]);
     render(<CopyTreeRecentsPanel onCopyFullContext={noop} onRunRecent={noop} />);
 
-    const dialog = screen.getByRole("dialog");
-    const labelId = dialog.getAttribute("aria-labelledby");
-    expect(labelId).toBeTruthy();
-    // The name has to resolve to real text inside the panel — a dangling id
-    // leaves the dialog anonymous to a screen reader. Asserted by resolution
-    // rather than against a duplicated literal.
-    expect(document.getElementById(labelId!)?.textContent?.trim()).toBeTruthy();
+    expect(screen.getByRole("dialog", { name: /copy context/i })).toBeTruthy();
 
     expect(document.activeElement).toBe(screen.getByRole("button", { name: "Copy full context" }));
   });

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -127,6 +127,8 @@ import {
   isInsideCopyTreePanel,
   restoreCopyTreeTriggerFocus,
 } from "@/components/CopyTree/copyTreeFocus";
+import { useCopyTreeCompletionNotice } from "@/hooks/useCopyTreeCompletionNotice";
+import { useCopyTreeRunStore } from "@/store/copyTreeRunStore";
 import type { CopyTreeHistoryRecord } from "@shared/types";
 
 import {
@@ -145,6 +147,7 @@ const LazyCopyTreeRecentsPanel = lazy(() =>
 type OverflowMenuMeta = { label: string; icon: React.ComponentType<{ className?: string }> };
 
 const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text relative";
+
 // These controls are project-only visually, but their no-drag rectangles must
 // exist on first paint so secondary windows don't cache them as titlebar drag.
 const PROJECT_SCOPED_TOOLBAR_IDS = new Set<AnyToolbarButtonId>(["dev-server", "forge-stats"]);
@@ -242,6 +245,10 @@ function OverflowMenu({
   shortcutById,
 }: OverflowMenuProps) {
   const [open, setOpen] = useState(false);
+  // Read here rather than threaded through props: the overflow copy-tree item
+  // mirrors the visible button's disabled states, and in-flight copies can
+  // start from routes that never touch this menu (MCP, Cmd+Shift+C).
+  const isCopyingTree = useCopyTreeRunStore((s) => s.activeRunCount > 0);
   // Snapshot of the repo stats taken when the menu opens. The stats live in
   // ForgeStatsToolbarButton's hook and are exposed through its imperative
   // handle, so they can't be read during render (refs aren't reactive — the
@@ -490,10 +497,12 @@ function OverflowMenu({
           }
           const Icon = meta.icon;
           const shortcut = shortcutById[id];
-          // Mirror the visible copy-tree button, which is aria-disabled with an
-          // "Open a worktree first" tooltip when no worktree is active — without
-          // this the overflow item would silently close with no feedback.
-          const disabled = id === "copy-tree" && !hasActiveWorktree;
+          // Mirror the visible copy-tree button, which is aria-disabled both
+          // when no worktree is active ("Open a worktree first" tooltip) and
+          // while a copy is in flight — without this the overflow item would
+          // look live yet silently close with no feedback, since its handler
+          // guards on the same two conditions.
+          const disabled = id === "copy-tree" && (!hasActiveWorktree || isCopyingTree);
           return [
             <DropdownMenuItem key={id} disabled={disabled} onClick={() => overflowActions[id]?.()}>
               <Icon className="mr-2 h-3.5 w-3.5" />
@@ -653,12 +662,30 @@ export function Toolbar({
   const effectiveAgentSettings = liveAgentSettings ?? agentSettings;
 
   const [isFullscreen, setIsFullscreen] = useState(false);
-  const [isCopyingTree, setIsCopyingTree] = useState(false);
+  // Store-derived rather than local click state so every clipboard copy spins
+  // the button — an MCP or assistant dispatch runs the same bracketed actions
+  // a click does, and this button is the one place that work is visible.
+  const isCopyingTree = useCopyTreeRunStore((s) => s.activeRunCount > 0);
   const showCopyingSpinner = useDohertyGate(isCopyingTree);
+  // The tooltip's ordinary hover state — the Radix root is controlled with the
+  // union of this and the completion notice below, so a completion can force
+  // it open while hover keeps working through onOpenChange.
+  const [copyTreeTooltipHovered, setCopyTreeTooltipHovered] = useState(false);
   // Local to the toolbar — the panel has no palette entry or action of its own,
   // so nothing outside this component needs to open it (#11733).
   const [copyTreeOpen, setCopyTreeOpen] = useState(false);
   const copyTreeButtonRef = useRef<HTMLButtonElement>(null);
+  // Completion feedback for clipboard copies: the action layer announces every
+  // finished copy (announceCopyTreeCopy) and this hook's presenter pins it to
+  // the button as a short-lived tooltip, with a toast fallback whenever the
+  // button can't anchor one. Suppressed while the recents panel is open — both
+  // portal to the same anchor, and an MCP completion landing mid-browse would
+  // stack the tooltip on the panel.
+  const {
+    notice: copyTreeNotice,
+    announcement: copyTreeAnnouncement,
+    clearNotice: clearCopyTreeNotice,
+  } = useCopyTreeCompletionNotice(copyTreeButtonRef, { suppress: copyTreeOpen });
   // Latch after first open so reopening never re-suspends.
   const copyTreePanelMounted = useKeepMounted(copyTreeOpen);
 
@@ -819,23 +846,15 @@ export function Toolbar({
     return window.electron.window.onFullscreenChange(setIsFullscreen);
   }, []);
 
-  // Promise-method cleanup instead of try/finally: a statement-level finally
-  // clause bails React Compiler memoization for the whole Toolbar component.
-  //
-  // Completion feedback is the `worktree.copyTree` action's toast, not inline
-  // state here. The button used to swap in a check icon and force its tooltip
-  // open, which the overflow menu couldn't show at all (#9821) and which no
-  // other copy-tree route had — so both entry points now share this handler and
-  // the one toast covers them, along with Cmd+Shift+C and the palette (#11735).
-  // The spinner stays: it reports work in flight, which the toast can't.
+  // Feedback is owned by the action layer, not inline state here: the
+  // `worktree.copyTree` action brackets the shared run store (which drives the
+  // spinner above) and announces its completion through the button's transient
+  // tooltip, so every route — this handler, the overflow item, Cmd+Shift+C,
+  // the palette, MCP — reports identically (#11735). This handler only guards
+  // and dispatches.
   const handleCopyTreeClick = useCallback(() => {
     if (isCopyingTree || !activeWorktree) return;
-
-    setIsCopyingTree(true);
-
-    return handleCopyTree(activeWorktree, "toolbar").finally(() => {
-      setIsCopyingTree(false);
-    });
+    return handleCopyTree(activeWorktree, "toolbar");
   }, [isCopyingTree, activeWorktree, handleCopyTree]);
 
   // Warm the panel chunk before the first click — React 19 `lazy` still shows
@@ -866,8 +885,11 @@ export function Toolbar({
   // panel whose rows would all decline to run.
   const handleCopyTreeToggle = useCallback(() => {
     if (isCopyingTree || !activeWorktree) return;
+    // A lingering completion tooltip and the opening panel would anchor to the
+    // same button; the click is also an acknowledgement of the notice.
+    clearCopyTreeNotice();
     setCopyTreeOpen((open) => !open);
-  }, [isCopyingTree, activeWorktree]);
+  }, [isCopyingTree, activeWorktree, clearCopyTreeNotice]);
 
   // The panel's primary row: the old one-click behavior, now one click deeper.
   const handleCopyTreeFullContext = useCallback(() => {
@@ -883,21 +905,21 @@ export function Toolbar({
     (record: CopyTreeHistoryRecord) => {
       closeCopyTreePanel();
       if (isCopyingTree || !activeWorktree) return;
-
-      setIsCopyingTree(true);
-      void handleCopyTreeWithOptions(activeWorktree, record.options, "toolbar").finally(() => {
-        setIsCopyingTree(false);
-      });
+      void handleCopyTreeWithOptions(activeWorktree, record.options, "toolbar");
     },
     [closeCopyTreePanel, isCopyingTree, activeWorktree, handleCopyTreeWithOptions]
   );
 
-  // The anchor stops being interactive without a worktree, and the panel's rows
-  // all need one to run — leaving it open would strand a dead menu over the
-  // toolbar.
+  // The anchor stops being interactive without a worktree or while a copy is
+  // in flight (it renders aria-disabled for both), and the panel's rows decline
+  // in both states — leaving it open would strand a dead menu over the toolbar.
+  // The in-flight half matters because copies start without the trigger: MCP
+  // and assistant dispatches, Cmd+Shift+C, and the palette can all begin one
+  // while the panel is open. `closeCopyTreePanel` rather than a bare state
+  // flip so focus stranded inside the closing panel returns to the trigger.
   useEffect(() => {
-    if (!activeWorktree && copyTreeOpen) setCopyTreeOpen(false);
-  }, [activeWorktree, copyTreeOpen]);
+    if ((!activeWorktree || isCopyingTree) && copyTreeOpen) closeCopyTreePanel();
+  }, [activeWorktree, isCopyingTree, copyTreeOpen, closeCopyTreePanel]);
 
   const getToolbarItems = useCallback(
     () =>
@@ -1239,7 +1261,21 @@ export function Toolbar({
           <div className="relative">
             <ContextMenu>
               <ContextMenuTrigger asChild>
-                <Tooltip>
+                {/* Controlled union: hover opens through onOpenChange as
+                    normal, while a completion notice forces the tooltip open
+                    for its short display window — the whole feedback for a
+                    finished copy, in place of a toast. Close requests clear
+                    the notice too, so Escape, a click, and the shared
+                    dialog-transition dismissal can end the window early
+                    instead of being overridden by the forced half of the
+                    union. */}
+                <Tooltip
+                  open={copyTreeTooltipHovered || copyTreeNotice !== null}
+                  onOpenChange={(open) => {
+                    setCopyTreeTooltipHovered(open);
+                    if (!open) clearCopyTreeNotice();
+                  }}
+                >
                   <TooltipTrigger asChild>
                     <Button
                       ref={copyTreeButtonRef}
@@ -1263,11 +1299,20 @@ export function Toolbar({
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent side="bottom" className="font-medium">
-                    {isCopyingTree
-                      ? "Copying…"
-                      : !activeWorktree
-                        ? "Open a worktree first"
-                        : createTooltipContent("Copy context", copyTreeShortcut)}
+                    {copyTreeNotice ? (
+                      <span className="flex flex-col gap-0.5">
+                        <span>{copyTreeNotice.title}</span>
+                        <span className="font-normal text-daintree-text/60">
+                          {copyTreeNotice.message}
+                        </span>
+                      </span>
+                    ) : isCopyingTree ? (
+                      "Copying…"
+                    ) : !activeWorktree ? (
+                      "Open a worktree first"
+                    ) : (
+                      createTooltipContent("Copy context", copyTreeShortcut)
+                    )}
                   </TooltipContent>
                 </Tooltip>
               </ContextMenuTrigger>
@@ -1292,6 +1337,14 @@ export function Toolbar({
                 </Suspense>
               )}
             </FixedDropdown>
+            {/* The toast this tooltip replaced was announced by assistive
+                tech; a forced-open tooltip isn't, so the notice is mirrored
+                into a live region. The hook toggles a zero-width space onto
+                identical back-to-back completions so the second overwrite
+                still announces. */}
+            <span role="status" className="sr-only">
+              {copyTreeAnnouncement}
+            </span>
           </div>
         ),
         isAvailable: true,
@@ -1391,6 +1444,10 @@ export function Toolbar({
       closeCopyTreePanel,
       copyTreeOpen,
       copyTreePanelMounted,
+      copyTreeNotice,
+      copyTreeAnnouncement,
+      copyTreeTooltipHovered,
+      clearCopyTreeNotice,
       isCopyingTree,
       showCopyingSpinner,
       activeWorktree,

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -1268,8 +1268,13 @@ export function Toolbar({
                     the notice too, so Escape, a click, and the shared
                     dialog-transition dismissal can end the window early
                     instead of being overridden by the forced half of the
-                    union. */}
+                    union. The shared auto-dismiss is off while a notice is up:
+                    its timer arms on the open transition, so a completion that
+                    lands mid-hover would inherit whatever's left of the hover
+                    window instead of getting the notice's own. Hover-only opens
+                    keep the shared window. */}
                 <Tooltip
+                  autoDismiss={copyTreeNotice === null}
                   open={copyTreeTooltipHovered || copyTreeNotice !== null}
                   onOpenChange={(open) => {
                     setCopyTreeTooltipHovered(open);

--- a/src/components/Layout/__tests__/Toolbar.overflow.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.overflow.test.ts
@@ -134,9 +134,12 @@ describe("Toolbar overflow menu state preservation — issue #9821", () => {
       );
     });
 
-    it("disables the overflow copy-tree item when there is no active worktree", () => {
-      // Mirrors the visible button's aria-disabled "Open a worktree first" state.
-      expect(source).toMatch(/id === "copy-tree" && !hasActiveWorktree/);
+    it("disables the overflow copy-tree item exactly when its handler would refuse", () => {
+      // Mirrors the visible button's aria-disabled states: no active worktree
+      // ("Open a worktree first") and a copy already in flight — which can
+      // start from routes that never touch this menu (MCP, Cmd+Shift+C), so
+      // the item must not look live while activation would silently no-op.
+      expect(source).toMatch(/id === "copy-tree" && \(!hasActiveWorktree \|\| isCopyingTree\)/);
       expect(source).toContain("disabled={disabled}");
     });
   });

--- a/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
@@ -224,20 +224,36 @@ describe("Toolbar shortcut tooltips — issue #3443", () => {
       expect(copyTreeBlock![0]).toContain("<Folders />");
     });
 
-    it("carries no inline completion feedback — the toast owns it (issue #11735)", () => {
-      // The button used to swap in a check icon and force its tooltip open for
-      // two seconds. That feedback was invisible from the overflow menu and had
-      // no counterpart on any other copy-tree route, so it moved to the
-      // `worktree.copyTree` completion toast. Only the in-flight spinner stays.
+    it("presents completion as the button's transient tooltip, not a checkmark swap", () => {
+      // Completion feedback is a short-lived tooltip pinned to the button (the
+      // toast it replaced felt heavy for a one-second copy). The presenter,
+      // hide timer, and decline rules are useCopyTreeCompletionNotice's and
+      // are behavior-tested in its own suite; the toolbar's half of the
+      // contract — asserted here — is the wiring: the hook feeds the tooltip's
+      // controlled `open` as a union with ordinary hover, close requests clear
+      // the notice too (Escape and dialog transitions must be able to end the
+      // display window early), and the notice is mirrored into a live region,
+      // since tooltips aren't announced the way the old toast was. The old
+      // check-icon swap stays gone — the glyph slot belongs to the spinner.
       const copyTreeBlock = source.match(/"copy-tree":\s*\{[\s\S]*?isAvailable/);
       expect(copyTreeBlock).not.toBeNull();
-      expect(copyTreeBlock![0]).not.toContain("treeCopied");
       expect(copyTreeBlock![0]).not.toContain("<Check />");
       expect(copyTreeBlock![0]).not.toContain("text-status-success");
-      // A controlled `open` prop is what forced the tooltip; the plain <Tooltip>
-      // must stay uncontrolled.
-      expect(copyTreeBlock![0]).not.toMatch(/<Tooltip\s+open=/);
-      expect(copyTreeBlock![0]).not.toContain('role="status"');
+      expect(copyTreeBlock![0]).toMatch(
+        /open=\{copyTreeTooltipHovered \|\| copyTreeNotice !== null\}/
+      );
+      expect(copyTreeBlock![0]).toContain("if (!open) clearCopyTreeNotice()");
+      expect(copyTreeBlock![0]).toContain('role="status"');
+      expect(copyTreeBlock![0]).toContain("{copyTreeAnnouncement}");
+      expect(source).toContain("useCopyTreeCompletionNotice(copyTreeButtonRef");
+    });
+
+    it("suppresses the completion tooltip while the recents panel holds the anchor", () => {
+      // Both surfaces portal to the same button; an MCP completion landing
+      // mid-browse would stack the tooltip on the open panel.
+      expect(source).toMatch(
+        /useCopyTreeCompletionNotice\(copyTreeButtonRef,\s*\{\s*suppress:\s*copyTreeOpen\s*\}\)/
+      );
     });
 
     it("skips the hover hint, matching the action's suppressShortcutHint opt-out", async () => {

--- a/src/hooks/__tests__/useCopyTreeCompletionNotice.test.tsx
+++ b/src/hooks/__tests__/useCopyTreeCompletionNotice.test.tsx
@@ -1,0 +1,200 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import type React from "react";
+
+const notifyMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/notify", () => ({ notify: notifyMock }));
+
+import {
+  COPY_TREE_NOTICE_DURATION_MS,
+  useCopyTreeCompletionNotice,
+} from "../useCopyTreeCompletionNotice";
+import { announceCopyTreeCopy, _resetCopyTreeNoticePresenterForTest } from "@/lib/copyTreeFeedback";
+
+const NOTICE = { title: "Context copied", message: "Copied 3 files (4 KB) as XML to clipboard" };
+
+/**
+ * jsdom computes no layout, so `offsetParent` is null on every element — the
+ * exact signal the presenter reads as "overflow-evicted". The visible-anchor
+ * fixture stubs it the way a laid-out toolbar button would report.
+ */
+function makeAnchor({ visible = true }: { visible?: boolean } = {}): {
+  ref: React.RefObject<HTMLElement | null>;
+  el: HTMLElement;
+} {
+  const el = document.createElement("button");
+  document.body.appendChild(el);
+  if (visible) {
+    Object.defineProperty(el, "offsetParent", { get: () => document.body });
+  }
+  return { ref: { current: el }, el };
+}
+
+/** Announce through the real seam so the register/decline contract is what's under test. */
+function announce(): void {
+  act(() => {
+    announceCopyTreeCopy({ ...NOTICE }, "worktree.copyTree");
+  });
+}
+
+// jsdom reports an unfocused document by default, which the presenter reads as
+// "window blurred → decline". Present-path tests need a focused one; the
+// blur-decline case re-spies to false on top of this.
+beforeEach(() => {
+  vi.spyOn(document, "hasFocus").mockReturnValue(true);
+});
+
+afterEach(() => {
+  _resetCopyTreeNoticePresenterForTest();
+  notifyMock.mockClear();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  document.body.innerHTML = "";
+});
+
+describe("useCopyTreeCompletionNotice", () => {
+  it("presents a completion on a visible anchor instead of the toast", () => {
+    const { ref } = makeAnchor();
+    const { result } = renderHook(() => useCopyTreeCompletionNotice(ref));
+
+    announce();
+
+    expect(result.current.notice).toEqual(NOTICE);
+    expect(result.current.announcement).toBe(`${NOTICE.title}. ${NOTICE.message}`);
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("hides the notice and clears the announcement after the display window", () => {
+    vi.useFakeTimers();
+    const { ref } = makeAnchor();
+    const { result } = renderHook(() => useCopyTreeCompletionNotice(ref));
+
+    announce();
+    act(() => {
+      vi.advanceTimersByTime(COPY_TREE_NOTICE_DURATION_MS);
+    });
+
+    expect(result.current.notice).toBeNull();
+    expect(result.current.announcement).toBe("");
+  });
+
+  it("re-arms the display window when a second completion lands mid-notice", () => {
+    vi.useFakeTimers();
+    const { ref } = makeAnchor();
+    const { result } = renderHook(() => useCopyTreeCompletionNotice(ref));
+
+    announce();
+    act(() => {
+      vi.advanceTimersByTime(COPY_TREE_NOTICE_DURATION_MS - 500);
+    });
+    announce();
+    act(() => {
+      vi.advanceTimersByTime(COPY_TREE_NOTICE_DURATION_MS - 500);
+    });
+
+    // A stale first-notice timer would have hidden this 500ms ago.
+    expect(result.current.notice).toEqual(NOTICE);
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(result.current.notice).toBeNull();
+  });
+
+  it("re-announces an identical back-to-back completion by toggling a zero-width space", () => {
+    // The live region only speaks when its text CHANGES, so a second copy with
+    // the same summary would otherwise be silent for a screen-reader user.
+    vi.useFakeTimers();
+    const { ref } = makeAnchor();
+    const { result } = renderHook(() => useCopyTreeCompletionNotice(ref));
+
+    announce();
+    const first = result.current.announcement;
+    announce();
+
+    expect(result.current.announcement).toBe(`${first}\u200b`);
+  });
+
+  it("clears the notice and announcement on demand", () => {
+    const { ref } = makeAnchor();
+    const { result } = renderHook(() => useCopyTreeCompletionNotice(ref));
+
+    announce();
+    act(() => {
+      result.current.clearNotice();
+    });
+
+    expect(result.current.notice).toBeNull();
+    expect(result.current.announcement).toBe("");
+  });
+
+  it.each([
+    ["the anchor is gone", () => ({ ref: { current: null } })],
+    ["the anchor is overflow-evicted (offsetParent null)", () => makeAnchor({ visible: false })],
+    [
+      "the anchor sits under an aria-hidden wrapper",
+      () => {
+        const anchor = makeAnchor();
+        const wrapper = document.createElement("div");
+        wrapper.setAttribute("aria-hidden", "true");
+        document.body.appendChild(wrapper);
+        wrapper.appendChild(anchor.el);
+        return anchor;
+      },
+    ],
+  ])("declines to the toast fallback when %s", (_label, setup) => {
+    const { ref } = setup();
+    const { result } = renderHook(() => useCopyTreeCompletionNotice(ref));
+
+    announce();
+
+    expect(result.current.notice).toBeNull();
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("declines when the caller suppresses presentation (recents panel open)", () => {
+    const { ref } = makeAnchor();
+    const { result } = renderHook(() => useCopyTreeCompletionNotice(ref, { suppress: true }));
+
+    announce();
+
+    expect(result.current.notice).toBeNull();
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("declines when the view is background-hidden", () => {
+    // MCP dispatches run in their project's renderer even when another project
+    // is on screen; a tooltip there evaporates unseen while the toast fallback
+    // at least leaves an inbox row.
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+    const { ref } = makeAnchor();
+    const { result } = renderHook(() => useCopyTreeCompletionNotice(ref));
+
+    announce();
+
+    expect(result.current.notice).toBeNull();
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("declines when the window is blurred", () => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
+    const { ref } = makeAnchor();
+    const { result } = renderHook(() => useCopyTreeCompletionNotice(ref));
+
+    announce();
+
+    expect(result.current.notice).toBeNull();
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("unregisters its presenter on unmount", () => {
+    const { ref } = makeAnchor();
+    const { unmount } = renderHook(() => useCopyTreeCompletionNotice(ref));
+
+    unmount();
+    announce();
+
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useCopyTreeCompletionNotice.ts
+++ b/src/hooks/useCopyTreeCompletionNotice.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useState } from "react";
+import type React from "react";
+import {
+  registerCopyTreeNoticePresenter,
+  type CopyTreeCompletionNotice,
+} from "@/lib/copyTreeFeedback";
+
+/**
+ * How long a copy-tree completion notice stays pinned to the Copy context
+ * button. A display window, not a motion tier: long enough to read "Context
+ * copied" plus its one-line summary, short enough that the tooltip never
+ * outstays a signal about work that took a second or two.
+ */
+export const COPY_TREE_NOTICE_DURATION_MS = 2000;
+
+export interface CopyTreeNoticeState {
+  /** The completion currently pinned to the anchor, shown as a tooltip. */
+  notice: CopyTreeCompletionNotice | null;
+  /**
+   * Live-region mirror of the notice — tooltips aren't announced by assistive
+   * tech the way the toast this replaced was. Identical back-to-back
+   * completions toggle a zero-width space so the text change re-announces
+   * (same pattern as BrowserToolbar's history announcements).
+   */
+  announcement: string;
+  /** Dismiss early — Escape, dialog transitions, opening the recents panel. */
+  clearNotice: () => void;
+}
+
+/**
+ * The anchor's half of the copy-tree completion contract (the announce half
+ * lives in `@/lib/copyTreeFeedback`): registers a presenter that pins each
+ * finished clipboard copy to the anchor as a short-lived notice — including
+ * MCP and assistant copies the user never clicked for — and declines (falling
+ * back to a toast) whenever the notice would go unseen:
+ *
+ * - the anchor can't carry it — unmounted, or overflow-evicted (`invisible
+ *   absolute` under an aria-hidden wrapper, so offsetParent is null);
+ * - nobody is looking — the view is background-hidden (MCP dispatches run in
+ *   their project's renderer even when another project is on screen) or the
+ *   window is blurred. A two-second tooltip in an unwatched window evaporates,
+ *   where the fallback toast also leaves a durable inbox row;
+ * - the caller suppressed it — e.g. while the recents dropdown is open on the
+ *   same anchor, where the two portaled surfaces would stack.
+ */
+export function useCopyTreeCompletionNotice(
+  anchorRef: React.RefObject<HTMLElement | null>,
+  options?: { suppress?: boolean }
+): CopyTreeNoticeState {
+  const suppress = options?.suppress ?? false;
+  const [notice, setNotice] = useState<CopyTreeCompletionNotice | null>(null);
+  const [announcement, setAnnouncement] = useState("");
+
+  useEffect(() => {
+    return registerCopyTreeNoticePresenter((next) => {
+      if (suppress) return false;
+      if (document.visibilityState !== "visible" || !document.hasFocus()) return false;
+      const el = anchorRef.current;
+      if (!el || el.offsetParent === null || el.closest('[aria-hidden="true"]') !== null) {
+        return false;
+      }
+      // Spread so back-to-back completions always change identity and re-arm
+      // the hide timer below.
+      setNotice({ ...next });
+      const text = `${next.title}. ${next.message}`;
+      setAnnouncement((prev) => (prev === text ? `${text}\u200b` : text));
+      return true;
+    });
+  }, [anchorRef, suppress]);
+
+  useEffect(() => {
+    if (!notice) return;
+    const timer = setTimeout(() => {
+      setNotice(null);
+      // Cleared together so a later identical completion re-announces as a
+      // plain text change, and stale text isn't left for a screen reader
+      // walking the toolbar to stumble over.
+      setAnnouncement("");
+    }, COPY_TREE_NOTICE_DURATION_MS);
+    return () => clearTimeout(timer);
+  }, [notice]);
+
+  const clearNotice = useCallback(() => {
+    setNotice(null);
+    setAnnouncement("");
+  }, []);
+
+  return { notice, announcement, clearNotice };
+}

--- a/src/lib/__tests__/copyTreeFeedback.test.ts
+++ b/src/lib/__tests__/copyTreeFeedback.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const notifyMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/notify", () => ({ notify: notifyMock }));
+
+import {
+  announceCopyTreeCopy,
+  registerCopyTreeNoticePresenter,
+  _resetCopyTreeNoticePresenterForTest,
+} from "../copyTreeFeedback";
+
+const NOTICE = { title: "Context copied", message: "Copied 3 files (4 KB) as XML to clipboard" };
+
+afterEach(() => {
+  _resetCopyTreeNoticePresenterForTest();
+  notifyMock.mockClear();
+});
+
+describe("announceCopyTreeCopy", () => {
+  it("hands the notice to the presenter and raises no toast when it presents", () => {
+    const presenter = vi.fn().mockReturnValue(true);
+    registerCopyTreeNoticePresenter(presenter);
+
+    announceCopyTreeCopy(NOTICE, "worktree.copyTree");
+
+    expect(presenter).toHaveBeenCalledWith(NOTICE);
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a toast carrying the caller's rate-limit bucket when the presenter declines", () => {
+    // A presenter declines when its anchor is hidden — the completion must
+    // still land somewhere visible, in the shape the toast always had.
+    registerCopyTreeNoticePresenter(() => false);
+
+    announceCopyTreeCopy(NOTICE, "copyTree.generateAndCopyFile");
+
+    expect(notifyMock).toHaveBeenCalledWith({
+      type: "success",
+      title: NOTICE.title,
+      message: NOTICE.message,
+      rateLimitKey: "copyTree.generateAndCopyFile",
+      context: { eventKind: "agent" },
+    });
+  });
+
+  it("falls back to a toast when no presenter is registered at all", () => {
+    announceCopyTreeCopy(NOTICE, "worktree.copyTree");
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets a newer presenter's cleanup leave the current one in place", () => {
+    // StrictMode-shaped churn: A registers, is replaced by B, then A's
+    // unregister runs late. B must survive it.
+    const a = vi.fn().mockReturnValue(true);
+    const b = vi.fn().mockReturnValue(true);
+    const unregisterA = registerCopyTreeNoticePresenter(a);
+    registerCopyTreeNoticePresenter(b);
+    unregisterA();
+
+    announceCopyTreeCopy(NOTICE, "worktree.copyTree");
+
+    expect(b).toHaveBeenCalledTimes(1);
+    expect(a).not.toHaveBeenCalled();
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("unregisters cleanly so a torn-down presenter is never called", () => {
+    const presenter = vi.fn().mockReturnValue(true);
+    const unregister = registerCopyTreeNoticePresenter(presenter);
+    unregister();
+
+    announceCopyTreeCopy(NOTICE, "worktree.copyTree");
+
+    expect(presenter).not.toHaveBeenCalled();
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/copyTreeFeedback.ts
+++ b/src/lib/copyTreeFeedback.ts
@@ -1,0 +1,62 @@
+import { notify } from "@/lib/notify";
+
+/**
+ * Completion feedback for clipboard-bound copy-tree runs (the full toast felt
+ * heavy for a one-second copy). The toolbar's Copy context button registers a
+ * presenter that shows the notice as a transient tooltip on the button itself;
+ * `announceCopyTreeCopy` hands each completion to that presenter first and only
+ * falls back to the old toast when no visible button can carry it — the button
+ * unpinned from the toolbar, evicted into the overflow menu, or not mounted at
+ * all. Feedback about a silent clipboard overwrite must never just vanish.
+ */
+export interface CopyTreeCompletionNotice {
+  /** Short outcome line, e.g. "Context copied". */
+  title: string;
+  /** The one-line summary from `formatCopyResultMessage`. */
+  message: string;
+}
+
+type CopyTreeNoticePresenter = (notice: CopyTreeCompletionNotice) => boolean;
+
+let presenter: CopyTreeNoticePresenter | null = null;
+
+/**
+ * One presenter at a time — each project view runs its own V8 context with its
+ * own toolbar, so "the" button is unambiguous here. The presenter returns false
+ * to decline (its anchor is currently hidden), which sends the notice down the
+ * toast fallback instead.
+ */
+export function registerCopyTreeNoticePresenter(next: CopyTreeNoticePresenter): () => void {
+  presenter = next;
+  return () => {
+    if (presenter === next) presenter = null;
+  };
+}
+
+export function announceCopyTreeCopy(notice: CopyTreeCompletionNotice, rateLimitKey: string): void {
+  if (presenter?.(notice)) return;
+
+  // The pre-tooltip toast, verbatim. No `context.worktreeId`, deliberately:
+  // notify() diverts a high-priority toast to the inbox when context names the
+  // worktree already on screen — the common case here — which would silence
+  // exactly this signal. A clipboard overwrite is invisible whichever worktree
+  // is displayed. "agent", not "completed": both route active → high, but
+  // "completed" owns the `completedEnabled` setting, which gates only
+  // main-process completion watches and never a renderer notify(). The
+  // rateLimitKey keeps each caller in its own bucket so an unrelated success
+  // burst can't swallow the one message saying what is now on the clipboard
+  // (#11735).
+  // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
+  notify({
+    type: "success",
+    title: notice.title,
+    message: notice.message,
+    rateLimitKey,
+    context: { eventKind: "agent" },
+  });
+}
+
+/** Test-only: drop whatever presenter a case left behind. */
+export function _resetCopyTreeNoticePresenterForTest(): void {
+  presenter = null;
+}

--- a/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
@@ -66,6 +66,8 @@ import {
   setWorktreePathIndexAccessor,
   resetStoreAccessorsForTesting,
 } from "@/store/storeAccessors";
+import { _resetCopyTreeNoticePresenterForTest } from "@/lib/copyTreeFeedback";
+import { useCopyTreeRunStore } from "@/store/copyTreeRunStore";
 
 function setupActions(): {
   run: (id: string, args?: unknown, ctx?: Record<string, unknown>) => Promise<unknown>;
@@ -104,6 +106,11 @@ beforeEach(() => {
   // The worktree path index leaks across files otherwise, so a later suite
   // would inherit whichever map the last path-resolution test installed.
   resetStoreAccessorsForTesting();
+  // The completion-toast assertions below are FALLBACK coverage: they hold
+  // because no presenter is registered. Reset explicitly so a future test that
+  // registers one can't make ordering matter, and settle the run counter.
+  _resetCopyTreeNoticePresenterForTest();
+  useCopyTreeRunStore.setState({ activeRunCount: 0 });
   for (const fn of Object.values(filesClientMock)) fn.mockResolvedValue(undefined);
   for (const fn of Object.values(copyTreeClientMock)) fn.mockResolvedValue(undefined);
   for (const fn of Object.values(slashCommandsClientMock)) fn.mockResolvedValue(undefined);
@@ -434,6 +441,49 @@ describe("systemActions adversarial", () => {
       await expect(
         run("copyTree.generateAndCopyFile", undefined, { activeWorktreeId: "wt-active" })
       ).rejects.toThrow("Failed to copy file to clipboard: EACCES");
+    });
+
+    it("brackets the shared run store so the toolbar spinner tracks MCP copies", async () => {
+      // This is the action MCP clipboard copies and the recents replay land
+      // on; the toolbar's Copy context spinner derives from this count.
+      const { run } = setupActions();
+      let midFlightCount = -1;
+      copyTreeClientMock.generateAndCopyFile.mockImplementationOnce(async () => {
+        midFlightCount = useCopyTreeRunStore.getState().activeRunCount;
+        return { ...COPY_TREE_RESULT };
+      });
+
+      await run(
+        "copyTree.generateAndCopyFile",
+        { worktreeId: "wt-1" },
+        { dispatchSource: "agent" }
+      );
+
+      expect(midFlightCount).toBe(1);
+      expect(useCopyTreeRunStore.getState().activeRunCount).toBe(0);
+    });
+
+    it("settles the run count even when the copy rejects", async () => {
+      const { run } = setupActions();
+      copyTreeClientMock.generateAndCopyFile.mockRejectedValueOnce(new Error("boom"));
+      await expect(
+        run("copyTree.generateAndCopyFile", undefined, { activeWorktreeId: "wt-active" })
+      ).rejects.toThrow("boom");
+      expect(useCopyTreeRunStore.getState().activeRunCount).toBe(0);
+    });
+
+    it("never blips the spinner for a dispatch refused before the client is reached", async () => {
+      // The agent-target guard throws before the bracket: a refused dispatch
+      // did no work, so it must not flash the button.
+      const { run } = setupActions();
+      await expect(
+        run("copyTree.generateAndCopyFile", undefined, {
+          dispatchSource: "agent",
+          activeWorktreeId: "wt-active",
+        })
+      ).rejects.toThrow(/explicit/i);
+      expect(useCopyTreeRunStore.getState().activeRunCount).toBe(0);
+      expect(copyTreeClientMock.generateAndCopyFile).not.toHaveBeenCalled();
     });
 
     it("resolves an explicit worktreePath to the id its IPC takes", async () => {

--- a/src/services/actions/definitions/__tests__/worktreeContextActions.copyTree.test.ts
+++ b/src/services/actions/definitions/__tests__/worktreeContextActions.copyTree.test.ts
@@ -21,6 +21,11 @@ vi.mock("@/clients", () => ({
 }));
 
 import { registerWorktreeContextActions } from "../worktreeContextActions";
+import {
+  registerCopyTreeNoticePresenter,
+  _resetCopyTreeNoticePresenterForTest,
+} from "@/lib/copyTreeFeedback";
+import { useCopyTreeRunStore } from "@/store/copyTreeRunStore";
 
 function setupActions(): {
   run: (id: string, args?: unknown, ctx?: Record<string, unknown>) => Promise<unknown>;
@@ -48,15 +53,68 @@ const COPY_TREE_RESULT = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  _resetCopyTreeNoticePresenterForTest();
+  useCopyTreeRunStore.setState({ activeRunCount: 0 });
   copyTreeClientMock.generateAndCopyFile.mockResolvedValue({ ...COPY_TREE_RESULT });
 });
 
 // Issue #11735 — this action is the single completion point for every copy-tree
 // route that isn't the context menu: the toolbar button, its overflow item,
 // Cmd+Shift+C, the command palette, the `worktree.copyContext` alias, and agent
-// dispatches. All of them were silent or relied on inline button state that
-// three of them could not show.
-describe("worktree.copyTree completion toast", () => {
+// dispatches. Completion goes through announceCopyTreeCopy: the toolbar button
+// presents it as a transient tooltip, and with no presenter registered — as in
+// every case below unless one is — it falls back to the toast the notifyMock
+// observes, so those cases pin the fallback payload.
+describe("worktree.copyTree completion announcement", () => {
+  it("prefers a registered presenter over the toast fallback", async () => {
+    // The tooltip path: when the toolbar button is visible its presenter
+    // consumes the notice, and no toast may stack on top of it.
+    const presenter = vi.fn().mockReturnValue(true);
+    registerCopyTreeNoticePresenter(presenter);
+
+    const { run } = setupActions();
+    await run("worktree.copyTree", { worktreeId: "wt-1", format: "xml" });
+
+    expect(presenter).toHaveBeenCalledWith({
+      title: "Context copied",
+      message: "Copied 3 files (4 KB) as XML to clipboard",
+    });
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the toast when the presenter declines", async () => {
+    // A registered presenter whose anchor is hidden (overflow-evicted button)
+    // returns false; the completion must still land somewhere visible.
+    registerCopyTreeNoticePresenter(() => false);
+
+    const { run } = setupActions();
+    await run("worktree.copyTree", { worktreeId: "wt-1" });
+
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("brackets the shared run store so the toolbar spinner tracks every route", async () => {
+    // The spinner derives from this count, so an MCP dispatch spins the button
+    // exactly like a click. Sampled mid-flight through the client mock.
+    const { run } = setupActions();
+    let midFlightCount = -1;
+    copyTreeClientMock.generateAndCopyFile.mockImplementationOnce(async () => {
+      midFlightCount = useCopyTreeRunStore.getState().activeRunCount;
+      return { ...COPY_TREE_RESULT };
+    });
+
+    await run("worktree.copyTree", { worktreeId: "wt-1" }, { dispatchSource: "agent" });
+
+    expect(midFlightCount).toBe(1);
+    expect(useCopyTreeRunStore.getState().activeRunCount).toBe(0);
+  });
+
+  it("settles the run count even when the copy fails", async () => {
+    const { run } = setupActions();
+    copyTreeClientMock.generateAndCopyFile.mockRejectedValueOnce(new Error("boom"));
+    await expect(run("worktree.copyTree", { worktreeId: "wt-1" })).rejects.toThrow("boom");
+    expect(useCopyTreeRunStore.getState().activeRunCount).toBe(0);
+  });
   it.each([
     ["the toolbar button and palette", "user"],
     ["Cmd+Shift+C", "keybinding"],

--- a/src/services/actions/definitions/systemActions.ts
+++ b/src/services/actions/definitions/systemActions.ts
@@ -612,7 +612,7 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
         // button advertises a clipboard copy, and neither touches the clipboard.
         const runStore = useCopyTreeRunStore.getState();
         runStore.beginRun();
-        let result;
+        let result: CopyTreeResult;
         try {
           result = await copyTreeClient.generateAndCopyFile(
             requireWorktreeId(args, ctx),

--- a/src/services/actions/definitions/systemActions.ts
+++ b/src/services/actions/definitions/systemActions.ts
@@ -12,6 +12,8 @@ import {
 } from "./locationArgs";
 import { z } from "zod";
 import { notify } from "@/lib/notify";
+import { announceCopyTreeCopy } from "@/lib/copyTreeFeedback";
+import { useCopyTreeRunStore } from "@/store/copyTreeRunStore";
 import { formatCopyResultMessage } from "@/lib/formatCopyResult";
 import { resolveCopyTreeRunSource } from "@/lib/copyTreeRunSource";
 import { resolveCopyTreeRunName } from "@shared/utils/copyTreeHistory";
@@ -602,52 +604,50 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
       mcpOutputSchema: true,
       run: async (args, ctx: ActionContext) => {
         requireExplicitWorktreeForAgentDispatch("copyTree.generateAndCopyFile", args, ctx);
-        const result = await copyTreeClient.generateAndCopyFile(
-          requireWorktreeId(args, ctx),
-          args?.options,
-          resolveCopyTreeRunSource(ctx.dispatchSource, ctx.copyTreeRunSource),
-          args?.name
-        );
+        // Bracketed for the toolbar's Copy context spinner — this is the action
+        // MCP clipboard copies and the recents replay land on, and both should
+        // spin the button exactly like a direct click (the other clipboard
+        // route, worktree.copyTree, brackets itself the same way). The
+        // temp-file and terminal-injection siblings deliberately don't: the
+        // button advertises a clipboard copy, and neither touches the clipboard.
+        const runStore = useCopyTreeRunStore.getState();
+        runStore.beginRun();
+        let result;
+        try {
+          result = await copyTreeClient.generateAndCopyFile(
+            requireWorktreeId(args, ctx),
+            args?.options,
+            resolveCopyTreeRunSource(ctx.dispatchSource, ctx.copyTreeRunSource),
+            args?.name
+          );
+        } finally {
+          runStore.endRun();
+        }
         throwOnCopyTreeFailure(result);
         const { filePath, outputBytes } = requireGeneratedFile(result);
         // Announced for every dispatch source, not just agents. The old
         // agent-only gate assumed a person who triggered this already knows
         // their clipboard changed — true of a button with inline feedback, but
-        // this action's only human route is the command palette, which leaves
-        // nothing on screen at all (#11735). Ordered after the failure checks so
-        // a failed generate or a failed clipboard write can never announce
+        // this action's other human routes (palette, recents replay) leave
+        // nothing on screen at all (#11735). The announcement is a transient
+        // tooltip on the toolbar's Copy context button, with a toast fallback
+        // when that button isn't visible. Ordered after the failure checks so a
+        // failed generate or a failed clipboard write can never announce
         // success.
-        //
-        // No `context.worktreeId` here, deliberately: notify() suppresses a
-        // high-priority toast into the inbox when context names the worktree
-        // the user is already looking at, and copying the ACTIVE worktree is the
-        // common case — passing it would silence exactly this toast. A clipboard
-        // overwrite is invisible no matter which worktree is on screen, so the
-        // origin-surface rule doesn't hold here.
-        // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
-        notify({
-          type: "success",
-          // Matches the title every other copy-tree completion uses for this
-          // artifact ("context", never "reference file"), paired with the same
-          // formatCopyResultMessage body — see worktreeContextActions.ts.
-          title: copyTreeRunTitle("Context copied", args?.name),
-          message: formatCopyResultMessage({
-            fileCount: result.fileCount,
-            stats: result.stats,
-            format: args?.options?.format,
-          }),
-          // Its own bucket. The key otherwise falls back to `type`, putting
-          // every "success" toast in the app in one bucket — three unrelated
-          // ones would swallow this into a generic overflow row and lose the
-          // message that says what is on the clipboard.
-          rateLimitKey: "copyTree.generateAndCopyFile",
-          // "agent", not "completed": both route identically (active → high),
-          // but "completed" owns the `completedEnabled` setting, which gates
-          // only main-process completion watches and never a renderer
-          // notify() — so it would offer a "silence completed notifications"
-          // affordance that leaves these copies firing anyway.
-          context: { eventKind: "agent" },
-        });
+        announceCopyTreeCopy(
+          {
+            // Matches the title every other copy-tree completion uses for this
+            // artifact ("context", never "reference file"), paired with the
+            // same formatCopyResultMessage body — see worktreeContextActions.ts.
+            title: copyTreeRunTitle("Context copied", args?.name),
+            message: formatCopyResultMessage({
+              fileCount: result.fileCount,
+              stats: result.stats,
+              format: args?.options?.format,
+            }),
+          },
+          "copyTree.generateAndCopyFile"
+        );
         return {
           filePath,
           fileCount: result.fileCount,

--- a/src/services/actions/definitions/worktreeContextActions.ts
+++ b/src/services/actions/definitions/worktreeContextActions.ts
@@ -16,7 +16,8 @@ import { isMcpSpawnFocusSuppressed } from "@/store/mcpSpawnFocusGuard";
 import { isAssistantFocused } from "@/store/macroFocusStore";
 import { DEFAULT_COPYTREE_FORMAT } from "@/lib/copyTreeFormat";
 import { formatCopyResultMessage } from "@/lib/formatCopyResult";
-import { notify } from "@/lib/notify";
+import { announceCopyTreeCopy } from "@/lib/copyTreeFeedback";
+import { useCopyTreeRunStore } from "@/store/copyTreeRunStore";
 import { deriveCommitMessageSeed } from "@/lib/worktreeAiNote";
 import { buildWorkingTreeDiffModel } from "@/lib/workingTreeDiff";
 import { basename } from "@shared/utils/path";
@@ -307,12 +308,12 @@ export function registerWorktreeContextActions(
       kind: "command",
       danger: "safe",
       scope: "renderer",
-      // This action now raises its own completion toast, which lands top-right —
-      // the same corner the hint anchors to on the toolbar button. 219e2908f
-      // already dismissed the hint for exactly this overlap back when the result
-      // showed in a forced tooltip; the toast inherits that conflict and says
-      // strictly more than the hint does. The hint only fires for source "user",
-      // so this costs the toolbar and palette routes nothing the toast doesn't
+      // Completion feedback is a transient tooltip pinned to the toolbar's Copy
+      // context button (announceCopyTreeCopy), which a shortcut hint on that
+      // same button would sit directly on top of. 219e2908f already dismissed
+      // the hint for exactly this overlap back when the result showed in a
+      // forced tooltip. The hint only fires for source "user", so this costs
+      // the toolbar and palette routes nothing the completion notice doesn't
       // already cover, and the keybinding route never raised one (#11735).
       suppressShortcutHint: true,
       argsSchema: z
@@ -347,16 +348,26 @@ export function registerWorktreeContextActions(
 
         const format = explicitFormat ?? DEFAULT_COPYTREE_FORMAT;
 
-        const result = await copyTreeClient.generateAndCopyFile(
-          targetWorktreeId,
-          {
-            format,
-            modified,
-            ...(includePaths && includePaths.length > 0 ? { includePaths } : {}),
-            ...(scopePaths && scopePaths.length > 0 ? { scopePaths } : {}),
-          },
-          resolveCopyTreeRunSource(ctx.dispatchSource, ctx.copyTreeRunSource)
-        );
+        // Bracketed for the toolbar spinner, whoever dispatched — an MCP copy
+        // spins the Copy context button the same as a clicked one. After the
+        // no-worktree return so a refused dispatch never blips it.
+        const runStore = useCopyTreeRunStore.getState();
+        runStore.beginRun();
+        let result;
+        try {
+          result = await copyTreeClient.generateAndCopyFile(
+            targetWorktreeId,
+            {
+              format,
+              modified,
+              ...(includePaths && includePaths.length > 0 ? { includePaths } : {}),
+              ...(scopePaths && scopePaths.length > 0 ? { scopePaths } : {}),
+            },
+            resolveCopyTreeRunSource(ctx.dispatchSource, ctx.copyTreeRunSource)
+          );
+        } finally {
+          runStore.endRun();
+        }
 
         if (result.error) {
           if (modified && result.error.includes("No valid files")) {
@@ -370,7 +381,7 @@ export function registerWorktreeContextActions(
         // Cmd+Shift+C, the palette, the `worktree.copyContext` alias, and any
         // agent dispatch. `copyContextWithFeedback` is the sole "context-menu"
         // caller and updates its own spinner toast in place, so announcing here
-        // too would double-toast it. Ordered after the failure checks so a
+        // too would double-report it. Ordered after the failure checks so a
         // failed copy can never announce success (#11735).
         if (ctx.dispatchSource !== "context-menu") {
           // Deliberately no empty-result explanation here, unlike the
@@ -378,32 +389,17 @@ export function registerWorktreeContextActions(
           // folder, whereas `includePaths`/`scopePaths` also carry globs and
           // individual files, so "this folder…" would be the wrong words for an
           // unmatched pattern. A plain count stays true for every caller.
-          // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
-          notify({
-            type: "success",
-            title: "Context copied",
-            message: formatCopyResultMessage({
-              fileCount: result.fileCount,
-              stats: result.stats,
-              format,
-            }),
-            // Its own bucket. The key otherwise falls back to `type`, pooling
-            // this with every other success toast in the app, where an
-            // unrelated burst would swallow the one message saying what is now
-            // on the clipboard.
-            rateLimitKey: "worktree.copyTree",
-            // No `context.worktreeId`, deliberately: notify() diverts a
-            // high-priority toast to the inbox when context names the worktree
-            // already on screen — the common case here — which would silence
-            // exactly this signal. A clipboard overwrite is invisible whichever
-            // worktree is displayed.
-            //
-            // "agent", not "completed": both route active → high, but
-            // "completed" owns the `completedEnabled` setting, which gates only
-            // main-process completion watches and never a renderer notify() —
-            // it would offer a toggle that leaves these copies firing anyway.
-            context: { eventKind: "agent" },
-          });
+          announceCopyTreeCopy(
+            {
+              title: "Context copied",
+              message: formatCopyResultMessage({
+                fileCount: result.fileCount,
+                stats: result.stats,
+                format,
+              }),
+            },
+            "worktree.copyTree"
+          );
         }
 
         return {

--- a/src/services/actions/definitions/worktreeContextActions.ts
+++ b/src/services/actions/definitions/worktreeContextActions.ts
@@ -3,6 +3,7 @@ import { defineAction } from "../defineAction";
 import { z } from "zod";
 import type { ActionContext } from "@shared/types/actions";
 import type { BuiltInRuntimeActionId } from "@shared/config/actionIds";
+import type { CopyTreeResult } from "@shared/types";
 import { copyTreeClient, systemClient } from "@/clients";
 import { resolveCopyTreeRunSource } from "@/lib/copyTreeRunSource";
 import { actionService } from "@/services/ActionService";
@@ -353,7 +354,7 @@ export function registerWorktreeContextActions(
         // no-worktree return so a refused dispatch never blips it.
         const runStore = useCopyTreeRunStore.getState();
         runStore.beginRun();
-        let result;
+        let result: CopyTreeResult;
         try {
           result = await copyTreeClient.generateAndCopyFile(
             targetWorktreeId,

--- a/src/store/__tests__/copyTreeRunStore.test.ts
+++ b/src/store/__tests__/copyTreeRunStore.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useCopyTreeRunStore } from "../copyTreeRunStore";
+
+beforeEach(() => {
+  useCopyTreeRunStore.setState({ activeRunCount: 0 });
+});
+
+describe("copyTreeRunStore", () => {
+  it("keeps the count positive until every overlapping run has settled", () => {
+    // The reason this is a count and not a boolean: an MCP copy landing while
+    // a manual one is generating must not switch the spinner off early.
+    const { beginRun, endRun } = useCopyTreeRunStore.getState();
+
+    beginRun();
+    beginRun();
+    endRun();
+    expect(useCopyTreeRunStore.getState().activeRunCount).toBe(1);
+
+    endRun();
+    expect(useCopyTreeRunStore.getState().activeRunCount).toBe(0);
+  });
+
+  it("clamps at zero so a double-settled run cannot eat the next run's spinner", () => {
+    const { beginRun, endRun } = useCopyTreeRunStore.getState();
+
+    endRun();
+    expect(useCopyTreeRunStore.getState().activeRunCount).toBe(0);
+
+    beginRun();
+    expect(useCopyTreeRunStore.getState().activeRunCount).toBe(1);
+  });
+});

--- a/src/store/copyTreeRunStore.ts
+++ b/src/store/copyTreeRunStore.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+
+/**
+ * Clipboard-bound copy-tree runs currently in flight, whatever started them —
+ * the toolbar button, Cmd+Shift+C, the palette, a recents replay, a context
+ * menu, or an MCP/assistant dispatch. The toolbar's Copy context button derives
+ * its spinner from this count, so an agent-driven copy spins it exactly like a
+ * clicked one.
+ *
+ * A count rather than a boolean: runs can overlap (an MCP copy landing while a
+ * manual one is generating), and a boolean would let the first completion
+ * switch the spinner off under the run still going.
+ */
+interface CopyTreeRunState {
+  activeRunCount: number;
+  beginRun: () => void;
+  endRun: () => void;
+}
+
+export const useCopyTreeRunStore = create<CopyTreeRunState>((set) => ({
+  activeRunCount: 0,
+  beginRun: () => set((s) => ({ activeRunCount: s.activeRunCount + 1 })),
+  // Clamped so a double-settled promise can never wedge the count negative and
+  // eat the next run's spinner.
+  endRun: () => set((s) => ({ activeRunCount: Math.max(0, s.activeRunCount - 1) })),
+}));


### PR DESCRIPTION
This PR polishes the copy context toolbar button.

## Dropdown panel

The two small headings were removed. The primary "Copy full context" action is now a framed button at the top of the panel, which acts as the panel's header, with the run history listed directly below it.

## Completion feedback

The completion toast was a little too much for a copy that takes a second or two, so it's been replaced with a small tooltip that appears on the toolbar button for about two seconds after a copy finishes, showing the file count and total size. The toast is kept only as a fallback for when the button can't show the tooltip, for example when the button is in the overflow menu or the window isn't focused. An `sr-only` live region keeps completions announced for screen readers.

## MCP parity

The button spinner now also spins for copies started over MCP, driven by a shared run counter (`copyTreeRunStore`), and those copies show the same completion tooltip. While any copy is in flight, the recents panel closes and the overflow item is disabled, matching the button's own disabled state.

The code was reviewed and I've added behavioural tests for the new `useCopyTreeCompletionNotice` hook, the run counter store, and both action paths (`worktree.copyTree` and `copyTree.generateAndCopyFile`).