### PR TITLE
fix(worktree): resolve base branch's remote instead of origin

### DIFF
--- a/electron/ipc/handlers/__tests__/forgeResolution.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeResolution.test.ts
@@ -60,7 +60,7 @@ const pluginServiceMock = vi.hoisted(() => ({
 
 vi.mock("../../../services/PluginService.js", () => ({ pluginService: pluginServiceMock }));
 
-import { resolveForCwd } from "../forgeResolution.js";
+import { resolveForCwd, resolveForgeRemoteNameForCwd } from "../forgeResolution.js";
 
 const giteaEntry: ForgeProviderEntry = {
   pluginId: "acme",
@@ -518,5 +518,79 @@ describe("resolveForCwd — cwd validation", () => {
     // the next failure in the chain rather than the validation error.
     await expect(resolveForCwd("/abs/path")).rejects.toThrow("Not a git repository");
     expect(gitServiceCacheMock.getGitService).toHaveBeenCalledWith("/abs/path");
+  });
+});
+describe("resolveForgeRemoteNameForCwd", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    gitServiceCacheMock.getGitService.mockReturnValue(gitServiceMock);
+    gitServiceMock.getRemoteUrl.mockResolvedValue("https://github.com/owner/repo.git");
+    gitServiceMock.listWorktrees.mockResolvedValue([
+      { path: "/repo", branch: "main", bare: false, isMainWorktree: true },
+    ]);
+    gitServiceMock.getRepositoryRoot.mockResolvedValue("/repo");
+    projectStoreMock.getProjectByPath.mockResolvedValue({ id: "project-1", path: "/repo" });
+    projectStoreMock.getProjectSettings.mockResolvedValue({ runCommands: [] });
+    gitServiceMock.listRemotes.mockResolvedValue([
+      { name: "origin", fetchUrl: "https://github.com/owner/repo.git" },
+    ]);
+    registryMock.listMatchingProviders.mockReturnValue([{}]);
+  });
+
+  it("returns the remote name, not its URL", async () => {
+    // The PR-head refspec addresses the forge by remote name, so the name is
+    // the part that has to survive resolution (#11747).
+    await expect(resolveForgeRemoteNameForCwd("/repo")).resolves.toBe("origin");
+  });
+
+  it("returns the configured forgeRemote when the project names one", async () => {
+    projectStoreMock.getProjectSettings.mockResolvedValue({
+      runCommands: [],
+      forgeRemote: "upstream",
+    });
+    gitServiceMock.listRemotes.mockResolvedValue([
+      { name: "origin", fetchUrl: "https://github.com/me/fork.git" },
+      { name: "upstream", fetchUrl: "https://github.com/owner/repo.git" },
+    ]);
+
+    await expect(resolveForgeRemoteNameForCwd("/repo")).resolves.toBe("upstream");
+  });
+
+  it("picks the provider-parseable remote when the forge is not origin", async () => {
+    gitServiceMock.listRemotes.mockResolvedValue([
+      { name: "origin", fetchUrl: "https://internal.example/mirror.git" },
+      { name: "github", fetchUrl: "https://github.com/owner/repo.git" },
+    ]);
+    registryMock.listMatchingProviders.mockImplementation((url: string) =>
+      url.includes("github.com") ? [{}] : []
+    );
+
+    await expect(resolveForgeRemoteNameForCwd("/repo")).resolves.toBe("github");
+  });
+
+  it("propagates a stale configured remote instead of falling back to origin", async () => {
+    // PR numbers are per-repository, so substituting a remote could fetch a
+    // completely unrelated PR that happens to share the number.
+    projectStoreMock.getProjectSettings.mockResolvedValue({
+      runCommands: [],
+      forgeRemote: "gone",
+    });
+    gitServiceMock.listRemotes.mockResolvedValue([
+      { name: "origin", fetchUrl: "https://github.com/owner/repo.git" },
+    ]);
+
+    await expect(resolveForgeRemoteNameForCwd("/repo")).rejects.toThrow(/gone/);
+  });
+
+  it("returns null for a path that is not a git repository", async () => {
+    gitServiceCacheMock.getGitService.mockReturnValue(null);
+
+    await expect(resolveForgeRemoteNameForCwd("/not-a-repo")).resolves.toBeNull();
+  });
+
+  it("returns null when the repo has no usable remote", async () => {
+    gitServiceMock.listRemotes.mockResolvedValue([]);
+
+    await expect(resolveForgeRemoteNameForCwd("/repo")).resolves.toBeNull();
   });
 });

--- a/electron/ipc/handlers/__tests__/forgeResolution.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeResolution.test.ts
@@ -582,6 +582,29 @@ describe("resolveForgeRemoteNameForCwd", () => {
     await expect(resolveForgeRemoteNameForCwd("/repo")).rejects.toThrow(/gone/);
   });
 
+  it("refuses to guess when a configured remote cannot be verified", async () => {
+    // Enumeration failing is NOT the same as "this repo has no remote". The
+    // caller's fallback is origin, and PR numbers are per-repository, so
+    // fetching origin's PR 42 for an upstream-configured project would check
+    // out an unrelated PR that happens to share the number.
+    projectStoreMock.getProjectSettings.mockResolvedValue({
+      runCommands: [],
+      forgeRemote: "upstream",
+    });
+    gitServiceMock.listRemotes.mockRejectedValue(new Error("git exploded"));
+
+    await expect(resolveForgeRemoteNameForCwd("/repo")).rejects.toThrow(/upstream/);
+  });
+
+  it("still returns null on enumeration failure when nothing is configured", async () => {
+    // Nothing was named, so there is no user intent to contradict — the
+    // caller's origin default is the pre-existing behavior.
+    gitServiceMock.listRemotes.mockRejectedValue(new Error("git exploded"));
+    gitServiceMock.getRemoteUrl.mockResolvedValue(null);
+
+    await expect(resolveForgeRemoteNameForCwd("/repo")).resolves.toBeNull();
+  });
+
   it("returns null for a path that is not a git repository", async () => {
     gitServiceCacheMock.getGitService.mockReturnValue(null);
 

--- a/electron/ipc/handlers/forgeResolution.ts
+++ b/electron/ipc/handlers/forgeResolution.ts
@@ -210,7 +210,18 @@ export async function resolveForgeRemoteNameForCwd(cwd: string): Promise<string 
     forgeRemote,
     forgeProviderOverride
   );
-  return selected?.name ?? null;
+  if (selected) return selected.name;
+  // `null` from a *configured* remote means enumeration failed, so we could
+  // not verify the remote the user named — not that the repo has none. The
+  // caller's fallback is `origin`, and PR numbers are per-repository: fetching
+  // `origin pull/42/head` for a project pointed at `upstream` would silently
+  // check out an unrelated PR that happens to share the number. Fail closed.
+  if (forgeRemote) {
+    throw new Error(
+      `Couldn't confirm this project's "${forgeRemote}" remote, so the repository to fetch from is unknown. Check the remote and try again.`
+    );
+  }
+  return null;
 }
 
 export async function resolveForCwd(cwd: string): Promise<ResolvedForgeContext> {

--- a/electron/ipc/handlers/forgeResolution.ts
+++ b/electron/ipc/handlers/forgeResolution.ts
@@ -86,11 +86,43 @@ export async function resolveEffectiveRemoteUrl(
   forgeRemote: string | null,
   forgeProviderOverride: string | null = null
 ): Promise<string | null> {
+  const selected = await resolveEffectiveForgeRemote(
+    gitService,
+    cwd,
+    forgeRemote,
+    forgeProviderOverride
+  );
+  return selected?.fetchUrl ?? null;
+}
+
+/**
+ * As {@link resolveEffectiveRemoteUrl}, but keeps the remote's *name*.
+ *
+ * Git operations that address the forge by remote name rather than URL —
+ * fetching a PR head, which only exists on the repository the PR was opened
+ * against (#11747) — need the name, and re-deriving it at those call sites
+ * would let the precedence chain drift from the one the toolbar uses.
+ * `resolveEffectiveRemoteUrl` delegates here so there is exactly one copy.
+ *
+ * Propagates {@link StaleForgeRemoteError} rather than falling back: a
+ * configured-but-missing remote means we cannot tell which repository the user
+ * meant, and PR numbers are per-repository, so substituting one would happily
+ * fetch a completely unrelated PR that happens to share the number.
+ */
+export async function resolveEffectiveForgeRemote(
+  gitService: RemoteReader,
+  cwd: string,
+  forgeRemote: string | null,
+  forgeProviderOverride: string | null = null
+): Promise<{ name: string; fetchUrl: string } | null> {
   const remotes = await gitService.listRemotes(cwd).catch(() => null);
 
   if (remotes === null) {
     if (forgeRemote) return null;
-    return gitService.getRemoteUrl(cwd).catch(() => null);
+    const fetchUrl = await gitService.getRemoteUrl(cwd).catch(() => null);
+    // The origin-only fallback path knows the URL but not a verified name;
+    // `origin` is what `getRemoteUrl` reads, so it is the honest label.
+    return fetchUrl ? { name: "origin", fetchUrl } : null;
   }
 
   const { remote, missingConfiguredRemote } = resolveForgeRemote({
@@ -106,7 +138,79 @@ export async function resolveEffectiveRemoteUrl(
       : (url) => listMatchingProviders(url).length > 0,
   });
   if (missingConfiguredRemote) throw new StaleForgeRemoteError(missingConfiguredRemote);
-  return remote?.fetchUrl ?? null;
+  return remote ? { name: remote.name, fetchUrl: remote.fetchUrl } : null;
+}
+
+/**
+ * Read the project-scoped forge settings that decide which remote to use.
+ *
+ * The cwd may be a linked-worktree subdirectory, so an exact match against
+ * `project.path` would miss. `git worktree list` reports the main worktree
+ * first from anywhere inside the repo — that path is what ProjectStore keys on.
+ *
+ * Resolved before any remote URL (#11408): the project's `forgeRemote` setting
+ * decides *which* remote we read, so the settings have to be in hand first.
+ */
+async function readProjectForgeSettings(
+  gitService: { listWorktrees(): Promise<Array<{ path: string; isMainWorktree?: boolean }>> } & {
+    getRepositoryRoot(cwd: string): Promise<string | null>;
+  },
+  cwd: string
+): Promise<{
+  forgeRemote: string | null;
+  forgeProviderOverride: string | null;
+  /** Repo root the settings were keyed on — what `repoRef.projectPath` stamps (#10563). */
+  mainWorktreePath: string;
+}> {
+  const worktrees = await gitService.listWorktrees().catch(() => []);
+  const mainWorktreePath =
+    worktrees.find((wt) => wt.isMainWorktree)?.path ??
+    (await gitService.getRepositoryRoot(cwd).catch(() => null)) ??
+    cwd;
+  const project = await projectStore.getProjectByPath(mainWorktreePath).catch(() => null);
+  // A registered project whose settings we cannot read is NOT the same as an
+  // unregistered path: the former may well have a `forgeRemote` we are about to
+  // ignore, and auto-detecting past it would point a mutation at whichever repo
+  // origin happens to be. Only a genuinely absent project may auto-detect.
+  let settings = null;
+  if (project) {
+    try {
+      settings = await projectStore.getProjectSettings(project.id);
+    } catch (error) {
+      throw new Error(
+        `Couldn't read this project's forge settings, so the remote to use is unknown: ${formatErrorMessage(error, "settings read failed")}`,
+        { cause: error }
+      );
+    }
+  }
+  return {
+    forgeRemote: settings?.forgeRemote ?? settings?.githubRemote ?? null,
+    forgeProviderOverride: settings?.forgeProviderOverride ?? null,
+    mainWorktreePath,
+  };
+}
+
+/**
+ * The forge remote's *name* for a cwd, for git commands that address the
+ * forge by remote rather than URL (PR-head fetches, #11747).
+ *
+ * Deliberately lighter than {@link resolveForCwd}: it reads the remote table
+ * and the project setting, and stops there. No provider matching, no lazy
+ * plugin activation — a PR checkout doesn't need a live provider
+ * implementation, and dragging one in would make the fetch depend on plugin
+ * startup.
+ */
+export async function resolveForgeRemoteNameForCwd(cwd: string): Promise<string | null> {
+  const gitService = gitServiceCache.getGitService(cwd);
+  if (!gitService) return null;
+  const { forgeRemote, forgeProviderOverride } = await readProjectForgeSettings(gitService, cwd);
+  const selected = await resolveEffectiveForgeRemote(
+    gitService,
+    cwd,
+    forgeRemote,
+    forgeProviderOverride
+  );
+  return selected?.name ?? null;
 }
 
 export async function resolveForCwd(cwd: string): Promise<ResolvedForgeContext> {
@@ -130,33 +234,15 @@ export async function resolveForCwd(cwd: string): Promise<ResolvedForgeContext> 
   // setting decides *which* remote we read, so the settings have to be in hand
   // first. Previously this block ran after an origin-only `getRemoteUrl`, which
   // is why the setting never reached the toolbar's data path.
-  const worktrees = await gitService.listWorktrees().catch(() => []);
-  const mainWorktreePath =
-    worktrees.find((wt) => wt.isMainWorktree)?.path ??
-    (await gitService.getRepositoryRoot(cwd).catch(() => null)) ??
-    cwd;
-  const project = await projectStore.getProjectByPath(mainWorktreePath).catch(() => null);
-  // A registered project whose settings we cannot read is NOT the same as an
-  // unregistered path: the former may well have a `forgeRemote` we are about to
-  // ignore, and auto-detecting past it would point a mutation at whichever repo
-  // origin happens to be. Only a genuinely absent project may auto-detect.
-  let settings = null;
-  if (project) {
-    try {
-      settings = await projectStore.getProjectSettings(project.id);
-    } catch (error) {
-      throw new Error(
-        `Couldn't read this project's forge settings, so the remote to use is unknown: ${formatErrorMessage(error, "settings read failed")}`,
-        { cause: error }
-      );
-    }
-  }
-  const forgeProviderOverride = settings?.forgeProviderOverride ?? null;
+  const { forgeRemote, forgeProviderOverride, mainWorktreePath } = await readProjectForgeSettings(
+    gitService,
+    cwd
+  );
 
   const remoteUrl = await resolveEffectiveRemoteUrl(
     gitService,
     cwd,
-    settings?.forgeRemote ?? settings?.githubRemote ?? null,
+    forgeRemote,
     forgeProviderOverride
   );
   if (!remoteUrl) {

--- a/electron/ipc/handlers/worktree/branches.ts
+++ b/electron/ipc/handlers/worktree/branches.ts
@@ -4,6 +4,7 @@ import type { BranchInfo } from "../../../../shared/types/git.js";
 import { generateWorktreePath, validatePathPattern } from "../../../../shared/utils/pathPattern.js";
 import { resolveWorktreePattern } from "../../../utils/worktreePattern.js";
 import { gitServiceCache } from "../../../services/GitServiceCache.js";
+import { resolveForgeRemoteNameForCwd } from "../forgeResolution.js";
 import { defineIpcNamespace, op } from "../../define.js";
 
 export function registerWorktreeBranchHandlers(deps: HandlerDependencies): () => void {
@@ -33,10 +34,19 @@ export function registerWorktreeBranchHandlers(deps: HandlerDependencies): () =>
     if (!payload.headRefName || typeof payload.headRefName !== "string") {
       throw new Error("headRefName is required");
     }
+    // The PR ref only exists on the repository the PR was opened against, so
+    // fetching from `origin` fails outright when the forge is configured as
+    // `upstream`/`github` (#11747). Resolved here rather than in the renderer
+    // (which has no remote table) or the workspace-host (which must not gain a
+    // forge-provider dependency). A StaleForgeRemoteError propagates rather
+    // than falling back: PR numbers are per-repository, so guessing a remote
+    // could fetch an unrelated PR that happens to share the number.
+    const remoteName = await resolveForgeRemoteNameForCwd(payload.rootPath);
     await deps.worktreeService.fetchPRBranch(
       payload.rootPath,
       payload.prNumber,
-      payload.headRefName
+      payload.headRefName,
+      remoteName ?? undefined
     );
   };
 

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -929,7 +929,12 @@ export class WorkspaceClient extends EventEmitter {
     return result.branches;
   }
 
-  async fetchPRBranch(rootPath: string, prNumber: number, headRefName: string): Promise<void> {
+  async fetchPRBranch(
+    rootPath: string,
+    prNumber: number,
+    headRefName: string,
+    remoteName?: string
+  ): Promise<void> {
     const host = this.pool.resolveHostForPath(rootPath);
     if (!host) throw new Error("No workspace host for project");
     const requestId = host.generateRequestId();
@@ -939,6 +944,7 @@ export class WorkspaceClient extends EventEmitter {
       rootPath,
       prNumber,
       headRefName,
+      remoteName,
     });
   }
 

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -576,7 +576,8 @@ port.on("message", async (rawMsg: any) => {
           request.requestId,
           request.rootPath,
           request.prNumber,
-          request.headRefName
+          request.headRefName,
+          request.remoteName
         );
         break;
 

--- a/electron/workspace-host/BaseDivergence.ts
+++ b/electron/workspace-host/BaseDivergence.ts
@@ -86,12 +86,20 @@ export class BaseDivergence {
   ) {}
 
   /**
-   * Remote the last computed divergence measured against, or `null` when it
-   * fell back to a local ref. Lets the fetch scheduler refresh the remote this
-   * worktree actually reads instead of assuming `origin`.
+   * Remote the divergence *wants* to compare against — the resolution's answer,
+   * not whichever ref the last pass happened to succeed against.
+   *
+   * The distinction is load-bearing. A `rev-list upstream/main...HEAD` that
+   * fails because `upstream/main` hasn't been fetched yet falls back to the
+   * local branch and records `baseRemote: null` on the result. Reporting that
+   * null here would drop `upstream` from the fetch plan, so the ref would never
+   * arrive, so the stat key would never move, so the fallback result would be
+   * served from cache forever — a deadlock that bites exactly the fresh-fork
+   * setup this issue is about. Reporting the resolved remote keeps it in the
+   * fetch plan until it succeeds.
    */
   get baseRemote(): string | null {
-    return this.lastResult?.baseRemote ?? null;
+    return this.resolution?.remote ?? null;
   }
 
   /** Remotes this repo has, as of the last resolution. Empty until one runs. */
@@ -224,7 +232,13 @@ export class BaseDivergence {
     dirs: GitDirs
   ): Promise<RemoteResolution | null> {
     const stamp = await this.buildResolutionStamp(branch, baseBranch, hasUpstream, dirs);
-    const aged = Date.now() - this.resolutionAt >= RESOLUTION_MAX_AGE_MS;
+    // The age ceiling only earns its spawns where the answer is genuinely
+    // ambiguous. With at most one remote there is nothing to choose between,
+    // and anything that could introduce a second one writes `.git/config`,
+    // which the stamp already covers — so the overwhelmingly common repo
+    // re-resolves on real events only, never on a timer.
+    const ambiguous = (this.resolution?.availableRemotes.length ?? 0) > 1;
+    const aged = ambiguous && Date.now() - this.resolutionAt >= RESOLUTION_MAX_AGE_MS;
     // A null stamp means a stat failed unexpectedly. Re-resolving on every such
     // poll would turn a flaky filesystem into a spawn storm, so the cached
     // answer is held until it ages out on its own.
@@ -286,21 +300,26 @@ export class BaseDivergence {
 
   /**
    * Which remotes carry `<baseBranch>`. Uses `for-each-ref` rather than a
-   * readdir so packed refs are found too; the `*` matches exactly the
-   * remote-name path component, so a slash-bearing base (`release/2.0`) still
-   * matches as a literal suffix.
+   * readdir so packed refs are found too.
+   *
+   * One literal pattern per known remote rather than a single
+   * `refs/remotes/*` glob: git's ref-filter wildcard does not cross `/`, so a
+   * remote whose own name contains a slash (`team/fork`) would never appear in
+   * the glob's output, and the exact cross-reference below cannot recover a ref
+   * that was never listed.
    */
   private async readRemotesCarrying(
     git: GitRunner,
     baseBranch: string,
     availableRemotes: readonly string[]
   ): Promise<string[]> {
+    if (availableRemotes.length === 0) return [];
     try {
       const out = await git.raw([
         "for-each-ref",
         "--format=%(refname)",
         "--",
-        `refs/remotes/*/${baseBranch}`,
+        ...availableRemotes.map((remote) => `${REMOTE_REF_PREFIX}${remote}/${baseBranch}`),
       ]);
       const found: string[] = [];
       for (const line of out.split("\n")) {

--- a/electron/workspace-host/BaseDivergence.ts
+++ b/electron/workspace-host/BaseDivergence.ts
@@ -2,13 +2,56 @@ import { join as pathJoin } from "path";
 import { createHardenedGit, createWslHardenedGit } from "../utils/hardenedGit.js";
 import type { WslGitInvocation } from "../utils/hardenedGit.js";
 import { getGitDir } from "../utils/gitUtils.js";
+import { resolveBaseCompareRef } from "../../shared/utils/baseRemoteSelection.js";
 import type { StatPrecheck } from "./StatPrecheck.js";
+
+/**
+ * Ceiling on how long a cached remote resolution may be reused while its stat
+ * stamp looks unchanged. The stamp covers the mutations that matter (config
+ * writes, packed-refs, the candidate refs themselves), but a stat set is a
+ * fixed set — anything outside it changes invisibly, exactly the failure class
+ * #10956 fixed for the status pre-check. `git remote add upstream` followed by
+ * a fetch that only touches a nested `refs/remotes/upstream/release/` directory
+ * is the concrete case. The ceiling bounds every such miss to one interval
+ * instead of forever, for the cost of a handful of local git spawns per
+ * worktree per interval.
+ */
+const RESOLUTION_MAX_AGE_MS = 5 * 60_000;
+
+const REMOTE_REF_PREFIX = "refs/remotes/";
 
 interface BaseDivergenceResult {
   baseBranchName: string | null;
   aheadCount: number | null;
   behindCount: number | null;
   matchesUpstream: boolean;
+  /**
+   * The ref the counts were actually measured against — `upstream/main`, or a
+   * bare `main` when we fell back to the local branch. Surfaced so the badge
+   * tooltip can name it: on the multi-remote layouts this resolution can still
+   * get wrong, naming the ref turns a silently wrong number into an obviously
+   * wrong one (#11747).
+   */
+  baseCompareRef: string | null;
+  /**
+   * Remote `baseCompareRef` lives on, or `null` on the local fallback. Read by
+   * `WorkspaceService` to decide which remotes background fetch must refresh —
+   * resolving the right ref but never fetching it is just a slower way to be
+   * stale.
+   */
+  baseRemote: string | null;
+}
+
+/** Cached output of the (spawning) remote-resolution step. */
+interface RemoteResolution {
+  /** Short ref to diff against (`upstream/main`), or null to use the fallback chain. */
+  compareRef: string | null;
+  /** Remote `compareRef` lives on. */
+  remote: string | null;
+  /** Full ref `@{u}` resolves to, so `buildKey` stats the ref that actually moves. */
+  upstreamRef: string | null;
+  /** `git remote` output, cached so the stat stamp can cover each candidate ref. */
+  availableRemotes: readonly string[];
 }
 
 export interface BaseDivergenceHost {
@@ -21,15 +64,40 @@ export interface BaseDivergenceHost {
   readonly abortSignal: AbortSignal;
 }
 
+interface GitDirs {
+  gitDir: string;
+  commonDir: string;
+}
+
+type GitRunner = { raw(args: string[]): Promise<string> };
+
 /** Ahead/behind divergence of the current branch against its base branch. */
 export class BaseDivergence {
   private lastKey: string | null = null;
   private lastResult: BaseDivergenceResult | null = null;
 
+  private resolutionStamp: string | null = null;
+  private resolution: RemoteResolution | null = null;
+  private resolutionAt = 0;
+
   constructor(
     private readonly host: BaseDivergenceHost,
     private readonly statPrecheck: StatPrecheck
   ) {}
+
+  /**
+   * Remote the last computed divergence measured against, or `null` when it
+   * fell back to a local ref. Lets the fetch scheduler refresh the remote this
+   * worktree actually reads instead of assuming `origin`.
+   */
+  get baseRemote(): string | null {
+    return this.lastResult?.baseRemote ?? null;
+  }
+
+  /** Remotes this repo has, as of the last resolution. Empty until one runs. */
+  get availableRemotes(): readonly string[] {
+    return this.resolution?.availableRemotes ?? [];
+  }
 
   async compute(hasUpstream: boolean): Promise<BaseDivergenceResult | null> {
     const branch = this.host.branch;
@@ -42,27 +110,40 @@ export class BaseDivergence {
     // the repository's main/integration branch.
     const baseBranch = this.host.linkedPrBaseRef?.trim() || this.host.mainBranch;
 
+    const dirs = await this.resolveDirs();
+
+    // Which remote holds the base branch is a git-config question, so it must
+    // not be asked on every poll. It's cached behind its own stat stamp and
+    // only re-derived when that stamp moves (or ages out), which keeps the
+    // key-matched fast path below entirely spawn-free.
+    const resolution = dirs
+      ? await this.resolveRemotes(branch, baseBranch, hasUpstream, dirs)
+      : null;
+
     // Divergence only moves when refs move, never on working-tree edits, so
     // a stat key over the involved refs lets forced passes (watcher-driven
     // edit storms) reuse the last result without any git spawns.
-    const key = await this.buildKey(branch, baseBranch, hasUpstream);
+    const key = dirs
+      ? await this.buildKey(branch, baseBranch, hasUpstream, dirs, resolution)
+      : null;
     if (key !== null && key === this.lastKey) {
       return this.lastResult;
     }
 
-    const wsl = this.host.wslInvocation;
-    const git = wsl
-      ? await createWslHardenedGit(wsl, this.host.abortSignal)
-      : await createHardenedGit(this.host.path, this.host.abortSignal);
+    const git = await this.createGit();
 
     try {
-      // Resolve base ref via the rev-list itself: try origin/<branch> first
-      // (remote ref stays fresh after fetch), fall back to the local branch
-      // for repos without a remote.
-      const remoteRef = `origin/${baseBranch}`;
+      // Resolve base ref via the rev-list itself: try the resolved remote ref
+      // first (remote refs stay fresh after fetch), fall back to the local
+      // branch for repos without a remote. `origin/<base>` remains the
+      // pre-resolution default, so a repo whose remote can't be resolved
+      // behaves exactly as it did before #11747.
+      const remoteRef = resolution?.compareRef ?? `origin/${baseBranch}`;
+      const remoteName = resolution?.compareRef ? resolution.remote : null;
       const localRef = baseBranch;
       const baseBranchName = baseBranch;
       let resolvedRef = remoteRef;
+      let resolvedRemote = remoteName;
       let result: string;
       try {
         result = await git.raw(["rev-list", "--count", "--left-right", `${remoteRef}...HEAD`]);
@@ -70,6 +151,7 @@ export class BaseDivergence {
         try {
           result = await git.raw(["rev-list", "--count", "--left-right", `${localRef}...HEAD`]);
           resolvedRef = localRef;
+          resolvedRemote = null;
         } catch {
           this.lastKey = null;
           return null;
@@ -99,12 +181,176 @@ export class BaseDivergence {
         aheadCount: Number.isFinite(aheadCount) ? aheadCount : null,
         behindCount: Number.isFinite(behindCount) ? behindCount : null,
         matchesUpstream,
+        baseCompareRef: resolvedRef,
+        baseRemote: resolvedRemote,
       };
       this.lastKey = key;
       this.lastResult = divergence;
       return divergence;
     } catch {
       this.lastKey = null;
+      return null;
+    }
+  }
+
+  private async createGit(): Promise<GitRunner> {
+    const wsl = this.host.wslInvocation;
+    return wsl
+      ? await createWslHardenedGit(wsl, this.host.abortSignal)
+      : await createHardenedGit(this.host.path, this.host.abortSignal);
+  }
+
+  private async resolveDirs(): Promise<GitDirs | null> {
+    const gitDir = await getGitDir(this.host.path, { cache: true, logErrors: false });
+    if (!gitDir) return null;
+    try {
+      const commonDir = await this.statPrecheck.resolveCommonDirAsync(gitDir);
+      return { gitDir, commonDir };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Resolve (and cache) which remote ref the base branch should be compared
+   * against. Spawns git, so it runs only when the stat stamp moves or the
+   * cached answer ages past {@link RESOLUTION_MAX_AGE_MS} — on a steady poll
+   * loop it never spawns at all.
+   */
+  private async resolveRemotes(
+    branch: string,
+    baseBranch: string,
+    hasUpstream: boolean,
+    dirs: GitDirs
+  ): Promise<RemoteResolution | null> {
+    const stamp = await this.buildResolutionStamp(branch, baseBranch, hasUpstream, dirs);
+    const aged = Date.now() - this.resolutionAt >= RESOLUTION_MAX_AGE_MS;
+    // A null stamp means a stat failed unexpectedly. Re-resolving on every such
+    // poll would turn a flaky filesystem into a spawn storm, so the cached
+    // answer is held until it ages out on its own.
+    if (this.resolution !== null && !aged && (stamp === null || stamp === this.resolutionStamp)) {
+      return this.resolution;
+    }
+
+    const git = await this.createGit();
+    const availableRemotes = await this.readRemotes(git);
+    const trackedRef = await this.readSymbolicRef(git, `${baseBranch}@{upstream}`);
+    const remotesWithBaseRef = trackedRef
+      ? []
+      : await this.readRemotesCarrying(git, baseBranch, availableRemotes);
+    const upstreamRef = hasUpstream ? await this.readSymbolicRef(git, "@{u}") : null;
+
+    const { compareRef, remote } = resolveBaseCompareRef({
+      baseBranch,
+      trackedRef,
+      remotesWithBaseRef,
+      availableRemotes,
+    });
+
+    this.resolution = { compareRef, remote, upstreamRef, availableRemotes };
+    this.resolutionAt = Date.now();
+    // Re-derive the stamp: the first resolution discovers the remote names the
+    // stamp's candidate-ref stats are built from, so the stamp computed before
+    // resolving covered fewer paths than the one that must match next poll.
+    this.resolutionStamp = await this.buildResolutionStamp(branch, baseBranch, hasUpstream, dirs);
+    return this.resolution;
+  }
+
+  /** `git remote` — names only, no URLs, no network. */
+  private async readRemotes(git: GitRunner): Promise<string[]> {
+    try {
+      const out = await git.raw(["remote"]);
+      return out
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Resolve a revision to its full symbolic ref. Returns `null` when the
+   * revision has no upstream (git exits non-zero), which is the normal case
+   * for an unpushed branch.
+   */
+  private async readSymbolicRef(git: GitRunner, rev: string): Promise<string | null> {
+    try {
+      const out = await git.raw(["rev-parse", "--symbolic-full-name", rev]);
+      const trimmed = out.trim();
+      return trimmed.length > 0 ? trimmed : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Which remotes carry `<baseBranch>`. Uses `for-each-ref` rather than a
+   * readdir so packed refs are found too; the `*` matches exactly the
+   * remote-name path component, so a slash-bearing base (`release/2.0`) still
+   * matches as a literal suffix.
+   */
+  private async readRemotesCarrying(
+    git: GitRunner,
+    baseBranch: string,
+    availableRemotes: readonly string[]
+  ): Promise<string[]> {
+    try {
+      const out = await git.raw([
+        "for-each-ref",
+        "--format=%(refname)",
+        "--",
+        `refs/remotes/*/${baseBranch}`,
+      ]);
+      const found: string[] = [];
+      for (const line of out.split("\n")) {
+        const ref = line.trim();
+        if (!ref.startsWith(REMOTE_REF_PREFIX)) continue;
+        const shortRef = ref.slice(REMOTE_REF_PREFIX.length);
+        // Remote names may contain `/`, so match against the known names
+        // rather than splitting on the first separator.
+        for (const remote of availableRemotes) {
+          if (shortRef === `${remote}/${baseBranch}` && !found.includes(remote)) {
+            found.push(remote);
+          }
+        }
+      }
+      return found;
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Stat stamp gating the (spawning) remote resolution. Covers the effective
+   * config files — `commonDir/config` is the shared one, and
+   * `gitDir/config.worktree` carries per-worktree overrides when
+   * `extensions.worktreeConfig` is on, so `branch.<base>.remote` can differ
+   * per worktree — plus packed-refs and each known remote's candidate ref, so
+   * a newly fetched base ref re-opens the question. `branch`/`baseBranch` are
+   * part of the identity: a PR relink changes `linkedPrBaseRef` without
+   * touching any file, and reusing the previous base's remote would compare
+   * against the wrong ref entirely.
+   */
+  private async buildResolutionStamp(
+    branch: string,
+    baseBranch: string,
+    hasUpstream: boolean,
+    dirs: GitDirs
+  ): Promise<string | null> {
+    const { gitDir, commonDir } = dirs;
+    try {
+      const candidatePaths = (this.resolution?.availableRemotes ?? []).map((remote) =>
+        pathJoin(commonDir, "refs", "remotes", ...remote.split("/"), ...baseBranch.split("/"))
+      );
+      const stats = await Promise.all([
+        this.statPrecheck.statMtime(pathJoin(commonDir, "config")),
+        this.statPrecheck.statMtime(pathJoin(gitDir, "config.worktree")),
+        this.statPrecheck.statMtime(pathJoin(commonDir, "packed-refs")),
+        ...candidatePaths.map((path) => this.statPrecheck.statMtime(path)),
+      ]);
+      return [branch, baseBranch, hasUpstream, ...stats].join(" ");
+    } catch {
       return null;
     }
   }
@@ -116,27 +362,35 @@ export class BaseDivergence {
    * `matchesUpstream`), and packed-refs. The remote-ref stats are essential —
    * `git fetch` writes loose refs under refs/remotes/ without touching
    * packed-refs, so the stat-baseline fields alone would serve stale
-   * behind-of-base counts after background fetches. Returns `null` (compute,
-   * don't cache) on any stat failure beyond ENOENT.
+   * behind-of-base counts after background fetches. Both remote paths follow
+   * the resolved refs rather than assuming `origin`, and the resolved compare
+   * ref is part of the key so a resolution flip invalidates the cached counts.
+   * Returns `null` (compute, don't cache) on any stat failure beyond ENOENT.
    */
   private async buildKey(
     branch: string,
     baseBranch: string,
-    hasUpstream: boolean
+    hasUpstream: boolean,
+    dirs: GitDirs,
+    resolution: RemoteResolution | null
   ): Promise<string | null> {
-    const gitDir = await getGitDir(this.host.path, { cache: true, logErrors: false });
-    if (!gitDir) return null;
+    const { gitDir, commonDir } = dirs;
     try {
-      const commonDir = await this.statPrecheck.resolveCommonDirAsync(gitDir);
+      const compareRefPath = resolution?.compareRef
+        ? pathJoin(commonDir, "refs", "remotes", ...resolution.compareRef.split("/"))
+        : pathJoin(commonDir, "refs", "remotes", "origin", ...baseBranch.split("/"));
+      const upstreamRefPath = resolution?.upstreamRef
+        ? pathJoin(commonDir, ...resolution.upstreamRef.split("/"))
+        : pathJoin(commonDir, "refs", "remotes", "origin", ...branch.split("/"));
       const stats = await Promise.all([
         this.statPrecheck.statMtime(pathJoin(gitDir, "HEAD")),
-        this.statPrecheck.statMtime(pathJoin(commonDir, "refs", "heads", branch)),
+        this.statPrecheck.statMtime(pathJoin(commonDir, "refs", "heads", ...branch.split("/"))),
         this.statPrecheck.statMtime(pathJoin(commonDir, "packed-refs")),
-        this.statPrecheck.statMtime(pathJoin(commonDir, "refs", "heads", baseBranch)),
-        this.statPrecheck.statMtime(pathJoin(commonDir, "refs", "remotes", "origin", baseBranch)),
-        this.statPrecheck.statMtime(pathJoin(commonDir, "refs", "remotes", "origin", branch)),
+        this.statPrecheck.statMtime(pathJoin(commonDir, "refs", "heads", ...baseBranch.split("/"))),
+        this.statPrecheck.statMtime(compareRefPath),
+        this.statPrecheck.statMtime(upstreamRefPath),
       ]);
-      return [branch, baseBranch, hasUpstream, ...stats].join(" ");
+      return [branch, baseBranch, hasUpstream, resolution?.compareRef ?? "", ...stats].join(" ");
     } catch {
       return null;
     }

--- a/electron/workspace-host/GitStatusPass.ts
+++ b/electron/workspace-host/GitStatusPass.ts
@@ -115,6 +115,7 @@ export class GitStatusPass {
   private baseAheadCountValue: number | null | undefined;
   private baseBehindCountValue: number | null | undefined;
   private baseMatchesUpstreamValue: boolean | undefined;
+  private baseCompareRefValue: string | null | undefined;
   private activityTimestamp: number | null = null;
 
   constructor(
@@ -168,6 +169,10 @@ export class GitStatusPass {
 
   get baseMatchesUpstream(): boolean | undefined {
     return this.baseMatchesUpstreamValue;
+  }
+
+  get baseCompareRef(): string | null | undefined {
+    return this.baseCompareRefValue;
   }
 
   get lastActivityTimestamp(): number | null {
@@ -370,6 +375,7 @@ export class GitStatusPass {
       const nextBaseAheadCount = baseDivergenceResult?.aheadCount ?? undefined;
       const nextBaseBehindCount = baseDivergenceResult?.behindCount ?? undefined;
       const nextBaseMatchesUpstream = baseDivergenceResult?.matchesUpstream ?? undefined;
+      const nextBaseCompareRef = baseDivergenceResult?.baseCompareRef ?? undefined;
 
       const currentHash = this.calculateStateHash(newChanges);
       const stateChanged = currentHash !== this.previousStateHash;
@@ -385,7 +391,8 @@ export class GitStatusPass {
         nextBaseBranchName !== this.baseBranchNameValue ||
         nextBaseAheadCount !== this.baseAheadCountValue ||
         nextBaseBehindCount !== this.baseBehindCountValue ||
-        nextBaseMatchesUpstream !== this.baseMatchesUpstreamValue;
+        nextBaseMatchesUpstream !== this.baseMatchesUpstreamValue ||
+        nextBaseCompareRef !== this.baseCompareRefValue;
 
       const gitStateChanged =
         this.host.isDetached !== this.host.prevEmittedIsDetached ||
@@ -460,6 +467,7 @@ export class GitStatusPass {
       this.baseAheadCountValue = nextBaseAheadCount;
       this.baseBehindCountValue = nextBaseBehindCount;
       this.baseMatchesUpstreamValue = nextBaseMatchesUpstream;
+      this.baseCompareRefValue = nextBaseCompareRef;
       this.host.hasInitialStatus = true;
 
       this.host.emitUpdate();

--- a/electron/workspace-host/RepoFetchCoordinator.ts
+++ b/electron/workspace-host/RepoFetchCoordinator.ts
@@ -60,13 +60,38 @@ interface FetchFailureEntry {
   confirmed?: boolean;
 }
 
-interface RepoState {
-  /** In-flight chain — every fetch awaits the prior one for the same commondir. */
-  chain: Promise<void>;
+/**
+ * Recency and failure state for one (commondir, remote) pair.
+ *
+ * Deliberately NOT per-commondir: once a repo fetches more than one remote, a
+ * shared entry lets a broken credential on one remote suspend fetches of a
+ * perfectly healthy sibling, and lets two remotes' failures interleave into
+ * one `authRetryCount` — which would confirm an auth failure on a single burst
+ * instead of across retries over time, re-alarming every card.
+ *
+ * The serialization chain stays per-commondir (see {@link RepoFetchCoordinator.chains}).
+ * The two scopes look symmetric and are not: refs are shared through the
+ * commondir, so concurrent fetches race on `packed-refs.lock` no matter which
+ * remote each one targets, while credentials and reachability are per-remote.
+ */
+interface RemoteState {
   failure: FetchFailureEntry | null;
   lastSuccessfulFetch: number | null;
   /** Bumped when the repo's monitors are torn down so stale completions discard. */
   generation: number;
+}
+
+/** The remote assumed when a caller names none — matches the pre-#11747 behavior. */
+const DEFAULT_REMOTE = "origin";
+
+/**
+ * Control character, so it can't collide with a path or a remote name (git
+ * forbids control characters in both).
+ */
+const STATE_KEY_DELIMITER = "\u0000";
+
+function stateKey(commonDir: string, remote: string): string {
+  return `${commonDir}${STATE_KEY_DELIMITER}${remote}`;
 }
 
 export interface RepoFetchCoordinatorCallbacks {
@@ -78,7 +103,7 @@ export interface RepoFetchCoordinatorCallbacks {
    * the per-card stripe. Fires only on the unconfirmed→confirmed transition;
    * `clearAuthFailures()` resets the state so a later re-confirmation re-fires.
    */
-  onAuthFailureConfirmed?: (commonDir: string, reason: GitOperationReason) => void;
+  onAuthFailureConfirmed?: (commonDir: string, remote: string, reason: GitOperationReason) => void;
 }
 
 export interface FetchOptions {
@@ -86,6 +111,26 @@ export interface FetchOptions {
   worktreePath: string;
   /** When true, ignore the failure cache (manual user-triggered refresh). */
   force?: boolean;
+  /**
+   * Remotes to refresh, in any order. Deduped internally, and `primaryRemote`
+   * is always fetched first. Defaults to `[origin]`, which is what every
+   * single-remote repo resolves to — so the common case still issues exactly
+   * one `git fetch`, unchanged from before #11747.
+   *
+   * Never expanded to `--all`: a mirror or a slow deploy remote would land on
+   * the poll loop, and `--all` also collapses per-remote failure isolation
+   * back into one opaque exit code.
+   */
+  remotes?: readonly string[];
+  /**
+   * The remote whose outcome describes this worktree — the one the divergence
+   * counts are actually measured against. Its result is what
+   * {@link RepoFetchCoordinator.fetchForWorktree} returns and what the card
+   * renders, because an auxiliary remote succeeding says nothing about whether
+   * the numbers on screen are fresh. Defaults to the first entry of
+   * `remotes`.
+   */
+  primaryRemote?: string;
 }
 
 export interface FetchResult {
@@ -95,28 +140,36 @@ export interface FetchResult {
   /** Why we skipped — for logging / diagnostics. */
   skipReason?: "no-common-dir" | "in-failure-window" | "auth-suspended" | "stale-generation";
   /**
-   * Coordinator's per-commondir `lastSuccessfulFetch` after this call settled.
-   * Set on success (the timestamp just written) and on skipped/failed
-   * outcomes (the prior timestamp, if any). Lets `WorkspaceService` propagate
-   * the freshest known value to monitors without reaching into coordinator
-   * internals.
+   * Coordinator's `lastSuccessfulFetch` for the primary (commondir, remote)
+   * after this call settled. Set on success (the timestamp just written) and
+   * on skipped/failed outcomes (the prior timestamp, if any). Lets
+   * `WorkspaceService` propagate the freshest known value to monitors without
+   * reaching into coordinator internals.
+   *
+   * Scoped to the primary remote on purpose: taking the newest timestamp
+   * across every fetched remote would let a healthy auxiliary `origin` vouch
+   * for counts measured against a base remote that failed, which is a
+   * fresh-looking badge over stale data — the same class of bug #11747 exists
+   * to fix.
    */
   lastFetchedAt?: number | null;
   /**
    * True when this call ended in (or remained in) an auth-class failure for
-   * this commondir. Includes the `auth-suspended` skip case so the renderer
-   * keeps showing the "Sign in to refresh" affordance instead of flashing
-   * stale counts when a sibling's force-fetch is rate-cached.
+   * the primary remote. Includes the `auth-suspended` skip case so the
+   * renderer keeps showing the "Sign in to refresh" affordance instead of
+   * flashing stale counts when a sibling's force-fetch is rate-cached.
    */
   authFailed?: boolean;
   /**
    * True when this call ended in (or remained in) a transient (network /
-   * repo-not-found-first / generic transient) failure. Drives the
-   * "Couldn't reach origin" tooltip line on the worktree card. False on
-   * success, on auth-class failures (those use `authFailed`), and on the
-   * `no-common-dir` skip path where we have no state to report.
+   * repo-not-found-first / generic transient) failure for the primary remote.
+   * Drives the "Couldn't reach the remote" tooltip line on the worktree card.
+   * False on success, on auth-class failures (those use `authFailed`), and on
+   * the `no-common-dir` skip path where we have no state to report.
    */
   networkFailed?: boolean;
+  /** Remote this result describes. Absent only on the `no-common-dir` skip. */
+  remote?: string;
 }
 
 /**
@@ -150,12 +203,28 @@ export interface FetchResult {
  *     recency window dedups them: when the repo fetched successfully moments
  *     ago, return that success without spawning git. Refs are shared via the
  *     commondir, so they are genuinely fresh for every sibling.
- */
-export class RepoFetchCoordinator {
-  private readonly states = new Map<string, RepoState>();
+ *   - A repo may need more than one remote refreshed — a fork whose base
+ *     branch lives on `upstream` reads refs `origin` never carries (#11747).
+ *     Serialization stays per-commondir because the `packed-refs.lock` race
+ *     doesn't care which remote is being fetched; recency and failure state go
+ *     per-(commondir, remote) because credentials and reachability very much
+ *     do. The two scopes look symmetric and need opposite keying.
+ */ export class RepoFetchCoordinator {
+  /**
+   * Recency and failure state, keyed by (commondir, remote) — see
+   * {@link RemoteState} for why this dimension is not shared with the chain.
+   */
+  private readonly states = new Map<string, RemoteState>();
+  /**
+   * In-flight chain per commondir. Every fetch awaits the prior one for the
+   * same repo regardless of which remote it targets, because `packed-refs` is
+   * shared through the commondir and does not care whose refs are being
+   * written.
+   */
+  private readonly chains = new Map<string, Promise<void>>();
   /**
    * Coordinator-wide generation baseline. Bumped by `destroy()` so any new
-   * `RepoState` created after a project switch (e.g. when reopening the same
+   * `RemoteState` created after a project switch (e.g. when reopening the same
    * repo path on a fresh project) starts at a higher generation than any
    * still-in-flight pre-destroy fetch. Without this, a stale completion that
    * captured `generationAtStart=0` could pass the guard against a fresh
@@ -166,9 +235,10 @@ export class RepoFetchCoordinator {
   constructor(private readonly callbacks: RepoFetchCoordinatorCallbacks = {}) {}
 
   /**
-   * Schedule a fetch for the given worktree. Resolves with a status describing
-   * what happened. Multiple worktrees that share a `git common-dir` are
-   * serialized on a single per-repo promise chain.
+   * Schedule a fetch for the given worktree. Resolves with the status of the
+   * primary remote — the one whose freshness the worktree's counts depend on.
+   * Multiple worktrees that share a `git common-dir` are serialized on a
+   * single per-repo promise chain, as are the remotes within one call.
    */
   async fetchForWorktree(opts: FetchOptions): Promise<FetchResult> {
     const baseGenerationAtStart = this.baseGeneration;
@@ -183,33 +253,119 @@ export class RepoFetchCoordinator {
       return { status: "skipped", skipReason: "stale-generation" };
     }
 
-    const state = this.getOrCreateState(commonDir);
+    const remotes = this.planRemotes(opts);
+    const primary = remotes[0]!;
 
-    if (!opts.force) {
-      const skip = this.failureSkipResult(state);
-      // Inside the backoff window we skip; once it elapses, fall through and
-      // re-attempt. Auth-class failures auto-retry on a widening schedule
-      // rather than suspending the repo's fetch indefinitely.
-      if (skip) return skip;
+    // Pre-chain triage: a remote inside its backoff window or covered by a
+    // recent success is answered without queueing at all, so a burst of
+    // sibling polls collapses instead of stacking chain links.
+    const settled = new Map<string, FetchResult>();
+    const pending: string[] = [];
+    for (const remote of remotes) {
+      const state = this.getOrCreateState(commonDir, remote);
+      if (!opts.force) {
+        const skip = this.failureSkipResult(state, remote);
+        // Inside the backoff window we skip; once it elapses, fall through and
+        // re-attempt. Auth-class failures auto-retry on a widening schedule
+        // rather than suspending the repo's fetch indefinitely.
+        if (skip) {
+          settled.set(remote, skip);
+          continue;
+        }
+      }
+      const recent = this.recentSuccessResult(state, opts.force === true, remote);
+      if (recent) {
+        settled.set(remote, recent);
+        continue;
+      }
+      pending.push(remote);
     }
 
-    const recent = this.recentSuccessResult(state, opts.force === true);
-    if (recent) {
-      return recent;
+    if (pending.length > 0) {
+      const generations = new Map(
+        pending.map((remote) => [remote, this.getOrCreateState(commonDir, remote).generation])
+      );
+      const chain = this.chains.get(commonDir) ?? Promise.resolve();
+      const batch = chain.then(() => this.runBatch(commonDir, pending, generations, opts));
+      this.chains.set(
+        commonDir,
+        batch.then(
+          () => undefined,
+          () => undefined
+        )
+      );
+      for (const [remote, result] of await batch) {
+        settled.set(remote, result);
+      }
     }
 
-    const generationAtStart = state.generation;
-    const result = state.chain.then(() => this.runFetch(commonDir, generationAtStart, opts));
-    state.chain = result.then(
-      () => undefined,
-      () => undefined
+    return (
+      settled.get(primary) ?? { status: "skipped", skipReason: "stale-generation", remote: primary }
     );
-    return result;
+  }
+
+  /**
+   * The deduped remote list for one call, primary first. Fetch order matters:
+   * the primary's result is what the card renders, so it should not sit behind
+   * a slow auxiliary remote's 60s timeout.
+   */
+  private planRemotes(opts: FetchOptions): string[] {
+    const requested = (opts.remotes ?? []).filter(
+      (remote) => typeof remote === "string" && remote.length > 0
+    );
+    const primary =
+      opts.primaryRemote && opts.primaryRemote.length > 0
+        ? opts.primaryRemote
+        : (requested[0] ?? DEFAULT_REMOTE);
+    const ordered = [primary];
+    for (const remote of requested) {
+      if (!ordered.includes(remote)) ordered.push(remote);
+    }
+    return ordered;
+  }
+
+  /**
+   * Fetch each pending remote in turn on the caller's chain link. Sequential
+   * rather than concurrent: they share `packed-refs`, which is the same reason
+   * sibling worktrees serialize. A failure on one remote does not stop the
+   * others — that isolation is the point of the per-remote state.
+   */
+  private async runBatch(
+    commonDir: string,
+    remotes: readonly string[],
+    generations: ReadonlyMap<string, number>,
+    opts: FetchOptions
+  ): Promise<Map<string, FetchResult>> {
+    const results = new Map<string, FetchResult>();
+    let anyFetched = false;
+    for (const remote of remotes) {
+      const generationAtStart = generations.get(remote) ?? this.baseGeneration;
+      const { result, fetched } = await this.runFetch(commonDir, remote, generationAtStart, opts);
+      results.set(remote, result);
+      // `fetched`, not `status === "success"`: the post-chain recency check
+      // also reports success, and firing the observer for a sibling that
+      // merely reused another's refs would refresh every card N times per
+      // scheduled poll.
+      if (fetched) anyFetched = true;
+    }
+    // One notification per batch, not per remote: the observer refreshes the
+    // worktree's status, and doing that N times for one scheduled poll is
+    // wasted work. Fired outside runFetch so a throwing observer can't poison
+    // any remote's failure cache.
+    if (anyFetched) {
+      try {
+        this.callbacks.onFetchSuccess?.(opts.worktreeId);
+      } catch {
+        // Observer threw — silently swallow; the fetches themselves succeeded.
+      }
+    }
+    return results;
   }
 
   /**
    * Drop network-class failures so the next fetch attempt is allowed
-   * immediately. Called on OS wake / network reconnect.
+   * immediately. Called on OS wake / network reconnect. Applies across every
+   * remote — a reconnect restores all of them at once.
    */
   clearNetworkFailures(): void {
     for (const state of this.states.values()) {
@@ -224,7 +380,9 @@ export class RepoFetchCoordinator {
 
   /**
    * Drop auth-suspension entries. Called when the user signs in / refreshes
-   * GitHub credentials so previously-failing repos can fetch again.
+   * GitHub credentials so previously-failing repos can fetch again. Applies
+   * across every remote: a credential refresh is not remote-specific, and
+   * leaving a sibling remote suspended would make the retry look ineffective.
    */
   clearAuthFailures(): void {
     for (const state of this.states.values()) {
@@ -254,17 +412,31 @@ export class RepoFetchCoordinator {
       state.failure = null;
     }
     this.states.clear();
+    this.chains.clear();
     this.baseGeneration += 1;
   }
 
-  /** Test/diagnostic accessor. */
-  hasFailureFor(commonDir: string): boolean {
-    return this.states.get(commonDir)?.failure != null;
+  /**
+   * Test/diagnostic accessor. With no `remote`, reports whether ANY remote of
+   * the repo is in a failure window.
+   */
+  hasFailureFor(commonDir: string, remote?: string): boolean {
+    if (remote !== undefined) {
+      return this.states.get(stateKey(commonDir, remote))?.failure != null;
+    }
+    const prefix = `${commonDir}${STATE_KEY_DELIMITER}`;
+    for (const [key, state] of this.states) {
+      if (key.startsWith(prefix) && state.failure != null) return true;
+    }
+    return false;
   }
 
-  /** Test/diagnostic accessor. */
-  getLastSuccessfulFetch(commonDir: string): number | null {
-    return this.states.get(commonDir)?.lastSuccessfulFetch ?? null;
+  /**
+   * Test/diagnostic accessor. Scoped to one remote — a repo-wide maximum would
+   * report a freshness the primary remote may not have.
+   */
+  getLastSuccessfulFetch(commonDir: string, remote: string = DEFAULT_REMOTE): number | null {
+    return this.states.get(stateKey(commonDir, remote))?.lastSuccessfulFetch ?? null;
   }
 
   /**
@@ -273,7 +445,11 @@ export class RepoFetchCoordinator {
    * failure so failure surfacing keeps today's semantics. A negative elapsed
    * (clock moved backwards) also forces a real fetch.
    */
-  private recentSuccessResult(state: RepoState, force: boolean): FetchResult | null {
+  private recentSuccessResult(
+    state: RemoteState,
+    force: boolean,
+    remote: string
+  ): FetchResult | null {
     if (state.failure || state.lastSuccessfulFetch === null) return null;
     const window = force ? FORCE_FETCH_RECENCY_WINDOW_MS : FETCH_RECENCY_WINDOW_MS;
     const elapsed = Date.now() - state.lastSuccessfulFetch;
@@ -283,17 +459,18 @@ export class RepoFetchCoordinator {
       lastFetchedAt: state.lastSuccessfulFetch,
       authFailed: false,
       networkFailed: false,
+      remote,
     };
   }
 
   /**
-   * Skip result for a repo still inside its failure backoff window — `null`
+   * Skip result for a remote still inside its failure backoff window — `null`
    * once the window elapses (so the caller re-attempts the fetch). Shared by
    * the pre-queue check and the post-chain re-check so a burst of sibling
    * fetches that all queue before the first failure lands still collapses to a
    * single git invocation once that failure is cached.
    */
-  private failureSkipResult(state: RepoState): FetchResult | null {
+  private failureSkipResult(state: RemoteState, remote: string): FetchResult | null {
     const failure = state.failure;
     if (!failure || Date.now() >= failure.retryAt) return null;
     const isAuth = failure.kind === "auth";
@@ -304,55 +481,65 @@ export class RepoFetchCoordinator {
       lastFetchedAt: state.lastSuccessfulFetch,
       // Only surface the per-card auth stripe once the failure is confirmed
       // (several retries exhausted). Pre-confirmation auth failures show the
-      // softer transient "Couldn't reach origin" tooltip instead, so a single
-      // blip doesn't alarm every worktree card.
+      // softer transient "Couldn't reach the remote" tooltip instead, so a
+      // single blip doesn't alarm every worktree card.
       authFailed: isAuth && failure.confirmed === true,
       networkFailed: isAuth ? failure.confirmed !== true : true,
+      remote,
     };
   }
 
-  private getOrCreateState(commonDir: string): RepoState {
-    let state = this.states.get(commonDir);
+  private getOrCreateState(commonDir: string, remote: string): RemoteState {
+    const key = stateKey(commonDir, remote);
+    let state = this.states.get(key);
     if (!state) {
       state = {
-        chain: Promise.resolve(),
         failure: null,
         lastSuccessfulFetch: null,
         generation: this.baseGeneration,
       };
-      this.states.set(commonDir, state);
+      this.states.set(key, state);
     }
     return state;
   }
 
+  /**
+   * Run one remote's fetch. `fetched` distinguishes a git invocation that
+   * actually landed from a result reused off another sibling's — only the
+   * former should notify observers.
+   */
   private async runFetch(
     commonDir: string,
+    remote: string,
     generationAtStart: number,
     opts: FetchOptions
-  ): Promise<FetchResult> {
-    const stateAtStart = this.states.get(commonDir);
+  ): Promise<{ result: FetchResult; fetched: boolean }> {
+    const key = stateKey(commonDir, remote);
+    const stateAtStart = this.states.get(key);
     if (!stateAtStart || stateAtStart.generation !== generationAtStart) {
-      return { status: "skipped", skipReason: "stale-generation" };
+      return {
+        result: { status: "skipped", skipReason: "stale-generation", remote },
+        fetched: false,
+      };
     }
     // Re-check recency after waiting on the chain — back-to-back sibling
     // fetches (wake storm, auth retry) all queue before the first completes,
     // so the dedup has to look at the timestamp the prior link just wrote.
-    const recent = this.recentSuccessResult(stateAtStart, opts.force === true);
+    const recent = this.recentSuccessResult(stateAtStart, opts.force === true, remote);
     if (recent) {
-      return recent;
+      return { result: recent, fetched: false };
     }
     // Same dedup for failures: once the first sibling in a burst caches a
     // failure, the rest skip instead of each spawning another git fetch (and
     // re-incrementing the auth retry count). Force fetches still bypass this —
     // their same-window failures are coalesced in `buildAuthFailureEntry`.
     if (opts.force !== true) {
-      const skip = this.failureSkipResult(stateAtStart);
-      if (skip) return skip;
+      const skip = this.failureSkipResult(stateAtStart, remote);
+      if (skip) return { result: skip, fetched: false };
     }
 
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), FETCH_ABORT_TIMEOUT_MS);
-    let succeeded = false;
     try {
       const git = await createBackgroundFetchGit(opts.worktreePath, {
         signal: controller.signal,
@@ -361,70 +548,75 @@ export class RepoFetchCoordinator {
       // so concurrent foreground operations (status polls, user pushes) don't
       // contend on the same file. Requires Git ≥ 2.29 — all supported platforms
       // ship ≥ 2.34, so no version guard is needed.
-      await git.raw(["fetch", "origin", "--no-auto-gc", "--prune", "--no-write-fetch-head"]);
+      await git.raw(["fetch", remote, "--no-auto-gc", "--prune", "--no-write-fetch-head"]);
 
-      const state = this.states.get(commonDir);
+      const state = this.states.get(key);
       if (!state || state.generation !== generationAtStart) {
-        return { status: "skipped", skipReason: "stale-generation" };
+        return {
+          result: { status: "skipped", skipReason: "stale-generation", remote },
+          fetched: false,
+        };
       }
       state.failure = null;
       state.lastSuccessfulFetch = Date.now();
-      succeeded = true;
       return {
-        status: "success",
-        lastFetchedAt: state.lastSuccessfulFetch,
-        authFailed: false,
-        networkFailed: false,
+        result: {
+          status: "success",
+          lastFetchedAt: state.lastSuccessfulFetch,
+          authFailed: false,
+          networkFailed: false,
+          remote,
+        },
+        fetched: true,
       };
     } catch (error) {
       const reason = classifyGitError(error);
-      const state = this.states.get(commonDir);
+      const state = this.states.get(key);
       if (!state || state.generation !== generationAtStart) {
-        return { status: "skipped", skipReason: "stale-generation" };
+        return {
+          result: { status: "skipped", skipReason: "stale-generation", remote },
+          fetched: false,
+        };
       }
-      state.failure = this.classifyForCache(reason, commonDir, state, error);
+      state.failure = this.classifyForCache(reason, commonDir, remote, state, error);
       const failure = state.failure;
       const isAuth = failure.kind === "auth";
       return {
-        status: "failed",
-        reason,
-        lastFetchedAt: state.lastSuccessfulFetch,
-        // Auth-class failures only raise the per-card stripe once confirmed;
-        // until then (and for every non-auth failure) the softer transient
-        // "Couldn't reach origin" tooltip line carries the signal.
-        authFailed: isAuth && failure.confirmed === true,
-        networkFailed: isAuth ? failure.confirmed !== true : true,
+        result: {
+          status: "failed",
+          reason,
+          lastFetchedAt: state.lastSuccessfulFetch,
+          // Auth-class failures only raise the per-card stripe once confirmed;
+          // until then (and for every non-auth failure) the softer transient
+          // "Couldn't reach the remote" tooltip line carries the signal.
+          authFailed: isAuth && failure.confirmed === true,
+          networkFailed: isAuth ? failure.confirmed !== true : true,
+          remote,
+        },
+        fetched: false,
       };
     } finally {
       clearTimeout(timeout);
-      // Notify outside the try/catch so a throwing observer can't poison the
-      // failure cache. Wrapped defensively — `onFetchSuccess` is fire-and-forget.
-      if (succeeded) {
-        try {
-          this.callbacks.onFetchSuccess?.(opts.worktreeId);
-        } catch {
-          // Observer threw — silently swallow; fetch itself succeeded.
-        }
-      }
     }
   }
 
   private classifyForCache(
     reason: GitOperationReason,
     commonDir: string,
-    state: RepoState,
+    remote: string,
+    state: RemoteState,
     error: unknown
   ): FetchFailureEntry {
     const now = Date.now();
     if (reason === "auth-failed") {
-      return this.buildAuthFailureEntry(reason, commonDir, state, now);
+      return this.buildAuthFailureEntry(reason, commonDir, remote, state, now);
     }
     if (reason === "repository-not-found") {
-      // After at least one prior success, a 404 from origin almost always
+      // After at least one prior success, a 404 from this remote almost always
       // indicates GitHub's "404 instead of 403" permission masking. Treat it
       // on the same auth backoff/confirmation path so we don't hammer retries.
       if (state.lastSuccessfulFetch !== null) {
-        return this.buildAuthFailureEntry(reason, commonDir, state, now);
+        return this.buildAuthFailureEntry(reason, commonDir, remote, state, now);
       }
       return {
         kind: "repo-not-found-first",
@@ -475,11 +667,17 @@ export class RepoFetchCoordinator {
    * exponential backoff ladder, and marks the failure `confirmed` once it
    * persists past the threshold — firing `onAuthFailureConfirmed` exactly once
    * on the unconfirmed→confirmed transition.
+   *
+   * `state` is the per-(commondir, remote) entry, so the retry count advances
+   * per remote. Sharing it across remotes would let two independent failures
+   * confirm each other, which is the same "fake confirmation threshold" bug
+   * the same-window coalescing below exists to prevent.
    */
   private buildAuthFailureEntry(
     reason: GitOperationReason,
     commonDir: string,
-    state: RepoState,
+    remote: string,
+    state: RemoteState,
     now: number
   ): FetchFailureEntry {
     const prior = state.failure?.kind === "auth" ? state.failure : null;
@@ -500,7 +698,7 @@ export class RepoFetchCoordinator {
       // Notify on the transition only. Wrapped defensively — a throwing
       // observer must not abort building the failure entry below.
       try {
-        this.callbacks.onAuthFailureConfirmed?.(commonDir, reason);
+        this.callbacks.onAuthFailureConfirmed?.(commonDir, remote, reason);
       } catch {
         // Observer threw — swallow; the failure cache must stay consistent.
       }

--- a/electron/workspace-host/SnapshotBuilder.ts
+++ b/electron/workspace-host/SnapshotBuilder.ts
@@ -59,6 +59,7 @@ export interface SnapshotBuilderHost {
   readonly baseAheadCount: number | null | undefined;
   readonly baseBehindCount: number | null | undefined;
   readonly baseMatchesUpstream: boolean | undefined;
+  readonly baseCompareRef: string | null | undefined;
   readonly lastFetchedAt: number | null;
   readonly lastGitStatusCheckedAt: number;
   readonly workingTreeChangedAt: number;
@@ -165,6 +166,7 @@ export class SnapshotBuilder {
       baseAheadCount: this.host.baseAheadCount ?? undefined,
       baseBehindCount: this.host.baseBehindCount ?? undefined,
       baseMatchesUpstream: this.host.baseMatchesUpstream ?? undefined,
+      baseCompareRef: this.host.baseCompareRef ?? undefined,
       lastFetchedAt: this.host.lastFetchedAt ?? undefined,
       lastGitStatusCheckedAt: this.host.lastGitStatusCheckedAt,
       // 0 → undefined so a worktree that has never seen a raw fs write serializes

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -47,6 +47,7 @@ import { WorktreeMonitor } from "./WorktreeMonitor.js";
 import { WorktreeListService } from "./WorktreeListService.js";
 import { PRIntegrationService, type PRIntegrationCallbacks } from "./PRIntegrationService.js";
 import { RepoFetchCoordinator } from "./RepoFetchCoordinator.js";
+import { planFetchRemotes } from "../../shared/utils/baseRemoteSelection.js";
 import { waitForPathExists } from "../utils/fs.js";
 import { markHostPerformance } from "../utils/hostPerformance.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
@@ -356,7 +357,7 @@ export class WorkspaceService {
         // not surface as an unhandled rejection.
         void this.refreshStatusForFetchSiblings(worktreeId).catch(() => {});
       },
-      onAuthFailureConfirmed: (commonDir, reason) =>
+      onAuthFailureConfirmed: (commonDir, _remote, reason) =>
         this.handleAuthFailureConfirmed(commonDir, reason),
     });
     const prCallbacks: PRIntegrationCallbacks = {
@@ -1337,10 +1338,16 @@ export class WorkspaceService {
         onScheduleFetch: async (worktreeId, _isCurrent, force) => {
           const target = this.monitors.get(worktreeId);
           if (!target || !target.isRunning) return;
+          const { remotes, primaryRemote } = planFetchRemotes({
+            baseRemote: target.baseRemote,
+            availableRemotes: target.availableRemotes,
+          });
           const result = await this.fetchCoordinator.fetchForWorktree({
             worktreeId,
             worktreePath: target.path,
             force,
+            remotes,
+            primaryRemote,
           });
           // Skipped for "no-common-dir" (e.g. path was just removed) means we
           // have no commondir to fan out on — bail.
@@ -3169,15 +3176,31 @@ export class WorkspaceService {
     }
   }
 
+  /**
+   * Fetch a PR's head into a local branch.
+   *
+   * `remoteName` is the forge remote resolved in main (#11747) — the PR ref
+   * only exists on the repository the PR was opened against, so with GitHub
+   * configured as `upstream` a fetch from `origin` fails outright with
+   * "couldn't find remote ref". Defaults to `origin` when the caller can't
+   * resolve one, which is the pre-fix behavior.
+   *
+   * The refspec itself stays GitHub-shaped (`pull/<n>/head`, also served by
+   * Gitea and Forgejo). GitLab's `merge-requests/<n>/head` and Bitbucket's
+   * variants would need per-provider refspec mapping — a separate gap this
+   * doesn't claim to close.
+   */
   async fetchPRBranch(
     requestId: string,
     rootPath: string,
     prNumber: number,
-    headRefName: string
+    headRefName: string,
+    remoteName?: string
   ): Promise<void> {
     try {
       const git = await createAuthenticatedGit(rootPath);
-      await git.raw(["fetch", "origin", `pull/${prNumber}/head:${headRefName}`]);
+      const remote = remoteName && remoteName.length > 0 ? remoteName : "origin";
+      await git.raw(["fetch", remote, `pull/${prNumber}/head:${headRefName}`]);
       this.sendEvent({ type: "fetch-pr-branch-result", requestId, success: true });
     } catch (error) {
       const gitReason = classifyGitError(error);

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -48,6 +48,18 @@ import { WorktreeListService } from "./WorktreeListService.js";
 import { PRIntegrationService, type PRIntegrationCallbacks } from "./PRIntegrationService.js";
 import { RepoFetchCoordinator } from "./RepoFetchCoordinator.js";
 import { planFetchRemotes } from "../../shared/utils/baseRemoteSelection.js";
+
+/**
+ * The remote a worktree's displayed counts depend on. Derived through the same
+ * planner that chose what to fetch, so the "which remote did we fetch for this
+ * card" and "which remote may update this card" answers cannot drift apart.
+ */
+function dependsOnRemote(monitor: WorktreeMonitor): string {
+  return planFetchRemotes({
+    baseRemote: monitor.baseRemote,
+    availableRemotes: monitor.availableRemotes,
+  }).primaryRemote;
+}
 import { waitForPathExists } from "../utils/fs.js";
 import { markHostPerformance } from "../utils/hostPerformance.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
@@ -1362,6 +1374,7 @@ export class WorkspaceService {
             lastFetchedAt: result.lastFetchedAt ?? null,
             authFailed: result.authFailed ?? false,
             networkFailed: result.networkFailed ?? false,
+            remote: result.remote,
           });
         },
       },
@@ -1597,7 +1610,16 @@ export class WorkspaceService {
    */
   private async applyFetchResultToSiblings(
     triggering: WorktreeMonitor,
-    result: { lastFetchedAt: number | null; authFailed: boolean; networkFailed: boolean }
+    result: {
+      lastFetchedAt: number | null;
+      authFailed: boolean;
+      networkFailed: boolean;
+      /**
+       * Remote the result describes. A sibling only adopts it when that is the
+       * remote the sibling's own counts depend on — see the fan-out note below.
+       */
+      remote: string | undefined;
+    }
   ): Promise<void> {
     const triggeringCommonDir = await getGitCommonDir(triggering.path, { logErrors: false });
     if (!triggeringCommonDir) {
@@ -1609,9 +1631,24 @@ export class WorkspaceService {
     for (const monitor of this.monitors.values()) {
       if (!monitor.isRunning) continue;
       const monitorCommonDir = await getGitCommonDir(monitor.path, { logErrors: false });
-      if (monitorCommonDir === triggeringCommonDir) {
-        monitor.setFetchState(result.lastFetchedAt, result.authFailed, result.networkFailed);
-      }
+      if (monitorCommonDir !== triggeringCommonDir) continue;
+      // Sharing a commondir no longer implies sharing a fetch outcome. Once a
+      // repo refreshes more than one remote, a sibling measuring against
+      // `upstream` must not be stamped fresh by an `origin` success, nor
+      // marked failed by an `upstream` failure it doesn't read — whichever
+      // remote finished last would otherwise win across every card, hiding the
+      // stale behind-count this issue exists to fix.
+      // The monitor that asked for this fetch always adopts the answer: the
+      // fetch was planned from its own resolution, and a poll landing mid-fetch
+      // could otherwise re-plan it into never accepting the result it asked for.
+      const isTriggering = monitor.id === triggering.id;
+      if (
+        !isTriggering &&
+        result.remote !== undefined &&
+        dependsOnRemote(monitor) !== result.remote
+      )
+        continue;
+      monitor.setFetchState(result.lastFetchedAt, result.authFailed, result.networkFailed);
     }
   }
 

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -552,6 +552,9 @@ export class WorktreeMonitor {
       get baseBehindCount() {
         return monitor.gitStatusPass.baseBehindCount;
       },
+      get baseCompareRef() {
+        return monitor.gitStatusPass.baseCompareRef;
+      },
       get baseMatchesUpstream() {
         return monitor.gitStatusPass.baseMatchesUpstream;
       },
@@ -898,6 +901,21 @@ export class WorktreeMonitor {
   setRemoteFetchUrl(url: string | undefined): void {
     if (!this._isRunning) return;
     this._remoteFetchUrl = url;
+  }
+
+  /**
+   * Remote the base-branch divergence last compared against, or `null` when it
+   * used a local ref (or hasn't run yet). Read by `WorkspaceService` so the
+   * background fetch refreshes the remote this worktree actually measures
+   * itself against instead of assuming `origin` (#11747).
+   */
+  get baseRemote(): string | null {
+    return this.baseDivergence.baseRemote;
+  }
+
+  /** Remotes this repo has, as of the divergence pass's last resolution. */
+  get availableRemotes(): readonly string[] {
+    return this.baseDivergence.availableRemotes;
   }
 
   /**

--- a/electron/workspace-host/__tests__/BaseDivergence.test.ts
+++ b/electron/workspace-host/__tests__/BaseDivergence.test.ts
@@ -68,7 +68,22 @@ function installRepo(fixture: RepoFixture): void {
 
   mockGitRaw.mockImplementation(async (args: string[]) => {
     if (args[0] === "remote") return `${remotes.join("\n")}\n`;
-    if (args[0] === "for-each-ref") return `${remoteBaseRefs.join("\n")}\n`;
+    if (args[0] === "for-each-ref") {
+      // Model git's ref-filter matching rather than echoing the fixture back:
+      // `*` does NOT cross `/`, which is exactly the behaviour that decides
+      // whether slash-bearing remote names are discoverable.
+      const patterns = args.slice(args.indexOf("--") + 1);
+      const matches = remoteBaseRefs.filter((ref) =>
+        patterns.some((pattern) => {
+          const source = pattern
+            .split("*")
+            .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+            .join("[^/]*");
+          return new RegExp(`^${source}$`).test(ref);
+        })
+      );
+      return `${matches.join("\n")}\n`;
+    }
     if (args[0] === "rev-parse" && args[1] === "--symbolic-full-name") {
       const resolved = symbolicRefs[args[2]!];
       if (!resolved) throw new Error(`no upstream configured for ${args[2]}`);
@@ -350,6 +365,45 @@ describe("BaseDivergence", () => {
       expect(result?.baseCompareRef).toBe("upstream/main");
       expect(mockCreateWslHardenedGit).toHaveBeenCalled();
       expect(mockCreateHardenedGit).not.toHaveBeenCalled();
+    });
+
+    it("keeps the resolved remote in the fetch plan even when its ref is not fetched yet", async () => {
+      // Fresh fork: `upstream` is configured but `refs/remotes/upstream/main`
+      // has never been fetched, so the rev-list against it fails and the pass
+      // falls back to the local branch. If that made the divergence report no
+      // base remote, upstream would drop out of the fetch plan, the ref would
+      // never arrive, the stat key would never move, and the fallback would be
+      // served from cache forever.
+      installRepo({
+        remotes: ["origin", "upstream"],
+        remoteBaseRefs: ["refs/remotes/upstream/main"],
+        revList: { "main...HEAD": "0\t2\n" },
+      });
+      const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());
+
+      const result = await divergence.compute(false);
+
+      // Display tells the truth about what was measured...
+      expect(result?.baseCompareRef).toBe("main");
+      expect(result?.baseRemote).toBeNull();
+      // ...while the fetch plan still targets the remote we need.
+      expect(divergence.baseRemote).toBe("upstream");
+    });
+
+    it("discovers a remote whose own name contains a slash", async () => {
+      // git's ref-filter wildcard does not cross `/`, so a single
+      // `refs/remotes/*/main` glob would never surface `team/fork`.
+      installRepo({
+        remotes: ["team/fork"],
+        remoteBaseRefs: ["refs/remotes/team/fork/main"],
+        revList: { "team/fork/main...HEAD": "1\t0\n" },
+      });
+      const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());
+
+      const result = await divergence.compute(false);
+
+      expect(result?.baseCompareRef).toBe("team/fork/main");
+      expect(divergence.baseRemote).toBe("team/fork");
     });
 
     it("keeps today's origin fallback when the remote table can't be read", async () => {

--- a/electron/workspace-host/__tests__/BaseDivergence.test.ts
+++ b/electron/workspace-host/__tests__/BaseDivergence.test.ts
@@ -39,6 +39,63 @@ function makeStatPrecheck(): StatPrecheck {
   } as unknown as StatPrecheck;
 }
 
+interface RepoFixture {
+  /** `git remote` output. */
+  remotes?: string[];
+  /** Full refs keyed by the revision passed to `rev-parse --symbolic-full-name`. */
+  symbolicRefs?: Record<string, string>;
+  /** Full refs `for-each-ref` reports for the base-branch glob. */
+  remoteBaseRefs?: string[];
+  /** rev-list output keyed by the `<ref>...HEAD` range; absent ranges throw. */
+  revList?: Record<string, string>;
+  /** Output of the two-rev `rev-parse` that drives matchesUpstream. */
+  revParsePair?: string;
+}
+
+/**
+ * Route git invocations to a declarative repo fixture, so a test states the
+ * repository's shape rather than an ordered list of mock return values — the
+ * resolution step's call count varies with that shape.
+ */
+function installRepo(fixture: RepoFixture): void {
+  const {
+    remotes = ["origin"],
+    symbolicRefs = {},
+    remoteBaseRefs = [],
+    revList = {},
+    revParsePair,
+  } = fixture;
+
+  mockGitRaw.mockImplementation(async (args: string[]) => {
+    if (args[0] === "remote") return `${remotes.join("\n")}\n`;
+    if (args[0] === "for-each-ref") return `${remoteBaseRefs.join("\n")}\n`;
+    if (args[0] === "rev-parse" && args[1] === "--symbolic-full-name") {
+      const resolved = symbolicRefs[args[2]!];
+      if (!resolved) throw new Error(`no upstream configured for ${args[2]}`);
+      return `${resolved}\n`;
+    }
+    if (args[0] === "rev-parse") {
+      if (revParsePair === undefined) throw new Error("unknown revision");
+      return revParsePair;
+    }
+    if (args[0] === "rev-list") {
+      const range = args[3]!;
+      const out = revList[range];
+      if (out === undefined) throw new Error(`unknown revision: ${range}`);
+      return out;
+    }
+    throw new Error(`unexpected git invocation: ${args.join(" ")}`);
+  });
+}
+
+/** The `rev-list` ranges a run actually asked for, in order. */
+function revListRanges(): string[] {
+  return mockGitRaw.mock.calls
+    .map((call) => call[0] as string[])
+    .filter((args) => args[0] === "rev-list")
+    .map((args) => args[3] as string);
+}
+
 describe("BaseDivergence", () => {
   beforeEach(() => {
     mockGitRaw.mockReset();
@@ -52,17 +109,22 @@ describe("BaseDivergence", () => {
   });
 
   it("returns null for the main worktree", async () => {
+    installRepo({});
     const divergence = new BaseDivergence(makeHost({ isMainWorktree: true }), makeStatPrecheck());
     expect(await divergence.compute(false)).toBeNull();
   });
 
   it("returns null when there is no branch", async () => {
+    installRepo({});
     const divergence = new BaseDivergence(makeHost({ branch: undefined }), makeStatPrecheck());
     expect(await divergence.compute(false)).toBeNull();
   });
 
   it("prefers the linked PR's base branch over mainBranch", async () => {
-    mockGitRaw.mockResolvedValueOnce("2\t3\n");
+    installRepo({
+      remoteBaseRefs: ["refs/remotes/origin/release"],
+      revList: { "origin/release...HEAD": "2\t3\n" },
+    });
     const divergence = new BaseDivergence(
       makeHost({ linkedPrBaseRef: " release " }),
       makeStatPrecheck()
@@ -71,25 +133,24 @@ describe("BaseDivergence", () => {
     const result = await divergence.compute(false);
 
     expect(result?.baseBranchName).toBe("release");
-    expect(mockGitRaw).toHaveBeenCalledWith([
-      "rev-list",
-      "--count",
-      "--left-right",
-      "origin/release...HEAD",
-    ]);
+    expect(revListRanges()).toContain("origin/release...HEAD");
   });
 
   it("falls back to mainBranch when there is no linked PR base ref", async () => {
-    mockGitRaw.mockResolvedValueOnce("0\t0\n");
+    installRepo({
+      remoteBaseRefs: ["refs/remotes/origin/main"],
+      revList: { "origin/main...HEAD": "0\t0\n" },
+    });
     const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());
 
-    const result = await divergence.compute(false);
-
-    expect(result?.baseBranchName).toBe("main");
+    expect((await divergence.compute(false))?.baseBranchName).toBe("main");
   });
 
   it("parses ahead/behind counts from the rev-list output", async () => {
-    mockGitRaw.mockResolvedValueOnce("4\t7\n");
+    installRepo({
+      remoteBaseRefs: ["refs/remotes/origin/main"],
+      revList: { "origin/main...HEAD": "4\t7\n" },
+    });
     const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());
 
     const result = await divergence.compute(false);
@@ -99,70 +160,209 @@ describe("BaseDivergence", () => {
   });
 
   it("falls back to the local base ref when the remote ref rev-list fails", async () => {
-    mockGitRaw
-      .mockRejectedValueOnce(new Error("unknown revision: origin/main"))
-      .mockResolvedValueOnce("1\t2\n");
+    installRepo({ revList: { "main...HEAD": "1\t2\n" } });
     const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());
 
     const result = await divergence.compute(false);
 
     expect(result?.behindCount).toBe(1);
-    expect(mockGitRaw).toHaveBeenNthCalledWith(2, [
-      "rev-list",
-      "--count",
-      "--left-right",
-      "main...HEAD",
-    ]);
+    expect(revListRanges().at(-1)).toBe("main...HEAD");
+    // The local fallback measured against a plain branch, not a remote one.
+    expect(result?.baseCompareRef).toBe("main");
+    expect(result?.baseRemote).toBeNull();
   });
 
   it("returns null when both the remote and local rev-list fail", async () => {
-    mockGitRaw.mockRejectedValue(new Error("no such ref"));
+    installRepo({});
     const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());
 
     expect(await divergence.compute(false)).toBeNull();
   });
 
   it("sets matchesUpstream true only when @{u} and the base ref resolve to the same commit", async () => {
-    mockGitRaw.mockResolvedValueOnce("0\t0\n").mockResolvedValueOnce("abc123\nabc123\n");
+    installRepo({
+      remoteBaseRefs: ["refs/remotes/origin/main"],
+      revList: { "origin/main...HEAD": "0\t0\n" },
+      symbolicRefs: { "@{u}": "refs/remotes/origin/feature/x" },
+      revParsePair: "abc123\nabc123\n",
+    });
     const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());
 
-    const result = await divergence.compute(true);
-
-    expect(result?.matchesUpstream).toBe(true);
+    expect((await divergence.compute(true))?.matchesUpstream).toBe(true);
   });
 
   it("sets matchesUpstream false when @{u} and the base ref diverge", async () => {
-    mockGitRaw.mockResolvedValueOnce("0\t0\n").mockResolvedValueOnce("abc123\ndef456\n");
+    installRepo({
+      remoteBaseRefs: ["refs/remotes/origin/main"],
+      revList: { "origin/main...HEAD": "0\t0\n" },
+      symbolicRefs: { "@{u}": "refs/remotes/origin/feature/x" },
+      revParsePair: "abc123\ndef456\n",
+    });
     const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());
 
-    const result = await divergence.compute(true);
-
-    expect(result?.matchesUpstream).toBe(false);
+    expect((await divergence.compute(true))?.matchesUpstream).toBe(false);
   });
 
   it("reuses the cached result when the stat-derived key is unchanged", async () => {
-    mockGitRaw.mockResolvedValueOnce("0\t0\n");
-    const statPrecheck = makeStatPrecheck();
-    const divergence = new BaseDivergence(makeHost(), statPrecheck);
+    installRepo({
+      remoteBaseRefs: ["refs/remotes/origin/main"],
+      revList: { "origin/main...HEAD": "0\t0\n" },
+    });
+    const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());
 
     await divergence.compute(false);
+    const spawnsAfterFirst = mockGitRaw.mock.calls.length;
     await divergence.compute(false);
 
-    // Only the first compute() should have spawned a git process; the second
-    // reused the cached result via the unchanged stat key.
-    expect(mockGitRaw).toHaveBeenCalledTimes(1);
+    // The second pass must be entirely spawn-free — that fast path is what
+    // keeps the worktree dashboard's poll loop cheap.
+    expect(mockGitRaw.mock.calls.length).toBe(spawnsAfterFirst);
   });
 
   it("recomputes when a ref's stat mtime changes", async () => {
-    mockGitRaw.mockResolvedValueOnce("0\t0\n").mockResolvedValueOnce("1\t1\n");
+    installRepo({
+      remoteBaseRefs: ["refs/remotes/origin/main"],
+      revList: { "origin/main...HEAD": "0\t0\n" },
+    });
     const statPrecheck = makeStatPrecheck();
     const divergence = new BaseDivergence(makeHost(), statPrecheck);
 
     await divergence.compute(false);
     vi.mocked(statPrecheck.statMtime).mockResolvedValue(2_000);
+    mockGitRaw.mockImplementation(async (args: string[]) => {
+      if (args[0] === "remote") return "origin\n";
+      if (args[0] === "for-each-ref") return "refs/remotes/origin/main\n";
+      if (args[0] === "rev-parse") throw new Error("no upstream");
+      if (args[0] === "rev-list") return "1\t1\n";
+      throw new Error("unexpected");
+    });
     const second = await divergence.compute(false);
 
-    expect(mockGitRaw).toHaveBeenCalledTimes(2);
     expect(second?.behindCount).toBe(1);
+  });
+
+  describe("remote resolution", () => {
+    it("compares against upstream when the fork layout leaves it ambiguous", async () => {
+      // origin is the fork and carries a stale base; upstream is canonical.
+      installRepo({
+        remotes: ["origin", "upstream"],
+        remoteBaseRefs: ["refs/remotes/origin/main", "refs/remotes/upstream/main"],
+        revList: { "upstream/main...HEAD": "200\t3\n", "origin/main...HEAD": "0\t3\n" },
+      });
+      const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());
+
+      const result = await divergence.compute(false);
+
+      expect(result?.baseCompareRef).toBe("upstream/main");
+      expect(result?.baseRemote).toBe("upstream");
+      expect(result?.behindCount).toBe(200);
+    });
+
+    it("honours the base branch's tracking config over the name heuristic", async () => {
+      installRepo({
+        remotes: ["origin", "upstream"],
+        symbolicRefs: { "main@{upstream}": "refs/remotes/origin/main" },
+        remoteBaseRefs: ["refs/remotes/origin/main", "refs/remotes/upstream/main"],
+        revList: { "origin/main...HEAD": "5\t1\n" },
+      });
+      const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());
+
+      const result = await divergence.compute(false);
+
+      expect(result?.baseCompareRef).toBe("origin/main");
+      expect(result?.baseRemote).toBe("origin");
+    });
+
+    it("keeps single-remote repos on origin", async () => {
+      installRepo({
+        remoteBaseRefs: ["refs/remotes/origin/main"],
+        revList: { "origin/main...HEAD": "1\t1\n" },
+      });
+      const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());
+
+      const result = await divergence.compute(false);
+
+      expect(result?.baseCompareRef).toBe("origin/main");
+      expect(divergence.baseRemote).toBe("origin");
+    });
+
+    it("re-resolves when the base branch changes, rather than reusing the prior base's remote", async () => {
+      installRepo({
+        remotes: ["origin", "upstream"],
+        remoteBaseRefs: ["refs/remotes/upstream/main"],
+        revList: { "upstream/main...HEAD": "1\t1\n", "origin/release...HEAD": "2\t2\n" },
+      });
+      const linked: { baseRef: string | undefined } = { baseRef: undefined };
+      const host = makeHost();
+      Object.defineProperty(host, "linkedPrBaseRef", {
+        get: () => linked.baseRef,
+      });
+      const divergence = new BaseDivergence(host, makeStatPrecheck());
+
+      expect((await divergence.compute(false))?.baseCompareRef).toBe("upstream/main");
+
+      // A PR relink changes the base branch without touching any file on disk,
+      // so the resolution cache has to key on it directly.
+      linked.baseRef = "release";
+      mockGitRaw.mockImplementation(async (args: string[]) => {
+        if (args[0] === "remote") return "origin\nupstream\n";
+        if (args[0] === "for-each-ref") return "refs/remotes/origin/release\n";
+        if (args[0] === "rev-parse") throw new Error("no upstream");
+        if (args[0] === "rev-list") {
+          if (args[3] === "origin/release...HEAD") return "2\t2\n";
+          throw new Error(`unknown revision: ${args[3]}`);
+        }
+        throw new Error("unexpected");
+      });
+
+      const second = await divergence.compute(false);
+      expect(second?.baseBranchName).toBe("release");
+      expect(second?.baseCompareRef).toBe("origin/release");
+    });
+
+    it("resolves a slash-bearing base branch without splitting it", async () => {
+      installRepo({
+        remotes: ["origin", "upstream"],
+        remoteBaseRefs: ["refs/remotes/upstream/release/2.0"],
+        revList: { "upstream/release/2.0...HEAD": "3\t0\n" },
+      });
+      const divergence = new BaseDivergence(
+        makeHost({ linkedPrBaseRef: "release/2.0" }),
+        makeStatPrecheck()
+      );
+
+      expect((await divergence.compute(false))?.baseCompareRef).toBe("upstream/release/2.0");
+    });
+
+    it("resolves through the WSL git path too", async () => {
+      installRepo({
+        remotes: ["origin", "upstream"],
+        remoteBaseRefs: ["refs/remotes/origin/main", "refs/remotes/upstream/main"],
+        revList: { "upstream/main...HEAD": "9\t0\n" },
+      });
+      const divergence = new BaseDivergence(
+        makeHost({ wslInvocation: { distro: "Ubuntu", path: "/mnt/c/repo" } as never }),
+        makeStatPrecheck()
+      );
+
+      const result = await divergence.compute(false);
+
+      expect(result?.baseCompareRef).toBe("upstream/main");
+      expect(mockCreateWslHardenedGit).toHaveBeenCalled();
+      expect(mockCreateHardenedGit).not.toHaveBeenCalled();
+    });
+
+    it("keeps today's origin fallback when the remote table can't be read", async () => {
+      mockGitRaw.mockImplementation(async (args: string[]) => {
+        if (args[0] === "rev-list" && args[3] === "origin/main...HEAD") return "1\t1\n";
+        throw new Error("git unavailable");
+      });
+      const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());
+
+      const result = await divergence.compute(false);
+
+      expect(result?.behindCount).toBe(1);
+      expect(result?.baseCompareRef).toBe("origin/main");
+    });
   });
 });

--- a/electron/workspace-host/__tests__/RepoFetchCoordinator.test.ts
+++ b/electron/workspace-host/__tests__/RepoFetchCoordinator.test.ts
@@ -128,7 +128,7 @@ describe("RepoFetchCoordinator", () => {
     expect(f3.status).toBe("failed");
     expect(f3.authFailed).toBe(true);
     expect(onAuthFailureConfirmed).toHaveBeenCalledTimes(1);
-    expect(onAuthFailureConfirmed).toHaveBeenCalledWith("/repo/.git", "auth-failed");
+    expect(onAuthFailureConfirmed).toHaveBeenCalledWith("/repo/.git", "origin", "auth-failed");
 
     // A skip after confirmation keeps the stripe up but does not re-fire.
     const skipped = await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
@@ -857,5 +857,234 @@ describe("RepoFetchCoordinator", () => {
     expect(result.networkFailed).toBe(true);
     expect(result.authFailed).toBe(false);
     expect(coord.hasFailureFor("/repo/.git")).toBe(true);
+  });
+  describe("multiple remotes", () => {
+    it("fetches only origin for a single-remote repo", async () => {
+      mockGetGitCommonDir.mockReturnValue("/repo/.git");
+      const mockGit = makeMockGit(() => Promise.resolve());
+      mockCreateBackgroundFetchGit.mockReturnValue(mockGit);
+
+      const coord = new RepoFetchCoordinator();
+      await coord.fetchForWorktree({
+        worktreeId: "wt1",
+        worktreePath: "/repo",
+        remotes: ["origin"],
+        primaryRemote: "origin",
+      });
+
+      const fetched = mockGit.raw.mock.calls.map((call) => call[0][1]);
+      expect(fetched).toEqual(["origin"]);
+    });
+
+    it("fetches the primary remote before the auxiliary one", async () => {
+      mockGetGitCommonDir.mockReturnValue("/repo/.git");
+      const mockGit = makeMockGit(() => Promise.resolve());
+      mockCreateBackgroundFetchGit.mockReturnValue(mockGit);
+
+      const coord = new RepoFetchCoordinator();
+      await coord.fetchForWorktree({
+        worktreeId: "wt1",
+        worktreePath: "/repo",
+        remotes: ["origin", "upstream"],
+        primaryRemote: "upstream",
+      });
+
+      // The primary's result is what the card renders, so it must not queue
+      // behind a slow auxiliary fetch.
+      expect(mockGit.raw.mock.calls.map((call) => call[0][1])).toEqual(["upstream", "origin"]);
+    });
+
+    it("never fetches the same remote twice in one call", async () => {
+      mockGetGitCommonDir.mockReturnValue("/repo/.git");
+      const mockGit = makeMockGit(() => Promise.resolve());
+      mockCreateBackgroundFetchGit.mockReturnValue(mockGit);
+
+      const coord = new RepoFetchCoordinator();
+      await coord.fetchForWorktree({
+        worktreeId: "wt1",
+        worktreePath: "/repo",
+        remotes: ["origin", "origin", "upstream"],
+        primaryRemote: "origin",
+      });
+
+      expect(mockGit.raw.mock.calls.map((call) => call[0][1])).toEqual(["origin", "upstream"]);
+    });
+
+    it("reports the primary remote's outcome, not an auxiliary success", async () => {
+      mockGetGitCommonDir.mockReturnValue("/repo/.git");
+      mockCreateBackgroundFetchGit.mockImplementation(() =>
+        makeMockGit(function (this: void) {
+          return Promise.resolve();
+        })
+      );
+      // upstream fails, origin succeeds.
+      mockCreateBackgroundFetchGit.mockReturnValue({
+        raw: vi
+          .fn()
+          .mockImplementation((args: string[]) =>
+            args[1] === "upstream"
+              ? Promise.reject(new Error("Could not resolve host: upstream.example"))
+              : Promise.resolve()
+          ),
+      });
+
+      const coord = new RepoFetchCoordinator();
+      const result = await coord.fetchForWorktree({
+        worktreeId: "wt1",
+        worktreePath: "/repo",
+        remotes: ["origin", "upstream"],
+        primaryRemote: "upstream",
+      });
+
+      // A healthy origin must not vouch for counts measured against upstream.
+      expect(result.status).toBe("failed");
+      expect(result.remote).toBe("upstream");
+      expect(result.lastFetchedAt).toBeNull();
+    });
+
+    it("keeps one remote's failure out of another's backoff", async () => {
+      mockGetGitCommonDir.mockReturnValue("/repo/.git");
+      mockCreateBackgroundFetchGit.mockReturnValue({
+        raw: vi
+          .fn()
+          .mockImplementation((args: string[]) =>
+            args[1] === "upstream"
+              ? Promise.reject(new Error("Authentication failed for 'https://x'"))
+              : Promise.resolve()
+          ),
+      });
+
+      const coord = new RepoFetchCoordinator();
+      await coord.fetchForWorktree({
+        worktreeId: "wt1",
+        worktreePath: "/repo",
+        remotes: ["origin", "upstream"],
+        primaryRemote: "upstream",
+      });
+
+      expect(coord.hasFailureFor("/repo/.git", "upstream")).toBe(true);
+      expect(coord.hasFailureFor("/repo/.git", "origin")).toBe(false);
+      // origin fetched cleanly, so it carries a timestamp; upstream does not.
+      expect(coord.getLastSuccessfulFetch("/repo/.git", "origin")).not.toBeNull();
+      expect(coord.getLastSuccessfulFetch("/repo/.git", "upstream")).toBeNull();
+      // The repo-wide diagnostic still reports that something is failing.
+      expect(coord.hasFailureFor("/repo/.git")).toBe(true);
+    });
+
+    it("does not let a second remote advance the first's auth retry count", async () => {
+      mockGetGitCommonDir.mockReturnValue("/repo/.git");
+      mockCreateBackgroundFetchGit.mockReturnValue(
+        makeMockGit(() => Promise.reject(new Error("Authentication failed for 'https://x'")))
+      );
+
+      const onAuthFailureConfirmed = vi.fn();
+      const coord = new RepoFetchCoordinator({ onAuthFailureConfirmed });
+
+      // Both remotes fail on every round. Confirmation must still take the
+      // full number of rounds per remote — two remotes failing once each is
+      // not the same evidence as one remote failing twice.
+      await coord.fetchForWorktree({
+        worktreeId: "wt1",
+        worktreePath: "/repo",
+        remotes: ["origin", "upstream"],
+        primaryRemote: "upstream",
+      });
+      expect(onAuthFailureConfirmed).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(5 * 60_000 + 1_000);
+      await coord.fetchForWorktree({
+        worktreeId: "wt1",
+        worktreePath: "/repo",
+        remotes: ["origin", "upstream"],
+        primaryRemote: "upstream",
+      });
+      expect(onAuthFailureConfirmed).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(15 * 60_000 + 1_000);
+      await coord.fetchForWorktree({
+        worktreeId: "wt1",
+        worktreePath: "/repo",
+        remotes: ["origin", "upstream"],
+        primaryRemote: "upstream",
+      });
+
+      // Each remote confirms on its own third round, and each reports itself.
+      const confirmedRemotes = onAuthFailureConfirmed.mock.calls.map((call) => call[1]);
+      expect(new Set(confirmedRemotes)).toEqual(new Set(["origin", "upstream"]));
+    });
+
+    it("fires one success notification per batch, not one per remote", async () => {
+      mockGetGitCommonDir.mockReturnValue("/repo/.git");
+      mockCreateBackgroundFetchGit.mockReturnValue(makeMockGit(() => Promise.resolve()));
+
+      const onFetchSuccess = vi.fn();
+      const coord = new RepoFetchCoordinator({ onFetchSuccess });
+      await coord.fetchForWorktree({
+        worktreeId: "wt1",
+        worktreePath: "/repo",
+        remotes: ["origin", "upstream"],
+        primaryRemote: "upstream",
+      });
+
+      expect(onFetchSuccess).toHaveBeenCalledTimes(1);
+    });
+
+    it("serializes every remote of a repo on one chain", async () => {
+      mockGetGitCommonDir.mockReturnValue("/repo/.git");
+      let concurrent = 0;
+      let maxConcurrent = 0;
+      mockCreateBackgroundFetchGit.mockReturnValue({
+        raw: vi.fn().mockImplementation(async () => {
+          concurrent += 1;
+          maxConcurrent = Math.max(maxConcurrent, concurrent);
+          await Promise.resolve();
+          concurrent -= 1;
+        }),
+      });
+
+      const coord = new RepoFetchCoordinator();
+      await Promise.all([
+        coord.fetchForWorktree({
+          worktreeId: "wtA",
+          worktreePath: "/repo/a",
+          remotes: ["origin", "upstream"],
+          primaryRemote: "upstream",
+        }),
+        coord.fetchForWorktree({
+          worktreeId: "wtB",
+          worktreePath: "/repo/b",
+          remotes: ["origin", "upstream"],
+          primaryRemote: "upstream",
+        }),
+      ]);
+
+      // Refs are shared through the commondir, so concurrent fetches race on
+      // packed-refs.lock regardless of which remote each one targets.
+      expect(maxConcurrent).toBe(1);
+    });
+
+    it("clears auth failures across every remote", async () => {
+      mockGetGitCommonDir.mockReturnValue("/repo/.git");
+      mockCreateBackgroundFetchGit.mockReturnValue(
+        makeMockGit(() => Promise.reject(new Error("Authentication failed for 'https://x'")))
+      );
+
+      const coord = new RepoFetchCoordinator();
+      await coord.fetchForWorktree({
+        worktreeId: "wt1",
+        worktreePath: "/repo",
+        remotes: ["origin", "upstream"],
+        primaryRemote: "upstream",
+      });
+      expect(coord.hasFailureFor("/repo/.git", "origin")).toBe(true);
+      expect(coord.hasFailureFor("/repo/.git", "upstream")).toBe(true);
+
+      // A credential refresh is not remote-specific; leaving a sibling
+      // suspended would make the user's retry look ineffective.
+      coord.clearAuthFailures();
+
+      expect(coord.hasFailureFor("/repo/.git", "origin")).toBe(false);
+      expect(coord.hasFailureFor("/repo/.git", "upstream")).toBe(false);
+    });
   });
 });

--- a/electron/workspace-host/__tests__/SnapshotBuilder.test.ts
+++ b/electron/workspace-host/__tests__/SnapshotBuilder.test.ts
@@ -50,6 +50,7 @@ function makeHost(overrides: Partial<SnapshotBuilderHost> = {}): SnapshotBuilder
     baseAheadCount: null,
     baseBehindCount: null,
     baseMatchesUpstream: undefined,
+    baseCompareRef: null,
     lastFetchedAt: null,
     lastGitStatusCheckedAt: 0,
     workingTreeChangedAt: 0,

--- a/electron/workspace-host/__tests__/WorkspaceService.fetchPRBranch.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.fetchPRBranch.test.ts
@@ -134,6 +134,29 @@ describe("WorkspaceService.fetchPRBranch", () => {
     vi.restoreAllMocks();
   });
 
+  it("fetches from the resolved forge remote when it is not origin", async () => {
+    mockSimpleGit.raw.mockResolvedValueOnce("");
+
+    await service.fetchPRBranch("req-fork", "/test/root", 42, "feature/my-branch", "upstream");
+
+    // With GitHub configured as `upstream`, a fetch from origin fails with
+    // "couldn't find remote ref pull/42/head" — the PR ref only exists on the
+    // repository the PR was opened against (#11747).
+    expect(mockSimpleGit.raw).toHaveBeenCalledWith([
+      "fetch",
+      "upstream",
+      "pull/42/head:feature/my-branch",
+    ]);
+  });
+
+  it("falls back to origin when no remote could be resolved", async () => {
+    mockSimpleGit.raw.mockResolvedValueOnce("");
+
+    await service.fetchPRBranch("req-default", "/test/root", 7, "feature/x", undefined);
+
+    expect(mockSimpleGit.raw).toHaveBeenCalledWith(["fetch", "origin", "pull/7/head:feature/x"]);
+  });
+
   it("should fetch PR branch using createAuthenticatedGit and emit success", async () => {
     const { createAuthenticatedGit } = await import("../../utils/hardenedGit.js");
     const { createHardenedGit } = await import("../../utils/hardenedGit.js");

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -173,6 +173,14 @@ export interface WorktreeSnapshot {
   baseMatchesUpstream?: boolean;
 
   /**
+   * The ref the base counts were measured against — `upstream/main`, or a bare
+   * `main` on the local fallback. Named in the badge tooltip so a multi-remote
+   * repo the resolution still gets wrong reads as obviously wrong rather than
+   * silently wrong (#11747).
+   */
+  baseCompareRef?: string | null;
+
+  /**
    * Epoch ms of the last successful background `git fetch` for this worktree's
    * repo. Mirrored from `RepoFetchCoordinator` so siblings sharing a commondir
    * see the same timestamp. `null` until the first success lands.
@@ -399,6 +407,11 @@ export type WorkspaceHostRequest =
       rootPath: string;
       prNumber: number;
       headRefName: string;
+      /**
+       * Forge remote the PR ref lives on, resolved in main. Omitted falls back
+       * to `origin` (#11747).
+       */
+      remoteName?: string;
     }
   // Git operations
   | {

--- a/shared/types/worktree.ts
+++ b/shared/types/worktree.ts
@@ -257,6 +257,14 @@ export interface Worktree {
   baseMatchesUpstream?: boolean;
 
   /**
+   * The ref the base counts were measured against — `upstream/main`, or a bare
+   * `main` on the local fallback. Named in the badge tooltip so a multi-remote
+   * repo the resolution still gets wrong reads as obviously wrong rather than
+   * silently wrong (#11747).
+   */
+  baseCompareRef?: string | null;
+
+  /**
    * Epoch ms of the last successful background `git fetch` for this worktree's
    * repo. Mirrors `RepoFetchCoordinator`'s per-commondir `lastSuccessfulFetch`
    * so all sibling worktrees sharing a `.git/objects` see the same timestamp.

--- a/shared/utils/__tests__/baseRemoteSelection.test.ts
+++ b/shared/utils/__tests__/baseRemoteSelection.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from "vitest";
+import { resolveBaseCompareRef, planFetchRemotes } from "../baseRemoteSelection.js";
+
+describe("resolveBaseCompareRef", () => {
+  it("resolves nothing when the repo has no remotes", () => {
+    expect(
+      resolveBaseCompareRef({
+        baseBranch: "main",
+        trackedRef: null,
+        remotesWithBaseRef: [],
+        availableRemotes: [],
+      })
+    ).toEqual({ compareRef: null, remote: null });
+  });
+
+  it("uses the base branch's own tracking ref over any heuristic", () => {
+    const { compareRef, remote } = resolveBaseCompareRef({
+      baseBranch: "main",
+      trackedRef: "refs/remotes/upstream/main",
+      remotesWithBaseRef: ["origin", "upstream"],
+      availableRemotes: ["origin", "upstream"],
+    });
+    expect(compareRef).toBe("upstream/main");
+    expect(remote).toBe("upstream");
+  });
+
+  it("keeps the tracked ref's own branch name when it differs from the base branch", () => {
+    // `branch.develop.merge = refs/heads/main` — the remote branch is named
+    // differently, so appending the base branch would build a ref that doesn't
+    // exist.
+    const { compareRef } = resolveBaseCompareRef({
+      baseBranch: "develop",
+      trackedRef: "refs/remotes/upstream/main",
+      remotesWithBaseRef: [],
+      availableRemotes: ["origin", "upstream"],
+    });
+    expect(compareRef).toBe("upstream/main");
+  });
+
+  it("prefers upstream over origin when both carry the base and nothing is configured", () => {
+    // The reported bug: origin is the fork, so measuring against it reads ~0
+    // behind while the branch trails the canonical repo.
+    const { compareRef, remote } = resolveBaseCompareRef({
+      baseBranch: "main",
+      trackedRef: null,
+      remotesWithBaseRef: ["origin", "upstream"],
+      availableRemotes: ["origin", "upstream"],
+    });
+    expect(compareRef).toBe("upstream/main");
+    expect(remote).toBe("upstream");
+  });
+
+  it("selects origin when it is the only remote carrying the base branch", () => {
+    const { compareRef, remote } = resolveBaseCompareRef({
+      baseBranch: "main",
+      trackedRef: null,
+      remotesWithBaseRef: ["origin"],
+      availableRemotes: ["origin", "heroku"],
+    });
+    expect(compareRef).toBe("origin/main");
+    expect(remote).toBe("origin");
+  });
+
+  it("falls back to listing order when neither preferred name is present", () => {
+    const { remote } = resolveBaseCompareRef({
+      baseBranch: "main",
+      trackedRef: null,
+      remotesWithBaseRef: ["mirror", "canonical"],
+      availableRemotes: ["mirror", "canonical"],
+    });
+    expect(remote).toBe("mirror");
+  });
+
+  it("preserves a slash-bearing base branch in the compare ref", () => {
+    const { compareRef } = resolveBaseCompareRef({
+      baseBranch: "release/2.0",
+      trackedRef: null,
+      remotesWithBaseRef: ["origin"],
+      availableRemotes: ["origin"],
+    });
+    expect(compareRef).toBe("origin/release/2.0");
+  });
+
+  it("splits a slash-bearing remote name at the right boundary", () => {
+    const { compareRef, remote } = resolveBaseCompareRef({
+      baseBranch: "main",
+      trackedRef: "refs/remotes/team/fork/main",
+      remotesWithBaseRef: [],
+      availableRemotes: ["team/fork"],
+    });
+    expect(remote).toBe("team/fork");
+    expect(compareRef).toBe("team/fork/main");
+  });
+
+  it("treats the local pseudo-remote as unresolved rather than fetchable", () => {
+    // `branch.main.remote = .` tracks another local branch; there is no
+    // remote-tracking ref to diff against and nothing to fetch.
+    expect(
+      resolveBaseCompareRef({
+        baseBranch: "main",
+        trackedRef: null,
+        remotesWithBaseRef: ["."],
+        availableRemotes: ["."],
+      })
+    ).toEqual({ compareRef: null, remote: null });
+  });
+
+  it("ignores candidates that are not in the remote table", () => {
+    // A leftover refs/remotes/ tree after `git remote remove` must not become
+    // a fetch target.
+    const { compareRef, remote } = resolveBaseCompareRef({
+      baseBranch: "main",
+      trackedRef: null,
+      remotesWithBaseRef: ["ghost", "origin"],
+      availableRemotes: ["origin"],
+    });
+    expect(remote).toBe("origin");
+    expect(compareRef).toBe("origin/main");
+  });
+
+  it("ignores a tracked ref whose remote is no longer in the table", () => {
+    const { compareRef } = resolveBaseCompareRef({
+      baseBranch: "main",
+      trackedRef: "refs/remotes/gone/main",
+      remotesWithBaseRef: [],
+      availableRemotes: ["origin"],
+    });
+    expect(compareRef).toBeNull();
+  });
+
+  it("ignores a tracked ref that is not under refs/remotes", () => {
+    const { compareRef } = resolveBaseCompareRef({
+      baseBranch: "main",
+      trackedRef: "refs/heads/main",
+      remotesWithBaseRef: [],
+      availableRemotes: ["origin"],
+    });
+    expect(compareRef).toBeNull();
+  });
+});
+
+describe("planFetchRemotes", () => {
+  it("fetches exactly one remote for a single-remote repo", () => {
+    const plan = planFetchRemotes({ baseRemote: "origin", availableRemotes: ["origin"] });
+    expect(plan.remotes).toEqual(["origin"]);
+    expect(plan.primaryRemote).toBe("origin");
+  });
+
+  it("defaults to origin before the first resolution has run", () => {
+    const plan = planFetchRemotes({ baseRemote: null, availableRemotes: [] });
+    expect(plan.remotes).toEqual(["origin"]);
+    expect(plan.primaryRemote).toBe("origin");
+  });
+
+  it("fetches the base remote and origin when they differ, base first", () => {
+    const plan = planFetchRemotes({
+      baseRemote: "upstream",
+      availableRemotes: ["origin", "upstream"],
+    });
+    // Base remote leads: its result is what the card renders, so it must not
+    // queue behind a slow auxiliary fetch.
+    expect(plan.remotes).toEqual(["upstream", "origin"]);
+    expect(plan.primaryRemote).toBe("upstream");
+  });
+
+  it("omits origin when the repo does not have one", () => {
+    const plan = planFetchRemotes({ baseRemote: "upstream", availableRemotes: ["upstream"] });
+    expect(plan.remotes).toEqual(["upstream"]);
+  });
+
+  it("does not invent an origin fetch for a repo whose only remote is named otherwise", () => {
+    const plan = planFetchRemotes({ baseRemote: null, availableRemotes: ["canonical"] });
+    expect(plan.remotes).toEqual(["canonical"]);
+    expect(plan.primaryRemote).toBe("canonical");
+  });
+
+  it("never repeats a remote", () => {
+    const plan = planFetchRemotes({
+      baseRemote: "origin",
+      availableRemotes: ["origin", "upstream"],
+    });
+    expect(plan.remotes).toEqual(["origin"]);
+  });
+
+  it("leaves deploy-remote layouts fetching only origin", () => {
+    // origin genuinely is the code remote; heroku/dokku must stay off the poll
+    // loop.
+    const plan = planFetchRemotes({
+      baseRemote: "origin",
+      availableRemotes: ["origin", "heroku", "dokku"],
+    });
+    expect(plan.remotes).toEqual(["origin"]);
+  });
+});

--- a/shared/utils/baseRemoteSelection.ts
+++ b/shared/utils/baseRemoteSelection.ts
@@ -1,0 +1,180 @@
+const REMOTE_REF_PREFIX = "refs/remotes/";
+
+/**
+ * git's "local repository" pseudo-remote. A branch configured with
+ * `branch.<name>.remote = .` tracks another *local* branch, so there is no
+ * remote-tracking ref to diff against and nothing to fetch.
+ */
+const LOCAL_PSEUDO_REMOTE = ".";
+
+export interface ResolveBaseCompareRefInputs {
+  /** The branch the worktree measures itself against (`main`, `release/2.0`). */
+  baseBranch: string;
+  /**
+   * `<baseBranch>@{upstream}` resolved to a full ref
+   * (`refs/remotes/upstream/main`), or `null` when the base branch has no
+   * local counterpart or no tracking config.
+   *
+   * Deliberately the *resolved ref* rather than `branch.<base>.remote`: a
+   * branch may track a differently-named remote branch
+   * (`branch.develop.merge = refs/heads/main`), and appending `/<baseBranch>`
+   * to a bare remote name would build a ref that doesn't exist.
+   */
+  trackedRef: string | null;
+  /** Remote names that actually carry `refs/remotes/<remote>/<baseBranch>`. */
+  remotesWithBaseRef: readonly string[];
+  /** `git remote` output — the remotes that exist at all. */
+  availableRemotes: readonly string[];
+}
+
+export interface BaseCompareRefSelection {
+  /**
+   * Short ref to diff against (`upstream/main`), or `null` when nothing
+   * resolved — callers keep their existing `origin/<base>` → local-`<base>`
+   * fallback chain, so single-remote and no-remote repos are unaffected.
+   */
+  compareRef: string | null;
+  /**
+   * Remote `compareRef` lives on. This is the remote background fetch has to
+   * refresh; a resolved ref that is never fetched is just a different way to
+   * be stale.
+   */
+  remote: string | null;
+}
+
+/**
+ * Pick the remote-tracking ref the base-branch divergence should compare
+ * against. Pure function — no I/O, no registry import, no main-process
+ * bindings — so the workspace-host UtilityProcess and the renderer can both
+ * import it (same constraint as `forgeRemoteSelection`, issue #8316).
+ *
+ * Precedence (issue #11747):
+ *
+ *   1. The base branch's own tracking ref, when it has one. Explicit git
+ *      config beats any heuristic: the user already answered the question.
+ *   2. Otherwise the remotes that actually carry the base branch, ranked by
+ *      {@link NAME_PREFERENCE}.
+ *   3. Otherwise `null` — the caller keeps today's behavior.
+ *
+ * Fails SOFT throughout, which is the opposite of `resolveForgeRemote`'s
+ * fail-closed contract, and deliberately so: this feeds a *displayed count*,
+ * while `resolveForgeRemote` backs mutations where substituting a repository
+ * could redirect a write to a fork. The worst case here is the pre-fix
+ * behavior, so there is no configuration in which this resolver makes a repo
+ * worse off than it is today.
+ */
+export function resolveBaseCompareRef(
+  inputs: ResolveBaseCompareRefInputs
+): BaseCompareRefSelection {
+  const { baseBranch, trackedRef, remotesWithBaseRef, availableRemotes } = inputs;
+
+  const tracked = parseRemoteRef(trackedRef, availableRemotes);
+  if (tracked) return tracked;
+
+  const candidates = remotesWithBaseRef.filter(
+    (remote) => remote !== LOCAL_PSEUDO_REMOTE && availableRemotes.includes(remote)
+  );
+  if (candidates.length === 0) return { compareRef: null, remote: null };
+
+  const remote = preferByName(candidates);
+  return { compareRef: `${remote}/${baseBranch}`, remote };
+}
+
+export interface FetchRemotePlanInputs {
+  /** Remote the base divergence compares against, or `null` if unresolved. */
+  baseRemote: string | null;
+  /** `git remote` output. Empty before the first resolution has run. */
+  availableRemotes: readonly string[];
+}
+
+export interface FetchRemotePlan {
+  /** Remotes background fetch should refresh, primary first, deduped. */
+  remotes: string[];
+  /** The remote whose freshness the displayed counts depend on. */
+  primaryRemote: string;
+}
+
+/**
+ * Decide which remotes a worktree's background fetch has to refresh.
+ *
+ * Two remotes are read on a fork layout and both must be fresh: the base
+ * remote, which the `↓N behind` count is measured against, and `origin`, which
+ * normally carries the branch's own `@{u}` and therefore the top-line
+ * ahead/behind counts. On the single-remote repos that are the overwhelming
+ * majority these collapse to one entry, so the common case still issues
+ * exactly one `git fetch` — the same one it issued before #11747.
+ *
+ * `origin` is included only when the repo actually has it. A repo whose sole
+ * remote is named something else must not acquire a guaranteed-failing
+ * `git fetch origin` that would then occupy a real backoff slot.
+ */
+export function planFetchRemotes(inputs: FetchRemotePlanInputs): FetchRemotePlan {
+  const { baseRemote, availableRemotes } = inputs;
+  const hasOrigin = availableRemotes.includes(DEFAULT_REMOTE);
+
+  // Before the first divergence resolution lands, `availableRemotes` is empty
+  // and this returns plain `origin` — byte-identical to the pre-#11747
+  // behavior, and self-correcting on the next poll.
+  const primaryRemote =
+    baseRemote ??
+    (hasOrigin || availableRemotes.length === 0 ? DEFAULT_REMOTE : availableRemotes[0]!);
+
+  const remotes = [primaryRemote];
+  if (hasOrigin && !remotes.includes(DEFAULT_REMOTE)) remotes.push(DEFAULT_REMOTE);
+  return { remotes, primaryRemote };
+}
+
+/** git's conventional default remote, and the pre-#11747 hardcoded one. */
+const DEFAULT_REMOTE = "origin";
+
+/**
+ * Split `refs/remotes/<remote>/<branch>` into its remote and short-ref parts.
+ *
+ * Remote names may themselves contain `/`, so the boundary can't be found by
+ * position — it's resolved by testing the known remote names longest-first,
+ * which makes `foo/bar` win over a hypothetical `foo` for
+ * `refs/remotes/foo/bar/main`.
+ */
+function parseRemoteRef(
+  fullRef: string | null,
+  availableRemotes: readonly string[]
+): BaseCompareRefSelection | null {
+  if (!fullRef || !fullRef.startsWith(REMOTE_REF_PREFIX)) return null;
+  const shortRef = fullRef.slice(REMOTE_REF_PREFIX.length);
+  if (!shortRef) return null;
+
+  const byLongestName = [...availableRemotes].sort((a, b) => b.length - a.length);
+  for (const remote of byLongestName) {
+    if (remote === LOCAL_PSEUDO_REMOTE) continue;
+    if (shortRef.startsWith(`${remote}/`) && shortRef.length > remote.length + 1) {
+      return { compareRef: shortRef, remote };
+    }
+  }
+  return null;
+}
+
+/**
+ * `upstream` before `origin` before everything else.
+ *
+ * Deliberately the INVERSE of `forgeRemoteSelection`'s origin-first ladder,
+ * because the two resolvers answer different questions. That one picks the
+ * repository the forge integration talks to, where preferring origin keeps
+ * the toolbar and the PR badges on one repo. This one picks the ref that
+ * represents "the canonical base I might be behind" — and on the fork layout
+ * this issue is about (`origin` = your fork, `upstream` = canonical), origin
+ * is precisely the ref that reads `↓0` while the branch sits hundreds of
+ * commits behind. `upstream` has exactly one conventional meaning in git and
+ * it is this one.
+ *
+ * Only reached when the base branch has no tracking config AND more than one
+ * remote carries it, so single-remote repos never observe the difference.
+ */
+const NAME_PREFERENCE = ["upstream", "origin"];
+
+function preferByName(remotes: readonly string[]): string {
+  for (const name of NAME_PREFERENCE) {
+    if (remotes.includes(name)) return name;
+  }
+  // Non-null: the caller has already checked for a non-empty list.
+  return remotes[0]!;
+}

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -415,13 +415,18 @@ export function NewWorktreeDialog({
         if (initialPR?.headRef) {
           // Any remote may carry the PR head — on a fork layout the forge is
           // `upstream`, not `origin` (#11747). Matched as an exact
-          // `<remote>/<headRef>` rather than a suffix so a head named `x`
-          // can't match `origin/feature/x`; `origin` only breaks ties.
+          // `<remote>/<headRef>` rather than a suffix, so a head named `x`
+          // can't match `origin/feature/x`.
           const remoteCandidates = branchList.filter(
             (b) => b.remote && b.name === `${b.remote}/${initialPR.headRef}`
           );
-          const remoteBranch =
-            remoteCandidates.find((b) => b.remote === "origin") ?? remoteCandidates[0];
+          // A branch name is not a PR identity. When two remotes both carry the
+          // name they may be different commits, and this component has no way
+          // to tell which repo the PR belongs to — picking either could build
+          // the worktree from the wrong commit. Fall through to the PR-number
+          // fetch, which is authoritative. One match is unambiguous enough to
+          // keep the fast path (and is the single-remote case).
+          const remoteBranch = remoteCandidates.length === 1 ? remoteCandidates[0] : undefined;
           const localBranch = branchList.find((b) => b.name === initialPR.headRef && !b.remote);
           if (remoteBranch) {
             setBaseBranch(remoteBranch.name);

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -413,11 +413,18 @@ export function NewWorktreeDialog({
         setBranches(branchList);
 
         if (initialPR?.headRef) {
-          const remoteBranchName = `origin/${initialPR.headRef}`;
-          const remoteBranch = branchList.find((b) => b.name === remoteBranchName);
+          // Any remote may carry the PR head — on a fork layout the forge is
+          // `upstream`, not `origin` (#11747). Matched as an exact
+          // `<remote>/<headRef>` rather than a suffix so a head named `x`
+          // can't match `origin/feature/x`; `origin` only breaks ties.
+          const remoteCandidates = branchList.filter(
+            (b) => b.remote && b.name === `${b.remote}/${initialPR.headRef}`
+          );
+          const remoteBranch =
+            remoteCandidates.find((b) => b.remote === "origin") ?? remoteCandidates[0];
           const localBranch = branchList.find((b) => b.name === initialPR.headRef && !b.remote);
           if (remoteBranch) {
-            setBaseBranch(remoteBranchName);
+            setBaseBranch(remoteBranch.name);
             setFromRemote(true);
             setPrBranchResolved(true);
           } else if (localBranch) {

--- a/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
+++ b/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
@@ -107,6 +107,7 @@ export function NonMainSecondaryRow({
       baseAheadCount={worktree.baseAheadCount}
       baseBehindCount={worktree.baseBehindCount}
       baseMatchesUpstream={worktree.baseMatchesUpstream}
+      baseCompareRef={worktree.baseCompareRef}
       fetchIntervalMs={fetchIntervalMs}
     />
   ) : null;

--- a/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
@@ -20,6 +20,13 @@ interface UpstreamSyncBadgeProps {
   baseAheadCount?: number | null;
   baseBehindCount?: number | null;
   baseMatchesUpstream?: boolean;
+  /**
+   * Ref the base counts were measured against (`upstream/main`). Named in the
+   * tooltip while the compact pill keeps the bare branch name — the pill is
+   * scanned across a dozen cards, the tooltip is where the disambiguation
+   * belongs.
+   */
+  baseCompareRef?: string | null;
   fetchIntervalMs?: number;
 }
 
@@ -39,6 +46,7 @@ export function UpstreamSyncBadge({
   baseAheadCount,
   baseBehindCount,
   baseMatchesUpstream,
+  baseCompareRef,
   fetchIntervalMs,
 }: UpstreamSyncBadgeProps) {
   const hasAhead = aheadCount !== undefined && aheadCount > 0;
@@ -198,19 +206,19 @@ export function UpstreamSyncBadge({
           <div className="text-text-muted/70">
             {baseAheadCount != null && baseAheadCount > 0 && (
               <span>
-                {baseAheadCount} ahead of {baseBranchName}
+                {baseAheadCount} ahead of {baseCompareRef || baseBranchName}
               </span>
             )}
             {baseBehindCount != null && baseBehindCount > 0 && (
               <span>
-                {baseBehindCount} behind {baseBranchName}
+                {baseBehindCount} behind {baseCompareRef || baseBranchName}
               </span>
             )}
           </div>
         )}
         {fetchNetworkFailed && (
           <div className="text-status-warning/80" data-testid="upstream-sync-network-warning">
-            Couldn't reach origin
+            Couldn't reach the remote
           </div>
         )}
         {isStale && lastFetchedAt != null && (

--- a/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.compareRef.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.compareRef.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+// The real tooltip lazy-loads Radix and renders nothing until it resolves, so
+// its content is invisible to jsdom. Flatten it — these tests are about the
+// tooltip's copy, which is where #11747 names the ref it compared against.
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/lib/formatRelativeTime", () => ({
+  formatRelativeTime: () => "just now",
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn() },
+}));
+
+import { UpstreamSyncBadge } from "../UpstreamSyncBadge";
+
+type Props = Parameters<typeof UpstreamSyncBadge>[0];
+
+const baseProps: Props = {
+  aheadCount: 0,
+  behindCount: 0,
+  isFetchInFlight: false,
+  lastFetchedAt: Date.now(),
+  fetchAuthFailed: false,
+  fetchNetworkFailed: false,
+  hasAuthFailedSignIn: false,
+  containerGapClass: "gap-1.5",
+  baseBranchName: "main",
+  baseAheadCount: 0,
+  baseBehindCount: 200,
+  baseMatchesUpstream: false,
+};
+
+function renderBadge(extra: Partial<Props> = {}) {
+  return render(<UpstreamSyncBadge {...baseProps} {...extra} />);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("UpstreamSyncBadge — base compare ref (#11747)", () => {
+  it("names the resolved remote ref in the tooltip, not just the branch", () => {
+    // On a fork layout the canonical base lives on `upstream`. Naming the ref
+    // is what turns a still-wrong resolution from silently wrong into
+    // obviously wrong.
+    renderBadge({ baseCompareRef: "upstream/main" });
+
+    expect(document.body.textContent).toContain("200 behind upstream/main");
+  });
+
+  it("keeps the compact pill on the bare branch name", () => {
+    renderBadge({ baseCompareRef: "upstream/main" });
+
+    // The pill is scanned across a dozen cards; the disambiguation belongs in
+    // the tooltip, not in the dense triage row.
+    const pill = screen.getByTestId("upstream-sync-indicator");
+    expect(pill.textContent).toContain("main");
+    expect(pill.textContent).not.toContain("upstream/");
+  });
+
+  it("falls back to the branch name when no compare ref was resolved", () => {
+    renderBadge({ baseCompareRef: null, baseBehindCount: 4 });
+
+    expect(document.body.textContent).toContain("4 behind main");
+  });
+
+  it("names the compare ref on the ahead line too", () => {
+    renderBadge({ baseBehindCount: 0, baseAheadCount: 6, baseCompareRef: "upstream/main" });
+
+    expect(document.body.textContent).toContain("6 ahead of upstream/main");
+  });
+
+  it("does not name a specific remote in the unreachable-remote warning", () => {
+    // The fetch that failed may not have been origin at all once a repo
+    // refreshes more than one remote.
+    renderBadge({ fetchNetworkFailed: true });
+
+    const warning = screen.getByTestId("upstream-sync-network-warning");
+    expect(warning.textContent).not.toContain("origin");
+  });
+});

--- a/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
+++ b/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
@@ -786,6 +786,68 @@ describe("NewWorktreeDialog — branch list cache", () => {
     expect(document.getElementById("base-branch")?.textContent).toContain("main");
   });
 
+  it("resolves a PR head that lives on a non-origin remote without re-fetching", async () => {
+    // Fork layout: the forge is `upstream`, so the PR head is only ever
+    // tracked as `upstream/<headRef>` (#11747). Probing `origin/<headRef>`
+    // misses it and triggers a redundant fetch.
+    mockListBranches.mockResolvedValue([
+      { name: "main", current: true, commit: "abc123" },
+      { name: "upstream/feature/test", current: false, commit: "zzz999", remote: "upstream" },
+    ]);
+    renderDialog({
+      initialPR: {
+        number: 42,
+        title: "Test PR",
+        body: "",
+        headRef: "feature/test",
+        baseRef: "main",
+        state: "open",
+        rawState: "OPEN",
+        url: "https://github.com/test/repo/pull/42",
+        author: { login: "user", avatarUrl: "", rawData: null },
+        isDraft: false,
+        merged: false,
+        createdAt: 0,
+        updatedAt: 0,
+        rawData: null,
+      },
+    });
+    await advanceTimersGradually(500);
+
+    expect(mockFetchPRBranch).not.toHaveBeenCalled();
+    expect(document.getElementById("base-branch")?.textContent).toContain("upstream/feature/test");
+  });
+
+  it("does not mistake a nested branch for the PR head", async () => {
+    // `origin/feature/test` must not satisfy a head named `test` — an exact
+    // `<remote>/<headRef>` match, not a suffix match.
+    mockListBranches.mockResolvedValue([
+      { name: "main", current: true, commit: "abc123" },
+      { name: "origin/feature/test", current: false, commit: "zzz999", remote: "origin" },
+    ]);
+    renderDialog({
+      initialPR: {
+        number: 43,
+        title: "Test PR",
+        body: "",
+        headRef: "test",
+        baseRef: "main",
+        state: "open",
+        rawState: "OPEN",
+        url: "https://github.com/test/repo/pull/43",
+        author: { login: "user", avatarUrl: "", rawData: null },
+        isDraft: false,
+        merged: false,
+        createdAt: 0,
+        updatedAt: 0,
+        rawData: null,
+      },
+    });
+    await advanceTimersGradually(500);
+
+    expect(mockFetchPRBranch).toHaveBeenCalledWith("/test/root", 43, "test");
+  });
+
   it("bypasses the cache and keeps the skeleton for PR checkout opens", async () => {
     renderDialog();
     await advanceTimersGradually(500);

--- a/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
+++ b/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
@@ -818,6 +818,39 @@ describe("NewWorktreeDialog — branch list cache", () => {
     expect(document.getElementById("base-branch")?.textContent).toContain("upstream/feature/test");
   });
 
+  it("falls through to the PR fetch when two remotes carry the same head name", async () => {
+    // A branch name is not a PR identity: origin/feature/test and
+    // upstream/feature/test can be different commits, and the dialog has no
+    // way to tell which repo the PR belongs to. Building from the wrong one is
+    // worse than paying for the authoritative PR-number fetch.
+    mockListBranches.mockResolvedValue([
+      { name: "main", current: true, commit: "abc123" },
+      { name: "origin/feature/test", current: false, commit: "aaa111", remote: "origin" },
+      { name: "upstream/feature/test", current: false, commit: "bbb222", remote: "upstream" },
+    ]);
+    renderDialog({
+      initialPR: {
+        number: 44,
+        title: "Test PR",
+        body: "",
+        headRef: "feature/test",
+        baseRef: "main",
+        state: "open",
+        rawState: "OPEN",
+        url: "https://github.com/test/repo/pull/44",
+        author: { login: "user", avatarUrl: "", rawData: null },
+        isDraft: false,
+        merged: false,
+        createdAt: 0,
+        updatedAt: 0,
+        rawData: null,
+      },
+    });
+    await advanceTimersGradually(500);
+
+    expect(mockFetchPRBranch).toHaveBeenCalledWith("/test/root", 44, "feature/test");
+  });
+
   it("does not mistake a nested branch for the PR head", async () => {
     // `origin/feature/test` must not satisfy a head named `test` — an exact
     // `<remote>/<headRef>` match, not a suffix match.

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -1754,6 +1754,7 @@ function snapshotsEqual(a: WorktreeSnapshot, b: WorktreeSnapshot): boolean {
     a.baseAheadCount === b.baseAheadCount &&
     a.baseBehindCount === b.baseBehindCount &&
     a.baseMatchesUpstream === b.baseMatchesUpstream &&
+    a.baseCompareRef === b.baseCompareRef &&
     // lastGitStatusCheckedAt and workingTreeChangedAt are deliberately NOT
     // compared (like `timestamp`): both advance on events that change nothing
     // else in the snapshot, so comparing either here would force a new


### PR DESCRIPTION
## Summary
- The worktree card's `↓N behind` pill compared the current branch against `origin/<base>`. On a fork setup, where `origin` is the user's fork and `upstream` is the canonical repo, this always read `↓0` even while the branch sat hundreds of commits behind. Background fetch only ever fetched `origin`, so a non-origin base ref was never refreshed.
- `fetchPRBranch` ran `git fetch origin pull/<n>/head:<ref>`, which fails outright with `couldn't find remote ref` when GitHub is configured as `upstream` or `github` instead of `origin`.
- This fixes both by resolving the base branch's own remote instead of assuming `origin`, and by fetching the PR head from the resolved forge remote.

Resolves #11747

## Changes
- New pure module `shared/utils/baseRemoteSelection.ts`: `resolveBaseCompareRef` picks the base branch's compare ref, preferring its own tracking ref, then falling back to the remotes that actually carry the base branch (preferring `upstream` over `origin`). `planFetchRemotes` derives the deduped background-fetch set. Importable from the workspace-host `UtilityProcess`, matching the purity constraint on the existing `forgeRemoteSelection` module (#8316).
- Note the deliberate inversion: this resolver prefers `upstream` over `origin`, the opposite of `forgeRemoteSelection`'s order, because the two modules answer different questions. `forgeRemoteSelection` picks the repo the forge talks to; this one picks the canonical base branch the user might be behind. The ordering only matters when the base has no tracking config and more than one remote carries it, so single-remote repos see no change.
- `BaseDivergence.ts`: remote resolution is now cached behind its own stat stamp (shared `config`, per-worktree `config.worktree` for `extensions.worktreeConfig`, `packed-refs`, and each known remote's candidate ref) plus a staleness ceiling, so the per-card poll loop stays free of new process spawns. The resolved ref is part of the divergence cache key and is exposed as `baseCompareRef`.
- `RepoFetchCoordinator.ts`: failure and backoff state is now keyed per remote per common directory, while the serialization chain stays per common directory, since refs are shared and concurrent fetches race on `packed-refs.lock` regardless of remote, but credentials and reachability differ per remote. Remotes are batched into one fetch call, the primary fetches first, and the primary's outcome is what the card renders. Never `--all`.
- PR checkout now fetches the PR head from the resolved forge remote, resolved in the main process via a new `resolveEffectiveForgeRemote`. A stale configured remote fails closed rather than silently falling back to `origin`, since PR numbers are per-repository.
- Badge tooltip now names the ref it compared against, and the unreachable-remote message no longer says `origin`.
- Out of scope: the `pull/<n>/head` refspec stays GitHub, Gitea, and Forgejo shaped. GitLab's `merge-requests/<n>/head` and Bitbucket differ; this fixes which remote gets fetched, not cross-forge PR checkout.
- Single-remote and no-remote repos keep the exact prior behavior (`origin/<base>` then local `<base>`, one `git fetch origin`). Deploy-remote layouts (`origin` plus `heroku` or `dokku`) are unchanged.

## Testing
553 tests across 21 files, all green locally, including a new `shared/utils/__tests__/baseRemoteSelection.test.ts` and new coverage for the fork layout, slash-bearing remote and base names, per-remote backoff isolation, the spawn-free fast path, and non-origin PR checkout.