### PR TITLE
fix(copytree): resolve worktrees by sender view, not by window

### DIFF
--- a/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
@@ -240,7 +240,6 @@ describe("copyTree handlers", () => {
         },
         ptyClient: { hasTerminal: vi.fn(() => false), write: vi.fn() },
         worktreeService: {
-          getAllStatesAsync: vi.fn().mockResolvedValue([{ id: "wt-1", path: "/wt-1" }]),
           getAllStatesForProjectAsync: vi.fn().mockResolvedValue([{ id: "wt-1", path: "/wt-1" }]),
           testConfig,
         },
@@ -306,7 +305,6 @@ describe("copyTree handlers", () => {
         },
         ptyClient: { hasTerminal: vi.fn(() => false), write: vi.fn() },
         worktreeService: {
-          getAllStatesAsync: vi.fn().mockResolvedValue([{ id: "wt-1", path: "/wt-1" }]),
           getAllStatesForProjectAsync: vi.fn().mockResolvedValue([{ id: "wt-1", path: "/wt-1" }]),
           getContextFileTree,
           getFileTree,
@@ -562,6 +560,7 @@ describe("copyTree handlers", () => {
         payload: {},
         optionsArgIndex: 1,
         acceptsRuntimeOptions: true,
+        refusalMode: "return" as const,
       },
       {
         channel: CHANNELS.COPYTREE_GENERATE,
@@ -569,6 +568,7 @@ describe("copyTree handlers", () => {
         payload: {},
         optionsArgIndex: 1,
         acceptsRuntimeOptions: true,
+        refusalMode: "return" as const,
       },
       {
         channel: CHANNELS.COPYTREE_GENERATE_AND_COPY_FILE,
@@ -576,6 +576,7 @@ describe("copyTree handlers", () => {
         payload: {},
         optionsArgIndex: 1,
         acceptsRuntimeOptions: true,
+        refusalMode: "return" as const,
       },
       {
         channel: CHANNELS.COPYTREE_INJECT,
@@ -583,6 +584,7 @@ describe("copyTree handlers", () => {
         payload: { terminalId: "term-1" },
         optionsArgIndex: 1,
         acceptsRuntimeOptions: true,
+        refusalMode: "return" as const,
       },
       {
         // The listing takes no per-call options: it answers for the project's
@@ -593,6 +595,9 @@ describe("copyTree handlers", () => {
         payload: {},
         optionsArgIndex: 2,
         acceptsRuntimeOptions: false,
+        // The listing is the one channel that rejects rather than resolving an
+        // error field; its callers await a tree, not a result envelope.
+        refusalMode: "throw" as const,
       },
     ];
 
@@ -602,30 +607,39 @@ describe("copyTree handlers", () => {
     }
 
     /**
-     * The message for a refused worktree, whichever shape the channel uses:
-     * get-file-tree rejects, the rest resolve with an `error` field. Written to
-     * accept either so a channel that changed shape can't quietly pass.
+     * The message for a refused worktree, asserted through the shape that
+     * channel is contracted to use: get-file-tree rejects, the other four
+     * resolve with an `error` field. Asserting the shape rather than accepting
+     * either is the point — a handler that started throwing where the renderer
+     * expects a resolved `{ error }` would break every caller, so a helper that
+     * normalized both would hide exactly the regression worth catching.
      */
     async function invokeExpectingRefusal(
       channel: string,
+      refusalMode: "throw" | "return",
       extraPayload: Record<string, unknown>
     ): Promise<string | undefined> {
       const handler = getInvokeHandler(channel);
-      try {
-        const result = (await handler(mockEvent, {
-          worktreeId: "wt-1",
-          options: {},
-          ...extraPayload,
-        })) as { error?: string } | undefined;
-        return result?.error;
-      } catch (error) {
-        return (error as Error).message;
+      const call = () => handler(mockEvent, { worktreeId: "wt-1", options: {}, ...extraPayload });
+
+      if (refusalMode === "throw") {
+        return await call().then(
+          (result) => {
+            throw new Error(
+              `${channel} resolved with ${JSON.stringify(result)} but must reject on a refused worktree`
+            );
+          },
+          (error: Error) => error.message
+        );
       }
+
+      const result = (await call()) as { error?: string } | undefined;
+      return result?.error;
     }
 
     describe.each(SCOPED_CALL_SITES)(
       "$channel",
-      ({ channel, seam, payload, optionsArgIndex, acceptsRuntimeOptions }) => {
+      ({ channel, seam, payload, optionsArgIndex, acceptsRuntimeOptions, refusalMode }) => {
         it("merges the sender window's project settings, not the globally current project's", async () => {
           aimGlobalSourcesAtGlobalProject();
           const seams = registerWithScope({
@@ -652,7 +666,7 @@ describe("copyTree handlers", () => {
           const depsPvm = makePvm(GLOBAL_PROJECT);
           const seams = registerWithScope({ windowScopedPvm: makePvm(null), depsPvm });
 
-          const error = await invokeExpectingRefusal(channel, payload);
+          const error = await invokeExpectingRefusal(channel, refusalMode, payload);
 
           // An unbound view names no project, and every copyTree channel makes
           // worktreeId mandatory — so there is nothing to resolve it against.
@@ -697,7 +711,7 @@ describe("copyTree handlers", () => {
           // Worktree ids are normalized absolute paths, so a renderer can guess
           // a sibling project's. The window is showing GLOBAL_PROJECT, so the
           // pre-#11751 lookup would have found this and bundled its contents.
-          const error = await invokeExpectingRefusal(channel, {
+          const error = await invokeExpectingRefusal(channel, refusalMode, {
             ...payload,
             worktreeId: ownWorktreeIdFor(GLOBAL_PROJECT),
           });
@@ -719,14 +733,75 @@ describe("copyTree handlers", () => {
           });
           // A scratch is a workspace id with no project row (#11484); scratch
           // switching never invokes the worktree service at all.
-          projectStoreMock.getProjectById.mockReturnValue(null);
+          //
+          // Only the scratch is rowless — every other project still resolves.
+          // Nulling the whole store instead would let a "no row, so use the
+          // current project" regression pass here while, in production, it
+          // bundled the global project's worktree.
+          projectStoreMock.getProjectById.mockImplementation((projectId) =>
+            projectId === "scratch-1"
+              ? null
+              : { id: projectId, path: projectPathFor(projectId), status: "active" }
+          );
 
-          const error = await invokeExpectingRefusal(channel, payload);
+          const error = await invokeExpectingRefusal(channel, refusalMode, payload);
 
           expect(error).toBe("Worktree not found: wt-1");
           expect(seams[seam]).not.toHaveBeenCalled();
           expect(seams.getAllStatesAsync).not.toHaveBeenCalled();
           expect(seams.getAllStatesForProjectAsync).not.toHaveBeenCalled();
+          // ...and it reached for no global project to stand in for the scratch.
+          expect(projectStoreMock.getCurrentProjectId).not.toHaveBeenCalled();
+          expect(projectStoreMock.getProjectSettings).not.toHaveBeenCalled();
+        });
+
+        it("refuses a sender whose project row is closed", async () => {
+          aimGlobalSourcesAtGlobalProject();
+          const seams = registerWithScope({
+            windowScopedPvm: makePvm(SENDER_PROJECT),
+            depsPvm: makePvm(GLOBAL_PROJECT),
+          });
+          // Unlike a scratch, a closed project keeps a row *and* a valid path,
+          // so it would sail through a guard that only checked for existence.
+          // Hydrating it would resurrect a workspace the user closed.
+          projectStoreMock.getProjectById.mockImplementation((projectId) => ({
+            id: projectId,
+            path: projectPathFor(projectId),
+            status: projectId === SENDER_PROJECT ? "closed" : "active",
+          }));
+
+          const error = await invokeExpectingRefusal(channel, refusalMode, payload);
+
+          expect(error).toBe("Worktree not found: wt-1");
+          expect(seams[seam]).not.toHaveBeenCalled();
+          expect(seams.getAllStatesAsync).not.toHaveBeenCalled();
+          expect(seams.getAllStatesForProjectAsync).not.toHaveBeenCalled();
+        });
+
+        it("propagates a host read failure instead of falling back to the window", async () => {
+          aimGlobalSourcesAtGlobalProject();
+          const seams = registerWithScope({
+            windowScopedPvm: makePvm(SENDER_PROJECT),
+            depsPvm: makePvm(GLOBAL_PROJECT),
+          });
+          // A matched, ready host can reject; the scoped read does not swallow
+          // it. A "resilience" catch that retried through the window-scoped
+          // read would reopen the cross-project disclosure this fix closed, so
+          // pin that the failure surfaces and no second lookup is attempted.
+          seams.getAllStatesForProjectAsync.mockRejectedValueOnce(
+            new Error("workspace host unavailable")
+          );
+
+          await expect(
+            getInvokeHandler(channel)(mockEvent, {
+              worktreeId: "wt-1",
+              options: {},
+              ...payload,
+            })
+          ).rejects.toThrow("workspace host unavailable");
+
+          expect(seams.getAllStatesAsync).not.toHaveBeenCalled();
+          expect(seams[seam]).not.toHaveBeenCalled();
         });
 
         it("keeps the sender's project settings when the view is evicted mid-request", async () => {
@@ -744,10 +819,19 @@ describe("copyTree handlers", () => {
 
           await invoke(channel, payload);
 
+          // The eviction has to have actually happened for the rest to mean
+          // anything: if the lookup stopped triggering the hook, every
+          // assertion below would still pass without the race being run.
+          expect(boundProject).toBeNull();
           const mergedOptions = seams[seam].mock.calls[0][optionsArgIndex];
           expect(mergedOptions.exclude).toEqual(senderSettings.excludedPaths);
           expect(mergedOptions.maxTotalSize).toBe(senderSettings.copyTreeSettings.maxContextSize);
           expect(projectStoreMock.getProjectSettings).toHaveBeenCalledWith(SENDER_PROJECT);
+          // The worktree came from the pinned project too, not a re-resolution.
+          expect(seams.getAllStatesForProjectAsync).toHaveBeenCalledWith(
+            projectPathFor(SENDER_PROJECT),
+            SENDER_PROJECT
+          );
         });
 
         it.runIf(acceptsRuntimeOptions)(
@@ -872,7 +956,9 @@ describe("file-backed generation", () => {
     vi.stubEnv("TMP", tmpRoot);
     // These cases are about the bundle's destination, not project scoping, but
     // the worktree lookup still has to resolve — so give them a project to
-    // resolve through. getProjectSettings stays unset, so no settings merge in.
+    // resolve through, with neutral settings. Leaving getProjectSettings unset
+    // would reach the same assertions through loadCopyTreeProjectSettings'
+    // catch block, testing error recovery rather than the ordinary path.
     projectStoreMock.getCurrentProjectId.mockReturnValue("proj-file-backed");
     projectStoreMock.getProjectById.mockReturnValue({
       id: "proj-file-backed",
@@ -880,6 +966,10 @@ describe("file-backed generation", () => {
       status: "active",
     });
     projectStoreMock.getProjectSettings.mockReset();
+    projectStoreMock.getProjectSettings.mockResolvedValue({
+      excludedPaths: [],
+      copyTreeSettings: {},
+    });
   });
 
   afterEach(async () => {
@@ -1507,7 +1597,7 @@ describe("copy-tree run history recording", () => {
     projectStoreMock.getProjectById.mockReturnValue({
       id: PROJECT_ID,
       path: "/repos/daintree",
-      status: "open",
+      status: "active",
     });
     windowRefMock.getProjectViewManager.mockReturnValue({
       getProjectIdForWebContents: () => PROJECT_ID,

--- a/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
@@ -15,7 +15,12 @@ const clipboardMock = vi.hoisted(() => ({
 
 const projectStoreMock = vi.hoisted(() => ({
   getCurrentProjectId: vi.fn<() => string | null>(() => null),
-  getProjectById: vi.fn<(projectId: string) => { id: string; status: string } | null>(() => null),
+  // `path` is load-bearing, not decoration: the worktree lookup selects a
+  // workspace host by the sender project's path (#11751), so a row without one
+  // would resolve no worktrees at all.
+  getProjectById: vi.fn<(projectId: string) => { id: string; path: string; status: string } | null>(
+    () => null
+  ),
   getProjectSettings: vi.fn<(projectId: string) => Promise<unknown>>(),
 }));
 
@@ -236,10 +241,16 @@ describe("copyTree handlers", () => {
         ptyClient: { hasTerminal: vi.fn(() => false), write: vi.fn() },
         worktreeService: {
           getAllStatesAsync: vi.fn().mockResolvedValue([{ id: "wt-1", path: "/wt-1" }]),
+          getAllStatesForProjectAsync: vi.fn().mockResolvedValue([{ id: "wt-1", path: "/wt-1" }]),
           testConfig,
         },
       } as never);
       projectStoreMock.getCurrentProjectId.mockReturnValue("proj-1" as never);
+      projectStoreMock.getProjectById.mockReturnValue({
+        id: "proj-1",
+        path: "/proj-1",
+        status: "active",
+      });
       projectStoreMock.getProjectSettings.mockResolvedValue(projectSettingsFixture as never);
       return testConfig;
     }
@@ -296,11 +307,17 @@ describe("copyTree handlers", () => {
         ptyClient: { hasTerminal: vi.fn(() => false), write: vi.fn() },
         worktreeService: {
           getAllStatesAsync: vi.fn().mockResolvedValue([{ id: "wt-1", path: "/wt-1" }]),
+          getAllStatesForProjectAsync: vi.fn().mockResolvedValue([{ id: "wt-1", path: "/wt-1" }]),
           getContextFileTree,
           getFileTree,
         },
       } as never);
       projectStoreMock.getCurrentProjectId.mockReturnValue("proj-1" as never);
+      projectStoreMock.getProjectById.mockReturnValue({
+        id: "proj-1",
+        path: "/proj-1",
+        status: "active",
+      });
       projectStoreMock.getProjectSettings.mockResolvedValue(projectSettingsFixture as never);
       return { getContextFileTree, getFileTree };
     }
@@ -399,6 +416,24 @@ describe("copyTree handlers", () => {
     const SENDER_PROJECT = "proj-sender";
     const GLOBAL_PROJECT = "proj-global";
 
+    const projectPathFor = (projectId: string) => `/repos/${projectId}`;
+    /**
+     * A worktree only that project owns. Real worktree ids are normalized
+     * absolute paths, so they never collide across projects — that uniqueness
+     * is what lets a cross-project lookup be caught (#11751).
+     */
+    const ownWorktreeIdFor = (projectId: string) => `${projectPathFor(projectId)}/own-wt`;
+
+    /**
+     * Every project also answers for the shared `wt-1` fixture the merge cases
+     * request, at its own path, so those cases keep exercising the merge rather
+     * than tripping the worktree guard.
+     */
+    const worktreesFor = (projectId: string) => [
+      { id: "wt-1", path: `${projectPathFor(projectId)}/wt-1` },
+      { id: ownWorktreeIdFor(projectId), path: `${projectPathFor(projectId)}/own-wt` },
+    ];
+
     // copyTree channels share one rate-limit bucket, and earlier tests in this
     // file exhaust it. Clear the bucket instead of advancing fake timers: each
     // vi.useFakeTimers() re-seeds from the real clock, so a fixed advance keeps
@@ -442,6 +477,22 @@ describe("copyTree handlers", () => {
       });
       const generateContext = vi.fn().mockResolvedValue({ content: "", fileCount: 1 });
       const getContextFileTree = vi.fn().mockResolvedValue([]);
+      // The window-scoped read answers for whatever project the window shows —
+      // GLOBAL_PROJECT throughout this block. Kept mocked, and kept returning a
+      // usable list, so a handler that regressed to it would *pass* its lookup
+      // and be caught by the explicit "never called" assertions rather than by
+      // an incidental crash.
+      const getAllStatesAsync = vi.fn(async () => worktreesFor(GLOBAL_PROJECT));
+      const getAllStatesForProjectAsync = vi.fn(
+        async (projectPath: string, expectedProjectId: string) => {
+          options.onWorkspaceCall?.();
+          // Mirrors the production guard: the path selects the host, the id
+          // authorizes it, and a mismatch resolves nothing.
+          return projectPath === projectPathFor(expectedProjectId)
+            ? worktreesFor(expectedProjectId)
+            : [];
+        }
+      );
 
       if (options.withSenderWindow !== false) {
         browserWindowMock.fromWebContents.mockReturnValue({
@@ -452,6 +503,7 @@ describe("copyTree handlers", () => {
 
       projectStoreMock.getProjectById.mockImplementation((projectId) => ({
         id: projectId,
+        path: projectPathFor(projectId),
         status: "active",
       }));
       projectStoreMock.getProjectSettings.mockImplementation(async (projectId) =>
@@ -466,10 +518,11 @@ describe("copyTree handlers", () => {
         },
         ptyClient: { hasTerminal: vi.fn(() => true), write: vi.fn() },
         worktreeService: {
-          getAllStatesAsync: vi.fn(async () => {
-            options.onWorkspaceCall?.();
-            return [{ id: "wt-1", path: "/wt-1" }];
-          }),
+          // Kept mocked so the assertions can prove it is never consulted: a
+          // window-scoped read answers for whatever project the window shows,
+          // which is the bug (#11751).
+          getAllStatesAsync,
+          getAllStatesForProjectAsync,
           testConfig,
           generateContext,
           getContextFileTree,
@@ -485,7 +538,13 @@ describe("copyTree handlers", () => {
         projectViewManager: options.depsPvm,
       } as never);
 
-      return { testConfig, generateContext, getContextFileTree };
+      return {
+        testConfig,
+        generateContext,
+        getContextFileTree,
+        getAllStatesAsync,
+        getAllStatesForProjectAsync,
+      };
     }
 
     /**
@@ -496,7 +555,7 @@ describe("copyTree handlers", () => {
      * (#11103, #6015), and for the file tree it would put the picker and the
      * bundle back on different settings (#11439).
      */
-    const MERGE_CALL_SITES = [
+    const SCOPED_CALL_SITES = [
       {
         channel: CHANNELS.COPYTREE_TEST_CONFIG,
         seam: "testConfig" as const,
@@ -542,7 +601,29 @@ describe("copyTree handlers", () => {
       await handler(mockEvent, { worktreeId: "wt-1", options: {}, ...extraPayload });
     }
 
-    describe.each(MERGE_CALL_SITES)(
+    /**
+     * The message for a refused worktree, whichever shape the channel uses:
+     * get-file-tree rejects, the rest resolve with an `error` field. Written to
+     * accept either so a channel that changed shape can't quietly pass.
+     */
+    async function invokeExpectingRefusal(
+      channel: string,
+      extraPayload: Record<string, unknown>
+    ): Promise<string | undefined> {
+      const handler = getInvokeHandler(channel);
+      try {
+        const result = (await handler(mockEvent, {
+          worktreeId: "wt-1",
+          options: {},
+          ...extraPayload,
+        })) as { error?: string } | undefined;
+        return result?.error;
+      } catch (error) {
+        return (error as Error).message;
+      }
+    }
+
+    describe.each(SCOPED_CALL_SITES)(
       "$channel",
       ({ channel, seam, payload, optionsArgIndex, acceptsRuntimeOptions }) => {
         it("merges the sender window's project settings, not the globally current project's", async () => {
@@ -566,21 +647,86 @@ describe("copyTree handlers", () => {
           expect(projectStoreMock.getCurrentProjectId).not.toHaveBeenCalled();
         });
 
-        it("applies no project settings when the sender's view is unbound", async () => {
+        it("refuses the request outright when the sender's view is unbound", async () => {
           aimGlobalSourcesAtGlobalProject();
           const depsPvm = makePvm(GLOBAL_PROJECT);
           const seams = registerWithScope({ windowScopedPvm: makePvm(null), depsPvm });
 
-          await invoke(channel, payload);
+          const error = await invokeExpectingRefusal(channel, payload);
 
-          // An unbound view must not inherit the global current project's settings
-          // from ANY source, so nothing back-fills the empty runtime options.
-          expect(seams[seam]).toHaveBeenCalledTimes(1);
-          const mergedOptions = seams[seam].mock.calls[0][optionsArgIndex];
-          expect(mergedOptions).toEqual({});
+          // An unbound view names no project, and every copyTree channel makes
+          // worktreeId mandatory — so there is nothing to resolve it against.
+          // Before #11751 this ran to completion against whichever worktree the
+          // *window* was showing, producing a bundle from a project the caller
+          // never named and with none of its settings applied.
+          expect(error).toBe("Worktree not found: wt-1");
+          expect(seams[seam]).not.toHaveBeenCalled();
+          expect(seams.getAllStatesAsync).not.toHaveBeenCalled();
+          // Still the original guarantee: no global source may be consulted.
           expect(depsPvm.getProjectIdForWebContents).not.toHaveBeenCalled();
           expect(projectStoreMock.getProjectSettings).not.toHaveBeenCalled();
           expect(projectStoreMock.getCurrentProjectId).not.toHaveBeenCalled();
+        });
+
+        it("resolves the worktree in the sender's project, not the window's", async () => {
+          aimGlobalSourcesAtGlobalProject();
+          const seams = registerWithScope({
+            windowScopedPvm: makePvm(SENDER_PROJECT),
+            depsPvm: makePvm(GLOBAL_PROJECT),
+          });
+
+          await invoke(channel, payload);
+
+          expect(seams.getAllStatesForProjectAsync).toHaveBeenCalledWith(
+            projectPathFor(SENDER_PROJECT),
+            SENDER_PROJECT
+          );
+          expect(seams.getAllStatesAsync).not.toHaveBeenCalled();
+          // The path handed downstream is the sender project's copy of wt-1 —
+          // proof the resolved snapshot, not just the lookup, came from A.
+          expect(seams[seam].mock.calls[0][0]).toBe(`${projectPathFor(SENDER_PROJECT)}/wt-1`);
+        });
+
+        it("refuses a worktree that belongs to the window's project", async () => {
+          aimGlobalSourcesAtGlobalProject();
+          const seams = registerWithScope({
+            windowScopedPvm: makePvm(SENDER_PROJECT),
+            depsPvm: makePvm(GLOBAL_PROJECT),
+          });
+
+          // Worktree ids are normalized absolute paths, so a renderer can guess
+          // a sibling project's. The window is showing GLOBAL_PROJECT, so the
+          // pre-#11751 lookup would have found this and bundled its contents.
+          const error = await invokeExpectingRefusal(channel, {
+            ...payload,
+            worktreeId: ownWorktreeIdFor(GLOBAL_PROJECT),
+          });
+
+          expect(error).toBe(`Worktree not found: ${ownWorktreeIdFor(GLOBAL_PROJECT)}`);
+          expect(seams[seam]).not.toHaveBeenCalled();
+          expect(seams.getAllStatesForProjectAsync).toHaveBeenCalledWith(
+            projectPathFor(SENDER_PROJECT),
+            SENDER_PROJECT
+          );
+          expect(seams.getAllStatesAsync).not.toHaveBeenCalled();
+        });
+
+        it("refuses a scratch sender, which has a workspace but no worktrees", async () => {
+          aimGlobalSourcesAtGlobalProject();
+          const seams = registerWithScope({
+            windowScopedPvm: makePvm("scratch-1"),
+            depsPvm: makePvm(GLOBAL_PROJECT),
+          });
+          // A scratch is a workspace id with no project row (#11484); scratch
+          // switching never invokes the worktree service at all.
+          projectStoreMock.getProjectById.mockReturnValue(null);
+
+          const error = await invokeExpectingRefusal(channel, payload);
+
+          expect(error).toBe("Worktree not found: wt-1");
+          expect(seams[seam]).not.toHaveBeenCalled();
+          expect(seams.getAllStatesAsync).not.toHaveBeenCalled();
+          expect(seams.getAllStatesForProjectAsync).not.toHaveBeenCalled();
         });
 
         it("keeps the sender's project settings when the view is evicted mid-request", async () => {
@@ -651,6 +797,14 @@ describe("copyTree handlers", () => {
           expect(mergedOptions.maxTotalSize).toBe(globalSettings.copyTreeSettings.maxContextSize);
           expect(mergedOptions.always).toEqual(globalSettings.copyTreeSettings.alwaysInclude);
           expect(projectStoreMock.getProjectSettings).toHaveBeenCalledWith(GLOBAL_PROJECT);
+          // The lenient fallback is deliberate, and it still resolves the
+          // worktree through the project it settled on — a senderless call must
+          // never reach the unscoped read, which unions every live host.
+          expect(seams.getAllStatesForProjectAsync).toHaveBeenCalledWith(
+            projectPathFor(GLOBAL_PROJECT),
+            GLOBAL_PROJECT
+          );
+          expect(seams.getAllStatesAsync).not.toHaveBeenCalled();
         });
       }
     );
@@ -694,7 +848,7 @@ describe("file-backed generation", () => {
       },
       ptyClient: { hasTerminal: vi.fn(() => true), write: vi.fn() },
       worktreeService: {
-        getAllStatesAsync: vi.fn(async () => [
+        getAllStatesForProjectAsync: vi.fn(async () => [
           { id: "wt-1", path: "/repos/daintree", branch: "main" },
         ]),
         generateContext,
@@ -716,8 +870,15 @@ describe("file-backed generation", () => {
     vi.stubEnv("TMPDIR", tmpRoot);
     vi.stubEnv("TEMP", tmpRoot);
     vi.stubEnv("TMP", tmpRoot);
-    projectStoreMock.getCurrentProjectId.mockReturnValue(null);
-    projectStoreMock.getProjectById.mockReturnValue(null);
+    // These cases are about the bundle's destination, not project scoping, but
+    // the worktree lookup still has to resolve — so give them a project to
+    // resolve through. getProjectSettings stays unset, so no settings merge in.
+    projectStoreMock.getCurrentProjectId.mockReturnValue("proj-file-backed");
+    projectStoreMock.getProjectById.mockReturnValue({
+      id: "proj-file-backed",
+      path: "/repos/daintree",
+      status: "active",
+    });
     projectStoreMock.getProjectSettings.mockReset();
   });
 
@@ -1213,7 +1374,7 @@ describe("copy-tree run history recording", () => {
       },
       ptyClient: { hasTerminal: vi.fn(() => hasTerminal), write: vi.fn() },
       worktreeService: {
-        getAllStatesAsync: vi.fn(async () => [
+        getAllStatesForProjectAsync: vi.fn(async () => [
           { id: "wt-1", path: "/repos/daintree", branch: "main" },
         ]),
         generateContext,
@@ -1241,7 +1402,13 @@ describe("copy-tree run history recording", () => {
     vi.stubEnv("TEMP", tmpRoot);
     vi.stubEnv("TMP", tmpRoot);
     projectStoreMock.getCurrentProjectId.mockReturnValue(PROJECT_ID);
-    projectStoreMock.getProjectById.mockReturnValue(null);
+    // The recorded project id comes from the same resolution the worktree
+    // lookup uses, so the row has to resolve for the run to reach the history.
+    projectStoreMock.getProjectById.mockReturnValue({
+      id: PROJECT_ID,
+      path: "/repos/daintree",
+      status: "active",
+    });
     projectStoreMock.getProjectSettings.mockReset();
   });
 
@@ -1337,7 +1504,11 @@ describe("copy-tree run history recording", () => {
       excludedPaths: ["vendor"],
       copyTreeSettings: { maxContextSize: 4242, alwaysInclude: ["*.md"] },
     });
-    projectStoreMock.getProjectById.mockReturnValue({ id: PROJECT_ID, status: "open" });
+    projectStoreMock.getProjectById.mockReturnValue({
+      id: PROJECT_ID,
+      path: "/repos/daintree",
+      status: "open",
+    });
     windowRefMock.getProjectViewManager.mockReturnValue({
       getProjectIdForWebContents: () => PROJECT_ID,
     });

--- a/electron/ipc/handlers/copyTree.ts
+++ b/electron/ipc/handlers/copyTree.ts
@@ -103,8 +103,10 @@ import {
 import type {
   CopyTreeCancelPayload,
   CopyTreeTestConfigOptions,
+  Project,
   ProjectSettings,
 } from "../../types/index.js";
+import type { WorktreeSnapshot } from "../../../shared/types/workspace-host.js";
 import { projectStore } from "../../services/ProjectStore.js";
 import { recordCopyTreeRun } from "../../services/copyTreeHistoryService.js";
 import { contextInjectionTracker } from "../../services/ContextInjectionTracker.js";
@@ -239,6 +241,72 @@ export function resolveCopyTreeProjectId(
     return projectStore.getCurrentProjectId();
   }
   return scopedProject.project?.id ?? null;
+}
+
+/**
+ * The sender view's project id and its row, resolved together so the worktree
+ * lookup and the settings load can never answer for two different projects.
+ */
+interface CopyTreeSender {
+  projectId: string | null;
+  /** Null for an unbound view, a scratch (#11484), or an unknown id. */
+  project: Project | null;
+}
+
+/**
+ * Both halves of the sender's identity, resolved synchronously.
+ *
+ * Call this exactly where `resolveCopyTreeProjectId` used to be called — before
+ * the handler's first `await`, for the reason documented on that function. The
+ * row lookup is synchronous too, so pinning it here costs nothing.
+ */
+function resolveCopyTreeSender(ctx: IpcContext, deps: HandlerDependencies): CopyTreeSender {
+  const projectId = resolveCopyTreeProjectId(ctx, deps);
+  return {
+    projectId,
+    project: projectId ? (projectStore.getProjectById(projectId) ?? null) : null,
+  };
+}
+
+/**
+ * The requested worktree, looked up in the *sender's* project rather than the
+ * window's (#11751).
+ *
+ * `getAllStatesAsync(windowId)` resolves through `WorkspaceHostPool`'s
+ * `windowToProject`, which is repointed to the incoming project the instant a
+ * switch starts — so a call from a backgrounded view was answered by whichever
+ * project the window happens to show, and its own worktree came back "not
+ * found" while `worktree.list` reported that same id as valid. Worse, a sender
+ * with no window at all fell into the `windowId === undefined` branch, which
+ * unions every live host: worktree ids are normalized absolute paths, so a
+ * guessed one could bundle a sibling project's file contents (the containment
+ * `fileBrowser.ts` states for its own worktree lookup, #11366).
+ *
+ * Takes the already-resolved sender instead of `ctx` so it *cannot* re-resolve
+ * the project after the await — the eviction race #6015/#11103 fixed for
+ * settings applies verbatim here.
+ *
+ * A sender with no project row resolves nothing. Every copyTree channel makes
+ * `worktreeId` mandatory, and a supplied worktree id demands a project row —
+ * the workspace root a scratch or worktree-less project has is not a worktree,
+ * and falling back to one would silently widen the bundle to a folder the
+ * caller never named.
+ */
+async function findSenderWorktree(
+  sender: CopyTreeSender,
+  worktreeId: string,
+  worktreeService: NonNullable<HandlerDependencies["worktreeService"]>
+): Promise<WorktreeSnapshot | undefined> {
+  if (!sender.project) {
+    return undefined;
+  }
+  // Path and id come from the one row: the path selects the host, the id
+  // authorizes it (a project's path is mutable, so it is not an identity).
+  const states = await worktreeService.getAllStatesForProjectAsync(
+    sender.project.path,
+    sender.project.id
+  );
+  return states.find((wt) => wt.id === worktreeId);
 }
 
 /**
@@ -396,10 +464,9 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
 
     // Capture the sender's project before awaiting: the view can be evicted
     // while the workspace call is in flight, taking its binding with it.
-    const settingsProjectId = resolveCopyTreeProjectId(ctx, deps);
+    const sender = resolveCopyTreeSender(ctx, deps);
 
-    const states = await deps.worktreeService.getAllStatesAsync(senderWindow?.id);
-    const worktree = states.find((wt) => wt.id === validated.worktreeId);
+    const worktree = await findSenderWorktree(sender, validated.worktreeId, deps.worktreeService);
 
     if (!worktree) {
       return {
@@ -419,7 +486,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
     };
 
     // Merge project settings with runtime options
-    const projectSettings = await loadCopyTreeProjectSettings(settingsProjectId);
+    const projectSettings = await loadCopyTreeProjectSettings(sender.projectId);
     const mergedOptions = mergeCopyTreeOptions(projectSettings, validated.options);
 
     const result = await generateToFile(worktree, mergedOptions, onProgress);
@@ -427,7 +494,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       return result;
     }
 
-    await recordCompletedCopyTreeRun(settingsProjectId, validated, result);
+    await recordCompletedCopyTreeRun(sender.projectId, validated, result);
 
     if (!result.filePath || !validated.includeContent) {
       return result;
@@ -489,10 +556,9 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
 
     // Capture the sender's project before awaiting: the view can be evicted
     // while the workspace call is in flight, taking its binding with it.
-    const settingsProjectId = resolveCopyTreeProjectId(ctx, deps);
+    const sender = resolveCopyTreeSender(ctx, deps);
 
-    const states = await deps.worktreeService.getAllStatesAsync(senderWindow?.id);
-    const worktree = states.find((wt) => wt.id === validated.worktreeId);
+    const worktree = await findSenderWorktree(sender, validated.worktreeId, deps.worktreeService);
 
     if (!worktree) {
       return {
@@ -512,7 +578,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
     };
 
     // Merge project settings with runtime options
-    const projectSettings = await loadCopyTreeProjectSettings(settingsProjectId);
+    const projectSettings = await loadCopyTreeProjectSettings(sender.projectId);
     const mergedOptions = mergeCopyTreeOptions(projectSettings, validated.options);
 
     // Written by the workspace host straight to disk. This handler used to pull
@@ -528,7 +594,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
     // exists and its path rides back even when the clipboard step throws, so a
     // run the user would most want to retry is exactly the one that must not be
     // missing from the history.
-    await recordCompletedCopyTreeRun(settingsProjectId, validated, result);
+    await recordCompletedCopyTreeRun(sender.projectId, validated, result);
 
     const filePath = result.filePath;
 
@@ -638,13 +704,12 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
 
     // Capture the sender's project before awaiting: the view can be evicted
     // while the workspace call is in flight, taking its binding with it.
-    const settingsProjectId = resolveCopyTreeProjectId(ctx, deps);
+    const sender = resolveCopyTreeSender(ctx, deps);
 
     contextInjectionTracker.beginInjection(validated.terminalId, injectionId);
 
     try {
-      const states = await deps.worktreeService.getAllStatesAsync(senderWindow?.id);
-      const worktree = states.find((wt) => wt.id === validated.worktreeId);
+      const worktree = await findSenderWorktree(sender, validated.worktreeId, deps.worktreeService);
 
       if (!worktree) {
         return {
@@ -672,7 +737,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       };
 
       // Merge project settings with runtime options
-      const projectSettings = await loadCopyTreeProjectSettings(settingsProjectId);
+      const projectSettings = await loadCopyTreeProjectSettings(sender.projectId);
       const mergedOptions = mergeCopyTreeOptions(projectSettings, validated.options || {});
 
       const result = await deps.worktreeService.generateContext(
@@ -728,7 +793,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       // Injection is the same intent as a copy with a different delivery, so it
       // earns a history entry too — and dedupes against the clipboard run that
       // used the same options.
-      await recordCompletedCopyTreeRun(settingsProjectId, validated, result);
+      await recordCompletedCopyTreeRun(sender.projectId, validated, result);
 
       // The renderer reads only fileCount/stats; drop the (possibly multi-MB)
       // content so the contextBridge doesn't clone a second copy into the heap.
@@ -810,10 +875,9 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
 
     // Capture the sender's project before awaiting: the view can be evicted
     // while the workspace call is in flight, taking its binding with it.
-    const settingsProjectId = resolveCopyTreeProjectId(ctx, deps);
+    const sender = resolveCopyTreeSender(ctx, deps);
 
-    const states = await deps.worktreeService.getAllStatesAsync(ctx.senderWindow?.id);
-    const worktree = states.find((wt) => wt.id === validated.worktreeId);
+    const worktree = await findSenderWorktree(sender, validated.worktreeId, deps.worktreeService);
 
     if (!worktree) {
       throw new Error(`Worktree not found: ${validated.worktreeId}`);
@@ -823,7 +887,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
     // CopyTree's defaults while the bundle is built with the project's
     // exclusions and budgets — the disagreement this channel exists to end
     // (#11439).
-    const projectSettings = await loadCopyTreeProjectSettings(settingsProjectId);
+    const projectSettings = await loadCopyTreeProjectSettings(sender.projectId);
     const mergedOptions = mergeCopyTreeOptions(projectSettings, undefined);
 
     return deps.worktreeService.getContextFileTree(
@@ -869,11 +933,9 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
 
     // Capture the sender's project before awaiting: the view can be evicted
     // while the workspace call is in flight, taking its binding with it.
-    const settingsProjectId = resolveCopyTreeProjectId(ctx, deps);
+    const sender = resolveCopyTreeSender(ctx, deps);
 
-    const senderWindowTestConfig = ctx.senderWindow;
-    const states = await deps.worktreeService.getAllStatesAsync(senderWindowTestConfig?.id);
-    const worktree = states.find((wt) => wt.id === validated.worktreeId);
+    const worktree = await findSenderWorktree(sender, validated.worktreeId, deps.worktreeService);
 
     if (!worktree) {
       return {
@@ -884,7 +946,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
     }
 
     // Merge project settings with runtime options
-    const projectSettings = await loadCopyTreeProjectSettings(settingsProjectId);
+    const projectSettings = await loadCopyTreeProjectSettings(sender.projectId);
     const mergedOptions = mergeCopyTreeOptions(projectSettings, validated.options);
 
     return deps.worktreeService.testConfig(worktree.path, mergedOptions);


### PR DESCRIPTION
## Summary

- All five CopyTree IPC handlers in `electron/ipc/handlers/copyTree.ts` resolved worktrees window scoped, via `deps.worktreeService.getAllStatesAsync(senderWindow?.id)`. That call resolves through `WorkspaceHostPool`'s `windowToProject` map, which gets repointed to the incoming project the instant a project switch starts, so a call from a backgrounded or cached view was answered using whichever project the window currently showed. The view's own worktree came back `Worktree not found` even though the view-scoped `worktree.list` and `worktree.getCurrent` reported that same id as valid. A sender with no window at all hit the `windowId === undefined` branch, which unions worktrees across every live host, and since worktree ids are normalized absolute paths, a guessed id could reach a sibling project's files.
- Fixed by resolving the sender's own project instead of the window's, matching the pattern `fileBrowser.ts` already established for the same lookup (#11366).
- Note a deliberate behavior change below: senders with no project row now fail closed instead of silently succeeding against the window's project.

Resolves #11751

## Changes

- Added `resolveCopyTreeSender(ctx, deps)`, which pins the sender's project id and its row synchronously, before the handler's first await. This closes a known eviction race (#6015, #11103).
- Added `findSenderWorktree(sender, worktreeId, worktreeService)`, which reads `getAllStatesForProjectAsync(project.path, project.id)`. It deliberately takes the already-resolved sender rather than the raw context, so it structurally cannot re-resolve the project after the await.
- Converted all five handlers (`handleCopyTreeGenerate`, `handleCopyTreeGenerateAndCopyFile`, `handleCopyTreeInject`, `handleCopyTreeGetFileTree`, `handleCopyTreeTestConfig`) to use these.
- Removed the now-dead `senderWindowTestConfig` local.
- Behavior change: a sender that resolves to no project row (an unbound view, or a scratch workspace, a workspace id with no `Project` row, #11484) now gets `Worktree not found` instead of silently succeeding against the window's project. Every CopyTree channel already makes `worktreeId` mandatory, and a supplied worktree id demands a project row, same as `fileBrowser.ts` (#11366). Scratch switching never invokes the worktree service and scratch hydration cannot adopt an active worktree, so no legitimate flow depends on the old behavior.
- Brings `copyTree.ts` in line with the two existing users of the same project-scoped API: `fileBrowser.ts` (#11366) and `worktree/lifecycle.ts`'s `handleWorktreeGetAll` (#11387).

## Testing

Added per-channel coverage across all five channels in the existing `describe.each` table:

- Sender's-project resolution (asserts the window-scoped read is never called, and the downstream seam receives the sender project's worktree path)
- Refusal of a worktree belonging to the window's project
- Refusal of scratch, unbound, and closed-row senders
- Propagation of a rejecting host read rather than falling back to the window-scoped lookup
- The preserved no-PVM global fallback

292 tests pass across the branch's modules and every module sharing the `getAllStatesForProjectAsync` contract. Also ran `tsc -b electron/tsconfig.json` clean, and `eslint`/`prettier` clean on both changed files.
