### PR TITLE
feat(copytree): let a scoped copy past the ignore file that blocks it

### DIFF
--- a/electron/schemas/__tests__/copyTreeSelectionValidation.test.ts
+++ b/electron/schemas/__tests__/copyTreeSelectionValidation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { CopyTreeOptionsSchema } from "../ipc.js";
+import { CopyTreeOptionsSchema, CopyTreeTestConfigOptionsSchema } from "../ipc.js";
 
 /**
  * The IPC half of the selection guard (#11722).
@@ -42,5 +42,73 @@ describe("CopyTreeOptionsSchema selection guards", () => {
     // above must not have made the field effectively required.
     expect(parse({})).toBe(true);
     expect(parse({ format: "xml" })).toBe(true);
+  });
+});
+
+/**
+ * The ignore-file escape is scope-bound (#11750): the SDK only consults it while
+ * walking `scope` entries, so `scopeIgnoresIgnoreFiles` without `scopePaths` is
+ * inert. Accepting it would hand back a short bundle and say nothing — the exact
+ * failure the issue was filed about — so the boundary names the missing field
+ * instead. Pinned here and on the renderer action schema; neither derives from
+ * the other.
+ */
+describe("CopyTreeOptionsSchema ignore-file bypass guard", () => {
+  const parse = (options: unknown) => CopyTreeOptionsSchema.safeParse(options);
+
+  it("accepts the bypass when a scope was named", () => {
+    expect(parse({ scopePaths: ["docs"], scopeIgnoresIgnoreFiles: true }).success).toBe(true);
+  });
+
+  it("rejects the bypass when nothing scopes it, whatever else the request carries", () => {
+    for (const options of [
+      { scopeIgnoresIgnoreFiles: true },
+      // Neither pattern spelling scopes anything: both feed the SDK's `filter`,
+      // which the escape never looks at.
+      { scopeIgnoresIgnoreFiles: true, includePaths: ["docs/guide.md"] },
+      { scopeIgnoresIgnoreFiles: true, filter: ["docs/**"] },
+      // `always` is a force-include, not a selection — it would not rescue this
+      // even though it happens to defeat ignore files by other means.
+      { scopeIgnoresIgnoreFiles: true, always: ["docs/**"] },
+      { scopeIgnoresIgnoreFiles: true, modified: true },
+    ]) {
+      expect(parse(options).success).toBe(false);
+    }
+  });
+
+  it("points the failure at the flag and names what it needs", () => {
+    const result = parse({ scopeIgnoresIgnoreFiles: true });
+
+    // A caller acts on the issue, not on `success: false`. Asserting the path
+    // and the named field is what makes the rejection worth more than silence.
+    const issue = result.success ? undefined : result.error.issues[0];
+    expect(issue?.path).toEqual(["scopeIgnoresIgnoreFiles"]);
+    expect(issue?.message).toContain("scopePaths");
+  });
+
+  it("leaves every request that did not ask for the bypass alone", () => {
+    // The guard must fire on the opt-in only — never on absence, and never on
+    // the default spelled out, which builds the same bundle as omitting it.
+    expect(parse({}).success).toBe(true);
+    expect(parse({ scopeIgnoresIgnoreFiles: false }).success).toBe(true);
+    expect(parse({ includePaths: ["src/a.ts"] }).success).toBe(true);
+  });
+
+  it("applies the same rule to a test-config dry run", () => {
+    // The dry-run variant re-types six fields as nullable and is built from the
+    // same object base. A refinement attached to only one of the two would let
+    // the settings preview disagree with the run it is previewing.
+    expect(
+      CopyTreeTestConfigOptionsSchema.safeParse({ scopeIgnoresIgnoreFiles: true }).success
+    ).toBe(false);
+    expect(
+      CopyTreeTestConfigOptionsSchema.safeParse({
+        scopePaths: ["docs"],
+        scopeIgnoresIgnoreFiles: true,
+        // Cleared-field sentinel, to prove the base's nullable overrides survived
+        // being re-wrapped by the refinement.
+        always: null,
+      }).success
+    ).toBe(true);
   });
 });

--- a/electron/schemas/__tests__/copyTreeSelectionValidation.test.ts
+++ b/electron/schemas/__tests__/copyTreeSelectionValidation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { CopyTreeOptionsSchema, CopyTreeTestConfigOptionsSchema } from "../ipc.js";
+import { CopyTreeHistoryRecordSchema } from "../copyTreeHistory.js";
 
 /**
  * The IPC half of the selection guard (#11722).
@@ -92,6 +93,36 @@ describe("CopyTreeOptionsSchema ignore-file bypass guard", () => {
     expect(parse({}).success).toBe(true);
     expect(parse({ scopeIgnoresIgnoreFiles: false }).success).toBe(true);
     expect(parse({ includePaths: ["src/a.ts"] }).success).toBe(true);
+  });
+
+  it("carries the rule into a rehydrated history record", () => {
+    // `CopyTreeHistoryRecordSchema.options` is `CopyTreeOptionsSchema.unwrap()`,
+    // which reaches the REFINED object rather than the plain base — the whole
+    // reason the base is a separate export instead of the thing everything
+    // extends. A future cleanup that swapped the unwrap for the base would let a
+    // persisted record rehydrate into a request the generate handlers reject,
+    // and nothing else in the suite would notice.
+    const record = (options: unknown) => ({
+      id: "r1",
+      dedupeKey: "k1",
+      name: "Docs",
+      options,
+      source: "mcp",
+      worktreeId: "wt-1",
+      stats: { fileCount: 1 },
+      createdAt: 1,
+      lastUsedAt: 2,
+      runCount: 1,
+    });
+
+    expect(
+      CopyTreeHistoryRecordSchema.safeParse(record({ scopeIgnoresIgnoreFiles: true })).success
+    ).toBe(false);
+    expect(
+      CopyTreeHistoryRecordSchema.safeParse(
+        record({ scopePaths: ["docs"], scopeIgnoresIgnoreFiles: true })
+      ).success
+    ).toBe(true);
   });
 
   it("applies the same rule to a test-config dry run", () => {

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -472,10 +472,16 @@ export const SlashCommandListRequestSchema = z.object({
 export const CopyTreeFormatSchema = z.enum(["xml", "json", "markdown", "tree", "ndjson", "sarif"]);
 
 /**
- * The unrefined object base — exported so the test-config variant can `.extend()`
- * it and the history codec can reuse it without reaching through the
- * `.superRefine` wrapper below, mirroring `PanelContributionObjectSchema`.
- * Runtime validation goes through {@link CopyTreeOptionsSchema}.
+ * The unrefined object base, mirroring `PanelContributionObjectSchema`. It exists
+ * so {@link CopyTreeTestConfigOptionsSchema} can `.extend()` a plain object —
+ * that is the one operation the refined schema below cannot serve.
+ *
+ * Extend from here ONLY when you also re-apply
+ * {@link requireScopeForIgnoreFileBypass}; anything that just needs to validate
+ * should use {@link CopyTreeOptionsSchema}. Notably the history codec unwraps
+ * the refined schema on purpose, so a persisted record cannot rehydrate into a
+ * request the generate handlers would have rejected — swapping it to this base
+ * would silently drop that check.
  */
 export const CopyTreeOptionsObjectSchema = z.object({
   format: CopyTreeFormatSchema.optional(),

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -471,32 +471,64 @@ export const SlashCommandListRequestSchema = z.object({
 
 export const CopyTreeFormatSchema = z.enum(["xml", "json", "markdown", "tree", "ndjson", "sarif"]);
 
-export const CopyTreeOptionsSchema = z
-  .object({
-    format: CopyTreeFormatSchema.optional(),
-    // `filter`/`includePaths` are one selection set and are unioned in
-    // CopyTreeService. Non-empty at both levels, like `scopePaths` below: an
-    // empty list or a blank entry leaves the selection empty, which the SDK
-    // reads as "no filter" — i.e. the whole worktree. Rejecting them here keeps
-    // a malformed narrow request from widening into a full-repo copy.
-    filter: z.union([z.string().min(1), z.array(z.string().min(1)).min(1)]).optional(),
-    exclude: z.union([z.string(), z.array(z.string())]).optional(),
-    always: z.array(z.string()).optional(),
-    includePaths: z.array(z.string().min(1)).min(1).optional(),
-    // Non-empty at both levels: an empty list or a blank entry would resolve to
-    // the worktree root, turning a folder copy into a whole-worktree copy that
-    // no caller asked for. Absent still means "no scoping".
-    scopePaths: z.array(z.string().min(1)).min(1).optional(),
-    modified: z.boolean().optional(),
-    changed: z.string().optional(),
-    maxFileSize: z.number().int().positive().optional(),
-    maxTotalSize: z.number().int().positive().optional(),
-    maxFileCount: z.number().int().positive().optional(),
-    withLineNumbers: z.boolean().optional(),
-    charLimit: z.number().int().positive().optional(),
-    sort: z.enum(["path", "size", "modified", "name", "extension", "depth"]).optional(),
-  })
-  .optional();
+/**
+ * The unrefined object base — exported so the test-config variant can `.extend()`
+ * it and the history codec can reuse it without reaching through the
+ * `.superRefine` wrapper below, mirroring `PanelContributionObjectSchema`.
+ * Runtime validation goes through {@link CopyTreeOptionsSchema}.
+ */
+export const CopyTreeOptionsObjectSchema = z.object({
+  format: CopyTreeFormatSchema.optional(),
+  // `filter`/`includePaths` are one selection set and are unioned in
+  // CopyTreeService. Non-empty at both levels, like `scopePaths` below: an
+  // empty list or a blank entry leaves the selection empty, which the SDK
+  // reads as "no filter" — i.e. the whole worktree. Rejecting them here keeps
+  // a malformed narrow request from widening into a full-repo copy.
+  filter: z.union([z.string().min(1), z.array(z.string().min(1)).min(1)]).optional(),
+  exclude: z.union([z.string(), z.array(z.string())]).optional(),
+  always: z.array(z.string()).optional(),
+  includePaths: z.array(z.string().min(1)).min(1).optional(),
+  // Non-empty at both levels: an empty list or a blank entry would resolve to
+  // the worktree root, turning a folder copy into a whole-worktree copy that
+  // no caller asked for. Absent still means "no scoping".
+  scopePaths: z.array(z.string().min(1)).min(1).optional(),
+  scopeIgnoresIgnoreFiles: z.boolean().optional(),
+  modified: z.boolean().optional(),
+  changed: z.string().optional(),
+  maxFileSize: z.number().int().positive().optional(),
+  maxTotalSize: z.number().int().positive().optional(),
+  maxFileCount: z.number().int().positive().optional(),
+  withLineNumbers: z.boolean().optional(),
+  charLimit: z.number().int().positive().optional(),
+  sort: z.enum(["path", "size", "modified", "name", "extension", "depth"]).optional(),
+});
+
+/**
+ * `scopeIgnoresIgnoreFiles` is scope-bound: the SDK only consults it while
+ * walking `scope` entries, so setting it alone does exactly nothing. Silently
+ * accepting that is the shape of the bug #11750 was filed about — a caller
+ * believes it asked for the ignored files back, gets a short bundle, and is
+ * told nothing. Rejecting names the missing field instead, in one round trip.
+ *
+ * Shared by the ordinary and test-config variants so the rule cannot drift
+ * between them.
+ */
+function requireScopeForIgnoreFileBypass(
+  options: { scopeIgnoresIgnoreFiles?: boolean; scopePaths?: string[] },
+  ctx: z.RefinementCtx
+): void {
+  if (options.scopeIgnoresIgnoreFiles === true && !options.scopePaths?.length) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["scopeIgnoresIgnoreFiles"],
+      message: "scopeIgnoresIgnoreFiles requires scopePaths",
+    });
+  }
+}
+
+export const CopyTreeOptionsSchema = CopyTreeOptionsObjectSchema.superRefine(
+  requireScopeForIgnoreFileBypass
+).optional();
 
 /**
  * Which surface asked for a copy-tree run (#11732). Left `.optional()` rather
@@ -552,15 +584,15 @@ export const CopyTreeCancelPayloadSchema = z.object({
 // unsaved settings form (Electron's structured clone drops `undefined` keys, so
 // `null` is the only sentinel that survives IPC). `null` blocks the saved-settings
 // back-fill in mergeCopyTreeOptions; absent/undefined still falls back.
-export const CopyTreeTestConfigOptionsSchema = CopyTreeOptionsSchema.unwrap()
-  .extend({
-    exclude: z.union([z.string(), z.array(z.string())]).nullish(),
-    always: z.array(z.string()).nullish(),
-    maxFileSize: z.number().int().positive().nullish(),
-    maxTotalSize: z.number().int().positive().nullish(),
-    charLimit: z.number().int().positive().nullish(),
-    sort: z.enum(["path", "size", "modified", "name", "extension", "depth"]).nullish(),
-  })
+export const CopyTreeTestConfigOptionsSchema = CopyTreeOptionsObjectSchema.extend({
+  exclude: z.union([z.string(), z.array(z.string())]).nullish(),
+  always: z.array(z.string()).nullish(),
+  maxFileSize: z.number().int().positive().nullish(),
+  maxTotalSize: z.number().int().positive().nullish(),
+  charLimit: z.number().int().positive().nullish(),
+  sort: z.enum(["path", "size", "modified", "name", "extension", "depth"]).nullish(),
+})
+  .superRefine(requireScopeForIgnoreFileBypass)
   .optional();
 
 export const CopyTreeTestConfigPayloadSchema = z.object({

--- a/electron/services/CopyTreeService.ts
+++ b/electron/services/CopyTreeService.ts
@@ -768,9 +768,12 @@ class CopyTreeService {
       // The one escape hatch a caller can open (#11750), and it is deliberately
       // the ignore-FILE one rather than `always`. The SDK strips only the rules
       // standing between the root and each scope entry, so config exclusions,
-      // the caller's `exclude`, `.git`, the git filters, the size gate and every
-      // budget keep applying — none of which survive a force-include, which
-      // globs with `ignore: []` and then outranks `exclude` in ProfileFilterStage.
+      // the caller's `exclude`, the git filters and the per-file size gate keep
+      // applying. A force-include survives all four — `collectForcedEntries`
+      // globs with `ignore: []` and `ProfileFilterStage` returns before it ever
+      // reads `exclude` — which is why the selection is never promoted into
+      // `always`. (The later budgets bound both equally: `BudgetStage` and
+      // `CharLimitStage` have no force-include exemption.)
       //
       // `=== true` rather than a truthy read: the field crosses IPC from an MCP
       // caller, and only the boolean the schemas admit should open this.

--- a/electron/services/CopyTreeService.ts
+++ b/electron/services/CopyTreeService.ts
@@ -760,12 +760,24 @@ class CopyTreeService {
       filter: CopyTreeService.mergeSelectionPatterns(options.includePaths, options.filter),
       // Literal paths, not patterns, and orthogonal to `filter`: the walk starts
       // here but the ignore stack is still built from the root down, so a folder
-      // copy drops what a whole-project copy would have dropped. Both
-      // `scopeIgnores*` escape hatches stay off for that reason.
+      // copy drops what a whole-project copy would have dropped.
       scope: options.scopePaths?.length ? options.scopePaths : undefined,
       exclude: options.exclude || undefined,
       always: options.always,
       respectGitignore: true,
+      // The one escape hatch a caller can open (#11750), and it is deliberately
+      // the ignore-FILE one rather than `always`. The SDK strips only the rules
+      // standing between the root and each scope entry, so config exclusions,
+      // the caller's `exclude`, `.git`, the git filters, the size gate and every
+      // budget keep applying — none of which survive a force-include, which
+      // globs with `ignore: []` and then outranks `exclude` in ProfileFilterStage.
+      //
+      // `=== true` rather than a truthy read: the field crosses IPC from an MCP
+      // caller, and only the boolean the schemas admit should open this.
+      // `scopeIgnoresConfigExcludes` stays off unconditionally — lifting an
+      // ignore rule the caller named a path inside of is a different question
+      // from dragging `node_modules` in, and only the first was asked for.
+      scopeIgnoresIgnoreFiles: options.scopeIgnoresIgnoreFiles === true,
 
       modified: options.modified,
       changed: options.changed,

--- a/electron/services/__tests__/CopyTreeService.sdk-contract.test.ts
+++ b/electron/services/__tests__/CopyTreeService.sdk-contract.test.ts
@@ -250,6 +250,9 @@ describe("CopyTreeService against the installed CopyTree", () => {
         // Paired rather than asserted alone: the default half is what proves the
         // fixture's rule actually bites, so the bypass half cannot pass for the
         // wrong reason (an unwritten ignore file would satisfy it silently).
+        // Both errors checked, or the default half passes on a failed run.
+        expect(obeyed.error).toBeUndefined();
+        expect(bypassed.error).toBeUndefined();
         expect(obeyed.files?.map((file) => file.path) ?? []).not.toContain("docs/guide.md");
         expect(bypassed.files?.map((file) => file.path)).toContain("docs/guide.md");
       });
@@ -289,6 +292,11 @@ describe("CopyTreeService against the installed CopyTree", () => {
 
       it("still applies the caller's own exclude inside the unblocked folder", async () => {
         await buildIgnoredDocs();
+        // A control the `exclude` does NOT name. Without it this test passes on a
+        // bypass that silently stopped working: `docs/` is ignored by the
+        // fixture either way, so "guide.md is absent" alone proves nothing about
+        // `exclude` having run.
+        await fs.writeFile(path.join(tempDir, "docs", "intro.md"), "# intro\n");
 
         const result = await copyTreeService.testConfig(tempDir, {
           scopePaths: ["docs"],
@@ -296,10 +304,65 @@ describe("CopyTreeService against the installed CopyTree", () => {
           exclude: ["**/guide.md"],
         });
 
-        // The single behaviour that ruled out force-including the selection:
-        // `always` would have resurrected this file, since ProfileFilterStage
-        // returns before it ever consults `exclude`.
-        expect(result.files?.map((file) => file.path) ?? []).not.toContain("docs/guide.md");
+        expect(result.error).toBeUndefined();
+        const paths = result.files?.map((file) => file.path) ?? [];
+        // The bypass worked...
+        expect(paths).toContain("docs/intro.md");
+        // ...and `exclude` still bit inside it. This is the single behaviour that
+        // ruled out force-including the selection: `always` would have
+        // resurrected this file, since ProfileFilterStage returns on
+        // `alwaysInclude` before it ever consults `exclude`.
+        expect(paths).not.toContain("docs/guide.md");
+        // Attribution, so the absence is booked to `exclude` and not to some
+        // other layer that happened to drop it.
+        expect(result.excluded?.byReason.optionExclude ?? 0).toBeGreaterThan(0);
+      });
+
+      it("still applies the file-count budget, which a force-include would not have", async () => {
+        await buildIgnoredDocs();
+        await fs.writeFile(path.join(tempDir, "docs", "intro.md"), "# intro\n");
+
+        const result = await copyTreeService.testConfig(tempDir, {
+          scopePaths: ["docs"],
+          scopeIgnoresIgnoreFiles: true,
+          maxFileCount: 1,
+          sort: "path",
+        });
+
+        expect(result.error).toBeUndefined();
+        // Two files are now reachable inside the unblocked folder, and the budget
+        // has to bound them. Pinned because the `always` wire text promises the
+        // budgets outlive a force-include too — `BudgetStage` has no
+        // `alwaysInclude` exemption — and that claim needs a test of its own.
+        expect(result.files?.length).toBe(1);
+        expect(result.excluded?.byReason.fileCountBudget ?? 0).toBeGreaterThan(0);
+      });
+
+      it("lets a directory scope subsume a file scope, so the child gets no override", async () => {
+        await buildIgnoredDocs();
+        await fs.writeFile(path.join(tempDir, "docs", ".copytreeignore"), "draft.md\n");
+        await fs.writeFile(path.join(tempDir, "docs", "draft.md"), "# draft\n");
+
+        const result = await copyTreeService.testConfig(tempDir, {
+          // `resolveScope` drops an entry already covered by a directory
+          // ancestor, so this collapses to `["docs"]` and `draft.md` never gets
+          // its own root-to-entry override. Naming the exact file INSTEAD of its
+          // parent is the remedy, which is why the wire text says so.
+          scopePaths: ["docs", "docs/draft.md"],
+          scopeIgnoresIgnoreFiles: true,
+        });
+
+        expect(result.error).toBeUndefined();
+        const paths = result.files?.map((file) => file.path) ?? [];
+        expect(paths).toContain("docs/guide.md");
+        expect(paths).not.toContain("docs/draft.md");
+
+        // The remedy actually works: scope the file on its own and it arrives.
+        const exact = await copyTreeService.testConfig(tempDir, {
+          scopePaths: ["docs/draft.md"],
+          scopeIgnoresIgnoreFiles: true,
+        });
+        expect(exact.files?.map((file) => file.path)).toContain("docs/draft.md");
       });
 
       it("still applies the per-file size gate inside the unblocked folder", async () => {
@@ -326,7 +389,7 @@ describe("CopyTreeService against the installed CopyTree", () => {
       // directory a caller is most likely to scope into expecting this flag to
       // work, precisely because its own `.gitignore` usually names it too.
       it.each(["node_modules", "build"])(
-        "leaves the config exclusion on %s standing, bypass or not",
+        "leaves the config exclusion on %s standing even under the bypass",
         async (excludedDir) => {
           await fs.mkdir(path.join(tempDir, excludedDir, "nested"), { recursive: true });
           await fs.writeFile(
@@ -339,11 +402,16 @@ describe("CopyTreeService against the installed CopyTree", () => {
             scopeIgnoresIgnoreFiles: true,
           });
 
+          // Errors first: `includedFiles === 0` is also what a failed run and an
+          // empty traversal look like, so on its own it would pass without the
+          // config layer doing anything.
+          expect(result.error).toBeUndefined();
+          expect(result.includedFiles).toBe(0);
           // The companion `scopeIgnoresConfigExcludes` escape is deliberately
           // never set: lifting an ignore rule is a different request from
           // dragging a dependency tree or a build output in, and only the first
-          // one is on offer.
-          expect(result.includedFiles).toBe(0);
+          // one is on offer. Attribution proves it was that layer.
+          expect(result.excluded?.byReason.configExclude ?? 0).toBeGreaterThan(0);
         }
       );
 

--- a/electron/services/__tests__/CopyTreeService.sdk-contract.test.ts
+++ b/electron/services/__tests__/CopyTreeService.sdk-contract.test.ts
@@ -219,6 +219,177 @@ describe("CopyTreeService against the installed CopyTree", () => {
       expect(paths).not.toContain("src/d/other.ts");
     });
 
+    // #11750. `.copytreeignore` is layered at every depth on every SDK code
+    // path, with no option or config key that drops it, so "bypass the ignore
+    // file" is not literally expressible. What IS exposed is the ignore-FILE
+    // escape for a named subtree, and these pin how much it lifts — because the
+    // alternative (promoting the selection into `always`) globs with
+    // `ignore: []` and then outranks the caller's own `exclude`, which is the
+    // reason it was rejected. Run against the installed package: every claim in
+    // the wire description is a claim about the SDK, not about our adapter.
+    describe("bypassing an ignore file that blocks a scoped path", () => {
+      async function buildIgnoredDocs() {
+        // One file, two rules: `docs/` stands between the root and the
+        // selection, `*.secret` does not. Both live in the same ignore file, so
+        // a bypass that dropped the file wholesale would take `*.secret` with it.
+        await fs.writeFile(path.join(tempDir, ".copytreeignore"), "docs/\n*.secret\n");
+        await fs.mkdir(path.join(tempDir, "docs"), { recursive: true });
+        await fs.writeFile(path.join(tempDir, "docs", "guide.md"), "# guide\n");
+        await fs.writeFile(path.join(tempDir, "docs", "key.secret"), "shhh\n");
+      }
+
+      it("drops the scoped folder by default, and returns it when the bypass is on", async () => {
+        await buildIgnoredDocs();
+
+        const obeyed = await copyTreeService.testConfig(tempDir, { scopePaths: ["docs"] });
+        const bypassed = await copyTreeService.testConfig(tempDir, {
+          scopePaths: ["docs"],
+          scopeIgnoresIgnoreFiles: true,
+        });
+
+        // Paired rather than asserted alone: the default half is what proves the
+        // fixture's rule actually bites, so the bypass half cannot pass for the
+        // wrong reason (an unwritten ignore file would satisfy it silently).
+        expect(obeyed.files?.map((file) => file.path) ?? []).not.toContain("docs/guide.md");
+        expect(bypassed.files?.map((file) => file.path)).toContain("docs/guide.md");
+      });
+
+      it("lifts only the rule that blocked the way in, not the rest of the file", async () => {
+        await buildIgnoredDocs();
+
+        const result = await copyTreeService.testConfig(tempDir, {
+          scopePaths: ["docs"],
+          scopeIgnoresIgnoreFiles: true,
+        });
+
+        const paths = result.files?.map((file) => file.path) ?? [];
+        expect(paths).toContain("docs/guide.md");
+        // The whole reason this is safe: `*.secret` never stood between the root
+        // and `docs`, so it survives. Dropping the layer instead of the blocking
+        // rule would exfiltrate exactly the files an ignore file exists to hide.
+        expect(paths).not.toContain("docs/key.secret");
+      });
+
+      it("keeps honouring an ignore file that lives inside the selection", async () => {
+        await buildIgnoredDocs();
+        await fs.writeFile(path.join(tempDir, "docs", ".copytreeignore"), "draft.md\n");
+        await fs.writeFile(path.join(tempDir, "docs", "draft.md"), "# draft\n");
+
+        const result = await copyTreeService.testConfig(tempDir, {
+          scopePaths: ["docs"],
+          scopeIgnoresIgnoreFiles: true,
+        });
+
+        const paths = result.files?.map((file) => file.path) ?? [];
+        expect(paths).toContain("docs/guide.md");
+        // Rules at or below the selection describe the subtree the caller asked
+        // for, so they are not what "let me in" was about.
+        expect(paths).not.toContain("docs/draft.md");
+      });
+
+      it("still applies the caller's own exclude inside the unblocked folder", async () => {
+        await buildIgnoredDocs();
+
+        const result = await copyTreeService.testConfig(tempDir, {
+          scopePaths: ["docs"],
+          scopeIgnoresIgnoreFiles: true,
+          exclude: ["**/guide.md"],
+        });
+
+        // The single behaviour that ruled out force-including the selection:
+        // `always` would have resurrected this file, since ProfileFilterStage
+        // returns before it ever consults `exclude`.
+        expect(result.files?.map((file) => file.path) ?? []).not.toContain("docs/guide.md");
+      });
+
+      it("still applies the per-file size gate inside the unblocked folder", async () => {
+        await buildIgnoredDocs();
+        await fs.writeFile(path.join(tempDir, "docs", "big.md"), "x".repeat(300 * 1024));
+
+        const result = await copyTreeService.testConfig(tempDir, {
+          scopePaths: ["docs"],
+          scopeIgnoresIgnoreFiles: true,
+          maxFileSize: 100 * 1024,
+        });
+
+        const paths = result.files?.map((file) => file.path) ?? [];
+        expect(paths).toContain("docs/guide.md");
+        // `always` lifts the gate; this must not, or "bypass an ignore file"
+        // would quietly also mean "ignore the size limit I set".
+        expect(paths).not.toContain("docs/big.md");
+      });
+
+      // Both names sit in the SDK's `globalExcludedDirectories`, and they are
+      // excluded by that config layer rather than by any ignore file — so the
+      // bypass has nothing to lift for them even when a caller scopes straight
+      // in. `build` is the one worth pinning alongside `node_modules`: it is the
+      // directory a caller is most likely to scope into expecting this flag to
+      // work, precisely because its own `.gitignore` usually names it too.
+      it.each(["node_modules", "build"])(
+        "leaves the config exclusion on %s standing, bypass or not",
+        async (excludedDir) => {
+          await fs.mkdir(path.join(tempDir, excludedDir, "nested"), { recursive: true });
+          await fs.writeFile(
+            path.join(tempDir, excludedDir, "nested", "index.js"),
+            "module.exports = 1;\n"
+          );
+
+          const result = await copyTreeService.testConfig(tempDir, {
+            scopePaths: [excludedDir],
+            scopeIgnoresIgnoreFiles: true,
+          });
+
+          // The companion `scopeIgnoresConfigExcludes` escape is deliberately
+          // never set: lifting an ignore rule is a different request from
+          // dragging a dependency tree or a build output in, and only the first
+          // one is on offer.
+          expect(result.includedFiles).toBe(0);
+        }
+      );
+
+      it("also lifts a .gitignore rule blocking the way in, which the wire text has to admit", async () => {
+        // Deliberately not a name from `globalExcludedDirectories` — `build` or
+        // `dist` would be held out by the config layer and this would pass
+        // without the ignore rule ever being consulted.
+        await fs.writeFile(path.join(tempDir, ".gitignore"), "local-notes/\n");
+        await fs.mkdir(path.join(tempDir, "local-notes"), { recursive: true });
+        await fs.writeFile(path.join(tempDir, "local-notes", "todo.md"), "# todo\n");
+
+        const obeyed = await copyTreeService.testConfig(tempDir, {
+          scopePaths: ["local-notes"],
+        });
+        const result = await copyTreeService.testConfig(tempDir, {
+          scopePaths: ["local-notes"],
+          scopeIgnoresIgnoreFiles: true,
+        });
+
+        expect(obeyed.files?.map((file) => file.path) ?? []).not.toContain("local-notes/todo.md");
+        // Pinning the over-reach, not endorsing it: the SDK's escape covers both
+        // ignore files and cannot be narrowed to `.copytreeignore`. If a future
+        // SDK separates them this test is what says the description must change.
+        expect(result.files?.map((file) => file.path)).toContain("local-notes/todo.md");
+      });
+
+      it("scopes each named file independently, so a scattered curated bundle works", async () => {
+        await buildIgnoredDocs();
+        await fs.mkdir(path.join(tempDir, "src"), { recursive: true });
+        await fs.writeFile(path.join(tempDir, "src", "gen.ts"), "export const g = 1;\n");
+
+        const result = await copyTreeService.testConfig(tempDir, {
+          scopePaths: ["src/gen.ts", "docs/guide.md"],
+          scopeIgnoresIgnoreFiles: true,
+        });
+
+        // The issue's actual shape: source files plus a few docs the ignore file
+        // dropped. Each entry gets its own root-to-entry override, so mixing an
+        // ignored path with an ordinary one needs no per-file `always` patterns.
+        expect((result.files?.map((file) => file.path) ?? []).sort()).toEqual([
+          "docs/guide.md",
+          "src/gen.ts",
+        ]);
+      });
+    });
+
     it("explains an excluded folder as an exclusion rather than an empty result", async () => {
       await fs.mkdir(path.join(tempDir, "node_modules", "left-pad"), { recursive: true });
       await fs.writeFile(

--- a/electron/services/__tests__/CopyTreeService.sdk-contract.test.ts
+++ b/electron/services/__tests__/CopyTreeService.sdk-contract.test.ts
@@ -318,7 +318,7 @@ describe("CopyTreeService against the installed CopyTree", () => {
         expect(result.excluded?.byReason.optionExclude ?? 0).toBeGreaterThan(0);
       });
 
-      it("still applies the file-count budget, which a force-include would not have", async () => {
+      it("still applies the file-count budget inside the unblocked folder", async () => {
         await buildIgnoredDocs();
         await fs.writeFile(path.join(tempDir, "docs", "intro.md"), "# intro\n");
 
@@ -330,12 +330,39 @@ describe("CopyTreeService against the installed CopyTree", () => {
         });
 
         expect(result.error).toBeUndefined();
-        // Two files are now reachable inside the unblocked folder, and the budget
-        // has to bound them. Pinned because the `always` wire text promises the
-        // budgets outlive a force-include too — `BudgetStage` has no
-        // `alwaysInclude` exemption — and that claim needs a test of its own.
+        // Two files are reachable inside the unblocked folder once the root rule
+        // is lifted (`key.secret` is dropped earlier by the surviving rule), so
+        // the budget has to bound them.
         expect(result.files?.length).toBe(1);
         expect(result.excluded?.byReason.fileCountBudget ?? 0).toBeGreaterThan(0);
+      });
+
+      it("bounds even a force-include by the file-count budget", async () => {
+        await buildIgnoredDocs();
+        await fs.writeFile(path.join(tempDir, "docs", "intro.md"), "# intro\n");
+
+        const forced = await copyTreeService.testConfig(tempDir, { always: ["docs/*.md"] });
+        const budgeted = await copyTreeService.testConfig(tempDir, {
+          always: ["docs/*.md"],
+          maxFileCount: 1,
+          sort: "path",
+        });
+
+        expect(forced.error).toBeUndefined();
+        expect(budgeted.error).toBeUndefined();
+        // Unbudgeted, `always` really does drag both ignored docs back in — that
+        // is the blast radius the wire text warns about, and asserting it here
+        // stops the budgeted half passing because the force-include silently
+        // stopped working. Containment rather than an exact list: this run is
+        // unscoped, so the fixture's root-level files come along too.
+        expect(forced.files?.map((file) => file.path)).toEqual(
+          expect.arrayContaining(["docs/guide.md", "docs/intro.md"])
+        );
+        // Budgeted, it does not: `BudgetStage` has no `alwaysInclude` exemption,
+        // which is the one bound the `always` description promises survives a
+        // force-include. Nothing else in the suite pins that claim.
+        expect(budgeted.files?.length).toBe(1);
+        expect(budgeted.excluded?.byReason.fileCountBudget ?? 0).toBeGreaterThan(0);
       });
 
       it("lets a directory scope subsume a file scope, so the child gets no override", async () => {

--- a/electron/services/__tests__/CopyTreeService.test.ts
+++ b/electron/services/__tests__/CopyTreeService.test.ts
@@ -444,6 +444,55 @@ describe("CopyTreeService", () => {
       expect(options.respectGitignore).toBe(true);
     });
 
+    // #11750: the caller-facing opt-out, and the blast radius it must NOT widen.
+    it("opens only the ignore-file escape when the caller asks for it", async () => {
+      await copyTreeService.generate(tempDir, {
+        scopePaths: ["docs"],
+        scopeIgnoresIgnoreFiles: true,
+      });
+
+      const options = sdkOptions();
+      expect(options.scopeIgnoresIgnoreFiles).toBe(true);
+      // The companion escape lifts node_modules and the configured excludes. It
+      // answers a different question and was never asked, so opting into one
+      // must never drag in the other.
+      expect(options.scopeIgnoresConfigExcludes).toBeFalsy();
+      expect(options.respectGitignore).toBe(true);
+    });
+
+    it("leaves the selection out of always, so no other exclusion layer moves", async () => {
+      await copyTreeService.generate(tempDir, {
+        scopePaths: ["docs"],
+        includePaths: ["docs/**"],
+        exclude: ["**/*.secret"],
+        scopeIgnoresIgnoreFiles: true,
+      });
+
+      const options = sdkOptions();
+      // The rejected design promoted the selection into `always`, which globs
+      // with `ignore: []` and then outranks `exclude` in ProfileFilterStage —
+      // silently resurrecting files the caller (or the project's settings)
+      // explicitly excluded. The selection has to stay in `filter` alone.
+      expect(options.always).toBeUndefined();
+      expect(options.filter).toEqual(["docs/**"]);
+      expect(options.exclude).toEqual(["**/*.secret"]);
+    });
+
+    it.each([
+      ["omitted", undefined],
+      ["explicitly false", false],
+      // Only the exact boolean opens it: the field crosses IPC from an MCP
+      // caller, so a truthy read here would let a stray string through.
+      ["a truthy non-boolean", "yes"],
+    ])("keeps the escape shut when the flag is %s", async (_label, value) => {
+      await copyTreeService.generate(tempDir, {
+        scopePaths: ["docs"],
+        ...(value === undefined ? {} : { scopeIgnoresIgnoreFiles: value as boolean }),
+      });
+
+      expect(sdkOptions().scopeIgnoresIgnoreFiles).toBe(false);
+    });
+
     it("passes the remaining budgets through untouched", async () => {
       await copyTreeService.generate(tempDir, {
         maxTotalSize: 1234,

--- a/shared/types/ipc/copyTree.ts
+++ b/shared/types/ipc/copyTree.ts
@@ -30,6 +30,33 @@ export interface CopyTreeOptions {
    */
   scopePaths?: string[];
 
+  /**
+   * Let `scopePaths` into subtrees an ignore file would have pruned (#11750).
+   *
+   * Absent or `false` is the default every existing caller keeps: a scoped copy
+   * returns what a whole-worktree copy would have returned for that subtree.
+   * `true` requires `scopePaths` and is rejected without it at both option
+   * schemas — the flag is scope-bound, so accepting it alone would silently do
+   * nothing, which is the failure mode the issue was filed about.
+   *
+   * The lift is surgical, and only the SDK's ignore-FILE escape is used: the
+   * rules removed are the ones standing between the worktree root and each
+   * scope entry, in the `.gitignore` and `.copytreeignore` layers only. Every
+   * unrelated rule in those same files survives, negations survive, and ignore
+   * files at or below the selection still apply — they describe the subtree the
+   * caller asked for. Project and config exclusions (`node_modules`), the
+   * caller's own `exclude`, `.git`, the git filters, the per-file size gate and
+   * every budget are untouched, because the companion `scopeIgnoresConfigExcludes`
+   * escape stays off.
+   *
+   * It cannot be narrowed to `.copytreeignore` alone: the SDK layers that file
+   * at every depth on every code path, with no option or config key to drop it
+   * (`FileDiscoveryStage`, copytree 0.17.0). Lifting the ignore-file rules
+   * blocking a named subtree is the closest thing it does expose, and unlike
+   * `always` it leaves every other exclusion layer standing.
+   */
+  scopeIgnoresIgnoreFiles?: boolean;
+
   /** Git filtering - only include files modified in working directory (staged + unstaged changes, excludes untracked files) */
   modified?: boolean;
   /** Git filtering - only include files changed since specified commit/branch */

--- a/shared/utils/__tests__/copyTreeHistory.test.ts
+++ b/shared/utils/__tests__/copyTreeHistory.test.ts
@@ -85,6 +85,24 @@ describe("canonicalizeCopyTreeOptions", () => {
     );
   });
 
+  it("folds the ignore-file bypass's default spelling onto the same entry", () => {
+    // #11750. `false` is what the flag already does when absent, so the two
+    // build a byte-identical bundle. Everything else here is generic — a scalar
+    // lands in the hash verbatim — which would have filed one run under two
+    // rows the moment a caller started sending the default explicitly.
+    const scoped = { scopePaths: ["docs"] };
+
+    expect(canonicalizeCopyTreeOptions({ ...scoped, scopeIgnoresIgnoreFiles: false })).toEqual(
+      canonicalizeCopyTreeOptions(scoped)
+    );
+    // Only the default folds away. `true` selects a different set of files, so
+    // collapsing it too would hand a caller the obeyed run it was trying to
+    // get past.
+    expect(canonicalizeCopyTreeOptions({ ...scoped, scopeIgnoresIgnoreFiles: true })).not.toEqual(
+      canonicalizeCopyTreeOptions(scoped)
+    );
+  });
+
   it("still separates a selection from no selection at all", () => {
     expect(canonicalizeCopyTreeOptions({ filter: ["src/**"] })).not.toEqual(
       canonicalizeCopyTreeOptions({})

--- a/shared/utils/copyTreeHistory.ts
+++ b/shared/utils/copyTreeHistory.ts
@@ -56,6 +56,12 @@ export function canonicalizeCopyTreeOptions(options?: CopyTreeOptions): Record<s
 
   for (const [key, value] of Object.entries(options)) {
     if (value === undefined) continue;
+    // Explicit `false` is the default spelled out, and builds a byte-identical
+    // bundle to omitting it — so it must dedupe onto the same entry rather than
+    // splitting one run into two history rows (#11750). Only the exact boolean
+    // is folded away: `true` changes the bundle, and any other value is a shape
+    // the schemas rejected and stays verbatim so two malformed inputs differ.
+    if (key === "scopeIgnoresIgnoreFiles" && value === false) continue;
     if ((SELECTION_FIELDS as readonly string[]).includes(key)) continue;
 
     if (!UNORDERED_ARRAY_FIELDS.has(key as keyof CopyTreeOptions)) {

--- a/src/services/actions/definitions/__tests__/schemaDescriptions.test.ts
+++ b/src/services/actions/definitions/__tests__/schemaDescriptions.test.ts
@@ -173,17 +173,21 @@ describe("argument descriptions carry the semantics prose no longer states", () 
 
   // #11750. The flag's whole safety story is "it lifts less than you fear", and
   // a caller can only learn the boundary from this text — the type is a bare
-  // boolean and the SDK's own docs are not on the wire. Each assertion below is
-  // a claim `CopyTreeService.sdk-contract.test.ts` proves against the real SDK;
-  // if one of those flips, the description here is what has to change with it.
+  // boolean and the SDK's own docs are not on the wire. The claims about what
+  // survives are pinned against the real SDK in
+  // `CopyTreeService.sdk-contract.test.ts`; if one of those flips, this text is
+  // what has to change with it.
+  //
+  // Every pattern below carries polarity. A bare /budget/ would be satisfied by
+  // "budgets no longer apply" — text that says the exact opposite of what the
+  // code does — so matching the topic word alone would enforce nothing.
   it("bounds what the ignore-file bypass lifts, and what it leaves standing", () => {
     const bypass =
       emit(CopyTreeOptionsSchema).properties?.scopeIgnoresIgnoreFiles?.description ?? "";
 
     // Scope-bound, and refused without one — a caller that sets it alone gets a
     // parse error, so the text has to explain the pairing before it happens.
-    expect(bypass).toMatch(/scopePaths/);
-    expect(bypass).toMatch(/rejected|requires/i);
+    expect(bypass).toMatch(/(requires|rejected without)[^.]{0,40}`?scopePaths/i);
 
     // Both ignore files, stated. The SDK cannot narrow this to `.copytreeignore`
     // and a description naming only that one would understate the reach.
@@ -191,13 +195,17 @@ describe("argument descriptions carry the semantics prose no longer states", () 
     expect(bypass).toMatch(/\.gitignore/);
 
     // The limit that makes it safe: only the rules blocking entry are removed.
-    expect(bypass).toMatch(/only the rules/i);
+    expect(bypass).toMatch(/only the rules blocking/i);
 
-    // And the layers that keep applying. Without these a caller has no way to
-    // tell this apart from `always`, which lifts every one of them.
+    // And the layers that keep applying — the half that distinguishes this from
+    // `always`, which lifts every one of them.
+    expect(bypass).toMatch(/(still|continue to|remain)[^.]{0,120}(apply|applies)/i);
     expect(bypass).toMatch(/node_modules/);
-    expect(bypass).toMatch(/exclude/);
-    expect(bypass).toMatch(/budget/i);
+
+    // The composition trap a caller hits the moment it moves a selection into
+    // `scopePaths`: a rule inside the selection needs the exact file, not its
+    // parent, because a scoped directory subsumes its children.
+    expect(bypass).toMatch(/exact file/i);
   });
 
   it("warns that always is the blunt instrument the bypass is not", () => {
@@ -208,7 +216,19 @@ describe("argument descriptions carry the semantics prose no longer states", () 
     // narrower field is the half that changes behaviour — a warning with no
     // alternative just leaves the caller where it started.
     expect(always).toMatch(/scopeIgnoresIgnoreFiles/);
-    expect(always).toMatch(/node_modules/);
+
+    // Polarity again, and in the dangerous direction: "cannot pull in
+    // node_modules" would satisfy a bare /node_modules/ while telling a caller
+    // the opposite of the truth.
+    expect(always).toMatch(/can pull in[^.]{0,40}node_modules/i);
+
+    // The budgets are the one bound that DOES outlive a force-include
+    // (`BudgetStage` has no `alwaysInclude` exemption). An earlier draft of this
+    // text claimed only `.git` and the memory ceiling survived, which was wrong
+    // in the direction that matters — it undersold the remaining safety net.
+    // `[\s\S]` rather than `[^.]` because the clause lists `.git` on the way,
+    // and a dot-excluding span cannot reach past it.
+    expect(always).toMatch(/does not override[\s\S]{0,140}maxFileCount/i);
   });
 
   it("says a scope restricts traversal, so patterns cannot widen it", () => {

--- a/src/services/actions/definitions/__tests__/schemaDescriptions.test.ts
+++ b/src/services/actions/definitions/__tests__/schemaDescriptions.test.ts
@@ -171,6 +171,55 @@ describe("argument descriptions carry the semantics prose no longer states", () 
     expect(scope).toMatch(/prefer this over[^.]*folder/i);
   });
 
+  // #11750. The flag's whole safety story is "it lifts less than you fear", and
+  // a caller can only learn the boundary from this text — the type is a bare
+  // boolean and the SDK's own docs are not on the wire. Each assertion below is
+  // a claim `CopyTreeService.sdk-contract.test.ts` proves against the real SDK;
+  // if one of those flips, the description here is what has to change with it.
+  it("bounds what the ignore-file bypass lifts, and what it leaves standing", () => {
+    const bypass =
+      emit(CopyTreeOptionsSchema).properties?.scopeIgnoresIgnoreFiles?.description ?? "";
+
+    // Scope-bound, and refused without one — a caller that sets it alone gets a
+    // parse error, so the text has to explain the pairing before it happens.
+    expect(bypass).toMatch(/scopePaths/);
+    expect(bypass).toMatch(/rejected|requires/i);
+
+    // Both ignore files, stated. The SDK cannot narrow this to `.copytreeignore`
+    // and a description naming only that one would understate the reach.
+    expect(bypass).toMatch(/\.copytreeignore/);
+    expect(bypass).toMatch(/\.gitignore/);
+
+    // The limit that makes it safe: only the rules blocking entry are removed.
+    expect(bypass).toMatch(/only the rules/i);
+
+    // And the layers that keep applying. Without these a caller has no way to
+    // tell this apart from `always`, which lifts every one of them.
+    expect(bypass).toMatch(/node_modules/);
+    expect(bypass).toMatch(/exclude/);
+    expect(bypass).toMatch(/budget/i);
+  });
+
+  it("warns that always is the blunt instrument the bypass is not", () => {
+    const always = emit(CopyTreeOptionsSchema).properties?.always?.description ?? "";
+
+    // Undocumented on the wire until #11750, which is how a caller ended up
+    // hand-computing per-file patterns for it instead of scoping. Naming the
+    // narrower field is the half that changes behaviour — a warning with no
+    // alternative just leaves the caller where it started.
+    expect(always).toMatch(/scopeIgnoresIgnoreFiles/);
+    expect(always).toMatch(/node_modules/);
+  });
+
+  it("says a scope restricts traversal, so patterns cannot widen it", () => {
+    const scope = emit(CopyTreeOptionsSchema).properties?.scopePaths?.description ?? "";
+
+    // The composition trap the bypass makes reachable: a caller told to move its
+    // selection into `scopePaths` will keep its `includePaths` alongside, and
+    // anything outside the scope silently disappears.
+    expect(scope).toMatch(/never add a file outside|cannot add|only narrow/i);
+  });
+
   it("keeps the terminal-id contract on the hand-written wait schema", () => {
     // A hand-written JSON Schema rather than a zod conversion, so none of the
     // propagation above applies to it. Note this constant is NOT what the

--- a/src/services/actions/definitions/__tests__/schemaDescriptions.test.ts
+++ b/src/services/actions/definitions/__tests__/schemaDescriptions.test.ts
@@ -198,14 +198,16 @@ describe("argument descriptions carry the semantics prose no longer states", () 
     expect(bypass).toMatch(/only the rules blocking/i);
 
     // And the layers that keep applying — the half that distinguishes this from
-    // `always`, which lifts every one of them.
-    expect(bypass).toMatch(/(still|continue to|remain)[^.]{0,120}(apply|applies)/i);
+    // `always`, which lifts every one of them. "all still apply" rather than a
+    // /still.*apply/ span, which "still do not apply" would satisfy.
+    expect(bypass).toMatch(/all still apply/i);
     expect(bypass).toMatch(/node_modules/);
+    expect(bypass).not.toMatch(/not only the rules/i);
 
     // The composition trap a caller hits the moment it moves a selection into
     // `scopePaths`: a rule inside the selection needs the exact file, not its
     // parent, because a scoped directory subsumes its children.
-    expect(bypass).toMatch(/exact file/i);
+    expect(bypass).toMatch(/scope the exact file/i);
   });
 
   it("warns that always is the blunt instrument the bypass is not", () => {
@@ -221,6 +223,13 @@ describe("argument descriptions carry the semantics prose no longer states", () 
     // node_modules" would satisfy a bare /node_modules/ while telling a caller
     // the opposite of the truth.
     expect(always).toMatch(/can pull in[^.]{0,40}node_modules/i);
+
+    // A `../` pattern really does escape the worktree — `collectForcedEntries`
+    // hands the patterns straight to fast-glob and only checks root containment
+    // when `followSymlinks` is on. An earlier draft of this text claimed the
+    // opposite. The field predates this change and is not being narrowed here,
+    // so the wire has to say what it actually does.
+    expect(always).toMatch(/outside the worktree/i);
 
     // The budgets are the one bound that DOES outlive a force-include
     // (`BudgetStage` has no `alwaysInclude` exemption). An earlier draft of this

--- a/src/services/actions/definitions/__tests__/worktreeContextActions.copyTree.test.ts
+++ b/src/services/actions/definitions/__tests__/worktreeContextActions.copyTree.test.ts
@@ -255,8 +255,8 @@ describe("worktree.copyTree ignore-file bypass", () => {
 
   it.each([
     ["omitted", {}],
-    // The default spelled out. Forwarding it would file an identical bundle
-    // under its own history row, since the run hashes the options it was given.
+    // The default spelled out, which the SDK reads identically to absence — so
+    // the payload should not carry it, matching how the path fields are spread.
     ["explicitly false", { scopeIgnoresIgnoreFiles: false }],
   ])("omits the field entirely when it is %s", async (_label, extra) => {
     const { run } = setupActions();

--- a/src/services/actions/definitions/__tests__/worktreeContextActions.copyTree.test.ts
+++ b/src/services/actions/definitions/__tests__/worktreeContextActions.copyTree.test.ts
@@ -29,15 +29,28 @@ import { useCopyTreeRunStore } from "@/store/copyTreeRunStore";
 
 function setupActions(): {
   run: (id: string, args?: unknown, ctx?: Record<string, unknown>) => Promise<unknown>;
+  parseArgs: (id: string, args: unknown) => { success: boolean; message?: string };
 } {
   const actions: ActionRegistry = new Map();
   const callbacks: ActionCallbacks = {} as unknown as ActionCallbacks;
   registerWorktreeContextActions(actions, callbacks);
+  const define = (id: string): AnyActionDefinition => {
+    const factory = actions.get(id);
+    if (!factory) throw new Error(`missing ${id}`);
+    return factory() as AnyActionDefinition;
+  };
   return {
-    run: async (id, args, ctx) => {
-      const factory = actions.get(id);
-      if (!factory) throw new Error(`missing ${id}`);
-      return (factory() as AnyActionDefinition).run(args, (ctx ?? {}) as never);
+    run: async (id, args, ctx) => define(id).run(args, (ctx ?? {}) as never),
+    // `run` is dispatched with already-validated args, so a schema-only rule is
+    // invisible to it. ActionService parses `argsSchema` first; this reaches the
+    // same schema so a guard that never fires cannot pass as one that does.
+    parseArgs: (id, args) => {
+      const schema = define(id).argsSchema;
+      if (!schema) throw new Error(`${id} has no argsSchema`);
+      const result = schema.safeParse(args);
+      return result.success
+        ? { success: true }
+        : { success: false, message: result.error.issues[0]?.message };
     },
   };
 }
@@ -212,5 +225,68 @@ describe("worktree.copyTree completion announcement", () => {
     const payload = notifyMock.mock.calls[0]?.[0] as { rateLimitKey?: string; type: string };
     expect(payload.rateLimitKey).toBeTruthy();
     expect(payload.rateLimitKey).not.toBe(payload.type);
+  });
+});
+
+/**
+ * #11750. This action hand-rolls its `argsSchema` instead of reusing
+ * `CopyTreeOptionsSchema`, and builds its options object by conditional spread
+ * — so a field added to the shared schema reaches it in neither place. These
+ * pin both halves against exactly that drift.
+ */
+describe("worktree.copyTree ignore-file bypass", () => {
+  const optionsOf = () =>
+    copyTreeClientMock.generateAndCopyFile.mock.calls[0]?.[1] as Record<string, unknown>;
+
+  it("forwards the bypass alongside the scope that justifies it", async () => {
+    const { run } = setupActions();
+
+    await run("worktree.copyTree", {
+      worktreeId: "wt-1",
+      scopePaths: ["docs"],
+      scopeIgnoresIgnoreFiles: true,
+    });
+
+    expect(optionsOf()).toMatchObject({
+      scopePaths: ["docs"],
+      scopeIgnoresIgnoreFiles: true,
+    });
+  });
+
+  it.each([
+    ["omitted", {}],
+    // The default spelled out. Forwarding it would file an identical bundle
+    // under its own history row, since the run hashes the options it was given.
+    ["explicitly false", { scopeIgnoresIgnoreFiles: false }],
+  ])("omits the field entirely when it is %s", async (_label, extra) => {
+    const { run } = setupActions();
+
+    await run("worktree.copyTree", { worktreeId: "wt-1", scopePaths: ["docs"], ...extra });
+
+    expect(optionsOf()).not.toHaveProperty("scopeIgnoresIgnoreFiles");
+  });
+
+  it("refuses the bypass at the schema when no scope accompanies it", () => {
+    const { parseArgs } = setupActions();
+
+    // Scope-bound in the SDK, so this combination is inert rather than wrong —
+    // and an inert flag that parses is how a caller gets a short bundle with no
+    // explanation, which is the whole complaint behind the issue.
+    expect(parseArgs("worktree.copyTree", { scopeIgnoresIgnoreFiles: true }).success).toBe(false);
+    expect(
+      parseArgs("worktree.copyTree", {
+        scopeIgnoresIgnoreFiles: true,
+        includePaths: ["docs/guide.md"],
+      })
+    ).toMatchObject({ success: false, message: expect.stringContaining("scopePaths") });
+
+    expect(
+      parseArgs("worktree.copyTree", { scopePaths: ["docs"], scopeIgnoresIgnoreFiles: true })
+        .success
+    ).toBe(true);
+    // The guard fires on the opt-in only; every request that never asked for it
+    // has to keep parsing exactly as before.
+    expect(parseArgs("worktree.copyTree", { includePaths: ["src/**"] }).success).toBe(true);
+    expect(parseArgs("worktree.copyTree", undefined).success).toBe(true);
   });
 });

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -257,57 +257,88 @@ export function PaginatedResultSchema<T extends z.ZodTypeAny>(item: T) {
   });
 }
 
-export const CopyTreeOptionsSchema = z.object({
-  format: z.enum(["xml", "json", "markdown", "tree", "ndjson", "sarif"]).optional(),
-  // `filter` and `includePaths` are two spellings of one selection set, and both
-  // feed the SDK's single `filter`. They used to collapse with `||`, so a caller
-  // that put literal files in one and globs in the other silently lost the
-  // second — the exact shape a curated bundle takes (#11722). They are unioned
-  // now, and say so here, since the union is only discoverable from these
-  // descriptions on the MCP wire.
-  // Non-empty at both levels, like `scopePaths` below. An empty list and a
-  // blank entry both leave the selection empty, and an empty selection reads as
-  // "no filter" to the SDK — i.e. the whole worktree. Accepting either would
-  // turn a malformed narrow request into a full-repo copy onto the clipboard,
-  // so they are rejected here rather than normalized away downstream.
-  filter: z
-    .union([z.string().min(1), z.array(z.string().min(1)).min(1)])
-    .optional()
-    .describe(
-      "Selects which files to include, as worktree-relative exact file paths or glob patterns. Patterns match file paths, so a folder needs a glob: pass 'src/panels/**', not 'src/panels'; prefer `scopePaths` when selecting a folder. Combined with `includePaths` when both are given; omit both to include the whole worktree."
-    ),
-  exclude: z.union([z.string(), z.array(z.string())]).optional(),
-  always: z.array(z.string()).optional(),
-  includePaths: z
-    .array(z.string().min(1))
-    .min(1)
-    .optional()
-    .describe(
-      "Selects which files to include, as worktree-relative exact file paths or glob patterns. Patterns match file paths, so a folder needs a glob: pass 'src/panels/**', not 'src/panels'; prefer `scopePaths` when selecting a folder. Use this to assemble a curated bundle of scattered files — sources, their supporting code, and their tests — in one call. Combined with `filter` when both are given. Unlike `scopePaths` this does not restrict traversal, so patterns may match anywhere in the worktree."
-    ),
-  // An empty list or blank entry would resolve to the worktree root — a folder
-  // copy that silently became a whole-worktree copy. Absent means no scoping.
-  scopePaths: z
-    .array(z.string().min(1))
-    .min(1)
-    .optional()
-    .describe(
-      "Restricts the copy to these subtrees, as worktree-relative literal file or directory paths to walk — not glob patterns, so pass 'src/panels', not 'src/panels/**'. Prefer this over `filter` or `includePaths` when selecting a folder. Omit to include the whole worktree; supplying an empty list is rejected rather than treated as no scoping, since that would silently copy everything."
-    ),
-  modified: z.boolean().optional(),
-  changed: z.string().optional(),
-  maxFileSize: z.number().int().positive().optional(),
-  maxTotalSize: z.number().int().positive().optional(),
-  maxFileCount: z.number().int().positive().optional(),
-  withLineNumbers: z.boolean().optional(),
-  charLimit: z.number().int().positive().optional(),
-  // These actions validate against their own copy of the options schema, so a
-  // field only the IPC schema knows about is stripped before the request ever
-  // leaves the renderer. `sort` was missing here while `CopyTreeOptions` and the
-  // IPC schema both accepted it, so an MCP caller asking for a sort order
-  // silently got the default one.
-  sort: z.enum(["path", "size", "modified", "name", "extension", "depth"]).optional(),
-});
+export const CopyTreeOptionsSchema = z
+  .object({
+    format: z.enum(["xml", "json", "markdown", "tree", "ndjson", "sarif"]).optional(),
+    // `filter` and `includePaths` are two spellings of one selection set, and both
+    // feed the SDK's single `filter`. They used to collapse with `||`, so a caller
+    // that put literal files in one and globs in the other silently lost the
+    // second — the exact shape a curated bundle takes (#11722). They are unioned
+    // now, and say so here, since the union is only discoverable from these
+    // descriptions on the MCP wire.
+    // Non-empty at both levels, like `scopePaths` below. An empty list and a
+    // blank entry both leave the selection empty, and an empty selection reads as
+    // "no filter" to the SDK — i.e. the whole worktree. Accepting either would
+    // turn a malformed narrow request into a full-repo copy onto the clipboard,
+    // so they are rejected here rather than normalized away downstream.
+    filter: z
+      .union([z.string().min(1), z.array(z.string().min(1)).min(1)])
+      .optional()
+      .describe(
+        "Selects which files to include, as worktree-relative exact file paths or glob patterns. Patterns match file paths, so a folder needs a glob: pass 'src/panels/**', not 'src/panels'; prefer `scopePaths` when selecting a folder. Combined with `includePaths` when both are given; omit both to include the whole worktree."
+      ),
+    exclude: z.union([z.string(), z.array(z.string())]).optional(),
+    // Undocumented on the wire until #11750, which is how a caller ended up
+    // hand-computing per-file patterns for it. Described now as the blunt
+    // instrument it is, so `scopeIgnoresIgnoreFiles` below reads as the narrower
+    // tool rather than a synonym.
+    always: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Force-includes matching files, overriding every exclusion layer at once: ignore files, project and config exclusions, your own `exclude`, the git filters and the per-file size gate. Only `.git` and the memory ceiling survive it, so a broad pattern here can pull in `node_modules`. Prefer `scopePaths` with `scopeIgnoresIgnoreFiles` when you only need past an ignore file."
+      ),
+    includePaths: z
+      .array(z.string().min(1))
+      .min(1)
+      .optional()
+      .describe(
+        "Selects which files to include, as worktree-relative exact file paths or glob patterns. Patterns match file paths, so a folder needs a glob: pass 'src/panels/**', not 'src/panels'; prefer `scopePaths` when selecting a folder. Use this to assemble a curated bundle of scattered files — sources, their supporting code, and their tests — in one call. Combined with `filter` when both are given. Unlike `scopePaths` this does not restrict traversal, so patterns may match anywhere in the worktree."
+      ),
+    // An empty list or blank entry would resolve to the worktree root — a folder
+    // copy that silently became a whole-worktree copy. Absent means no scoping.
+    scopePaths: z
+      .array(z.string().min(1))
+      .min(1)
+      .optional()
+      .describe(
+        "Restricts the copy to these subtrees, as worktree-relative literal file or directory paths to walk — not glob patterns, so pass 'src/panels', not 'src/panels/**'. Prefer this over `filter` or `includePaths` when selecting a folder. Omit to include the whole worktree; supplying an empty list is rejected rather than treated as no scoping, since that would silently copy everything. This restricts traversal, so `filter` and `includePaths` can only narrow within these paths and never add a file outside them."
+      ),
+    scopeIgnoresIgnoreFiles: z
+      .boolean()
+      .optional()
+      .describe(
+        "Lets `scopePaths` into subtrees an ignore file would have pruned (default false — a scoped copy returns what a whole-worktree copy would have returned). Requires `scopePaths` and is rejected without it. Set true when a path you named is being dropped by a `.copytreeignore` or `.gitignore` rule: only the rules blocking entry into each scoped path are removed, from those two ignore files. Unrelated rules in the same files, negations, and ignore files at or below the selection still apply — as do project and config exclusions such as node_modules, your own `exclude`, `.git`, the git filters, the size gate and all budgets. Scope the exact file rather than its parent folder to override a rule that lives inside the selection."
+      ),
+    modified: z.boolean().optional(),
+    changed: z.string().optional(),
+    maxFileSize: z.number().int().positive().optional(),
+    maxTotalSize: z.number().int().positive().optional(),
+    maxFileCount: z.number().int().positive().optional(),
+    withLineNumbers: z.boolean().optional(),
+    charLimit: z.number().int().positive().optional(),
+    // These actions validate against their own copy of the options schema, so a
+    // field only the IPC schema knows about is stripped before the request ever
+    // leaves the renderer. `sort` was missing here while `CopyTreeOptions` and the
+    // IPC schema both accepted it, so an MCP caller asking for a sort order
+    // silently got the default one.
+    sort: z.enum(["path", "size", "modified", "name", "extension", "depth"]).optional(),
+  })
+  // Scope-bound, so `scopeIgnoresIgnoreFiles` alone does nothing at all: the SDK
+  // only consults it while walking `scope` entries. Accepting it silently is the
+  // shape of the bug #11750 was filed about — the caller believes it asked for
+  // the ignored files back, gets a short bundle, and is told nothing. Naming the
+  // missing field costs one round trip instead. Pinned on the IPC schema too;
+  // neither derives from the other.
+  .superRefine((options, ctx) => {
+    if (options.scopeIgnoresIgnoreFiles === true && !options.scopePaths?.length) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["scopeIgnoresIgnoreFiles"],
+        message: "scopeIgnoresIgnoreFiles requires scopePaths",
+      });
+    }
+  });
 
 export const AgentPresetSchema = z.object({
   id: z.string(),

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -286,7 +286,7 @@ export const CopyTreeOptionsSchema = z
       .array(z.string())
       .optional()
       .describe(
-        "Force-includes matching files, overriding every exclusion layer at once: ignore files, project and config exclusions, your own `exclude`, the git filters and the per-file size gate. Only `.git` and the memory ceiling survive it, so a broad pattern here can pull in `node_modules`. Prefer `scopePaths` with `scopeIgnoresIgnoreFiles` when you only need past an ignore file."
+        "Force-includes matching files, overriding several exclusion layers at once: ignore files, project and config exclusions, your own `exclude`, the `modified`/`changed` git filters, and `maxFileSize`. A broad pattern here can pull in `node_modules`, so it is the blunt option. What it does NOT override: `.git`, the worktree boundary, `scopePaths`, and the `maxFileCount`/`maxTotalSize`/`charLimit` budgets, which still drop force-included files. Prefer `scopePaths` with `scopeIgnoresIgnoreFiles` when you only need past an ignore rule."
       ),
     includePaths: z
       .array(z.string().min(1))
@@ -308,7 +308,7 @@ export const CopyTreeOptionsSchema = z
       .boolean()
       .optional()
       .describe(
-        "Lets `scopePaths` into subtrees an ignore file would have pruned (default false — a scoped copy returns what a whole-worktree copy would have returned). Requires `scopePaths` and is rejected without it. Set true when a path you named is being dropped by a `.copytreeignore` or `.gitignore` rule: only the rules blocking entry into each scoped path are removed, from those two ignore files. Unrelated rules in the same files, negations, and ignore files at or below the selection still apply — as do project and config exclusions such as node_modules, your own `exclude`, `.git`, the git filters, the size gate and all budgets. Scope the exact file rather than its parent folder to override a rule that lives inside the selection."
+        "Lets `scopePaths` into subtrees an ignore file would have pruned (default false — a scoped copy returns what a whole-worktree copy would have returned). Requires `scopePaths` and is rejected without it. Set true when a path you named is being dropped by a `.copytreeignore` or `.gitignore` rule: only the rules blocking entry into each scoped path are removed, from those two ignore files. Unrelated rules in the same files, negations, and ignore files at or below the selection all still apply — as do project and config exclusions such as node_modules, your own `exclude`, `.git`, the `modified`/`changed` filters, `maxFileSize` and every budget. To get past a rule declared inside a selected folder, scope the exact file instead of that folder: a scoped directory subsumes any of its children you also list, so naming both changes nothing."
       ),
     modified: z.boolean().optional(),
     changed: z.string().optional(),

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -286,7 +286,7 @@ export const CopyTreeOptionsSchema = z
       .array(z.string())
       .optional()
       .describe(
-        "Force-includes matching files, overriding several exclusion layers at once: ignore files, project and config exclusions, your own `exclude`, the `modified`/`changed` git filters, and `maxFileSize`. A broad pattern here can pull in `node_modules`, so it is the blunt option. What it does NOT override: `.git`, the worktree boundary, `scopePaths`, and the `maxFileCount`/`maxTotalSize`/`charLimit` budgets, which still drop force-included files. Prefer `scopePaths` with `scopeIgnoresIgnoreFiles` when you only need past an ignore rule."
+        "Force-includes matching files, overriding several exclusion layers at once: ignore files, project and config exclusions, your own `exclude`, the `modified`/`changed` git filters, and `maxFileSize`. It is the blunt option: a broad pattern can pull in `node_modules`, and a `../` pattern reaches outside the worktree entirely. What it does not override: `.git`, CopyTree's internal 10MB memory ceiling, and the `maxFileCount`/`maxTotalSize`/`charLimit` budgets, which still drop force-included files. Prefer `scopePaths` with `scopeIgnoresIgnoreFiles` when you only need past an ignore rule."
       ),
     includePaths: z
       .array(z.string().min(1))

--- a/src/services/actions/definitions/worktreeContextActions.ts
+++ b/src/services/actions/definitions/worktreeContextActions.ts
@@ -334,13 +334,13 @@ export function registerWorktreeContextActions(
             .min(1)
             .optional()
             .describe(
-              "Worktree-relative literal file or directory paths to walk — not patterns, so pass 'src/panels', not 'src/panels/**'. Ignore rules still resolve from the worktree root, so the result matches what a whole-worktree copy would have returned for that subtree. Prefer this over includePaths when selecting a folder. This restricts traversal, so includePaths can only narrow within these paths and never add a file outside them."
+              "Worktree-relative literal file or directory paths to walk — not patterns, so pass 'src/panels', not 'src/panels/**'. Ignore rules still resolve from the worktree root, so by default the result matches what a whole-worktree copy would have returned for that subtree — unless scopeIgnoresIgnoreFiles is true. Prefer this over includePaths when selecting a folder. This restricts traversal, so includePaths can only narrow within these paths and never add a file outside them."
             ),
           scopeIgnoresIgnoreFiles: z
             .boolean()
             .optional()
             .describe(
-              "Lets scopePaths into subtrees an ignore file would have pruned (default false). Requires scopePaths and is rejected without it. Set true when a path you named is being dropped by a `.copytreeignore` or `.gitignore` rule: only the rules blocking entry into each scoped path are removed. Project and config exclusions such as node_modules, `.git`, the size gate and all budgets still apply."
+              "Lets scopePaths into subtrees an ignore file would have pruned (default false). Requires scopePaths and is rejected without it. Set true when a path you named is being dropped by a `.copytreeignore` or `.gitignore` rule: only the rules blocking entry into each scoped path are removed. Unrelated rules, ignore files inside a scoped folder, project and config exclusions such as node_modules, `.git`, `modified`, and every budget all still apply. To get past a rule declared inside a selected folder, scope the exact file instead of that folder — a scoped directory subsumes any of its children you also list."
             ),
         })
         // Same guard as `CopyTreeOptionsSchema`, restated because this action
@@ -382,9 +382,12 @@ export function registerWorktreeContextActions(
               modified,
               ...(includePaths && includePaths.length > 0 ? { includePaths } : {}),
               ...(scopePaths && scopePaths.length > 0 ? { scopePaths } : {}),
-              // Only forwarded when true: the field is absent-means-default, and
-              // sending an explicit `false` would file the run under its own
-              // history entry despite building an identical bundle.
+              // Only forwarded when true, matching the conditional spreads
+              // above: the field is absent-means-default, so an explicit `false`
+              // is noise in the payload. (History would dedupe it onto the same
+              // entry either way — `canonicalizeCopyTreeOptions` folds exact
+              // `false` away — so this is about keeping the request honest, not
+              // about the run history.)
               ...(scopeIgnoresIgnoreFiles === true ? { scopeIgnoresIgnoreFiles } : {}),
             },
             resolveCopyTreeRunSource(ctx.dispatchSource, ctx.copyTreeRunSource)

--- a/src/services/actions/definitions/worktreeContextActions.ts
+++ b/src/services/actions/definitions/worktreeContextActions.ts
@@ -334,8 +334,26 @@ export function registerWorktreeContextActions(
             .min(1)
             .optional()
             .describe(
-              "Worktree-relative literal file or directory paths to walk — not patterns, so pass 'src/panels', not 'src/panels/**'. Ignore rules still resolve from the worktree root, so the result matches what a whole-worktree copy would have returned for that subtree. Prefer this over includePaths when selecting a folder."
+              "Worktree-relative literal file or directory paths to walk — not patterns, so pass 'src/panels', not 'src/panels/**'. Ignore rules still resolve from the worktree root, so the result matches what a whole-worktree copy would have returned for that subtree. Prefer this over includePaths when selecting a folder. This restricts traversal, so includePaths can only narrow within these paths and never add a file outside them."
             ),
+          scopeIgnoresIgnoreFiles: z
+            .boolean()
+            .optional()
+            .describe(
+              "Lets scopePaths into subtrees an ignore file would have pruned (default false). Requires scopePaths and is rejected without it. Set true when a path you named is being dropped by a `.copytreeignore` or `.gitignore` rule: only the rules blocking entry into each scoped path are removed. Project and config exclusions such as node_modules, `.git`, the size gate and all budgets still apply."
+            ),
+        })
+        // Same guard as `CopyTreeOptionsSchema`, restated because this action
+        // hand-rolls its args rather than reusing that schema — the field would
+        // otherwise reach the service unaccompanied and do nothing (#11750).
+        .superRefine((args, ctx) => {
+          if (args.scopeIgnoresIgnoreFiles === true && !args.scopePaths?.length) {
+            ctx.addIssue({
+              code: "custom",
+              path: ["scopeIgnoresIgnoreFiles"],
+              message: "scopeIgnoresIgnoreFiles requires scopePaths",
+            });
+          }
         })
         .optional(),
       run: async (args, ctx: ActionContext) => {
@@ -344,6 +362,7 @@ export function registerWorktreeContextActions(
         const modified = args?.modified;
         const includePaths = args?.includePaths;
         const scopePaths = args?.scopePaths;
+        const scopeIgnoresIgnoreFiles = args?.scopeIgnoresIgnoreFiles;
         const targetWorktreeId = worktreeId ?? ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
         if (!targetWorktreeId) return null;
 
@@ -363,6 +382,10 @@ export function registerWorktreeContextActions(
               modified,
               ...(includePaths && includePaths.length > 0 ? { includePaths } : {}),
               ...(scopePaths && scopePaths.length > 0 ? { scopePaths } : {}),
+              // Only forwarded when true: the field is absent-means-default, and
+              // sending an explicit `false` would file the run under its own
+              // history entry despite building an identical bundle.
+              ...(scopeIgnoresIgnoreFiles === true ? { scopeIgnoresIgnoreFiles } : {}),
             },
             resolveCopyTreeRunSource(ctx.dispatchSource, ctx.copyTreeRunSource)
           );


### PR DESCRIPTION
## What

Adds `scopeIgnoresIgnoreFiles` to `CopyTreeOptions`. Set it with `scopePaths` and a scoped copy gets past the `.copytreeignore` (or `.gitignore`) rule that was pruning the folder you named. Absent or `false` is exactly today's behaviour, so nothing existing moves.

It reaches all four surfaces that share the options bag: `copyTree.generate`, `copyTree.generateAndCopyFile`, `copyTree.injectToTerminal` and `worktree.copyTree`. The last one hand-rolls its own args schema, so it needed the field and the guard written out separately.

## Why it isn't a `.copytreeignore` switch

The issue left open whether the flag should govern `.copytreeignore` alone or the whole ignore stack. It can't be `.copytreeignore` alone — the SDK layers that file at every depth on every code path (`FileDiscoveryStage` builds `ignoreFileNames` with it in all three branches) and exposes no option or config key that drops it.

That leaves two levers, and only one of them is safe.

**`always` — rejected.** It does defeat ignore rules, but it defeats far more than that: `collectForcedEntries` globs with `ignore: []`, `ProfileFilterStage` returns on `alwaysInclude` before it ever reads your `exclude`, and `GitFilterStage` keeps forced entries past `modified`/`changed`. Promoting a caller's selection into it would silently resurrect files that caller — or the project's own `excludedPaths`, which `mergeCopyTreeOptions` back-fills — had explicitly excluded, and lift the per-file size gate on the way. A broad pattern would also pull in `node_modules`.

**`scopeIgnoresIgnoreFiles` — shipped.** The lift is surgical: `withoutRulesBlocking` strips only the individual rules standing between the worktree root and each scope entry. Unrelated rules in the same ignore file survive, negations survive, and ignore files at or below the selection still apply. Config exclusions, your `exclude`, `.git`, the git filters, the size gate and every budget are untouched — the companion `scopeIgnoresConfigExcludes` stays off.

The honest cost: it also lifts `.gitignore` rules blocking that same chain. That's a much narrower over-reach than `always`, and the wire text says so plainly.

## On the second open question

`stats.excluded` needs no change. With the bypass on, the files simply aren't excluded, so `byReason.copytreeignore` falls — which is the correct explanation, not a missing one. Inventing a "bypassed" reason would be a lie: the file was included.

## Rejected without a scope

`true` on its own does nothing at all, since the SDK only consults the flag while walking scope entries. Accepting that would hand back a short bundle and explain nothing — the exact complaint behind this issue — so all three boundaries reject it and name the missing field.

## `always` is documented now

It reached the MCP wire with no `.describe()`, which is how an assistant ended up hand-computing per-file patterns for it. It has one now, including what it does *not* override (the `maxFileCount`/`maxTotalSize`/`charLimit` budgets do bound it — `BudgetStage` has no force-include exemption).

## Found while documenting `always`: it escapes the worktree

Not fixed here, and worth its own issue. `always: ["../sibling/secret.ts"]` resolves outside the base path and lands in the bundle — `collectForcedEntries` hands patterns straight to fast-glob and only checks real-root containment when `followSymlinks` is on. I verified it against the installed SDK. The field predates this change and is passed through unaltered, and closing it is a cross-cutting call about path containment on `always`/`scopePaths`/`includePaths` rather than a rider on this PR. The wire text now states the real behaviour instead of promising a boundary nothing enforces.

## Tests

`CopyTreeService.sdk-contract.test.ts` runs the real installed package rather than a mock, which is where the claims above are actually pinned: the ignored folder comes back, `*.secret` in the same ignore file does not, a nested ignore file inside the selection still bites, `exclude` still wins, the size gate and the file-count budget still bind, `node_modules` and `build` stay out, and a scoped directory subsumes a child you also list. Plus the schema guards on all three boundaries, the history-record unwrap invariant, dedupe canonicalization, and polarity-bearing assertions on the wire prose.

Resolves #11750